### PR TITLE
fix(proxy): address auto-update review feedback

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1212,15 +1212,22 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     const QUIET_THRESHOLD_MS = 120 * 1000; // 2 minutes of silence
     const UPDATE_TIMEOUT_MS = 30 * 1000; // 30 seconds to come healthy
 
-    // Get running version from /health endpoint
+    // Get running version from /health endpoint (with timeout to avoid hanging)
     let runningVersion = PROXY_VERSION; // fallback
     try {
-      const healthResp = await fetch(`http://${host}:${port}/health`);
+      const healthResp = await fetch(`http://${host}:${port}/health`, {
+        signal: AbortSignal.timeout(5_000),
+      });
       const healthData = (await healthResp.json()) as { version?: string };
       runningVersion = healthData.version ?? PROXY_VERSION;
     } catch {
       /* use fallback */
     }
+
+    // Auto-update only works on macOS with launchd. On other platforms,
+    // there's no restart mechanism, so skip the update loop entirely.
+    const canAutoUpdate =
+      process.platform === "darwin" && (await isLaunchdManaging());
 
     let updateInProgress = false;
     let updateRestartInProgress = false;
@@ -1328,7 +1335,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         try {
           execFileSync(
             "launchctl",
-            ["kickstart", "-k", `gui/${uid}/com.neurolink.proxy`],
+            ["kickstart", "-k", `gui/${uid}/${PLIST_LABEL}`],
             {
               timeout: 10_000,
               stdio: "pipe",
@@ -1385,8 +1392,10 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     };
 
     // Run first check after a short delay, then on interval
-    setTimeout(runUpdateCheck, 30_000);
-    setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
+    if (canAutoUpdate) {
+      setTimeout(runUpdateCheck, 30_000);
+      setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
+    }
 
     const startedAt = Date.now();
     let parentStatus = getProcessStatus(parentPid);

--- a/src/lib/proxy/quietDetector.ts
+++ b/src/lib/proxy/quietDetector.ts
@@ -23,12 +23,26 @@ const DEFAULT_QUIET_THRESHOLD_MS = 120_000;
 const TAIL_READ_SIZE = 4096;
 
 /**
- * Build the path to today's proxy debug log file.
+ * Build the path to a proxy debug log file for a given date.
  * Format: ~/.neurolink/logs/proxy-debug-YYYY-MM-DD.jsonl
  */
-function getTodayLogPath(): string {
-  const today = new Date().toISOString().split("T")[0];
-  return join(homedir(), ".neurolink", "logs", `proxy-debug-${today}.jsonl`);
+function getLogPathForDate(date: Date): string {
+  const dateStr = date.toISOString().split("T")[0];
+  return join(homedir(), ".neurolink", "logs", `proxy-debug-${dateStr}.jsonl`);
+}
+
+/**
+ * Get the most relevant log file path. Uses today's log if it exists,
+ * otherwise falls back to yesterday's to handle the midnight rollover case
+ * (last request at 23:59, update check at 00:01).
+ */
+function getActiveLogPath(): string {
+  const todayPath = getLogPathForDate(new Date());
+  if (existsSync(todayPath)) {
+    return todayPath;
+  }
+  const yesterday = new Date(Date.now() - 86_400_000);
+  return getLogPathForDate(yesterday);
 }
 
 /**
@@ -103,7 +117,7 @@ export function checkTrafficQuiet(
     silenceDurationMs: Infinity,
   };
 
-  const logPath = getTodayLogPath();
+  const logPath = getActiveLogPath();
 
   if (!existsSync(logPath)) {
     return noActivityResult;

--- a/src/lib/proxy/updateState.ts
+++ b/src/lib/proxy/updateState.ts
@@ -93,10 +93,13 @@ export function loadUpdateState(stateFilePath?: string): UpdateState | null {
     const content = fs.readFileSync(filePath, "utf8");
     const parsed = JSON.parse(content);
     // Minimal shape check — reject valid JSON that isn't an UpdateState
+    // Note: typeof null === "object", so we check both
     if (
       typeof parsed !== "object" ||
       parsed === null ||
       typeof parsed.suppressedVersions !== "object" ||
+      parsed.suppressedVersions === null ||
+      Array.isArray(parsed.suppressedVersions) ||
       typeof parsed.lastCheckAt !== "string"
     ) {
       return getDefaultUpdateState();

--- a/test/unit/quietDetector.test.ts
+++ b/test/unit/quietDetector.test.ts
@@ -221,6 +221,34 @@ describe("checkTrafficQuiet", () => {
   });
 
   // ---------------------------------------------------------------
+  // 7. Midnight rollover: falls back to yesterday's log
+  // ---------------------------------------------------------------
+  it("falls back to yesterday's log when today's file doesn't exist", () => {
+    // Remove today's file if it exists
+    const todayFile = logFilePath();
+    if (existsSync(todayFile)) {
+      rmSync(todayFile);
+    }
+
+    // Create yesterday's log file with a recent timestamp
+    const yesterday = new Date(Date.now() - 86_400_000);
+    const yesterdayStr = yesterday.toISOString().split("T")[0];
+    const yesterdayFile = join(LOG_DIR, `proxy-debug-${yesterdayStr}.jsonl`);
+    const recentTimestamp = new Date(Date.now() - 30_000).toISOString();
+    writeFileSync(yesterdayFile, makeLogLine(recentTimestamp) + "\n");
+
+    const result = checkTrafficQuiet();
+
+    // Should read from yesterday's log, NOT return quiet (only 30s ago)
+    expect(result.isQuiet).toBe(false);
+    expect(result.lastActivityAt).toBeInstanceOf(Date);
+    expect(result.silenceDurationMs).toBeLessThan(60_000);
+
+    // Cleanup
+    rmSync(yesterdayFile);
+  });
+
+  // ---------------------------------------------------------------
   // Additional: custom threshold
   // ---------------------------------------------------------------
   it("respects a custom quietThresholdMs", () => {

--- a/test/unit/updateState.test.ts
+++ b/test/unit/updateState.test.ts
@@ -199,6 +199,36 @@ describe("updateState", () => {
     expect(state).toEqual(getDefaultUpdateState());
   });
 
+  it("returns default state when suppressedVersions is null", () => {
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        lastCheckAt: new Date().toISOString(),
+        lastCheckVersion: "1.0.0",
+        suppressedVersions: null,
+        lastUpdateAt: null,
+        lastUpdateVersion: null,
+      }),
+    );
+    const state = loadUpdateState(stateFile);
+    expect(state).toEqual(getDefaultUpdateState());
+  });
+
+  it("returns default state when suppressedVersions is an array", () => {
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        lastCheckAt: new Date().toISOString(),
+        lastCheckVersion: "1.0.0",
+        suppressedVersions: [],
+        lastUpdateAt: null,
+        lastUpdateVersion: null,
+      }),
+    );
+    const state = loadUpdateState(stateFile);
+    expect(state).toEqual(getDefaultUpdateState());
+  });
+
   // -------------------------------------------------------
   // getDefaultUpdateState
   // -------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to juspay/neurolink#907 — addresses all review comments from Copilot and CodeRabbit.

### Fixes

- **Health fetch timeout** — Added `AbortSignal.timeout(5000)` to initial `/health` fetch in guard startup to prevent indefinite hangs
- **Platform gate** — Auto-update loop only runs on macOS when launchd is managing the service. Non-macOS or foreground starts skip the update loop entirely, preventing `pnpm add -g` + failed `launchctl kickstart` suppression
- **PLIST_LABEL constant** — Replaced hardcoded `com.neurolink.proxy` string with `PLIST_LABEL` constant in kickstart call
- **suppressedVersions null check** — Added `parsed.suppressedVersions === null` and `Array.isArray()` guards to `loadUpdateState` shape validation (`typeof null === "object"` gotcha)
- **Midnight log rollover** — `quietDetector` now falls back to yesterday's log file when today's doesn't exist yet, preventing false "quiet" detection at midnight boundary

## Test plan

- [x] CLI build clean
- [x] 32/32 unit tests passing
- [x] Prettier formatting clean
- [x] ESLint 0 errors