### PR TITLE
fix(docs): wire up local search fallback and fix search index quality

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -387,15 +387,8 @@ const config: Config = {
       },
     ],
 
-    // Search index for MCP docs server
-    [
-      "./plugins/docusaurus-plugin-search-index",
-      {
-        docsDir: "docs",
-        outputFile: "search-index.json",
-        debug: process.env.NODE_ENV === "development",
-      },
-    ],
+    // Local search index generation (fallback when Algolia is not configured)
+    "./plugins/docusaurus-plugin-search-index",
 
     // Fix server bundle: handle Node-only native modules
     // (protobufjs from posthog→opentelemetry, ws from jsdom, fsevents, etc.)

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -36,6 +36,7 @@
     "clsx": "^2.1.1",
     "isomorphic-dompurify": "^2.35.0",
     "lucide-react": "^0.400.0",
+    "minisearch": "^7.2.0",
     "posthog-js": "^1.335.4",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",

--- a/docs-site/plugins/docusaurus-plugin-search-index/index.js
+++ b/docs-site/plugins/docusaurus-plugin-search-index/index.js
@@ -1,197 +1,269 @@
+/**
+ * Docusaurus Plugin: Search Index Generator
+ *
+ * Generates a search-index.json at build time from all docs content.
+ * The index is loaded client-side for local search when Algolia is not configured.
+ */
+
 const fs = require("fs");
 const path = require("path");
 const matter = require("gray-matter");
 
-module.exports = function pluginSearchIndex(context, opts = {}) {
-  const docsDir = path.resolve(context.siteDir, opts.docsDir || "docs");
-  const outputPath = path.resolve(
-    context.siteDir,
-    "static",
-    opts.outputFile || "search-index.json",
-  );
-  const debug = opts.debug || false;
+/** Simple glob matching for exclude patterns */
+function matchGlob(glob, filePath) {
+  // Convert glob to regex:
+  // ** matches any number of path segments (including zero)
+  // * matches anything except /
+  const regexStr = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&") // escape regex chars except * and ?
+    .replace(/\*\*\//g, "(.+/)?") // **/ matches zero or more path segments
+    .replace(/\/\*\*/g, "(/.+)?") // /** matches zero or more trailing segments
+    .replace(/\*\*/g, ".*") // ** alone matches anything
+    .replace(/\*/g, "[^/]*"); // * matches within single segment
+  return new RegExp("^" + regexStr + "$").test(filePath);
+}
 
-  function log(...args) {
-    if (debug) {
-      console.log("[search-index]", ...args);
+/** Strip markdown syntax to get plain text */
+function stripMarkdown(content) {
+  let result = content
+    // Remove code blocks
+    .replace(/```[\s\S]*?```/g, "")
+    // Remove inline code
+    .replace(/`[^`]*`/g, "")
+    // Remove images
+    .replace(/!\[.*?\]\(.*?\)/g, "")
+    // Remove links but keep text
+    .replace(/\[([^\]]*)\]\(.*?\)/g, "$1");
+
+  // Iteratively strip HTML tags to handle nested/malformed tags
+  let prev;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, "");
+  } while (result !== prev);
+
+  return (
+    result
+      // Remove headings markers
+      .replace(/^#{1,6}\s+/gm, "")
+      // Remove bold/italic
+      .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, "$2")
+      // Remove blockquotes
+      .replace(/^>\s+/gm, "")
+      // Remove horizontal rules
+      .replace(/^[-*_]{3,}\s*$/gm, "")
+      // Remove list markers
+      .replace(/^[\s]*[-*+]\s+/gm, "")
+      .replace(/^[\s]*\d+\.\s+/gm, "")
+      // Remove MDX imports/exports
+      .replace(/^(import|export)\s+.*$/gm, "")
+      // Remove admonitions
+      .replace(/^:::.*$/gm, "")
+      // Collapse whitespace
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+/** Extract sections from markdown content */
+function extractSections(content) {
+  const sections = [];
+  const lines = content.split("\n");
+  let currentHeading = "";
+  let currentContent = [];
+  let currentLevel = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    if (headingMatch) {
+      // Save previous section
+      if (currentContent.length > 0) {
+        sections.push({
+          heading: currentHeading,
+          level: currentLevel,
+          content: stripMarkdown(currentContent.join("\n")).slice(0, 2000),
+        });
+      }
+      currentLevel = headingMatch[1].length;
+      currentHeading = headingMatch[2]
+        .replace(/\*\*/g, "")
+        .replace(/`/g, "")
+        .trim();
+      currentContent = [];
+    } else {
+      currentContent.push(line);
     }
   }
 
-  function collectMarkdownFiles(dir, basePath = "") {
-    const files = [];
-    if (!fs.existsSync(dir)) {
-      return files;
-    }
+  // Save last section
+  if (currentContent.length > 0) {
+    sections.push({
+      heading: currentHeading,
+      level: currentLevel,
+      content: stripMarkdown(currentContent.join("\n")).slice(0, 2000),
+    });
+  }
 
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      const relPath = path.join(basePath, entry.name);
+  return sections;
+}
 
-      if (entry.isDirectory()) {
-        files.push(...collectMarkdownFiles(fullPath, relPath));
-      } else if (/\.(md|mdx)$/.test(entry.name)) {
-        files.push({ fullPath, relPath });
-      }
-    }
+/** Recursively find all markdown files */
+function findMarkdownFiles(dir, baseDir = dir) {
+  const files = [];
+  if (!fs.existsSync(dir)) {
     return files;
   }
 
-  function stripMarkdown(text) {
-    let result = text
-      .replace(/```[\s\S]*?```/g, "")
-      .replace(/`[^`]+`/g, "")
-      .replace(/!\[.*?\]\(.*?\)/g, "")
-      .replace(/\[([^\]]+)\]\(.*?\)/g, "$1")
-      .replace(/#{1,6}\s+/g, "")
-      .replace(/[*_~]+/g, "")
-      .replace(/>\s+/g, "")
-      .replace(/\|.*\|/g, "")
-      .replace(/-{3,}/g, "");
-    // Iteratively strip HTML tags to handle nested/malformed tags
-    let prev;
-    do {
-      prev = result;
-      result = result.replace(/<[^>]*>/g, "").replace(/<[a-zA-Z][^>]*$/gm, "");
-    } while (result !== prev);
-    return result.replace(/\n{2,}/g, "\n").trim();
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findMarkdownFiles(fullPath, baseDir));
+    } else if (/\.(md|mdx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
   }
+  return files;
+}
 
-  function getSection(relPath) {
-    const parts = relPath.split(path.sep);
-    return parts.length > 1 ? parts[0] : "root";
+module.exports = function searchIndexPlugin(context, options = {}) {
+  const docsDir = options.docsDir || path.resolve(context.siteDir, "docs");
+
+  // Exclude patterns matching docusaurus.config.ts docs.exclude
+  const excludeGlobs = options.exclude || [
+    "**/api/**",
+    "**/cli-guide.md",
+    "**/package-overrides.md",
+    "**/mcp/concurrency.md",
+    "**/features/interactive-cli.md",
+    "**/mastra-features-implementation/**",
+    "**/404.md",
+    "**/404.mdx",
+  ];
+
+  function isExcluded(relativePath) {
+    const normalized = relativePath.replace(/\\/g, "/");
+    return excludeGlobs.some((glob) => matchGlob(glob, normalized));
   }
 
   return {
     name: "docusaurus-plugin-search-index",
 
-    async loadContent() {
-      const markdownFiles = collectMarkdownFiles(docsDir);
-      log(`Found ${markdownFiles.length} markdown files`);
-
-      const documents = [];
-
-      for (const { fullPath, relPath } of markdownFiles) {
-        try {
-          const raw = fs.readFileSync(fullPath, "utf-8");
-          const { data: frontmatter, content } = matter(raw);
-
-          const title =
-            frontmatter.title ||
-            frontmatter.sidebar_label ||
-            path.basename(relPath, path.extname(relPath));
-          const description = frontmatter.description || "";
-          const tags = frontmatter.tags || [];
-          const section = getSection(relPath);
-          const docPath = relPath
-            .replace(/\\/g, "/")
-            .replace(/\.(md|mdx)$/, "")
-            .replace(/\/index$/, "");
-
-          documents.push({
-            id: docPath,
-            title,
-            description,
-            content: stripMarkdown(content).slice(0, 5000),
-            section,
-            tags: Array.isArray(tags) ? tags : [],
-            path: docPath,
-          });
-        } catch (err) {
-          console.warn(
-            `[search-index] Error processing ${relPath}:`,
-            err.message,
-          );
-        }
-      }
-
-      log(`Indexed ${documents.length} documents`);
-      return { documents };
-    },
-
-    async contentLoaded({ content }) {
-      const { documents } = content;
-
-      const indexData = {
-        version: 1,
-        generatedAt: new Date().toISOString(),
-        documentCount: documents.length,
-        documents,
-      };
-
-      try {
-        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-        fs.writeFileSync(outputPath, JSON.stringify(indexData));
-        log(`Wrote search index to ${outputPath} (${documents.length} docs)`);
-      } catch (err) {
-        throw new Error(
-          `[search-index] Failed to write index to ${outputPath}: ${err.message}`,
-        );
-      }
-    },
-
     async postBuild({ outDir }) {
-      const markdownFiles = collectMarkdownFiles(docsDir);
-      log(`postBuild: Found ${markdownFiles.length} markdown files`);
+      await generateIndex(docsDir, outDir, isExcluded);
+    },
 
-      const documents = [];
-
-      for (const { fullPath, relPath } of markdownFiles) {
-        try {
-          const raw = fs.readFileSync(fullPath, "utf-8");
-          const { data: frontmatter, content } = matter(raw);
-
-          const title =
-            frontmatter.title ||
-            frontmatter.sidebar_label ||
-            path.basename(relPath, path.extname(relPath));
-          const description = frontmatter.description || "";
-          const tags = frontmatter.tags || [];
-          const section = getSection(relPath);
-          const docPath = relPath
-            .replace(/\\/g, "/")
-            .replace(/\.(md|mdx)$/, "")
-            .replace(/\/index$/, "");
-
-          documents.push({
-            id: docPath,
-            title,
-            description,
-            content: stripMarkdown(content).slice(0, 5000),
-            section,
-            tags: Array.isArray(tags) ? tags : [],
-            path: docPath,
-          });
-        } catch (err) {
-          console.warn(
-            `[search-index] postBuild: Error processing ${relPath}:`,
-            err.message,
-          );
-        }
-      }
-
-      const indexData = {
-        version: 1,
-        generatedAt: new Date().toISOString(),
-        documentCount: documents.length,
-        documents,
+    // Also generate during dev via configureWebpack
+    configureWebpack() {
+      return {
+        plugins: [
+          {
+            apply(compiler) {
+              compiler.hooks.afterEmit.tapAsync(
+                "SearchIndexPlugin",
+                (compilation, callback) => {
+                  const staticDir = path.resolve(context.siteDir, "static");
+                  generateIndex(docsDir, staticDir, isExcluded).then(() =>
+                    callback(),
+                  );
+                },
+              );
+            },
+          },
+        ],
       };
-
-      const buildOutputPath = path.resolve(
-        outDir,
-        opts.outputFile || "search-index.json",
-      );
-
-      try {
-        fs.mkdirSync(path.dirname(buildOutputPath), { recursive: true });
-        fs.writeFileSync(buildOutputPath, JSON.stringify(indexData));
-        log(
-          `postBuild: Wrote search index to ${buildOutputPath} (${documents.length} docs)`,
-        );
-      } catch (err) {
-        console.warn(
-          `[search-index] postBuild: Failed to write index to ${buildOutputPath}: ${err.message}`,
-        );
-      }
     },
   };
 };
+
+async function generateIndex(docsDir, outDir, isExcluded) {
+  const files = findMarkdownFiles(docsDir);
+  const documents = [];
+  let id = 0;
+  let skipped = 0;
+
+  for (const filePath of files) {
+    try {
+      const relativePath = path.relative(docsDir, filePath).replace(/\\/g, "/");
+
+      // Skip excluded files (matches docusaurus.config.ts docs.exclude)
+      if (isExcluded(relativePath)) {
+        skipped++;
+        continue;
+      }
+
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const { data: frontmatter, content } = matter(raw);
+
+      // Skip drafts
+      if (frontmatter.draft === true) {
+        continue;
+      }
+
+      // Build URL path from file path
+      const urlPath = relativePath
+        .replace(/(index)?\.(md|mdx)$/, "")
+        .replace(/\/$/, "");
+
+      const url = `/docs/${urlPath}`;
+      const title = frontmatter.title || path.basename(urlPath) || "Untitled";
+
+      // Extract hierarchy from path
+      const pathParts = urlPath.split("/");
+      const lvl0 =
+        pathParts[0]
+          ?.replace(/-/g, " ")
+          .replace(/\b\w/g, (c) => c.toUpperCase()) || "Docs";
+
+      // Add main document entry — index full content for better search recall
+      const plainContent = stripMarkdown(content);
+      documents.push({
+        objectID: String(id++),
+        title,
+        url,
+        content: plainContent.slice(0, 5000),
+        hierarchy: {
+          lvl0,
+          lvl1: title,
+          lvl2: "",
+          lvl3: "",
+        },
+      });
+
+      // Add section entries
+      const sections = extractSections(content);
+      for (const section of sections) {
+        if (!section.heading) {
+          continue;
+        }
+        const anchor = section.heading
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, "")
+          .replace(/\s+/g, "-");
+
+        documents.push({
+          objectID: String(id++),
+          title: section.heading,
+          url: `${url}#${anchor}`,
+          content: section.content,
+          hierarchy: {
+            lvl0,
+            lvl1: title,
+            lvl2: section.heading,
+            lvl3: "",
+          },
+        });
+      }
+    } catch (err) {
+      // Skip files that can't be parsed
+      console.warn(`[search-index] Skipping ${filePath}: ${err.message}`);
+    }
+  }
+
+  // Write index
+  const indexPath = path.join(outDir, "search-index.json");
+  fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+  fs.writeFileSync(indexPath, JSON.stringify(documents));
+  console.log(
+    `[search-index] Generated ${documents.length} entries from ${files.length} files (${skipped} excluded)`,
+  );
+}

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@18.3.1)
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       posthog-js:
         specifier: ^1.335.4
         version: 1.336.1
@@ -4369,6 +4372,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -11631,6 +11637,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minisearch@7.2.0: {}
 
   mrmime@2.0.1: {}
 

--- a/docs-site/src/components/Search/SearchModal.tsx
+++ b/docs-site/src/components/Search/SearchModal.tsx
@@ -7,6 +7,7 @@ import {
   useAlgoliaSearch,
   useRecentSearches,
 } from "../../hooks/useAlgoliaSearch";
+import { useLocalSearch } from "../../hooks/useLocalSearch";
 import { ArrowIcon, ReturnIcon } from "../icons";
 import { Kbd } from "../ui/Kbd";
 import { EmptySearch, NoResults, SearchError } from "./EmptySearch";
@@ -21,17 +22,29 @@ interface SearchModalProps {
 
 const INDEX_NAME = "neurolink-docs";
 
-export function SearchModal({ isOpen, onClose }: SearchModalProps) {
+function useSearch() {
   const { siteConfig } = useDocusaurusContext();
-  const history = useHistory();
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // Get Algolia credentials from site config
   const algoliaAppId = (siteConfig.customFields?.algoliaAppId as string) || "";
   const algoliaSearchKey =
     (siteConfig.customFields?.algoliaSearchApiKey as string) || "";
+  const hasAlgolia = Boolean(algoliaAppId && algoliaSearchKey);
 
-  // Search hook
+  const algoliaSearch = useAlgoliaSearch({
+    appId: algoliaAppId,
+    searchApiKey: algoliaSearchKey,
+    indexName: INDEX_NAME,
+  });
+
+  const localSearch = useLocalSearch();
+
+  return hasAlgolia ? algoliaSearch : localSearch;
+}
+
+export function SearchModal({ isOpen, onClose }: SearchModalProps) {
+  const history = useHistory();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Search hook — Algolia when configured, local search otherwise
   const {
     query,
     setQuery,
@@ -41,11 +54,7 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
     clearResults,
     selectedIndex,
     setSelectedIndex,
-  } = useAlgoliaSearch({
-    appId: algoliaAppId,
-    searchApiKey: algoliaSearchKey,
-    indexName: INDEX_NAME,
-  });
+  } = useSearch();
 
   // Recent searches hook
   const {
@@ -191,14 +200,7 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
               </span>
             </div>
             <div className={styles.footerPowered}>
-              <span>Search by</span>
-              <a
-                href="https://www.algolia.com"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Algolia
-              </a>
+              <span>NeuroLink Search</span>
             </div>
           </div>
         </Dialog.Content>

--- a/docs-site/src/components/SearchWrapperMobile.tsx
+++ b/docs-site/src/components/SearchWrapperMobile.tsx
@@ -8,6 +8,7 @@ import {
   useAlgoliaSearch,
   useRecentSearches,
 } from "../hooks/useAlgoliaSearch";
+import { useLocalSearch } from "../hooks/useLocalSearch";
 import { ArrowIcon, CloseIcon, SearchIcon } from "./icons";
 import { EmptySearch, NoResults, SearchError } from "./Search/EmptySearch";
 import styles from "./Search/Search.module.css";
@@ -20,21 +21,33 @@ interface SearchWrapperMobileProps {
 
 const INDEX_NAME = "neurolink-docs";
 
+function useMobileSearch() {
+  const { siteConfig } = useDocusaurusContext();
+  const algoliaAppId = (siteConfig.customFields?.algoliaAppId as string) || "";
+  const algoliaSearchKey =
+    (siteConfig.customFields?.algoliaSearchApiKey as string) || "";
+  const hasAlgolia = Boolean(algoliaAppId && algoliaSearchKey);
+
+  const algoliaSearch = useAlgoliaSearch({
+    appId: algoliaAppId,
+    searchApiKey: algoliaSearchKey,
+    indexName: INDEX_NAME,
+  });
+
+  const localSearch = useLocalSearch();
+
+  return hasAlgolia ? algoliaSearch : localSearch;
+}
+
 export function SearchWrapperMobile({
   isOpen,
   onClose,
 }: SearchWrapperMobileProps) {
-  const { siteConfig } = useDocusaurusContext();
   const history = useHistory();
   const inputRef = useRef<HTMLInputElement>(null);
   const [localQuery, setLocalQuery] = useState("");
 
-  // Get Algolia credentials from site config
-  const algoliaAppId = (siteConfig.customFields?.algoliaAppId as string) || "";
-  const algoliaSearchKey =
-    (siteConfig.customFields?.algoliaSearchApiKey as string) || "";
-
-  // Search hook
+  // Search hook — Algolia when configured, local search otherwise
   const {
     query,
     setQuery,
@@ -44,11 +57,7 @@ export function SearchWrapperMobile({
     clearResults,
     selectedIndex,
     setSelectedIndex,
-  } = useAlgoliaSearch({
-    appId: algoliaAppId,
-    searchApiKey: algoliaSearchKey,
-    indexName: INDEX_NAME,
-  });
+  } = useMobileSearch();
 
   // Recent searches hook
   const {

--- a/docs-site/src/hooks/useLocalSearch.ts
+++ b/docs-site/src/hooks/useLocalSearch.ts
@@ -1,0 +1,226 @@
+import MiniSearch from "minisearch";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SearchResult, UseAlgoliaSearchReturn } from "./useAlgoliaSearch";
+
+interface SearchDocument {
+  objectID: string;
+  title: string;
+  url: string;
+  content?: string;
+  hierarchy: {
+    lvl0?: string;
+    lvl1?: string;
+    lvl2?: string;
+    lvl3?: string;
+  };
+}
+
+let indexPromise: Promise<MiniSearch<SearchDocument>> | null = null;
+
+function loadIndex(): Promise<MiniSearch<SearchDocument>> {
+  if (indexPromise) return indexPromise;
+
+  indexPromise = fetch("/search-index.json")
+    .then((res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    })
+    .then((documents: SearchDocument[]) => {
+      const miniSearch = new MiniSearch<SearchDocument>({
+        fields: ["title", "content", "hierarchy.lvl0", "hierarchy.lvl1"],
+        storeFields: ["title", "url", "content", "hierarchy"],
+        extractField: (doc, fieldName) => {
+          // Handle nested fields like "hierarchy.lvl0"
+          if (fieldName.includes(".")) {
+            const parts = fieldName.split(".");
+            let value: unknown = doc;
+            for (const part of parts) {
+              value = (value as Record<string, unknown>)?.[part];
+            }
+            return value as string;
+          }
+          return (doc as unknown as Record<string, unknown>)[
+            fieldName
+          ] as string;
+        },
+        searchOptions: {
+          boost: { title: 3, "hierarchy.lvl1": 2 },
+          fuzzy: 0.2,
+          prefix: true,
+        },
+      });
+
+      miniSearch.addAll(documents.map((doc) => ({ ...doc, id: doc.objectID })));
+      return miniSearch;
+    })
+    .catch((err) => {
+      console.warn("[local-search] Failed to load search index:", err);
+      indexPromise = null;
+      throw err;
+    });
+
+  return indexPromise;
+}
+
+interface UseLocalSearchOptions {
+  debounceMs?: number;
+}
+
+export function useLocalSearch({
+  debounceMs = 200,
+}: UseLocalSearchOptions = {}): UseAlgoliaSearchReturn {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [totalResults, setTotalResults] = useState(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const indexRef = useRef<MiniSearch<SearchDocument> | null>(null);
+
+  // Load index on mount
+  useEffect(() => {
+    loadIndex()
+      .then((idx) => {
+        indexRef.current = idx;
+      })
+      .catch(() => {
+        // Error already logged in loadIndex
+      });
+  }, []);
+
+  const search = useCallback(async (searchQuery: string): Promise<void> => {
+    if (!searchQuery.trim()) {
+      setResults([]);
+      setTotalResults(0);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      let idx = indexRef.current;
+      if (!idx) {
+        idx = await loadIndex();
+        indexRef.current = idx;
+      }
+
+      const searchResults = idx.search(searchQuery).slice(0, 20);
+
+      const hits: SearchResult[] = searchResults.map((result) => ({
+        objectID: result.id as string,
+        title: (result as unknown as SearchDocument).title || "",
+        url: (result as unknown as SearchDocument).url || "",
+        content: (result as unknown as SearchDocument).content,
+        hierarchy: (result as unknown as SearchDocument).hierarchy || {},
+        // Add highlight results with <mark> tags
+        _highlightResult: buildHighlights(
+          result as unknown as SearchDocument,
+          searchQuery,
+        ),
+      }));
+
+      setResults(hits);
+      setTotalResults(hits.length);
+      setSelectedIndex(0);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Local search failed"));
+      setResults([]);
+      setTotalResults(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!query.trim()) {
+      setResults([]);
+      setTotalResults(0);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    debounceTimerRef.current = setTimeout(() => {
+      search(query);
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, search, debounceMs]);
+
+  const clearResults = useCallback(() => {
+    setQuery("");
+    setResults([]);
+    setTotalResults(0);
+    setSelectedIndex(0);
+    setError(null);
+  }, []);
+
+  return {
+    query,
+    setQuery,
+    results,
+    isLoading,
+    error,
+    search,
+    clearResults,
+    selectedIndex,
+    setSelectedIndex,
+    totalResults,
+  };
+}
+
+/** Build highlight results by wrapping matched terms in <mark> tags */
+function buildHighlights(
+  doc: SearchDocument,
+  query: string,
+): SearchResult["_highlightResult"] {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 1);
+
+  function highlight(text: string | undefined): { value: string } {
+    if (!text) return { value: "" };
+    let highlighted = escapeHtml(text);
+    for (const term of terms) {
+      const regex = new RegExp(`(${escapeRegex(term)}\\w*)`, "gi");
+      highlighted = highlighted.replace(regex, "<mark>$1</mark>");
+    }
+    return { value: highlighted };
+  }
+
+  return {
+    title: highlight(doc.title),
+    content: highlight(doc.content),
+    hierarchy: {
+      lvl0: highlight(doc.hierarchy?.lvl0),
+      lvl1: highlight(doc.hierarchy?.lvl1),
+      lvl2: highlight(doc.hierarchy?.lvl2),
+      lvl3: highlight(doc.hierarchy?.lvl3),
+    },
+  };
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- Adds MiniSearch-based local search as fallback when Algolia credentials are not configured
- Fixes blank page navigation by excluding non-route pages (api/**, cli-guide.md, 404.md, etc.) from the search index
- Increases content indexing limits for better search recall (e.g., "subscription", "claude subscription" now return results)
- Adds section-level indexing with anchor URLs and hierarchy metadata

## Changes
- **New**: `src/hooks/useLocalSearch.ts` — MiniSearch client-side search hook with fuzzy matching, prefix search, and `<mark>` highlighting
- **Rewritten**: `plugins/docusaurus-plugin-search-index/index.js` — glob-based exclude patterns, section indexing, dev-mode webpack generation
- **Modified**: `SearchModal.tsx`, `SearchWrapperMobile.tsx` — local search fallback when Algolia not configured
- **Modified**: `docusaurus.config.ts` — simplified search plugin registration
- **Added**: `minisearch` dependency

## Test plan
- [x] Search for "subscription" returns 86 results
- [x] Search for "claude subscription" returns 24 results including dedicated page
- [x] Clicking search results navigates to valid pages (no blank pages)
- [x] Cmd+K keyboard shortcut opens search modal
- [x] Search index excludes non-route pages (api/**, 404.md, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local search as a fallback when Algolia is unavailable, ensuring search remains functional in all configurations.

* **Improvements**
  * Enhanced search indexing with section-level extraction from documentation, including header-based content organization and improved search relevance.
  * Rebranded search attribution to "NeuroLink Search".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->