### PR TITLE
fix(cli): prevent debug log persistence in production deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @juspay/neurolink
 
+## 1.5.3
+
+### Patch Changes
+
+- **🔧 CLI Debug Log Persistence Fix**: Fixed unwanted debug logs appearing in production deployments
+  - **Issue**: CLI showed debug logs even when `--debug` flag was not provided, cluttering production output
+  - **Root Cause**: CLI middleware had logical gap where `NEUROLINK_DEBUG` wasn't explicitly set to `'false'` when no debug flag provided, allowing inherited environment variables to persist
+  - **Solution**: Updated middleware to always set `NEUROLINK_DEBUG = 'false'` when debug mode not enabled
+  - **Impact**: **Deterministic logging behavior** - debug logs only appear when explicitly requested with `--debug` flag
+
+### Technical Changes
+
+- **Clean Production Output**: No debug logs in deployed CLI unless `--debug` flag explicitly provided
+- **Deterministic Behavior**: Logging controlled by CLI flags, not inherited environment variables
+- **Backward Compatible**: Debug mode still works perfectly when `--debug` flag is used
+- **Environment Independence**: CLI output no longer affected by external `NEUROLINK_DEBUG` settings
+
+### CLI Behavior Fix
+
+```bash
+# Before Fix (Problematic)
+neurolink generate-text "test"
+# Could show debug logs if NEUROLINK_DEBUG was set in environment
+
+# After Fix (Clean)
+neurolink generate-text "test"
+# Output: ⠋ 🤖 Generating text... ✔ ✅ Text generated successfully! [content]
+
+# Debug still works when requested
+neurolink generate-text "test" --debug
+# Output: [debug logs] + spinner + success + content
+```
+
 ## 1.5.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@juspay/neurolink",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"description": "Universal AI Development Platform with external MCP server integration, multi-provider support, and professional CLI. Connect to 65+ MCP servers for filesystem, GitHub, database operations, and more. Build, test, and deploy AI applications with OpenAI, Anthropic, Google Vertex AI, and AWS Bedrock.",
 	"author": {
 		"name": "Juspay Technologies",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -180,8 +180,8 @@ const cli = yargs(args)
     // Control SDK logging based on debug flag
     if (argv.debug) {
       process.env.NEUROLINK_DEBUG = 'true';
-    } else if (typeof argv.debug !== 'undefined') {
-      // Only set to false if debug flag was explicitly provided
+    } else {
+      // Always set to false when debug is not enabled (including when not provided)
       process.env.NEUROLINK_DEBUG = 'false';
     }
     // Keep existing quiet middleware


### PR DESCRIPTION
- Fixed CLI middleware logical gap where NEUROLINK_DEBUG wasn't explicitly set to 'false' when no debug flag provided
- Prevents inherited environment variables from causing unwanted debug logs in production
- Ensures deterministic logging behavior controlled by CLI flags, not external environment
- Maintains backward compatibility - debug mode still works perfectly with --debug flag

Fixes: Debug logs appearing in deployed CLI without --debug flag
Impact: Clean production output, environment-independent logging behavior
Version: 1.5.3
