### PR TITLE
fix(neurolink): add Zod schema detection for inputSchema field in bas…

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1070,9 +1070,14 @@ export abstract class BaseProvider implements AIProvider {
       let finalSchema: z.ZodSchema | ReturnType<typeof jsonSchema>;
       let originalInputSchema: Record<string, unknown> | undefined;
 
-      // Prioritize parameters (Zod), then inputSchema (JSON Schema)
+      // Prioritize parameters (Zod), then inputSchema (Zod or JSON Schema)
       if (toolInfo.parameters && this.isZodSchema(toolInfo.parameters)) {
         finalSchema = toolInfo.parameters as z.ZodSchema;
+      } else if (
+        toolInfo.inputSchema &&
+        this.isZodSchema(toolInfo.inputSchema)
+      ) {
+        finalSchema = toolInfo.inputSchema as z.ZodSchema;
       } else if (
         toolInfo.inputSchema &&
         typeof toolInfo.inputSchema === "object"


### PR DESCRIPTION
Description

  Fix NeuroLink v7.51.x schema validation bug that broke chart
  generation tools and any other tools using Zod schemas in the
  inputSchema field.

  Changes:
  - Added isZodSchema() check for inputSchema before wrapping with
  jsonSchema()
  - Fixes schema validation error: 'type: "None"' for chart generation
  tools
  - Maintains compatibility with both Zod schemas and JSON Schemas
  - Resolves breaking change introduced in commit 020e15a (PDF support)

  Root Cause:
  Commit 020e15a (Oct 9, 2025) assumed inputSchema field always
  contains JSON Schema objects and wrapped them with AI SDK's
  jsonSchema() function without checking if they were Zod schemas
  first. This caused Zod schemas to be incorrectly processed, leading
  to validation failures.

  Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing
  functionality to not work as expected)
  - [ ] 📚 Documentation update
  - [ ] 🧹 Code refactoring (no functional changes)
  - [ ] ⚡ Performance improvement
  - [ ] 🧪 Test coverage improvement
  - [ ] 🔧 Build/CI configuration change

  Related Issues

  - Fixes BZ-45451
  - Related to commit 020e15a (breaking commit)

  Changes Made

  File: src/lib/core/baseProvider.ts (lines 1076-1080)

  Before:
  } else if (
    toolInfo.inputSchema &&
    typeof toolInfo.inputSchema === "object"
  ) {
    // Assumed inputSchema is always JSON Schema
    originalInputSchema = toolInfo.inputSchema as Record<string,
  unknown>;
    finalSchema = jsonSchema(originalInputSchema);
  }

  After:
  } else if (
    toolInfo.inputSchema &&
    this.isZodSchema(toolInfo.inputSchema)
  ) {
    // NEW: Check if inputSchema is a Zod schema first
    finalSchema = toolInfo.inputSchema as z.ZodSchema;
  } else if (
    toolInfo.inputSchema &&
    typeof toolInfo.inputSchema === "object"
  ) {
    // Now we know it's actually JSON Schema
    originalInputSchema = toolInfo.inputSchema as Record<string,
  unknown>;
    finalSchema = jsonSchema(originalInputSchema);
  }

  Impact:
  - Adds Zod schema detection for inputSchema field
  - Preserves existing JSON Schema support for PDF/multimodal features
  - Maintains backward compatibility with v7.50.0 Zod schema handling
  - No breaking changes to existing functionality

  AI Provider Impact

  - OpenAI
  - Anthropic
  - Google AI/Vertex
  - AWS Bedrock
  - Azure OpenAI
  - Hugging Face
  - Ollama
  - Mistral
  - All providers
  - No provider-specific changes

  Explanation: This fix is in baseProvider.ts which is the base class
  for all AI providers. The schema validation happens before
  provider-specific logic, so all providers benefit from this fix.

  Component Impact

  - CLI
  - SDK
  - MCP Integration
  - Streaming
  - Tool Calling
  - Configuration
  - Documentation
  - Tests

  Details:
  - SDK: Core schema handling in baseProvider affects all SDK tool
  registrations
  - Tool Calling: Directly fixes tool schema validation for all tools
  with Zod schemas

  Testing

  - Unit tests added/updated
  - Integration tests added/updated
  - E2E tests added/updated
  - Manual testing performed
  - All existing tests pass

  Manual Testing Performed:
  1. ✅ Lighthouse chat mode with chart generation tools (bar, line,
  donut, stat card)
  2. ✅ Verified no "Middleware execution failed: guardrails" errors
  3. ✅ Confirmed chart tools execute successfully
  4. ✅ Validated both Zod and JSON Schema handling
  5. ✅ Tested with NeuroLink v7.51.2 + fix

  Test Environment

  - OS: macOS Darwin 25.0.0
  - Node.js version: >=18.20.0
  - Package manager: pnpm 10.15.0

  Performance Impact

  - No performance impact
  - Performance improvement
  - Minor performance impact (acceptable)
  - Significant performance impact (needs discussion)

  Analysis: Added one additional isZodSchema() check in the schema
  resolution path. This is a lightweight check (verifies parse is a
  function) with negligible performance overhead.

  Breaking Changes

  None. This fix restores functionality that was broken in v7.51.0. It
  does not introduce any new breaking changes.

  Migration: No migration needed. Users can upgrade from:
  - v7.50.0 → v7.51.2+ (with fix): No code changes required
  - v7.51.0-7.51.2 (broken) → v7.51.2+ (with fix): Chat mode will start
   working again

  Screenshots/Demo

  Error Before Fix:
  [NEUROLINK:WARN] Middleware execution failed: guardrails {
    executionTime: 240,
    error: "Invalid schema for function
  'chart-generation_generate_bar_chart': 
           schema must be a JSON Schema of 'type: \"object\"', got 
  'type: \"None\"'."
  }

  After Fix:
  ✅ Chat mode functional✅ Chart generation tools working✅ No schema
  validation errors

  Checklist

  - My code follows the project's style guidelines
  - I have performed a self-review of my code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my
  feature works
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published

  Additional Notes

  Context

  Breaking Commit Analysis:
  - Commit: 020e15a (Oct 9, 2025)
  - Author: Sachin Sharma
  - Title: feat(multimodal): add comprehensive PDF file support
  - Intent: Preserve original JSON Schemas for OpenAI strict mode
  - Unintended Effect: Broke Zod schema handling in inputSchema field

  Why v7.50.0 Worked:
  - Used convertJsonSchemaToZod() which had graceful fallbacks
  - Converted all non-Zod schemas to Zod before passing to AI SDK

  Why v7.51.x Failed:
  - Assumed inputSchema always contains JSON Schemas
  - Wrapped all inputSchema values with jsonSchema() without checking
  type
  - Zod schemas incorrectly processed as JSON Schemas → validation
  failure

  Fix Strategy:
  - Add Zod detection before JSON Schema wrapping
  - Maintain support for both schema types
  - Preserve PDF/multimodal improvements from 020e15a

  Affected Integrations

  Any integration passing Zod schemas via inputSchema field was
  affected:
  - ✅ Lighthouse: Chart generation tools (primary reporter)
  - ⚠️ Potential: Any custom MCP servers using Zod in inputSchema

  Recommendation

  Consider adding integration tests to prevent schema handling
  regressions in future releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced schema handling for tool parameters to support multiple input format options, providing improved flexibility in configuration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->