### PR TITLE
feat(observability): add external TracerProvider support with operation name auto-detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,165 @@ neurolink generate "Complex task" --thinking-level high
 
 Note: When `thinkingLevel` is enabled, some providers may have limitations (see Important Constraints).
 
+### External TracerProvider Support
+
+NeuroLink supports integration with applications that have existing OpenTelemetry instrumentation:
+
+**Configuration Options:**
+
+- `useExternalTracerProvider: true` - Skip TracerProvider creation/registration
+- `autoDetectExternalProvider: true` - Auto-detect existing provider
+
+**Exports for External Provider Integration:**
+
+- `getSpanProcessors()` - Returns [ContextEnricher, LangfuseSpanProcessor]
+- `createContextEnricher()` - Factory for ContextEnricher
+- `isUsingExternalTracerProvider()` - Check if in external mode
+
+**Context Management Exports:**
+
+- `setLangfuseContext<T>(context, callback?)` - Set context with extended fields, returns callback result
+- `getLangfuseContext()` - Read current context from AsyncLocalStorage
+- `getTracer(name?, version?)` - Get OpenTelemetry Tracer for custom spans
+
+**Extended Context Fields:**
+
+- `userId`, `sessionId` - User and session identification
+- `conversationId` - Group related traces by conversation/thread
+- `requestId` - Correlate with application logs
+- `traceName` - Custom trace names in Langfuse UI
+- `metadata` - Custom key-value metadata on spans
+
+**Type Exports:**
+
+- `LangfuseSpanAttributes` - GenAI semantic convention attributes from Vercel AI SDK
+
+**Use Case:** When your application already initializes OpenTelemetry (e.g., for HTTP/DB tracing to Jaeger), enable external mode to avoid "duplicate registration" errors.
+
+**Example - External Provider Mode:**
+
+```typescript
+import { NeuroLink, getSpanProcessors } from "@juspay/neurolink";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+// Initialize NeuroLink with external provider mode
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+      secretKey: process.env.LANGFUSE_SECRET_KEY,
+      useExternalTracerProvider: true,
+    },
+  },
+});
+
+// Add NeuroLink's processors to your existing OTEL setup
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new BatchSpanProcessor(yourExistingExporter),
+    ...getSpanProcessors(),
+  ],
+});
+```
+
+**Example - Enhanced Context with Callback:**
+
+```typescript
+import {
+  setLangfuseContext,
+  getLangfuseContext,
+  getTracer,
+} from "@juspay/neurolink";
+
+// Set context and get result from callback
+const result = await setLangfuseContext(
+  {
+    userId: "user-123",
+    sessionId: "session-456",
+    conversationId: "conv-789",
+    requestId: "req-abc",
+    traceName: "chat-completion",
+    metadata: { feature: "customer-support", tier: "premium" },
+  },
+  async () => {
+    return await neurolink.generate({ prompt: "Hello" });
+  },
+);
+
+// Read current context
+const context = getLangfuseContext();
+console.log(context?.userId, context?.conversationId);
+
+// Create custom spans
+const tracer = getTracer("my-app");
+const span = tracer.startSpan("custom-operation");
+try {
+  // ... do work
+} finally {
+  span.end();
+}
+```
+
+### Operation Name Support
+
+NeuroLink automatically detects and includes operation names in trace naming for better observability in Langfuse.
+
+**Auto-detection:**
+
+- Automatically detects operation names from Vercel AI SDK spans (`ai.streamText`, `ai.generateText`, etc.)
+- Falls back to `unknown` if no operation can be detected
+
+**Trace Name Format:**
+
+- Default format: `userId:operationName` (e.g., `user@email.com:ai.streamText`)
+- When userId is not set: uses just the operation name
+- Customizable via `traceNameFormat` function
+
+**Configuration Options:**
+
+- `autoDetectOperationName: boolean` (default: `true`) - Enable/disable automatic operation detection from spans
+- `traceNameFormat: TraceNameFormat` - Custom function to format trace names
+- `operationName` in context - Explicit operation name override (takes precedence over auto-detection)
+
+**Example - Custom Trace Name Format:**
+
+```typescript
+import { NeuroLink, setLangfuseContext } from "@juspay/neurolink";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+      secretKey: process.env.LANGFUSE_SECRET_KEY,
+      autoDetectOperationName: true, // default
+      traceNameFormat: (context) => {
+        // Custom format: "op/streamText/user@email.com"
+        return `op/${context.operationName}/${context.userId || "anonymous"}`;
+      },
+    },
+  },
+});
+
+// Explicit operation name override in context
+await setLangfuseContext(
+  {
+    userId: "user@email.com",
+    operationName: "customer-support-chat", // overrides auto-detected operation
+  },
+  async () => {
+    return await neurolink.stream({ prompt: "Hello" });
+  },
+);
+```
+
+**Wrapper Span Support:**
+
+When host apps create wrapper spans before AI operations, auto-detection in `onStart()` fails because the AI span does not exist yet. NeuroLink handles this automatically by detecting operations from child spans and updating the trace name in `onEnd()` of the wrapper span. No code changes required.
+
 ### Memory Management
 
 - Redis for distributed memory (production)

--- a/README.md
+++ b/README.md
@@ -35,30 +35,32 @@ Extracted from production systems at Juspay and battle-tested at enterprise scal
 
 ## What's New (Q1 2026)
 
-| Feature                            | Version | Description                                                                                                                                    | Guide                                                         |
-| ---------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Server Adapters**                | v8.41.0 | Multi-framework HTTP server with Hono, Express, Fastify, Koa support. Full CLI for server management with foreground/background modes.         | [Server Adapters Guide](docs/guides/server-adapters/index.md) |
-| **Title Generation Events**        | v8.38.0 | Emit `conversation:titleGenerated` event when conversation title is generated. Supports custom title prompts via `NEUROLINK_TITLE_PROMPT`.     | [Conversation Memory Guide](docs/conversation-memory.md)      |
-| **Video Generation with Veo**      | v8.32.0 | Video generation using Veo 3.1 (`veo-3.1`). Realistic video generation with many parameter options                                             | [Video Generation Guide](docs/features/video-generation.md)   |
-| **Image Generation with Gemini**   | v8.31.0 | Native image generation using Gemini 2.0 Flash Experimental (`imagen-3.0-generate-002`). High-quality image synthesis directly from Google AI. | [Image Generation Guide](docs/image-generation-streaming.md)  |
-| **HTTP/Streamable HTTP Transport** | v8.29.0 | Connect to remote MCP servers via HTTP with authentication headers, automatic retry with exponential backoff, and configurable rate limiting.  | [HTTP Transport Guide](docs/mcp-http-transport.md)            |
+| Feature                             | Version | Description                                                                                                                                    | Guide                                                         |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **External TracerProvider Support** | v8.43.0 | Integrate NeuroLink with existing OpenTelemetry instrumentation. Prevents duplicate registration conflicts.                                    | [Observability Guide](docs/features/observability.md)         |
+| **Server Adapters**                 | v8.43.0 | Multi-framework HTTP server with Hono, Express, Fastify, Koa support. Full CLI for server management with foreground/background modes.         | [Server Adapters Guide](docs/guides/server-adapters/index.md) |
+| **Title Generation Events**         | v8.38.0 | Emit `conversation:titleGenerated` event when conversation title is generated. Supports custom title prompts via `NEUROLINK_TITLE_PROMPT`.     | [Conversation Memory Guide](docs/conversation-memory.md)      |
+| **Video Generation with Veo**       | v8.32.0 | Video generation using Veo 3.1 (`veo-3.1`). Realistic video generation with many parameter options                                             | [Video Generation Guide](docs/features/video-generation.md)   |
+| **Image Generation with Gemini**    | v8.31.0 | Native image generation using Gemini 2.0 Flash Experimental (`imagen-3.0-generate-002`). High-quality image synthesis directly from Google AI. | [Image Generation Guide](docs/image-generation-streaming.md)  |
+| **HTTP/Streamable HTTP Transport**  | v8.29.0 | Connect to remote MCP servers via HTTP with authentication headers, automatic retry with exponential backoff, and configurable rate limiting.  | [HTTP Transport Guide](docs/mcp-http-transport.md)            |
 
+- **External TracerProvider Support** – Integrate NeuroLink with applications that already have OpenTelemetry instrumentation. Supports auto-detection and manual configuration. → [Observability Guide](docs/features/observability.md)
 - **Server Adapters** – Deploy NeuroLink as an HTTP API server with your framework of choice (Hono, Express, Fastify, Koa). Full CLI support with `serve` and `server` commands for foreground/background modes, route management, and OpenAPI generation. → [Server Adapters Guide](docs/guides/server-adapters/index.md)
 - **Title Generation Events** – Emit real-time events when conversation titles are auto-generated. Listen to `conversation:titleGenerated` for session tracking. → [Conversation Memory Guide](docs/conversation-memory.md#title-generation-events)
 - **Custom Title Prompts** – Customize conversation title generation with `NEUROLINK_TITLE_PROMPT` environment variable. Use `${userMessage}` placeholder for dynamic prompts. → [Conversation Memory Guide](docs/conversation-memory.md#customizing-the-title-prompt)
 - **Video Generation** – Transform images into 8-second videos with synchronized audio using Google Veo 3.1 via Vertex AI. Supports 720p/1080p resolutions, portrait/landscape aspect ratios. → [Video Generation Guide](docs/features/video-generation.md)
-- **Image Generation** – Generate images from text prompts using Gemini models via Vertex AI or Google AI Studio. Supports streaming mode with automatic file saving. → [Image Generation Guide](docs/IMAGE-GENERATION-STREAMING.md)
-- **HTTP/Streamable HTTP Transport for MCP** – Connect to remote MCP servers via HTTP with authentication headers, retry logic, and rate limiting. → [HTTP Transport Guide](docs/MCP-HTTP-TRANSPORT.md)
+- **Image Generation** – Generate images from text prompts using Gemini models via Vertex AI or Google AI Studio. Supports streaming mode with automatic file saving. → [Image Generation Guide](docs/image-generation-streaming.md)
+- **HTTP/Streamable HTTP Transport for MCP** – Connect to remote MCP servers via HTTP with authentication headers, retry logic, and rate limiting. → [HTTP Transport Guide](docs/mcp-http-transport.md)
 - 🧠 **Gemini 3 Preview Support** - Full support for gemini-3-flash-preview and gemini-3-pro-preview with extended thinking capabilities
 - **Structured Output with Zod Schemas** – Type-safe JSON generation with automatic validation using `schema` + `output.format: "json"` in `generate()`. → [Structured Output Guide](docs/features/structured-output.md)
 - **CSV File Support** – Attach CSV files to prompts for AI-powered data analysis with auto-detection. → [CSV Guide](docs/features/multimodal-chat.md#csv-file-support)
 - **PDF File Support** – Process PDF documents with native visual analysis for Vertex AI, Anthropic, Bedrock, AI Studio. → [PDF Guide](docs/features/pdf-support.md)
-- **LiteLLM Integration** – Access 100+ AI models from all major providers through unified interface. → [Setup Guide](docs/LITELLM-INTEGRATION.md)
-- **SageMaker Integration** – Deploy and use custom trained models on AWS infrastructure. → [Setup Guide](docs/SAGEMAKER-INTEGRATION.md)
+- **LiteLLM Integration** – Access 100+ AI models from all major providers through unified interface. → [Setup Guide](docs/litellm-integration.md)
+- **SageMaker Integration** – Deploy and use custom trained models on AWS infrastructure. → [Setup Guide](docs/sagemaker-integration.md)
 - **OpenRouter Integration** – Access 300+ models from OpenAI, Anthropic, Google, Meta, and more through a single unified API. → [Setup Guide](docs/getting-started/providers/openrouter.md)
 - **Human-in-the-loop workflows** – Pause generation for user approval/input before tool execution. → [HITL Guide](docs/features/hitl.md)
 - **Guardrails middleware** – Block PII, profanity, and unsafe content with built-in filtering. → [Guardrails Guide](docs/features/guardrails.md)
-- **Context summarization** – Automatic conversation compression for long-running sessions. → [Summarization Guide](docs/CONTEXT-SUMMARIZATION.md)
+- **Context summarization** – Automatic conversation compression for long-running sessions. → [Summarization Guide](docs/context-summarization.md)
 - **Redis conversation export** – Export full session history as JSON for analytics and debugging. → [History Guide](docs/features/conversation-history.md)
 
 ```typescript

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,8 @@
-**NeuroLink API Reference v8.32.0**
+**NeuroLink API Reference v8.42.0**
 
 ---
 
-# NeuroLink API Reference v8.32.0
+# NeuroLink API Reference v8.42.0
 
 NeuroLink AI Toolkit
 
@@ -88,6 +88,8 @@ console.log(result.content);
 - [DynamicModelConfig](type-aliases/DynamicModelConfig.md)
 - [ModelRegistry](type-aliases/ModelRegistry.md)
 - [LangfuseConfig](type-aliases/LangfuseConfig.md)
+- [LangfuseSpanAttributes](type-aliases/LangfuseSpanAttributes.md)
+- [TraceNameFormat](type-aliases/TraceNameFormat.md)
 - [OpenTelemetryConfig](type-aliases/OpenTelemetryConfig.md)
 - [ObservabilityConfig](type-aliases/ObservabilityConfig.md)
 - [SupportedModelName](type-aliases/SupportedModelName.md)
@@ -146,6 +148,13 @@ console.log(result.content);
 - [shutdownOpenTelemetry](functions/shutdownOpenTelemetry.md)
 - [getLangfuseHealthStatus](functions/getLangfuseHealthStatus.md)
 - [setLangfuseContext](functions/setLangfuseContext.md)
+- [getLangfuseContext](functions/getLangfuseContext.md)
+- [getTracer](functions/getTracer.md)
+- [getSpanProcessors](functions/getSpanProcessors.md)
+- [createContextEnricher](functions/createContextEnricher.md)
+- [isUsingExternalTracerProvider](functions/isUsingExternalTracerProvider.md)
+- [getTracerProvider](functions/getTracerProvider.md)
+- [getLangfuseSpanProcessor](functions/getLangfuseSpanProcessor.md)
 - [buildObservabilityConfigFromEnv](functions/buildObservabilityConfigFromEnv.md)
 - [getBestProvider](functions/getBestProvider.md)
 - [getAvailableProviders](functions/getAvailableProviders.md)

--- a/docs/api/functions/createContextEnricher.md
+++ b/docs/api/functions/createContextEnricher.md
@@ -1,0 +1,76 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / createContextEnricher
+
+# Function: createContextEnricher()
+
+> **createContextEnricher**(): `SpanProcessor`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:558](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L558)
+
+Create a new ContextEnricher span processor
+
+Use this when `useExternalTracerProvider` is true to add context enrichment
+to your own TracerProvider. The ContextEnricher adds Langfuse context
+(userId, sessionId, conversationId, etc.) to spans.
+
+## Returns
+
+`SpanProcessor`
+
+A new ContextEnricher instance implementing the OpenTelemetry SpanProcessor interface
+
+## ContextEnricher Behavior
+
+### onStart(span)
+
+Enriches the span with context from AsyncLocalStorage:
+
+- `user.id` - User identifier
+- `session.id` - Session identifier
+- `conversation.id` - Conversation/thread identifier
+- `request.id` - Request identifier for log correlation
+- `trace.name` - Custom trace name
+- `metadata.*` - Custom metadata as prefixed attributes
+
+### onEnd(span)
+
+Reads GenAI semantic convention attributes from the span and logs token usage
+for debugging. Detects spans from Vercel AI SDK's `experimental_telemetry`.
+
+## Example
+
+```typescript
+import {
+  createContextEnricher,
+  getLangfuseSpanProcessor,
+} from "@juspay/neurolink";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+const provider = new NodeTracerProvider();
+
+// Add ContextEnricher for Langfuse context propagation
+provider.addSpanProcessor(createContextEnricher());
+
+// Add Langfuse processor for sending to Langfuse
+const langfuseProcessor = getLangfuseSpanProcessor();
+if (langfuseProcessor) {
+  provider.addSpanProcessor(langfuseProcessor);
+}
+
+provider.register();
+```
+
+## Notes
+
+- Each call creates a new ContextEnricher instance
+- Can be called before or after initialization
+- Works with any TracerProvider, not just NeuroLink's
+
+## See Also
+
+- [getSpanProcessors](./getSpanProcessors.md) - Get both processors together
+- [setLangfuseContext](./setLangfuseContext.md) - Set context for enrichment
+- [LangfuseSpanAttributes](../type-aliases/LangfuseSpanAttributes.md) - GenAI attributes

--- a/docs/api/functions/getLangfuseContext.md
+++ b/docs/api/functions/getLangfuseContext.md
@@ -1,0 +1,92 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / getLangfuseContext
+
+# Function: getLangfuseContext()
+
+> **getLangfuseContext**(): `LangfuseContext` \| `undefined`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:595](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L595)
+
+Get the current Langfuse context from AsyncLocalStorage
+
+Returns the current context including userId, sessionId, conversationId,
+requestId, traceName, and metadata. Returns undefined if no context is set.
+
+## Returns
+
+`LangfuseContext` \| `undefined`
+
+The current LangfuseContext or undefined if no context is set
+
+### LangfuseContext Properties
+
+| Property         | Type                              | Description                                        |
+| ---------------- | --------------------------------- | -------------------------------------------------- |
+| `userId`         | `string \| null`                  | User identifier attached to spans                  |
+| `sessionId`      | `string \| null`                  | Session identifier attached to spans               |
+| `conversationId` | `string \| null`                  | Conversation/thread identifier for grouping traces |
+| `requestId`      | `string \| null`                  | Request identifier for log correlation             |
+| `traceName`      | `string \| null`                  | Custom trace name in Langfuse UI                   |
+| `metadata`       | `Record<string, unknown> \| null` | Custom key-value metadata                          |
+
+## Examples
+
+### Basic usage
+
+```typescript
+import { getLangfuseContext, setLangfuseContext } from "@juspay/neurolink";
+
+// Set some context
+await setLangfuseContext({
+  userId: "user-123",
+  conversationId: "conv-456",
+});
+
+// Read it back
+const context = getLangfuseContext();
+console.log(context?.userId); // "user-123"
+console.log(context?.conversationId); // "conv-456"
+```
+
+### Check if context exists
+
+```typescript
+import { getLangfuseContext } from "@juspay/neurolink";
+
+const context = getLangfuseContext();
+if (context) {
+  console.log("Context is set:", context.userId, context.sessionId);
+} else {
+  console.log("No context set in current async scope");
+}
+```
+
+### Access in middleware or handlers
+
+```typescript
+import { getLangfuseContext } from "@juspay/neurolink";
+
+async function handleRequest(req: Request) {
+  // Context was set earlier in the request pipeline
+  const context = getLangfuseContext();
+
+  // Log with correlation IDs
+  console.log(
+    `[${context?.requestId}] Processing request for user ${context?.userId}`,
+  );
+
+  // Use context for business logic
+  if (context?.metadata?.tier === "premium") {
+    // Premium user handling
+  }
+}
+```
+
+## See Also
+
+- [setLangfuseContext](./setLangfuseContext.md) - Set the context
+- [getTracer](./getTracer.md) - Get a Tracer for custom spans
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options

--- a/docs/api/functions/getLangfuseSpanProcessor.md
+++ b/docs/api/functions/getLangfuseSpanProcessor.md
@@ -1,0 +1,88 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / getLangfuseSpanProcessor
+
+# Function: getLangfuseSpanProcessor()
+
+> **getLangfuseSpanProcessor**(): `LangfuseSpanProcessor | null`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:457](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L457)
+
+Get the LangfuseSpanProcessor instance
+
+Returns the LangfuseSpanProcessor that sends spans to the Langfuse platform.
+This processor is created during initialization and is available in both
+standalone and external provider modes.
+
+## Returns
+
+`LangfuseSpanProcessor | null`
+
+The LangfuseSpanProcessor instance, or `null` if:
+
+- Langfuse is not enabled
+- Credentials are missing or invalid
+- Initialization has not occurred
+
+## Example
+
+```typescript
+import { getLangfuseSpanProcessor } from "@juspay/neurolink";
+
+const processor = getLangfuseSpanProcessor();
+if (processor) {
+  // Manually flush pending spans to Langfuse
+  await processor.forceFlush();
+
+  // Shutdown the processor
+  await processor.shutdown();
+}
+```
+
+## External Provider Mode Usage
+
+```typescript
+import {
+  createContextEnricher,
+  getLangfuseSpanProcessor,
+} from "@juspay/neurolink";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+// Create your own TracerProvider
+const provider = new NodeTracerProvider();
+
+// Add NeuroLink's processors
+provider.addSpanProcessor(createContextEnricher());
+
+const langfuseProcessor = getLangfuseSpanProcessor();
+if (langfuseProcessor) {
+  provider.addSpanProcessor(langfuseProcessor);
+}
+
+provider.register();
+```
+
+## Processor Behavior
+
+The LangfuseSpanProcessor:
+
+1. **Collects spans** from OpenTelemetry instrumentation
+2. **Transforms spans** to Langfuse trace format
+3. **Batches spans** for efficient network usage
+4. **Sends to Langfuse** via the configured `baseUrl`
+
+## Notes
+
+- The processor is reused across calls (singleton)
+- Available in both standalone and external provider modes
+- Requires valid Langfuse credentials (`publicKey`, `secretKey`)
+- Use `getSpanProcessors()` to get both ContextEnricher and LangfuseSpanProcessor together
+
+## See Also
+
+- [getSpanProcessors](./getSpanProcessors.md) - Get both processors together
+- [createContextEnricher](./createContextEnricher.md) - Create ContextEnricher for context propagation
+- [flushOpenTelemetry](./flushOpenTelemetry.md) - Convenience method to flush all spans
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options

--- a/docs/api/functions/getSpanProcessors.md
+++ b/docs/api/functions/getSpanProcessors.md
@@ -1,0 +1,77 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / getSpanProcessors
+
+# Function: getSpanProcessors()
+
+> **getSpanProcessors**(): `SpanProcessor[]`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:568](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L568)
+
+Get all span processors that NeuroLink would use
+
+Convenience function that returns `[ContextEnricher, LangfuseSpanProcessor]`.
+Use this when integrating with an external TracerProvider to add NeuroLink's
+observability capabilities to your existing OpenTelemetry setup.
+
+## Returns
+
+`SpanProcessor[]`
+
+Array of span processors, or empty array if not initialized
+
+The returned array contains:
+
+1. **ContextEnricher** - Enriches spans with Langfuse context (userId, sessionId, etc.)
+2. **LangfuseSpanProcessor** - Sends spans to Langfuse platform
+
+## Example
+
+```typescript
+import { NeuroLink, getSpanProcessors } from "@juspay/neurolink";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+
+// 1. Initialize NeuroLink with external provider mode
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      useExternalTracerProvider: true,
+    },
+  },
+});
+
+// 2. Get NeuroLink's span processors
+const neurolinkProcessors = getSpanProcessors();
+
+// 3. Add to your existing OTEL setup
+const jaegerExporter = new OTLPTraceExporter({
+  url: "http://jaeger:4318/v1/traces",
+});
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new BatchSpanProcessor(jaegerExporter),
+    ...neurolinkProcessors,
+  ],
+});
+sdk.start();
+```
+
+## Notes
+
+- Must be called after `initializeOpenTelemetry()` or NeuroLink initialization
+- Returns empty array if observability is not initialized or disabled
+- Each call to `getSpanProcessors()` creates a new ContextEnricher instance
+- The LangfuseSpanProcessor is reused across calls
+
+## See Also
+
+- [createContextEnricher](./createContextEnricher.md) - Create ContextEnricher separately
+- [isUsingExternalTracerProvider](./isUsingExternalTracerProvider.md) - Check provider mode
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options

--- a/docs/api/functions/getTracer.md
+++ b/docs/api/functions/getTracer.md
@@ -1,0 +1,144 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / getTracer
+
+# Function: getTracer()
+
+> **getTracer**(`name?`, `version?`): `Tracer`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:615](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L615)
+
+Get an OpenTelemetry Tracer for creating custom spans
+
+This allows applications to create their own spans that will be
+processed by the same span processors (ContextEnricher + LangfuseSpanProcessor).
+Custom spans will inherit the Langfuse context set via `setLangfuseContext()`.
+
+## Parameters
+
+### name?
+
+`string`
+
+Tracer name, defaults to "neurolink"
+
+### version?
+
+`string`
+
+Tracer version (optional)
+
+## Returns
+
+`Tracer`
+
+OpenTelemetry Tracer instance from `@opentelemetry/api`
+
+## Examples
+
+### Basic custom span
+
+```typescript
+import { getTracer } from "@juspay/neurolink";
+
+const tracer = getTracer("my-app");
+const span = tracer.startSpan("custom-operation");
+try {
+  // ... do work
+  span.setAttribute("custom.key", "value");
+} finally {
+  span.end();
+}
+```
+
+### Nested spans with context
+
+```typescript
+import { getTracer, setLangfuseContext } from "@juspay/neurolink";
+
+const tracer = getTracer("my-app", "1.0.0");
+
+await setLangfuseContext({ userId: "user-123" }, async () => {
+  const parentSpan = tracer.startSpan("parent-operation");
+
+  try {
+    // Create child span
+    const childSpan = tracer.startSpan("child-operation");
+    try {
+      await doSomeWork();
+      childSpan.setAttribute("result", "success");
+    } finally {
+      childSpan.end();
+    }
+  } finally {
+    parentSpan.end();
+  }
+});
+```
+
+### Tracing async operations
+
+```typescript
+import { getTracer } from "@juspay/neurolink";
+import { context, trace } from "@opentelemetry/api";
+
+const tracer = getTracer("my-app");
+
+async function tracedOperation() {
+  return tracer.startActiveSpan("my-operation", async (span) => {
+    try {
+      const result = await fetchData();
+      span.setAttribute("data.count", result.length);
+      return result;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: 2, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+```
+
+### With error recording
+
+```typescript
+import { getTracer } from "@juspay/neurolink";
+import { SpanStatusCode } from "@opentelemetry/api";
+
+const tracer = getTracer("my-app");
+
+async function riskyOperation() {
+  const span = tracer.startSpan("risky-operation");
+  try {
+    await doRiskyThing();
+    span.setStatus({ code: SpanStatusCode.OK });
+  } catch (error) {
+    span.recordException(error as Error);
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: (error as Error).message,
+    });
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+```
+
+## Notes
+
+- The tracer uses the global TracerProvider (either NeuroLink's or your external one)
+- Spans created with this tracer will be processed by ContextEnricher and LangfuseSpanProcessor
+- In external provider mode, spans will be sent to your configured exporters
+- Always call `span.end()` to ensure spans are properly recorded
+
+## See Also
+
+- [setLangfuseContext](./setLangfuseContext.md) - Set context for spans
+- [getLangfuseContext](./getLangfuseContext.md) - Read current context
+- [getSpanProcessors](./getSpanProcessors.md) - Get span processors for external providers
+- [LangfuseSpanAttributes](../type-aliases/LangfuseSpanAttributes.md) - GenAI attribute types

--- a/docs/api/functions/getTracerProvider.md
+++ b/docs/api/functions/getTracerProvider.md
@@ -1,0 +1,86 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / getTracerProvider
+
+# Function: getTracerProvider()
+
+> **getTracerProvider**(): `NodeTracerProvider | null`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:464](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L464)
+
+Get the NodeTracerProvider instance managed by NeuroLink
+
+Returns the TracerProvider that NeuroLink created and registered, or `null`
+if NeuroLink is operating in external provider mode or if not initialized.
+
+## Returns
+
+`NodeTracerProvider | null`
+
+The NodeTracerProvider instance, or `null` if:
+
+- NeuroLink is in external provider mode (`useExternalTracerProvider: true`)
+- OpenTelemetry is not initialized
+- Langfuse is disabled
+
+## When This Returns Null
+
+- `useExternalTracerProvider: true` was set in LangfuseConfig
+- `autoDetectExternalProvider: true` detected an external provider
+- TracerProvider registration failed (switched to external mode)
+- `initializeOpenTelemetry()` was not called or failed
+
+## Example
+
+```typescript
+import {
+  getTracerProvider,
+  isUsingExternalTracerProvider,
+} from "@juspay/neurolink";
+
+// Check the mode first
+if (isUsingExternalTracerProvider()) {
+  console.log("External mode - no TracerProvider from NeuroLink");
+} else {
+  const provider = getTracerProvider();
+  if (provider) {
+    console.log("Standalone mode - NeuroLink managing TracerProvider");
+    // Access provider methods if needed
+    await provider.forceFlush();
+  }
+}
+```
+
+## Advanced Usage
+
+```typescript
+import { getTracerProvider } from "@juspay/neurolink";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+// Add additional exporters to NeuroLink's provider
+const provider = getTracerProvider();
+if (provider) {
+  // Add Jaeger exporter alongside Langfuse
+  const jaegerExporter = new OTLPTraceExporter({
+    url: "http://jaeger:4318/v1/traces",
+  });
+  provider.addSpanProcessor(new BatchSpanProcessor(jaegerExporter));
+}
+```
+
+## Notes
+
+- In standalone mode, NeuroLink creates and registers its own TracerProvider
+- In external provider mode, this always returns `null`
+- Use `isUsingExternalTracerProvider()` to check the current mode
+- The provider includes ContextEnricher and LangfuseSpanProcessor
+
+## See Also
+
+- [isUsingExternalTracerProvider](./isUsingExternalTracerProvider.md) - Check provider mode
+- [getSpanProcessors](./getSpanProcessors.md) - Get processors for external mode
+- [getLangfuseSpanProcessor](./getLangfuseSpanProcessor.md) - Get Langfuse processor directly
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options

--- a/docs/api/functions/isUsingExternalTracerProvider.md
+++ b/docs/api/functions/isUsingExternalTracerProvider.md
@@ -1,0 +1,87 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / isUsingExternalTracerProvider
+
+# Function: isUsingExternalTracerProvider()
+
+> **isUsingExternalTracerProvider**(): `boolean`
+
+Defined in: [services/server/ai/observability/instrumentation.ts:584](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L584)
+
+Check if using external TracerProvider mode
+
+Returns true if NeuroLink is operating in external TracerProvider mode,
+meaning it did not create or register its own TracerProvider. In this mode,
+you must add NeuroLink's span processors to your own TracerProvider.
+
+## Returns
+
+`boolean`
+
+`true` if operating in external TracerProvider mode, `false` otherwise
+
+## When This Returns True
+
+- `useExternalTracerProvider: true` was set in LangfuseConfig
+- `autoDetectExternalProvider: true` was set and detected external provider
+- TracerProvider registration failed due to duplicate registration
+
+## Example
+
+```typescript
+import {
+  isUsingExternalTracerProvider,
+  getSpanProcessors,
+} from "@juspay/neurolink";
+
+// Check mode after initialization
+if (isUsingExternalTracerProvider()) {
+  console.log(
+    "External provider mode - add processors to your TracerProvider:",
+  );
+  const processors = getSpanProcessors();
+  // Add processors to your existing OTEL setup
+  myTracerProvider.addSpanProcessor(processors[0]); // ContextEnricher
+  myTracerProvider.addSpanProcessor(processors[1]); // LangfuseSpanProcessor
+} else {
+  console.log("Standalone mode - NeuroLink managing its own TracerProvider");
+}
+```
+
+## Conditional Setup
+
+```typescript
+import {
+  NeuroLink,
+  isUsingExternalTracerProvider,
+  getSpanProcessors,
+} from "@juspay/neurolink";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      autoDetectExternalProvider: true, // Auto-detect mode
+    },
+  },
+});
+
+// Only set up OTEL SDK if NeuroLink isn't managing it
+if (isUsingExternalTracerProvider()) {
+  const sdk = new NodeSDK({
+    spanProcessors: [...getSpanProcessors()],
+  });
+  sdk.start();
+}
+```
+
+## See Also
+
+- [getSpanProcessors](./getSpanProcessors.md) - Get processors for external mode
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options
+- [Observability Guide](../../features/observability.md) - Full setup guide

--- a/docs/api/functions/setLangfuseContext.md
+++ b/docs/api/functions/setLangfuseContext.md
@@ -1,4 +1,4 @@
-[**NeuroLink API Reference v8.32.0**](../README.md)
+[**NeuroLink API Reference v8.42.0**](../README.md)
 
 ---
 
@@ -6,39 +6,207 @@
 
 # Function: setLangfuseContext()
 
-> **setLangfuseContext**(`context`, `callback?`): `Promise`\<`void`\>
+> **setLangfuseContext**\<`T`\>(`context`, `callback?`): `Promise`\<`T` \| `void`\>
 
-Defined in: [services/server/ai/observability/instrumentation.ts:242](https://github.com/juspay/neurolink/blob/1be79595b7d7307795c98da4267c1728cb50033d/src/lib/services/server/ai/observability/instrumentation.ts#L242)
+Defined in: [services/server/ai/observability/instrumentation.ts:550](https://github.com/juspay/neurolink/blob/main/src/lib/services/server/ai/observability/instrumentation.ts#L550)
 
 Set user and session context for Langfuse spans in the current async context
 
 Merges the provided context with existing AsyncLocalStorage context. If a callback is provided,
-the context is scoped to that callback execution. Without a callback, the context applies to
-the current execution context and its children.
+the context is scoped to that callback execution and returns the callback's result.
+Without a callback, the context applies to the current execution context and its children.
 
 Uses AsyncLocalStorage to properly scope context per request, avoiding race conditions
 in concurrent scenarios.
+
+## Type Parameters
+
+### T
+
+The return type of the callback function (defaults to `void`)
 
 ## Parameters
 
 ### context
 
-Object containing optional userId and/or sessionId to merge with existing context
+Object containing context fields to merge with existing context
 
 #### userId?
 
 `string` \| `null`
 
+User identifier to attach to spans
+
 #### sessionId?
 
 `string` \| `null`
 
+Session identifier to attach to spans
+
+#### conversationId?
+
+`string` \| `null`
+
+Conversation/thread identifier for grouping related traces
+
+#### requestId?
+
+`string` \| `null`
+
+Request identifier for correlating with application logs
+
+#### traceName?
+
+`string` \| `null`
+
+Custom trace name for better organization in Langfuse UI
+
+#### metadata?
+
+`Record<string, unknown>` \| `null`
+
+Custom metadata to attach to spans as key-value pairs
+
+#### operationName?
+
+`string` \| `null`
+
+Explicit operation name for the trace. Overrides auto-detection when set.
+
+Use this to provide meaningful names like "customer-support-chat" or "code-review"
+that will appear in the trace name alongside the userId.
+
+#### autoDetectOperationName?
+
+`boolean`
+
+Override the global `autoDetectOperationName` setting for this specific context.
+
+When `undefined`, uses the global setting from `LangfuseConfig` (defaults to `true`).
+Set to `false` to disable auto-detection for this context only.
+
 ### callback?
 
-() => `void` \| `Promise`\<`void`\>
+`() => T | Promise<T>`
 
 Optional callback to run within the context scope. If omitted, context applies to current execution
 
 ## Returns
 
-`Promise`\<`void`\>
+`Promise`\<`T` \| `void`\>
+
+The callback's return value if provided, otherwise void
+
+## Examples
+
+### With callback - returns the result
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+const result = await setLangfuseContext(
+  { userId: "user123", conversationId: "conv-456" },
+  async () => {
+    return await generateText({ model: "gpt-4", prompt: "Hello" });
+  },
+);
+// result is typed as the return value of the callback
+```
+
+### Without callback - sets context for current execution
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+await setLangfuseContext({
+  sessionId: "session456",
+  traceName: "chat-completion",
+  metadata: { feature: "support", tier: "premium" },
+});
+// Context now applies to all subsequent spans in this async context
+```
+
+### With full context
+
+```typescript
+import { setLangfuseContext, getLangfuseContext } from "@juspay/neurolink";
+
+await setLangfuseContext({
+  userId: "user-123",
+  sessionId: "session-456",
+  conversationId: "conv-789",
+  requestId: "req-abc",
+  traceName: "customer-support-chat",
+  metadata: {
+    feature: "support",
+    tier: "premium",
+    region: "us-east-1",
+  },
+});
+
+// Verify context was set
+const context = getLangfuseContext();
+console.log(context?.conversationId); // "conv-789"
+```
+
+### With explicit operation name
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+// Explicit operation name overrides auto-detection
+await setLangfuseContext(
+  {
+    userId: "user@email.com",
+    operationName: "customer-support-chat",
+  },
+  async () => {
+    // Trace name will be: "user@email.com:customer-support-chat"
+    return await generateText({ model: "gpt-4", prompt: "Help me with..." });
+  },
+);
+```
+
+### Disabling auto-detection for specific context
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+// Disable operation name auto-detection for this context only
+// (global setting remains unchanged for other contexts)
+await setLangfuseContext(
+  {
+    userId: "user@email.com",
+    autoDetectOperationName: false,
+  },
+  async () => {
+    // Trace name will be: "user@email.com" (legacy behavior)
+    return await streamText({ model: "gpt-4", prompt: "Stream this..." });
+  },
+);
+```
+
+### Combining explicit operation name with auto-detection off
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+// When both are set, operationName takes precedence
+await setLangfuseContext(
+  {
+    userId: "user@email.com",
+    operationName: "my-custom-operation",
+    autoDetectOperationName: false, // This is redundant when operationName is set
+  },
+  async () => {
+    // Trace name: "user@email.com:my-custom-operation"
+    return await generateText({ model: "gpt-4", prompt: "..." });
+  },
+);
+```
+
+## See Also
+
+- [getLangfuseContext](./getLangfuseContext.md) - Read the current context
+- [getTracer](./getTracer.md) - Get a Tracer for custom spans
+- [LangfuseConfig](../type-aliases/LangfuseConfig.md) - Configuration options

--- a/docs/api/type-aliases/LangfuseConfig.md
+++ b/docs/api/type-aliases/LangfuseConfig.md
@@ -1,4 +1,4 @@
-[**NeuroLink API Reference v8.32.0**](../README.md)
+[**NeuroLink API Reference v8.42.0**](../README.md)
 
 ---
 
@@ -8,7 +8,7 @@
 
 > **LangfuseConfig** = `object`
 
-Defined in: [types/observability.ts:10](https://github.com/juspay/neurolink/blob/1be79595b7d7307795c98da4267c1728cb50033d/src/lib/types/observability.ts#L10)
+Defined in: [types/observability.ts:68](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L68)
 
 Langfuse observability configuration
 
@@ -96,3 +96,104 @@ Optional default user id to attach to spans
 Defined in: [types/observability.ts:31](https://github.com/juspay/neurolink/blob/1be79595b7d7307795c98da4267c1728cb50033d/src/lib/types/observability.ts#L31)
 
 Optional default session id to attach to spans
+
+---
+
+### useExternalTracerProvider?
+
+> `optional` **useExternalTracerProvider**: `boolean`
+
+Defined in: [types/observability.ts:43](https://github.com/juspay/neurolink/blob/1be79595b7d7307795c98da4267c1728cb50033d/src/lib/types/observability.ts#L43)
+
+If true, NeuroLink will NOT create or register its own TracerProvider.
+Instead, it will only create the LangfuseSpanProcessor and ContextEnricher,
+which the parent application must add to its own TracerProvider.
+
+Use this when your application already has OpenTelemetry instrumentation.
+
+#### Default
+
+`false`
+
+---
+
+### autoDetectExternalProvider?
+
+> `optional` **autoDetectExternalProvider**: `boolean`
+
+Defined in: [types/observability.ts:110](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L110)
+
+If true, NeuroLink will automatically detect if a TracerProvider is already
+registered globally and skip its own registration to avoid conflicts.
+
+This is a convenience option that combines well with useExternalTracerProvider.
+
+#### Default
+
+`false`
+
+---
+
+### autoDetectOperationName?
+
+> `optional` **autoDetectOperationName**: `boolean`
+
+Defined in: [types/observability.ts:133](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L133)
+
+Enable auto-detection of operation names from span names.
+
+When `true` (default), AI operation spans (`ai.streamText`, `ai.generateText`, etc.)
+will have their operation name automatically extracted and included in the
+trace name.
+
+#### Default
+
+`true`
+
+#### Examples
+
+```typescript
+// With auto-detection enabled (default):
+// Span "ai.streamText" + userId "user@email.com"
+// → Trace name: "user@email.com:ai.streamText"
+
+// With auto-detection disabled:
+// → Trace name: "user@email.com" (legacy behavior)
+```
+
+---
+
+### traceNameFormat?
+
+> `optional` **traceNameFormat**: [`TraceNameFormat`](./TraceNameFormat.md)
+
+Defined in: [types/observability.ts:155](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L155)
+
+Format for trace names in Langfuse.
+
+Controls how `userId` and `operationName` are combined to form the trace name.
+Can be a predefined format string or a custom function for full control.
+
+#### Default
+
+`"userId:operationName"`
+
+#### Examples
+
+```typescript
+// Predefined formats:
+traceNameFormat: "userId:operationName"; // "user@email.com:ai.streamText"
+traceNameFormat: "operationName:userId"; // "ai.streamText:user@email.com"
+traceNameFormat: "operationName"; // "ai.streamText"
+traceNameFormat: "userId"; // "user@email.com" (legacy)
+
+// Custom function:
+traceNameFormat: (ctx) => `[${ctx.operationName || "unknown"}] ${ctx.userId}`;
+// → "[ai.streamText] user@email.com"
+```
+
+## See Also
+
+- [TraceNameFormat](./TraceNameFormat.md) - Type definition for trace name formats
+- [setLangfuseContext](../functions/setLangfuseContext.md) - Set context for spans
+- [getSpanProcessors](../functions/getSpanProcessors.md) - Get span processors for external provider mode

--- a/docs/api/type-aliases/LangfuseSpanAttributes.md
+++ b/docs/api/type-aliases/LangfuseSpanAttributes.md
@@ -1,0 +1,106 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / LangfuseSpanAttributes
+
+# Type Alias: LangfuseSpanAttributes
+
+> **LangfuseSpanAttributes** = `object`
+
+Defined in: [types/observability.ts:14](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L14)
+
+Standard GenAI semantic convention attributes from OpenTelemetry
+
+These are the attributes that Vercel AI SDK's `experimental_telemetry` creates on spans.
+NeuroLink's ContextEnricher reads these attributes in `onEnd()` to log token usage
+and other GenAI-specific metrics.
+
+## Properties
+
+### Core GenAI Attributes
+
+These follow the OpenTelemetry GenAI semantic conventions:
+
+| Property                         | Type       | Description                                           |
+| -------------------------------- | ---------- | ----------------------------------------------------- |
+| `gen_ai.system`                  | `string`   | AI system/provider name (e.g., "openai", "anthropic") |
+| `gen_ai.request.model`           | `string`   | Model name used in request                            |
+| `gen_ai.response.model`          | `string`   | Actual model used in response                         |
+| `gen_ai.request.max_tokens`      | `number`   | Max tokens requested                                  |
+| `gen_ai.request.temperature`     | `number`   | Temperature setting                                   |
+| `gen_ai.request.top_p`           | `number`   | Top-p sampling setting                                |
+| `gen_ai.usage.input_tokens`      | `number`   | Input/prompt tokens used                              |
+| `gen_ai.usage.output_tokens`     | `number`   | Output/completion tokens used                         |
+| `gen_ai.usage.total_tokens`      | `number`   | Total tokens used                                     |
+| `gen_ai.response.finish_reasons` | `string[]` | Finish reasons from model                             |
+| `gen_ai.prompt`                  | `string`   | The prompt sent (if enabled)                          |
+| `gen_ai.completion`              | `string`   | The completion received (if enabled)                  |
+
+### Vercel AI SDK Specific Attributes
+
+Additional attributes created by Vercel AI SDK's telemetry:
+
+| Property                    | Type     | Description                       |
+| --------------------------- | -------- | --------------------------------- |
+| `ai.model.id`               | `string` | Model identifier                  |
+| `ai.model.provider`         | `string` | Provider identifier               |
+| `ai.operationId`            | `string` | Operation identifier              |
+| `ai.telemetry.functionId`   | `string` | Function identifier for telemetry |
+| `ai.finishReason`           | `string` | Why generation finished           |
+| `ai.usage.promptTokens`     | `number` | Prompt tokens (alias)             |
+| `ai.usage.completionTokens` | `number` | Completion tokens (alias)         |
+
+### Custom Attributes
+
+The type also allows arbitrary custom attributes:
+
+```typescript
+[key: string]: unknown
+```
+
+## Example Usage
+
+```typescript
+import type { LangfuseSpanAttributes } from "@juspay/neurolink";
+
+// Type-safe attribute access
+function logTokenUsage(attributes: LangfuseSpanAttributes) {
+  const inputTokens =
+    attributes["gen_ai.usage.input_tokens"] ??
+    attributes["ai.usage.promptTokens"];
+
+  const outputTokens =
+    attributes["gen_ai.usage.output_tokens"] ??
+    attributes["ai.usage.completionTokens"];
+
+  console.log(`Tokens: ${inputTokens} in, ${outputTokens} out`);
+}
+
+// Check if span is GenAI-related
+function isGenAISpan(attributes: LangfuseSpanAttributes): boolean {
+  return !!(
+    attributes["gen_ai.system"] ||
+    attributes["ai.model.id"] ||
+    attributes["gen_ai.request.model"]
+  );
+}
+```
+
+## How NeuroLink Uses These
+
+NeuroLink's `ContextEnricher` span processor reads these attributes in its `onEnd()` method:
+
+1. Detects GenAI spans by checking for `gen_ai.system`, `ai.model.id`, or `gen_ai.request.model`
+2. Logs the model and provider for debugging
+3. Captures token usage metrics for observability
+4. Enriches spans with Langfuse context (userId, sessionId, etc.)
+
+This enables automatic capture of AI operation metrics when using Vercel AI SDK's
+`experimental_telemetry` feature with NeuroLink's Langfuse integration.
+
+## See Also
+
+- [setLangfuseContext](../functions/setLangfuseContext.md) - Set context for spans
+- [LangfuseConfig](./LangfuseConfig.md) - Langfuse configuration
+- [getSpanProcessors](../functions/getSpanProcessors.md) - Get span processors

--- a/docs/api/type-aliases/TraceNameFormat.md
+++ b/docs/api/type-aliases/TraceNameFormat.md
@@ -1,0 +1,182 @@
+[**NeuroLink API Reference v8.42.0**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / TraceNameFormat
+
+# Type Alias: TraceNameFormat
+
+> **TraceNameFormat** = `"userId:operationName"` \| `"operationName:userId"` \| `"operationName"` \| `"userId"` \| `(context: { userId?: string; operationName?: string }) => string`
+
+Defined in: [types/observability.ts:25](https://github.com/juspay/neurolink/blob/main/src/lib/types/observability.ts#L25)
+
+Trace name format for Langfuse traces.
+
+Controls how `userId` and `operationName` are combined to form the trace name.
+Can be a predefined format string or a custom function for full control.
+
+## Predefined Format Options
+
+| Format                   | Example Output                   | Description                                                         |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------- |
+| `"userId:operationName"` | `"user@email.com:ai.streamText"` | Default format. User first, then operation.                         |
+| `"operationName:userId"` | `"ai.streamText:user@email.com"` | Operation first, then user. Useful for operation-centric filtering. |
+| `"operationName"`        | `"ai.streamText"`                | Operation name only. User ID not included in trace name.            |
+| `"userId"`               | `"user@email.com"`               | User ID only. Legacy behavior, operation name not included.         |
+
+## Custom Function Format
+
+For full control over trace naming, provide a function that receives the context:
+
+```typescript
+type CustomFormat = (context: {
+  userId?: string;
+  operationName?: string;
+}) => string;
+```
+
+## Examples
+
+### Using predefined formats
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+// Default: userId:operationName
+const neurolink1 = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: "userId:operationName",
+    },
+  },
+});
+// Trace name: "user@email.com:ai.streamText"
+
+// Operation-centric naming
+const neurolink2 = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: "operationName:userId",
+    },
+  },
+});
+// Trace name: "ai.streamText:user@email.com"
+
+// Operation only (no user in trace name)
+const neurolink3 = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: "operationName",
+    },
+  },
+});
+// Trace name: "ai.streamText"
+
+// Legacy behavior (user only)
+const neurolink4 = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: "userId",
+    },
+  },
+});
+// Trace name: "user@email.com"
+```
+
+### Using a custom function
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+// Custom format with brackets
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: (ctx) =>
+        `[${ctx.operationName || "unknown"}] ${ctx.userId || "anonymous"}`,
+    },
+  },
+});
+// Trace name: "[ai.streamText] user@email.com"
+```
+
+### Custom function with environment prefix
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const env = process.env.NODE_ENV || "dev";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      environment: env,
+      traceNameFormat: (ctx) => {
+        const parts = [env];
+        if (ctx.operationName) parts.push(ctx.operationName);
+        if (ctx.userId) parts.push(ctx.userId);
+        return parts.join(":");
+      },
+    },
+  },
+});
+// Trace name: "prod:ai.streamText:user@email.com"
+```
+
+### Handling missing values
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: "pk-...",
+      secretKey: "sk-...",
+      traceNameFormat: (ctx) => {
+        // Handle cases where operationName or userId might be undefined
+        if (ctx.operationName && ctx.userId) {
+          return `${ctx.userId}/${ctx.operationName}`;
+        }
+        if (ctx.operationName) {
+          return ctx.operationName;
+        }
+        return ctx.userId || "trace";
+      },
+    },
+  },
+});
+```
+
+## Fallback Behavior
+
+When `operationName` is not available (e.g., auto-detection is disabled and no explicit name is set),
+predefined formats that include `operationName` will fall back gracefully:
+
+- `"userId:operationName"` falls back to `"userId"`
+- `"operationName:userId"` falls back to `"userId"`
+- `"operationName"` falls back to `"userId"`
+
+## See Also
+
+- [LangfuseConfig](./LangfuseConfig.md) - Configuration options including `traceNameFormat`
+- [setLangfuseContext](../functions/setLangfuseContext.md) - Set operation name per-context

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -1,0 +1,647 @@
+# Observability Guide
+
+Enterprise-grade observability for AI operations with Langfuse and OpenTelemetry integration.
+
+## Overview
+
+NeuroLink provides comprehensive observability features for monitoring AI operations in production:
+
+- **Langfuse Integration**: LLM-specific observability with token tracking, cost analysis, and trace visualization
+- **OpenTelemetry Support**: Standard distributed tracing compatible with Jaeger, Zipkin, and other backends
+- **External Provider Mode**: Integrate with existing OpenTelemetry instrumentation without conflicts
+- **Context Propagation**: Automatic context enrichment with user, session, and custom metadata
+
+## Quick Start
+
+### Basic Langfuse Setup
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      baseUrl: "https://cloud.langfuse.com",
+      environment: "production",
+      release: "1.0.0",
+    },
+  },
+});
+```
+
+### Environment Variables
+
+```bash
+# Langfuse credentials
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com  # or self-hosted
+
+# Optional defaults
+LANGFUSE_ENVIRONMENT=production
+LANGFUSE_RELEASE=1.0.0
+```
+
+## Context Management
+
+### Setting Context
+
+Use `setLangfuseContext` to attach metadata to all spans in an async context:
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+// With callback - context is scoped to callback execution
+const result = await setLangfuseContext(
+  {
+    userId: "user-123",
+    sessionId: "session-456",
+    conversationId: "conv-789",
+    requestId: "req-abc",
+    traceName: "customer-support-chat",
+    metadata: {
+      feature: "support",
+      tier: "premium",
+      region: "us-east-1",
+    },
+  },
+  async () => {
+    return await neurolink.generate({ prompt: "Hello" });
+  },
+);
+
+// Without callback - context applies to current execution
+await setLangfuseContext({
+  userId: "user-123",
+  sessionId: "session-456",
+});
+```
+
+### Context Fields
+
+| Field            | Purpose                                    |
+| ---------------- | ------------------------------------------ |
+| `userId`         | Identify the user for per-user analytics   |
+| `sessionId`      | Group traces within a user session         |
+| `conversationId` | Group traces in a conversation thread      |
+| `requestId`      | Correlate with application logs            |
+| `traceName`      | Custom name in Langfuse UI                 |
+| `metadata`       | Key-value pairs for filtering and analysis |
+
+### Reading Context
+
+```typescript
+import { getLangfuseContext } from "@juspay/neurolink";
+
+const context = getLangfuseContext();
+if (context) {
+  console.log(
+    `User: ${context.userId}, Conversation: ${context.conversationId}`,
+  );
+}
+```
+
+## Operation Name Support
+
+NeuroLink automatically detects operation names from AI SDK spans and includes them in trace names for better observability. This provides immediate visibility into what type of AI operation is being performed.
+
+### Operation Name Configuration
+
+By default, NeuroLink automatically detects operation names from:
+
+- **Vercel AI SDK spans**: Spans starting with `ai.` (e.g., `ai.streamText`, `ai.generateText`, `ai.embed`)
+- **OpenTelemetry GenAI conventions**: Standard semantic convention operations (`chat`, `embeddings`, `text_completion`)
+
+```typescript
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      autoDetectOperationName: true, // Enabled by default
+    },
+  },
+});
+```
+
+When auto-detection is enabled, traces automatically include the detected operation:
+
+- A `generateText` call becomes: `user@email.com:ai.generateText`
+- A `streamText` call becomes: `user@email.com:ai.streamText`
+- An embedding call becomes: `user@email.com:embeddings`
+
+### Trace Name Formats
+
+Control how trace names are constructed using the `traceNameFormat` option:
+
+| Format                   | Example Output                 | Description                 |
+| ------------------------ | ------------------------------ | --------------------------- |
+| `"userId:operationName"` | `user@email.com:ai.streamText` | Default format, user first  |
+| `"operationName:userId"` | `ai.streamText:user@email.com` | Operation first             |
+| `"operationName"`        | `ai.streamText`                | Operation only              |
+| `"userId"`               | `user@email.com`               | User only (legacy behavior) |
+| Custom function          | Custom output                  | Full control over format    |
+
+```typescript
+// Global configuration with format
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      autoDetectOperationName: true,
+      traceNameFormat: "operationName:userId", // Operation first
+    },
+  },
+});
+```
+
+### Custom Format Function
+
+For full control over trace naming, provide a custom function:
+
+```typescript
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      autoDetectOperationName: true,
+      traceNameFormat: (context) => {
+        // Custom logic for trace name
+        const env = process.env.NODE_ENV === "production" ? "prod" : "dev";
+        if (context.operationName && context.userId) {
+          return `[${env}] ${context.operationName} - ${context.userId}`;
+        }
+        return context.operationName || context.userId || "unknown";
+      },
+    },
+  },
+});
+// Output: "[prod] ai.streamText - user@email.com"
+```
+
+### Context-Level Configuration
+
+Override operation name behavior at the context level:
+
+```typescript
+import { setLangfuseContext } from "@juspay/neurolink";
+
+// Explicit operation name (overrides auto-detection)
+await setLangfuseContext(
+  {
+    userId: "user-123",
+    operationName: "custom-rag-pipeline",
+  },
+  async () => {
+    return await neurolink.generate({ prompt: "Hello" });
+  },
+);
+// Trace name: "user-123:custom-rag-pipeline"
+
+// Disable auto-detection for specific context
+await setLangfuseContext(
+  {
+    userId: "user-123",
+    autoDetectOperationName: false, // Override global setting
+  },
+  async () => {
+    return await neurolink.generate({ prompt: "Hello" });
+  },
+);
+// Trace name: "user-123" (legacy behavior)
+
+// Enable auto-detection when globally disabled
+await setLangfuseContext(
+  {
+    userId: "user-123",
+    autoDetectOperationName: true, // Enable for this context
+  },
+  async () => {
+    return await neurolink.generate({ prompt: "Hello" });
+  },
+);
+// Trace name: "user-123:ai.generateText"
+```
+
+### Backward Compatibility
+
+Operation name support is fully backward compatible:
+
+1. **Explicit `traceName` takes priority**: If you set `traceName` in context, it always overrides auto-detected names:
+
+   ```typescript
+   await setLangfuseContext(
+     {
+       userId: "user-123",
+       traceName: "my-custom-trace", // This takes priority
+       operationName: "ignored-operation",
+     },
+     async () => {
+       return await neurolink.generate({ prompt: "Hello" });
+     },
+   );
+   // Trace name: "my-custom-trace"
+   ```
+
+2. **Disable for legacy behavior**: Set `autoDetectOperationName: false` to restore previous behavior:
+
+   ```typescript
+   const neurolink = new NeuroLink({
+     observability: {
+       langfuse: {
+         enabled: true,
+         publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+         secretKey: process.env.LANGFUSE_SECRET_KEY!,
+         autoDetectOperationName: false, // Legacy behavior
+       },
+     },
+   });
+   // Trace names will be userId only, as before
+   ```
+
+3. **Existing code works unchanged**: Code using `traceName` continues to work exactly as before:
+
+   ```typescript
+   // This still works exactly as before
+   await setLangfuseContext(
+     {
+       userId: "user-123",
+       sessionId: "session-456",
+       traceName: "customer-support-chat",
+     },
+     async () => {
+       return await neurolink.generate({ prompt: "Hello" });
+     },
+   );
+   // Trace name: "customer-support-chat"
+   ```
+
+### Priority Order
+
+When determining the trace name, NeuroLink follows this priority order:
+
+1. **Explicit `traceName`** in context (highest priority)
+2. **Explicit `operationName`** in context + userId (formatted per `traceNameFormat`)
+3. **Auto-detected operation name** from span + userId (if `autoDetectOperationName` is enabled)
+4. **userId only** (fallback)
+
+### Wrapper Span Support
+
+When host applications create wrapper spans (trace-root spans) before AI operations, the standard auto-detection in `onStart()` fails because the AI SDK span does not exist yet at wrapper span creation time.
+
+**The Problem:**
+
+```typescript
+// Host app creates wrapper span first
+const span = tracer.startSpan("my-operation"); // onStart() runs here - no AI span yet
+await neurolink.generate({ prompt: "Hello" }); // AI SDK creates "ai.generateText" span later
+span.end();
+```
+
+At the time the wrapper span starts, there is no AI SDK span to detect the operation from, so the trace name would only include the userId.
+
+**The Solution:**
+
+NeuroLink automatically handles this by detecting operations from child spans and updating the trace name when the wrapper span ends:
+
+1. **Wrapper span starts** - `onStart()` sets traceName to just userId (e.g., `user-123`)
+2. **AI SDK span starts** - `onStart()` detects `ai.streamText` and stores operation in a map keyed by traceId
+3. **Wrapper span ends** - `onEnd()` looks up the stored operation and updates traceName to `user-123:ai.streamText`
+
+This behavior is automatic and requires no code changes in host applications. The trace name in Langfuse will correctly include both the userId and the detected operation name.
+
+## Custom Spans
+
+Create custom spans for detailed tracing:
+
+```typescript
+import { getTracer, setLangfuseContext } from "@juspay/neurolink";
+
+const tracer = getTracer("my-app", "1.0.0");
+
+await setLangfuseContext({ userId: "user-123" }, async () => {
+  const span = tracer.startSpan("process-request");
+  try {
+    // Add custom attributes
+    span.setAttribute("request.type", "chat");
+    span.setAttribute("model", "gpt-4");
+
+    const result = await neurolink.generate({ prompt: "Hello" });
+
+    span.setAttribute("tokens.total", result.usage?.totalTokens ?? 0);
+    return result;
+  } catch (error) {
+    span.recordException(error as Error);
+    throw error;
+  } finally {
+    span.end();
+  }
+});
+```
+
+## External TracerProvider Mode
+
+If your application already has OpenTelemetry instrumentation (e.g., for HTTP, database tracing), use external provider mode to avoid "duplicate registration" errors:
+
+### Configuration
+
+```typescript
+import { NeuroLink, getSpanProcessors } from "@juspay/neurolink";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+// 1. Initialize NeuroLink with external provider mode
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      useExternalTracerProvider: true, // Don't create TracerProvider
+    },
+  },
+});
+
+// 2. Get NeuroLink's span processors
+const neurolinkProcessors = getSpanProcessors();
+// Returns: [ContextEnricher, LangfuseSpanProcessor]
+
+// 3. Add to your existing OTEL setup
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+
+const jaegerExporter = new OTLPTraceExporter({
+  url: "http://jaeger:4318/v1/traces",
+});
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new BatchSpanProcessor(jaegerExporter),
+    ...neurolinkProcessors,
+  ],
+});
+sdk.start();
+```
+
+### Auto-Detection Mode
+
+Alternatively, let NeuroLink auto-detect external providers:
+
+```typescript
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      autoDetectExternalProvider: true, // Auto-detect and skip if needed
+    },
+  },
+});
+```
+
+### Available Exports
+
+| Export                            | Description                                        |
+| --------------------------------- | -------------------------------------------------- |
+| `getSpanProcessors()`             | Returns `[ContextEnricher, LangfuseSpanProcessor]` |
+| `createContextEnricher()`         | Factory for creating ContextEnricher instances     |
+| `isUsingExternalTracerProvider()` | Check if in external provider mode                 |
+| `getLangfuseSpanProcessor()`      | Get the LangfuseSpanProcessor directly             |
+| `getTracerProvider()`             | Get the TracerProvider (null in external mode)     |
+
+## Vercel AI SDK Integration
+
+NeuroLink automatically captures GenAI semantic convention attributes from Vercel AI SDK's `experimental_telemetry`:
+
+```typescript
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { setLangfuseContext } from "@juspay/neurolink";
+
+await setLangfuseContext(
+  { userId: "user-123", conversationId: "conv-456" },
+  async () => {
+    const result = await generateText({
+      model: openai("gpt-4"),
+      prompt: "Explain quantum computing",
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "explain-topic",
+      },
+    });
+    // Token usage, model info, and finish reason automatically captured
+    return result;
+  },
+);
+```
+
+### Captured Attributes
+
+The `ContextEnricher` automatically reads these GenAI attributes:
+
+- `gen_ai.system` - AI provider (openai, anthropic, etc.)
+- `gen_ai.request.model` - Model requested
+- `gen_ai.usage.input_tokens` - Input tokens used
+- `gen_ai.usage.output_tokens` - Output tokens used
+- `ai.finishReason` - Why generation finished
+
+## Health Monitoring
+
+Check Langfuse health status:
+
+```typescript
+import { getLangfuseHealthStatus } from "@juspay/neurolink";
+
+const status = getLangfuseHealthStatus();
+console.log({
+  isHealthy: status.isHealthy,
+  initialized: status.initialized,
+  credentialsValid: status.credentialsValid,
+  enabled: status.enabled,
+  hasProcessor: status.hasProcessor,
+  usingExternalProvider: status.usingExternalProvider,
+  config: status.config,
+});
+```
+
+## Flushing and Shutdown
+
+Ensure all spans are sent before process exit:
+
+```typescript
+import { flushOpenTelemetry, shutdownOpenTelemetry } from "@juspay/neurolink";
+
+// Flush pending spans
+await flushOpenTelemetry();
+
+// Graceful shutdown (flushes and cleans up)
+await shutdownOpenTelemetry();
+```
+
+### Graceful Shutdown Example
+
+```typescript
+process.on("SIGTERM", async () => {
+  console.log("Shutting down...");
+  await flushOpenTelemetry();
+  await shutdownOpenTelemetry();
+  process.exit(0);
+});
+```
+
+## Best Practices
+
+### 1. Always Set Context at Request Boundaries
+
+```typescript
+app.use(async (req, res, next) => {
+  await setLangfuseContext({
+    userId: req.user?.id,
+    sessionId: req.session?.id,
+    requestId: req.headers["x-request-id"],
+  });
+  next();
+});
+```
+
+### 2. Use Metadata for Filtering
+
+```typescript
+await setLangfuseContext({
+  metadata: {
+    feature: "chat",
+    experiment: "gpt4-vs-claude",
+    abTestGroup: "B",
+  },
+});
+```
+
+### 3. Create Spans for Business Logic
+
+```typescript
+const tracer = getTracer("my-app");
+const span = tracer.startSpan("retrieve-context");
+try {
+  const docs = await vectorStore.search(query);
+  span.setAttribute("docs.count", docs.length);
+} finally {
+  span.end();
+}
+```
+
+### 4. Handle Errors Properly
+
+```typescript
+const span = tracer.startSpan("ai-generation");
+try {
+  return await neurolink.generate({ prompt });
+} catch (error) {
+  span.recordException(error as Error);
+  span.setStatus({ code: 2, message: (error as Error).message });
+  throw error;
+} finally {
+  span.end();
+}
+```
+
+## Troubleshooting
+
+### Empty span processors from getSpanProcessors()
+
+**Problem**: `getSpanProcessors()` returns an empty array.
+
+**Solution**: Ensure NeuroLink is initialized before calling `getSpanProcessors()`:
+
+```typescript
+// Wrong - calling before initialization
+const processors = getSpanProcessors(); // Returns []
+
+// Correct - call after initialization
+const neurolink = new NeuroLink({
+  observability: { langfuse: { enabled: true, ... } }
+});
+const processors = getSpanProcessors(); // Returns [ContextEnricher, LangfuseSpanProcessor]
+```
+
+### Context not appearing in Langfuse traces
+
+**Problem**: `userId`, `sessionId`, or other context fields don't appear in Langfuse.
+
+**Solution**: Ensure `setLangfuseContext` is called in the same async context as your AI operations:
+
+```typescript
+// Wrong - context set outside the request handler
+await setLangfuseContext({ userId: "user-123" });
+// ... later in different async context
+await neurolink.generate({ prompt: "Hello" }); // Context lost!
+
+// Correct - use callback to scope context
+await setLangfuseContext({ userId: "user-123" }, async () => {
+  await neurolink.generate({ prompt: "Hello" }); // Context attached!
+});
+```
+
+### Duplicate TracerProvider registration errors
+
+**Problem**: Error like "TracerProvider already registered" or "duplicate registration".
+
+**Solution**: Set `useExternalTracerProvider: true` in your config:
+
+```typescript
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      useExternalTracerProvider: true, // Add this!
+    },
+  },
+});
+```
+
+### Spans not being sent to Langfuse
+
+**Problem**: Traces don't appear in Langfuse dashboard.
+
+**Solution**:
+
+1. Verify credentials are correct
+2. Check health status:
+
+   ```typescript
+   const status = getLangfuseHealthStatus();
+   console.log(status); // Check isHealthy, credentialsValid
+   ```
+
+3. Ensure `flushOpenTelemetry()` is called before process exit
+4. Check network connectivity to Langfuse endpoint
+
+## API Reference
+
+The following functions and types are exported from `@juspay/neurolink`:
+
+**Functions:**
+
+- `setLangfuseContext` - Set context for Langfuse traces
+- `getLangfuseContext` - Get current Langfuse context
+- `getTracer` - Get OpenTelemetry tracer instance
+- `getSpanProcessors` - Get span processors for external TracerProvider integration
+
+**Types:**
+
+- `LangfuseConfig` - Configuration options for Langfuse integration
+- `LangfuseSpanAttributes` - GenAI semantic convention attributes
+
+## See Also
+
+- [Telemetry Guide](../telemetry-guide.md) - OpenTelemetry setup with Jaeger
+- [Enterprise Monitoring](../guides/enterprise/monitoring.md) - Prometheus and Grafana setup
+- [Analytics Reference](../reference/analytics.md) - Token and cost tracking

--- a/docs/telemetry-guide.md
+++ b/docs/telemetry-guide.md
@@ -18,6 +18,133 @@ NeuroLink includes optional OpenTelemetry integration for enterprise monitoring 
 
 ---
 
+## 🎯 Langfuse Integration
+
+NeuroLink provides native integration with [Langfuse](https://langfuse.com/) for LLM-specific observability.
+
+### Quick Setup
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      baseUrl: "https://cloud.langfuse.com", // or self-hosted URL
+      environment: "production",
+      release: "1.0.0",
+    },
+  },
+});
+```
+
+### Context Enrichment
+
+Add user, session, and custom metadata to your traces:
+
+```typescript
+import { setLangfuseContext, getLangfuseContext } from "@juspay/neurolink";
+
+// Set context with all available fields
+await setLangfuseContext({
+  userId: "user-123",
+  sessionId: "session-456",
+  conversationId: "conv-789",
+  requestId: "req-abc",
+  traceName: "customer-support-chat",
+  metadata: {
+    feature: "support",
+    tier: "premium",
+    region: "us-east-1",
+  },
+});
+
+// Read current context
+const context = getLangfuseContext();
+console.log(context?.conversationId);
+```
+
+### Custom Spans
+
+Create your own spans for detailed tracing:
+
+```typescript
+import { getTracer, setLangfuseContext } from "@juspay/neurolink";
+
+const tracer = getTracer("my-app");
+
+await setLangfuseContext({ userId: "user-123" }, async () => {
+  const span = tracer.startSpan("process-request");
+  try {
+    const result = await neurolink.generate({ prompt: "Hello" });
+    span.setAttribute("tokens.total", result.usage?.totalTokens);
+    return result;
+  } finally {
+    span.end();
+  }
+});
+```
+
+### External TracerProvider Mode
+
+If your application already has OpenTelemetry instrumentation, use external provider mode:
+
+```typescript
+import { NeuroLink, getSpanProcessors } from "@juspay/neurolink";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+// Initialize NeuroLink without creating its own TracerProvider
+const neurolink = new NeuroLink({
+  observability: {
+    langfuse: {
+      enabled: true,
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+      secretKey: process.env.LANGFUSE_SECRET_KEY!,
+      useExternalTracerProvider: true, // Don't create TracerProvider
+    },
+  },
+});
+
+// Create your existing exporter wrapped in BatchSpanProcessor
+const exporter = new OTLPTraceExporter({
+  url: "http://localhost:4318/v1/traces",
+});
+
+// Add NeuroLink's processors to your existing OTEL setup
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new BatchSpanProcessor(exporter),
+    ...getSpanProcessors(), // [ContextEnricher, LangfuseSpanProcessor]
+  ],
+});
+sdk.start();
+```
+
+### Vercel AI SDK Integration
+
+NeuroLink automatically captures GenAI semantic convention attributes from Vercel AI SDK:
+
+```typescript
+import { generateText } from "ai";
+import { setLangfuseContext } from "@juspay/neurolink";
+
+await setLangfuseContext({ userId: "user-123" }, async () => {
+  const result = await generateText({
+    model: openai("gpt-4"),
+    prompt: "Hello",
+    experimental_telemetry: { isEnabled: true },
+  });
+  // Token usage and model info automatically captured
+});
+```
+
+---
+
 ## 🔧 Basic Setup
 
 ### Environment Configuration

--- a/package.json
+++ b/package.json
@@ -183,14 +183,11 @@
     "@langfuse/otel": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@openrouter/ai-sdk-provider": "^0.7.5",
-    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.56.0",
     "@opentelemetry/core": "^2.1.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.202.0",
     "@opentelemetry/resources": "^2.1.0",
     "@opentelemetry/sdk-node": "^0.56.0",
-    "@opentelemetry/sdk-trace-base": "^2.1.0",
-    "@opentelemetry/sdk-trace-node": "^2.1.0",
     "@opentelemetry/semantic-conventions": "^1.30.1",
     "adm-zip": "^0.5.16",
     "ai": "4.3.19",
@@ -222,6 +219,11 @@
     "zod-to-json-schema": "^3.24.6",
     "@google-cloud/text-to-speech": "^5.0.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.0"
+  },
   "optionalDependencies": {
     "@hono/node-server": "^1.13.0",
     "canvas": "^3.2.0",
@@ -239,6 +241,9 @@
     "@fastify/rate-limit": "^10.3.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^15.3.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.1.0",
+    "@opentelemetry/sdk-trace-node": "^2.1.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^0.7.5
         version: 0.7.5(ai@4.3.19(react@19.2.0)(zod@3.25.76))(zod@3.25.76)
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.56.0
         version: 0.56.1(@opentelemetry/api@1.9.0)(encoding@0.1.13)
@@ -101,12 +98,6 @@ importers:
       '@opentelemetry/sdk-node':
         specifier: ^0.56.0
         version: 0.56.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base':
-        specifier: ^2.1.0
-        version: 2.1.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node':
-        specifier: ^2.1.0
-        version: 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.30.1
         version: 1.37.0
@@ -133,7 +124,7 @@ importers:
         version: 9.15.1(encoding@0.1.13)
       hono:
         specifier: ^4.6.0
-        version: 4.11.5
+        version: 4.11.7
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.19)
@@ -228,6 +219,15 @@ importers:
       '@koa/router':
         specifier: ^15.3.0
         version: 15.3.0(koa@3.1.1)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.1.0
+        version: 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.1.0
+        version: 2.1.0(@opentelemetry/api@1.9.0)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@24.2.9(typescript@5.9.3))
@@ -323,7 +323,7 @@ importers:
         version: 5.1.0
       fastify:
         specifier: ^5.7.2
-        version: 5.7.2
+        version: 5.7.4
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -384,7 +384,7 @@ importers:
     optionalDependencies:
       '@hono/node-server':
         specifier: ^1.13.0
-        version: 1.19.9(hono@4.11.5)
+        version: 1.19.9(hono@4.11.7)
       canvas:
         specifier: ^3.2.0
         version: 3.2.0
@@ -3958,8 +3958,8 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.7.2:
-    resolution: {integrity: sha512-dBJolW+hm6N/yJVf6J5E1BxOBNkuXNl405nrfeR8SpvGWG3aCC2XDHyiFBdow8Win1kj7sjawQc257JlYY6M/A==}
+  fastify@5.7.4:
+    resolution: {integrity: sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4298,8 +4298,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.11.5:
-    resolution: {integrity: sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==}
+  hono@4.11.7:
+    resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -8091,9 +8091,9 @@ snapshots:
 
   '@hapi/bourne@3.0.0': {}
 
-  '@hono/node-server@1.19.9(hono@4.11.5)':
+  '@hono/node-server@1.19.9(hono@4.11.7)':
     dependencies:
-      hono: 4.11.5
+      hono: 4.11.7
     optional: true
 
   '@huggingface/inference@2.8.1':
@@ -8873,7 +8873,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
       forwarded-parse: 2.1.2
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9074,7 +9074,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.14.4
       require-in-the-middle: 7.5.2
-      semver: 7.7.2
+      semver: 7.7.3
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -9086,7 +9086,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.14.4
       require-in-the-middle: 7.5.2
-      semver: 7.7.2
+      semver: 7.7.3
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -9370,7 +9370,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.29.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.29.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.29.0(@opentelemetry/api@1.9.0)
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9380,7 +9380,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@opentelemetry/sdk-trace-node@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9445,7 +9445,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.7.3
       tar-fs: 3.1.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -10305,7 +10305,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.19.19
+      '@types/node': 20.19.25
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -11630,7 +11630,7 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.7.2:
+  fastify@5.7.4:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -12074,7 +12074,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.11.5: {}
+  hono@4.11.7: {}
 
   hook-std@4.0.0: {}
 
@@ -12511,7 +12511,7 @@ snapshots:
       escape-html: 1.0.3
       fresh: 0.5.2
       http-assert: 1.5.0
-      http-errors: 2.0.1
+      http-errors: 2.0.0
       koa-compose: 4.1.0
       mime-types: 3.0.1
       on-finished: 2.4.1
@@ -12698,7 +12698,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   make-fetch-happen@9.1.0:
     dependencies:
@@ -13024,7 +13024,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:

--- a/src/lib/core/modules/TelemetryHandler.ts
+++ b/src/lib/core/modules/TelemetryHandler.ts
@@ -171,6 +171,8 @@ export class TelemetryHandler {
         isEnabled: boolean;
         functionId?: string;
         metadata?: Record<string, string | number | boolean>;
+        recordInputs?: boolean;
+        recordOutputs?: boolean;
       }
     | undefined {
     // Check if telemetry is enabled via NeuroLink observability config
@@ -209,6 +211,8 @@ export class TelemetryHandler {
       isEnabled: true,
       functionId,
       metadata,
+      recordInputs: true,
+      recordOutputs: true,
     };
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -70,6 +70,8 @@ export type {
   ObservabilityConfig,
   LangfuseConfig,
   OpenTelemetryConfig,
+  LangfuseSpanAttributes,
+  TraceNameFormat,
 } from "./types/observability.js";
 
 export { buildObservabilityConfigFromEnv } from "./utils/observabilityHelpers.js";
@@ -80,6 +82,16 @@ import {
   flushOpenTelemetry,
   getLangfuseHealthStatus,
   setLangfuseContext,
+  getLangfuseSpanProcessor,
+  getTracerProvider,
+  isOpenTelemetryInitialized,
+  // NEW EXPORTS - External TracerProvider Support
+  getSpanProcessors,
+  createContextEnricher,
+  isUsingExternalTracerProvider,
+  // Enhanced context and tracing
+  getLangfuseContext,
+  getTracer,
 } from "./services/server/ai/observability/instrumentation.js";
 import {
   initializeTelemetry as init,
@@ -92,6 +104,16 @@ export {
   flushOpenTelemetry,
   getLangfuseHealthStatus,
   setLangfuseContext,
+  getLangfuseSpanProcessor,
+  getTracerProvider,
+  isOpenTelemetryInitialized,
+  // NEW EXPORTS - External TracerProvider Support
+  getSpanProcessors,
+  createContextEnricher,
+  isUsingExternalTracerProvider,
+  // Enhanced context and tracing
+  getLangfuseContext,
+  getTracer,
 };
 
 // Middleware exports

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -140,6 +140,7 @@ import {
   flushOpenTelemetry,
   getLangfuseHealthStatus,
   setLangfuseContext,
+  isOpenTelemetryInitialized,
 } from "./services/server/ai/observability/instrumentation.js";
 import type { ObservabilityConfig } from "./types/observability.js";
 import type { NeurolinkConstructorConfig } from "./types/configTypes.js";
@@ -929,7 +930,12 @@ Current user's request: ${currentInput}`;
     try {
       const langfuseConfig = this.observabilityConfig?.langfuse;
 
-      if (langfuseConfig?.enabled) {
+      // Check if we should use external provider mode - bypass enabled check
+      const useExternalProvider =
+        langfuseConfig?.autoDetectExternalProvider === true ||
+        langfuseConfig?.useExternalTracerProvider === true;
+
+      if (langfuseConfig?.enabled || useExternalProvider) {
         logger.debug(`[NeuroLink] 📊 LOG_POINT_C019_LANGFUSE_INIT_START`, {
           logPoint: "C019_LANGFUSE_INIT_START",
           constructorId,
@@ -1662,7 +1668,12 @@ Current user's request: ${currentInput}`;
    * Centralized utility to avoid duplication across providers
    */
   isTelemetryEnabled(): boolean {
-    return this.observabilityConfig?.langfuse?.enabled || false;
+    // Check if observability config enables telemetry
+    if (this.observabilityConfig?.langfuse?.enabled) {
+      return true;
+    }
+    // Check if OpenTelemetry was initialized (by this or external app)
+    return isOpenTelemetryInitialized();
   }
 
   /**

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -16,14 +16,59 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { AsyncLocalStorage } from "async_hooks";
+import { trace } from "@opentelemetry/api";
 import { logger } from "../../../../utils/logger.js";
-import type { LangfuseConfig } from "../../../../types/observability.js";
+import type {
+  LangfuseConfig,
+  LangfuseSpanAttributes,
+} from "../../../../types/observability.js";
 
 const LOG_PREFIX = "[OpenTelemetry]";
 
+/**
+ * Extended context for Langfuse spans
+ * Supports all Langfuse trace attributes for rich observability
+ */
 type LangfuseContext = {
   userId?: string | null;
   sessionId?: string | null;
+  /** Conversation/thread identifier for grouping related traces */
+  conversationId?: string | null;
+  /** Request identifier for correlating with application logs */
+  requestId?: string | null;
+  /** Custom trace name for better organization in Langfuse UI */
+  traceName?: string | null;
+  /** Custom metadata to attach to spans */
+  metadata?: Record<string, unknown> | null;
+
+  // Operation Name Support
+
+  /**
+   * Explicit operation name (e.g., "ai.streamText", "chat", "embeddings")
+   *
+   * If set, this overrides auto-detection from the span name.
+   * Use this when you want a custom operation name that doesn't match
+   * the auto-detected Vercel AI SDK operation.
+   *
+   * @example
+   * await setLangfuseContext({
+   *   userId: "user@email.com",
+   *   operationName: "customer-support-chat"
+   * }, async () => {
+   *   // Trace name: "user@email.com:customer-support-chat"
+   * });
+   */
+  operationName?: string | null;
+
+  /**
+   * Override global autoDetectOperationName setting for this context.
+   *
+   * When undefined, uses the global setting from LangfuseConfig.
+   * Set to false to disable auto-detection for this specific context.
+   *
+   * @default undefined (uses global setting, which defaults to true)
+   */
+  autoDetectOperationName?: boolean;
 };
 
 const contextStorage = new AsyncLocalStorage<LangfuseContext>();
@@ -33,28 +78,387 @@ let langfuseProcessor: LangfuseSpanProcessor | null = null;
 let isInitialized = false;
 let isCredentialsValid = false;
 let currentConfig: LangfuseConfig | null = null;
+let usingExternalProvider = false;
+let cachedContextEnricher: ContextEnricher | null = null;
+
+/**
+ * Check if a real TracerProvider (not ProxyTracerProvider) is already registered
+ *
+ * IMPORTANT: This function checks the @opentelemetry/api global state as seen by THIS
+ * module's bundled copy of @opentelemetry/api. If Neurolink is bundled with its own
+ * copy of @opentelemetry/api (which is common in bundled libraries), this function
+ * will NOT detect TracerProviders registered by the host application on their
+ * @opentelemetry/api instance. Use `useExternalTracerProvider: true` or
+ * `autoDetectExternalProvider: true` to explicitly signal external provider usage.
+ *
+ * @returns true if an external TracerProvider is detected in this module's OTEL instance
+ */
+function _hasExternalTracerProvider(): boolean {
+  try {
+    const provider = trace.getTracerProvider();
+
+    if (!provider) {
+      return false;
+    }
+
+    // ProxyTracerProvider is the default "no-op" provider
+    // Any other provider means someone else registered one
+    const providerName = provider.constructor?.name || "";
+    const isProxy =
+      providerName === "ProxyTracerProvider" ||
+      providerName === "NoopTracerProvider";
+
+    if (!isProxy) {
+      logger.debug(
+        `${LOG_PREFIX} Detected external TracerProvider: ${providerName}`,
+      );
+    }
+
+    return !isProxy;
+  } catch (error) {
+    logger.warn(`${LOG_PREFIX} Error checking for external TracerProvider`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
 
 /**
  * Span processor that enriches spans with user and session context from AsyncLocalStorage
+ * Also extracts GenAI semantic convention attributes for Langfuse integration
+ *
+ * Key features:
+ * - Enriches spans with userId, sessionId, conversationId, requestId
+ * - Auto-detects operation names from Vercel AI SDK span names
+ * - Builds formatted trace names for Langfuse (e.g., "user@email.com:ai.streamText")
+ * - Supports custom trace name formats via configuration
+ * - Handles wrapper spans by detecting operations from child spans and updating trace name in onEnd()
  */
 class ContextEnricher implements SpanProcessor {
+  /**
+   * Maximum number of detected operations to track to prevent memory leaks.
+   * Once this limit is reached, oldest entries are evicted (FIFO).
+   */
+  private static readonly MAX_DETECTED_OPERATIONS = 10000;
+
+  /**
+   * Track detected operations per trace for wrapper span support.
+   * When a host app creates a wrapper span before AI operations, the wrapper's
+   * onStart() runs before the AI SDK child span exists. We store detected
+   * operations here so we can update the trace name in onEnd().
+   */
+  private detectedOperations = new Map<string, string>();
+
   onStart(span: Span): void {
     const context = contextStorage.getStore();
-    const userId = context?.userId ?? currentConfig?.userId;
+    const userId = context?.userId ?? currentConfig?.userId ?? "guest";
     const sessionId = context?.sessionId ?? currentConfig?.sessionId;
 
-    if (userId) {
+    // Get span name for operation auto-detection
+    const spanName = (span as unknown as { name?: string }).name;
+
+    // Determine if auto-detection is enabled for this context
+    const autoDetect = this.shouldAutoDetectOperationName(context);
+
+    // Resolve operation name: explicit > auto-detected > undefined
+    const operationName = this.resolveOperationName(
+      context?.operationName,
+      spanName,
+      autoDetect,
+    );
+
+    // Store detected AI operations for wrapper span support (optional, defensive).
+    // When a host app creates a wrapper span before calling AI operations,
+    // this allows us to update the trace name in onEnd() with the operation.
+    // Only store the first detected operation for each trace (subsequent operations are ignored).
+    try {
+      if (operationName && spanName?.startsWith("ai.")) {
+        const traceId = span.spanContext?.()?.traceId;
+        if (traceId && !this.detectedOperations.has(traceId)) {
+          // Evict oldest entry if at capacity to prevent memory leak
+          if (
+            this.detectedOperations.size >=
+            ContextEnricher.MAX_DETECTED_OPERATIONS
+          ) {
+            const firstKey = this.detectedOperations.keys().next().value;
+            if (firstKey) {
+              this.detectedOperations.delete(firstKey);
+            }
+          }
+          this.detectedOperations.set(traceId, operationName);
+        }
+      }
+    } catch {
+      // Wrapper span support is optional - don't fail if spanContext isn't available
+    }
+
+    // Build trace name based on priority:
+    // 1. Explicit traceName (100% backward compatible)
+    // 2. Formatted name with userId + operationName
+    // 3. userId only (legacy fallback)
+    const traceName = this.buildTraceName(
+      context?.traceName,
+      userId,
+      operationName,
+    );
+
+    // Set user and session attributes
+    if (userId && userId !== "guest") {
       span.setAttribute("user.id", userId);
     }
     if (sessionId) {
       span.setAttribute("session.id", sessionId);
     }
+
+    // Add extended context fields
+    if (context?.conversationId) {
+      span.setAttribute("conversation.id", context.conversationId);
+    }
+    if (context?.requestId) {
+      span.setAttribute("request.id", context.requestId);
+    }
+
+    // Set trace name for Langfuse (using proper Langfuse attribute)
+    if (traceName) {
+      span.setAttribute("langfuse.trace.name", traceName);
+      span.setAttribute("trace.name", traceName); // Keep for compatibility
+    }
+
+    // Set operation name as separate attribute for filtering/analytics
+    if (operationName) {
+      span.setAttribute("gen_ai.operation.name", operationName);
+    }
+
+    // Add custom metadata as span attributes
+    const metadata = context?.metadata;
+    if (metadata && typeof metadata === "object") {
+      for (const [key, value] of Object.entries(metadata)) {
+        if (value !== undefined && value !== null) {
+          // Preserve primitive types that OTEL supports natively
+          if (
+            typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value === "boolean"
+          ) {
+            span.setAttribute(`metadata.${key}`, value);
+          } else if (
+            Array.isArray(value) &&
+            value.every(
+              (v) =>
+                typeof v === "string" ||
+                typeof v === "number" ||
+                typeof v === "boolean",
+            )
+          ) {
+            // OTEL supports homogeneous arrays of primitives
+            span.setAttribute(
+              `metadata.${key}`,
+              value as string[] | number[] | boolean[],
+            );
+          } else {
+            // Fall back to JSON string for complex types
+            span.setAttribute(`metadata.${key}`, JSON.stringify(value));
+          }
+        }
+      }
+    }
   }
 
-  onEnd(): void {}
+  /**
+   * Determine if auto-detection should be used for operation names
+   */
+  private shouldAutoDetectOperationName(context?: LangfuseContext): boolean {
+    // Context-level override takes precedence
+    if (context?.autoDetectOperationName !== undefined) {
+      return context.autoDetectOperationName;
+    }
+    // Fall back to global config (default: true)
+    return currentConfig?.autoDetectOperationName !== false;
+  }
+
+  /**
+   * Resolve operation name from explicit setting, auto-detection, or undefined
+   */
+  private resolveOperationName(
+    explicit: string | null | undefined,
+    spanName: string | undefined,
+    autoDetect: boolean,
+  ): string | undefined {
+    // Explicit operation name takes precedence
+    if (explicit) {
+      return explicit;
+    }
+
+    // Auto-detect from span name if enabled
+    if (autoDetect && spanName) {
+      // Detect Vercel AI SDK operation spans (ai.streamText, ai.generateText, etc.)
+      if (spanName.startsWith("ai.")) {
+        return spanName;
+      }
+      // Detect OpenTelemetry GenAI convention spans (chat, embeddings, text_completion)
+      if (
+        spanName === "chat" ||
+        spanName === "embeddings" ||
+        spanName === "text_completion"
+      ) {
+        return spanName;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Build trace name based on format configuration and available data
+   */
+  private buildTraceName(
+    explicitTraceName: string | null | undefined,
+    userId: string,
+    operationName: string | undefined,
+  ): string {
+    // 1. Explicit traceName always wins (100% backward compatibility)
+    if (explicitTraceName) {
+      return explicitTraceName;
+    }
+
+    // 2. Build formatted trace name based on config
+    const format = currentConfig?.traceNameFormat ?? "userId:operationName";
+
+    // Handle custom function format
+    if (typeof format === "function") {
+      return format({ userId, operationName });
+    }
+
+    // Handle predefined string formats
+    switch (format) {
+      case "userId:operationName":
+        return operationName ? `${userId}:${operationName}` : userId;
+      case "operationName:userId":
+        return operationName ? `${operationName}:${userId}` : userId;
+      case "operationName":
+        return operationName || userId;
+      case "userId":
+      default:
+        return userId;
+    }
+  }
+
+  /**
+   * Called when span ends - extracts GenAI semantic convention attributes
+   * from Vercel AI SDK spans and enriches them for Langfuse.
+   *
+   * Also handles wrapper span support: when a host app creates a wrapper/trace-root
+   * span before AI operations, we update the trace name here with the detected operation.
+   */
+  onEnd(span: Span): void {
+    try {
+      // Get span attributes (ReadableSpan interface)
+      const readableSpan = span as unknown as {
+        attributes?: LangfuseSpanAttributes;
+        name?: string;
+      };
+      const attributes = readableSpan.attributes || {};
+
+      // Handle wrapper/trace-root spans: update trace name with detected operation
+      // This supports host apps (like Curator) that create wrapper spans before AI calls
+      // This is optional - if spanContext fails, we skip wrapper span support
+      try {
+        const traceId = span.spanContext?.()?.traceId;
+        if (traceId) {
+          const isTraceRoot = attributes["langfuse.span.type"] === "trace-root";
+          const detectedOp = this.detectedOperations.get(traceId);
+
+          if (isTraceRoot && detectedOp) {
+            const context = contextStorage.getStore();
+            const userId =
+              (attributes["user.id"] as string) ||
+              context?.userId ||
+              currentConfig?.userId ||
+              "guest";
+
+            // Only update if there's no explicit traceName set
+            const existingTraceName = attributes[
+              "langfuse.trace.name"
+            ] as string;
+            const hasExplicitTraceName =
+              context?.traceName ||
+              (existingTraceName && existingTraceName !== userId);
+
+            if (!hasExplicitTraceName) {
+              const newTraceName = this.buildTraceName(
+                null,
+                userId,
+                detectedOp,
+              );
+
+              // Update the trace name attribute
+              span.setAttribute("langfuse.trace.name", newTraceName);
+              span.setAttribute("trace.name", newTraceName);
+              span.setAttribute("gen_ai.operation.name", detectedOp);
+
+              logger.debug(
+                `${LOG_PREFIX} Updated trace-root span with detected operation`,
+                {
+                  traceId,
+                  operation: detectedOp,
+                  newTraceName,
+                },
+              );
+            }
+
+            // Cleanup the detected operation
+            this.detectedOperations.delete(traceId);
+          }
+        }
+      } catch {
+        // Wrapper span support is optional - don't fail if spanContext isn't available
+      }
+
+      // Check if this is a GenAI span (from Vercel AI SDK)
+      const isGenAISpan =
+        attributes["gen_ai.system"] ||
+        attributes["ai.model.id"] ||
+        attributes["gen_ai.request.model"];
+
+      if (isGenAISpan) {
+        logger.debug(`${LOG_PREFIX} GenAI span detected`, {
+          spanName: readableSpan.name,
+          model:
+            attributes["gen_ai.request.model"] || attributes["ai.model.id"],
+          provider:
+            attributes["gen_ai.system"] || attributes["ai.model.provider"],
+        });
+
+        // Log token usage for observability
+        const inputTokens =
+          attributes["gen_ai.usage.input_tokens"] ||
+          attributes["ai.usage.promptTokens"];
+        const outputTokens =
+          attributes["gen_ai.usage.output_tokens"] ||
+          attributes["ai.usage.completionTokens"];
+
+        if (inputTokens !== undefined || outputTokens !== undefined) {
+          logger.debug(`${LOG_PREFIX} Token usage captured`, {
+            inputTokens,
+            outputTokens,
+            totalTokens: attributes["gen_ai.usage.total_tokens"],
+          });
+        }
+      }
+    } catch (error) {
+      // Don't fail span processing on errors
+      logger.debug(`${LOG_PREFIX} Error reading span attributes`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   shutdown(): Promise<void> {
+    // Clean up tracked operations to prevent memory leaks
+    this.detectedOperations.clear();
     return Promise.resolve();
   }
+
   forceFlush(): Promise<void> {
     return Promise.resolve();
   }
@@ -68,23 +472,154 @@ class ContextEnricher implements SpanProcessor {
  * 2. Creating a NodeTracerProvider with service metadata and span processor
  * 3. Registering the provider globally for AI SDK to use
  *
+ * NEW: If useExternalTracerProvider is true or autoDetectExternalProvider detects
+ * an existing provider, steps 2 and 3 are skipped. The span processors are still
+ * created and can be retrieved via getSpanProcessors().
+ *
  * @param config - Langfuse configuration passed from parent application
  */
 export function initializeOpenTelemetry(config: LangfuseConfig): void {
+  // Guard against multiple initializations
   if (isInitialized) {
-    logger.debug(`${LOG_PREFIX} Already initialized`);
+    logger.debug(`${LOG_PREFIX} Already initialized`, {
+      usingExternalProvider,
+      hasLangfuseProcessor: !!langfuseProcessor,
+    });
     return;
   }
 
-  if (!config.enabled) {
-    logger.debug(`${LOG_PREFIX} Langfuse disabled, skipping initialization`);
+  // FIRST: Check for external provider mode - bypasses enabled check
+  // NOTE: When autoDetectExternalProvider is true, we trust the flag directly rather than
+  // calling hasExternalTracerProvider(). This is because Neurolink may bundle its own copy
+  // of @opentelemetry/api, which has a separate global state from the host application.
+  // The hasExternalTracerProvider() check would query Neurolink's bundled @opentelemetry/api
+  // global state (which has no provider registered), not the host's global state.
+  // By trusting autoDetectExternalProvider=true, we let the host application signal that
+  // it has already registered a TracerProvider.
+  const shouldUseExternal =
+    config?.useExternalTracerProvider === true ||
+    config?.autoDetectExternalProvider === true;
+
+  if (shouldUseExternal) {
+    // Validate credentials even in external mode
+    if (!config?.publicKey || !config?.secretKey) {
+      logger.warn(
+        `${LOG_PREFIX} External provider mode but missing credentials, skipping initialization`,
+        {
+          hasPublicKey: !!config?.publicKey,
+          hasSecretKey: !!config?.secretKey,
+        },
+      );
+      isInitialized = true;
+      isCredentialsValid = false;
+      return;
+    }
+
+    try {
+      currentConfig = config;
+      isCredentialsValid = true;
+
+      // Create span processor for external provider mode
+      langfuseProcessor = new LangfuseSpanProcessor({
+        publicKey: config.publicKey,
+        secretKey: config.secretKey,
+        baseUrl: config.baseUrl || "https://cloud.langfuse.com",
+        environment: config.environment || "dev",
+        release: config.release || "v1.0.0",
+      });
+
+      usingExternalProvider = true;
+      isInitialized = true;
+
+      // Auto-register ContextEnricher with the global TracerProvider
+      // This ensures trace names are set even when host doesn't call getSpanProcessors()
+      try {
+        const globalProvider = trace.getTracerProvider();
+
+        // Check if it's a real provider with addSpanProcessor method (not the no-op default)
+        if (
+          globalProvider &&
+          typeof (globalProvider as unknown as { addSpanProcessor?: unknown })
+            .addSpanProcessor === "function"
+        ) {
+          const provider = globalProvider as unknown as {
+            addSpanProcessor: (processor: SpanProcessor) => void;
+          };
+
+          // Add ContextEnricher for trace name enrichment
+          provider.addSpanProcessor(new ContextEnricher());
+
+          // Also add LangfuseSpanProcessor so traces are sent to Langfuse
+          provider.addSpanProcessor(langfuseProcessor);
+
+          logger.info(
+            `${LOG_PREFIX} Auto-registered processors with global TracerProvider`,
+            {
+              processors: ["ContextEnricher", "LangfuseSpanProcessor"],
+              reason: "External provider mode with auto-registration",
+            },
+          );
+        } else {
+          // No real provider found - host will need to add processors manually
+          logger.info(`${LOG_PREFIX} Using external TracerProvider mode`, {
+            reason: config.useExternalTracerProvider
+              ? "useExternalTracerProvider=true"
+              : "autoDetectExternalProvider=true (trusting host signal)",
+            instructions:
+              "Add span processors to your TracerProvider using getSpanProcessors()",
+          });
+
+          logger.info(`${LOG_PREFIX} Span processors ready for external use`, {
+            processors: ["ContextEnricher", "LangfuseSpanProcessor"],
+            usage: "import { getSpanProcessors } from '@juspay/neurolink'",
+          });
+        }
+      } catch (autoRegisterError) {
+        // Auto-registration failed - fall back to manual registration
+        logger.warn(
+          `${LOG_PREFIX} Auto-registration failed, manual registration required`,
+          {
+            error:
+              autoRegisterError instanceof Error
+                ? autoRegisterError.message
+                : String(autoRegisterError),
+            instructions:
+              "Add span processors to your TracerProvider using getSpanProcessors()",
+          },
+        );
+      }
+
+      return;
+    } catch (error) {
+      logger.error(
+        `${LOG_PREFIX} Failed to create span processor for external mode`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+      );
+      isInitialized = true;
+      return;
+    }
+  }
+
+  // THEN: Check enabled for standalone mode
+  if (!config?.enabled) {
+    logger.debug(
+      `${LOG_PREFIX} Langfuse disabled and no external provider, skipping initialization`,
+    );
     isInitialized = true;
     return;
   }
 
+  // Validate credentials for standalone mode
   if (!config.publicKey || !config.secretKey) {
     logger.warn(
       `${LOG_PREFIX} Langfuse enabled but missing credentials, skipping initialization`,
+      {
+        hasPublicKey: !!config.publicKey,
+        hasSecretKey: !!config.secretKey,
+      },
     );
     isInitialized = true;
     isCredentialsValid = false;
@@ -95,6 +630,7 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
     currentConfig = config;
     isCredentialsValid = true;
 
+    // Step 1: Create LangfuseSpanProcessor for standalone mode
     langfuseProcessor = new LangfuseSpanProcessor({
       publicKey: config.publicKey,
       secretKey: config.secretKey,
@@ -103,6 +639,12 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
       release: config.release || "v1.0.0",
     });
 
+    logger.debug(`${LOG_PREFIX} Created LangfuseSpanProcessor`, {
+      baseUrl: config.baseUrl || "https://cloud.langfuse.com",
+      environment: config.environment || "dev",
+    });
+
+    // Step 2: Create our own TracerProvider (standalone behavior)
     const resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: "neurolink",
       [ATTR_SERVICE_VERSION]: config.release || "v1.0.0",
@@ -114,17 +656,46 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
       spanProcessors: [new ContextEnricher(), langfuseProcessor],
     });
 
+    // Step 4: Register globally
     tracerProvider.register();
+    usingExternalProvider = false;
     isInitialized = true;
 
     logger.info(`${LOG_PREFIX} Initialized with Langfuse span processor`, {
       baseUrl: config.baseUrl || "https://cloud.langfuse.com",
       environment: config.environment || "dev",
       release: config.release || "v1.0.0",
+      mode: "standalone",
     });
   } catch (error) {
+    // Check if this is a duplicate registration error
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const isDuplicateError =
+      errorMessage.includes("duplicate registration") ||
+      errorMessage.includes("already registered") ||
+      errorMessage.includes("already set");
+
+    if (isDuplicateError) {
+      // Graceful handling: switch to external mode
+      logger.warn(
+        `${LOG_PREFIX} TracerProvider already registered, switching to external mode`,
+        {
+          error: errorMessage,
+          recommendation:
+            "Set useExternalTracerProvider=true or autoDetectExternalProvider=true in config",
+        },
+      );
+
+      usingExternalProvider = true;
+      isInitialized = true;
+
+      // Don't throw - processors are still usable
+      return;
+    }
+
+    // Other errors: log and re-throw
     logger.error(`${LOG_PREFIX} Initialization failed`, {
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
       stack: error instanceof Error ? error.stack : undefined,
     });
     throw error;
@@ -162,16 +733,32 @@ export async function flushOpenTelemetry(): Promise<void> {
  * Shutdown OpenTelemetry and Langfuse span processor
  */
 export async function shutdownOpenTelemetry(): Promise<void> {
-  if (!isInitialized || !tracerProvider) {
+  if (!isInitialized) {
     return;
   }
 
   try {
-    await tracerProvider.shutdown();
+    // Only shutdown tracerProvider if we created it
+    if (tracerProvider && !usingExternalProvider) {
+      await tracerProvider.shutdown();
+    }
+
+    // Always shutdown the Langfuse processor
+    if (langfuseProcessor) {
+      await langfuseProcessor.shutdown();
+    }
+
+    // Shutdown cached ContextEnricher
+    if (cachedContextEnricher) {
+      await cachedContextEnricher.shutdown();
+    }
+
     tracerProvider = null;
     langfuseProcessor = null;
+    cachedContextEnricher = null;
     isInitialized = false;
     isCredentialsValid = false;
+    usingExternalProvider = false;
 
     logger.debug(`${LOG_PREFIX} Shutdown complete`);
   } catch (error) {
@@ -204,18 +791,34 @@ export function isOpenTelemetryInitialized(): boolean {
 
 /**
  * Get health status for Langfuse observability
+ *
+ * @returns Health status object with initialization and configuration details
  */
-export function getLangfuseHealthStatus() {
+export function getLangfuseHealthStatus(): {
+  isHealthy: boolean;
+  initialized: boolean;
+  credentialsValid: boolean;
+  enabled: boolean;
+  hasProcessor: boolean;
+  usingExternalProvider: boolean;
+  config?: {
+    baseUrl: string;
+    environment: string;
+    release: string;
+  };
+} {
   return {
-    isHealthy:
+    isHealthy: !!(
       currentConfig?.enabled &&
       isInitialized &&
       isCredentialsValid &&
-      langfuseProcessor !== null,
+      langfuseProcessor !== null
+    ),
     initialized: isInitialized,
     credentialsValid: isCredentialsValid,
     enabled: currentConfig?.enabled || false,
     hasProcessor: langfuseProcessor !== null,
+    usingExternalProvider,
     config: currentConfig
       ? {
           baseUrl: currentConfig.baseUrl || "https://cloud.langfuse.com",
@@ -230,22 +833,41 @@ export function getLangfuseHealthStatus() {
  * Set user and session context for Langfuse spans in the current async context
  *
  * Merges the provided context with existing AsyncLocalStorage context. If a callback is provided,
- * the context is scoped to that callback execution. Without a callback, the context applies to
- * the current execution context and its children.
+ * the context is scoped to that callback execution and returns the callback's result.
+ * Without a callback, the context applies to the current execution context and its children.
  *
  * Uses AsyncLocalStorage to properly scope context per request, avoiding race conditions
  * in concurrent scenarios.
  *
- * @param context - Object containing optional userId and/or sessionId to merge with existing context
+ * @param context - Object containing context fields to merge with existing context
  * @param callback - Optional callback to run within the context scope. If omitted, context applies to current execution
+ * @returns The callback's return value if provided, otherwise void
+ *
+ * @example
+ * // With callback - returns the result
+ * const result = await setLangfuseContext({ userId: "user123" }, async () => {
+ *   return await generateText({ model: "gpt-4", prompt: "Hello" });
+ * });
+ *
+ * @example
+ * // Without callback - sets context for current execution
+ * await setLangfuseContext({ sessionId: "session456", traceName: "chat-completion" });
  */
-export async function setLangfuseContext(
+export async function setLangfuseContext<T = void>(
   context: {
     userId?: string | null;
     sessionId?: string | null;
+    conversationId?: string | null;
+    requestId?: string | null;
+    traceName?: string | null;
+    metadata?: Record<string, unknown> | null;
+    /** Explicit operation name (overrides auto-detection) */
+    operationName?: string | null;
+    /** Override global autoDetectOperationName for this context */
+    autoDetectOperationName?: boolean;
   },
-  callback?: () => void | Promise<void>,
-): Promise<void> {
+  callback?: () => T | Promise<T>,
+): Promise<T | void> {
   const currentContext = contextStorage.getStore() || {};
   const newContext: LangfuseContext = {
     userId:
@@ -254,6 +876,31 @@ export async function setLangfuseContext(
       context.sessionId !== undefined
         ? context.sessionId
         : currentContext.sessionId,
+    conversationId:
+      context.conversationId !== undefined
+        ? context.conversationId
+        : currentContext.conversationId,
+    requestId:
+      context.requestId !== undefined
+        ? context.requestId
+        : currentContext.requestId,
+    traceName:
+      context.traceName !== undefined
+        ? context.traceName
+        : currentContext.traceName,
+    metadata:
+      context.metadata !== undefined
+        ? context.metadata
+        : currentContext.metadata,
+    // Operation name support
+    operationName:
+      context.operationName !== undefined
+        ? context.operationName
+        : currentContext.operationName,
+    autoDetectOperationName:
+      context.autoDetectOperationName !== undefined
+        ? context.autoDetectOperationName
+        : currentContext.autoDetectOperationName,
   };
 
   if (callback) {
@@ -261,4 +908,83 @@ export async function setLangfuseContext(
   } else {
     contextStorage.enterWith(newContext);
   }
+}
+
+/**
+ * Get the current Langfuse context from AsyncLocalStorage
+ *
+ * Returns the current context including userId, sessionId, conversationId,
+ * requestId, traceName, and metadata. Returns undefined if no context is set.
+ *
+ * @returns The current LangfuseContext or undefined
+ *
+ * @example
+ * const context = getLangfuseContext();
+ * console.log(context?.userId, context?.sessionId);
+ */
+export function getLangfuseContext(): LangfuseContext | undefined {
+  return contextStorage.getStore();
+}
+
+/**
+ * Get an OpenTelemetry Tracer for creating custom spans
+ *
+ * This allows applications to create their own spans that will be
+ * processed by the same span processors (ContextEnricher + LangfuseSpanProcessor).
+ *
+ * @param name - Tracer name, defaults to "neurolink"
+ * @param version - Tracer version, optional
+ * @returns OpenTelemetry Tracer instance
+ *
+ * @example
+ * const tracer = getTracer("my-app");
+ * const span = tracer.startSpan("custom-operation");
+ * try {
+ *   // ... do work
+ * } finally {
+ *   span.end();
+ * }
+ */
+export function getTracer(
+  name: string = "neurolink",
+  version?: string,
+): ReturnType<typeof trace.getTracer> {
+  return trace.getTracer(name, version);
+}
+
+/**
+ * Create a new ContextEnricher span processor
+ * Use this when useExternalTracerProvider is true to add to your own TracerProvider
+ *
+ * @returns A new ContextEnricher instance
+ */
+export function createContextEnricher(): SpanProcessor {
+  return new ContextEnricher();
+}
+
+/**
+ * Get all span processors that NeuroLink would use
+ * Convenience function that returns [ContextEnricher, LangfuseSpanProcessor]
+ *
+ * @returns Array of span processors, or empty array if not initialized
+ */
+export function getSpanProcessors(): SpanProcessor[] {
+  if (!isInitialized || !langfuseProcessor) {
+    logger.warn(`${LOG_PREFIX} getSpanProcessors called but not initialized`);
+    return [];
+  }
+  // Reuse cached ContextEnricher to avoid creating multiple instances
+  if (!cachedContextEnricher) {
+    cachedContextEnricher = new ContextEnricher();
+  }
+  return [cachedContextEnricher, langfuseProcessor];
+}
+
+/**
+ * Check if using external TracerProvider mode
+ *
+ * @returns true if operating in external TracerProvider mode
+ */
+export function isUsingExternalTracerProvider(): boolean {
+  return usingExternalProvider;
 }

--- a/src/lib/types/observability.ts
+++ b/src/lib/types/observability.ts
@@ -4,6 +4,66 @@
  * to enable telemetry and observability features in Neurolink SDK
  */
 
+import type { AttributeValue } from "@opentelemetry/api";
+
+/**
+ * Trace name format for Langfuse traces
+ *
+ * Controls how userId and operationName are combined to form the trace name.
+ * Can be a predefined format string or a custom function.
+ *
+ * @example
+ * // Predefined formats:
+ * "userId:operationName" → "user@email.com:ai.streamText"
+ * "operationName:userId" → "ai.streamText:user@email.com"
+ * "operationName" → "ai.streamText"
+ * "userId" → "user@email.com" (legacy)
+ *
+ * @example
+ * // Custom function:
+ * (ctx) => `[${ctx.operationName}] ${ctx.userId}`
+ * // → "[ai.streamText] user@email.com"
+ */
+export type TraceNameFormat =
+  | "userId:operationName"
+  | "operationName:userId"
+  | "operationName"
+  | "userId"
+  | ((context: { userId?: string; operationName?: string }) => string);
+
+/**
+ * Standard GenAI semantic convention attributes from OpenTelemetry
+ * These are the attributes that Vercel AI SDK's experimental_telemetry creates
+ * @see https://opentelemetry.io/docs/specs/semconv/gen-ai/
+ */
+export type LangfuseSpanAttributes = {
+  // Core GenAI attributes
+  "gen_ai.system"?: string;
+  "gen_ai.request.model"?: string;
+  "gen_ai.response.model"?: string;
+  "gen_ai.request.max_tokens"?: number;
+  "gen_ai.request.temperature"?: number;
+  "gen_ai.request.top_p"?: number;
+  "gen_ai.usage.input_tokens"?: number;
+  "gen_ai.usage.output_tokens"?: number;
+  "gen_ai.usage.total_tokens"?: number;
+  "gen_ai.response.finish_reasons"?: string[];
+  "gen_ai.prompt"?: string;
+  "gen_ai.completion"?: string;
+
+  // Vercel AI SDK specific attributes
+  "ai.model.id"?: string;
+  "ai.model.provider"?: string;
+  "ai.operationId"?: string;
+  "ai.telemetry.functionId"?: string;
+  "ai.finishReason"?: string;
+  "ai.usage.promptTokens"?: number;
+  "ai.usage.completionTokens"?: number;
+
+  // Allow additional custom attributes
+  [key: string]: AttributeValue | undefined;
+};
+
 /**
  * Langfuse observability configuration
  */
@@ -29,6 +89,72 @@ export type LangfuseConfig = {
   userId?: string;
   /** Optional default session id to attach to spans */
   sessionId?: string;
+
+  // NEW FIELDS - External TracerProvider Support
+  /**
+   * If true, NeuroLink will NOT create or register its own TracerProvider.
+   * Instead, it will only create the LangfuseSpanProcessor and ContextEnricher,
+   * which the parent application must add to its own TracerProvider.
+   *
+   * Use this when your application already has OpenTelemetry instrumentation.
+   *
+   * @default false
+   */
+  useExternalTracerProvider?: boolean;
+
+  /**
+   * If true, NeuroLink will automatically detect if a TracerProvider is already
+   * registered globally and skip its own registration to avoid conflicts.
+   *
+   * This is a convenience option that combines well with useExternalTracerProvider.
+   *
+   * @default false
+   */
+  autoDetectExternalProvider?: boolean;
+
+  // Operation Name Support
+
+  /**
+   * Enable auto-detection of operation names from span names.
+   *
+   * When true (default), AI operation spans (ai.streamText, ai.generateText, etc.)
+   * will have their operation name automatically extracted and included in the
+   * trace name.
+   *
+   * @default true
+   *
+   * @example
+   * // With auto-detection enabled (default):
+   * // Span "ai.streamText" + userId "user@email.com"
+   * // → Trace name: "user@email.com:ai.streamText"
+   *
+   * @example
+   * // With auto-detection disabled:
+   * // → Trace name: "user@email.com" (legacy behavior)
+   */
+  autoDetectOperationName?: boolean;
+
+  /**
+   * Format for trace names in Langfuse.
+   *
+   * Controls how userId and operationName are combined to form the trace name.
+   * Can be a predefined format string or a custom function for full control.
+   *
+   * @default "userId:operationName"
+   *
+   * @example
+   * // Predefined formats:
+   * traceNameFormat: "userId:operationName" // "user@email.com:ai.streamText"
+   * traceNameFormat: "operationName:userId" // "ai.streamText:user@email.com"
+   * traceNameFormat: "operationName"        // "ai.streamText"
+   * traceNameFormat: "userId"               // "user@email.com" (legacy)
+   *
+   * @example
+   * // Custom function:
+   * traceNameFormat: (ctx) => `[${ctx.operationName || 'unknown'}] ${ctx.userId}`
+   * // → "[ai.streamText] user@email.com"
+   */
+  traceNameFormat?: TraceNameFormat;
 };
 
 /**

--- a/test/unit/observability/externalTracerProvider.test.ts
+++ b/test/unit/observability/externalTracerProvider.test.ts
@@ -1,0 +1,1847 @@
+/**
+ * External TracerProvider Support Tests
+ * Tests for external OpenTelemetry TracerProvider integration
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock logger before importing module
+vi.mock("../../../src/lib/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock OpenTelemetry modules
+vi.mock("@opentelemetry/api", () => ({
+  trace: {
+    getTracerProvider: vi.fn(),
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-trace-node", () => ({
+  NodeTracerProvider: vi.fn().mockImplementation(() => ({
+    register: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  ATTR_SERVICE_NAME: "service.name",
+  ATTR_SERVICE_VERSION: "service.version",
+}));
+
+vi.mock("@langfuse/otel", () => ({
+  LangfuseSpanProcessor: vi.fn().mockImplementation(() => ({
+    forceFlush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe("External TracerProvider Support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset module state between tests
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("initializeOpenTelemetry", () => {
+    it("should register provider when no external provider exists (default behavior)", async () => {
+      const {
+        initializeOpenTelemetry,
+        isUsingExternalTracerProvider,
+        getTracerProvider,
+      } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+      });
+
+      expect(isUsingExternalTracerProvider()).toBe(false);
+      expect(getTracerProvider()).not.toBeNull();
+    });
+
+    it("should skip registration when useExternalTracerProvider is true", async () => {
+      const {
+        initializeOpenTelemetry,
+        isUsingExternalTracerProvider,
+        getTracerProvider,
+        getLangfuseSpanProcessor,
+      } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      expect(isUsingExternalTracerProvider()).toBe(true);
+      expect(getTracerProvider()).toBeNull();
+      expect(getLangfuseSpanProcessor()).not.toBeNull();
+    });
+
+    it("should auto-detect external provider when autoDetectExternalProvider is true", async () => {
+      // Setup: Mock existing provider
+      const { trace } = await import("@opentelemetry/api");
+      vi.mocked(trace.getTracerProvider).mockReturnValue({
+        constructor: { name: "NodeTracerProvider" },
+      } as never);
+
+      const { initializeOpenTelemetry, isUsingExternalTracerProvider } =
+        await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        autoDetectExternalProvider: true,
+      });
+
+      expect(isUsingExternalTracerProvider()).toBe(true);
+    });
+
+    it("should use standalone mode when autoDetect not set (even with ProxyTracerProvider)", async () => {
+      // Setup: Mock ProxyTracerProvider (default no-op)
+      const { trace } = await import("@opentelemetry/api");
+      vi.mocked(trace.getTracerProvider).mockReturnValue({
+        constructor: { name: "ProxyTracerProvider" },
+      } as never);
+
+      // Re-apply NodeTracerProvider mock after resetModules
+      const { NodeTracerProvider } = await import(
+        "@opentelemetry/sdk-trace-node"
+      );
+      vi.mocked(NodeTracerProvider).mockImplementation(
+        () =>
+          ({
+            register: vi.fn(),
+            shutdown: vi.fn().mockResolvedValue(undefined),
+          }) as never,
+      );
+
+      const { initializeOpenTelemetry, isUsingExternalTracerProvider } =
+        await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+      // Standalone mode: enabled=true, no external provider flags
+      // Should create its own TracerProvider, NOT enter external mode
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        // Note: NOT setting autoDetectExternalProvider or useExternalTracerProvider
+      });
+
+      expect(isUsingExternalTracerProvider()).toBe(false);
+    });
+
+    it("should skip initialization when disabled", async () => {
+      const { initializeOpenTelemetry, isOpenTelemetryInitialized } =
+        await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+      initializeOpenTelemetry({
+        enabled: false,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+      });
+
+      expect(isOpenTelemetryInitialized()).toBe(true);
+    });
+
+    it("should skip initialization when missing credentials", async () => {
+      const { initializeOpenTelemetry, getLangfuseHealthStatus } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "",
+        secretKey: "sk-test",
+      });
+
+      const status = getLangfuseHealthStatus();
+      expect(status.credentialsValid).toBe(false);
+    });
+  });
+
+  describe("getSpanProcessors", () => {
+    it("should return span processors when initialized with external mode", async () => {
+      const { initializeOpenTelemetry, getSpanProcessors } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      const processors = getSpanProcessors();
+      expect(processors).toHaveLength(2);
+    });
+
+    it("should return empty array when not initialized", async () => {
+      const { getSpanProcessors } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      const processors = getSpanProcessors();
+      expect(processors).toHaveLength(0);
+    });
+  });
+
+  describe("createContextEnricher", () => {
+    it("should create a new ContextEnricher instance", async () => {
+      const { createContextEnricher } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      const enricher = createContextEnricher();
+      expect(enricher).toBeDefined();
+      expect(enricher.onStart).toBeDefined();
+      expect(enricher.onEnd).toBeDefined();
+      expect(enricher.shutdown).toBeDefined();
+      expect(enricher.forceFlush).toBeDefined();
+    });
+  });
+
+  describe("getLangfuseHealthStatus", () => {
+    it("should include usingExternalProvider in health status", async () => {
+      const { initializeOpenTelemetry, getLangfuseHealthStatus } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      const status = getLangfuseHealthStatus();
+      expect(status).toHaveProperty("usingExternalProvider");
+      expect(status.usingExternalProvider).toBe(true);
+    });
+
+    it("should report healthy status with external provider", async () => {
+      const { initializeOpenTelemetry, getLangfuseHealthStatus } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      const status = getLangfuseHealthStatus();
+      expect(status.isHealthy).toBe(true);
+      expect(status.initialized).toBe(true);
+      expect(status.credentialsValid).toBe(true);
+      expect(status.hasProcessor).toBe(true);
+    });
+  });
+
+  describe("graceful error handling", () => {
+    it("should handle duplicate registration gracefully", async () => {
+      const { NodeTracerProvider } = await import(
+        "@opentelemetry/sdk-trace-node"
+      );
+      vi.mocked(NodeTracerProvider).mockImplementation(
+        () =>
+          ({
+            register: vi.fn().mockImplementation(() => {
+              throw new Error("duplicate registration of API: trace");
+            }),
+            shutdown: vi.fn().mockResolvedValue(undefined),
+          }) as never,
+      );
+
+      const { initializeOpenTelemetry, isUsingExternalTracerProvider } =
+        await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+      // Should not throw
+      expect(() => {
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+      }).not.toThrow();
+
+      // Should have switched to external mode
+      expect(isUsingExternalTracerProvider()).toBe(true);
+    });
+  });
+
+  describe("shutdownOpenTelemetry", () => {
+    it("should not shutdown tracerProvider in external mode", async () => {
+      const mockShutdown = vi.fn().mockResolvedValue(undefined);
+      const { NodeTracerProvider } = await import(
+        "@opentelemetry/sdk-trace-node"
+      );
+      vi.mocked(NodeTracerProvider).mockImplementation(
+        () =>
+          ({
+            register: vi.fn(),
+            shutdown: mockShutdown,
+          }) as never,
+      );
+
+      const { initializeOpenTelemetry, shutdownOpenTelemetry } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      await shutdownOpenTelemetry();
+
+      // TracerProvider.shutdown should NOT be called in external mode
+      expect(mockShutdown).not.toHaveBeenCalled();
+    });
+
+    it("should shutdown tracerProvider in standalone mode", async () => {
+      const mockShutdown = vi.fn().mockResolvedValue(undefined);
+      const { NodeTracerProvider } = await import(
+        "@opentelemetry/sdk-trace-node"
+      );
+      vi.mocked(NodeTracerProvider).mockImplementation(
+        () =>
+          ({
+            register: vi.fn(),
+            shutdown: mockShutdown,
+          }) as never,
+      );
+
+      const { initializeOpenTelemetry, shutdownOpenTelemetry } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+      });
+
+      await shutdownOpenTelemetry();
+
+      // TracerProvider.shutdown SHOULD be called in standalone mode
+      expect(mockShutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe("isUsingExternalTracerProvider", () => {
+    it("should return false by default", async () => {
+      const { isUsingExternalTracerProvider } = await import(
+        "../../../src/lib/services/server/ai/observability/instrumentation.js"
+      );
+
+      expect(isUsingExternalTracerProvider()).toBe(false);
+    });
+
+    it("should return true after external mode initialization", async () => {
+      const { initializeOpenTelemetry, isUsingExternalTracerProvider } =
+        await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+      initializeOpenTelemetry({
+        enabled: true,
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        useExternalTracerProvider: true,
+      });
+
+      expect(isUsingExternalTracerProvider()).toBe(true);
+    });
+  });
+
+  describe("operationName feature", () => {
+    /**
+     * Helper to create a mock span for testing ContextEnricher
+     */
+    function createMockSpan(
+      spanName?: string,
+      traceId: string = "test-trace-id",
+    ) {
+      const attributes: Record<string, unknown> = {};
+      return {
+        name: spanName,
+        setAttribute: vi.fn((key: string, value: unknown) => {
+          attributes[key] = value;
+        }),
+        spanContext: vi.fn(() => ({
+          traceId,
+          spanId: "test-span-id",
+          traceFlags: 1,
+        })),
+        _getAttributes: () => attributes,
+      };
+    }
+
+    describe("auto-detection of operation names", () => {
+      it("should auto-detect operation name from ai.streamText span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.streamText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("ai.streamText");
+        expect(attrs["langfuse.trace.name"]).toBe("guest:ai.streamText");
+      });
+
+      it("should auto-detect operation name from ai.generateText span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.generateText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("ai.generateText");
+      });
+
+      it("should auto-detect operation name from ai.generateObject span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.generateObject");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("ai.generateObject");
+      });
+
+      it("should auto-detect operation name from chat span (OpenTelemetry GenAI convention)", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("chat");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("chat");
+      });
+
+      it("should auto-detect operation name from embeddings span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("embeddings");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("embeddings");
+      });
+
+      it("should auto-detect operation name from text_completion span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("text_completion");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("text_completion");
+      });
+
+      it("should not auto-detect operation name from non-AI span names", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("http.request");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+        expect(attrs["langfuse.trace.name"]).toBe("guest");
+      });
+    });
+
+    describe("explicit operationName in context", () => {
+      it("should override auto-detection when explicit operationName is provided", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext(
+          { operationName: "custom-operation", userId: "user@email.com" },
+          async () => {
+            const mockSpan = createMockSpan("ai.streamText");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            expect(attrs["gen_ai.operation.name"]).toBe("custom-operation");
+            expect(attrs["langfuse.trace.name"]).toBe(
+              "user@email.com:custom-operation",
+            );
+          },
+        );
+      });
+    });
+
+    describe("explicit traceName in context", () => {
+      it("should override everything when explicit traceName is provided (backward compatibility)", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext(
+          {
+            traceName: "my-custom-trace-name",
+            operationName: "custom-operation",
+            userId: "user@email.com",
+          },
+          async () => {
+            const mockSpan = createMockSpan("ai.streamText");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            // traceName should win over everything
+            expect(attrs["langfuse.trace.name"]).toBe("my-custom-trace-name");
+            // But operation name is still set
+            expect(attrs["gen_ai.operation.name"]).toBe("custom-operation");
+          },
+        );
+      });
+
+      it("should use explicit traceName even when no operationName or userId", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext(
+          { traceName: "standalone-trace-name" },
+          async () => {
+            const mockSpan = createMockSpan("some-span");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            expect(attrs["langfuse.trace.name"]).toBe("standalone-trace-name");
+          },
+        );
+      });
+    });
+
+    describe("autoDetectOperationName: false", () => {
+      it("should disable auto-detection when global autoDetectOperationName is false", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          autoDetectOperationName: false,
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.streamText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        // Should not auto-detect operation name
+        expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+        // Should use userId only for trace name
+        expect(attrs["langfuse.trace.name"]).toBe("guest");
+      });
+    });
+
+    describe("context-level autoDetectOperationName override", () => {
+      it("should disable auto-detection for specific context when context autoDetectOperationName is false", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        // Global auto-detect is enabled (default)
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        // But context-level disables it
+        await setLangfuseContext(
+          { autoDetectOperationName: false, userId: "user@test.com" },
+          async () => {
+            const mockSpan = createMockSpan("ai.streamText");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            // Should not auto-detect operation name
+            expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+            // Should use userId only for trace name
+            expect(attrs["langfuse.trace.name"]).toBe("user@test.com");
+          },
+        );
+      });
+
+      it("should enable auto-detection for specific context even when global is disabled", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        // Global auto-detect is disabled
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          autoDetectOperationName: false,
+        });
+
+        const enricher = createContextEnricher();
+
+        // But context-level enables it
+        await setLangfuseContext(
+          { autoDetectOperationName: true, userId: "user@test.com" },
+          async () => {
+            const mockSpan = createMockSpan("ai.streamText");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            // Should auto-detect operation name due to context override
+            expect(attrs["gen_ai.operation.name"]).toBe("ai.streamText");
+            expect(attrs["langfuse.trace.name"]).toBe(
+              "user@test.com:ai.streamText",
+            );
+          },
+        );
+      });
+    });
+
+    describe("custom traceNameFormat function", () => {
+      it("should use custom function for trace name formatting", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: (ctx) =>
+            `[${ctx.operationName || "unknown"}] ${ctx.userId}`,
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.streamText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["langfuse.trace.name"]).toBe("[ai.streamText] guest");
+      });
+
+      it("should handle custom function when operationName is undefined", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: (ctx) =>
+            `[${ctx.operationName || "unknown"}] ${ctx.userId}`,
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("http.request");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["langfuse.trace.name"]).toBe("[unknown] guest");
+      });
+    });
+
+    describe("traceNameFormat string options", () => {
+      it('should format trace name as "userId:operationName" (default)', async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: "userId:operationName",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "john@example.com" }, async () => {
+          const mockSpan = createMockSpan("ai.generateText");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          expect(attrs["langfuse.trace.name"]).toBe(
+            "john@example.com:ai.generateText",
+          );
+        });
+      });
+
+      it('should format trace name as "operationName:userId"', async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: "operationName:userId",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "john@example.com" }, async () => {
+          const mockSpan = createMockSpan("ai.generateText");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          expect(attrs["langfuse.trace.name"]).toBe(
+            "ai.generateText:john@example.com",
+          );
+        });
+      });
+
+      it('should format trace name as "operationName" only', async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: "operationName",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "john@example.com" }, async () => {
+          const mockSpan = createMockSpan("ai.generateText");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          expect(attrs["langfuse.trace.name"]).toBe("ai.generateText");
+        });
+      });
+
+      it('should format trace name as "userId" only', async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: "userId",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "john@example.com" }, async () => {
+          const mockSpan = createMockSpan("ai.generateText");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          expect(attrs["langfuse.trace.name"]).toBe("john@example.com");
+        });
+      });
+    });
+
+    describe("fallback behavior", () => {
+      it("should fall back to userId when no operation detected", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          const mockSpan = createMockSpan("some-random-span");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          // No operation detected, should fall back to userId
+          expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+          expect(attrs["langfuse.trace.name"]).toBe("user@test.com");
+        });
+      });
+
+      it("should fall back to userId when operationName format specified but no operation detected", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          traceNameFormat: "operationName",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          const mockSpan = createMockSpan("http.request");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          // No operation detected with "operationName" format should fall back to userId
+          expect(attrs["langfuse.trace.name"]).toBe("user@test.com");
+        });
+      });
+
+      it("should use guest as default when no userId provided", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("http.request");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["langfuse.trace.name"]).toBe("guest");
+      });
+    });
+
+    describe("span attributes", () => {
+      it("should set gen_ai.operation.name attribute when operation is detected", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.embedText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBe("ai.embedText");
+      });
+
+      it("should set langfuse.trace.name attribute with formatted trace name", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext({ userId: "admin@company.com" }, async () => {
+          const mockSpan = createMockSpan("ai.streamObject");
+          enricher.onStart(mockSpan as never);
+
+          const attrs = mockSpan._getAttributes();
+          expect(attrs["langfuse.trace.name"]).toBe(
+            "admin@company.com:ai.streamObject",
+          );
+          expect(attrs["trace.name"]).toBe("admin@company.com:ai.streamObject");
+        });
+      });
+
+      it("should set both trace.name and langfuse.trace.name for compatibility", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.generateText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["langfuse.trace.name"]).toBe("guest:ai.generateText");
+        expect(attrs["trace.name"]).toBe("guest:ai.generateText");
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle undefined span name gracefully", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan(undefined);
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+        expect(attrs["langfuse.trace.name"]).toBe("guest");
+      });
+
+      it("should handle empty span name gracefully", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["gen_ai.operation.name"]).toBeUndefined();
+        expect(attrs["langfuse.trace.name"]).toBe("guest");
+      });
+
+      it("should handle explicit null operationName in context", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+
+        await setLangfuseContext(
+          { operationName: null, userId: "user@test.com" },
+          async () => {
+            const mockSpan = createMockSpan("ai.streamText");
+            enricher.onStart(mockSpan as never);
+
+            const attrs = mockSpan._getAttributes();
+            // null operationName should still allow auto-detection
+            expect(attrs["gen_ai.operation.name"]).toBe("ai.streamText");
+          },
+        );
+      });
+
+      it("should use config userId when context userId is not set", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const { initializeOpenTelemetry, createContextEnricher } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+          userId: "config-user@test.com",
+        });
+
+        const enricher = createContextEnricher();
+        const mockSpan = createMockSpan("ai.streamText");
+
+        enricher.onStart(mockSpan as never);
+
+        const attrs = mockSpan._getAttributes();
+        expect(attrs["langfuse.trace.name"]).toBe(
+          "config-user@test.com:ai.streamText",
+        );
+        expect(attrs["user.id"]).toBe("config-user@test.com");
+      });
+    });
+
+    describe("wrapper span support (trace-root spans)", () => {
+      /**
+       * Helper to create a mock span for testing onEnd() with trace-root
+       */
+      function createMockSpanWithAttributes(
+        spanName: string,
+        initialAttributes: Record<string, unknown> = {},
+        traceId: string = "test-trace-id",
+      ) {
+        const attributes: Record<string, unknown> = { ...initialAttributes };
+        return {
+          name: spanName,
+          setAttribute: vi.fn((key: string, value: unknown) => {
+            attributes[key] = value;
+          }),
+          spanContext: vi.fn(() => ({
+            traceId,
+            spanId: "test-span-id",
+            traceFlags: 1,
+          })),
+          attributes,
+          _getAttributes: () => attributes,
+        };
+      }
+
+      it("should update trace-root span name in onEnd() with detected operation", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const traceId = "shared-trace-id-123";
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          // Step 1: Wrapper span starts (no AI operation detected yet)
+          const wrapperSpan = createMockSpanWithAttributes(
+            "langfuse-trace",
+            { "user.id": "user@test.com" },
+            traceId,
+          );
+          enricher.onStart(wrapperSpan as never);
+
+          // Wrapper span should have userId only at this point
+          expect(wrapperSpan._getAttributes()["langfuse.trace.name"]).toBe(
+            "user@test.com",
+          );
+
+          // Step 2: AI SDK span starts (operation detected)
+          const aiSpan = createMockSpanWithAttributes(
+            "ai.streamText",
+            {},
+            traceId,
+          );
+          enricher.onStart(aiSpan as never);
+
+          // Step 3: AI SDK span ends
+          enricher.onEnd(aiSpan as never);
+
+          // Step 4: Wrapper (trace-root) span ends - should update trace name
+          wrapperSpan.attributes["langfuse.span.type"] = "trace-root";
+          enricher.onEnd(wrapperSpan as never);
+
+          // Trace name should be updated with detected operation
+          expect(wrapperSpan.setAttribute).toHaveBeenCalledWith(
+            "langfuse.trace.name",
+            "user@test.com:ai.streamText",
+          );
+          expect(wrapperSpan.setAttribute).toHaveBeenCalledWith(
+            "gen_ai.operation.name",
+            "ai.streamText",
+          );
+        });
+      });
+
+      it("should not override explicit traceName on trace-root span", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const traceId = "trace-with-explicit-name";
+
+        await setLangfuseContext(
+          { userId: "user@test.com", traceName: "my-explicit-trace" },
+          async () => {
+            // Wrapper span with explicit traceName
+            const wrapperSpan = createMockSpanWithAttributes(
+              "langfuse-trace",
+              {
+                "user.id": "user@test.com",
+                "langfuse.trace.name": "my-explicit-trace",
+              },
+              traceId,
+            );
+            enricher.onStart(wrapperSpan as never);
+
+            // AI SDK span
+            const aiSpan = createMockSpanWithAttributes(
+              "ai.generateText",
+              {},
+              traceId,
+            );
+            enricher.onStart(aiSpan as never);
+            enricher.onEnd(aiSpan as never);
+
+            // Wrapper span ends
+            wrapperSpan.attributes["langfuse.span.type"] = "trace-root";
+
+            // Clear mock to check what happens in onEnd
+            wrapperSpan.setAttribute.mockClear();
+            enricher.onEnd(wrapperSpan as never);
+
+            // Should NOT override the explicit traceName
+            const setAttrCalls = wrapperSpan.setAttribute.mock.calls;
+            const traceNameCall = setAttrCalls.find(
+              (call: unknown[]) => call[0] === "langfuse.trace.name",
+            );
+            expect(traceNameCall).toBeUndefined();
+          },
+        );
+      });
+
+      it("should handle multiple AI operations - use first detected", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const traceId = "multi-operation-trace";
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          const wrapperSpan = createMockSpanWithAttributes(
+            "langfuse-trace",
+            { "user.id": "user@test.com" },
+            traceId,
+          );
+          enricher.onStart(wrapperSpan as never);
+
+          // First AI operation
+          const aiSpan1 = createMockSpanWithAttributes(
+            "ai.streamText",
+            {},
+            traceId,
+          );
+          enricher.onStart(aiSpan1 as never);
+
+          // Second AI operation (should not override first)
+          const aiSpan2 = createMockSpanWithAttributes(
+            "ai.generateObject",
+            {},
+            traceId,
+          );
+          enricher.onStart(aiSpan2 as never);
+
+          enricher.onEnd(aiSpan1 as never);
+          enricher.onEnd(aiSpan2 as never);
+
+          wrapperSpan.attributes["langfuse.span.type"] = "trace-root";
+          enricher.onEnd(wrapperSpan as never);
+
+          // Should use first detected operation
+          expect(wrapperSpan.setAttribute).toHaveBeenCalledWith(
+            "langfuse.trace.name",
+            "user@test.com:ai.streamText",
+          );
+        });
+      });
+
+      it("should not update non-trace-root spans in onEnd()", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const traceId = "non-trace-root-test";
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          // Regular span (not trace-root)
+          const regularSpan = createMockSpanWithAttributes(
+            "http-handler",
+            { "user.id": "user@test.com" },
+            traceId,
+          );
+          enricher.onStart(regularSpan as never);
+
+          // AI span
+          const aiSpan = createMockSpanWithAttributes(
+            "ai.streamText",
+            {},
+            traceId,
+          );
+          enricher.onStart(aiSpan as never);
+          enricher.onEnd(aiSpan as never);
+
+          // Regular span ends (no trace-root attribute)
+          regularSpan.setAttribute.mockClear();
+          enricher.onEnd(regularSpan as never);
+
+          // Should NOT update trace name on non-trace-root spans
+          const setAttrCalls = regularSpan.setAttribute.mock.calls;
+          const traceNameCall = setAttrCalls.find(
+            (call: unknown[]) => call[0] === "langfuse.trace.name",
+          );
+          expect(traceNameCall).toBeUndefined();
+        });
+      });
+
+      it("should cleanup detected operations after trace-root span ends", async () => {
+        const { NodeTracerProvider } = await import(
+          "@opentelemetry/sdk-trace-node"
+        );
+        vi.mocked(NodeTracerProvider).mockImplementation(
+          () =>
+            ({
+              register: vi.fn(),
+              shutdown: vi.fn().mockResolvedValue(undefined),
+            }) as never,
+        );
+
+        const {
+          initializeOpenTelemetry,
+          createContextEnricher,
+          setLangfuseContext,
+        } = await import(
+          "../../../src/lib/services/server/ai/observability/instrumentation.js"
+        );
+
+        initializeOpenTelemetry({
+          enabled: true,
+          publicKey: "pk-test",
+          secretKey: "sk-test",
+        });
+
+        const enricher = createContextEnricher();
+        const traceId = "cleanup-test-trace";
+
+        await setLangfuseContext({ userId: "user@test.com" }, async () => {
+          // First trace
+          const wrapperSpan1 = createMockSpanWithAttributes(
+            "langfuse-trace",
+            { "user.id": "user@test.com" },
+            traceId,
+          );
+          enricher.onStart(wrapperSpan1 as never);
+
+          const aiSpan1 = createMockSpanWithAttributes(
+            "ai.streamText",
+            {},
+            traceId,
+          );
+          enricher.onStart(aiSpan1 as never);
+          enricher.onEnd(aiSpan1 as never);
+
+          wrapperSpan1.attributes["langfuse.span.type"] = "trace-root";
+          enricher.onEnd(wrapperSpan1 as never);
+
+          // Second trace with same traceId should start fresh
+          const wrapperSpan2 = createMockSpanWithAttributes(
+            "langfuse-trace",
+            { "user.id": "user@test.com" },
+            traceId,
+          );
+          enricher.onStart(wrapperSpan2 as never);
+
+          // No AI span this time
+          wrapperSpan2.attributes["langfuse.span.type"] = "trace-root";
+          wrapperSpan2.setAttribute.mockClear();
+          enricher.onEnd(wrapperSpan2 as never);
+
+          // Should NOT have operation from previous trace
+          const setAttrCalls = wrapperSpan2.setAttribute.mock.calls;
+          const opNameCall = setAttrCalls.find(
+            (call: unknown[]) => call[0] === "gen_ai.operation.name",
+          );
+          expect(opNameCall).toBeUndefined();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for integrating NeuroLink's Langfuse observability with applications that have existing OpenTelemetry instrumentation.

### Key Features

- **External TracerProvider Mode**: Skip internal TracerProvider creation when host app already has OpenTelemetry
- **Operation Name Auto-Detection**: Automatically extract operation names from Vercel AI SDK spans (e.g., `ai.streamText`, `ai.generateText`)
- **Configurable Trace Name Formats**: Flexible trace naming with predefined formats or custom functions
- **Wrapper Span Support**: Correctly handle cases where host apps create trace-root spans before AI operations
- **Auto-Registration**: Automatically register processors with global TracerProvider in external mode
- **peerDependencies Migration**: Share OpenTelemetry global state with host applications

### New Configuration Options

```typescript
const neurolink = new NeuroLink({
  observability: {
    langfuse: {
      enabled: true,
      publicKey: "...",
      secretKey: "...",
      // NEW OPTIONS
      useExternalTracerProvider: true,     // Skip internal TracerProvider
      autoDetectExternalProvider: true,    // Auto-detect existing provider
      autoDetectOperationName: true,       // Extract operation from span names
      traceNameFormat: "userId:operationName", // Trace name format
    },
  },
});
```

### New Exports

| Export | Description |
|--------|-------------|
| `getSpanProcessors()` | Get `[ContextEnricher, LangfuseSpanProcessor]` for external providers |
| `createContextEnricher()` | Factory for ContextEnricher processor |
| `isUsingExternalTracerProvider()` | Check if in external mode |
| `getLangfuseSpanProcessor()` | Get Langfuse processor instance |
| `getTracerProvider()` | Get internal TracerProvider (null in external mode) |
| `getLangfuseContext()` | Get current request's Langfuse context |
| `getTracer(name?)` | Get a tracer instance |
| `TraceNameFormat` | Type for trace name format options |

### Breaking Changes

⚠️ **peerDependencies**: The following packages are now peer dependencies. Host applications must install them directly:

- `@opentelemetry/api@^1.9.0`
- `@opentelemetry/sdk-trace-node@^2.0.0`
- `@opentelemetry/sdk-trace-base@^2.0.0`

This change ensures NeuroLink shares the same OpenTelemetry global state as the host application, fixing auto-registration and trace correlation issues.

### Files Changed

- **Core Implementation**: `instrumentation.ts` (+692 lines)
- **Types**: `observability.ts` (+124 lines)
- **Exports**: `index.ts` (+22 lines)
- **Package**: Moved OpenTelemetry to peerDependencies
- **Documentation**: 11 new doc files, updated existing docs
- **Tests**: 50 new unit tests (1,846 lines)

## Test Plan

- [x] Run unit tests: `pnpm test test/unit/observability/`
- [x] All 50 tests pass
- [x] Build succeeds: `pnpm build`
- [ ] Manual testing in Curator (host application)
- [ ] Verify Langfuse traces show correct trace names (e.g., `user@email.com:ai.streamText`)
- [ ] Verify auto-registration works without manual `getSpanProcessors()` calls

## Related Issues

Fixes trace name appearing as empty string in Langfuse when using external TracerProvider mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External TracerProvider support and standalone OpenTelemetry mode
  * Automatic operation-name detection and customizable trace-name formats
  * Expanded context fields (conversationId, requestId, traceName, metadata, operationName)
  * New public observability APIs for tracer/span processor access

* **Documentation**
  * Comprehensive Observability Guide, API docs, examples, and README updates

* **Tests**
  * Extensive unit tests covering external provider flows, naming, and lifecycle

* **Chores**
  * Updated dependency declarations to peer/dev dependency model for OpenTelemetry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->