### PR TITLE
fix(proxy): skip launchd guard when launched by launchd itself

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -418,8 +418,10 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
         process.exit(1);
       }
 
-      // Guard: launchd is managing the service — don't start manually
-      if (await isLaunchdManaging()) {
+      // Guard: launchd is managing the service — don't start manually.
+      // Skip this guard when WE are the process launchd is managing
+      // (PPID 1 = launched by launchd on macOS).
+      if (process.ppid !== 1 && (await isLaunchdManaging())) {
         if (spinner) {
           spinner.fail(
             chalk.red(


### PR DESCRIPTION
## Summary

- **Fix launchd deadlock on proxy start/restart** — the `isLaunchdManaging()` guard was blocking launchd itself from starting the proxy, causing an infinite restart loop: launchd starts proxy → proxy detects launchd → exits → launchd restarts → repeat.
- **Skip the guard when `process.ppid === 1`** (launchd is always PID 1 on macOS), so the proxy starts normally when launched by launchd while still preventing manual `proxy start` from conflicting with a launchd-managed instance.
- Fixes both `proxy setup` initial start and crash recovery restarts.

## Test plan

- [ ] Run `neurolink proxy setup` — proxy should start and respond to health check
- [ ] Kill the proxy PID (`kill <PID>`) — launchd should auto-restart it within 5-10 seconds
- [ ] Run `neurolink proxy start` manually while launchd is managing — should still show the guard message
- [ ] `pnpm run check` passes (verified)
- [ ] `pnpm run lint` passes (verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proxy startup behavior by refining launchd management guard logic. Manual proxy startup is now correctly permitted when the proxy process itself is running under launchd process management, while still properly preventing startup attempts in other scenarios where blocking is necessary to maintain system stability and prevent potential process conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->