### PR TITLE
fix(pdf): remove mistral from pdf provider configs

### DIFF
--- a/docs/features/multimodal-chat.md
+++ b/docs/features/multimodal-chat.md
@@ -315,10 +315,9 @@ const stream = await neurolink.stream({
 | **Azure OpenAI**      | 10 MB    | 100       | Uses OpenAI Files API           |
 | **LiteLLM**           | 10 MB    | 100       | Depends on upstream model       |
 | **OpenAI Compatible** | 10 MB    | 100       | Depends on upstream model       |
-| **Mistral**           | 10 MB    | 100       | Native PDF support              |
 | **Hugging Face**      | 10 MB    | 100       | Native PDF support              |
 
-**Not supported:** Ollama
+**Not supported:** Mistral, Ollama
 
 ### Best Practices
 

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1083,10 +1083,8 @@ async function convertMultimodalToProviderFormat(
     }
   }
 
-  // Add PDFs using Vercel AI SDK standard format (works for all providers except Mistral)
-  // NOTE: Mistral API has a fundamental limitation - it does NOT support PDFs in any form.
-  // The API strictly requires image content to start with data:image/, rejecting data:application/pdf
-  // See: MISTRAL_PDF_FIX_SUMMARY.md for full investigation details
+  // Add PDFs using Vercel AI SDK standard format
+  // Note: Some providers don't support PDF files. Check provider configuration in pdfProcessor.ts
   content.push(
     ...pdfFiles.map((pdf): FilePart => {
       logger.info(

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -93,13 +93,6 @@ const PDF_PROVIDER_CONFIGS: Record<string, PDFProviderConfig> = {
     requiresCitations: false,
     apiType: "files-api",
   },
-  mistral: {
-    maxSizeMB: 10,
-    maxPages: 100,
-    supportsNative: false,
-    requiresCitations: false,
-    apiType: "files-api",
-  },
   "hugging-face": {
     maxSizeMB: 10,
     maxPages: 100,


### PR DESCRIPTION
Resolves the contradiction where Mistral was listed in `PDF_PROVIDER_CONFIGS` but marked as `supportsNative: false`, creating user confusion. Mistral's API fundamentally does not support file content parts in user messages, so it should not be configured for PDF processing at all.

Changes:
- Remove Mistral from PDF_PROVIDER_CONFIGS in src/lib/utils/pdfProcessor.ts
- Update docs/features/multimodal-chat.md to list Mistral in "Not supported" providers
- Simplify comments in src/lib/utils/messageBuilder.ts
- Update .env.example to document Mistral's PDF limitation

Users will now receive a clear error message when attempting PDF processing with Mistral.
fix #268 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported providers list—Mistral no longer listed as available
  * Clarified that PDF support depends on provider configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->