### PR TITLE
fix(proxy): use stored tokenType instead of prefix heuristic for OAuth detection

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -364,12 +364,11 @@ export function createClaudeProxyRoutes(
                 }
 
                 // Detect whether this is an API key or an OAuth token.
-                // API keys start with "sk-ant-" and must use x-api-key header.
-                const accountType: "oauth" | "api_key" = accessToken.startsWith(
-                  "sk-ant-",
-                )
-                  ? "api_key"
-                  : "oauth";
+                // Use the stored tokenType (set at auth time) rather than a
+                // prefix heuristic — both API keys (sk-ant-api03-…) and OAuth
+                // access tokens (sk-ant-oat01-…) share the "sk-ant-" prefix.
+                const accountType: "oauth" | "api_key" =
+                  tokens.tokenType === "Bearer" ? "oauth" : "api_key";
 
                 accounts.push({
                   key,


### PR DESCRIPTION
## Summary

- **Fix OAuth token misclassification in proxy passthrough** — the prefix heuristic (`startsWith("sk-ant-")`) incorrectly classified OAuth access tokens (`sk-ant-oat01-…`) as API keys, since both share the `sk-ant-` prefix. This caused OAuth tokens to be sent via `x-api-key` header instead of `Authorization: Bearer`, resulting in `401 authentication_error` from Anthropic's API.
- **Use the stored `tokens.tokenType` field** (already set at auth time: `"Bearer"` for OAuth, `"api-key"` for API keys) to correctly distinguish account types.
- **Unblocks OAuth token refresh on 401** — the misclassification also prevented the retry logic from attempting token refresh, since it checked `account.type === "oauth"` before refreshing.

## Test plan

- [ ] `pnpm run check` — type-check passes (verified)
- [ ] `pnpm run lint` — no new warnings (verified)
- [ ] Authenticate with `auth login anthropic --method oauth`, then verify proxy sends `Authorization: Bearer` (not `x-api-key`)
- [ ] Authenticate with `auth login anthropic --method create-api-key`, then verify proxy sends `x-api-key`
- [ ] Verify failover between OAuth and API key accounts works correctly
- [ ] Verify token refresh triggers on 401 for OAuth accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced account authentication detection to use stored authentication metadata for more reliable and consistent account type classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->