### PR TITLE
chore(deps): update landing dependencies

### DIFF
--- a/landing/package.json
+++ b/landing/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-vercel": "^6.3.1",
-    "@sveltejs/kit": "^2.50.2",
+    "@sveltejs/kit": "^2.55.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.1.13",
     "prettier": "^3.8.1",
@@ -34,5 +34,13 @@
     "lucide-svelte": "^0.563.0",
     "satori": "^0.19.2",
     "satori-html": "^0.3.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "tar": ">=7.5.11",
+      "devalue": ">=5.6.4",
+      "rollup": ">=4.59.0",
+      "minimatch": ">=10.2.3"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Updates landing page dependencies to resolve open dependabot PRs.

### Changes
- `@sveltejs/kit` ^2.50.2 → ^2.55.0
- Added pnpm overrides for transitive security dependencies:
  - `tar` >=7.5.11
  - `devalue` >=5.6.4
  - `rollup` >=4.59.0
  - `minimatch` >=10.2.3

### Supersedes
- #871 (tar 7.5.7 → 7.5.11)
- #869 (devalue 5.6.2 → 5.6.4)
- #840 (rollup 4.57.1 → 4.59.0)
- #838 (minimatch 10.1.2 → 10.2.3)
- #829 (@sveltejs/kit 2.50.2 → 2.52.2)

All closed PRs are resolved by this single change.

## Test plan
- [x] Landing page builds successfully (`pnpm run build` in landing/)
- [x] Landing page verified with browser agent (all content renders, no broken assets, navigation works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to maintain security and compatibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->