### PR TITLE
fix: add ffprobe-static type reference for ncc build

### DIFF
--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -43,6 +43,8 @@
  * ```
  */
 
+/// <reference path="./ffprobe-static.d.ts" />
+
 import { randomUUID } from "crypto";
 import type { FfprobeData, FfprobeStream } from "fluent-ffmpeg";
 import ffmpegCommand from "fluent-ffmpeg";


### PR DESCRIPTION
## Summary
- Adds `/// <reference path="./ffprobe-static.d.ts" />` to `VideoProcessor.ts` so the `ncc` build (used for GitHub Action packaging) can resolve the `ffprobe-static` ambient type declaration
- The regular TypeScript build picks up `.d.ts` files automatically, but `ncc` follows imports from the entry point and misses ambient declarations in non-imported files

## Root Cause
The `build:action` step (`ncc build src/action/index.ts`) compiles TypeScript independently and doesn't discover the `ffprobe-static.d.ts` ambient module declaration alongside `VideoProcessor.ts`. This causes `TS7016: Could not find a declaration file for module 'ffprobe-static'`.

## Test plan
- [x] Verified `pnpm run build:action` passes locally
- [x] Verified `pnpm run build` passes locally
- [x] Verified `pnpm run format:check` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type declarations for enhanced development tooling support. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->