### PR TITLE
fix(ci): resolve external contributor PR failures in single commit policy validation

### DIFF
--- a/.github/workflows/single-commit-enforcement.yml
+++ b/.github/workflows/single-commit-enforcement.yml
@@ -33,12 +33,28 @@ jobs:
           # Determine the base branch and current branch
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_BRANCH="origin/${{ github.base_ref }}"
-            CURRENT_BRANCH="origin/${{ github.head_ref }}"
             BRANCH_NAME="${{ github.head_ref }}"
             
-            # For PR events, check out the actual head branch instead of merge commit
-            echo "🔄 Switching to actual PR head branch for validation..."
-            git checkout "origin/${{ github.head_ref }}"
+            # Handle external vs internal contributors differently
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              # External contributor - use the PR head SHA directly
+              CURRENT_BRANCH="HEAD"
+              echo "📡 External contributor detected"
+              echo "🔍 Head repository: ${{ github.event.pull_request.head.repo.full_name }}"
+              echo "🔍 Base repository: ${{ github.repository }}"
+              echo "🔍 Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+              
+              # For external PRs, checkout the actual PR commit (not the merge commit)
+              echo "🔄 Checking out PR head commit for validation..."
+              git checkout "${{ github.event.pull_request.head.sha }}"
+              CURRENT_BRANCH="HEAD"
+            else
+              # Internal branch - can checkout the actual branch
+              echo "🏠 Internal contributor detected"
+              echo "🔄 Switching to actual PR head branch for validation..."
+              git checkout "origin/${{ github.head_ref }}"
+              CURRENT_BRANCH="origin/${{ github.head_ref }}"
+            fi
           else
             BASE_BRANCH="origin/release"
             CURRENT_BRANCH="HEAD"


### PR DESCRIPTION
## Description

Fixes GitHub Actions workflow failure when external contributors submit PRs. The single commit policy validation was attempting to checkout external contributor branches that don't exist as origin remotes, causing pathspec errors and preventing external contributions.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI configuration change

## Related Issues

- Fixes external contributor PR failures (e.g., PR #60)
- Related to single commit policy enforcement

## Changes Made

- Add external contributor detection using head/base repo comparison
- Implement SHA-based checkout for external PRs instead of branch-based checkout
- Preserve existing branch-based checkout for internal contributors
- Maintain all existing policy validation logic (commit count, message format, merge commit detection)
- Add comprehensive logging for debugging external vs internal contributor workflows

## AI Provider Impact

- [x] No provider-specific changes

## Component Impact

- [x] Tests

## Testing

- [x] Manual testing performed
- [x] All existing tests pass

### Test Environment

- OS: macOS Darwin 24.5.0
- Node.js version: 18+
- Package manager: pnpm

## Performance Impact

- [x] No performance impact

## Breaking Changes

No breaking changes. This is a backward-compatible fix that preserves all existing functionality for internal contributors while adding support for external contributors.

## Screenshots/Demo

Verified with:
- PR #60 (external contributor): Previously failed with pathspec error, now works
- Internal contributors: Continue to work as before

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This fix is critical for accepting external contributions. The original workflow failed with:
```
error: pathspec 'origin/BZ-43202-add-conversation-memory-architecture' did not match any file(s) known to git
```

The solution uses GitHub Actions context variables to detect external PRs and handle them appropriately while maintaining the same validation logic for both internal and external contributors.