### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,3 +749,8 @@ Full command and API breakdown lives in [`docs/cli/commands.md`](docs/cli/comman
 ---
 
 NeuroLink is built with ❤️ by Juspay. Contributions, questions, and production feedback are always welcome.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/juspay-neurolink).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/juspay-neurolink)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a hosted deployment option available on Frontier AI, including a direct access link for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->