### PR TITLE
fix(proxy): change default strategy from round-robin to fill-first

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -359,9 +359,9 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
       .option("strategy", {
         type: "string",
         alias: "s",
-        choices: ["round-robin", "fill-first"],
+        choices: ["fill-first", "round-robin"],
         description:
-          "Account selection strategy for routing requests (default: round-robin)",
+          "Account selection strategy for routing requests (default: fill-first)",
       })
       .option("health-interval", {
         type: "number",
@@ -389,11 +389,11 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
       })
       .example(
         "neurolink proxy start",
-        "Start proxy on default port 55669 with round-robin strategy",
+        "Start proxy on default port 55669 with fill-first strategy",
       )
       .example(
-        "neurolink proxy start -p 8080 -s round-robin",
-        "Start proxy on port 8080 with round-robin",
+        "neurolink proxy start -p 8080 -s fill-first",
+        "Start proxy on port 8080 with fill-first",
       )
       .example(
         "neurolink proxy start --health-interval 60",
@@ -515,7 +515,7 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
       // -----------------------------------------------------------------
 
       const strategy =
-        argv.strategy ?? proxyConfig?.routing?.strategy ?? "round-robin";
+        argv.strategy ?? proxyConfig?.routing?.strategy ?? "fill-first";
       let modelRouter: ModelRouter | undefined;
 
       if (proxyConfig?.routing) {
@@ -1768,7 +1768,7 @@ export const proxyInstallCommand: CommandModule = {
           pid: Number(pidMatch[1]),
           port,
           host,
-          strategy: "round-robin",
+          strategy: "fill-first",
           startTime: new Date().toISOString(),
           managedBy: "launchd",
         });


### PR DESCRIPTION
## Summary

Changes the default proxy account selection strategy from `round-robin` to `fill-first`.

Fill-first exhausts one account's quota before touching the next, preventing split usage across accounts that causes both to hit rate limits simultaneously. Round-robin is still available via `--strategy round-robin`.

## Changes

Single file: `src/cli/commands/proxy.ts` — 5 occurrences of `round-robin` default changed to `fill-first`.

## Test plan

- [x] CLI build clean
- [x] Prettier formatting clean
- [x] ESLint 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples in the CLI start command.

* **Chores**
  * Reordered available proxy strategy options.
  * Changed the default proxy load-balancing strategy from "round-robin" to "fill-first".
  * Updated macOS proxy service installation to persist "fill-first" as the default strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->