### PR TITLE
feat(History): Added the functionality to export the conversation his…

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -83,7 +83,10 @@ import {
   CircuitBreaker,
 } from "./utils/errorHandling.js";
 import { EventEmitter } from "events";
-import type { ConversationMemoryConfig } from "./types/conversationTypes.js";
+import type {
+  ConversationMemoryConfig,
+  ChatMessage,
+} from "./types/conversationTypes.js";
 import { ConversationMemoryManager } from "./core/conversationMemoryManager.js";
 import {
   applyConversationMemoryDefaults,
@@ -2839,6 +2842,42 @@ export class NeuroLink {
     }
 
     return await this.conversationMemory.getStats();
+  }
+
+  /**
+   * Get complete conversation history for a specific session (public API)
+   * @param sessionId - The session ID to retrieve history for
+   * @returns Array of ChatMessage objects in chronological order, or empty array if session doesn't exist
+   */
+  async getConversationHistory(sessionId: string): Promise<ChatMessage[]> {
+    if (!this.conversationMemory) {
+      throw new Error("Conversation memory is not enabled");
+    }
+
+    if (!sessionId || typeof sessionId !== "string") {
+      throw new Error("Session ID must be a non-empty string");
+    }
+
+    try {
+      // Use the existing buildContextMessages method to get the complete history
+      const messages = this.conversationMemory.buildContextMessages(sessionId);
+
+      logger.debug("Retrieved conversation history", {
+        sessionId,
+        messageCount: messages.length,
+        turnCount: messages.length / 2, // Each turn = user + assistant message
+      });
+
+      return messages;
+    } catch (error) {
+      logger.error("Failed to retrieve conversation history", {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // Return empty array for graceful handling of missing sessions
+      return [];
+    }
   }
 
   /**


### PR DESCRIPTION
…tory for debugging purpose

# Pull Request

## Description

<!-- Provide a clear and concise description of the changes -->

Added a new getConversationHistory() method to the NeuroLink class that enables retrieval of complete conversation history for debugging and analysis purposes. This method provides access to the full message array for any given session, supporting both generate() and stream() conversation types.

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Build/CI configuration change

## Related Issues

<!-- Link to related issues using keywords like "Fixes #123" or "Closes #456" -->

- Fixes #
- Related to #

## Changes Made

<!-- Provide a detailed list of changes -->
- __Added `getConversationHistory(sessionId: string): Promise<ChatMessage[]>` method__ to the NeuroLink class in `src/lib/neurolink.ts`

- __Enhanced conversation memory testing__ with 3 new comprehensive test scenarios (TEST 11, 12, 13)

- __Validated stream conversation storage__ - ensured both `generate()` and `stream()` methods properly store conversation history

- __Added robust error handling__ for disabled conversation memory and invalid session IDs

- __Implemented edge case testing__ for non-existent sessions and invalid inputs


## AI Provider Impact

<!-- If applicable, indicate which AI providers are affected -->

- [ ] OpenAI
- [ ] Anthropic
- [ ] Google AI/Vertex
- [ ] AWS Bedrock
- [ ] Azure OpenAI
- [ ] Hugging Face
- [ ] Ollama
- [ ] Mistral
- [x] All providers
- [ ] No provider-specific changes

## Component Impact

<!-- Check all components that are affected -->

- [ ] CLI
- [x] SDK
- [ ] MCP Integration
- [x] Streaming
- [ ] Tool Calling
- [ ] Configuration
- [ ] Documentation
- [ ] Tests

## Testing

<!-- Describe the tests you've added or run -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

### Test Environment

- OS:
- Node.js version:
- Package manager:

## Performance Impact

<!-- If applicable, describe any performance implications -->

- [x] No performance impact
- [ ] Performance improvement
- [ ] Minor performance impact (acceptable)
- [ ] Significant performance impact (needs discussion)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Screenshots/Demo

<!-- If applicable, add screenshots or demo links -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that would be helpful for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public API to retrieve the full conversation history for a given session when conversation memory is enabled.
  - Returns messages in chronological order for easier review and processing.

- Bug Fixes
  - Improved input validation for session IDs to prevent invalid requests.
  - Added graceful error handling to avoid failures and return an empty result when retrieval is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->