### PR TITLE
fix(landing): dynamic GSAP imports for SSR compatibility

### DIFF
--- a/landing/src/lib/actions/reveal.ts
+++ b/landing/src/lib/actions/reveal.ts
@@ -1,10 +1,3 @@
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/ScrollTrigger";
-
-if (typeof window !== "undefined") {
-  gsap.registerPlugin(ScrollTrigger);
-}
-
 interface RevealOptions {
   y?: number;
   x?: number;
@@ -17,11 +10,10 @@ interface RevealOptions {
   stagger?: number;
 }
 
+let registered = false;
+
 export function reveal(node: HTMLElement, options: RevealOptions = {}) {
-  if (
-    typeof window !== "undefined" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  ) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     return { destroy() {} };
   }
 
@@ -37,24 +29,36 @@ export function reveal(node: HTMLElement, options: RevealOptions = {}) {
     stagger,
   } = options;
 
-  const target = stagger ? node.children : node;
+  let tween: any;
 
-  const tween = gsap.from(target, {
-    y,
-    x,
-    scale,
-    opacity,
-    duration,
-    delay,
-    ease,
-    stagger: stagger || 0,
-    scrollTrigger: { trigger: node, start, once: true },
-  });
+  (async () => {
+    const { gsap } = await import("gsap");
+    const { ScrollTrigger } = await import("gsap/ScrollTrigger");
+
+    if (!registered) {
+      gsap.registerPlugin(ScrollTrigger);
+      registered = true;
+    }
+
+    const target = stagger ? node.children : node;
+
+    tween = gsap.from(target, {
+      y,
+      x,
+      scale,
+      opacity,
+      duration,
+      delay,
+      ease,
+      stagger: stagger || 0,
+      scrollTrigger: { trigger: node, start, once: true },
+    });
+  })();
 
   return {
     destroy() {
-      tween.scrollTrigger?.kill();
-      tween.kill();
+      tween?.scrollTrigger?.kill();
+      tween?.kill();
     },
   };
 }


### PR DESCRIPTION
## Summary
- Top-level GSAP/ScrollTrigger imports in `reveal.ts` crash during SSR on Vercel's Node.js runtime, causing **500 errors** on every page load
- Switch to dynamic `import()` inside the action function so GSAP is only loaded client-side
- Plugin registration is cached with a `registered` flag to avoid redundant calls

## Root cause
```typescript
// BEFORE (fails in Node.js)
import { gsap } from "gsap";
import { ScrollTrigger } from "gsap/ScrollTrigger";

// AFTER (loads only in browser)
const { gsap } = await import("gsap");
const { ScrollTrigger } = await import("gsap/ScrollTrigger");
```

## Test plan
- [ ] Vercel deployment no longer returns 500
- [ ] Scroll-triggered reveal animations still work on all sections
- [ ] Reduced-motion preference still respected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized reveal animation performance and stability through improved module loading and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->