### PR TITLE
feat(tools): add per-tool timeout, maxRetries at registration and error category metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     }
   },
   "dependencies": {
-    "@juspay/hippocampus": "^0.1.3",
     "@ai-sdk/anthropic": "^3.0.50",
     "@ai-sdk/azure": "^3.0.38",
     "@ai-sdk/google": "^3.0.34",
@@ -185,6 +184,7 @@
     "@google/genai": "^1.43.0",
     "@google/generative-ai": "^0.24.1",
     "@huggingface/inference": "^4.13.14",
+    "@juspay/hippocampus": "^0.1.3",
     "@langfuse/otel": "^5.0.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@openrouter/ai-sdk-provider": "^2.2.3",
@@ -195,7 +195,7 @@
     "@opentelemetry/sdk-node": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "adm-zip": "^0.5.16",
-    "ai": "^6.0.105",
+    "ai": "^6.0.134",
     "chalk": "^5.6.2",
     "csv-parser": "^3.2.0",
     "dotenv": "^17.3.1",
@@ -233,21 +233,21 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "optionalDependencies": {
-    "@hono/node-server": "^1.19.9",
-    "canvas": "^3.2.1",
-    "express-rate-limit": "^8.2.1",
-    "ffmpeg-static": "^5.3.0",
-    "ffprobe-static": "^3.1.0",
-    "sharp": "^0.34.5",
-    "@fastify/rate-limit": "^10.3.0",
-    "fastify": "^5.7.2",
     "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^10.3.0",
+    "@hono/node-server": "^1.19.9",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^15.3.1",
+    "canvas": "^3.2.1",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.2.1",
+    "fastify": "^5.7.2",
+    "ffmpeg-static": "^5.3.0",
+    "ffprobe-static": "^3.1.0",
     "koa": "^3.1.1",
     "koa-bodyparser": "^4.4.1",
-    "express": "^5.1.0",
-    "cors": "^2.8.5"
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@actions/core": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.2.3
-        version: 2.3.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
+        version: 2.3.3(ai@6.0.134(zod@4.3.6))(zod@4.3.6)
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.71.0
         version: 0.71.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))
@@ -120,8 +120,8 @@ importers:
         specifier: ^0.5.16
         version: 0.5.16
       ai:
-        specifier: ^6.0.105
-        version: 6.0.116(zod@4.3.6)
+        specifier: ^6.0.134
+        version: 6.0.134(zod@4.3.6)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -481,8 +481,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.66':
-    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
+  '@ai-sdk/gateway@3.0.77':
+    resolution: {integrity: sha512-UdwIG2H2YMuntJQ5L+EmED5XiwnlvDT3HOmKfVFxR4Nq/RSLFA/HcchhwfNXHZ5UJjyuL2VO0huLbWSZ9ijemQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -543,6 +543,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.19':
     resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.21':
+    resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4164,8 +4170,8 @@ packages:
       react:
         optional: true
 
-  ai@6.0.116:
-    resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+  ai@6.0.134:
+    resolution: {integrity: sha512-YalNEaavld/kE444gOcsMKXdVVRGEe0SK77fAFcWYcqLg+a7xKnEet8bdfrEAJTfnMjj01rhgrIL10903w1a5Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8523,10 +8529,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.77(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
@@ -8604,6 +8610,13 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -10829,9 +10842,9 @@ snapshots:
       ai: 4.3.19(react@19.2.0)(zod@3.25.76)
       zod: 3.25.76
 
-  '@openrouter/ai-sdk-provider@2.3.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)':
+  '@openrouter/ai-sdk-provider@2.3.3(ai@6.0.134(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      ai: 6.0.116(zod@4.3.6)
+      ai: 6.0.134(zod@4.3.6)
       zod: 4.3.6
 
   '@opentelemetry/api-logs@0.202.0':
@@ -13887,11 +13900,11 @@ snapshots:
     optionalDependencies:
       react: 19.2.0
 
-  ai@6.0.116(zod@4.3.6):
+  ai@6.0.134(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.77(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 

--- a/src/lib/core/modules/ToolsManager.ts
+++ b/src/lib/core/modules/ToolsManager.ts
@@ -50,6 +50,7 @@ export class ToolsManager {
   protected toolExecutor?: (
     toolName: string,
     params: unknown,
+    options?: Record<string, unknown>,
   ) => Promise<unknown>;
 
   // Session context
@@ -95,7 +96,7 @@ export class ToolsManager {
     try {
       // Store custom tools for use in getAllTools()
       this.customTools = sdk.customTools;
-      this.toolExecutor = sdk.executeTool;
+      this.toolExecutor = sdk.executeTool.bind(sdk);
 
       logger.debug(`[${functionTag}] Setting up tool executor for provider`, {
         providerName: this.providerName,
@@ -383,6 +384,10 @@ export class ToolsManager {
       description?: string;
       parameters?: unknown;
       inputSchema?: unknown;
+      /** Per-tool timeout in milliseconds, set at registration time */
+      timeoutMs?: number;
+      /** Per-tool max retries, set at registration time */
+      maxRetries?: number;
     },
   ): Promise<Tool | null> {
     try {
@@ -439,7 +444,28 @@ export class ToolsManager {
             // Route through NeuroLink.executeTool() when available for MCP enhancement support
             // (cache, middleware, annotations, circuit breaker, routing)
             if (this.toolExecutor) {
-              const result = await this.toolExecutor(toolName, params);
+              // Per-tool timeout and retries flow through the customTools map
+              // (set at registration via ToolRegistrationOptions).
+              // The execute wrapper in registerTool already enforces timeouts,
+              // but we also forward them to toolExecutor for MCP-level handling.
+              const toolTimeoutMs = toolInfo.timeoutMs;
+              const toolMaxRetries = toolInfo.maxRetries;
+              const hasRegistrationOptions =
+                toolTimeoutMs !== undefined || toolMaxRetries !== undefined;
+              const result = await this.toolExecutor(
+                toolName,
+                params,
+                hasRegistrationOptions
+                  ? {
+                      ...(toolTimeoutMs !== undefined && {
+                        timeout: toolTimeoutMs,
+                      }),
+                      ...(toolMaxRetries !== undefined && {
+                        maxRetries: toolMaxRetries,
+                      }),
+                    }
+                  : undefined,
+              );
 
               const convertedResult = this.utilities?.convertToolResult
                 ? await this.utilities.convertToolResult(result)

--- a/src/lib/mcp/toolRegistry.ts
+++ b/src/lib/mcp/toolRegistry.ts
@@ -215,6 +215,12 @@ export class MCPToolRegistry extends MCPRegistry {
       // For other tools, use fully-qualified serverId.toolName to avoid collisions
       const isCustomTool = serverId.startsWith("custom-tool-");
       const toolId = isCustomTool ? tool.name : `${serverId}.${tool.name}`;
+      const toolTimeoutMs = serverInfo.metadata?.toolTimeoutMs as
+        | number
+        | undefined;
+      const toolMaxRetries = serverInfo.metadata?.toolMaxRetries as
+        | number
+        | undefined;
       const toolInfo = {
         name: tool.name,
         description: tool.description,
@@ -226,6 +232,8 @@ export class MCPToolRegistry extends MCPRegistry {
           serverId: serverInfo.id,
         }),
         permissions: [], // MCPServerInfo.tools doesn't have permissions
+        ...(toolTimeoutMs !== undefined && { timeoutMs: toolTimeoutMs }),
+        ...(toolMaxRetries !== undefined && { maxRetries: toolMaxRetries }),
       };
 
       // Register only with fully-qualified toolId to avoid collisions
@@ -244,6 +252,8 @@ export class MCPToolRegistry extends MCPRegistry {
           existingCategory: serverInfo.metadata?.category,
           serverId: serverInfo.id,
         }),
+        ...(toolTimeoutMs !== undefined && { timeoutMs: toolTimeoutMs }),
+        ...(toolMaxRetries !== undefined && { maxRetries: toolMaxRetries }),
       });
 
       // Tool registered successfully

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -154,6 +154,7 @@ import type {
   ToolExecutionContext,
   ToolExecutionSummary,
   ToolInfo,
+  ToolRegistrationOptions,
 } from "./types/tools.js";
 import type {
   BatchOperationResult,
@@ -269,6 +270,25 @@ function classifyMcpErrorMessage(
     return "validation_error";
   }
   return "unknown";
+}
+
+function mcpCategoryToErrorCategory(
+  mcpCategory: ReturnType<typeof classifyMcpErrorMessage>,
+): ErrorCategory {
+  switch (mcpCategory) {
+    case "not_found":
+      return ErrorCategory.VALIDATION;
+    case "permission_denied":
+      return ErrorCategory.PERMISSION;
+    case "timeout":
+      return ErrorCategory.TIMEOUT;
+    case "rate_limited":
+      return ErrorCategory.RESOURCE;
+    case "validation_error":
+      return ErrorCategory.VALIDATION;
+    case "unknown":
+      return ErrorCategory.EXECUTION;
+  }
 }
 
 /**
@@ -464,6 +484,7 @@ export class NeuroLink {
       failedExecutions: number;
       averageExecutionTime: number;
       lastExecutionTime: number;
+      errorCategories: Record<string, number>;
     }
   > = new Map();
 
@@ -488,13 +509,15 @@ export class NeuroLink {
     error?: Error,
   ): void {
     // Emit tool end event (NeuroLink format - enhanced with result/error)
+    // Serialize error to string for consumer compatibility (event listeners
+    // commonly check `typeof event.error === "string"`).
     this.emitter.emit("tool:end", {
       toolName,
       responseTime: Date.now() - startTime,
       success,
       timestamp: Date.now(),
       result: result, // Enhanced: include actual result
-      error: error, // Enhanced: include error if present
+      error: error ? error.message : undefined, // Emit as string, not Error object
     });
   }
   // Conversation memory support
@@ -1089,6 +1112,12 @@ export class NeuroLink {
                 metadata: { toolName, serverId: "direct", executionTime: 0 },
               };
             } catch (error) {
+              // Known limitation: this non-throwing error path returns
+              // { success: false } without recording errorCategories in
+              // toolExecutionMetrics. These are internal file-tool failures
+              // (low frequency), so the risk of metric gaps is minimal.
+              // A full fix would require access to the metrics map here,
+              // which is not available in the registration closure.
               return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error),
@@ -1208,6 +1237,12 @@ export class NeuroLink {
             try {
               return await toolDef.execute(params);
             } catch (error) {
+              // Known limitation: this non-throwing error path returns
+              // { success: false } without recording errorCategories in
+              // toolExecutionMetrics. These are internal memory-tool failures
+              // (low frequency), so the risk of metric gaps is minimal.
+              // A full fix would require access to the metrics map here,
+              // which is not available in the registration closure.
               return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error),
@@ -7185,7 +7220,11 @@ Current user's request: ${currentInput}`;
    * @param name - Unique name for the tool
    * @param tool - Tool in MCPExecutableTool format (unified MCP protocol type)
    */
-  registerTool(name: string, tool: MCPExecutableTool): void {
+  registerTool(
+    name: string,
+    tool: MCPExecutableTool,
+    options?: ToolRegistrationOptions,
+  ): void {
     this.invalidateToolCache(); // Invalidate cache when a tool is registered
     // Emit tool registration start event
     this.emitter.emit("tools-register:start", {
@@ -7239,8 +7278,70 @@ Current user's request: ${currentInput}`;
         })(),
       };
 
+      // Wrap execute with per-tool timeout if specified at registration.
+      // Uses AbortSignal.timeout() composed with any parent signal from the AI SDK.
+      // This ensures the timeout works regardless of the execution path
+      // (direct executeTool() or AI SDK generateText() tool calling).
+      if (
+        options?.timeout !== undefined &&
+        options.timeout > 0 &&
+        Number.isFinite(options.timeout)
+      ) {
+        const originalExecute = convertedTool.execute!;
+        const toolTimeout = options.timeout;
+        const toolName = name;
+        convertedTool.execute = async (...args: unknown[]) => {
+          const timeoutSignal = AbortSignal.timeout(toolTimeout);
+          // Compose with any parent abortSignal from ToolExecutionOptions
+          const execOptions = args[1] as
+            | { abortSignal?: AbortSignal }
+            | undefined;
+          const parentSignal = execOptions?.abortSignal;
+          const composedSignal = parentSignal
+            ? AbortSignal.any([parentSignal, timeoutSignal])
+            : timeoutSignal;
+
+          // Replace the abortSignal in execution options
+          const augmentedContext = {
+            ...execOptions,
+            abortSignal: composedSignal,
+          };
+
+          return Promise.race([
+            originalExecute(args[0], augmentedContext),
+            new Promise<never>((_, reject) => {
+              composedSignal.addEventListener(
+                "abort",
+                () => {
+                  if (timeoutSignal.aborted) {
+                    reject(
+                      new Error(
+                        `Tool '${toolName}' timed out after ${toolTimeout}ms (configured at registration)`,
+                      ),
+                    );
+                  } else {
+                    reject(
+                      new DOMException(
+                        "The operation was aborted",
+                        "AbortError",
+                      ),
+                    );
+                  }
+                },
+                { once: true },
+              );
+            }),
+          ]);
+        };
+      }
+
       // SMART DEFAULTS: Use utility to eliminate boilerplate creation
-      const mcpServerInfo = createCustomToolServerInfo(name, convertedTool);
+      const mcpServerInfo = createCustomToolServerInfo(
+        name,
+        convertedTool,
+        options?.timeout,
+        options?.maxRetries,
+      );
 
       // Register with toolRegistry using MCPServerInfo directly
       this.toolRegistry.registerServer(mcpServerInfo);
@@ -7250,6 +7351,7 @@ Current user's request: ${currentInput}`;
         toolName: name,
         success: true,
         timestamp: Date.now(),
+        timeoutMs: options?.timeout,
       });
     } catch (error) {
       logger.error(`Failed to register tool ${name}:`, error);
@@ -7679,6 +7781,12 @@ Current user's request: ${currentInput}`;
     const executionStartTime = Date.now();
 
     // === MCP ENHANCEMENT: RequestBatcher — batch programmatic tool calls ===
+    // LIMITATION: When the request batcher is enabled, per-tool timeout and retry
+    // settings (from registration options or call-site options) are NOT applied.
+    // The batcher uses its own hardcoded defaults for timeout and retry behavior.
+    // Use `bypassBatcher: true` to ensure per-tool timeout/retry is respected.
+    // Additionally, note that executeToolInternal's safe-tool retry logic may still
+    // trigger even when maxRetries is set to 0, since it operates independently.
     if (this.mcpToolBatcher && !options?.bypassBatcher) {
       return this.mcpToolBatcher.execute(toolName, params) as Promise<T>;
     }
@@ -7757,21 +7865,31 @@ Current user's request: ${currentInput}`;
             input: params, // Enhanced: add input parameters
           });
 
-          // Set default options
+          // NL-004: Use composite key (serverId.toolName) to avoid cross-server collisions
+          // Fetch toolInfo early so per-tool timeout is available for finalOptions
+          const toolInfo = this.toolRegistry.getToolInfo(toolName);
+
+          // Set default options — per-tool values from registration take precedence over global defaults.
+          // When not explicitly set at registration, global defaults are preserved for backward compatibility.
+          const registeredTimeout = toolInfo?.tool?.timeoutMs;
+          const registeredMaxRetries = toolInfo?.tool?.maxRetries;
           const finalOptions = {
-            timeout: options?.timeout || TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS, // 30 second default timeout
-            maxRetries: options?.maxRetries || RETRY_ATTEMPTS.DEFAULT, // Default 2 retries for retriable errors
-            retryDelayMs: options?.retryDelayMs || RETRY_DELAYS.BASE_MS, // 1 second delay between retries
-            authContext: options?.authContext, // Pass through authentication context
-            disableToolCache: options?.disableToolCache, // Pass through cache bypass flag
+            timeout:
+              options?.timeout ??
+              registeredTimeout ??
+              TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
+            maxRetries:
+              options?.maxRetries ??
+              registeredMaxRetries ??
+              RETRY_ATTEMPTS.DEFAULT,
+            retryDelayMs: options?.retryDelayMs || RETRY_DELAYS.BASE_MS,
+            authContext: options?.authContext,
+            disableToolCache: options?.disableToolCache,
           };
 
           // Track memory usage for tool execution
           const { MemoryManager } = await import("./utils/performance.js");
           const startMemory = MemoryManager.getMemoryUsageMB();
-
-          // NL-004: Use composite key (serverId.toolName) to avoid cross-server collisions
-          const toolInfo = this.toolRegistry.getToolInfo(toolName);
           const breakerServerId =
             externalTool?.serverId || toolInfo?.tool?.serverId || "unknown";
           const breakerKey = `${breakerServerId}.${toolName}`;
@@ -7796,6 +7914,7 @@ Current user's request: ${currentInput}`;
               failedExecutions: 0,
               averageExecutionTime: 0,
               lastExecutionTime: 0,
+              errorCategories: {},
             });
           }
           const metrics = this.toolExecutionMetrics.get(toolName);
@@ -7878,16 +7997,20 @@ Current user's request: ${currentInput}`;
               circuitBreakerState: circuitBreaker?.getState(),
             });
 
-            // Emit tool end event using the helper method
-            this.emitToolEndEvent(toolName, executionStartTime, true, result);
-
             // Set span success attributes
             // Check if result has isError flag (MCP tool error result)
+            // Also detect toolRegistry-wrapped errors that return { success: false }
+            const resultObj =
+              result && typeof result === "object"
+                ? (result as Record<string, unknown>)
+                : undefined;
             const isToolError =
-              result &&
-              typeof result === "object" &&
-              "isError" in result &&
-              (result as Record<string, unknown>).isError === true;
+              (resultObj &&
+                "isError" in resultObj &&
+                resultObj.isError === true) ||
+              (resultObj &&
+                "success" in resultObj &&
+                resultObj.success === false);
 
             // NL-001: Count isError:true results as circuit breaker failures
             // This ensures tools that return error results (not just thrown errors) are tracked
@@ -7954,7 +8077,39 @@ Current user's request: ${currentInput}`;
                 code: SpanStatusCode.ERROR,
                 message: `MCP tool returned isError: ${errorText.substring(0, 200)}`,
               });
+
+              if (metrics) {
+                metrics.failedExecutions++;
+                const prevSuccessful = metrics.successfulExecutions;
+                metrics.successfulExecutions = Math.max(
+                  0,
+                  metrics.successfulExecutions - 1,
+                );
+                // Recompute averageExecutionTime: back out this execution's duration
+                // which was incorrectly included as a success
+                if (prevSuccessful > 1) {
+                  metrics.averageExecutionTime =
+                    (metrics.averageExecutionTime * prevSuccessful -
+                      executionTime) /
+                    (prevSuccessful - 1);
+                } else {
+                  // No remaining successful executions, reset to 0
+                  metrics.averageExecutionTime = 0;
+                }
+                const mappedCategory =
+                  mcpCategoryToErrorCategory(errorCategory);
+                metrics.errorCategories[mappedCategory] =
+                  (metrics.errorCategories[mappedCategory] || 0) + 1;
+              }
             }
+
+            // Emit tool end event AFTER isError check so success flag is correct
+            this.emitToolEndEvent(
+              toolName,
+              executionStartTime,
+              !isToolError,
+              result,
+            );
 
             toolSpan.setAttribute(
               "tool.result.status",
@@ -8017,10 +8172,16 @@ Current user's request: ${currentInput}`;
               );
             }
 
-            // ADD: Centralized error event emission
-            this.emitter.emit("error", structuredError);
+            if (metrics) {
+              const category =
+                structuredError.category || ErrorCategory.EXECUTION;
+              metrics.errorCategories[category] =
+                (metrics.errorCategories[category] || 0) + 1;
+            }
 
-            // Emit tool end event using the helper method
+            // Emit tool end event BEFORE the error event.
+            // Node.js EventEmitter throws on unhandled 'error' events,
+            // which would prevent tool:end from being emitted.
             this.emitToolEndEvent(
               toolName,
               executionStartTime,
@@ -8028,6 +8189,9 @@ Current user's request: ${currentInput}`;
               undefined,
               structuredError,
             );
+
+            // Centralized error event emission
+            this.emitter.emit("error", structuredError);
 
             // Add execution context to structured error
             structuredError = new NeuroLinkError({
@@ -9111,6 +9275,7 @@ Current user's request: ${currentInput}`;
       successRate: number;
       averageExecutionTime: number;
       lastExecutionTime: number;
+      errorCategories: Record<string, number>;
     }
   > {
     const metrics: Record<
@@ -9122,12 +9287,14 @@ Current user's request: ${currentInput}`;
         successRate: number;
         averageExecutionTime: number;
         lastExecutionTime: number;
+        errorCategories: Record<string, number>;
       }
     > = {};
 
     for (const [toolName, toolMetrics] of this.toolExecutionMetrics.entries()) {
       metrics[toolName] = {
         ...toolMetrics,
+        errorCategories: { ...toolMetrics.errorCategories },
         successRate:
           toolMetrics.totalExecutions > 0
             ? toolMetrics.successfulExecutions / toolMetrics.totalExecutions
@@ -9231,6 +9398,7 @@ Current user's request: ${currentInput}`;
           successRate: number;
           averageExecutionTime: number;
           lastExecutionTime: number;
+          errorCategories: Record<string, number>;
         };
         circuitBreaker: {
           state: "closed" | "open" | "half-open";
@@ -9251,6 +9419,7 @@ Current user's request: ${currentInput}`;
           successRate: number;
           averageExecutionTime: number;
           lastExecutionTime: number;
+          errorCategories: Record<string, number>;
         };
         circuitBreaker: {
           state: "closed" | "open" | "half-open";
@@ -9311,6 +9480,28 @@ Current user's request: ${currentInput}`;
         recommendations.push("Optimize tool performance or increase timeout");
       }
 
+      if (metrics && metrics.errorCategories) {
+        const categories = metrics.errorCategories;
+        if (categories[ErrorCategory.TIMEOUT] > 0) {
+          issues.push(`Timeout errors: ${categories[ErrorCategory.TIMEOUT]}`);
+          recommendations.push(
+            "Consider increasing the tool timeout configuration",
+          );
+        }
+        if (categories[ErrorCategory.VALIDATION] > 0) {
+          issues.push(
+            `Validation errors: ${categories[ErrorCategory.VALIDATION]}`,
+          );
+          recommendations.push("Review input schemas and parameter validation");
+        }
+        if (categories[ErrorCategory.NETWORK] > 0) {
+          issues.push(`Network errors: ${categories[ErrorCategory.NETWORK]}`);
+          recommendations.push(
+            "Check network connectivity and endpoint availability",
+          );
+        }
+      }
+
       tools[toolName] = {
         name: toolName,
         isHealthy,
@@ -9319,6 +9510,9 @@ Current user's request: ${currentInput}`;
           successRate,
           averageExecutionTime: metrics?.averageExecutionTime || 0,
           lastExecutionTime: metrics?.lastExecutionTime || 0,
+          errorCategories: metrics?.errorCategories
+            ? { ...metrics.errorCategories }
+            : {},
         },
         circuitBreaker: {
           state: circuitBreaker?.getState() || "closed",

--- a/src/lib/types/tools.ts
+++ b/src/lib/types/tools.ts
@@ -65,6 +65,7 @@ export type ExecutionContext<T = StandardRecord> = {
   cacheOptions?: CacheOptions;
   fallbackOptions?: FallbackOptions;
   timeoutMs?: number;
+  maxRetries?: number;
   startTime?: number;
 };
 
@@ -102,6 +103,9 @@ export type ToolInfo = {
   outputSchema?: StandardRecord;
   /** MCP tool annotations (safety hints, metadata). Auto-inferred when mcp.annotations.autoInfer is enabled. */
   annotations?: import("../mcp/toolAnnotations.js").MCPToolAnnotations;
+  /** Per-tool timeout in milliseconds, set at registration time */
+  timeoutMs?: number;
+  maxRetries?: number;
   [key: string]: unknown; // Generic extensibility
 };
 
@@ -119,6 +123,9 @@ export type ToolImplementation = {
   outputSchema?: unknown;
   category?: string;
   permissions?: string[];
+  /** Per-tool timeout in milliseconds, set at registration time */
+  timeoutMs?: number;
+  maxRetries?: number;
 };
 
 /**
@@ -126,13 +133,51 @@ export type ToolImplementation = {
  * Extracted from toolRegistry.ts for centralized type management
  */
 export type ToolExecutionOptions = {
+  /**
+   * Caller-specified execution timeout in milliseconds.
+   * Used by executeTool() callers to override the default timeout for a
+   * single invocation. Takes precedence over `timeoutMs` when both are set.
+   */
   timeout?: number;
   retries?: number;
   context?: unknown;
   preferredSource?: string;
   fallbackEnabled?: boolean;
   validateBeforeExecution?: boolean;
+  /**
+   * Per-tool timeout in milliseconds, copied from ToolInfo at registration
+   * time. Acts as the tool-level default; overridden by `timeout` when the
+   * caller supplies an explicit value.
+   * @deprecated Prefer using `timeout` for caller-specified overrides.
+   *             This field exists for internal forwarding from ToolInfo and
+   *             may be consolidated in a future release.
+   */
   timeoutMs?: number;
+  maxRetries?: number;
+};
+
+/**
+ * Options for tool registration via registerTool()
+ *
+ * These options configure per-tool execution behavior. When not provided,
+ * the SDK's global defaults are used (30s timeout, 2 retries), preserving
+ * backward compatibility with existing production systems.
+ *
+ * @example
+ * // Register with custom timeout and no retries
+ * sdk.registerTool("myTool", tool, { timeout: 5000, maxRetries: 0 });
+ *
+ * // Register with defaults (same as before — no behavior change)
+ * sdk.registerTool("myTool", tool);
+ */
+export type ToolRegistrationOptions = {
+  /** Per-tool execution timeout in milliseconds. Only applied when explicitly set.
+   *  When omitted, the SDK's global default (30s) is used. */
+  timeout?: number;
+  /** Maximum retry attempts on failure. Only applied when explicitly set.
+   *  When omitted, the SDK's global default (2 retries) is used.
+   *  Set to 0 to disable retries for this tool. */
+  maxRetries?: number;
 };
 
 /**

--- a/src/lib/utils/mcpDefaults.ts
+++ b/src/lib/utils/mcpDefaults.ts
@@ -136,8 +136,10 @@ export function createMCPServerInfo(options: {
 export function createCustomToolServerInfo(
   toolName: string,
   tool: MCPExecutableTool,
+  timeoutMs?: number,
+  maxRetries?: number,
 ): MCPServerInfo {
-  return createMCPServerInfo({
+  const serverInfo = createMCPServerInfo({
     id: `custom-tool-${toolName}`,
     name: toolName,
     tool: {
@@ -148,6 +150,17 @@ export function createCustomToolServerInfo(
     },
     isCustomTool: true,
   });
+
+  if (serverInfo.metadata) {
+    if (timeoutMs !== undefined) {
+      serverInfo.metadata.toolTimeoutMs = timeoutMs;
+    }
+    if (maxRetries !== undefined) {
+      serverInfo.metadata.toolMaxRetries = maxRetries;
+    }
+  }
+
+  return serverInfo;
 }
 
 /**

--- a/test/continuous-test-suite-tool-reliability.ts
+++ b/test/continuous-test-suite-tool-reliability.ts
@@ -1,0 +1,1176 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite: Tool Reliability
+ *
+ * Tests tool execution metadata, event emitter completeness, timeout enforcement,
+ * error category tracking, and OTel span generation for tool operations.
+ *
+ * The SDK now supports:
+ * - Provider/model population on stream/generate results
+ * - Per-tool timeout via registerTool() options (third parameter)
+ * - Error categories (timeout, validation, internal) in tool execution metrics
+ *
+ * ALL OTel tests run locally using InMemorySpanExporter — no Langfuse credentials needed.
+ *
+ * Run: npx tsx test/continuous-test-suite-tool-reliability.ts --provider=vertex
+ */
+
+import * as fs from "fs";
+
+import { SpanStatusCode } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+// ============================================================
+// OTEL BOOTSTRAP — must register BEFORE importing NeuroLink
+// ============================================================
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+const spanExporter = new InMemorySpanExporter();
+const traceProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
+traceProvider.register();
+
+// Now import NeuroLink (tracers will pick up the registered provider)
+const { NeuroLink } = await import("../dist/index.js");
+
+// ============================================================
+// CONFIGURATION
+// ============================================================
+
+function resolveTestModel(provider: string): string | undefined {
+  if (process.env.TEST_MODEL) {
+    return process.env.TEST_MODEL;
+  }
+  const providerModelEnvMap: Record<string, string> = {
+    litellm: "LITELLM_MODEL",
+    openai: "OPENAI_MODEL",
+    vertex: "VERTEX_MODEL",
+    bedrock: "BEDROCK_MODEL",
+    "google-ai-studio": "GOOGLE_AI_MODEL",
+    "google-ai": "GOOGLE_AI_MODEL",
+    azure: "AZURE_OPENAI_MODEL",
+    anthropic: "ANTHROPIC_MODEL",
+    mistral: "MISTRAL_MODEL",
+    ollama: "OLLAMA_MODEL",
+  };
+  const envKey = providerModelEnvMap[provider];
+  return envKey ? process.env[envKey] : undefined;
+}
+
+const TEST_CONFIG = {
+  provider: process.env.TEST_PROVIDER || "vertex",
+  model: undefined as string | undefined,
+  timeout: 90000,
+  interTestDelay: 2000,
+};
+
+// ============================================================
+// LOGGING UTILITIES
+// ============================================================
+
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+};
+type ColorName = keyof typeof colors;
+
+function log(message: string, color: ColorName = "reset"): void {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function logSection(title: string): void {
+  log(`\n${"=".repeat(60)}`, "cyan");
+  log(`  ${title}`, "cyan");
+  log(`${"=".repeat(60)}`, "cyan");
+}
+
+function logTest(
+  testName: string,
+  status: "PASS" | "FAIL" | "SKIP" | "TESTING",
+  details?: string,
+): void {
+  const icons = { PASS: "PASS", FAIL: "FAIL", SKIP: "SKIP", TESTING: "TEST" };
+  const statusColors: Record<string, ColorName> = {
+    PASS: "green",
+    FAIL: "red",
+    SKIP: "yellow",
+    TESTING: "blue",
+  };
+  const icon = icons[status];
+  const clr = statusColors[status] || "reset";
+  const det = details ? ` — ${details}` : "";
+  log(`[${icon}] ${testName}${det}`, clr);
+}
+
+// ============================================================
+// TEST RESULTS TRACKING
+// ============================================================
+
+const testResults: Array<{
+  name: string;
+  result: boolean | null;
+  error: string | null;
+}> = [];
+
+// ============================================================
+// HELPERS
+// ============================================================
+
+function createSDK(): InstanceType<typeof NeuroLink> {
+  return new NeuroLink();
+}
+
+async function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function findSpan(name: string): ReadableSpan | undefined {
+  return spanExporter.getFinishedSpans().find((s) => s.name === name);
+}
+
+function findSpans(namePattern: string): ReadableSpan[] {
+  return spanExporter
+    .getFinishedSpans()
+    .filter((s) => s.name === namePattern || s.name.includes(namePattern));
+}
+
+function getAttr(span: ReadableSpan, key: string): unknown {
+  return span.attributes[key];
+}
+
+function resetSpans(): void {
+  spanExporter.reset();
+}
+
+function isExpectedProviderError(msg: string): boolean {
+  const lower = msg.toLowerCase();
+  return [
+    "api key",
+    "authentication",
+    "rate limit",
+    "quota",
+    "credentials",
+    "could not be resolved",
+    "cannot connect",
+    "failed to generate",
+    "google_application_credentials",
+    "permission",
+    "unauthorized",
+  ].some((p) => lower.includes(p));
+}
+
+// ============================================================
+// TEST #1: Stream result always includes provider and model
+// ============================================================
+
+async function test_stream_result_provider_model(): Promise<boolean | null> {
+  logSection("Test #1: Stream result always includes provider and model");
+  logTest("Stream result provider/model", "TESTING");
+
+  const sdk = createSDK();
+
+  try {
+    const streamResult = await sdk.stream({
+      input: { text: 'Say "hello" and nothing else.' },
+      provider: TEST_CONFIG.provider as string,
+      ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+      maxTokens: 50,
+    });
+
+    // Consume the full stream
+    let content = "";
+    if (streamResult?.stream) {
+      for await (const chunk of streamResult.stream) {
+        if ("content" in chunk && typeof chunk.content === "string") {
+          content += chunk.content;
+        }
+      }
+    }
+
+    // Wait for async resolution
+    await delay(500);
+
+    // Assert provider is a non-empty string
+    if (
+      typeof streamResult.provider !== "string" ||
+      streamResult.provider.length === 0
+    ) {
+      logTest(
+        "Stream result provider/model",
+        "FAIL",
+        `provider is missing or empty on stream result. Got: ${JSON.stringify(streamResult.provider)}`,
+      );
+      return false;
+    }
+
+    // Assert model is a non-empty string
+    if (
+      typeof streamResult.model !== "string" ||
+      streamResult.model.length === 0
+    ) {
+      logTest(
+        "Stream result provider/model",
+        "FAIL",
+        `model is missing or empty on stream result. Got: ${JSON.stringify(streamResult.model)}`,
+      );
+      return false;
+    }
+
+    logTest(
+      "Stream result provider/model",
+      "PASS",
+      `provider="${streamResult.provider}", model="${streamResult.model}", content length=${content.length}`,
+    );
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest("Stream result provider/model", "SKIP", `Provider error: ${msg}`);
+      return null;
+    }
+    logTest("Stream result provider/model", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (sdk as { shutdown?: () => Promise<void> }).shutdown?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST #2: Generate result always includes provider and model
+// ============================================================
+
+async function test_generate_result_provider_model(): Promise<boolean | null> {
+  logSection("Test #2: Generate result always includes provider and model");
+  logTest("Generate result provider/model", "TESTING");
+
+  const sdk = createSDK();
+
+  try {
+    const result = await sdk.generate({
+      input: { text: 'Say "hello" and nothing else.' },
+      provider: TEST_CONFIG.provider as string,
+      ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+      maxTokens: 50,
+    });
+
+    if (!result?.content) {
+      logTest(
+        "Generate result provider/model",
+        "FAIL",
+        "No content returned from generate",
+      );
+      return false;
+    }
+
+    // Assert provider is a non-empty string
+    if (typeof result.provider !== "string" || result.provider.length === 0) {
+      logTest(
+        "Generate result provider/model",
+        "FAIL",
+        `provider is missing or empty on generate result. Got: ${JSON.stringify(result.provider)}`,
+      );
+      return false;
+    }
+
+    // Assert model is a non-empty string
+    if (typeof result.model !== "string" || result.model.length === 0) {
+      logTest(
+        "Generate result provider/model",
+        "FAIL",
+        `model is missing or empty on generate result. Got: ${JSON.stringify(result.model)}`,
+      );
+      return false;
+    }
+
+    // Check analytics data has provider populated if available
+    let analyticsDetail = "";
+    if (result.analytics) {
+      const analytics = result.analytics;
+      const analyticsProvider =
+        typeof analytics === "object" &&
+        analytics !== null &&
+        "provider" in analytics
+          ? (analytics as Record<string, unknown>).provider
+          : undefined;
+      if (
+        typeof analyticsProvider === "string" &&
+        analyticsProvider.length > 0
+      ) {
+        analyticsDetail = `, analytics.provider="${analyticsProvider}"`;
+      } else {
+        analyticsDetail = ", analytics present but provider not populated";
+      }
+    }
+
+    logTest(
+      "Generate result provider/model",
+      "PASS",
+      `provider="${result.provider}", model="${result.model}"${analyticsDetail}`,
+    );
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest(
+        "Generate result provider/model",
+        "SKIP",
+        `Provider error: ${msg}`,
+      );
+      return null;
+    }
+    logTest("Generate result provider/model", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (sdk as { shutdown?: () => Promise<void> }).shutdown?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST #3: Tool execution events include complete metadata
+// ============================================================
+
+async function test_tool_execution_events(): Promise<boolean | null> {
+  logSection("Test #3: Tool execution events include complete metadata");
+  logTest("Tool execution events metadata", "TESTING");
+
+  const sdk = createSDK();
+
+  try {
+    // Register a simple getCurrentTime tool
+    sdk.registerTool("getCurrentTime", {
+      name: "getCurrentTime",
+      description:
+        "Get the current date and time as an ISO string. Always call this tool when asked about the current time.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => ({
+        currentTime: new Date().toISOString(),
+        timezone: "UTC",
+      }),
+    });
+
+    // Subscribe to tool events
+    const toolStartEvents: Array<Record<string, unknown>> = [];
+    const toolEndEvents: Array<Record<string, unknown>> = [];
+
+    const emitter = sdk.getEventEmitter();
+    emitter.on("tool:start", (event: Record<string, unknown>) => {
+      toolStartEvents.push(event);
+    });
+    emitter.on("tool:end", (event: Record<string, unknown>) => {
+      toolEndEvents.push(event);
+    });
+
+    // Call generate with a prompt that should trigger the tool
+    await sdk.generate({
+      input: {
+        text: "What is the current time right now? You must use the getCurrentTime tool to check.",
+      },
+      provider: TEST_CONFIG.provider as string,
+      ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+      maxTokens: 200,
+      maxSteps: 3,
+    });
+
+    // Wait for event propagation
+    await delay(1000);
+
+    // Check if the model triggered the tool at all
+    if (toolStartEvents.length === 0 && toolEndEvents.length === 0) {
+      logTest(
+        "Tool execution events metadata",
+        "SKIP",
+        "Model did not invoke the getCurrentTime tool (non-deterministic)",
+      );
+      return null;
+    }
+
+    // Verify tool:start event has the expected shape
+    let startValid = true;
+    if (toolStartEvents.length > 0) {
+      const startEvent = toolStartEvents[0];
+      const toolNameFromStart = startEvent.tool || startEvent.toolName;
+      if (
+        typeof toolNameFromStart !== "string" ||
+        toolNameFromStart.length === 0
+      ) {
+        log(
+          `  [detail] tool:start event missing tool/toolName. Keys: ${Object.keys(startEvent).join(", ")}`,
+          "red",
+        );
+        startValid = false;
+      } else {
+        log(
+          `  [detail] tool:start fired with tool="${toolNameFromStart}"`,
+          "green",
+        );
+      }
+    } else {
+      log("  [detail] tool:start event never fired", "red");
+      startValid = false;
+    }
+
+    // Verify tool:end event has the expected shape
+    let endValid = true;
+    if (toolEndEvents.length > 0) {
+      const endEvent = toolEndEvents[0];
+      const toolNameFromEnd = endEvent.tool || endEvent.toolName;
+      const duration = endEvent.duration || endEvent.responseTime;
+      const success = endEvent.success;
+
+      if (typeof toolNameFromEnd !== "string" || toolNameFromEnd.length === 0) {
+        log(
+          `  [detail] tool:end event missing tool/toolName. Keys: ${Object.keys(endEvent).join(", ")}`,
+          "red",
+        );
+        endValid = false;
+      }
+      if (typeof duration !== "number") {
+        log(
+          `  [detail] tool:end event missing duration/responseTime (expected number). Keys: ${Object.keys(endEvent).join(", ")}`,
+          "yellow",
+        );
+        // Non-critical: warn but don't fail
+      }
+      if (typeof success !== "boolean") {
+        log(
+          `  [detail] tool:end event missing success field (expected boolean). Keys: ${Object.keys(endEvent).join(", ")}`,
+          "yellow",
+        );
+        // Non-critical: warn but don't fail
+      }
+
+      log(
+        `  [detail] tool:end fired with tool="${toolNameFromEnd}", duration=${duration}, success=${success}`,
+        "green",
+      );
+    } else {
+      log("  [detail] tool:end event never fired", "red");
+      endValid = false;
+    }
+
+    if (startValid && endValid) {
+      logTest(
+        "Tool execution events metadata",
+        "PASS",
+        `tool:start fired ${toolStartEvents.length} time(s), tool:end fired ${toolEndEvents.length} time(s)`,
+      );
+      return true;
+    } else {
+      logTest(
+        "Tool execution events metadata",
+        "FAIL",
+        `startValid=${startValid}, endValid=${endValid}`,
+      );
+      return false;
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest(
+        "Tool execution events metadata",
+        "SKIP",
+        `Provider error: ${msg}`,
+      );
+      return null;
+    }
+    logTest("Tool execution events metadata", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (
+        sdk as { shutdown?: () => Promise<void>; dispose?: () => Promise<void> }
+      ).dispose?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST #4: Tool registered with timeout respects that timeout
+// ============================================================
+
+async function test_tool_timeout_enforcement(): Promise<boolean | null> {
+  logSection("Test #4: Tool registered with timeout respects that timeout");
+  logTest("Tool timeout enforcement", "TESTING");
+
+  const sdk = createSDK();
+
+  try {
+    // Register a tool that artificially sleeps for 5 seconds
+    const slowTool = {
+      name: "slowOperation",
+      description:
+        "A slow operation that takes a long time. Call this tool when asked to perform a slow task.",
+      inputSchema: { type: "object" as const, properties: {} },
+      execute: async () => {
+        await delay(5000);
+        return { result: "completed" };
+      },
+    };
+
+    // Register the tool with per-tool timeout and retry options
+    sdk.registerTool("slowOperation", slowTool, {
+      timeout: 2000,
+      maxRetries: 0,
+    });
+    const registeredWithTimeout = true;
+    log(
+      "  [detail] registerTool accepted timeout and maxRetries options",
+      "green",
+    );
+
+    // Trigger the tool via generate
+    const startTime = Date.now();
+    let toolTimedOut = false;
+    let toolCompleted = false;
+
+    // Track tool events for timeout detection
+    let toolEndError = "";
+    let toolStartFired = false;
+    const emitter = sdk.getEventEmitter();
+    emitter.on("tool:start", () => {
+      toolStartFired = true;
+    });
+    emitter.on("tool:end", (event: Record<string, unknown>) => {
+      if (event.error) {
+        // Handle both string errors and Error objects
+        toolEndError =
+          typeof event.error === "string"
+            ? event.error
+            : event.error instanceof Error
+              ? event.error.message
+              : String(event.error);
+      }
+      if (event.success === false && !toolEndError) {
+        toolEndError = "tool:end reported success=false";
+      }
+    });
+
+    try {
+      await sdk.generate({
+        input: {
+          text: "Please run the slowOperation tool right now.",
+        },
+        provider: TEST_CONFIG.provider as string,
+        ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+        maxTokens: 200,
+        maxSteps: 1, // Single step to avoid AI SDK retrying the tool call
+      });
+      toolCompleted = true;
+    } catch (toolError) {
+      const toolMsg =
+        toolError instanceof Error ? toolError.message : String(toolError);
+      if (
+        toolMsg.toLowerCase().includes("timeout") ||
+        toolMsg.toLowerCase().includes("timed out") ||
+        toolMsg.toLowerCase().includes("exceeded")
+      ) {
+        toolTimedOut = true;
+      }
+    }
+
+    // If the tool was never invoked by the model, skip the test
+    if (!toolStartFired) {
+      logTest(
+        "Tool timeout enforcement",
+        "SKIP",
+        "Model did not invoke the slowOperation tool (non-deterministic)",
+      );
+      return null;
+    }
+
+    // Check tool:end error message for timeout signal
+    if (!toolTimedOut && toolEndError.toLowerCase().includes("timed out")) {
+      toolTimedOut = true;
+    }
+    // Check execution metrics for timeout-specific error category
+    const metrics = sdk.getToolExecutionMetrics();
+    const slowToolMetrics = metrics["slowOperation"];
+    if (!toolTimedOut && slowToolMetrics) {
+      const metricsRecord = slowToolMetrics as Record<string, unknown>;
+      const errorCategories = metricsRecord.errorCategories as
+        | Record<string, unknown>
+        | undefined;
+      if (
+        errorCategories &&
+        typeof errorCategories.timeout === "number" &&
+        errorCategories.timeout > 0
+      ) {
+        toolTimedOut = true;
+        toolEndError = `errorCategories.timeout: ${errorCategories.timeout}`;
+      }
+    }
+
+    const elapsed = Date.now() - startTime;
+
+    if (!registeredWithTimeout) {
+      // registerTool() did not accept timeout — this is the expected failure
+      logTest(
+        "Tool timeout enforcement",
+        "FAIL",
+        `registerTool() does not accept timeout at registration. Elapsed: ${elapsed}ms. Tool completed: ${toolCompleted}`,
+      );
+      return false;
+    }
+
+    // The per-tool timeout fires correctly (visible in tool:end error events).
+    // generate() may still succeed with a text response after the tool fails,
+    // because the LLM can respond without the tool result.
+    // We verify by checking that the tool:end event contains the timeout error.
+    const timeoutEnforced =
+      toolTimedOut || toolEndError.toLowerCase().includes("timed out");
+
+    if (timeoutEnforced) {
+      logTest(
+        "Tool timeout enforcement",
+        "PASS",
+        `Tool timeout enforced (2000ms). Elapsed: ${elapsed}ms. toolTimedOut: ${toolTimedOut}, toolEndError: "${toolEndError.substring(0, 80)}"`,
+      );
+      return true;
+    } else if (toolCompleted && elapsed >= 4000) {
+      logTest(
+        "Tool timeout enforcement",
+        "FAIL",
+        `Tool completed without timeout after ${elapsed}ms. Timeout was not enforced. toolEndError: "${toolEndError}"`,
+      );
+      return false;
+    } else {
+      logTest(
+        "Tool timeout enforcement",
+        "FAIL",
+        `Unexpected state: timedOut=${toolTimedOut}, completed=${toolCompleted}, elapsed=${elapsed}ms`,
+      );
+      return false;
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest("Tool timeout enforcement", "SKIP", `Provider error: ${msg}`);
+      return null;
+    }
+    logTest("Tool timeout enforcement", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (
+        sdk as { shutdown?: () => Promise<void>; dispose?: () => Promise<void> }
+      ).dispose?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST #5: Tool execution metrics include error category breakdown
+// ============================================================
+
+async function test_tool_metrics_error_categories(): Promise<boolean | null> {
+  logSection(
+    "Test #5: Tool execution metrics include error category breakdown",
+  );
+  logTest("Tool metrics error categories", "TESTING");
+
+  const sdk = createSDK();
+
+  try {
+    // Register a tool that always succeeds
+    sdk.registerTool("successTool", {
+      name: "successTool",
+      description:
+        "A tool that always succeeds. Call this when asked to run a success test.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => ({ status: "ok" }),
+    });
+
+    // Register a tool that always fails with a validation error
+    sdk.registerTool("failingTool", {
+      name: "failingTool",
+      description:
+        "A tool that always fails with a validation error. Call this when asked to run a failure test.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async () => {
+        throw new Error("Validation error: missing required field 'name'");
+      },
+    });
+
+    // Trigger tools via generate — attempt to run the success tool
+    try {
+      await sdk.generate({
+        input: {
+          text: "Run the successTool right now to test it.",
+        },
+        provider: TEST_CONFIG.provider as string,
+        ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+        maxTokens: 200,
+        maxSteps: 3,
+      });
+    } catch {
+      // May fail if provider does not call the tool
+    }
+
+    await delay(500);
+
+    // Trigger the failing tool
+    try {
+      await sdk.generate({
+        input: {
+          text: "Run the failingTool right now to test it.",
+        },
+        provider: TEST_CONFIG.provider as string,
+        ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+        maxTokens: 200,
+        maxSteps: 3,
+      });
+    } catch {
+      // Expected: tool throws but generate might still return content
+    }
+
+    await delay(500);
+
+    // Get tool execution metrics
+    const metrics = sdk.getToolExecutionMetrics();
+    log(`  [detail] Metrics keys: ${Object.keys(metrics).join(", ")}`, "reset");
+
+    // Check if we have metrics at all
+    if (Object.keys(metrics).length === 0) {
+      logTest(
+        "Tool metrics error categories",
+        "SKIP",
+        "No tool execution metrics recorded (model may not have invoked tools)",
+      );
+      return null;
+    }
+
+    // Log metrics details
+    for (const [toolName, toolMetrics] of Object.entries(metrics)) {
+      log(
+        `  [detail] ${toolName}: total=${toolMetrics.totalExecutions}, success=${toolMetrics.successfulExecutions}, failed=${toolMetrics.failedExecutions}, successRate=${toolMetrics.successRate}`,
+        "reset",
+      );
+    }
+
+    // Check for errorCategories field in getToolExecutionMetrics()
+    let metricsHasErrorCategories = false;
+    for (const [, toolMetrics] of Object.entries(metrics)) {
+      const metricsRecord = toolMetrics as Record<string, unknown>;
+      if ("errorCategories" in metricsRecord) {
+        metricsHasErrorCategories = true;
+        break;
+      }
+    }
+
+    // Check for errorCategories field in getToolHealthReport()
+    let healthReportHasErrorCategories = false;
+    try {
+      const healthReport = await sdk.getToolHealthReport();
+      log(
+        `  [detail] Health report: totalTools=${healthReport.totalTools}, healthy=${healthReport.healthyTools}, unhealthy=${healthReport.unhealthyTools}`,
+        "reset",
+      );
+
+      for (const [toolName, toolHealth] of Object.entries(healthReport.tools)) {
+        const healthRecord = toolHealth as Record<string, unknown>;
+        // errorCategories is nested inside the metrics sub-object
+        const metricsObj = healthRecord.metrics as
+          | Record<string, unknown>
+          | undefined;
+        if (
+          "errorCategories" in healthRecord ||
+          (metricsObj && "errorCategories" in metricsObj)
+        ) {
+          healthReportHasErrorCategories = true;
+        }
+        if (
+          Array.isArray(healthRecord.issues) &&
+          (healthRecord.issues as string[]).length > 0
+        ) {
+          log(
+            `  [detail] ${toolName} issues: ${(healthRecord.issues as string[]).join(", ")}`,
+            "yellow",
+          );
+        }
+      }
+    } catch (healthErr) {
+      log(
+        `  [detail] getToolHealthReport() failed: ${healthErr instanceof Error ? healthErr.message : String(healthErr)}`,
+        "yellow",
+      );
+    }
+
+    if (metricsHasErrorCategories && healthReportHasErrorCategories) {
+      logTest(
+        "Tool metrics error categories",
+        "PASS",
+        "errorCategories found in both getToolExecutionMetrics() and getToolHealthReport()",
+      );
+      return true;
+    } else {
+      const missing = [];
+      if (!metricsHasErrorCategories) {
+        missing.push("getToolExecutionMetrics()");
+      }
+      if (!healthReportHasErrorCategories) {
+        missing.push("getToolHealthReport()");
+      }
+      logTest(
+        "Tool metrics error categories",
+        "FAIL",
+        `errorCategories missing from: ${missing.join(" and ")}`,
+      );
+      return false;
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest(
+        "Tool metrics error categories",
+        "SKIP",
+        `Provider error: ${msg}`,
+      );
+      return null;
+    }
+    logTest("Tool metrics error categories", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (
+        sdk as { shutdown?: () => Promise<void>; dispose?: () => Promise<void> }
+      ).dispose?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST #6: OTel spans created for tool executions
+// ============================================================
+
+async function test_otel_spans_for_tools(): Promise<boolean | null> {
+  logSection("Test #6: OTel spans created for tool executions");
+  logTest("OTel tool execution spans", "TESTING");
+
+  resetSpans();
+
+  const sdk = new NeuroLink({
+    observability: {
+      langfuse: {
+        enabled: true,
+        publicKey: "test-public-key",
+        secretKey: "test-secret-key",
+        baseUrl: "http://localhost:9999",
+        useExternalTracerProvider: true,
+      },
+    },
+  });
+
+  try {
+    // Register a tool
+    sdk.registerTool("getWeather", {
+      name: "getWeather",
+      description:
+        "Get current weather for a city. Always call this tool when asked about the weather.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          city: { type: "string", description: "City name" },
+        },
+      },
+      execute: async (params: unknown) => {
+        const input = params as Record<string, unknown>;
+        return {
+          city: input.city || "Unknown",
+          temperature: 22,
+          condition: "Sunny",
+          humidity: 45,
+        };
+      },
+    });
+
+    // Trigger the tool via generate
+    await sdk.generate({
+      input: {
+        text: "What is the weather in Tokyo right now? Use the getWeather tool to check.",
+      },
+      provider: TEST_CONFIG.provider as string,
+      ...(TEST_CONFIG.model ? { model: TEST_CONFIG.model } : {}),
+      maxTokens: 200,
+      maxSteps: 3,
+    });
+
+    // Wait for async span completion
+    await delay(1000);
+
+    const allSpans = spanExporter.getFinishedSpans();
+    log(`  [detail] Total spans captured: ${allSpans.length}`, "reset");
+
+    // Log all span names for debugging
+    const spanNames = allSpans.map((s) => s.name);
+    log(
+      `  [detail] Span names: [${spanNames.slice(0, 10).join(", ")}${spanNames.length > 10 ? "..." : ""}]`,
+      "reset",
+    );
+
+    // Look for tool execution spans with specific span names
+    const toolSpan = allSpans.find(
+      (s) =>
+        (s.name === "neurolink.tool.execute" ||
+          s.name === "neurolink.tools.execute_custom") &&
+        (getAttr(s, "gen_ai.tool.name") !== undefined ||
+          getAttr(s, "mcp.tool_name") !== undefined ||
+          getAttr(s, "tool.name") !== undefined),
+    );
+
+    if (!toolSpan) {
+      // Model did not invoke the tool (non-deterministic)
+      logTest(
+        "OTel tool execution spans",
+        "SKIP",
+        "Model did not invoke tool; no tool spans found",
+      );
+      return null;
+    }
+
+    // Verify span has tool-related attributes
+    const toolName =
+      getAttr(toolSpan, "gen_ai.tool.name") ||
+      getAttr(toolSpan, "mcp.tool_name") ||
+      getAttr(toolSpan, "tool.name");
+    const providerAttr =
+      getAttr(toolSpan, "neurolink.provider") ||
+      getAttr(toolSpan, "gen_ai.system");
+    const statusCode = toolSpan.status.code;
+
+    log(`  [detail] Tool span name: "${toolSpan.name}"`, "green");
+    log(
+      `  [detail] Tool name attr: ${toolName || "not set"}`,
+      toolName ? "green" : "yellow",
+    );
+    log(
+      `  [detail] Provider attr: ${providerAttr || "not set"}`,
+      providerAttr ? "green" : "yellow",
+    );
+    log(
+      `  [detail] Status code: ${statusCode} (OK=${SpanStatusCode.OK}, ERROR=${SpanStatusCode.ERROR})`,
+      "reset",
+    );
+
+    // Verify at minimum the span exists and has a name
+    if (toolSpan.name.length === 0) {
+      logTest("OTel tool execution spans", "FAIL", "Tool span has empty name");
+      return false;
+    }
+
+    // Check for additional attributes (informational, not gating)
+    const hasToolName = toolName !== undefined;
+    const hasProvider = providerAttr !== undefined;
+    const hasStatus = statusCode !== undefined;
+
+    logTest(
+      "OTel tool execution spans",
+      "PASS",
+      `Found tool span "${toolSpan.name}". toolName=${hasToolName}, provider=${hasProvider}, status=${hasStatus}`,
+    );
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (isExpectedProviderError(msg)) {
+      logTest("OTel tool execution spans", "SKIP", `Provider error: ${msg}`);
+      return null;
+    }
+    logTest("OTel tool execution spans", "FAIL", msg);
+    return false;
+  } finally {
+    try {
+      await (
+        sdk as { shutdown?: () => Promise<void>; dispose?: () => Promise<void> }
+      ).shutdown?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
+// TEST RUNNER
+// ============================================================
+
+async function runAllTests(): Promise<number> {
+  const startTime = Date.now();
+  log("\n--- NeuroLink Continuous Test Suite: Tool Reliability ---", "bright");
+  log(
+    `   Provider: ${TEST_CONFIG.provider}, Model: ${TEST_CONFIG.model || "default"}`,
+    "cyan",
+  );
+  log(
+    `   Mode: Local (InMemorySpanExporter — no Langfuse credentials needed)`,
+    "green",
+  );
+
+  // Prerequisite checks
+  if (!fs.existsSync("dist") || !fs.existsSync("dist/index.js")) {
+    log("Build not found. Run: pnpm run build", "red");
+    return 1;
+  }
+
+  const tests: Array<{ name: string; fn: () => Promise<boolean | null> }> = [
+    {
+      name: "Stream result provider/model",
+      fn: test_stream_result_provider_model,
+    },
+    {
+      name: "Generate result provider/model",
+      fn: test_generate_result_provider_model,
+    },
+    {
+      name: "Tool execution events metadata",
+      fn: test_tool_execution_events,
+    },
+    {
+      name: "Tool timeout enforcement",
+      fn: test_tool_timeout_enforcement,
+    },
+    {
+      name: "Tool metrics error categories",
+      fn: test_tool_metrics_error_categories,
+    },
+    {
+      name: "OTel tool execution spans",
+      fn: test_otel_spans_for_tools,
+    },
+  ];
+
+  for (const test of tests) {
+    try {
+      const result = await test.fn();
+      testResults.push({ name: test.name, result, error: null });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      testResults.push({ name: test.name, result: false, error: msg });
+    }
+    await delay(TEST_CONFIG.interTestDelay);
+  }
+
+  // Summary
+  logSection("Test Results Summary");
+  const passed = testResults.filter((r) => r.result === true).length;
+  const failed = testResults.filter((r) => r.result === false).length;
+  const skipped = testResults.filter((r) => r.result === null).length;
+  for (const t of testResults) {
+    logTest(
+      t.name,
+      t.result === true ? "PASS" : t.result === false ? "FAIL" : "SKIP",
+      t.error || "",
+    );
+  }
+
+  const duration = Math.round((Date.now() - startTime) / 1000);
+  log(
+    `\nFinal Results: ${passed} passed, ${failed} failed, ${skipped} skipped (${testResults.length} total) in ${duration}s`,
+    failed === 0 ? "green" : "red",
+  );
+
+  return failed === 0 ? 0 : 1;
+}
+
+// ============================================================
+// CLI ARGS + EXECUTION
+// ============================================================
+
+function parseArguments(): { provider?: string; model?: string } {
+  const args: { provider?: string; model?: string } = {};
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith("--provider=")) {
+      args.provider = arg.split("=")[1];
+    }
+    if (arg.startsWith("--model=")) {
+      args.model = arg.split("=")[1];
+    }
+    if (arg === "--help") {
+      console.log(
+        "Usage: npx tsx test/continuous-test-suite-tool-reliability.ts [--provider=X] [--model=Y]",
+      );
+      console.log(
+        "\nTests tool execution metadata, event completeness, timeout enforcement,",
+      );
+      console.log(
+        "error category tracking, and OTel span generation for tool operations.",
+      );
+      console.log(
+        "Uses in-process InMemorySpanExporter to capture and verify spans.",
+      );
+      console.log("Default provider: vertex");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+const cliArgs = parseArguments();
+if (cliArgs.provider) {
+  TEST_CONFIG.provider = cliArgs.provider;
+}
+if (cliArgs.model) {
+  TEST_CONFIG.model = cliArgs.model;
+}
+// Re-resolve model after CLI args override the provider
+if (!TEST_CONFIG.model) {
+  TEST_CONFIG.model = resolveTestModel(TEST_CONFIG.provider);
+}
+
+const _describe = (globalThis as Record<string, unknown>).describe as
+  | undefined
+  | (((name: string, fn: () => void) => void) & {
+      skip: (name: string, fn: () => void) => void;
+    });
+const _it = (globalThis as Record<string, unknown>).it as
+  | undefined
+  | ((name: string, fn: () => Promise<void>, timeout?: number) => void);
+
+if (typeof _describe === "undefined") {
+  runAllTests()
+    .then((exitCode) => {
+      process.exit(exitCode);
+    })
+    .catch((e) => {
+      log(
+        `Suite crashed: ${e instanceof Error ? e.message : String(e)}`,
+        "red",
+      );
+      process.exit(1);
+    });
+} else {
+  _describe.skip("Continuous Test Suite: Tool Reliability", () => {
+    _it!(
+      "runs standalone",
+      async () => {
+        const exitCode = await runAllTests();
+        if (exitCode !== 0) {
+          throw new Error(`Test suite failed with exit code ${exitCode}`);
+        }
+      },
+      600000,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds per-tool timeout and retry configuration at registration time, and error category breakdown in tool execution metrics.

### Per-Tool Timeout & Retries (BZ-745)

```typescript
// Register with custom timeout and no retries
sdk.registerTool("myTool", tool, { timeout: 5000, maxRetries: 0 });

// Register with defaults — no behavior change
sdk.registerTool("myTool", tool);
```

- `ToolRegistrationOptions` type with optional `timeout` and `maxRetries`
- Timeout enforced via `AbortSignal.timeout()` composed with parent signal
- Works in both direct `executeTool()` and AI SDK `generateText()` paths
- Resolution priority: explicit call option > registration option > 30s default
- Propagated through `createCustomToolServerInfo` → `toolRegistry` → `ToolsManager`

### Error Category Metrics (BZ-749)

```typescript
const metrics = sdk.getToolExecutionMetrics();
// Now includes: metrics[toolName].errorCategories = { timeout: 3, validation: 1 }

const report = await sdk.getToolHealthReport();
// Now includes per-tool errorCategories + category-aware recommendations
```

- `errorCategories: Record<string, number>` added to metrics storage
- Errors classified via `ErrorCategory` enum (timeout, validation, permission, network, execution)
- MCP `isError` results mapped via `mcpCategoryToErrorCategory()`
- Health report provides category-specific issues and recommendations

### Backward Compatibility

All changes are **fully backward compatible**:
- `registerTool(name, tool)` continues to work with 30s timeout and 2 retries
- New `errorCategories` field defaults to `{}` for tools with no errors
- Uses nullish coalescing (`??`) for proper `0` value handling (`maxRetries: 0`)

## Files Changed (6 source + 1 test)

| File | Change |
|------|--------|
| `src/lib/types/tools.ts` | `ToolRegistrationOptions` type, `timeoutMs`/`maxRetries` on `ToolInfo`/`ToolImplementation` |
| `src/lib/neurolink.ts` | `registerTool()` third param, timeout wrapper, error categories, health recommendations |
| `src/lib/utils/mcpDefaults.ts` | `createCustomToolServerInfo()` timeout/retries propagation |
| `src/lib/mcp/toolRegistry.ts` | Propagate `toolTimeoutMs`/`toolMaxRetries` from metadata |
| `src/lib/core/modules/ToolsManager.ts` | `toolExecutor` binding, third param type |
| `test/continuous-test-suite-tool-reliability.ts` | 6 integration test scenarios |

## Test Results

```
✅ Stream result provider/model — provider="vertex", model="gemini-2.5-flash"
✅ Generate result provider/model — provider="vertex", model="gemini-2.5-flash"
✅ Tool execution events metadata — tool:start and tool:end fire correctly
✅ Tool timeout enforcement — 2000ms timeout enforced, 3 failed executions recorded
✅ Tool metrics error categories — errorCategories populated correctly
✅ OTel spans for tool execution — spans created with provider attribute
```

Run: `npx tsx test/continuous-test-suite-tool-reliability.ts`

## Verification

- `tsc --noEmit --strict` — 0 errors
- `prettier --check` — all files formatted
- `pnpm run validate:all` — PASS
- ESLint on changed files — 0 new errors/warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-tool timeout and retry configuration is now supported
  * Enhanced error category tracking for improved diagnostics
  * Expanded tool execution metrics and health reports with error breakdowns

* **Tests**
  * Added comprehensive tool reliability test suite

* **Chores**
  * Updated dependencies, including critical package upgrades

<!-- end of auto-generated comment: release notes by coderabbit.ai -->