### PR TITLE
fix(docs): sync query on Algolia fallback and add Algolia index push

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -81,6 +81,13 @@ jobs:
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
 
+      - name: Push search index to Algolia
+        if: ${{ env.ALGOLIA_APP_ID != '' && env.ALGOLIA_ADMIN_API_KEY != '' }}
+        run: node scripts/push-algolia-index.js
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_ADMIN_API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs-site/scripts/push-algolia-index.js
+++ b/docs-site/scripts/push-algolia-index.js
@@ -1,0 +1,188 @@
+/**
+ * Push search-index.json to Algolia using atomic index replacement.
+ *
+ * Usage:
+ *   ALGOLIA_APP_ID=... ALGOLIA_ADMIN_API_KEY=... node scripts/push-algolia-index.js
+ *
+ * Reads the build-time generated search-index.json and replaces the Algolia
+ * index contents atomically via a temporary index + move operation, so live
+ * search is never interrupted.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const INDEX_NAME = "neurolink_docs_v1";
+const TMP_INDEX_NAME = `${INDEX_NAME}_tmp`;
+
+async function main() {
+  const appId = process.env.ALGOLIA_APP_ID;
+  const adminKey = process.env.ALGOLIA_ADMIN_API_KEY;
+
+  if (!appId || !adminKey) {
+    console.error(
+      "Missing ALGOLIA_APP_ID or ALGOLIA_ADMIN_API_KEY environment variables",
+    );
+    process.exit(1);
+  }
+
+  // Find the search index — prefer build output, fall back to static
+  const buildPath = path.join(__dirname, "..", "build", "search-index.json");
+  const staticPath = path.join(__dirname, "..", "static", "search-index.json");
+  const indexPath = fs.existsSync(buildPath) ? buildPath : staticPath;
+
+  if (!fs.existsSync(indexPath)) {
+    console.error(`Search index not found at ${buildPath} or ${staticPath}`);
+    console.error("Run the docs build first to generate search-index.json");
+    process.exit(1);
+  }
+
+  const records = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+  console.log(`Loaded ${records.length} records from ${indexPath}`);
+
+  const headers = {
+    "X-Algolia-Application-Id": appId,
+    "X-Algolia-API-Key": adminKey,
+    "Content-Type": "application/json",
+  };
+
+  const tmpBaseUrl = `https://${appId}.algolia.net/1/indexes/${TMP_INDEX_NAME}`;
+
+  // Step 1: Clear the temporary index
+  console.log(`Clearing temporary index "${TMP_INDEX_NAME}"...`);
+  const clearResp = await fetch(`${tmpBaseUrl}/clear`, {
+    method: "POST",
+    headers,
+  });
+  if (!clearResp.ok) {
+    const err = await clearResp.text();
+    console.error(`Failed to clear temp index: ${clearResp.status} ${err}`);
+    process.exit(1);
+  }
+  const clearResult = await clearResp.json();
+  await waitForTask(appId, TMP_INDEX_NAME, headers, clearResult.taskID);
+
+  // Step 2: Configure settings on the temporary index
+  console.log("Configuring index settings on temp index...");
+  const settingsResp = await fetch(`${tmpBaseUrl}/settings`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({
+      searchableAttributes: [
+        "title",
+        "hierarchy.lvl0",
+        "hierarchy.lvl1",
+        "hierarchy.lvl2",
+        "hierarchy.lvl3",
+        "content",
+      ],
+      attributesToRetrieve: [
+        "title",
+        "url",
+        "hierarchy",
+        "content",
+        "objectID",
+      ],
+      attributesToHighlight: [
+        "title",
+        "content",
+        "hierarchy.lvl0",
+        "hierarchy.lvl1",
+        "hierarchy.lvl2",
+        "hierarchy.lvl3",
+      ],
+      highlightPreTag: "<mark>",
+      highlightPostTag: "</mark>",
+      attributesToSnippet: ["content:30"],
+      distinct: true,
+      attributeForDistinct: "url",
+    }),
+  });
+
+  if (!settingsResp.ok) {
+    const err = await settingsResp.text();
+    console.error(`Failed to configure settings: ${settingsResp.status} ${err}`);
+    process.exit(1);
+  }
+  const settingsResult = await settingsResp.json();
+  await waitForTask(appId, TMP_INDEX_NAME, headers, settingsResult.taskID);
+
+  // Step 3: Batch upload records to the temporary index
+  const BATCH_SIZE = 1000;
+  let uploaded = 0;
+
+  for (let i = 0; i < records.length; i += BATCH_SIZE) {
+    const batch = records.slice(i, i + BATCH_SIZE);
+    const requests = batch.map((record) => ({
+      action: "addObject",
+      body: record,
+    }));
+
+    const batchResp = await fetch(`${tmpBaseUrl}/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ requests }),
+    });
+
+    if (!batchResp.ok) {
+      const err = await batchResp.text();
+      console.error(`Batch upload failed: ${batchResp.status} ${err}`);
+      process.exit(1);
+    }
+
+    const batchResult = await batchResp.json();
+    await waitForTask(appId, TMP_INDEX_NAME, headers, batchResult.taskID);
+
+    uploaded += batch.length;
+    console.log(`Uploaded ${uploaded}/${records.length} records`);
+  }
+
+  // Step 4: Atomically move temp index to production index
+  console.log(
+    `Atomically replacing "${INDEX_NAME}" with "${TMP_INDEX_NAME}"...`,
+  );
+  const moveResp = await fetch(
+    `https://${appId}.algolia.net/1/indexes/${TMP_INDEX_NAME}/operation`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operation: "move",
+        destination: INDEX_NAME,
+      }),
+    },
+  );
+
+  if (!moveResp.ok) {
+    const err = await moveResp.text();
+    console.error(`Failed to move index: ${moveResp.status} ${err}`);
+    process.exit(1);
+  }
+
+  const moveResult = await moveResp.json();
+  await waitForTask(appId, TMP_INDEX_NAME, headers, moveResult.taskID);
+
+  console.log(
+    `Done! Pushed ${records.length} records to Algolia index "${INDEX_NAME}" (zero-downtime swap)`,
+  );
+}
+
+async function waitForTask(appId, indexName, headers, taskID) {
+  const url = `https://${appId}.algolia.net/1/indexes/${indexName}/task/${taskID}`;
+  for (let i = 0; i < 30; i++) {
+    const resp = await fetch(url, { headers });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.status === "published") {
+        return;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  console.warn(`Task ${taskID} did not complete within 30s, continuing...`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/docs-site/src/components/Search/SearchModal.tsx
+++ b/docs-site/src/components/Search/SearchModal.tsx
@@ -42,7 +42,7 @@ function useSearch() {
     if (algoliaSearch.error && algoliaSearch.query) {
       localSearch.setQuery(algoliaSearch.query);
     }
-  }, [algoliaSearch.error, algoliaSearch.query, localSearch]);
+  }, [algoliaSearch.error, algoliaSearch.query, localSearch.setQuery]);
 
   // Fall back to local search if Algolia is not configured or errors out
   if (!hasAlgolia || algoliaSearch.error) {

--- a/docs-site/src/components/SearchWrapperMobile.tsx
+++ b/docs-site/src/components/SearchWrapperMobile.tsx
@@ -41,7 +41,7 @@ function useMobileSearch() {
     if (algoliaSearch.error && algoliaSearch.query) {
       localSearch.setQuery(algoliaSearch.query);
     }
-  }, [algoliaSearch.error, algoliaSearch.query, localSearch]);
+  }, [algoliaSearch.error, algoliaSearch.query, localSearch.setQuery]);
 
   // Fall back to local search if Algolia is not configured or errors out
   if (!hasAlgolia || algoliaSearch.error) {


### PR DESCRIPTION
## Summary

Follow-up to PR #856. Adds:

- **Query sync on fallback**: When Algolia errors out and search falls back to local MiniSearch, the user's typed query is preserved via a `useEffect` that syncs `algoliaSearch.query` → `localSearch.setQuery()` (fixes CodeRabbit review comment on #856)
- **Algolia index push script**: `docs-site/scripts/push-algolia-index.js` — reads `search-index.json` and pushes all records to the `neurolink_docs_v1` Algolia index with proper settings
- **CI integration**: Added "Push search index to Algolia" step to `docs-deploy.yml` that runs after build (gated on `ALGOLIA_ADMIN_API_KEY` secret)

## Test plan

- [x] TypeScript type-check clean
- [ ] Verify query preservation: type query → Algolia errors → local search shows results for same query
- [ ] Verify Algolia push: run `node scripts/push-algolia-index.js` manually with admin key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search indexing infrastructure now includes automated synchronization with external search service during deployment.

* **Bug Fixes**
  * Improved search reliability: automatically falls back to local search if the external search service becomes unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->