### PR TITLE
fix(vision): allow unknown models for proxy providers in vision check

### DIFF
--- a/src/lib/adapters/providerImageAdapter.ts
+++ b/src/lib/adapters/providerImageAdapter.ts
@@ -45,6 +45,26 @@ const IMAGE_LIMITS = {
 } as const;
 
 /**
+ * Proxy providers that route to arbitrary underlying models.
+ * Vision capability cannot be statically determined for these — pass requests
+ * through and let the underlying provider surface errors if needed.
+ */
+const PROXY_PROVIDERS = new Set(["litellm", "openrouter"]);
+
+/**
+ * Normalize provider name/alias to its canonical form for vision checks.
+ */
+function normalizeVisionProvider(provider: string): string {
+  const lower = provider.toLowerCase();
+  switch (lower) {
+    case "or":
+      return "openrouter";
+    default:
+      return lower;
+  }
+}
+
+/**
  * Vision capability definitions for each provider
  */
 const VISION_CAPABILITIES = {
@@ -697,7 +717,7 @@ export class ProviderImageAdapter {
    * Validate that provider and model support vision
    */
   private static validateVisionSupport(provider: string, model: string): void {
-    const normalizedProvider = provider.toLowerCase();
+    const normalizedProvider = normalizeVisionProvider(provider);
     const supportedModels =
       VISION_CAPABILITIES[
         normalizedProvider as keyof typeof VISION_CAPABILITIES
@@ -713,6 +733,12 @@ export class ProviderImageAdapter {
     const isSupported = supportedModels.some((supportedModel) =>
       model.toLowerCase().includes(supportedModel.toLowerCase()),
     );
+
+    // Proxy providers route to arbitrary underlying models — skip the allowlist
+    // check for unknown models and let the underlying provider error if needed.
+    if (!isSupported && PROXY_PROVIDERS.has(normalizedProvider)) {
+      return;
+    }
 
     if (!isSupported) {
       throw new Error(
@@ -772,7 +798,7 @@ export class ProviderImageAdapter {
    */
   static supportsVision(provider: string, model?: string): boolean {
     try {
-      const normalizedProvider = provider.toLowerCase();
+      const normalizedProvider = normalizeVisionProvider(provider);
       const supportedModels =
         VISION_CAPABILITIES[
           normalizedProvider as keyof typeof VISION_CAPABILITIES
@@ -786,9 +812,17 @@ export class ProviderImageAdapter {
         return true; // Provider supports vision, but need to check specific model
       }
 
-      return supportedModels.some((supportedModel) =>
+      const modelMatched = supportedModels.some((supportedModel) =>
         model.toLowerCase().includes(supportedModel.toLowerCase()),
       );
+
+      // Proxy providers route to arbitrary underlying models — pass through if
+      // the model isn't in the known allowlist.
+      if (!modelMatched && PROXY_PROVIDERS.has(normalizedProvider)) {
+        return true;
+      }
+
+      return modelMatched;
     } catch {
       return false;
     }

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -632,9 +632,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
           );
         }
         tools =
-          Object.keys(sanitized.tools).length > 0
-            ? sanitized.tools
-            : undefined;
+          Object.keys(sanitized.tools).length > 0 ? sanitized.tools : undefined;
       } else {
         tools = undefined;
       }

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -1145,9 +1145,7 @@ export class GoogleVertexProvider extends BaseProvider {
           );
         }
         tools =
-          Object.keys(sanitized.tools).length > 0
-            ? sanitized.tools
-            : undefined;
+          Object.keys(sanitized.tools).length > 0 ? sanitized.tools : undefined;
       } else if (isAnthropic && Object.keys(rawTools).length > 0) {
         // Anthropic models don't need Gemini sanitization — pass tools through
         tools = rawTools;


### PR DESCRIPTION
## Problem

When using the `litellm` provider with a custom/private model name (e.g. `private-large`), NeuroLink threw a pre-flight error even though the underlying model supported vision:

```
Provider litellm with model private-large does not support vision processing.
Supported providers: openai, google-ai, anthropic, azure, vertex, litellm, ...
```

## Root Cause

`ProviderImageAdapter.supportsVision()` and `validateVisionSupport()` use a hardcoded `VISION_CAPABILITIES` allowlist to validate model names. The check uses substring matching against known public model names — custom/private models never match.

**LiteLLM and OpenRouter are proxy providers** that route requests to arbitrary underlying models. NeuroLink cannot know in advance what models are deployed behind them, so a static allowlist is inherently incomplete for these providers.

## Fix

Added a `PROXY_PROVIDERS` constant (`["litellm", "openrouter"]`). In both vision check locations, if the model name doesn't match the allowlist **and** the provider is a proxy, the request is passed through instead of rejected.

The underlying provider (LiteLLM/OpenRouter) will naturally surface an error if the model truly doesn't support vision — no silent failures.

## Behaviour After Fix

| Scenario | Before | After |
|---|---|---|
| `litellm` + known model (e.g. `gpt-4o`) | ✅ passes | ✅ passes |
| `litellm` + custom model (e.g. `private-large`) | ❌ pre-flight error | ✅ passes through |
| `openrouter` + unknown model | ❌ pre-flight error | ✅ passes through |
| Non-proxy provider + unsupported model | ❌ throws (correct) | ❌ throws (unchanged) |

## Files Changed

- `src/lib/adapters/providerImageAdapter.ts` — patched `supportsVision()` and `validateVisionSupport()`
- `src/lib/providers/googleAiStudio.ts`, `googleVertex.ts` — pre-existing prettier formatting fixes (unblocked pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy providers now allow additional vision models by deferring validation to the underlying provider instead of relying solely on a static allowlist, reducing false rejections for unknown models.

* **Style**
  * Minor code formatting refinements for clearer conditional expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->