### PR TITLE
feat(provider): Add support to pass fallback provider through stream …

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -6161,7 +6161,12 @@ Current user's request: ${currentInput}`;
       /* non-blocking */
     }
 
-    const fallbackRoute = ModelRouter.getFallbackRoute(
+    const optFallbackProvider = enhancedOptions.fallbackProvider || undefined;
+    const optFallbackModel = enhancedOptions.fallbackModel || undefined;
+    const envFallbackProvider = process.env.FALLBACK_PROVIDER || undefined;
+    const envFallbackModel = process.env.FALLBACK_MODEL || undefined;
+
+    const modelConfigRoute = ModelRouter.getFallbackRoute(
       originalPrompt || enhancedOptions.input.text || "",
       {
         provider: providerName,
@@ -6172,9 +6177,23 @@ Current user's request: ${currentInput}`;
       { fallbackStrategy: "auto" },
     );
 
+    const fallbackRoute = {
+      ...modelConfigRoute,
+      provider:
+        optFallbackProvider ?? envFallbackProvider ?? modelConfigRoute.provider,
+      model: optFallbackModel ?? envFallbackModel ?? modelConfigRoute.model,
+    };
+
     logger.warn("Retrying with fallback provider", {
       originalProvider: providerName,
       fallbackProvider: fallbackRoute.provider,
+      fallbackModel: fallbackRoute.model,
+      fallbackSource:
+        optFallbackProvider || optFallbackModel
+          ? "options"
+          : envFallbackProvider || envFallbackModel
+            ? "env"
+            : "model_config",
       reason: errorMsg,
     });
 

--- a/src/lib/types/streamTypes.ts
+++ b/src/lib/types/streamTypes.ts
@@ -473,6 +473,8 @@ export type StreamOptions = {
    * @internal Set by NeuroLink SDK — not typically used directly by consumers.
    */
   fileRegistry?: unknown;
+  fallbackProvider?: string;
+  fallbackModel?: string;
 };
 
 /**


### PR DESCRIPTION
## Pull Request

### Description
**What does this PR do?**  
Adds support for specifying a fallback provider through stream options or environment variables, improving reliability when primary providers are unavailable.

---

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

---

### Changes Made
- Modified `src/lib/neurolink.ts` to support fallback provider configuration via stream options and environment variables  
- Updated `src/lib/types/streamTypes.ts` with new type definitions for fallback provider support  
- Added 21 lines of new functionality across 2 files  

---

### Breaking Changes
- [x] No breaking changes

---

### Testing
- [x] Manual testing completed  
- [x] Tested with multiple providers: primary provider, fallback provider support  

---

### Code Quality
- [x] Code follows the project's style guidelines (ESLint passes)  
- [x] Code is properly formatted (Prettier applied)  
- [x] TypeScript strict mode compliance  
- [x] Proper error handling implemented  

---

### Commit Message Format
- [x] Commit message follows format: `type(scope): description`  
- [x] Valid type used: `feat`  
- [x] Scope specified: `provider`  

**Commit:**  
`feat(provider): Add support to pass fallback provider through stream options or env`

---

### Dependencies
- [x] No dependency changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-call fallback provider and model configuration in streaming requests. Users can now directly specify custom fallback providers and models in request options, with automatic fallback to environment variables and model configuration defaults. This enhancement provides granular control over error recovery routing and provider selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->