### PR TITLE
fix(ci): prevent external contributor PR failures due to comment permissions

### DIFF
--- a/.github/workflows/single-commit-enforcement.yml
+++ b/.github/workflows/single-commit-enforcement.yml
@@ -35,13 +35,13 @@ jobs:
             BASE_BRANCH="origin/${{ github.base_ref }}"
             BRANCH_NAME="${{ github.head_ref }}"
             
-            # Handle external vs internal contributors differently
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            # Handle external vs internal contributors differently using repository IDs for security
+            if [ "${{ github.event.pull_request.head.repo.id }}" != "${{ github.event.repository.id }}" ]; then
               # External contributor - use the PR head SHA directly
               CURRENT_BRANCH="HEAD"
               echo "📡 External contributor detected"
-              echo "🔍 Head repository: ${{ github.event.pull_request.head.repo.full_name }}"
-              echo "🔍 Base repository: ${{ github.repository }}"
+              echo "🔍 Head repository ID: ${{ github.event.pull_request.head.repo.id }}"
+              echo "🔍 Base repository ID: ${{ github.event.repository.id }}"
               echo "🔍 Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
               
               # For external PRs, checkout the actual PR commit (not the merge commit)
@@ -184,8 +184,21 @@ jobs:
 
           exit 1
 
+      - name: Check Comment Permissions
+        if: steps.validate.outputs.status == 'compliant'
+        id: check-permissions
+        run: |
+          # Check if this is an external contributor PR using repository IDs for security
+          if [ "${{ github.event.pull_request.head.repo.id }}" != "${{ github.event.repository.id }}" ]; then
+            echo "🔒 External contributor PR detected - comment posting will be skipped due to GitHub security restrictions"
+            echo "can_comment=false" >> $GITHUB_OUTPUT
+          else
+            echo "🏠 Internal contributor PR - comment posting enabled"
+            echo "can_comment=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Find existing comment
-        if: github.event_name == 'pull_request' && steps.validate.outputs.status == 'compliant'
+        if: steps.validate.outputs.status == 'compliant' && steps.check-permissions.outputs.can_comment == 'true'
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
@@ -194,7 +207,7 @@ jobs:
           body-includes: Single Commit Policy
 
       - name: Post Minimal Success Comment
-        if: github.event_name == 'pull_request' && steps.validate.outputs.status == 'compliant'
+        if: steps.validate.outputs.status == 'compliant' && steps.check-permissions.outputs.can_comment == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Fixes workflow failures on external contributor PRs caused by GitHub's automatic permission restrictions. External contributor PRs cannot post comments due to security restrictions, but this was causing the entire validation workflow to fail even when validation passed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI configuration change

## Root Cause

GitHub automatically restricts GITHUB_TOKEN permissions for external contributor PRs for security reasons, preventing comment posting regardless of workflow permissions. This caused the 'Post Minimal Success Comment' step to fail with a 403 error, failing the entire workflow.

## Solution

- Add proactive permission check to detect external contributor PRs
- Skip comment posting entirely for external PRs instead of attempting and failing
- Maintain full comment functionality for internal contributor PRs
- Provide clear logging about why comments are skipped

## Changes Made

- Added 'Check Comment Permissions' step with external contributor detection
- Modified comment posting steps to only run for internal contributors
- Added informative logging for both scenarios

## Testing

- External contributor PRs: Comments skipped, validation passes
- Internal contributor PRs: Comments posted normally, validation passes

## Additional Notes

This is a proper fix that prevents the 403 permission error rather than just ignoring it with continue-on-error. The core validation logic works perfectly for both external and internal contributors.