### PR TITLE
fix(utils): add content-length:0 validation in URL downloader

### DIFF
--- a/src/lib/utils/imageProcessor.ts
+++ b/src/lib/utils/imageProcessor.ts
@@ -548,7 +548,13 @@ export const imageUtils = {
           );
         }
 
-        const len = Number(response.headers.get("content-length") || 0);
+        const contentLengthHeader = response.headers.get("content-length");
+        const len = Number(contentLengthHeader || 0);
+
+        if (contentLengthHeader !== null && len === 0) {
+          throw new Error("Empty response: content-length is 0");
+        }
+
         if (len && len > maxBytes) {
           throw new Error(`Content too large: ${len} bytes`);
         }

--- a/test/unit/utils/imageProcessor.test.ts
+++ b/test/unit/utils/imageProcessor.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { imageUtils } from "../../../src/lib/utils/imageProcessor.js";
+
+describe("imageUtils", () => {
+  describe("urlToBase64DataUri", () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should reject responses with content-length: 0", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => {
+            if (key === "content-type") {
+              return "image/jpeg";
+            }
+            if (key === "content-length") {
+              return "0";
+            }
+            return null;
+          },
+        },
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+      });
+
+      await expect(
+        imageUtils.urlToBase64DataUri("https://example.com/image.jpg"),
+      ).rejects.toThrow("Empty response: content-length is 0");
+    });
+
+    it("should accept responses with valid content-length", async () => {
+      const mockImageData = new Uint8Array([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+      ]);
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => {
+            if (key === "content-type") {
+              return "image/jpeg";
+            }
+            if (key === "content-length") {
+              return String(mockImageData.length);
+            }
+            return null;
+          },
+        },
+        arrayBuffer: vi.fn().mockResolvedValue(mockImageData.buffer),
+      });
+
+      const result = await imageUtils.urlToBase64DataUri(
+        "https://example.com/image.jpg",
+      );
+
+      expect(result).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it("should accept responses without content-length header", async () => {
+      const mockImageData = new Uint8Array([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+      ]);
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => {
+            if (key === "content-type") {
+              return "image/jpeg";
+            }
+            if (key === "content-length") {
+              return null; // No content-length header
+            }
+            return null;
+          },
+        },
+        arrayBuffer: vi.fn().mockResolvedValue(mockImageData.buffer),
+      });
+
+      const result = await imageUtils.urlToBase64DataUri(
+        "https://example.com/image.jpg",
+      );
+
+      expect(result).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it("should reject responses that exceed maxBytes", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => {
+            if (key === "content-type") {
+              return "image/jpeg";
+            }
+            if (key === "content-length") {
+              return "20000000"; // 20MB
+            }
+            return null;
+          },
+        },
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(20000000)),
+      });
+
+      await expect(
+        imageUtils.urlToBase64DataUri("https://example.com/large.jpg"),
+      ).rejects.toThrow("Content too large");
+    });
+
+    it("should reject non-image content types", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => {
+            if (key === "content-type") {
+              return "text/html";
+            }
+            if (key === "content-length") {
+              return "100";
+            }
+            return null;
+          },
+        },
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+      });
+
+      await expect(
+        imageUtils.urlToBase64DataUri("https://example.com/page.html"),
+      ).rejects.toThrow("Unsupported content-type");
+    });
+
+    it("should reject non-HTTP protocols", async () => {
+      await expect(
+        imageUtils.urlToBase64DataUri("file:///etc/passwd"),
+      ).rejects.toThrow("Unsupported protocol");
+
+      await expect(
+        imageUtils.urlToBase64DataUri("ftp://example.com/image.jpg"),
+      ).rejects.toThrow("Unsupported protocol");
+    });
+  });
+});


### PR DESCRIPTION
## Description
Add validation to reject HTTP responses with content-length: 0 in the URL-to-base64 converter. This prevents empty downloads that would result in invalid/empty data URIs.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues
- Fixes #549

## Changes Made
- Added check for content-length header being \"0\" in \`urlToBase64DataUri()\` function
- Throws descriptive error \"Empty response: content-length is 0\" before attempting download
- Added comprehensive unit tests (6 tests) covering the validation

## AI Provider Impact
- [x] No provider-specific changes (utility function affects all providers using image URLs)

## Component Impact
- [x] SDK
- [x] Tests

## Testing
- [x] Unit tests added/updated
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image fetching now rejects empty responses and oversized payloads; only recognized image content-types and secure protocols are allowed.
  * Handles cases where size header is missing while still validating content.

* **Tests**
  * Added unit tests covering empty responses, size limits, content-type and protocol validations, and successful image-to-data-uri conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->