### PR TITLE
feat(proxy): OAuth polyfill for non-Claude-Code clients

### DIFF
--- a/src/lib/models/anthropicModels.ts
+++ b/src/lib/models/anthropicModels.ts
@@ -41,11 +41,17 @@ export enum AnthropicModel {
   // Claude Sonnet 4 (Latest Sonnet)
   CLAUDE_SONNET_4 = "claude-sonnet-4-20250514",
 
+  // Claude Sonnet 4.6
+  CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
+
   // Claude 3 Opus (Legacy flagship)
   CLAUDE_3_OPUS = "claude-3-opus-20240229",
 
   // Claude Opus 4 (Latest flagship)
   CLAUDE_OPUS_4 = "claude-opus-4-20250514",
+
+  // Claude Opus 4.6
+  CLAUDE_OPUS_4_6 = "claude-opus-4-6",
 }
 
 // ============================================================================
@@ -74,6 +80,7 @@ export const MODEL_TIER_ACCESS: Record<ClaudeSubscriptionTier, string[]> = {
     AnthropicModel.CLAUDE_3_5_SONNET,
     AnthropicModel.CLAUDE_3_5_SONNET_V2,
     AnthropicModel.CLAUDE_SONNET_4,
+    AnthropicModel.CLAUDE_SONNET_4_6,
   ],
 
   // Max tier: All models including Opus
@@ -196,6 +203,34 @@ export const MODEL_METADATA: Record<string, AnthropicModelMetadata> = {
     deprecated: false,
     family: "opus",
     description: "Latest flagship model with advanced reasoning",
+  },
+
+  // Claude Sonnet 4.6
+  [AnthropicModel.CLAUDE_SONNET_4_6]: {
+    displayName: "Claude Sonnet 4.6",
+    contextWindow: 1000000,
+    maxOutputTokens: 64000,
+    supportsVision: true,
+    supportsExtendedThinking: true,
+    supportsToolUse: true,
+    supportsStreaming: true,
+    deprecated: false,
+    family: "sonnet",
+    description: "Claude 4.6 Sonnet with 1M context window",
+  },
+
+  // Claude Opus 4.6
+  [AnthropicModel.CLAUDE_OPUS_4_6]: {
+    displayName: "Claude Opus 4.6",
+    contextWindow: 1000000,
+    maxOutputTokens: 64000,
+    supportsVision: true,
+    supportsExtendedThinking: true,
+    supportsToolUse: true,
+    supportsStreaming: true,
+    deprecated: false,
+    family: "opus",
+    description: "Claude 4.6 Opus flagship with 1M context window",
   },
 };
 
@@ -492,11 +527,16 @@ export function getLatestModelsByFamily(): Record<
   const familyPriority: Record<AnthropicModelMetadata["family"], string[]> = {
     haiku: [AnthropicModel.CLAUDE_3_5_HAIKU, AnthropicModel.CLAUDE_3_HAIKU],
     sonnet: [
+      AnthropicModel.CLAUDE_SONNET_4_6,
       AnthropicModel.CLAUDE_SONNET_4,
       AnthropicModel.CLAUDE_3_5_SONNET_V2,
       AnthropicModel.CLAUDE_3_5_SONNET,
     ],
-    opus: [AnthropicModel.CLAUDE_OPUS_4, AnthropicModel.CLAUDE_3_OPUS],
+    opus: [
+      AnthropicModel.CLAUDE_OPUS_4_6,
+      AnthropicModel.CLAUDE_OPUS_4,
+      AnthropicModel.CLAUDE_3_OPUS,
+    ],
   };
 
   for (const family of Object.keys(familyPriority) as Array<

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -215,7 +215,32 @@ const detectSubscriptionTier = (
 const detectAuthMethod = (
   oauthToken: OAuthToken | null,
 ): AnthropicAuthMethod => {
-  // OAuth takes precedence if available
+  // Explicit env var takes highest precedence — allows forcing api_key mode
+  // even when OAuth credentials exist (e.g., when using a proxy that handles auth)
+  const explicit = process.env.ANTHROPIC_AUTH_METHOD?.toLowerCase();
+  if (explicit === "api_key" || explicit === "apikey") {
+    logger.debug(
+      "[detectAuthMethod] Forced to api_key by ANTHROPIC_AUTH_METHOD env var",
+    );
+    return "api_key";
+  }
+  if (explicit === "oauth") {
+    if (oauthToken) {
+      logger.debug(
+        "[detectAuthMethod] Forced to oauth by ANTHROPIC_AUTH_METHOD env var",
+      );
+      return "oauth";
+    }
+    logger.warn(
+      "[detectAuthMethod] ANTHROPIC_AUTH_METHOD=oauth but no OAuth token found; falling through to auto-detection",
+    );
+  } else if (explicit) {
+    logger.warn(
+      "[detectAuthMethod] Unrecognized ANTHROPIC_AUTH_METHOD value; falling through to auto-detection",
+      { value: explicit },
+    );
+  }
+  // Auto-detect: OAuth takes precedence if available
   const method: AnthropicAuthMethod = oauthToken ? "oauth" : "api_key";
   logger.debug("[detectAuthMethod] Auth method resolved", {
     method,
@@ -290,13 +315,24 @@ export class AnthropicProvider extends BaseProvider {
   ) {
     // Pre-compute effective model with tier validation before calling super
     const oauthToken = config?.oauthToken ?? getOAuthToken();
+    // Resolve auth method FIRST so that tier detection uses the chosen method.
+    // If ANTHROPIC_AUTH_METHOD=api_key wins over an existing OAuth token, the
+    // tier must reflect api_key mode (full model access) rather than the OAuth
+    // token's subscription level.
+    const authMethod = config?.authMethod ?? detectAuthMethod(oauthToken);
     const subscriptionTier =
-      config?.subscriptionTier ?? detectSubscriptionTier(oauthToken);
+      config?.subscriptionTier ??
+      (authMethod === "oauth" ? detectSubscriptionTier(oauthToken) : "api");
     const targetModel = modelName || getDefaultAnthropicModel();
 
-    // Determine effective model based on tier access
+    // Determine effective model based on tier access.
+    // Skip tier validation when a proxy is in use (ANTHROPIC_BASE_URL is set)
+    // — the proxy handles model access and auth, so the SDK should pass
+    // the requested model through without downgrading.
     let effectiveModel = targetModel;
+    const usingProxy = !!process.env.ANTHROPIC_BASE_URL;
     if (
+      !usingProxy &&
       subscriptionTier !== "api" &&
       !isModelAvailableForTier(targetModel, subscriptionTier)
     ) {
@@ -324,8 +360,8 @@ export class AnthropicProvider extends BaseProvider {
     this.oauthToken = oauthToken;
     this.subscriptionTier = subscriptionTier;
 
-    // Determine auth method - config takes precedence, then auto-detect
-    this.authMethod = config?.authMethod ?? detectAuthMethod(this.oauthToken);
+    // Use the auth method already resolved above (before tier computation)
+    this.authMethod = authMethod;
 
     // Build headers based on auth method and subscription tier
     const headers: Record<string, string> = this.getAuthHeaders();
@@ -474,6 +510,11 @@ export class AnthropicProvider extends BaseProvider {
    * ```
    */
   public validateModelAccess(model: string): boolean {
+    // Proxy mode: bypass tier validation entirely — the proxy handles model access
+    if (process.env.ANTHROPIC_BASE_URL) {
+      return true;
+    }
+
     // API tier has access to all models
     if (this.subscriptionTier === "api") {
       return true;

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -10,6 +10,9 @@
  * Without a router, models are passed through to the Anthropic provider.
  */
 
+import { readFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { RouteGroup, ServerContext } from "../types.js";
 import type { ModelRouter } from "../../proxy/modelRouter.js";
 import {
@@ -127,6 +130,163 @@ function advancePrimaryIfCurrent(
 }
 
 // ---------------------------------------------------------------------------
+// OAuth polyfill helpers (extracted to reduce block nesting)
+// ---------------------------------------------------------------------------
+
+const snapshotCache = new Map<
+  string,
+  { headers: Record<string, string>; loadedAt: number }
+>();
+const SNAPSHOT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Load a header snapshot captured from a real Claude Code session and apply
+ * any headers the client didn't send.  This makes non-Claude-Code requests
+ * (e.g. from Curator, custom apps) appear identical to Claude Code.
+ */
+async function applyHeaderSnapshot(
+  headers: Record<string, string>,
+  accountLabel: string,
+): Promise<void> {
+  try {
+    // Sanitize accountLabel to prevent directory traversal
+    const safeLabel = accountLabel.replace(/[^a-zA-Z0-9._@-]/g, "_");
+
+    // Check cache first
+    const cached = snapshotCache.get(safeLabel);
+    if (cached && Date.now() - cached.loadedAt < SNAPSHOT_CACHE_TTL_MS) {
+      for (const [sk, sv] of Object.entries(cached.headers)) {
+        const lower = sk.toLowerCase();
+        if (
+          typeof sv === "string" &&
+          !headers[lower] &&
+          !BLOCKED_UPSTREAM_HEADERS.has(lower) &&
+          lower !== "authorization" &&
+          lower !== "x-api-key"
+        ) {
+          headers[lower] = sv;
+        }
+      }
+      return;
+    }
+
+    const snapshotPath = join(
+      homedir(),
+      ".neurolink",
+      "header-snapshots",
+      `anthropic_${safeLabel}.json`,
+    );
+
+    try {
+      await access(snapshotPath);
+    } catch {
+      return;
+    }
+
+    const snapshot = JSON.parse(await readFile(snapshotPath, "utf8")) as {
+      headers?: Record<string, string>;
+    };
+    if (!snapshot.headers) {
+      return;
+    }
+
+    // Store in cache
+    snapshotCache.set(safeLabel, {
+      headers: snapshot.headers,
+      loadedAt: Date.now(),
+    });
+
+    for (const [sk, sv] of Object.entries(snapshot.headers)) {
+      const lower = sk.toLowerCase();
+      if (
+        typeof sv === "string" &&
+        !headers[lower] &&
+        !BLOCKED_UPSTREAM_HEADERS.has(lower) &&
+        lower !== "authorization" &&
+        lower !== "x-api-key"
+      ) {
+        headers[lower] = sv;
+      }
+    }
+  } catch {
+    // Snapshot missing or corrupt — continue without it
+  }
+}
+
+/**
+ * Polyfill the request body for OAuth accounts.
+ * Claude Code injects a billing header, agent block, and metadata.user_id
+ * into the body.  Non-CC clients (Curator, custom apps) don't send these —
+ * Anthropic rejects without them.
+ */
+function polyfillOAuthBody(bodyStr: string, accountToken: string): string {
+  try {
+    const parsed = JSON.parse(bodyStr);
+
+    // Billing header block (required by Anthropic for OAuth)
+    const randomHex = Math.random().toString(16).substring(2, 5);
+    const billingBlock = {
+      type: "text",
+      text: `x-anthropic-billing-header: cc_version=2.1.86.${randomHex}; cc_entrypoint=cli; cch=proxy;`,
+    };
+    const agentBlock = {
+      type: "text",
+      text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+    };
+
+    // Normalise system to array and prepend billing + agent
+    if (parsed.system) {
+      if (typeof parsed.system === "string") {
+        parsed.system = [{ type: "text", text: parsed.system }];
+      }
+      if (Array.isArray(parsed.system)) {
+        const hasBilling = parsed.system.some(
+          (b: { text?: string }) =>
+            typeof b.text === "string" &&
+            b.text.includes("x-anthropic-billing-header"),
+        );
+        const hasAgent = parsed.system.some(
+          (b: { text?: string }) =>
+            typeof b.text === "string" && b.text.includes("Claude Agent SDK"),
+        );
+        const toInsert = [];
+        if (!hasBilling) {
+          toInsert.push(billingBlock);
+        }
+        if (!hasAgent) {
+          toInsert.push(agentBlock);
+        }
+        if (toInsert.length > 0) {
+          parsed.system = [...toInsert, ...parsed.system];
+        }
+      }
+    } else {
+      parsed.system = [billingBlock, agentBlock];
+    }
+
+    // Inject metadata.user_id (required for OAuth)
+    if (!parsed.metadata?.user_id) {
+      const tokenPrefix = accountToken.substring(
+        0,
+        Math.min(20, accountToken.length),
+      );
+      const hash = Array.from(new TextEncoder().encode(tokenPrefix))
+        .reduce((a, b) => ((a << 5) - a + b) | 0, 0)
+        .toString(16)
+        .replace("-", "");
+      parsed.metadata = {
+        ...parsed.metadata,
+        user_id: `proxy-${hash}`,
+      };
+    }
+
+    return JSON.stringify(parsed);
+  } catch {
+    return bodyStr; // JSON parse failed — use original body
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Legacy credential refresh helper (extracted to reduce block nesting)
 // ---------------------------------------------------------------------------
 
@@ -229,7 +389,10 @@ export function createClaudeProxyRoutes(
           const body = ctx.body as ClaudeRequest | undefined;
 
           // 1. Validate
-          if (!body?.model || !body?.messages) {
+          if (
+            typeof body?.model !== "string" ||
+            !Array.isArray(body?.messages)
+          ) {
             return buildClaudeError(
               400,
               "Missing required fields: model, messages",
@@ -237,6 +400,17 @@ export function createClaudeProxyRoutes(
           }
 
           // 2. Resolve model via router (or pass through to anthropic)
+          // Guard: without a model router, only Claude models are allowed.
+          const modelLower = body.model.toLowerCase();
+          if (!modelRouter && !modelLower.startsWith("claude-")) {
+            return buildClaudeError(
+              404,
+              `Model '${body.model}' is not an Anthropic model. ` +
+                `The proxy only supports Claude models. ` +
+                `Use a model router to route non-Claude models to other providers.`,
+            );
+          }
+
           const route = modelRouter?.resolve(body.model) ?? {
             provider: "anthropic",
             model: body.model,
@@ -244,8 +418,14 @@ export function createClaudeProxyRoutes(
 
           try {
             // 3. Route based on target provider
-            const isClaudeTarget =
-              route.provider === "anthropic" || route.provider === null;
+            if (route.provider === null) {
+              return buildClaudeError(
+                404,
+                `Model '${body.model}' is not a Claude model. ` +
+                  `Use a model router to route it to another provider.`,
+              );
+            }
+            const isClaudeTarget = route.provider === "anthropic";
 
             if (isClaudeTarget) {
               // ─── PASSTHROUGH MODE (Claude → Claude) ───────────────
@@ -590,27 +770,58 @@ export function createClaudeProxyRoutes(
                 headers["content-type"] = "application/json";
                 if (isOAuth) {
                   headers["authorization"] = `Bearer ${account.token}`;
+                  delete headers["x-api-key"];
                 } else {
                   headers["x-api-key"] = account.token;
                   delete headers["authorization"];
                 }
 
-                // Defaults: only set when client didn't send them
+                // Apply header snapshot defaults for OAuth accounts
+                if (isOAuth) {
+                  await applyHeaderSnapshot(headers, account.label);
+                }
+
+                // Hard defaults for anything still missing
                 if (!headers["user-agent"]) {
-                  headers["user-agent"] = "claude-cli/2.1.80 (external, cli)";
+                  headers["user-agent"] = "claude-cli/2.1.86 (external, cli)";
                 }
                 if (!headers["anthropic-version"]) {
                   headers["anthropic-version"] = "2023-06-01";
                 }
-
-                // Ensure oauth beta is always present in the beta list
-                const existingBetas = headers["anthropic-beta"] ?? "";
-                if (!existingBetas) {
-                  headers["anthropic-beta"] = "oauth-2025-04-20";
-                } else if (!existingBetas.includes("oauth")) {
-                  headers["anthropic-beta"] =
-                    `${existingBetas},oauth-2025-04-20`;
+                if (!headers["anthropic-dangerous-direct-browser-access"]) {
+                  headers["anthropic-dangerous-direct-browser-access"] = "true";
                 }
+
+                // Manage anthropic-beta header based on auth type.
+                // OAuth requires specific betas; API-key must NOT carry them.
+                if (isOAuth) {
+                  const existing = new Set(
+                    (headers["anthropic-beta"] ?? "")
+                      .split(",")
+                      .map((s: string) => s.trim())
+                      .filter(Boolean),
+                  );
+                  existing.add("oauth-2025-04-20");
+                  existing.add("claude-code-20250219");
+                  headers["anthropic-beta"] = [...existing].join(",");
+                } else {
+                  // Strip OAuth-specific betas that may have leaked from client
+                  const cleaned = (headers["anthropic-beta"] ?? "")
+                    .split(",")
+                    .map((s: string) => s.trim())
+                    .filter((s: string) => s && s !== "oauth-2025-04-20")
+                    .join(",");
+                  if (cleaned) {
+                    headers["anthropic-beta"] = cleaned;
+                  } else {
+                    delete headers["anthropic-beta"];
+                  }
+                }
+
+                // Polyfill request body for OAuth accounts
+                const buildUpstreamBody = () =>
+                  isOAuth ? polyfillOAuthBody(bodyStr, account.token) : bodyStr;
+                const finalBodyStr = buildUpstreamBody();
 
                 logger.always(
                   `[proxy] → account=${account.label} (${account.type})`,
@@ -625,7 +836,7 @@ export function createClaudeProxyRoutes(
                   response = await fetch(url, {
                     method: "POST",
                     headers,
-                    body: bodyStr,
+                    body: finalBodyStr,
                     signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
                   });
                 } catch (fetchErr) {
@@ -659,6 +870,7 @@ export function createClaudeProxyRoutes(
                       cooldownMs = seconds * 1000;
                     } else {
                       const date = new Date(retryAfter);
+                      // eslint-disable-next-line max-depth
                       if (!Number.isNaN(date.getTime())) {
                         cooldownMs = Math.max(
                           date.getTime() - Date.now(),
@@ -722,6 +934,7 @@ export function createClaudeProxyRoutes(
                       logger.always(
                         `[proxy] ⚠ account=${account.label} refresh failed on attempt ${authRetry + 1}`,
                       );
+                      // eslint-disable-next-line max-depth
                       if (
                         accountState.consecutiveRefreshFailures >=
                         MAX_CONSECUTIVE_REFRESH_FAILURES
@@ -730,6 +943,7 @@ export function createClaudeProxyRoutes(
                         authFailureMessage = formatReauthMessage(account.label);
                         break;
                       }
+                      // eslint-disable-next-line max-depth
                       if (authRetry < MAX_AUTH_RETRIES - 1) {
                         await sleep(2000);
                       }
@@ -745,9 +959,10 @@ export function createClaudeProxyRoutes(
                       const retryResp = await fetch(url, {
                         method: "POST",
                         headers,
-                        body: bodyStr,
+                        body: buildUpstreamBody(),
                         signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
                       });
+                      // eslint-disable-next-line max-depth
                       if (retryResp.ok) {
                         authRetrySucceeded = true;
                         accountState.consecutiveRefreshFailures = 0;
@@ -859,6 +1074,7 @@ export function createClaudeProxyRoutes(
                       );
                       recordError(account.label, account.type, retryStatus);
 
+                      // eslint-disable-next-line max-depth
                       if (retryStatus === 429) {
                         sawRateLimit = true;
                         const retryAfter = retryResp.headers.get("retry-after");
@@ -881,6 +1097,7 @@ export function createClaudeProxyRoutes(
                         break;
                       }
 
+                      // eslint-disable-next-line max-depth
                       if (
                         retryStatus === 401 ||
                         retryStatus === 402 ||
@@ -893,6 +1110,7 @@ export function createClaudeProxyRoutes(
                         continue;
                       }
 
+                      // eslint-disable-next-line max-depth
                       if (isTransientHttpFailure(retryStatus, retryBody)) {
                         // Decision 8: No cooldown for transient errors — rotate immediately
                         sawTransientFailure = true;
@@ -904,6 +1122,7 @@ export function createClaudeProxyRoutes(
                         "api_error",
                         summarizeErrorMessage(retryBody),
                       );
+                      // eslint-disable-next-line max-depth
                       try {
                         return JSON.parse(retryBody);
                       } catch {
@@ -925,7 +1144,9 @@ export function createClaudeProxyRoutes(
                   }
 
                   if (!authRetrySucceeded) {
+                    // eslint-disable-next-line max-depth
                     if (!accountState.permanentlyDisabled) {
+                      // eslint-disable-next-line max-depth
                       if (
                         !accountState.coolingUntil ||
                         accountState.coolingUntil <= Date.now()
@@ -1271,6 +1492,7 @@ export function createClaudeProxyRoutes(
                       "anthropic-ratelimit-tokens-limit",
                     ]) {
                       const val = response.headers.get(h);
+                      // eslint-disable-next-line max-depth
                       if (val) {
                         responseHeaders[h] = val;
                       }


### PR DESCRIPTION
## Summary

Enable non-Claude-Code clients (Curator, custom apps) to use the Neurolink proxy with OAuth accounts by polyfilling the headers and body that Anthropic expects from Claude Code requests.

**Problem:** Anthropic's OAuth endpoint requires specific headers (`anthropic-beta: claude-code-20250219`, identity headers) and body fields (`x-anthropic-billing-header`, agent block, `metadata.user_id`) that only Claude Code sends. Non-CC clients get 401/400 errors.

**Solution:** The proxy now detects OAuth accounts and automatically injects the missing headers and body fields by loading header snapshots from `~/.neurolink/header-snapshots/` and generating the required billing/agent/metadata blocks.

### Changes

- **Skip SDK tier validation when `ANTHROPIC_BASE_URL` is set** — the proxy handles model access, so the SDK should pass the requested model through without downgrading
- **Honor `ANTHROPIC_AUTH_METHOD` env var** — allows forcing `api_key` mode even when OAuth credentials exist
- **Delete `x-api-key` for OAuth accounts** — prevents conflicting auth headers (both `x-api-key` and `authorization: Bearer`) reaching Anthropic
- **Header snapshot polyfill** — loads captured Claude Code headers from `~/.neurolink/header-snapshots/` and applies as defaults for OAuth requests
- **Body polyfill** — injects `x-anthropic-billing-header`, agent block, and `metadata.user_id` for OAuth requests
- **Non-Anthropic model rejection** — rejects gemini/gpt/mistral/llama models with a clear error instead of forwarding them to Anthropic
- **Add claude-opus-4-6 and claude-sonnet-4-6** — new model IDs added to enum, tier access, and metadata

### Files Changed

- `src/lib/providers/anthropic.ts` — tier skip for proxy, `ANTHROPIC_AUTH_METHOD` support, debug traces removed
- `src/lib/server/routes/claudeProxyRoutes.ts` — header/body polyfill helpers, model guard, auth header fix
- `src/lib/models/anthropicModels.ts` — new model enum entries, tier access, metadata

## Test plan

- [ ] Curator generates via proxy with OAuth account (already verified in prior session)
- [ ] Non-Anthropic models (e.g. `gemini-2.5-flash`) return clear 404 error
- [ ] API key accounts still work without polyfill injection
- [ ] Header snapshots are applied as defaults only (don't override client-sent headers)
- [ ] Build passes: both `svelte-package` and `build:cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Claude Sonnet 4.6 and Opus 4.6 models with expanded capabilities: 1M token context window and 64K max output tokens
  * Enhanced OAuth authentication handling with improved request header and body management
  * Improved proxy mode detection and model validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->