### PR TITLE
fix(landing): sync lockfile and add blog links

### DIFF
--- a/landing/pnpm-lock.yaml
+++ b/landing/pnpm-lock.yaml
@@ -28,13 +28,13 @@ importers:
         specifier: ^6.2.4
         version: 6.2.4(svelte@5.50.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
       '@tailwindcss/vite':
-        specifier: ^4.1.18
+        specifier: ^4.1.13
         version: 4.1.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
       prettier-plugin-svelte:
-        specifier: ^3.4.1
+        specifier: ^3.4.0
         version: 3.4.1(prettier@3.8.1)(svelte@5.50.1)
       svelte:
         specifier: ^5.49.2

--- a/landing/src/lib/components/Footer.svelte
+++ b/landing/src/lib/components/Footer.svelte
@@ -45,6 +45,7 @@
           label: "Discussions",
           href: "https://github.com/juspay/neurolink/discussions",
         },
+        { label: "Blog", href: "https://blog.neurolink.ink" },
         {
           label: "NPM Package",
           href: "https://www.npmjs.com/package/@juspay/neurolink",

--- a/landing/src/lib/components/Navbar.svelte
+++ b/landing/src/lib/components/Navbar.svelte
@@ -8,6 +8,7 @@
     { label: "Docs", href: "https://docs.neurolink.ink/docs/getting-started" },
     { label: "SDK", href: "https://docs.neurolink.ink/docs/sdk/api-reference" },
     { label: "CLI", href: "https://docs.neurolink.ink/docs/cli/commands" },
+    { label: "Blog", href: "https://blog.neurolink.ink" },
     { label: "GitHub", href: "https://github.com/juspay/neurolink" },
   ];
 


### PR DESCRIPTION
## Summary
- Regenerate `pnpm-lock.yaml` to match corrected dependency versions (`@tailwindcss/vite` ^4.1.13, `prettier-plugin-svelte` ^3.4.0), fixing Vercel build failure (`ERR_PNPM_OUTDATED_LOCKFILE`)
- Add `blog.neurolink.ink` links to Navbar and Footer components

## Test plan
- [ ] Vercel build succeeds (lockfile in sync with package.json)
- [ ] Blog link visible in navbar between CLI and GitHub
- [ ] Blog link visible in footer under Community column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Blog link to navigation bar
  * Added Blog link to footer Community section

Both links direct to https://blog.neurolink.ink

<!-- end of auto-generated comment: release notes by coderabbit.ai -->