### PR TITLE
fix(ci): resolve GitHub Copilot PR Review workflow failures for external contributors

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -128,7 +128,20 @@ jobs:
             node scripts/commit-validation.cjs "$commit_msg" || echo "⚠️ Commit message needs attention"
           done
 
+      - name: Check Comment Permissions
+        id: check-permissions
+        run: |
+          # Check if this is an external contributor PR using repository IDs for security
+          if [ "${{ github.event.pull_request.head.repo.id }}" != "${{ github.event.repository.id }}" ]; then
+            echo "🔒 External contributor PR detected - comment posting will be skipped due to GitHub security restrictions"
+            echo "can_comment=false" >> $GITHUB_OUTPUT
+          else
+            echo "🏠 Internal contributor PR - comment posting enabled"
+            echo "can_comment=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Find existing AI review comment
+        if: steps.check-permissions.outputs.can_comment == 'true'
         uses: peter-evans/find-comment@v3
         id: find-ai-comment
         with:
@@ -137,6 +150,7 @@ jobs:
           body-includes: AI-Powered PR Analysis
 
       - name: 📊 Consolidated PR Analysis & Compliance Summary
+        if: steps.check-permissions.outputs.can_comment == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add external contributor detection to GitHub Copilot PR Review workflow
- Skip comment posting for external contributor PRs to prevent 403 permission errors
- Apply same fix pattern used successfully in Single Commit Policy workflow

## Problem
The GitHub Copilot PR Review workflow was failing for external contributor PRs with HTTP 403 "Resource not accessible by integration" errors when attempting to post comments. This is due to GitHub Actions security restrictions for external contributor PRs.

## Solution
- Add repository ID-based external contributor detection for security
- Conditionally skip comment posting steps for external contributors
- Maintain all AI review functionality while preventing permission errors

## Test plan
- [x] Verify workflow works for internal contributor PRs (no regression)
- [ ] Test with external contributor PR to confirm no 403 errors
- [ ] Verify AI review still runs but skips comment posting for external PRs

This completes the fix for PR #60 external contributor workflow failures.

🤖 Generated with [Claude Code](https://claude.ai/code)