### PR TITLE
refactor(proxy): decompose large functions for lint compliance, add scorer definitions and unit tests

### DIFF
--- a/docs-site/config/redirects.ts
+++ b/docs-site/config/redirects.ts
@@ -127,7 +127,6 @@ const sectionReorganizationRedirects: PluginOptions["redirects"] = [
   // Analytics/observability redirects (redirect to telemetry as main observability page)
   { from: "/analytics", to: "/docs/observability/telemetry" },
   { from: "/docs/analytics", to: "/docs/observability/telemetry" },
-  { from: "/docs/reference/analytics", to: "/docs/observability/telemetry" },
   { from: "/observability", to: "/docs/observability/telemetry" },
   { from: "/telemetry", to: "/docs/observability/telemetry" },
 

--- a/docs-site/scripts/build-llms-txt.ts
+++ b/docs-site/scripts/build-llms-txt.ts
@@ -25,6 +25,8 @@ const DOCS_BASE_URL = process.env.DOCS_BASE_URL || "https://docs.neurolink.ink";
 // Summary file constraints
 const SUMMARY_MAX_SIZE_KB = 50;
 const SUMMARY_CONTENT_TRUNCATE_CHARS = 500;
+const SUMMARY_MIN_TRUNCATE_CHARS = 250;
+const SUMMARY_TRUNCATE_STEP_CHARS = 25;
 
 // Directories to exclude
 const EXCLUDED_DIRS = ["tracking", "phases", "analysis", "plans", "test-reports"];
@@ -416,7 +418,10 @@ function sortSections(sections: Map<string, DocFile[]>): string[] {
 /**
  * Build the summary llms.txt content (~50KB)
  */
-function buildSummaryLlmsTxt(files: DocFile[]): string {
+function buildSummaryLlmsTxt(
+  files: DocFile[],
+  truncateChars: number = SUMMARY_CONTENT_TRUNCATE_CHARS,
+): string {
   const timestamp = new Date().toISOString();
   const lines: string[] = [];
 
@@ -498,7 +503,7 @@ function buildSummaryLlmsTxt(files: DocFile[]): string {
       lines.push("");
 
       // Truncate content for summary
-      const truncated = truncateContent(file.content, SUMMARY_CONTENT_TRUNCATE_CHARS);
+      const truncated = truncateContent(file.content, truncateChars);
       lines.push(truncated);
       lines.push("");
       lines.push("---");
@@ -516,6 +521,27 @@ function buildSummaryLlmsTxt(files: DocFile[]): string {
   lines.push("");
 
   return lines.join("\n");
+}
+
+function buildSummaryWithinTarget(files: DocFile[]): {
+  content: string;
+  truncateChars: number;
+} {
+  let truncateChars = SUMMARY_CONTENT_TRUNCATE_CHARS;
+  let content = buildSummaryLlmsTxt(files, truncateChars);
+
+  while (
+    Buffer.byteLength(content, "utf8") > SUMMARY_MAX_SIZE_KB * 1024 &&
+    truncateChars > SUMMARY_MIN_TRUNCATE_CHARS
+  ) {
+    truncateChars = Math.max(
+      SUMMARY_MIN_TRUNCATE_CHARS,
+      truncateChars - SUMMARY_TRUNCATE_STEP_CHARS,
+    );
+    content = buildSummaryLlmsTxt(files, truncateChars);
+  }
+
+  return { content, truncateChars };
 }
 
 /**
@@ -620,15 +646,22 @@ async function buildLlmsTxtFiles(): Promise<void> {
 
   // Build summary version
   console.log("Building llms.txt (summary)...");
-  const summaryContent = buildSummaryLlmsTxt(files);
+  const summaryBuild = buildSummaryWithinTarget(files);
+  const summaryContent = summaryBuild.content;
   fs.writeFileSync(SUMMARY_OUTPUT, summaryContent, "utf-8");
   const summaryStats = fs.statSync(SUMMARY_OUTPUT);
   const summarySizeKB = (summaryStats.size / 1024).toFixed(2);
   console.log(`  Output: ${SUMMARY_OUTPUT}`);
   console.log(`  Size: ${summarySizeKB} KB`);
-
+  if (summaryBuild.truncateChars !== SUMMARY_CONTENT_TRUNCATE_CHARS) {
+    console.log(
+      `  Adjusted truncation length to ${summaryBuild.truncateChars} characters to stay within target size`,
+    );
+  }
   if (summaryStats.size > SUMMARY_MAX_SIZE_KB * 1024) {
-    console.log(`  Warning: Summary exceeds target size of ${SUMMARY_MAX_SIZE_KB}KB`);
+    console.log(
+      `  Warning: Summary still exceeds target size of ${SUMMARY_MAX_SIZE_KB}KB`,
+    );
   }
 
   // Build full version

--- a/docs/business-documentation.md
+++ b/docs/business-documentation.md
@@ -107,7 +107,7 @@ This hub provides comprehensive business-focused documentation for implementing 
 
 ### Week 2: Implementation
 
-1. **Follow**: [Quick Start Tutorial](./tutorials.md#quick-start-15-minutes)
+1. **Follow**: [Quick Start Tutorial](/tutorials/step-by-step#quick-start-15-minutes)
 2. **Enable**: Analytics and evaluation features
 3. **Configure**: Quality gates and cost monitoring
 4. **Test**: Validation using [Testing Guide](./testing.md)

--- a/docs/cookbook/rate-limit-handling.md
+++ b/docs/cookbook/rate-limit-handling.md
@@ -371,15 +371,15 @@ class RedisRateLimiter {
     const windowStart = now - this.window * 1000;
 
     // Remove old entries
-    await this.redis.zremrangebyscore(this.key, 0, windowStart);
+    await this.redis.zRemRangeByScore(this.key, 0, windowStart);
 
     // Count current requests
-    const count = await this.redis.zcard(this.key);
+    const count = await this.redis.zCard(this.key);
 
     if (count >= this.limit) {
-      const oldestEntry = await this.redis.zrange(this.key, 0, 0, "WITHSCORES");
-      const waitTime = oldestEntry[1]
-        ? parseInt(oldestEntry[1]) + this.window * 1000 - now
+      const [oldestEntry] = await this.redis.zRangeWithScores(this.key, 0, 0);
+      const waitTime = oldestEntry?.score
+        ? oldestEntry.score + this.window * 1000 - now
         : 1000;
 
       console.log(`⏳ Rate limit: waiting ${waitTime}ms`);
@@ -388,7 +388,9 @@ class RedisRateLimiter {
     }
 
     // Add current request
-    await this.redis.zadd(this.key, now, `${now}-${Math.random()}`);
+    await this.redis.zAdd(this.key, [
+      { score: now, value: `${now}-${Math.random()}` },
+    ]);
     await this.redis.expire(this.key, this.window * 2);
 
     return fn();

--- a/docs/features/claude-proxy-observability.md
+++ b/docs/features/claude-proxy-observability.md
@@ -28,6 +28,16 @@ This guide explains how to read the OpenObserve dashboard used to operate the Ne
 
 For a fresh local setup, use the NeuroLink-owned helper in `scripts/observability/` instead of borrowing telemetry files from another repo.
 
+If you do not already have the CLI installed, install it first:
+
+```bash
+pnpm add -g @juspay/neurolink
+# or
+npm install -g @juspay/neurolink
+```
+
+Then continue with the setup steps below.
+
 1. Optional: copy `scripts/observability/proxy-observability.env.example` to `scripts/observability/proxy-observability.env` only if your local ports or credentials need to differ from the defaults.
 2. Start the local OpenObserve stack and import the dashboard:
 

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -37,6 +37,16 @@ Anthropic API  /  Google AI  /  OpenAI  /  ...
 
 ## Quick Start
 
+If you do not already have the CLI installed, install it first:
+
+```bash
+pnpm add -g @juspay/neurolink
+# or
+npm install -g @juspay/neurolink
+```
+
+Then continue with the proxy setup steps below.
+
 ### One-command setup
 
 ```bash

--- a/docs/reference/provider-selection.md
+++ b/docs/reference/provider-selection.md
@@ -489,7 +489,7 @@ type ProviderConfig = {
   priority: number;
 };
 
-// Default priority: self-hosted first (no rate limits), then cloud providers
+// Default priority: self-hosted first, then cloud providers
 const providerChain: ProviderConfig[] = [
   { provider: "litellm", model: "openai/gpt-4o", priority: 1 },
   { provider: "ollama", model: "llama3.1:8b", priority: 2 },

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,3 +1,8 @@
+---
+title: Step-by-Step Integration Tutorials
+slug: tutorials/step-by-step
+---
+
 # 📚 Step-by-Step Integration Tutorials
 
 ## 🚀 Quick Start (15 minutes) {#quick-start-15-minutes}

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "@opentelemetry/core": "^2.6.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.214.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/resources": "^2.6.0",
     "@opentelemetry/sdk-logs": "^0.214.0",
     "@opentelemetry/sdk-metrics": "^2.6.1",
@@ -434,6 +434,7 @@
       "js-yaml@>=3.0.0 <3.14.2": ">=3.14.2",
       "markdown-it@<14.1.1": ">=14.1.1",
       "ajv@>=8.0.0 <8.18.0": ">=8.18.0",
+      "@xmldom/xmldom@<0.8.12": ">=0.8.12",
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   js-yaml@>=3.0.0 <3.14.2: '>=3.14.2'
   markdown-it@<14.1.1: '>=14.1.1'
   ajv@>=8.0.0 <8.18.0: '>=8.18.0'
+  '@xmldom/xmldom@<0.8.12': '>=0.8.12'
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
 
 pnpmfileChecksum: sha256-qFFlrDVMxTAG02VWf3xBAHmYpquoAuUauBBYPNQv57g=
@@ -93,7 +94,7 @@ importers:
         version: 0.1.4(@juspay/neurolink@9.37.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@langfuse/otel':
         specifier: ^5.0.1
-        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.28.0(zod@4.3.6)
@@ -116,8 +117,8 @@ importers:
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http':
-        specifier: ^0.213.0
-        version: 0.213.0(@opentelemetry/api@1.9.1)
+        specifier: ^0.214.0
+        version: 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
         specifier: ^2.6.0
         version: 2.6.1(@opentelemetry/api@1.9.1)
@@ -1934,6 +1935,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0':
+    resolution: {integrity: sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-proto@0.213.0':
     resolution: {integrity: sha512-six3vPq3sL+ge1iZOfKEg+RHuFQhGb8ZTdlvD234w/0gi8ty/qKD46qoGpKvM3amy5yYunWBKiFBW47WaVS26w==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -3172,9 +3179,9 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
-    engines: {node: '>=10.0.0'}
+  '@xmldom/xmldom@0.9.9':
+    resolution: {integrity: sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==}
+    engines: {node: '>=14.6'}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -8488,6 +8495,14 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 
+  '@langfuse/otel@5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@langfuse/core': 5.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
   '@lukeed/ms@2.0.2':
     optional: true
 
@@ -8924,6 +8939,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1)':
@@ -10522,7 +10546,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.9.9': {}
 
   abstract-logging@2.0.1:
     optional: true
@@ -12528,7 +12552,7 @@ snapshots:
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.9.9
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7

--- a/scripts/observability/check-proxy-telemetry.mjs
+++ b/scripts/observability/check-proxy-telemetry.mjs
@@ -112,7 +112,7 @@ async function readLatestLocalSummary() {
       handle = await fs.open(path, "r");
     } catch (err) {
       if (err.code === "ENOENT") {
-        return null;
+        continue;
       }
       throw err;
     }

--- a/scripts/observability/manage-local-openobserve.sh
+++ b/scripts/observability/manage-local-openobserve.sh
@@ -10,10 +10,40 @@ DOCTOR_SCRIPT="${SCRIPT_DIR}/check-proxy-telemetry.mjs"
 
 load_env() {
   if [[ -f "${ENV_FILE}" ]]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "${ENV_FILE}"
-    set +a
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+      [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+
+      line="${line#"${line%%[![:space:]]*}"}"
+      if [[ "${line}" =~ ^[[:space:]]*export[[:space:]]+ ]]; then
+        line="${line#export }"
+      fi
+
+      if [[ "${line}" != *=* ]]; then
+        continue
+      fi
+
+      local key="${line%%=*}"
+      local value="${line#*=}"
+
+      key="${key#"${key%%[![:space:]]*}"}"
+      key="${key%"${key##*[![:space:]]}"}"
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
+
+      if [[ "${value}" =~ ^\".*\"$ || "${value}" =~ ^\'.*\'$ ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+
+      if [[ -n "${key}" ]]; then
+        if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+          echo "Skipping invalid env var name in ${ENV_FILE}: ${key}" >&2
+          continue
+        fi
+        printf -v "${key}" '%s' "${value}"
+        export "${key}"
+      fi
+    done < "${ENV_FILE}"
   fi
 }
 
@@ -149,7 +179,8 @@ case "${command}" in
 Local proxy observability is ready.
 
 OpenObserve UI: ${NEUROLINK_OPENOBSERVE_URL}
-OpenObserve login: ${NEUROLINK_OPENOBSERVE_USER} / ${NEUROLINK_OPENOBSERVE_PASSWORD}
+OpenObserve login user: ${NEUROLINK_OPENOBSERVE_USER}
+OpenObserve password source: ${ENV_FILE} (NEUROLINK_OPENOBSERVE_PASSWORD)
 OTLP HTTP endpoint: http://localhost:${NEUROLINK_OTLP_HTTP_PORT}
 
 Set this before starting the proxy:

--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -42,6 +42,8 @@ const IGNORED_VULNERABLE_PACKAGES = [
   "jsondiffpatch", // XSS in ai dependency - tracked separately
   "undici", // DoS in transitive dependency - requires upstream fix
   "ai", // File upload bypass - planned upgrade
+  "lodash", // Code injection in @semantic-release dev dep - no patch available
+  "lodash-es", // Code injection in @semantic-release dev dep - no patch available
 ];
 
 interface SecurityIssue {
@@ -147,13 +149,6 @@ class SecurityValidator {
           (pkg) =>
             output.includes(`│ Package             │ ${pkg}`) ||
             output.includes(`Package: ${pkg}`),
-        );
-
-        // Check if ALL vulnerabilities are from ignored packages
-        const allIgnored = IGNORED_VULNERABLE_PACKAGES.every(
-          (pkg) =>
-            !output.includes("│ Package") ||
-            output.includes(`│ Package             │ ${pkg}`),
         );
 
         if (isIgnoredPackage) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -137,6 +137,23 @@ const POPULAR_MCP_SERVERS: Record<
   },
 };
 
+const MCP_STATUS_TIMEOUT_MS = 30_000;
+
+type ToolAnnotationInfo = {
+  serverName: string;
+  serverId: string;
+  toolName: string;
+  description: string;
+  annotations: MCPToolAnnotations;
+};
+
+type AnnotatedToolTarget = {
+  name: string;
+  description: string;
+  serverId: string;
+  serverName: string;
+};
+
 /**
  * MCP CLI command factory
  */
@@ -747,7 +764,10 @@ export class MCPCommandFactory {
         : ora("Testing MCP server connections...").start();
 
       const sdk = new NeuroLink();
-      await sdk.getMCPStatus();
+      await this.getMCPStatusWithTimeout(
+        sdk,
+        Number(argv.timeout) || MCP_STATUS_TIMEOUT_MS,
+      );
       let serversToTest = await sdk.listMCPServers();
       if (targetServer) {
         serversToTest = serversToTest.filter((s) => s.name === targetServer);
@@ -861,7 +881,7 @@ export class MCPCommandFactory {
       }
 
       const sdk = new NeuroLink();
-      await sdk.getMCPStatus();
+      await this.getMCPStatusWithTimeout(sdk);
 
       // Check if server exists and is connected
       const allServers = await sdk.listMCPServers();
@@ -989,7 +1009,7 @@ export class MCPCommandFactory {
       }
 
       const sdk = new NeuroLink();
-      await sdk.getMCPStatus();
+      await this.getMCPStatusWithTimeout(sdk);
       const allServers = await sdk.listMCPServers();
       const server = allServers.find((s) => s.name === serverName);
 
@@ -2997,100 +3017,12 @@ ${tools.length > 0 ? tools.map((t) => `- **${t}**: TODO: Add description`).join(
       const sdk = new NeuroLink();
       const servers = await sdk.listMCPServers();
 
-      // List mode - show all tools with annotations
       if (argv.list) {
-        const spinner = argv.quiet
-          ? null
-          : ora("Loading tool annotations...").start();
-
-        type ToolAnnotationInfo = {
-          serverName: string;
-          serverId: string;
-          toolName: string;
-          description: string;
-          annotations: MCPToolAnnotations;
-        };
-
-        const allTools: ToolAnnotationInfo[] = [];
-
-        for (const server of servers) {
-          if (server.status !== "connected") {
-            continue;
-          }
-
-          for (const tool of server.tools || []) {
-            const existing = (tool as { annotations?: MCPToolAnnotations })
-              .annotations;
-            const annotations =
-              existing ??
-              inferAnnotations({
-                name: tool.name,
-                description: tool.description,
-              });
-
-            allTools.push({
-              serverName: server.name,
-              serverId: server.id,
-              toolName: tool.name,
-              description: tool.description,
-              annotations,
-            });
-          }
-        }
-
-        if (spinner) {
-          spinner.succeed(`Found ${allTools.length} tools`);
-        }
-
-        if (argv.format === "json") {
-          logger.always(JSON.stringify(allTools, null, 2));
-          return;
-        }
-
-        logger.always(chalk.bold("\n Tool Annotations:\n"));
-
-        // Group by server
-        const byServer = allTools.reduce(
-          (acc, tool) => {
-            if (!acc[tool.serverId]) {
-              acc[tool.serverId] = {
-                serverName: tool.serverName,
-                tools: [],
-              };
-            }
-            acc[tool.serverId].tools.push(tool);
-            return acc;
-          },
-          {} as Record<
-            string,
-            { serverName: string; tools: ToolAnnotationInfo[] }
-          >,
-        );
-
-        for (const [serverId, { serverName, tools }] of Object.entries(
-          byServer,
-        )) {
-          logger.always(chalk.cyan.bold(`\n${serverName} (${serverId}):`));
-
-          for (const tool of tools) {
-            const annotationStr = getAnnotationSummary(tool.annotations);
-
-            logger.always(
-              `  ${chalk.yellow(tool.toolName)} ${chalk.gray(annotationStr)}`,
-            );
-            if (argv.detailed) {
-              logger.always(`    ${chalk.gray(tool.description)}`);
-            }
-          }
-        }
-
-        logger.always();
+        await this.listToolAnnotations(servers, argv);
         return;
       }
 
-      // Annotate specific tool
       const toolName = argv.tool as string | undefined;
-
       if (!toolName) {
         logger.error(
           chalk.red(
@@ -3100,37 +3032,8 @@ ${tools.length > 0 ? tools.map((t) => `- **${t}**: TODO: Add description`).join(
         process.exit(1);
       }
 
-      // Find the tool
-      let foundTool: {
-        name: string;
-        description: string;
-        serverId: string;
-        serverName: string;
-      } | null = null;
-
       const serverId = argv.server as string | undefined;
-
-      for (const server of servers) {
-        if (serverId && server.id !== serverId) {
-          continue;
-        }
-
-        for (const tool of server.tools || []) {
-          if (tool.name === toolName) {
-            foundTool = {
-              name: tool.name,
-              description: tool.description,
-              serverId: server.id,
-              serverName: server.name,
-            };
-            break;
-          }
-        }
-        if (foundTool) {
-          break;
-        }
-      }
-
+      const foundTool = this.findToolForAnnotation(servers, toolName, serverId);
       if (!foundTool) {
         logger.error(
           chalk.red(
@@ -3145,75 +3048,8 @@ ${tools.length > 0 ? tools.map((t) => `- **${t}**: TODO: Add description`).join(
         process.exit(1);
       }
 
-      // Build annotations from options
-      let annotations: MCPToolAnnotations = {};
-
-      // Parse JSON annotations if provided
-      if (argv.annotations) {
-        try {
-          const parsed = JSON.parse(argv.annotations as string);
-          annotations = { ...annotations, ...parsed };
-        } catch {
-          logger.error(chalk.red("Invalid JSON in --annotations"));
-          process.exit(1);
-        }
-      }
-
-      // Apply individual annotation flags
-      if (argv["read-only"] !== undefined) {
-        annotations.readOnlyHint = argv["read-only"] as boolean;
-      }
-      if (argv.destructive !== undefined) {
-        annotations.destructiveHint = argv.destructive as boolean;
-      }
-      if (argv.idempotent !== undefined) {
-        annotations.idempotentHint = argv.idempotent as boolean;
-      }
-      if (argv["requires-confirmation"] !== undefined) {
-        annotations.requiresConfirmation = argv[
-          "requires-confirmation"
-        ] as boolean;
-      }
-      if (argv.tags) {
-        annotations.tags = argv.tags as string[];
-      }
-      if (argv["estimated-duration"] !== undefined) {
-        annotations.estimatedDuration = argv["estimated-duration"] as number;
-      }
-      if (argv["rate-limit"] !== undefined) {
-        annotations.rateLimitHint = argv["rate-limit"] as number;
-      }
-      if (argv.cost !== undefined) {
-        annotations.costHint = argv.cost as number;
-      }
-      if (argv.complexity) {
-        annotations.complexity = argv.complexity as
-          | "simple"
-          | "medium"
-          | "complex";
-      }
-      if (argv["security-level"]) {
-        annotations.securityLevel = argv["security-level"] as
-          | "public"
-          | "internal"
-          | "restricted";
-      }
-      if (argv.audit !== undefined) {
-        annotations.auditRequired = argv.audit as boolean;
-      }
-
-      // Infer annotations if requested
-      if (argv.infer) {
-        const inferred = inferAnnotations({
-          name: foundTool.name,
-          description: foundTool.description,
-        });
-        annotations = mergeAnnotations(inferred, annotations);
-      }
-
-      // Validate annotations
+      const annotations = this.buildAnnotationsFromArgs(argv, foundTool);
       const errors = validateAnnotations(annotations);
-
       if (errors.length > 0) {
         logger.error(chalk.red("Annotation validation errors:"));
         for (const error of errors) {
@@ -3229,90 +3065,7 @@ ${tools.length > 0 ? tools.map((t) => `- **${t}**: TODO: Add description`).join(
         return;
       }
 
-      // Display the annotations
-      logger.always(chalk.bold("\n Tool Annotation Update:\n"));
-      logger.always(
-        `  Server: ${chalk.cyan(foundTool.serverName)} (${foundTool.serverId})`,
-      );
-      logger.always(`  Tool: ${chalk.yellow(foundTool.name)}`);
-      logger.always(`  Description: ${chalk.gray(foundTool.description)}`);
-      logger.always();
-      logger.always(chalk.bold("  Annotations:"));
-
-      if (annotations.readOnlyHint !== undefined) {
-        logger.always(
-          `    readOnlyHint: ${annotations.readOnlyHint ? chalk.green("true") : chalk.red("false")}`,
-        );
-      }
-      if (annotations.destructiveHint !== undefined) {
-        logger.always(
-          `    destructiveHint: ${annotations.destructiveHint ? chalk.red("true") : chalk.green("false")}`,
-        );
-      }
-      if (annotations.idempotentHint !== undefined) {
-        logger.always(
-          `    idempotentHint: ${annotations.idempotentHint ? chalk.green("true") : chalk.gray("false")}`,
-        );
-      }
-      if (annotations.requiresConfirmation !== undefined) {
-        logger.always(
-          `    requiresConfirmation: ${annotations.requiresConfirmation ? chalk.yellow("true") : chalk.gray("false")}`,
-        );
-      }
-      if (annotations.tags?.length) {
-        logger.always(`    tags: ${chalk.blue(annotations.tags.join(", "))}`);
-      }
-      if (annotations.estimatedDuration !== undefined) {
-        logger.always(
-          `    estimatedDuration: ${annotations.estimatedDuration}ms`,
-        );
-      }
-      if (annotations.rateLimitHint !== undefined) {
-        logger.always(
-          `    rateLimitHint: ${annotations.rateLimitHint} calls/min`,
-        );
-      }
-      if (annotations.costHint !== undefined) {
-        logger.always(`    costHint: ${annotations.costHint}`);
-      }
-      if (annotations.complexity) {
-        logger.always(`    complexity: ${chalk.cyan(annotations.complexity)}`);
-      }
-      if (annotations.securityLevel) {
-        const secColor =
-          annotations.securityLevel === "restricted"
-            ? chalk.red
-            : annotations.securityLevel === "internal"
-              ? chalk.yellow
-              : chalk.green;
-        logger.always(
-          `    securityLevel: ${secColor(annotations.securityLevel)}`,
-        );
-      }
-      if (annotations.auditRequired !== undefined) {
-        logger.always(
-          `    auditRequired: ${annotations.auditRequired ? chalk.yellow("true") : chalk.gray("false")}`,
-        );
-      }
-
-      logger.always();
-      logger.always(
-        chalk.gray("  Summary: ") + getAnnotationSummary(annotations),
-      );
-      logger.always();
-
-      // Note: In a full implementation, this would persist the annotations
-      // to a configuration file or database. For now, we just display them.
-      logger.always(
-        chalk.blue(
-          "Note: Annotations displayed above. To persist annotations, add them to your MCP server configuration.",
-        ),
-      );
-      logger.always(
-        chalk.gray(
-          `Example: Add to your server's tool definition or use environment-specific annotation overrides.`,
-        ),
-      );
+      this.printAnnotationUpdate(foundTool, annotations);
     } catch (error) {
       logger.error(
         chalk.red(
@@ -3321,5 +3074,280 @@ ${tools.length > 0 ? tools.map((t) => `- **${t}**: TODO: Add description`).join(
       );
       process.exit(1);
     }
+  }
+
+  private static async getMCPStatusWithTimeout(
+    sdk: NeuroLink,
+    timeoutMs: number = MCP_STATUS_TIMEOUT_MS,
+  ): Promise<MCPStatus> {
+    return withTimeout(
+      sdk.getMCPStatus(),
+      timeoutMs,
+      ErrorFactory.toolTimeout("mcpStatus", timeoutMs),
+    );
+  }
+
+  private static async listToolAnnotations(
+    servers: MCPServerInfo[],
+    argv: MCPCommandArgs,
+  ): Promise<void> {
+    const spinner = argv.quiet
+      ? null
+      : ora("Loading tool annotations...").start();
+    const allTools = this.collectToolAnnotations(servers);
+
+    if (spinner) {
+      spinner.succeed(`Found ${allTools.length} tools`);
+    }
+
+    if (argv.format === "json") {
+      logger.always(JSON.stringify(allTools, null, 2));
+      return;
+    }
+
+    logger.always(chalk.bold("\n Tool Annotations:\n"));
+
+    const byServer = allTools.reduce(
+      (acc, tool) => {
+        if (!acc[tool.serverId]) {
+          acc[tool.serverId] = {
+            serverName: tool.serverName,
+            tools: [],
+          };
+        }
+        acc[tool.serverId].tools.push(tool);
+        return acc;
+      },
+      {} as Record<string, { serverName: string; tools: ToolAnnotationInfo[] }>,
+    );
+
+    for (const [serverId, { serverName, tools }] of Object.entries(byServer)) {
+      logger.always(chalk.cyan.bold(`\n${serverName} (${serverId}):`));
+      for (const tool of tools) {
+        logger.always(
+          `  ${chalk.yellow(tool.toolName)} ${chalk.gray(getAnnotationSummary(tool.annotations))}`,
+        );
+        if (argv.detailed) {
+          logger.always(`    ${chalk.gray(tool.description)}`);
+        }
+      }
+    }
+
+    logger.always();
+  }
+
+  private static collectToolAnnotations(
+    servers: MCPServerInfo[],
+  ): ToolAnnotationInfo[] {
+    const allTools: ToolAnnotationInfo[] = [];
+
+    for (const server of servers) {
+      if (server.status !== "connected") {
+        continue;
+      }
+
+      for (const tool of server.tools || []) {
+        const existing = (tool as { annotations?: MCPToolAnnotations })
+          .annotations;
+        allTools.push({
+          serverName: server.name,
+          serverId: server.id,
+          toolName: tool.name,
+          description: tool.description,
+          annotations:
+            existing ??
+            inferAnnotations({
+              name: tool.name,
+              description: tool.description,
+            }),
+        });
+      }
+    }
+
+    return allTools;
+  }
+
+  private static findToolForAnnotation(
+    servers: MCPServerInfo[],
+    toolName: string,
+    serverId?: string,
+  ): AnnotatedToolTarget | null {
+    for (const server of servers) {
+      if (serverId && server.id !== serverId) {
+        continue;
+      }
+
+      for (const tool of server.tools || []) {
+        if (tool.name === toolName) {
+          return {
+            name: tool.name,
+            description: tool.description,
+            serverId: server.id,
+            serverName: server.name,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private static buildAnnotationsFromArgs(
+    argv: MCPCommandArgs,
+    foundTool: AnnotatedToolTarget,
+  ): MCPToolAnnotations {
+    let annotations: MCPToolAnnotations = {};
+
+    if (argv.annotations) {
+      try {
+        annotations = {
+          ...annotations,
+          ...(JSON.parse(argv.annotations as string) as MCPToolAnnotations),
+        };
+      } catch {
+        logger.error(chalk.red("Invalid JSON in --annotations"));
+        process.exit(1);
+      }
+    }
+
+    if (argv["read-only"] !== undefined) {
+      annotations.readOnlyHint = argv["read-only"] as boolean;
+    }
+    if (argv.destructive !== undefined) {
+      annotations.destructiveHint = argv.destructive as boolean;
+    }
+    if (argv.idempotent !== undefined) {
+      annotations.idempotentHint = argv.idempotent as boolean;
+    }
+    if (argv["requires-confirmation"] !== undefined) {
+      annotations.requiresConfirmation = argv[
+        "requires-confirmation"
+      ] as boolean;
+    }
+    if (argv.tags) {
+      annotations.tags = argv.tags as string[];
+    }
+    if (argv["estimated-duration"] !== undefined) {
+      annotations.estimatedDuration = argv["estimated-duration"] as number;
+    }
+    if (argv["rate-limit"] !== undefined) {
+      annotations.rateLimitHint = argv["rate-limit"] as number;
+    }
+    if (argv.cost !== undefined) {
+      annotations.costHint = argv.cost as number;
+    }
+    if (argv.complexity) {
+      annotations.complexity = argv.complexity as
+        | "simple"
+        | "medium"
+        | "complex";
+    }
+    if (argv["security-level"]) {
+      annotations.securityLevel = argv["security-level"] as
+        | "public"
+        | "internal"
+        | "restricted";
+    }
+    if (argv.audit !== undefined) {
+      annotations.auditRequired = argv.audit as boolean;
+    }
+
+    if (argv.infer) {
+      annotations = mergeAnnotations(
+        inferAnnotations({
+          name: foundTool.name,
+          description: foundTool.description,
+        }),
+        annotations,
+      );
+    }
+
+    return annotations;
+  }
+
+  private static printAnnotationUpdate(
+    foundTool: AnnotatedToolTarget,
+    annotations: MCPToolAnnotations,
+  ): void {
+    logger.always(chalk.bold("\n Tool Annotation Update:\n"));
+    logger.always(
+      `  Server: ${chalk.cyan(foundTool.serverName)} (${foundTool.serverId})`,
+    );
+    logger.always(`  Tool: ${chalk.yellow(foundTool.name)}`);
+    logger.always(`  Description: ${chalk.gray(foundTool.description)}`);
+    logger.always();
+    logger.always(chalk.bold("  Annotations:"));
+
+    if (annotations.readOnlyHint !== undefined) {
+      logger.always(
+        `    readOnlyHint: ${annotations.readOnlyHint ? chalk.green("true") : chalk.red("false")}`,
+      );
+    }
+    if (annotations.destructiveHint !== undefined) {
+      logger.always(
+        `    destructiveHint: ${annotations.destructiveHint ? chalk.red("true") : chalk.green("false")}`,
+      );
+    }
+    if (annotations.idempotentHint !== undefined) {
+      logger.always(
+        `    idempotentHint: ${annotations.idempotentHint ? chalk.green("true") : chalk.gray("false")}`,
+      );
+    }
+    if (annotations.requiresConfirmation !== undefined) {
+      logger.always(
+        `    requiresConfirmation: ${annotations.requiresConfirmation ? chalk.yellow("true") : chalk.gray("false")}`,
+      );
+    }
+    if (annotations.tags?.length) {
+      logger.always(`    tags: ${chalk.blue(annotations.tags.join(", "))}`);
+    }
+    if (annotations.estimatedDuration !== undefined) {
+      logger.always(
+        `    estimatedDuration: ${annotations.estimatedDuration}ms`,
+      );
+    }
+    if (annotations.rateLimitHint !== undefined) {
+      logger.always(
+        `    rateLimitHint: ${annotations.rateLimitHint} calls/min`,
+      );
+    }
+    if (annotations.costHint !== undefined) {
+      logger.always(`    costHint: ${annotations.costHint}`);
+    }
+    if (annotations.complexity) {
+      logger.always(`    complexity: ${chalk.cyan(annotations.complexity)}`);
+    }
+    if (annotations.securityLevel) {
+      const secColor =
+        annotations.securityLevel === "restricted"
+          ? chalk.red
+          : annotations.securityLevel === "internal"
+            ? chalk.yellow
+            : chalk.green;
+      logger.always(
+        `    securityLevel: ${secColor(annotations.securityLevel)}`,
+      );
+    }
+    if (annotations.auditRequired !== undefined) {
+      logger.always(
+        `    auditRequired: ${annotations.auditRequired ? chalk.yellow("true") : chalk.gray("false")}`,
+      );
+    }
+
+    logger.always();
+    logger.always(
+      chalk.gray("  Summary: ") + getAnnotationSummary(annotations),
+    );
+    logger.always();
+    logger.always(
+      chalk.blue(
+        "Note: Annotations displayed above. To persist annotations, add them to your MCP server configuration.",
+      ),
+    );
+    logger.always(
+      chalk.gray(
+        "Example: Add to your server's tool definition or use environment-specific annotation overrides.",
+      ),
+    );
   }
 }

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -13,7 +13,7 @@
 import type { CommandModule, Argv } from "yargs";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import { logger } from "../../lib/utils/logger.js";
@@ -386,6 +386,727 @@ export function mapClaudeErrorTypeToStatus(errorType?: string): number {
   }
 }
 
+type ProxySpinner = ReturnType<typeof ora> | null;
+type ProxyStartStrategy = "round-robin" | "fill-first";
+type ProxyModelRouterConfig = ConstructorParameters<typeof ModelRouter>[0];
+type LoadedProxyConfig = {
+  routing?: Partial<ProxyModelRouterConfig> & {
+    strategy?: ProxyStartStrategy;
+  };
+};
+type ProxyNeurolinkRuntime = Awaited<
+  ReturnType<typeof createProxyNeurolinkRuntime>
+>;
+type ProxyStartApp = Awaited<ReturnType<typeof createProxyStartApp>>;
+
+async function ensureProxyStartAllowed(spinner: ProxySpinner): Promise<void> {
+  const existingState = loadProxyState();
+  if (existingState) {
+    if (isProcessRunning(existingState.pid)) {
+      if (spinner) {
+        spinner.fail(
+          chalk.red(
+            `Proxy already running on port ${existingState.port} (PID: ${existingState.pid})`,
+          ),
+        );
+      }
+      logger.always(
+        chalk.yellow(
+          "Stop it first or use 'neurolink proxy status' to inspect",
+        ),
+      );
+      process.exit(process.ppid === 1 ? 0 : 1);
+    }
+    clearProxyState();
+  }
+
+  if (process.ppid === 1 || !(await isLaunchdManaging())) {
+    return;
+  }
+
+  if (spinner) {
+    spinner.fail(
+      chalk.red(
+        "Proxy is managed by launchd. Manual start would cause port conflicts.",
+      ),
+    );
+  }
+  logger.always(
+    chalk.yellow(
+      "Use 'neurolink proxy uninstall' to remove the service first, " +
+        "or 'launchctl kickstart gui/$(id -u)/com.neurolink.proxy' to restart.",
+    ),
+  );
+  process.exit(1);
+}
+
+async function loadProxyStartEnv(
+  argv: ProxyStartArgs,
+  spinner: ProxySpinner,
+): Promise<string | undefined> {
+  try {
+    const envResult = await loadProxyEnvFile({
+      explicitEnvFile: argv.envFile,
+    });
+    if (spinner && envResult.path) {
+      spinner.text = `Loaded proxy env from ${envResult.path}`;
+    }
+    return envResult.path;
+  } catch (error) {
+    if (spinner) {
+      spinner.fail(
+        chalk.red(error instanceof Error ? error.message : String(error)),
+      );
+    }
+    process.exit(1);
+  }
+}
+
+async function createProxyNeurolinkRuntime() {
+  process.env.NEUROLINK_SKIP_MCP = "true";
+
+  const { NeuroLink } = await import("../../lib/neurolink.js");
+  const neurolink = new NeuroLink();
+  const { initRequestLogger, cleanupLogs } =
+    await import("../../lib/proxy/requestLogger.js");
+
+  initRequestLogger(true);
+  cleanupLogs(7, 500);
+
+  return { neurolink, cleanupLogs };
+}
+
+async function loadProxyStartConfiguration(
+  argv: ProxyStartArgs,
+  spinner: ProxySpinner,
+): Promise<{
+  configPath: string;
+  proxyConfig: LoadedProxyConfig | null;
+  strategy: ProxyStartStrategy;
+  modelRouter: ModelRouter | undefined;
+  passthrough: boolean;
+}> {
+  const configPath =
+    argv.config ?? join(homedir(), ".neurolink", "proxy-config.yaml");
+  let proxyConfig: LoadedProxyConfig | null = null;
+
+  try {
+    const { loadProxyConfig } = await import("../../lib/proxy/proxyConfig.js");
+    proxyConfig = (await loadProxyConfig(configPath)) as LoadedProxyConfig;
+    if (spinner) {
+      spinner.text = `Loaded proxy config from ${configPath}`;
+    }
+  } catch (configError) {
+    if (argv.config) {
+      if (spinner) {
+        spinner.fail(chalk.red(`Failed to load proxy config: ${configPath}`));
+      }
+      process.exit(1);
+    }
+    const isNotFound =
+      configError instanceof Error &&
+      "code" in configError &&
+      (configError as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isNotFound) {
+      logger.warn(
+        `[proxy] Ignoring default config ${configPath}: ${configError instanceof Error ? configError.message : String(configError)}`,
+      );
+    }
+  }
+
+  const strategy = (argv.strategy ??
+    proxyConfig?.routing?.strategy ??
+    "fill-first") as ProxyStartStrategy;
+  let modelRouter: ModelRouter | undefined;
+
+  if (proxyConfig?.routing) {
+    const { ModelRouter } = await import("../../lib/proxy/modelRouter.js");
+    modelRouter = new ModelRouter({
+      strategy,
+      modelMappings: proxyConfig.routing.modelMappings ?? [],
+      fallbackChain: proxyConfig.routing.fallbackChain ?? [],
+      passthroughModels: proxyConfig.routing.passthroughModels,
+    });
+  }
+
+  return {
+    configPath,
+    proxyConfig,
+    strategy,
+    modelRouter,
+    passthrough: argv.passthrough ?? false,
+  };
+}
+
+async function createProxyStartApp(params: {
+  neurolink: ProxyNeurolinkRuntime["neurolink"];
+  modelRouter: ModelRouter | undefined;
+  strategy: ProxyStartStrategy;
+  passthrough: boolean;
+  port: number;
+  host: string;
+  proxyConfig: LoadedProxyConfig | null;
+}) {
+  const { createClaudeProxyRoutes } =
+    await import("../../lib/server/routes/claudeProxyRoutes.js");
+  const { Hono } = await import("hono");
+
+  const app = new Hono();
+  app.onError((err, c) => {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    logger.always(`[proxy] unhandled error: ${errMsg}`);
+    if (err instanceof Error && err.stack) {
+      logger.debug(`[proxy] stack: ${err.stack}`);
+    }
+    return c.json(
+      {
+        type: "error",
+        error: {
+          type: "api_error",
+          message: `Proxy internal error: ${errMsg}`,
+        },
+      },
+      502,
+    );
+  });
+
+  const routeGroup = createClaudeProxyRoutes(
+    params.modelRouter,
+    "",
+    params.strategy,
+    params.passthrough,
+  );
+
+  for (const route of routeGroup.routes) {
+    const method = route.method.toLowerCase() as "get" | "post";
+    app[method](route.path, async (c) => {
+      const emptyBody = {};
+      let body: unknown;
+      let rawBody: string | undefined;
+      if (method === "post") {
+        rawBody = await c.req.text().catch(() => undefined);
+        try {
+          body = rawBody ? JSON.parse(rawBody) : emptyBody;
+        } catch {
+          return c.json(
+            {
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message: "Request body must be valid JSON",
+              },
+            },
+            400,
+          );
+        }
+      }
+
+      const model = (body as Record<string, unknown>)?.model ?? "-";
+      const stream = (body as Record<string, unknown>)?.stream
+        ? "stream"
+        : "non-stream";
+      const bodyRec = body as Record<string, unknown> | undefined;
+      const toolCount = Array.isArray(bodyRec?.tools)
+        ? (bodyRec.tools as unknown[]).length
+        : 0;
+      logger.always(
+        `[proxy] ${c.req.method} ${c.req.path} → model=${model} ${stream} tools=${toolCount}`,
+      );
+
+      const ctx = {
+        requestId: crypto.randomUUID(),
+        method: c.req.method,
+        path: c.req.path,
+        headers: Object.fromEntries(c.req.raw.headers.entries()),
+        query: Object.fromEntries(new URL(c.req.url).searchParams.entries()),
+        params: c.req.param() as Record<string, string>,
+        body,
+        rawBody,
+        neurolink: params.neurolink,
+        toolRegistry: params.neurolink.getToolRegistry(),
+        timestamp: Date.now(),
+        metadata: {},
+      } as unknown as Parameters<typeof route.handler>[0];
+
+      const result = await route.handler(ctx);
+      if (result instanceof Response) {
+        return result;
+      }
+
+      if (
+        result &&
+        typeof result === "object" &&
+        Symbol.asyncIterator in Object(result)
+      ) {
+        const iterator = (result as AsyncIterable<string>)[
+          Symbol.asyncIterator
+        ]();
+        let cancelled = false;
+        const responseStream = new ReadableStream({
+          async start(controller) {
+            try {
+              while (!cancelled) {
+                const { value, done } = await iterator.next();
+                if (done) {
+                  break;
+                }
+                controller.enqueue(new TextEncoder().encode(value));
+              }
+              controller.close();
+            } catch (streamErr) {
+              if (cancelled) {
+                controller.close();
+                return;
+              }
+              const errMsg =
+                streamErr instanceof Error
+                  ? streamErr.message
+                  : String(streamErr);
+              const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Stream interrupted: ${errMsg}` } })}\n\n`;
+              try {
+                controller.enqueue(new TextEncoder().encode(errorEvent));
+              } catch {
+                // Controller already errored — ignore
+              }
+              controller.close();
+            }
+          },
+          async cancel() {
+            cancelled = true;
+            await iterator.return?.();
+          },
+        });
+        return new Response(responseStream, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        });
+      }
+
+      if (
+        result &&
+        typeof result === "object" &&
+        "httpStatus" in (result as Record<string, unknown>)
+      ) {
+        const httpResult = result as Record<string, unknown>;
+        const status = (httpResult.httpStatus as number) ?? 200;
+        delete httpResult.httpStatus;
+        return c.json(result, status as 400);
+      }
+
+      if (
+        result &&
+        typeof result === "object" &&
+        "type" in result &&
+        (result as Record<string, unknown>).type === "error"
+      ) {
+        const errorResult = result as {
+          type: string;
+          error?: { type?: string };
+        };
+        const status = mapClaudeErrorTypeToStatus(errorResult.error?.type);
+        return c.json(result, status as 400);
+      }
+
+      return c.json(result ?? {});
+    });
+  }
+
+  app.get("/health", (c) =>
+    c.json({
+      status: "ok",
+      strategy: params.strategy,
+      uptime: process.uptime(),
+      version: PROXY_VERSION,
+    }),
+  );
+
+  app.get("/status", async (c) => {
+    const { getStats } = await import("../../lib/proxy/usageStats.js");
+    const stats = getStats();
+    return c.json({
+      status: "running",
+      pid: process.pid,
+      port: params.port,
+      host: params.host,
+      strategy: params.strategy,
+      uptime: process.uptime(),
+      version: PROXY_VERSION,
+      stats: {
+        totalAttempts: stats.totalAttempts,
+        totalRequests: stats.totalRequests,
+        totalSuccess: stats.totalSuccess,
+        totalErrors: stats.totalErrors,
+        totalRateLimits: stats.totalRateLimits,
+        accounts: Object.values(stats.accounts).map((account) => ({
+          label: account.label,
+          type: account.type,
+          attempts: account.attemptCount,
+          requests: account.attemptCount,
+          success: account.successCount,
+          errors: account.errorCount,
+          rateLimits: account.rateLimitCount,
+          backoffLevel: account.currentBackoffLevel,
+          cooling: account.coolingUntil
+            ? account.coolingUntil > Date.now()
+            : false,
+        })),
+      },
+      config: params.proxyConfig
+        ? { hasRouting: !!params.proxyConfig.routing }
+        : null,
+    });
+  });
+
+  return { app };
+}
+
+async function initializeProxyOpenTelemetry(): Promise<void> {
+  try {
+    const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    if (!process.env.OTEL_SERVICE_NAME) {
+      process.env.OTEL_SERVICE_NAME = "neurolink-proxy";
+    }
+
+    process.env.OTEL_RESOURCE_ATTRIBUTES = [
+      "service.name=neurolink-proxy",
+      `service.version=${PROXY_VERSION}`,
+      "deployment.environment=local",
+      process.env.OTEL_RESOURCE_ATTRIBUTES,
+    ]
+      .filter(Boolean)
+      .join(",");
+
+    const { initializeOpenTelemetry, isOpenTelemetryInitialized } =
+      await import("../../lib/services/server/ai/observability/instrumentation.js");
+    const { buildObservabilityConfigFromEnv } =
+      await import("../../lib/utils/observabilityHelpers.js");
+
+    if (isOpenTelemetryInitialized()) {
+      return;
+    }
+
+    const observabilityConfig = buildObservabilityConfigFromEnv();
+    const langfuseConfig = observabilityConfig?.langfuse;
+    const langfuseEnabled = langfuseConfig?.enabled === true;
+    initializeOpenTelemetry({
+      enabled: langfuseEnabled,
+      publicKey: langfuseConfig?.publicKey || "",
+      secretKey: langfuseConfig?.secretKey || "",
+      baseUrl: langfuseConfig?.baseUrl,
+      environment: "proxy",
+      release: PROXY_VERSION,
+      userId: "neurolink-proxy",
+      autoDetectOperationName: true,
+    });
+
+    if (langfuseEnabled) {
+      logger.always(
+        `[proxy] Langfuse enabled — exporting to ${langfuseConfig.baseUrl || "https://cloud.langfuse.com"} (environment=proxy)`,
+      );
+    }
+    if (otlpEndpoint) {
+      logger.always(
+        `[proxy] OTLP exporter enabled — exporting to ${otlpEndpoint} (service.name=neurolink-proxy)`,
+      );
+    }
+    if (!langfuseEnabled && !otlpEndpoint) {
+      logger.always(
+        "[proxy] OpenTelemetry exporters disabled — set OTEL_EXPORTER_OTLP_ENDPOINT or Langfuse credentials to enable proxy observability",
+      );
+    }
+  } catch (error) {
+    logger.debug(
+      `[proxy] OpenTelemetry init failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function refreshProxyTokensInBackground(): Promise<void> {
+  const { needsRefresh, refreshToken, persistTokens } =
+    await import("../../lib/proxy/tokenRefresh.js");
+  const { tokenStore } = await import("../../lib/auth/tokenStore.js");
+
+  try {
+    const allKeys = await tokenStore.listProviders();
+    const anthropicKeys = allKeys.filter((key) => key.startsWith("anthropic:"));
+    for (const key of anthropicKeys) {
+      try {
+        const tokens = await tokenStore.loadTokens(key);
+        if (!tokens) {
+          continue;
+        }
+        const account = {
+          label: key,
+          token: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+        };
+        if (needsRefresh(account)) {
+          const result = await refreshToken(account);
+          if (result.success) {
+            await persistTokens({ providerKey: key }, account);
+            logger.debug(
+              `[proxy] background token refresh succeeded for ${key}`,
+            );
+          }
+        }
+      } catch {
+        // non-fatal per-account
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+
+  try {
+    const credPath = join(
+      homedir(),
+      ".neurolink",
+      "anthropic-credentials.json",
+    );
+    const { readFileSync } = await import("fs");
+    const creds = JSON.parse(readFileSync(credPath, "utf8"));
+    if (!creds.oauth) {
+      return;
+    }
+    const account = {
+      label: "background",
+      token: creds.oauth.accessToken,
+      refreshToken: creds.oauth.refreshToken,
+      expiresAt: creds.oauth.expiresAt,
+    };
+    if (needsRefresh(account)) {
+      const result = await refreshToken(account);
+      if (result.success) {
+        await persistTokens(credPath, account);
+        logger.debug("[proxy] background token refresh succeeded");
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
+function startProxyBackgroundMaintenance(
+  cleanupLogs: (days: number, maxMb: number) => void,
+): {
+  refreshInterval: NodeJS.Timeout;
+  logCleanupInterval: NodeJS.Timeout;
+} {
+  const refreshInterval = setInterval(() => {
+    void refreshProxyTokensInBackground();
+  }, 30_000);
+  const logCleanupInterval = setInterval(
+    () => {
+      cleanupLogs(7, 500);
+    },
+    60 * 60 * 1000,
+  );
+  return { refreshInterval, logCleanupInterval };
+}
+
+function registerProxyShutdownHandlers(params: {
+  server: { close?: () => void };
+  host: string;
+  port: number;
+  refreshInterval: NodeJS.Timeout;
+  logCleanupInterval: NodeJS.Timeout;
+}): void {
+  const shutdown = async (signal: string) => {
+    clearInterval(params.refreshInterval);
+    clearInterval(params.logCleanupInterval);
+    logger.always(`\nShutting down proxy (${signal})...`);
+
+    try {
+      const { flushOpenTelemetry, shutdownOpenTelemetry } =
+        await import("../../lib/services/server/ai/observability/instrumentation.js");
+      await flushOpenTelemetry();
+      await shutdownOpenTelemetry();
+    } catch {
+      // non-fatal — proxy shutdown must not block on OTel
+    }
+
+    if (signal === "SIGINT") {
+      try {
+        const shutdownHost =
+          params.host === "0.0.0.0" ? "localhost" : params.host;
+        await clearClaudeProxySettings(`http://${shutdownHost}:${params.port}`);
+      } catch {
+        // non-fatal
+      }
+    }
+
+    try {
+      params.server.close?.();
+    } catch {
+      // Best-effort close
+    }
+    clearProxyState();
+    process.exit(signal === "SIGINT" ? 0 : 1);
+  };
+
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
+  });
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
+  });
+}
+
+async function startProxyRuntime(params: {
+  argv: ProxyStartArgs;
+  spinner: ProxySpinner;
+  app: ProxyStartApp["app"];
+  host: string;
+  port: number;
+  strategy: ProxyStartStrategy;
+  proxyConfig: LoadedProxyConfig | null;
+  loadedEnvFile: string | undefined;
+  passthrough: boolean;
+  cleanupLogs: ProxyNeurolinkRuntime["cleanupLogs"];
+}): Promise<void> {
+  const { serve } = await import("@hono/node-server");
+  const server = serve({
+    fetch: params.app.fetch,
+    port: params.port,
+    hostname: params.host,
+  });
+  const guardPid = spawnFailOpenGuard(params.host, params.port, process.pid);
+  const fallbackChain: FallbackInfo[] | undefined =
+    params.proxyConfig?.routing?.fallbackChain?.map((entry) => ({
+      provider: entry.provider as string,
+      model: entry.model as string,
+    }));
+
+  saveProxyState({
+    pid: process.pid,
+    port: params.port,
+    host: params.host,
+    strategy: params.strategy,
+    startTime: new Date().toISOString(),
+    envFile: params.loadedEnvFile,
+    fallbackChain,
+    guardPid,
+    managedBy:
+      process.platform === "darwin" && process.ppid === 1
+        ? "launchd"
+        : "manual",
+    passthrough: params.passthrough,
+  });
+
+  if (params.spinner) {
+    params.spinner.succeed(chalk.green("Claude proxy started successfully"));
+  }
+
+  const normalizedHost = params.host === "0.0.0.0" ? "localhost" : params.host;
+  const url = `http://${normalizedHost}:${params.port}`;
+  printProxyBanner(url, params.strategy);
+  logger.always(
+    `  ${chalk.bold("Mode:")}       ${chalk.cyan(params.passthrough ? "passthrough" : "full")}`,
+  );
+  if (params.passthrough) {
+    logger.always(
+      chalk.yellow(
+        "  ! Passthrough mode forwards client auth directly to Anthropic",
+      ),
+    );
+    logger.always(
+      chalk.dim(
+        "    Stored proxy OAuth/API credentials are ignored; clients need their own valid Anthropic auth.",
+      ),
+    );
+  }
+  if (params.loadedEnvFile) {
+    logger.always(
+      `  ${chalk.bold("Env File:")}   ${chalk.cyan(params.loadedEnvFile)}`,
+    );
+  }
+
+  try {
+    await setClaudeProxySettings(url);
+    logger.always(chalk.green("  ✓ Auto-configured Claude Code settings"));
+    logger.always(
+      chalk.dim("    Restart Claude Code to connect through proxy"),
+    );
+  } catch (error) {
+    logger.debug(
+      "[proxy] Failed to auto-configure Claude Code: " +
+        (error instanceof Error ? error.message : String(error)),
+    );
+  }
+
+  const maintenance = startProxyBackgroundMaintenance(params.cleanupLogs);
+  registerProxyShutdownHandlers({
+    server,
+    host: params.host,
+    port: params.port,
+    ...maintenance,
+  });
+}
+
+async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
+  const spinner = argv.quiet ? null : ora("Starting Claude proxy...").start();
+
+  try {
+    await ensureProxyStartAllowed(spinner);
+    const loadedEnvFile = await loadProxyStartEnv(argv, spinner);
+    const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime();
+    const { proxyConfig, strategy, modelRouter, passthrough } =
+      await loadProxyStartConfiguration(argv, spinner);
+
+    if (spinner) {
+      spinner.text = "Configuring server...";
+    }
+
+    const port = argv.port ?? 55669;
+    const host = argv.host ?? "127.0.0.1";
+    const { app } = await createProxyStartApp({
+      neurolink,
+      modelRouter,
+      strategy,
+      passthrough,
+      port,
+      host,
+      proxyConfig,
+    });
+
+    await initializeProxyOpenTelemetry();
+
+    if (spinner) {
+      spinner.text = `Starting proxy on ${host}:${port}...`;
+    }
+
+    await startProxyRuntime({
+      argv,
+      spinner,
+      app,
+      host,
+      port,
+      strategy,
+      proxyConfig,
+      loadedEnvFile,
+      passthrough,
+      cleanupLogs,
+    });
+  } catch (error) {
+    if (spinner) {
+      spinner.fail(chalk.red("Failed to start proxy"));
+    }
+    logger.error(
+      chalk.red(
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+    if (argv.debug && error instanceof Error && error.stack) {
+      logger.error(chalk.gray(error.stack));
+    }
+    process.exit(1);
+  }
+}
+
 // =============================================================================
 // PROXY START COMMAND
 // =============================================================================
@@ -464,664 +1185,7 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
       ) as Argv<ProxyStartArgs>;
   },
   handler: async (argv) => {
-    const spinner = argv.quiet ? null : ora("Starting Claude proxy...").start();
-
-    try {
-      // Guard: proxy already running
-      const existingState = loadProxyState();
-      if (existingState) {
-        if (isProcessRunning(existingState.pid)) {
-          if (spinner) {
-            spinner.fail(
-              chalk.red(
-                `Proxy already running on port ${existingState.port} (PID: ${existingState.pid})`,
-              ),
-            );
-          }
-          logger.always(
-            chalk.yellow(
-              "Stop it first or use 'neurolink proxy status' to inspect",
-            ),
-          );
-          // Exit cleanly when managed by launchd so it doesn't treat this
-          // as a crash and spam-restart every ThrottleInterval seconds.
-          // For manual invocations, use non-zero so scripts/CI detect failure.
-          process.exit(process.ppid === 1 ? 0 : 1);
-        } else {
-          // Stale state file from a previous process that is no longer running.
-          // Clear it so subsequent startup logic doesn't get confused.
-          clearProxyState();
-        }
-      }
-
-      // Guard: launchd is managing the service — don't start manually.
-      // Skip this guard when WE are the process launchd is managing
-      // (PPID 1 = launched by launchd on macOS).
-      if (process.ppid !== 1 && (await isLaunchdManaging())) {
-        if (spinner) {
-          spinner.fail(
-            chalk.red(
-              "Proxy is managed by launchd. Manual start would cause port conflicts.",
-            ),
-          );
-        }
-        logger.always(
-          chalk.yellow(
-            "Use 'neurolink proxy uninstall' to remove the service first, " +
-              "or 'launchctl kickstart gui/$(id -u)/com.neurolink.proxy' to restart.",
-          ),
-        );
-        // This guard only runs for manual invocations (ppid !== 1),
-        // so launchd KeepAlive is unaffected. Use non-zero exit code
-        // so scripts/CI can detect that the proxy was not started.
-        process.exit(1);
-      }
-
-      // -----------------------------------------------------------------
-      // 1. Create NeuroLink instance — reads all env vars automatically
-      // -----------------------------------------------------------------
-
-      let loadedEnvFile: string | undefined;
-      try {
-        const envResult = await loadProxyEnvFile({
-          explicitEnvFile: argv.envFile,
-        });
-        loadedEnvFile = envResult.path;
-        if (spinner && loadedEnvFile) {
-          spinner.text = `Loaded proxy env from ${loadedEnvFile}`;
-        }
-      } catch (envError) {
-        if (spinner) {
-          spinner.fail(
-            chalk.red(
-              envError instanceof Error ? envError.message : String(envError),
-            ),
-          );
-        }
-        process.exit(1);
-      }
-
-      // Skip MCP initialization for proxy — tools come from Claude Code, not MCP servers
-      process.env.NEUROLINK_SKIP_MCP = "true";
-
-      const { NeuroLink } = await import("../../lib/neurolink.js");
-      const neurolink = new NeuroLink();
-
-      // Initialize request logger and usage stats
-      const { initRequestLogger, cleanupLogs } =
-        await import("../../lib/proxy/requestLogger.js");
-      const { getStats: _getStats, resetStats: _resetStats } =
-        await import("../../lib/proxy/usageStats.js");
-      initRequestLogger(true);
-      cleanupLogs(7, 500); // Delete logs older than 7 days or if total exceeds 500 MB
-
-      // -----------------------------------------------------------------
-      // 2. Load proxy config file (if --config or default exists)
-      // -----------------------------------------------------------------
-
-      const configPath =
-        argv.config ?? join(homedir(), ".neurolink", "proxy-config.yaml");
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let proxyConfig: any = null;
-      try {
-        const { loadProxyConfig } =
-          await import("../../lib/proxy/proxyConfig.js");
-        proxyConfig = await loadProxyConfig(configPath);
-        if (spinner) {
-          spinner.text = `Loaded proxy config from ${configPath}`;
-        }
-      } catch (configError) {
-        if (argv.config) {
-          if (spinner) {
-            spinner.fail(
-              chalk.red(`Failed to load proxy config: ${configPath}`),
-            );
-          }
-          process.exit(1);
-        }
-        // Only silently ignore file-not-found for the default config path.
-        // Log a warning for other errors (parse failures, permission issues, etc.)
-        const isNotFound =
-          configError instanceof Error &&
-          "code" in configError &&
-          (configError as NodeJS.ErrnoException).code === "ENOENT";
-        if (!isNotFound) {
-          logger.warn(
-            `[proxy] Ignoring default config ${configPath}: ${configError instanceof Error ? configError.message : String(configError)}`,
-          );
-        }
-      }
-
-      // -----------------------------------------------------------------
-      // 3. Create ModelRouter from config (if routing configured)
-      // -----------------------------------------------------------------
-
-      const strategy =
-        argv.strategy ?? proxyConfig?.routing?.strategy ?? "fill-first";
-      let modelRouter: ModelRouter | undefined;
-
-      if (proxyConfig?.routing) {
-        const { ModelRouter } = await import("../../lib/proxy/modelRouter.js");
-        modelRouter = new ModelRouter({
-          strategy: strategy as "round-robin" | "fill-first",
-          modelMappings: proxyConfig.routing.modelMappings ?? [],
-          fallbackChain: proxyConfig.routing.fallbackChain ?? [],
-          passthroughModels: proxyConfig.routing.passthroughModels,
-        });
-      }
-
-      if (spinner) {
-        spinner.text = "Configuring server...";
-      }
-
-      // -----------------------------------------------------------------
-      // 4. Build Hono app with Claude proxy routes and NeuroLink context
-      // -----------------------------------------------------------------
-
-      const { createClaudeProxyRoutes } =
-        await import("../../lib/server/routes/claudeProxyRoutes.js");
-      const { Hono } = await import("hono");
-      const { serve } = await import("@hono/node-server");
-
-      const app = new Hono();
-
-      app.onError((err, c) => {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        logger.always(`[proxy] unhandled error: ${errMsg}`);
-        if (err instanceof Error && err.stack) {
-          logger.debug(`[proxy] stack: ${err.stack}`);
-        }
-        return c.json(
-          {
-            type: "error",
-            error: {
-              type: "api_error",
-              message: `Proxy internal error: ${errMsg}`,
-            },
-          },
-          502,
-        );
-      });
-
-      const passthrough = argv.passthrough ?? false;
-
-      const routeGroup = createClaudeProxyRoutes(
-        modelRouter,
-        "",
-        strategy as "round-robin" | "fill-first",
-        passthrough,
-      );
-
-      // Register proxy routes — inject NeuroLink into ServerContext
-      for (const route of routeGroup.routes) {
-        const method = route.method.toLowerCase() as "get" | "post";
-        app[method](route.path, async (c) => {
-          const emptyBody = {};
-          let body: unknown;
-          let rawBody: string | undefined;
-          if (method === "post") {
-            rawBody = await c.req.text().catch(() => undefined);
-            try {
-              body = rawBody ? JSON.parse(rawBody) : emptyBody;
-            } catch {
-              body = emptyBody;
-            }
-          }
-
-          // Log incoming request
-          const model = (body as Record<string, unknown>)?.model ?? "-";
-          const stream = (body as Record<string, unknown>)?.stream
-            ? "stream"
-            : "non-stream";
-          const bodyRec = body as Record<string, unknown> | undefined;
-          const toolCount = Array.isArray(bodyRec?.tools)
-            ? (bodyRec.tools as unknown[]).length
-            : 0;
-          logger.always(
-            `[proxy] ${c.req.method} ${c.req.path} → model=${model} ${stream} tools=${toolCount}`,
-          );
-
-          // Build ServerContext with the real NeuroLink instance
-          const ctx = {
-            requestId: crypto.randomUUID(),
-            method: c.req.method,
-            path: c.req.path,
-            headers: Object.fromEntries(c.req.raw.headers.entries()),
-            query: Object.fromEntries(
-              new URL(c.req.url).searchParams.entries(),
-            ),
-            params: c.req.param() as Record<string, string>,
-            body,
-            rawBody, // Preserve original bytes for passthrough mode
-            neurolink, // NeuroLink instance for generate/stream
-            toolRegistry: neurolink.getToolRegistry(),
-            timestamp: Date.now(),
-            metadata: {},
-          } as unknown as Parameters<typeof route.handler>[0];
-
-          const result = await route.handler(ctx);
-
-          // Handle raw Response objects (passthrough streaming from upstream)
-          if (result instanceof Response) {
-            return result;
-          }
-
-          // Handle streaming response (async iterable)
-          if (
-            result &&
-            typeof result === "object" &&
-            Symbol.asyncIterator in Object(result)
-          ) {
-            const iterator = (result as AsyncIterable<string>)[
-              Symbol.asyncIterator
-            ]();
-            let cancelled = false;
-            const stream = new ReadableStream({
-              async start(controller) {
-                try {
-                  while (!cancelled) {
-                    const { value, done } = await iterator.next();
-                    if (done) {
-                      break;
-                    }
-                    controller.enqueue(new TextEncoder().encode(value));
-                  }
-                  controller.close();
-                } catch (streamErr) {
-                  if (cancelled) {
-                    // Client disconnected — just close
-                    controller.close();
-                    return;
-                  }
-                  // Emit an SSE error frame so the client gets a meaningful
-                  // error instead of a silent EOF / connection drop.
-                  const errMsg =
-                    streamErr instanceof Error
-                      ? streamErr.message
-                      : String(streamErr);
-                  const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Stream interrupted: ${errMsg}` } })}\n\n`;
-                  try {
-                    controller.enqueue(new TextEncoder().encode(errorEvent));
-                  } catch {
-                    // Controller already errored — ignore
-                  }
-                  controller.close();
-                }
-              },
-              async cancel() {
-                cancelled = true;
-                await iterator.return?.();
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-              },
-            });
-          }
-
-          // Handle error responses with httpStatus field
-          if (
-            result &&
-            typeof result === "object" &&
-            "httpStatus" in (result as Record<string, unknown>)
-          ) {
-            const httpResult = result as Record<string, unknown>;
-            const status = (httpResult.httpStatus as number) ?? 200;
-            delete httpResult.httpStatus;
-            return c.json(result, status as 400);
-          }
-
-          // Handle Anthropic-style error responses
-          if (
-            result &&
-            typeof result === "object" &&
-            "type" in result &&
-            (result as Record<string, unknown>).type === "error"
-          ) {
-            const errorResult = result as {
-              type: string;
-              error?: { type?: string };
-            };
-            const status = mapClaudeErrorTypeToStatus(errorResult.error?.type);
-            return c.json(result, status as 400);
-          }
-
-          return c.json(result ?? {});
-        });
-      }
-
-      // Health endpoint
-      app.get("/health", (c) =>
-        c.json({
-          status: "ok",
-          strategy,
-          uptime: process.uptime(),
-          version: PROXY_VERSION,
-        }),
-      );
-
-      // Status endpoint (detailed)
-      app.get("/status", async (c) => {
-        const { getStats } = await import("../../lib/proxy/usageStats.js");
-        const stats = getStats();
-        return c.json({
-          status: "running",
-          pid: process.pid,
-          port,
-          host,
-          strategy,
-          uptime: process.uptime(),
-          version: PROXY_VERSION,
-          stats: {
-            totalAttempts: stats.totalAttempts,
-            totalRequests: stats.totalRequests,
-            totalSuccess: stats.totalSuccess,
-            totalErrors: stats.totalErrors,
-            totalRateLimits: stats.totalRateLimits,
-            accounts: Object.values(stats.accounts).map((a) => ({
-              label: a.label,
-              type: a.type,
-              attempts: a.attemptCount,
-              requests: a.attemptCount,
-              success: a.successCount,
-              errors: a.errorCount,
-              rateLimits: a.rateLimitCount,
-              backoffLevel: a.currentBackoffLevel,
-              cooling: a.coolingUntil ? a.coolingUntil > Date.now() : false,
-            })),
-          },
-          config: proxyConfig ? { hasRouting: !!proxyConfig.routing } : null,
-        });
-      });
-
-      // -----------------------------------------------------------------
-      // 5. Initialize OpenTelemetry for proxy observability
-      // -----------------------------------------------------------------
-
-      try {
-        const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
-        if (!process.env.OTEL_SERVICE_NAME) {
-          process.env.OTEL_SERVICE_NAME = "neurolink-proxy";
-        }
-
-        // Merge resource attributes (preserving any existing ones)
-        process.env.OTEL_RESOURCE_ATTRIBUTES = [
-          `service.name=neurolink-proxy`,
-          `service.version=${PROXY_VERSION}`,
-          `deployment.environment=local`,
-          process.env.OTEL_RESOURCE_ATTRIBUTES,
-        ]
-          .filter(Boolean)
-          .join(",");
-
-        const { initializeOpenTelemetry, isOpenTelemetryInitialized } =
-          await import("../../lib/services/server/ai/observability/instrumentation.js");
-        const { buildObservabilityConfigFromEnv } =
-          await import("../../lib/utils/observabilityHelpers.js");
-
-        if (!isOpenTelemetryInitialized()) {
-          const observabilityConfig = buildObservabilityConfigFromEnv();
-          const langfuseConfig = observabilityConfig?.langfuse;
-          const langfuseEnabled = langfuseConfig?.enabled === true;
-          initializeOpenTelemetry({
-            enabled: langfuseEnabled,
-            publicKey: langfuseConfig?.publicKey || "",
-            secretKey: langfuseConfig?.secretKey || "",
-            baseUrl: langfuseConfig?.baseUrl,
-            environment: "proxy",
-            release: PROXY_VERSION,
-            userId: "neurolink-proxy",
-            autoDetectOperationName: true,
-          });
-
-          if (langfuseEnabled) {
-            logger.always(
-              `[proxy] Langfuse enabled — exporting to ${langfuseConfig.baseUrl || "https://cloud.langfuse.com"} (environment=proxy)`,
-            );
-          }
-
-          if (otlpEndpoint) {
-            logger.always(
-              `[proxy] OTLP exporter enabled — exporting to ${otlpEndpoint} (service.name=neurolink-proxy)`,
-            );
-          }
-
-          if (!langfuseEnabled && !otlpEndpoint) {
-            logger.always(
-              "[proxy] OpenTelemetry exporters disabled — set OTEL_EXPORTER_OTLP_ENDPOINT or Langfuse credentials to enable proxy observability",
-            );
-          }
-        }
-      } catch (otelError) {
-        // OTel is non-critical — proxy must still work without it
-        logger.debug(
-          `[proxy] OpenTelemetry init failed (non-fatal): ${otelError instanceof Error ? otelError.message : String(otelError)}`,
-        );
-      }
-
-      // -----------------------------------------------------------------
-      // 6. Start listening
-      // -----------------------------------------------------------------
-
-      const port = argv.port ?? 55669;
-      const host = argv.host ?? "127.0.0.1";
-
-      if (spinner) {
-        spinner.text = `Starting proxy on ${host}:${port}...`;
-      }
-
-      const server = serve({
-        fetch: app.fetch,
-        port,
-        hostname: host,
-      });
-
-      const guardPid = spawnFailOpenGuard(host, port, process.pid);
-
-      // Extract fallback chain from proxy config (if available)
-      const fallbackChain: FallbackInfo[] | undefined =
-        proxyConfig?.routing?.fallbackChain?.map(
-          (e: { provider: string; model: string }) => ({
-            provider: e.provider,
-            model: e.model,
-          }),
-        );
-
-      // Persist state (including fallback chain for `proxy status`)
-      const state: ProxyState = {
-        pid: process.pid,
-        port,
-        host,
-        strategy,
-        startTime: new Date().toISOString(),
-        envFile: loadedEnvFile,
-        fallbackChain,
-        guardPid,
-        managedBy:
-          process.platform === "darwin" && process.ppid === 1
-            ? "launchd"
-            : "manual",
-        passthrough,
-      };
-      saveProxyState(state);
-
-      if (spinner) {
-        spinner.succeed(chalk.green("Claude proxy started successfully"));
-      }
-
-      const normalizedHost = host === "0.0.0.0" ? "localhost" : host;
-      const url = `http://${normalizedHost}:${port}`;
-      printProxyBanner(url, strategy);
-      logger.always(
-        `  ${chalk.bold("Mode:")}       ${chalk.cyan(passthrough ? "passthrough" : "full")}`,
-      );
-      if (loadedEnvFile) {
-        logger.always(
-          `  ${chalk.bold("Env File:")}   ${chalk.cyan(loadedEnvFile)}`,
-        );
-      }
-
-      // Auto-configure Claude Code — use the normalized URL (localhost, not 0.0.0.0)
-      try {
-        await setClaudeProxySettings(url);
-        logger.always(chalk.green("  ✓ Auto-configured Claude Code settings"));
-        logger.always(
-          chalk.dim("    Restart Claude Code to connect through proxy"),
-        );
-      } catch (e) {
-        logger.debug(
-          "[proxy] Failed to auto-configure Claude Code: " +
-            (e instanceof Error ? e.message : String(e)),
-        );
-      }
-
-      // -----------------------------------------------------------------
-      // 7. Background token refresh (every 30 seconds)
-      // -----------------------------------------------------------------
-      const { needsRefresh, refreshToken, persistTokens } =
-        await import("../../lib/proxy/tokenRefresh.js");
-      const { tokenStore } = await import("../../lib/auth/tokenStore.js");
-      const refreshInterval = setInterval(async () => {
-        // Refresh token-pool accounts
-        try {
-          const allKeys = await tokenStore.listProviders();
-          const anthropicKeys = allKeys.filter((k) =>
-            k.startsWith("anthropic:"),
-          );
-          for (const key of anthropicKeys) {
-            try {
-              const tokens = await tokenStore.loadTokens(key);
-              if (!tokens) {
-                continue;
-              }
-              const account = {
-                label: key,
-                token: tokens.accessToken,
-                refreshToken: tokens.refreshToken,
-                expiresAt: tokens.expiresAt,
-              };
-              if (needsRefresh(account)) {
-                const result = await refreshToken(account);
-                if (result.success) {
-                  await persistTokens({ providerKey: key }, account);
-                  logger.debug(
-                    `[proxy] background token refresh succeeded for ${key}`,
-                  );
-                }
-              }
-            } catch {
-              /* non-fatal per-account */
-            }
-          }
-        } catch {
-          /* non-fatal */
-        }
-
-        // Refresh legacy credentials file
-        try {
-          const credPath = join(
-            homedir(),
-            ".neurolink",
-            "anthropic-credentials.json",
-          );
-          const { readFileSync } = await import("fs");
-          const creds = JSON.parse(readFileSync(credPath, "utf8"));
-          if (creds.oauth) {
-            const account = {
-              label: "background",
-              token: creds.oauth.accessToken,
-              refreshToken: creds.oauth.refreshToken,
-              expiresAt: creds.oauth.expiresAt,
-            };
-            if (needsRefresh(account)) {
-              const result = await refreshToken(account);
-              if (result.success) {
-                await persistTokens(credPath, account);
-                logger.debug("[proxy] background token refresh succeeded");
-              }
-            }
-          }
-        } catch {
-          /* non-fatal */
-        }
-      }, 30_000);
-
-      // Hourly log cleanup
-      const logCleanupInterval = setInterval(
-        () => {
-          cleanupLogs(7, 500);
-        },
-        60 * 60 * 1000,
-      );
-
-      // -----------------------------------------------------------------
-      // 8. Graceful shutdown
-      // -----------------------------------------------------------------
-
-      const shutdown = async (signal: string) => {
-        clearInterval(refreshInterval);
-        clearInterval(logCleanupInterval);
-        logger.always(`\nShutting down proxy (${signal})...`);
-
-        // Flush and shutdown OpenTelemetry before closing the server
-        try {
-          const { flushOpenTelemetry, shutdownOpenTelemetry } =
-            await import("../../lib/services/server/ai/observability/instrumentation.js");
-          await flushOpenTelemetry();
-          await shutdownOpenTelemetry();
-        } catch {
-          /* non-fatal — proxy shutdown must not block on OTel */
-        }
-
-        // Only clear Claude settings on user-initiated stop (SIGINT).
-        // On SIGTERM (launchd restart cycle), leave settings intact so
-        // the restarted proxy picks up seamlessly.
-        if (signal === "SIGINT") {
-          try {
-            const shutdownHost = host === "0.0.0.0" ? "localhost" : host;
-            await clearClaudeProxySettings(`http://${shutdownHost}:${port}`);
-          } catch {
-            /* non-fatal */
-          }
-        }
-
-        try {
-          if (
-            server &&
-            typeof (server as { close?: () => void }).close === "function"
-          ) {
-            (server as { close: () => void }).close();
-          }
-        } catch {
-          // Best-effort close
-        }
-        clearProxyState();
-
-        // SIGINT = user pressed Ctrl+C → exit 0 (launchd won't restart)
-        // SIGTERM = launchd/system stop → exit 1 (launchd WILL restart)
-        process.exit(signal === "SIGINT" ? 0 : 1);
-      };
-
-      process.on("SIGTERM", () => shutdown("SIGTERM"));
-      process.on("SIGINT", () => shutdown("SIGINT"));
-    } catch (error) {
-      if (spinner) {
-        spinner.fail(chalk.red("Failed to start proxy"));
-      }
-      logger.error(
-        chalk.red(
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
-      if (argv.debug && error instanceof Error && error.stack) {
-        logger.error(chalk.gray(error.stack));
-      }
-      process.exit(1);
-    }
+    await startProxyCommandHandler(argv);
   },
 };
 
@@ -1209,6 +1273,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         pid: null as number | null,
         port: null as number | null,
         host: null as string | null,
+        mode: null as "full" | "passthrough" | null,
         strategy: null as string | null,
         uptime: null as number | null,
         startTime: null as string | null,
@@ -1222,6 +1287,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         status.pid = state.pid;
         status.port = state.port;
         status.host = state.host;
+        status.mode = state.passthrough ? "passthrough" : "full";
         status.strategy = state.strategy;
         status.startTime = state.startTime;
         status.uptime = Date.now() - new Date(state.startTime).getTime();
@@ -1270,6 +1336,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         );
         logger.always(
           `  ${chalk.bold("Strategy:")}   ${chalk.cyan(status.strategy)}`,
+        );
+        logger.always(
+          `  ${chalk.bold("Mode:")}       ${chalk.cyan(status.mode ?? "full")}`,
         );
         logger.always(
           `  ${chalk.bold("Started:")}    ${chalk.cyan(status.startTime)}`,
@@ -2067,8 +2136,9 @@ export const proxyInstallCommand: CommandModule = {
     });
     const envFile = envResolution.path;
     const explicitConfig = (argv as { config?: string }).config;
-    const configPath =
-      explicitConfig ?? join(homedir(), ".neurolink", "proxy-config.yaml");
+    const configPath = explicitConfig
+      ? resolve(explicitConfig)
+      : join(homedir(), ".neurolink", "proxy-config.yaml");
     if (explicitConfig && !existsSync(configPath)) {
       console.info(chalk.red(`Proxy config file not found: ${configPath}`));
       process.exit(1);

--- a/src/lib/auth/anthropicOAuth.ts
+++ b/src/lib/auth/anthropicOAuth.ts
@@ -106,6 +106,7 @@ export type ClaudeCodeIdentity = {
 };
 
 const CLAUDE_CODE_IDENTITY_TTL_MS = 3_600_000;
+const CLAUDE_CODE_IDENTITY_CACHE_MAX_ENTRIES = 1024;
 const CLAUDE_CODE_IDENTITY_NAMESPACE = "neurolink-claude-code-identity-v1";
 const claudeCodeIdentityCache = new Map<
   string,
@@ -239,6 +240,7 @@ export function getOrCreateClaudeCodeIdentity(
     }),
     expiresAt: now + CLAUDE_CODE_IDENTITY_TTL_MS,
   };
+  enforceClaudeCodeIdentityCacheLimit(now);
   claudeCodeIdentityCache.set(cacheKey, identity);
   return identity;
 }
@@ -252,6 +254,20 @@ export function purgeExpiredClaudeCodeIdentities(now = Date.now()): number {
     }
   }
   return removed;
+}
+
+function enforceClaudeCodeIdentityCacheLimit(now = Date.now()): void {
+  purgeExpiredClaudeCodeIdentities(now);
+
+  while (
+    claudeCodeIdentityCache.size >= CLAUDE_CODE_IDENTITY_CACHE_MAX_ENTRIES
+  ) {
+    const oldestKey = claudeCodeIdentityCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    claudeCodeIdentityCache.delete(oldestKey);
+  }
 }
 
 export function buildStableClaudeCodeBillingHeader(

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1,5 +1,5 @@
 import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
-import type { ModelMessage, LanguageModel, Tool } from "ai";
+import type { LanguageModel, ModelMessage, Tool } from "ai";
 import { generateText } from "ai";
 import { directAgentTools } from "../agent/directTools.js";
 import type { AIProviderName } from "../constants/enums.js";
@@ -10,7 +10,6 @@ import type { NeuroLink } from "../neurolink.js";
 import { SpanStatus, SpanType } from "../observability/types/spanTypes.js";
 import { SpanSerializer } from "../observability/utils/spanSerializer.js";
 import { ATTR, tracers } from "../telemetry/index.js";
-import { calculateCost } from "../utils/pricing.js";
 import type { JsonValue, UnknownRecord } from "../types/common.js";
 import type {
   AIProvider,
@@ -28,6 +27,7 @@ import type {
 } from "../types/typeAliases.js";
 import { isAbortError } from "../utils/errorHandling.js";
 import { logger } from "../utils/logger.js";
+import { calculateCost } from "../utils/pricing.js";
 import {
   composeAbortSignals,
   createTimeoutController,
@@ -754,324 +754,17 @@ export abstract class BaseProvider implements AIProvider {
     });
     // Set this span as the active context so child spans (GenerationHandler, etc.) become descendants
     const activeCtx = trace.setSpan(context.active(), otelSpan);
-    let otelSpanEnded = false;
+    const otelSpanState = { ended: false };
 
-    return await context.with(activeCtx, async () => {
-      try {
-        // ===== VIDEO GENERATION MODE =====
-        // Generate video from image + prompt using Veo 3.1
-        if (options.output?.mode === "video") {
-          return await this.handleVideoGeneration(options, startTime);
-        }
-
-        // ===== IMAGE GENERATION MODE =====
-        // Route to executeImageGeneration for image generation models
-        const isImageModel = IMAGE_GENERATION_MODELS.some((m) =>
-          this.modelName.includes(m),
-        );
-
-        if (isImageModel) {
-          logger.info(
-            `Image generation model detected, routing to executeImageGeneration`,
-            {
-              provider: this.providerName,
-              model: this.modelName,
-            },
-          );
-
-          const imageResult = await this.executeImageGeneration(options);
-          return await this.enhanceResult(imageResult, options, startTime);
-        }
-
-        // ===== TTS MODE 1: Direct Input Synthesis (useAiResponse=false) =====
-        // Synthesize input text directly without AI generation
-        // This is optimal for simple read-aloud scenarios
-        if (options.tts?.enabled && !options.tts?.useAiResponse) {
-          const textToSynthesize = options.prompt ?? options.input?.text ?? "";
-
-          // Build base result structure - common to both paths
-          const baseResult: EnhancedGenerateResult = {
-            content: textToSynthesize,
-            provider: options.provider ?? this.providerName,
-            model: this.modelName,
-            usage: { input: 0, output: 0, total: 0 },
-          };
-
-          try {
-            const ttsResult = await TTSProcessor.synthesize(
-              textToSynthesize,
-              options.provider ?? this.providerName,
-              options.tts,
-            );
-            baseResult.audio = ttsResult;
-          } catch (ttsError) {
-            logger.error(
-              `TTS synthesis failed in Mode 1 (direct input synthesis):`,
-              ttsError,
-            );
-            // baseResult remains without audio - graceful degradation
-          }
-
-          // Call enhanceResult for consistency - enables analytics/evaluation for TTS-only requests
-          return await this.enhanceResult(baseResult, options, startTime);
-        }
-
-        // ===== Normal AI Generation Flow =====
-        const { tools, model } = await this.prepareGenerationContext(options);
-        const messages = await this.buildMessages(options);
-
-        // ===== VIDEO ANALYSIS FROM MESSAGES CONTENT =====
-        // Check if video files are present in messages content array
-        // If video analysis is needed, perform it via Gemini, then pass through Claude for formatting
-        if (hasVideoFrames(messages)) {
-          const videoAnalysisResult = await executeVideoAnalysis(messages, {
-            provider: options.provider,
-            providerName: this.providerName,
-            region: options.region,
-            // Don't pass the main conversation model — video analysis uses
-            // Google's Gemini API (generateContent) which only supports Gemini models.
-            // Let videoAnalysisProcessor use its own default (gemini-2.5-flash).
-          });
-
-          // Extract user's original text from messages (excluding image parts)
-          const userTextParts = messages
-            .filter((m) => m.role === "user")
-            .flatMap((m) =>
-              Array.isArray(m.content)
-                ? m.content
-                    .filter(
-                      (p): p is { type: "text"; text: string } =>
-                        p.type === "text",
-                    )
-                    .map((p) => p.text)
-                : [typeof m.content === "string" ? m.content : ""],
-            )
-            .filter(Boolean);
-          const userText = userTextParts.join("\n").trim();
-
-          // Pass Gemini's analysis through Claude for structured JSON formatting
-          // The system prompt (from Curator) includes JSON_REPORT_PROMPT_SUFFIX
-          // which instructs Claude to output {"summary": "...", "details": "..."}
-          let formattedContent = videoAnalysisResult;
-          let usage = { input: 0, output: 0, total: 0 };
-
-          if (options.systemPrompt) {
-            try {
-              const formattingPrompt = userText
-                ? `The user asked: "${userText}"\n\nHere is the video/image analysis result from the visual analysis system:\n\n${videoAnalysisResult}\n\nBased on this analysis, provide your response.`
-                : `Here is a video/image analysis result from the visual analysis system:\n\n${videoAnalysisResult}\n\nBased on this analysis, provide your response.`;
-
-              logger.debug("[VideoAnalysis] Formatting via Claude", {
-                userTextLength: userText.length,
-                analysisLength: videoAnalysisResult.length,
-              });
-
-              const formattedResult = await generateText({
-                model,
-                system: options.systemPrompt,
-                messages: [
-                  { role: "user" as const, content: formattingPrompt },
-                ],
-                maxOutputTokens: options.maxTokens || 8192,
-                temperature: 0.3,
-                abortSignal: options.abortSignal,
-                experimental_telemetry:
-                  this.telemetryHandler?.getTelemetryConfig(
-                    options,
-                    "generate",
-                  ),
-              });
-
-              formattedContent = formattedResult.text;
-              usage = {
-                input: formattedResult.usage?.inputTokens || 0,
-                output: formattedResult.usage?.outputTokens || 0,
-                total:
-                  (formattedResult.usage?.inputTokens || 0) +
-                  (formattedResult.usage?.outputTokens || 0),
-              };
-
-              logger.debug("[VideoAnalysis] Claude formatting complete", {
-                formattedLength: formattedContent.length,
-                usage,
-              });
-            } catch (error) {
-              logger.warn(
-                "[VideoAnalysis] Claude formatting failed, using raw Gemini output",
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              );
-              // formattedContent remains as raw videoAnalysisResult (graceful degradation)
-            }
-          }
-
-          const videoResult: EnhancedGenerateResult = {
-            content: formattedContent,
-            provider: options.provider ?? this.providerName,
-            model: this.modelName,
-            usage,
-          };
-
-          return await this.enhanceResult(videoResult, options, startTime);
-        }
-
-        // Compose timeout signal with user-provided abort signal (mirrors stream path)
-        const timeoutController = createTimeoutController(
-          options.timeout,
-          this.providerName,
-          "generate",
-        );
-        const composedSignal = composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        );
-        const composedOptions = composedSignal
-          ? { ...options, abortSignal: composedSignal }
-          : options;
-
-        let generateResult: Awaited<ReturnType<typeof generateText>>;
-        try {
-          generateResult = await this.executeGeneration(
-            model,
-            messages,
-            tools,
-            composedOptions,
-          );
-        } finally {
-          timeoutController?.cleanup();
-        }
-
-        this.analyzeAIResponse(
-          generateResult as unknown as Record<string, unknown>,
-        );
-        this.logGenerationComplete(generateResult);
-        const responseTime = Date.now() - startTime;
-        await this.recordPerformanceMetrics(generateResult.usage, responseTime);
-
-        const { toolsUsed, toolExecutions } =
-          this.extractToolInformation(generateResult);
-        let enhancedResult = this.formatEnhancedResult(
-          generateResult,
-          tools,
-          toolsUsed,
-          toolExecutions,
-          options,
-        );
-
-        // ===== TTS MODE 2: AI Response Synthesis (useAiResponse=true) =====
-        // Synthesize AI-generated response after generation completes
-        if (options.tts?.enabled && options.tts?.useAiResponse) {
-          const aiResponse = enhancedResult.content;
-          const provider = options.provider ?? this.providerName;
-
-          // Validate AI response and provider before synthesis
-          if (aiResponse && provider) {
-            try {
-              const ttsResult = await TTSProcessor.synthesize(
-                aiResponse,
-                provider,
-                options.tts,
-              );
-
-              // Add audio to enhanced result (TTSProcessor already includes latency in metadata)
-              enhancedResult = {
-                ...enhancedResult,
-                audio: ttsResult,
-              };
-            } catch (ttsError) {
-              // Log TTS error but continue with text-only result
-              logger.error(
-                `TTS synthesis failed in Mode 2 (AI response synthesis):`,
-                ttsError,
-              );
-              // enhancedResult remains unchanged (no audio field added)
-            }
-          } else {
-            logger.warn(`TTS synthesis skipped despite being enabled`, {
-              provider: this.providerName,
-              hasAiResponse: !!aiResponse,
-              aiResponseLength: aiResponse?.length ?? 0,
-              hasProvider: !!provider,
-              ttsConfig: {
-                enabled: options.tts?.enabled,
-                useAiResponse: options.tts?.useAiResponse,
-              },
-              reason: !aiResponse
-                ? "AI response is empty or undefined"
-                : "Provider is missing",
-            });
-          }
-        }
-
-        // Observability: record successful generate span with token/cost data
-        let enrichedGenerateSpan = { ...metricsSpan };
-        if (enhancedResult?.usage) {
-          enrichedGenerateSpan = SpanSerializer.enrichWithTokenUsage(
-            enrichedGenerateSpan,
-            {
-              promptTokens: enhancedResult.usage.input || 0,
-              completionTokens: enhancedResult.usage.output || 0,
-              totalTokens: enhancedResult.usage.total || 0,
-            },
-          );
-          const cost = calculateCost(this.providerName, this.modelName, {
-            input: enhancedResult.usage.input || 0,
-            output: enhancedResult.usage.output || 0,
-            total: enhancedResult.usage.total || 0,
-          });
-          if (cost && cost > 0) {
-            enrichedGenerateSpan = SpanSerializer.enrichWithCost(
-              enrichedGenerateSpan,
-              {
-                totalCost: cost,
-              },
-            );
-          }
-        }
-        const _endedGenerateSpan = SpanSerializer.endSpan(
-          enrichedGenerateSpan,
-          SpanStatus.OK,
-        );
-        // Note: Do NOT record to getMetricsAggregator() here — the neurolink.ts
-        // generation:end listener creates an authoritative span with richer context
-        // (provider name, model, input/output) and records to both aggregators.
-        // Recording here would double-count cost and token metrics.
-
-        return await this.enhanceResult(enhancedResult, options, startTime);
-      } catch (error) {
-        // Observability: record failed generate span
-        const _endedGenerateSpan = SpanSerializer.endSpan(
-          metricsSpan,
-          SpanStatus.ERROR,
-          error instanceof Error ? error.message : String(error),
-        );
-        // Note: Do NOT record to getMetricsAggregator() here — neurolink.ts
-        // handles authoritative metrics recording to avoid double-counting.
-
-        otelSpan.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
-        });
-        otelSpan.end();
-        otelSpanEnded = true;
-
-        // Abort errors are expected when a generation is cancelled — log at info, not error
-        if (isAbortError(error)) {
-          logger.info(`Generate aborted for ${this.providerName}`, {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        } else {
-          logger.error(`Generate failed for ${this.providerName}:`, error);
-        }
-        throw this.handleProviderError(error);
-      } finally {
-        if (!otelSpanEnded) {
-          otelSpan.setStatus({ code: SpanStatusCode.OK });
-          otelSpan.end();
-        }
-      }
-    }); // end context.with
+    return await context.with(activeCtx, async () =>
+      this.runGenerateInActiveContext(
+        options,
+        startTime,
+        metricsSpan,
+        otelSpan,
+        otelSpanState,
+      ),
+    );
   }
   /**
    * Alias for generate method - implements AIProvider interface
@@ -1081,6 +774,335 @@ export abstract class BaseProvider implements AIProvider {
     analysisSchema?: ValidationSchema,
   ): Promise<EnhancedGenerateResult | null> {
     return this.generate(optionsOrPrompt, analysisSchema);
+  }
+
+  private async runGenerateInActiveContext(
+    options: TextGenerationOptions,
+    startTime: number,
+    metricsSpan: ReturnType<typeof SpanSerializer.createSpan>,
+    otelSpan: ReturnType<typeof tracers.provider.startSpan>,
+    otelSpanState: { ended: boolean },
+  ): Promise<EnhancedGenerateResult | null> {
+    try {
+      if (options.output?.mode === "video") {
+        return await this.handleVideoGeneration(options, startTime);
+      }
+
+      const isImageModel = IMAGE_GENERATION_MODELS.some((m) =>
+        this.modelName.includes(m),
+      );
+      if (isImageModel) {
+        logger.info(
+          `Image generation model detected, routing to executeImageGeneration`,
+          {
+            provider: this.providerName,
+            model: this.modelName,
+          },
+        );
+
+        const imageResult = await this.executeImageGeneration(options);
+        return await this.enhanceResult(imageResult, options, startTime);
+      }
+
+      if (options.tts?.enabled && !options.tts?.useAiResponse) {
+        return this.handleDirectTTSSynthesis(options, startTime);
+      }
+
+      const { tools, model } = await this.prepareGenerationContext(options);
+      const messages = await this.buildMessages(options);
+      const videoFrameResult = await this.handleVideoFrameGeneration(
+        options,
+        messages,
+        model,
+        startTime,
+      );
+      if (videoFrameResult) {
+        return videoFrameResult;
+      }
+
+      return await this.executeStandardGenerateFlow(
+        options,
+        startTime,
+        metricsSpan,
+        model,
+        messages,
+        tools,
+      );
+    } catch (error) {
+      SpanSerializer.endSpan(
+        metricsSpan,
+        SpanStatus.ERROR,
+        error instanceof Error ? error.message : String(error),
+      );
+      otelSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      otelSpan.end();
+      otelSpanState.ended = true;
+
+      if (isAbortError(error)) {
+        logger.info(`Generate aborted for ${this.providerName}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } else {
+        logger.error(`Generate failed for ${this.providerName}:`, error);
+      }
+      throw this.handleProviderError(error);
+    } finally {
+      if (!otelSpanState.ended) {
+        otelSpan.setStatus({ code: SpanStatusCode.OK });
+        otelSpan.end();
+      }
+    }
+  }
+
+  private async handleDirectTTSSynthesis(
+    options: TextGenerationOptions,
+    startTime: number,
+  ): Promise<EnhancedGenerateResult> {
+    const textToSynthesize = options.prompt ?? options.input?.text ?? "";
+    const baseResult: EnhancedGenerateResult = {
+      content: textToSynthesize,
+      provider: options.provider ?? this.providerName,
+      model: this.modelName,
+      usage: { input: 0, output: 0, total: 0 },
+    };
+
+    try {
+      if (!options.tts) {
+        return this.enhanceResult(baseResult, options, startTime);
+      }
+      baseResult.audio = await TTSProcessor.synthesize(
+        textToSynthesize,
+        options.provider ?? this.providerName,
+        options.tts,
+      );
+    } catch (ttsError) {
+      logger.error(
+        `TTS synthesis failed in Mode 1 (direct input synthesis):`,
+        ttsError,
+      );
+    }
+
+    return this.enhanceResult(baseResult, options, startTime);
+  }
+
+  private async handleVideoFrameGeneration(
+    options: TextGenerationOptions,
+    messages: ModelMessage[],
+    model: LanguageModel,
+    startTime: number,
+  ): Promise<EnhancedGenerateResult | null> {
+    if (!hasVideoFrames(messages)) {
+      return null;
+    }
+
+    const videoAnalysisResult = await executeVideoAnalysis(messages, {
+      provider: options.provider,
+      providerName: this.providerName,
+      region: options.region,
+    });
+    const userText = messages
+      .filter((m) => m.role === "user")
+      .flatMap((m) =>
+        Array.isArray(m.content)
+          ? m.content
+              .filter(
+                (p): p is { type: "text"; text: string } => p.type === "text",
+              )
+              .map((p) => p.text)
+          : [typeof m.content === "string" ? m.content : ""],
+      )
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+
+    let formattedContent = videoAnalysisResult;
+    let usage = { input: 0, output: 0, total: 0 };
+
+    if (options.systemPrompt) {
+      try {
+        const formattingPrompt = userText
+          ? `The user asked: "${userText}"\n\nHere is the video/image analysis result from the visual analysis system:\n\n${videoAnalysisResult}\n\nBased on this analysis, provide your response.`
+          : `Here is a video/image analysis result from the visual analysis system:\n\n${videoAnalysisResult}\n\nBased on this analysis, provide your response.`;
+
+        logger.debug("[VideoAnalysis] Formatting via Claude", {
+          userTextLength: userText.length,
+          analysisLength: videoAnalysisResult.length,
+        });
+
+        const formattedResult = await generateText({
+          model,
+          system: options.systemPrompt,
+          messages: [{ role: "user" as const, content: formattingPrompt }],
+          maxOutputTokens: options.maxTokens || 8192,
+          temperature: 0.3,
+          abortSignal: options.abortSignal,
+          experimental_telemetry: this.telemetryHandler?.getTelemetryConfig(
+            options,
+            "generate",
+          ),
+        });
+        formattedContent = formattedResult.text;
+        usage = {
+          input: formattedResult.usage?.inputTokens || 0,
+          output: formattedResult.usage?.outputTokens || 0,
+          total:
+            (formattedResult.usage?.inputTokens || 0) +
+            (formattedResult.usage?.outputTokens || 0),
+        };
+
+        logger.debug("[VideoAnalysis] Claude formatting complete", {
+          formattedLength: formattedContent.length,
+          usage,
+        });
+      } catch (error) {
+        logger.warn(
+          "[VideoAnalysis] Claude formatting failed, using raw Gemini output",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
+    return this.enhanceResult(
+      {
+        content: formattedContent,
+        provider: options.provider ?? this.providerName,
+        model: this.modelName,
+        usage,
+      },
+      options,
+      startTime,
+    );
+  }
+
+  private async executeStandardGenerateFlow(
+    options: TextGenerationOptions,
+    startTime: number,
+    metricsSpan: ReturnType<typeof SpanSerializer.createSpan>,
+    model: LanguageModel,
+    messages: ModelMessage[],
+    tools: Record<string, Tool>,
+  ): Promise<EnhancedGenerateResult> {
+    const timeoutController = createTimeoutController(
+      options.timeout,
+      this.providerName,
+      "generate",
+    );
+    const composedSignal = composeAbortSignals(
+      options.abortSignal,
+      timeoutController?.controller.signal,
+    );
+    const composedOptions = composedSignal
+      ? { ...options, abortSignal: composedSignal }
+      : options;
+
+    let generateResult: Awaited<ReturnType<typeof generateText>>;
+    try {
+      generateResult = await this.executeGeneration(
+        model,
+        messages,
+        tools,
+        composedOptions,
+      );
+    } finally {
+      timeoutController?.cleanup();
+    }
+
+    this.analyzeAIResponse(
+      generateResult as unknown as Record<string, unknown>,
+    );
+    this.logGenerationComplete(generateResult);
+    const responseTime = Date.now() - startTime;
+    await this.recordPerformanceMetrics(generateResult.usage, responseTime);
+
+    const { toolsUsed, toolExecutions } =
+      this.extractToolInformation(generateResult);
+    let enhancedResult = this.formatEnhancedResult(
+      generateResult,
+      tools,
+      toolsUsed,
+      toolExecutions,
+      options,
+    );
+    enhancedResult = await this.synthesizeAIResponseIfNeeded(
+      enhancedResult,
+      options,
+    );
+
+    let enrichedGenerateSpan = { ...metricsSpan };
+    if (enhancedResult?.usage) {
+      enrichedGenerateSpan = SpanSerializer.enrichWithTokenUsage(
+        enrichedGenerateSpan,
+        {
+          promptTokens: enhancedResult.usage.input || 0,
+          completionTokens: enhancedResult.usage.output || 0,
+          totalTokens: enhancedResult.usage.total || 0,
+        },
+      );
+      const cost = calculateCost(this.providerName, this.modelName, {
+        input: enhancedResult.usage.input || 0,
+        output: enhancedResult.usage.output || 0,
+        total: enhancedResult.usage.total || 0,
+      });
+      if (cost && cost > 0) {
+        enrichedGenerateSpan = SpanSerializer.enrichWithCost(
+          enrichedGenerateSpan,
+          { totalCost: cost },
+        );
+      }
+    }
+    SpanSerializer.endSpan(enrichedGenerateSpan, SpanStatus.OK);
+    return this.enhanceResult(enhancedResult, options, startTime);
+  }
+
+  private async synthesizeAIResponseIfNeeded(
+    enhancedResult: EnhancedGenerateResult,
+    options: TextGenerationOptions,
+  ): Promise<EnhancedGenerateResult> {
+    if (!options.tts?.enabled || !options.tts?.useAiResponse) {
+      return enhancedResult;
+    }
+
+    const aiResponse = enhancedResult.content;
+    const provider = options.provider ?? this.providerName;
+    if (!aiResponse || !provider) {
+      logger.warn(`TTS synthesis skipped despite being enabled`, {
+        provider: this.providerName,
+        hasAiResponse: !!aiResponse,
+        aiResponseLength: aiResponse?.length ?? 0,
+        hasProvider: !!provider,
+        ttsConfig: {
+          enabled: options.tts?.enabled,
+          useAiResponse: options.tts?.useAiResponse,
+        },
+        reason: !aiResponse
+          ? "AI response is empty or undefined"
+          : "Provider is missing",
+      });
+      return enhancedResult;
+    }
+
+    try {
+      const ttsResult = await TTSProcessor.synthesize(
+        aiResponse,
+        provider,
+        options.tts,
+      );
+      return {
+        ...enhancedResult,
+        audio: ttsResult,
+      };
+    } catch (ttsError) {
+      logger.error(
+        `TTS synthesis failed in Mode 2 (AI response synthesis):`,
+        ttsError,
+      );
+      return enhancedResult;
+    }
   }
 
   /**

--- a/src/lib/core/factory.ts
+++ b/src/lib/core/factory.ts
@@ -68,6 +68,218 @@ export class AIProviderFactory {
       // This ensures the factory continues to work even if dynamic models fail
     }
   }
+
+  private static resolveModelFromEnvironment(
+    providerName: string,
+    modelName: string | null | undefined,
+    functionTag: string,
+  ): string | null | undefined {
+    if (modelName && modelName !== "default") {
+      logger.debug(
+        `[${functionTag}] Skipping environment variable check - explicit model provided: ${modelName}`,
+      );
+      return modelName;
+    }
+
+    logger.debug(
+      `[${functionTag}] Checking environment variables for provider: ${providerName}`,
+    );
+
+    const normalizedProvider = providerName.toLowerCase();
+    const envConfigs = [
+      {
+        match: ["bedrock"],
+        label: "Bedrock",
+        vars: ["BEDROCK_MODEL", "BEDROCK_MODEL_ID"],
+      },
+      {
+        match: ["vertex"],
+        label: "Vertex",
+        vars: ["VERTEX_MODEL"],
+      },
+      {
+        match: ["azure"],
+        label: "Azure",
+        vars: [
+          "AZURE_OPENAI_MODEL",
+          "AZURE_OPENAI_DEPLOYMENT",
+          "AZURE_OPENAI_DEPLOYMENT_ID",
+        ],
+      },
+      {
+        match: ["openai", "gpt", "chatgpt", "openai-compat"],
+        label: "OpenAI",
+        vars: ["OPENAI_MODEL"],
+      },
+      {
+        match: ["anthropic", "claude", "anthropic-claude"],
+        label: "Anthropic",
+        vars: ["ANTHROPIC_MODEL"],
+      },
+      {
+        match: ["google", "gemini"],
+        label: "Google AI",
+        vars: ["GOOGLE_AI_MODEL"],
+      },
+      {
+        match: ["mistral"],
+        label: "Mistral",
+        vars: ["MISTRAL_MODEL"],
+      },
+      {
+        match: ["ollama"],
+        label: "Ollama",
+        vars: ["OLLAMA_MODEL"],
+      },
+      {
+        match: ["litellm"],
+        label: "LiteLLM",
+        vars: ["LITELLM_MODEL"],
+      },
+    ] as const;
+
+    const envConfig = envConfigs.find((config) =>
+      config.match.some((match) => normalizedProvider.includes(match)),
+    );
+    if (!envConfig) {
+      logger.debug(
+        `[${functionTag}] Provider ${providerName} - no environment variable check implemented`,
+      );
+      return modelName;
+    }
+
+    const matchedVar = envConfig.vars.find((name) => process.env[name]);
+    const envModel = matchedVar ? process.env[matchedVar] : undefined;
+    if (envModel) {
+      logger.debug(
+        `[${functionTag}] Environment variable found for ${envConfig.label}`,
+        {
+          envVariable: matchedVar,
+          resolvedModel: envModel,
+        },
+      );
+      return envModel;
+    }
+
+    logger.debug(
+      `[${functionTag}] No ${envConfig.label} environment variables found (${envConfig.vars.join(", ")})`,
+    );
+    return modelName;
+  }
+
+  private static async resolveDynamicModelName(
+    providerName: string,
+    modelName: string | null | undefined,
+    resolvedModelName: string | null | undefined,
+    functionTag: string,
+  ): Promise<string | null | undefined> {
+    if (
+      (resolvedModelName && resolvedModelName !== "default") ||
+      (modelName && modelName !== "default")
+    ) {
+      logger.debug(`[${functionTag}] Skipping dynamic model resolution`, {
+        resolvedModelName: resolvedModelName || "none",
+        reason:
+          "Model already resolved from environment variables or explicit parameter",
+      });
+      return resolvedModelName;
+    }
+
+    logger.debug(`[${functionTag}] Attempting dynamic model resolution`, {
+      currentResolvedModel: resolvedModelName || "none",
+      reason: "No environment variable found and no explicit model provided",
+    });
+
+    try {
+      const normalizedProvider = this.normalizeProviderName(providerName);
+
+      if (dynamicModelProvider.needsRefresh()) {
+        logger.debug(
+          `[${functionTag}] Dynamic model provider needs refresh - initializing`,
+        );
+        await this.initializeDynamicProviderWithTimeout();
+      }
+
+      const dynamicModel = dynamicModelProvider.resolveModel(
+        normalizedProvider,
+        modelName || undefined,
+      );
+      if (!dynamicModel) {
+        logger.debug(
+          `[${functionTag}] Dynamic model resolution returned null`,
+          {
+            provider: normalizedProvider,
+            requestedModel: modelName || "default",
+          },
+        );
+        return resolvedModelName;
+      }
+
+      logger.debug(`[${functionTag}] Resolved dynamic model`, {
+        provider: normalizedProvider,
+        requestedModel: modelName || "default",
+        resolvedModel: dynamicModel.id,
+        displayName: dynamicModel.displayName,
+        pricing: dynamicModel.pricing.input,
+      });
+      return dynamicModel.id;
+    } catch (resolveError) {
+      logger.debug(
+        `[${functionTag}] Dynamic model resolution failed, using static fallback`,
+        {
+          error:
+            resolveError instanceof Error
+              ? resolveError.message
+              : String(resolveError),
+        },
+      );
+      return resolvedModelName;
+    }
+  }
+
+  private static async createResolvedProvider(
+    providerName: string,
+    resolvedModelName: string | null | undefined,
+    sdk: UnknownRecord | undefined,
+    region: string | undefined,
+    functionTag: string,
+  ): Promise<{
+    normalizedName: string;
+    finalModelName: string | undefined;
+    provider: AIProvider;
+  }> {
+    await withTimeout(
+      ProviderRegistry.registerAllProviders(),
+      30_000,
+      new Error("Provider registration timed out"),
+    );
+
+    const normalizedName = this.normalizeProviderName(providerName);
+    const finalModelName =
+      resolvedModelName === "default" || resolvedModelName === null
+        ? undefined
+        : resolvedModelName;
+
+    logger.debug(`[${functionTag}] Final provider configuration`, {
+      originalProviderName: providerName,
+      normalizedProviderName: normalizedName,
+      resolvedModelName: resolvedModelName || "not resolved",
+      finalModelName: finalModelName || "using provider default",
+    });
+
+    const provider = await withTimeout(
+      ProviderFactory.createProvider(
+        normalizedName,
+        finalModelName,
+        sdk,
+        region,
+      ),
+      30_000,
+      new Error(`Provider creation timed out for ${normalizedName}`),
+    );
+
+    return { normalizedName, finalModelName, provider };
+  }
   /**
    * Create a provider instance for the specified provider type
    * @param providerName - Name of the provider ('vertex', 'bedrock', 'openai')
@@ -122,269 +334,25 @@ export class AIProviderFactory {
           //
           // The dynamic model provider now provides reliable functionality without hanging
 
-          let resolvedModelName = modelName;
-
-          // PRIORITY 1: Check environment variables BEFORE dynamic resolution
-          if (!modelName || modelName === "default") {
-            logger.debug(
-              `[${functionTag}] Checking environment variables for provider: ${providerName}`,
-            );
-
-            // Check for provider-specific environment variables first
-            if (providerName.toLowerCase().includes("bedrock")) {
-              const envModel =
-                process.env.BEDROCK_MODEL || process.env.BEDROCK_MODEL_ID;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Bedrock`,
-                  {
-                    envVariable: process.env.BEDROCK_MODEL
-                      ? "BEDROCK_MODEL"
-                      : "BEDROCK_MODEL_ID",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Bedrock environment variables found (BEDROCK_MODEL, BEDROCK_MODEL_ID)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("vertex")) {
-              const envModel = process.env.VERTEX_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Vertex`,
-                  {
-                    envVariable: "VERTEX_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Vertex environment variables found (VERTEX_MODEL)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("azure")) {
-              const envModel =
-                process.env.AZURE_OPENAI_MODEL ||
-                process.env.AZURE_OPENAI_DEPLOYMENT ||
-                process.env.AZURE_OPENAI_DEPLOYMENT_ID;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Azure`,
-                  {
-                    envVariable: process.env.AZURE_OPENAI_MODEL
-                      ? "AZURE_OPENAI_MODEL"
-                      : process.env.AZURE_OPENAI_DEPLOYMENT
-                        ? "AZURE_OPENAI_DEPLOYMENT"
-                        : "AZURE_OPENAI_DEPLOYMENT_ID",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Azure environment variables found (AZURE_OPENAI_MODEL, AZURE_OPENAI_DEPLOYMENT, AZURE_OPENAI_DEPLOYMENT_ID)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("openai")) {
-              const envModel = process.env.OPENAI_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for OpenAI`,
-                  {
-                    envVariable: "OPENAI_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No OpenAI environment variables found (OPENAI_MODEL)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("anthropic")) {
-              const envModel = process.env.ANTHROPIC_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Anthropic`,
-                  {
-                    envVariable: "ANTHROPIC_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Anthropic environment variables found (ANTHROPIC_MODEL)`,
-                );
-              }
-            } else if (
-              providerName.toLowerCase().includes("google") ||
-              providerName.toLowerCase().includes("gemini")
-            ) {
-              const envModel = process.env.GOOGLE_AI_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Google AI`,
-                  {
-                    envVariable: "GOOGLE_AI_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Google AI environment variables found (GOOGLE_AI_MODEL)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("mistral")) {
-              const envModel = process.env.MISTRAL_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Mistral`,
-                  {
-                    envVariable: "MISTRAL_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Mistral environment variables found (MISTRAL_MODEL)`,
-                );
-              }
-            } else if (providerName.toLowerCase().includes("ollama")) {
-              const envModel = process.env.OLLAMA_MODEL;
-              if (envModel) {
-                resolvedModelName = envModel;
-                logger.debug(
-                  `[${functionTag}] Environment variable found for Ollama`,
-                  {
-                    envVariable: "OLLAMA_MODEL",
-                    resolvedModel: envModel,
-                  },
-                );
-              } else {
-                logger.debug(
-                  `[${functionTag}] No Ollama environment variables found (OLLAMA_MODEL)`,
-                );
-              }
-            } else {
-              logger.debug(
-                `[${functionTag}] Provider ${providerName} - no environment variable check implemented`,
-              );
-            }
-          } else {
-            logger.debug(
-              `[${functionTag}] Skipping environment variable check - explicit model provided: ${modelName}`,
-            );
-          }
-
-          // PRIORITY 2: Enable dynamic model resolution only if no env var found
-          if (
-            (!resolvedModelName || resolvedModelName === "default") &&
-            (!modelName || modelName === "default")
-          ) {
-            logger.debug(
-              `[${functionTag}] Attempting dynamic model resolution`,
-              {
-                currentResolvedModel: resolvedModelName || "none",
-                reason:
-                  "No environment variable found and no explicit model provided",
-              },
-            );
-
-            try {
-              const normalizedProvider =
-                this.normalizeProviderName(providerName);
-
-              // Initialize with timeout protection - won't hang anymore
-              if (dynamicModelProvider.needsRefresh()) {
-                logger.debug(
-                  `[${functionTag}] Dynamic model provider needs refresh - initializing`,
-                );
-                await this.initializeDynamicProviderWithTimeout();
-              }
-
-              const dynamicModel = dynamicModelProvider.resolveModel(
-                normalizedProvider,
-                modelName || undefined,
-              );
-
-              if (dynamicModel) {
-                resolvedModelName = dynamicModel.id;
-                logger.debug(`[${functionTag}] Resolved dynamic model`, {
-                  provider: normalizedProvider,
-                  requestedModel: modelName || "default",
-                  resolvedModel: resolvedModelName,
-                  displayName: dynamicModel.displayName,
-                  pricing: dynamicModel.pricing.input,
-                });
-              } else {
-                logger.debug(
-                  `[${functionTag}] Dynamic model resolution returned null`,
-                  {
-                    provider: normalizedProvider,
-                    requestedModel: modelName || "default",
-                  },
-                );
-              }
-            } catch (resolveError) {
-              logger.debug(
-                `[${functionTag}] Dynamic model resolution failed, using static fallback`,
-                {
-                  error:
-                    resolveError instanceof Error
-                      ? resolveError.message
-                      : String(resolveError),
-                },
-              );
-              // Continue with static model name - no functionality loss
-            }
-          } else {
-            logger.debug(`[${functionTag}] Skipping dynamic model resolution`, {
-              resolvedModelName: resolvedModelName || "none",
-              reason:
-                "Model already resolved from environment variables or explicit parameter",
-            });
-          }
-
-          // CRITICAL FIX: Initialize providers before using them
-          await withTimeout(
-            ProviderRegistry.registerAllProviders(),
-            30_000,
-            new Error("Provider registration timed out"),
+          let resolvedModelName = this.resolveModelFromEnvironment(
+            providerName,
+            modelName,
+            functionTag,
           );
-
-          // PURE FACTORY PATTERN: No switch statements - use ProviderFactory exclusively
-          const normalizedName = this.normalizeProviderName(providerName);
-          const finalModelName =
-            resolvedModelName === "default" || resolvedModelName === null
-              ? undefined
-              : resolvedModelName;
-
-          logger.debug(`[${functionTag}] Final provider configuration`, {
-            originalProviderName: providerName,
-            normalizedProviderName: normalizedName,
-            originalModelName: modelName || "not provided",
-            resolvedModelName: resolvedModelName || "not resolved",
-            finalModelName: finalModelName || "using provider default",
-          });
-
-          // Create provider with enhanced SDK and region support
-          const provider = await withTimeout(
-            ProviderFactory.createProvider(
-              normalizedName,
-              finalModelName,
+          resolvedModelName = await this.resolveDynamicModelName(
+            providerName,
+            modelName,
+            resolvedModelName,
+            functionTag,
+          );
+          const { normalizedName, finalModelName, provider } =
+            await this.createResolvedProvider(
+              providerName,
+              resolvedModelName,
               sdk,
               region,
-            ),
-            30_000,
-            new Error(`Provider creation timed out for ${normalizedName}`),
-          );
+              functionTag,
+            );
 
           // Summary logging in format expected by debugging tools
           logger.debug(

--- a/src/lib/evaluation/pipeline/evaluationPipeline.ts
+++ b/src/lib/evaluation/pipeline/evaluationPipeline.ts
@@ -12,7 +12,7 @@ import type {
   ScorerInput,
 } from "../../types/scorerTypes.js";
 import { logger } from "../../utils/logger.js";
-import { withTimeout } from "../../utils/errorHandling.js";
+import { ErrorFactory, withTimeout } from "../../utils/errorHandling.js";
 import { DEFAULT_SCORE_SCALE } from "../scorers/baseScorer.js";
 import { ScorerRegistry } from "../scorers/scorerRegistry.js";
 
@@ -265,8 +265,13 @@ export class EvaluationPipeline {
       !!options?.skipScorers && options.skipScorers.length > 0;
 
     if (hasOnlyScorers && hasSkipScorers) {
-      throw new Error(
+      throw ErrorFactory.invalidConfiguration(
+        "evaluation pipeline execution options",
         "Cannot specify both 'onlyScorers' and 'skipScorers' options",
+        {
+          onlyScorers: options?.onlyScorers,
+          skipScorers: options?.skipScorers,
+        },
       );
     }
   }

--- a/src/lib/evaluation/scorers/scorerRegistry.ts
+++ b/src/lib/evaluation/scorers/scorerRegistry.ts
@@ -14,6 +14,373 @@ import type {
 } from "../../types/scorerTypes.js";
 import { logger } from "../../utils/logger.js";
 
+type BuiltInScorerDefinition = {
+  metadata: ScorerMetadata;
+  factory: ScorerFactory;
+  aliases?: string[];
+};
+
+const BUILT_IN_LLM_SCORERS: BuiltInScorerDefinition[] = [
+  {
+    metadata: {
+      id: "hallucination",
+      name: "Hallucination Detection",
+      description:
+        "Detects factual errors, fabrications, and unsupported claims in responses",
+      type: "llm",
+      category: "accuracy",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.8,
+        weight: 1.5,
+        timeout: 30000,
+        retries: 2,
+      },
+      requiredInputs: ["query", "response"],
+      optionalInputs: ["context", "groundTruth"],
+    },
+    factory: async (config) => {
+      const { HallucinationScorer } =
+        await import("./llm/hallucinationScorer.js");
+      return new HallucinationScorer(config);
+    },
+    aliases: ["hallucination-detection", "hallucinations"],
+  },
+  {
+    metadata: {
+      id: "toxicity",
+      name: "Toxicity Analysis",
+      description:
+        "Detects harmful, offensive, or inappropriate content in responses",
+      type: "llm",
+      category: "safety",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.9,
+        weight: 2.0,
+        timeout: 20000,
+        retries: 1,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: ["query"],
+    },
+    factory: async (config) => {
+      const { ToxicityScorer } = await import("./llm/toxicityScorer.js");
+      return new ToxicityScorer(config);
+    },
+    aliases: ["toxic", "safety"],
+  },
+  {
+    metadata: {
+      id: "faithfulness",
+      name: "Faithfulness",
+      description:
+        "Evaluates if the response is faithfully grounded in provided context",
+      type: "llm",
+      category: "faithfulness",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.7,
+        weight: 1.2,
+        timeout: 30000,
+        retries: 2,
+      },
+      requiredInputs: ["response", "context"],
+      optionalInputs: ["query"],
+    },
+    factory: async (config) => {
+      const { FaithfulnessScorer } =
+        await import("./llm/faithfulnessScorer.js");
+      return new FaithfulnessScorer(config);
+    },
+    aliases: ["faithful", "grounding"],
+  },
+  {
+    metadata: {
+      id: "context-relevancy",
+      name: "Context Relevancy",
+      description:
+        "Evaluates how relevant the retrieved context is to the user query",
+      type: "llm",
+      category: "relevancy",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.6,
+        weight: 1.0,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["query", "context"],
+      optionalInputs: ["response"],
+    },
+    factory: async (config) => {
+      const { ContextRelevancyScorer } =
+        await import("./llm/contextRelevancyScorer.js");
+      return new ContextRelevancyScorer(config);
+    },
+    aliases: ["context-relevance"],
+  },
+  {
+    metadata: {
+      id: "answer-relevancy",
+      name: "Answer Relevancy",
+      description:
+        "Evaluates how relevant the AI response is to the user query",
+      type: "llm",
+      category: "relevancy",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.7,
+        weight: 1.0,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["query", "response"],
+      optionalInputs: ["context"],
+    },
+    factory: async (config) => {
+      const { AnswerRelevancyScorer } =
+        await import("./llm/answerRelevancyScorer.js");
+      return new AnswerRelevancyScorer(config);
+    },
+    aliases: ["response-relevancy", "relevancy"],
+  },
+  {
+    metadata: {
+      id: "context-precision",
+      name: "Context Precision",
+      description:
+        "Measures the precision of retrieved context - whether relevant chunks are ranked higher",
+      type: "llm",
+      category: "relevancy",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.6,
+        weight: 0.8,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["query", "context"],
+      optionalInputs: ["groundTruth"],
+    },
+    factory: async (config) => {
+      const { ContextPrecisionScorer } =
+        await import("./llm/contextPrecisionScorer.js");
+      return new ContextPrecisionScorer(config);
+    },
+    aliases: ["precision"],
+  },
+  {
+    metadata: {
+      id: "bias-detection",
+      name: "Bias Detection",
+      description: "Identifies potential biases in AI responses",
+      type: "llm",
+      category: "safety",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.8,
+        weight: 1.0,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: ["query", "context"],
+    },
+    factory: async (config) => {
+      const { BiasDetectionScorer } =
+        await import("./llm/biasDetectionScorer.js");
+      return new BiasDetectionScorer(config);
+    },
+    aliases: ["bias", "fairness"],
+  },
+  {
+    metadata: {
+      id: "tone-consistency",
+      name: "Tone Consistency",
+      description: "Checks for consistent tone throughout the response",
+      type: "llm",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.7,
+        weight: 0.8,
+        timeout: 20000,
+        retries: 1,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: ["query"],
+    },
+    factory: async (config) => {
+      const { ToneConsistencyScorer } =
+        await import("./llm/toneConsistencyScorer.js");
+      return new ToneConsistencyScorer(config);
+    },
+    aliases: ["tone"],
+  },
+  {
+    metadata: {
+      id: "prompt-alignment",
+      name: "Prompt Alignment",
+      description:
+        "Measures how well the response aligns with prompt instructions",
+      type: "llm",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.7,
+        weight: 1.0,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["query", "response"],
+      optionalInputs: [],
+    },
+    factory: async (config) => {
+      const { PromptAlignmentScorer } =
+        await import("./llm/promptAlignmentScorer.js");
+      return new PromptAlignmentScorer(config);
+    },
+    aliases: ["alignment", "instruction-following"],
+  },
+  {
+    metadata: {
+      id: "summarization",
+      name: "Summarization Quality",
+      description: "Evaluates the quality of AI-generated summaries",
+      type: "llm",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.7,
+        weight: 1.0,
+        timeout: 25000,
+        retries: 2,
+      },
+      requiredInputs: ["response", "context"],
+      optionalInputs: ["query"],
+    },
+    factory: async (config) => {
+      const { SummarizationScorer } =
+        await import("./llm/summarizationScorer.js");
+      return new SummarizationScorer(config);
+    },
+    aliases: ["summary"],
+  },
+];
+
+const BUILT_IN_RULE_SCORERS: BuiltInScorerDefinition[] = [
+  {
+    metadata: {
+      id: "keyword-coverage",
+      name: "Keyword Coverage",
+      description: "Checks if response covers expected keywords and concepts",
+      type: "rule",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.6,
+        weight: 0.8,
+        timeout: 1000,
+        retries: 0,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: ["query", "custom"],
+    },
+    factory: async (config) => {
+      const { KeywordCoverageScorer } =
+        await import("./rule/keywordCoverageScorer.js");
+      return new KeywordCoverageScorer(config);
+    },
+    aliases: ["keywords"],
+  },
+  {
+    metadata: {
+      id: "content-similarity",
+      name: "Content Similarity",
+      description: "Measures text similarity between response and reference",
+      type: "rule",
+      category: "accuracy",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.5,
+        weight: 1.0,
+        timeout: 2000,
+        retries: 0,
+      },
+      requiredInputs: ["response", "groundTruth"],
+      optionalInputs: [],
+    },
+    factory: async (config) => {
+      const { ContentSimilarityScorer } =
+        await import("./rule/contentSimilarityScorer.js");
+      return new ContentSimilarityScorer(config);
+    },
+    aliases: ["similarity", "text-similarity"],
+  },
+  {
+    metadata: {
+      id: "length",
+      name: "Response Length",
+      description: "Validates response length against configured bounds",
+      type: "rule",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.8,
+        weight: 0.5,
+        timeout: 100,
+        retries: 0,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: [],
+    },
+    factory: async (config) => {
+      const { LengthScorer } = await import("./rule/lengthScorer.js");
+      return new LengthScorer(config);
+    },
+    aliases: ["response-length"],
+  },
+  {
+    metadata: {
+      id: "format",
+      name: "Format Validation",
+      description:
+        "Checks if response follows expected formatting requirements",
+      type: "rule",
+      category: "quality",
+      version: "1.0.0",
+      defaultConfig: {
+        enabled: true,
+        threshold: 0.8,
+        weight: 0.5,
+        timeout: 100,
+        retries: 0,
+      },
+      requiredInputs: ["response"],
+      optionalInputs: ["custom"],
+    },
+    factory: async (config) => {
+      const { FormatScorer } = await import("./rule/formatScorer.js");
+      return new FormatScorer(config);
+    },
+    aliases: ["formatting"],
+  },
+];
+
 /**
  * Central registry for all scorers
  * Manages registration, discovery, and instantiation
@@ -66,6 +433,26 @@ export class ScorerRegistry {
     });
   }
 
+  private static registerScorerDefinitions(
+    definitions: BuiltInScorerDefinition[],
+  ): void {
+    for (const definition of definitions) {
+      ScorerRegistry.registerScorer(
+        definition.metadata,
+        definition.factory,
+        definition.aliases || [],
+      );
+    }
+  }
+
+  private static registerBuiltInLLMScorers(): void {
+    ScorerRegistry.registerScorerDefinitions(BUILT_IN_LLM_SCORERS);
+  }
+
+  private static registerBuiltInRuleScorers(): void {
+    ScorerRegistry.registerScorerDefinitions(BUILT_IN_RULE_SCORERS);
+  }
+
   /**
    * Register built-in scorers using dynamic imports
    */
@@ -79,378 +466,8 @@ export class ScorerRegistry {
 
     ScorerRegistry.initPromise = (async () => {
       try {
-        // Register LLM-based scorers with dynamic imports
-        ScorerRegistry.registerScorer(
-          {
-            id: "hallucination",
-            name: "Hallucination Detection",
-            description:
-              "Detects factual errors, fabrications, and unsupported claims in responses",
-            type: "llm",
-            category: "accuracy",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.8,
-              weight: 1.5,
-              timeout: 30000,
-              retries: 2,
-            },
-            requiredInputs: ["query", "response"],
-            optionalInputs: ["context", "groundTruth"],
-          },
-          async (config) => {
-            const { HallucinationScorer } =
-              await import("./llm/hallucinationScorer.js");
-            return new HallucinationScorer(config);
-          },
-          ["hallucination-detection", "hallucinations"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "toxicity",
-            name: "Toxicity Analysis",
-            description:
-              "Detects harmful, offensive, or inappropriate content in responses",
-            type: "llm",
-            category: "safety",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.9,
-              weight: 2.0,
-              timeout: 20000,
-              retries: 1,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: ["query"],
-          },
-          async (config) => {
-            const { ToxicityScorer } = await import("./llm/toxicityScorer.js");
-            return new ToxicityScorer(config);
-          },
-          ["toxic", "safety"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "faithfulness",
-            name: "Faithfulness",
-            description:
-              "Evaluates if the response is faithfully grounded in provided context",
-            type: "llm",
-            category: "faithfulness",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.7,
-              weight: 1.2,
-              timeout: 30000,
-              retries: 2,
-            },
-            requiredInputs: ["response", "context"],
-            optionalInputs: ["query"],
-          },
-          async (config) => {
-            const { FaithfulnessScorer } =
-              await import("./llm/faithfulnessScorer.js");
-            return new FaithfulnessScorer(config);
-          },
-          ["faithful", "grounding"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "context-relevancy",
-            name: "Context Relevancy",
-            description:
-              "Evaluates how relevant the retrieved context is to the user query",
-            type: "llm",
-            category: "relevancy",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.6,
-              weight: 1.0,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["query", "context"],
-            optionalInputs: ["response"],
-          },
-          async (config) => {
-            const { ContextRelevancyScorer } =
-              await import("./llm/contextRelevancyScorer.js");
-            return new ContextRelevancyScorer(config);
-          },
-          ["context-relevance"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "answer-relevancy",
-            name: "Answer Relevancy",
-            description:
-              "Evaluates how relevant the AI response is to the user query",
-            type: "llm",
-            category: "relevancy",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.7,
-              weight: 1.0,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["query", "response"],
-            optionalInputs: ["context"],
-          },
-          async (config) => {
-            const { AnswerRelevancyScorer } =
-              await import("./llm/answerRelevancyScorer.js");
-            return new AnswerRelevancyScorer(config);
-          },
-          ["response-relevancy", "relevancy"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "context-precision",
-            name: "Context Precision",
-            description:
-              "Measures the precision of retrieved context - whether relevant chunks are ranked higher",
-            type: "llm",
-            category: "relevancy",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.6,
-              weight: 0.8,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["query", "context"],
-            optionalInputs: ["groundTruth"],
-          },
-          async (config) => {
-            const { ContextPrecisionScorer } =
-              await import("./llm/contextPrecisionScorer.js");
-            return new ContextPrecisionScorer(config);
-          },
-          ["precision"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "bias-detection",
-            name: "Bias Detection",
-            description: "Identifies potential biases in AI responses",
-            type: "llm",
-            category: "safety",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.8,
-              weight: 1.0,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: ["query", "context"],
-          },
-          async (config) => {
-            const { BiasDetectionScorer } =
-              await import("./llm/biasDetectionScorer.js");
-            return new BiasDetectionScorer(config);
-          },
-          ["bias", "fairness"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "tone-consistency",
-            name: "Tone Consistency",
-            description: "Checks for consistent tone throughout the response",
-            type: "llm",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.7,
-              weight: 0.8,
-              timeout: 20000,
-              retries: 1,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: ["query"],
-          },
-          async (config) => {
-            const { ToneConsistencyScorer } =
-              await import("./llm/toneConsistencyScorer.js");
-            return new ToneConsistencyScorer(config);
-          },
-          ["tone"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "prompt-alignment",
-            name: "Prompt Alignment",
-            description:
-              "Measures how well the response aligns with prompt instructions",
-            type: "llm",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.7,
-              weight: 1.0,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["query", "response"],
-            optionalInputs: [],
-          },
-          async (config) => {
-            const { PromptAlignmentScorer } =
-              await import("./llm/promptAlignmentScorer.js");
-            return new PromptAlignmentScorer(config);
-          },
-          ["alignment", "instruction-following"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "summarization",
-            name: "Summarization Quality",
-            description: "Evaluates the quality of AI-generated summaries",
-            type: "llm",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.7,
-              weight: 1.0,
-              timeout: 25000,
-              retries: 2,
-            },
-            requiredInputs: ["response", "context"],
-            optionalInputs: ["query"],
-          },
-          async (config) => {
-            const { SummarizationScorer } =
-              await import("./llm/summarizationScorer.js");
-            return new SummarizationScorer(config);
-          },
-          ["summary"],
-        );
-
-        // Register rule-based scorers
-        ScorerRegistry.registerScorer(
-          {
-            id: "keyword-coverage",
-            name: "Keyword Coverage",
-            description:
-              "Checks if response covers expected keywords and concepts",
-            type: "rule",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.6,
-              weight: 0.8,
-              timeout: 1000,
-              retries: 0,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: ["query", "custom"],
-          },
-          async (config) => {
-            const { KeywordCoverageScorer } =
-              await import("./rule/keywordCoverageScorer.js");
-            return new KeywordCoverageScorer(config);
-          },
-          ["keywords"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "content-similarity",
-            name: "Content Similarity",
-            description:
-              "Measures text similarity between response and reference",
-            type: "rule",
-            category: "accuracy",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.5,
-              weight: 1.0,
-              timeout: 2000,
-              retries: 0,
-            },
-            requiredInputs: ["response", "groundTruth"],
-            optionalInputs: [],
-          },
-          async (config) => {
-            const { ContentSimilarityScorer } =
-              await import("./rule/contentSimilarityScorer.js");
-            return new ContentSimilarityScorer(config);
-          },
-          ["similarity", "text-similarity"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "length",
-            name: "Response Length",
-            description: "Validates response length against configured bounds",
-            type: "rule",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.8,
-              weight: 0.5,
-              timeout: 100,
-              retries: 0,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: [],
-          },
-          async (config) => {
-            const { LengthScorer } = await import("./rule/lengthScorer.js");
-            return new LengthScorer(config);
-          },
-          ["response-length"],
-        );
-
-        ScorerRegistry.registerScorer(
-          {
-            id: "format",
-            name: "Format Validation",
-            description:
-              "Checks if response follows expected formatting requirements",
-            type: "rule",
-            category: "quality",
-            version: "1.0.0",
-            defaultConfig: {
-              enabled: true,
-              threshold: 0.8,
-              weight: 0.5,
-              timeout: 100,
-              retries: 0,
-            },
-            requiredInputs: ["response"],
-            optionalInputs: ["custom"],
-          },
-          async (config) => {
-            const { FormatScorer } = await import("./rule/formatScorer.js");
-            return new FormatScorer(config);
-          },
-          ["formatting"],
-        );
+        ScorerRegistry.registerBuiltInLLMScorers();
+        ScorerRegistry.registerBuiltInRuleScorers();
 
         ScorerRegistry.initialized = true;
         logger.debug(

--- a/src/lib/mcp/toolRegistry.ts
+++ b/src/lib/mcp/toolRegistry.ts
@@ -22,6 +22,7 @@ import { shouldDisableBuiltinTools } from "../utils/toolUtils.js";
 import { directAgentTools } from "../agent/directTools.js";
 import { detectCategory, createMCPServerInfo } from "../utils/mcpDefaults.js";
 import { FlexibleToolValidator } from "./flexibleToolValidator.js";
+import { ErrorFactory } from "../utils/errorHandling.js";
 import type { HITLManager } from "../types/hitlTypes.js";
 import { HITLUserRejectedError, HITLTimeoutError } from "../hitl/hitlErrors.js";
 import { withSpan, tracers, ATTR } from "../telemetry/index.js";
@@ -346,31 +347,7 @@ export class MCPToolRegistry extends MCPRegistry {
             },
           );
 
-          // Try to find the tool by fully-qualified name first
-          let tool = this.tools.get(toolName);
-          registryLogger.info(
-            `🔍 [TOOL_LOOKUP] Direct lookup result for '${toolName}':`,
-            !!tool,
-          );
-
-          // If not found, search for tool by name across all entries (for backward compatibility)
-          let toolId = toolName;
-          if (!tool) {
-            const matches = Array.from(this.tools.entries()).filter(
-              ([, toolInfo]) => toolInfo.name === toolName,
-            );
-            if (matches.length > 1) {
-              throw new Error(
-                `Ambiguous tool name '${toolName}'. Use fully-qualified name 'serverId.${toolName}'.`,
-              );
-            }
-            if (matches.length === 1) {
-              const [candidateToolId, toolInfo] = matches[0];
-              tool = toolInfo;
-              toolId = candidateToolId;
-            }
-          }
-
+          const { tool, toolId } = this.resolveToolExecutionTarget(toolName);
           if (!tool) {
             throw new Error(`Tool '${toolName}' not found in registry`);
           }
@@ -386,21 +363,7 @@ export class MCPToolRegistry extends MCPRegistry {
           span.setAttribute("tool.type", toolType);
           span.setAttribute(ATTR.MCP_SERVER_ID, serverId);
 
-          // Try to get auth context if available
-          let authUserId: string | undefined;
-          try {
-            const authCtx = getAuthContext();
-            authUserId = authCtx?.user?.id;
-          } catch {
-            // Auth context not available — that's fine
-          }
-
-          // Create execution context if not provided
-          const execContext: ExecutionContext = {
-            ...context,
-            sessionId: context?.sessionId ?? randomUUID(),
-            userId: context?.userId ?? authUserId,
-          };
+          const execContext = this.createExecutionContext(context);
 
           // Get the tool implementation using the resolved toolId
           const toolImpl = this.toolImplementations.get(toolId);
@@ -700,6 +663,52 @@ export class MCPToolRegistry extends MCPRegistry {
       `Listed ${result.length} unique tools (${filter ? "filtered" : "unfiltered"})`,
     );
     return result;
+  }
+
+  private resolveToolExecutionTarget(toolName: string): {
+    tool: ToolInfo | undefined;
+    toolId: string;
+  } {
+    let tool = this.tools.get(toolName);
+    registryLogger.info(
+      `🔍 [TOOL_LOOKUP] Direct lookup result for '${toolName}':`,
+      !!tool,
+    );
+
+    let toolId = toolName;
+    if (!tool) {
+      const matches = Array.from(this.tools.entries()).filter(
+        ([, toolInfo]) => toolInfo.name === toolName,
+      );
+      if (matches.length > 1) {
+        throw ErrorFactory.toolExecutionFailed(
+          toolName,
+          new Error(
+            `Ambiguous tool name '${toolName}'. Use fully-qualified name 'serverId.${toolName}'.`,
+          ),
+        );
+      }
+      if (matches.length === 1) {
+        [toolId, tool] = matches[0];
+      }
+    }
+
+    return { tool, toolId };
+  }
+
+  private createExecutionContext(context?: ExecutionContext): ExecutionContext {
+    let authUserId: string | undefined;
+    try {
+      authUserId = getAuthContext()?.user?.id;
+    } catch {
+      // Auth context not available — that's fine
+    }
+
+    return {
+      ...context,
+      sessionId: context?.sessionId ?? randomUUID(),
+      userId: context?.userId ?? authUserId,
+    };
   }
 
   /**

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -35,7 +35,11 @@ import {
   TOOL_TIMEOUTS,
 } from "./constants/index.js";
 import { checkContextBudget } from "./context/budgetChecker.js";
-import { type CompactionConfig, type CompactionResult, ContextCompactor } from "./context/contextCompactor.js";
+import {
+  type CompactionConfig,
+  type CompactionResult,
+  ContextCompactor,
+} from "./context/contextCompactor.js";
 import { emergencyContentTruncation } from "./context/emergencyTruncation.js";
 import {
   getContextOverflowProvider,
@@ -65,10 +69,19 @@ import type { MCPToolAnnotations } from "./mcp/toolAnnotations.js";
 import { inferAnnotations, isSafeToRetry } from "./mcp/toolAnnotations.js";
 import type { ToolMiddleware } from "./mcp/toolIntegration.js";
 import { MCPToolRegistry } from "./mcp/toolRegistry.js";
-import { type HippocampusConfig, initializeHippocampus } from "./memory/hippocampusInitializer.js";
+import {
+  type HippocampusConfig,
+  initializeHippocampus,
+} from "./memory/hippocampusInitializer.js";
 import { createMemoryRetrievalTools } from "./memory/memoryRetrievalTools.js";
-import type { MetricsSummary, TraceView } from "./observability/metricsAggregator.js";
-import { getMetricsAggregator, MetricsAggregator } from "./observability/metricsAggregator.js";
+import type {
+  MetricsSummary,
+  TraceView,
+} from "./observability/metricsAggregator.js";
+import {
+  getMetricsAggregator,
+  MetricsAggregator,
+} from "./observability/metricsAggregator.js";
 import type { SpanData } from "./observability/types/spanTypes.js";
 import { SpanStatus, SpanType } from "./observability/types/spanTypes.js";
 import { SpanSerializer } from "./observability/utils/spanSerializer.js";
@@ -91,19 +104,44 @@ import type {
   MastraAuthProvider,
 } from "./types/authTypes.js";
 import { CircuitBreakerOpenError } from "./types/circuitBreakerErrors.js";
-import type { JsonObject, JsonValue, NeuroLinkEvents, TypedEventEmitter, UnknownRecord } from "./types/common.js";
-import type { MCPEnhancementsConfig, NeuroLinkAuthConfig, NeurolinkConstructorConfig } from "./types/configTypes.js";
-import type { ChatMessage, ConversationMemoryConfig, ProviderDetails } from "./types/conversation.js";
+import type {
+  JsonObject,
+  JsonValue,
+  NeuroLinkEvents,
+  TypedEventEmitter,
+  UnknownRecord,
+} from "./types/common.js";
+import type {
+  MCPEnhancementsConfig,
+  NeuroLinkAuthConfig,
+  NeurolinkConstructorConfig,
+} from "./types/configTypes.js";
+import type {
+  ChatMessage,
+  ConversationMemoryConfig,
+  ProviderDetails,
+} from "./types/conversation.js";
 import { ConversationMemoryError } from "./types/conversation.js";
-import { AuthenticationError, AuthorizationError, InvalidModelError } from "./types/errors.js";
+import {
+  AuthenticationError,
+  AuthorizationError,
+  InvalidModelError,
+} from "./types/errors.js";
 import type {
   ExternalMCPOperationResult,
   ExternalMCPServerInstance,
   ExternalMCPToolInfo,
 } from "./types/externalMcp.js";
 // NEW: Generate function imports
-import type { AdditionalMemoryUser, GenerateOptions, GenerateResult } from "./types/generateTypes.js";
-import type { ConfirmationResponseEvent, HITLConfig } from "./types/hitlTypes.js";
+import type {
+  AdditionalMemoryUser,
+  GenerateOptions,
+  GenerateResult,
+} from "./types/generateTypes.js";
+import type {
+  ConfirmationResponseEvent,
+  HITLConfig,
+} from "./types/hitlTypes.js";
 import type {
   AnalyticsData,
   EvaluationData,
@@ -112,13 +150,35 @@ import type {
   TextGenerationResult,
   TokenUsage,
 } from "./types/index.js";
-import type { MCPExecutableTool, MCPServerCategory, MCPServerInfo, MCPStatus } from "./types/mcpTypes.js";
+import type {
+  MCPExecutableTool,
+  MCPServerCategory,
+  MCPServerInfo,
+  MCPStatus,
+} from "./types/mcpTypes.js";
 import type { ObservabilityConfig } from "./types/observability.js";
-import type { AudioChunk, StreamOptions, StreamResult, ToolCall, ToolResult } from "./types/streamTypes.js";
+import type {
+  AudioChunk,
+  StreamOptions,
+  StreamResult,
+  ToolCall,
+  ToolResult,
+} from "./types/streamTypes.js";
 import type { TaskManagerConfig } from "./types/taskTypes.js";
-import type { ToolExecutionContext, ToolExecutionSummary, ToolInfo, ToolRegistrationOptions } from "./types/tools.js";
-import type { BatchOperationResult, ToolExecutionResult } from "./types/typeAliases.js";
-import { getConversationMessages, storeConversationTurn } from "./utils/conversationMemory.js";
+import type {
+  ToolExecutionContext,
+  ToolExecutionSummary,
+  ToolInfo,
+  ToolRegistrationOptions,
+} from "./types/tools.js";
+import type {
+  BatchOperationResult,
+  ToolExecutionResult,
+} from "./types/typeAliases.js";
+import {
+  getConversationMessages,
+  storeConversationTurn,
+} from "./utils/conversationMemory.js";
 // Enhanced error handling imports
 import {
   CircuitBreaker,
@@ -140,7 +200,10 @@ import {
   validateFactoryConfig,
 } from "./utils/factoryProcessing.js";
 import { logger, mcpLogger } from "./utils/logger.js";
-import { createCustomToolServerInfo, detectCategory } from "./utils/mcpDefaults.js";
+import {
+  createCustomToolServerInfo,
+  detectCategory,
+} from "./utils/mcpDefaults.js";
 import { resolveModel } from "./utils/modelAliasResolver.js";
 // Import orchestration components
 import { ModelRouter } from "./utils/modelRouter.js";
@@ -172,7 +235,13 @@ import type { WorkflowConfig } from "./workflow/types.js";
  */
 function classifyMcpErrorMessage(
   text: string,
-): "not_found" | "permission_denied" | "timeout" | "rate_limited" | "validation_error" | "unknown" {
+):
+  | "not_found"
+  | "permission_denied"
+  | "timeout"
+  | "rate_limited"
+  | "validation_error"
+  | "unknown" {
   const lower = text.toLowerCase();
   if (
     lower.includes("not found") ||
@@ -192,7 +261,11 @@ function classifyMcpErrorMessage(
   ) {
     return "permission_denied";
   }
-  if (lower.includes("timeout") || lower.includes("timed out") || lower.includes("deadline exceeded")) {
+  if (
+    lower.includes("timeout") ||
+    lower.includes("timed out") ||
+    lower.includes("deadline exceeded")
+  ) {
     return "timeout";
   }
   if (
@@ -214,7 +287,9 @@ function classifyMcpErrorMessage(
   return "unknown";
 }
 
-function mcpCategoryToErrorCategory(mcpCategory: ReturnType<typeof classifyMcpErrorMessage>): ErrorCategory {
+function mcpCategoryToErrorCategory(
+  mcpCategory: ReturnType<typeof classifyMcpErrorMessage>,
+): ErrorCategory {
   switch (mcpCategory) {
     case "not_found":
       return ErrorCategory.VALIDATION;
@@ -257,7 +332,11 @@ function isNonRetryableProviderError(error: unknown): boolean {
   if (error && typeof error === "object") {
     const err = error as Record<string, unknown>;
     const status =
-      typeof err.status === "number" ? err.status : typeof err.statusCode === "number" ? err.statusCode : undefined;
+      typeof err.status === "number"
+        ? err.status
+        : typeof err.statusCode === "number"
+          ? err.statusCode
+          : undefined;
 
     if (status && NON_RETRYABLE_HTTP_STATUS_CODES.includes(status)) {
       return true;
@@ -371,7 +450,8 @@ export class NeuroLink {
   private mcpInitialized = false;
   private mcpSkipped = false;
   private mcpInitPromise: Promise<void> | null = null;
-  private emitter = new EventEmitter() as unknown as TypedEventEmitter<NeuroLinkEvents>;
+  private emitter =
+    new EventEmitter() as unknown as TypedEventEmitter<NeuroLinkEvents>;
 
   // TaskManager — lazy-initialized on first access via `this.tasks`
   private _taskManager?: TaskManager;
@@ -399,7 +479,10 @@ export class NeuroLink {
 
   /** Extract sessionId from options context for compaction watermark keying */
   private getCompactionSessionId(options: { context?: unknown }): string {
-    return ((options.context as Record<string, unknown> | undefined)?.sessionId as string) || "__default__";
+    return (
+      ((options.context as Record<string, unknown> | undefined)
+        ?.sessionId as string) || "__default__"
+    );
   }
 
   // MCP Enhancement modules - wired into core execution path
@@ -458,7 +541,10 @@ export class NeuroLink {
     });
   }
   // Conversation memory support
-  public conversationMemory?: ConversationMemoryManager | RedisConversationMemoryManager | null;
+  public conversationMemory?:
+    | ConversationMemoryManager
+    | RedisConversationMemoryManager
+    | null;
   private conversationMemoryNeedsInit = false;
   private conversationMemoryConfig?: {
     conversationMemory?: Partial<ConversationMemoryConfig>;
@@ -495,19 +581,36 @@ export class NeuroLink {
     options: { context?: unknown },
     callback: () => Promise<T>,
   ): Promise<T> {
-    if (options.context && typeof options.context === "object" && options.context !== null) {
+    if (
+      options.context &&
+      typeof options.context === "object" &&
+      options.context !== null
+    ) {
       let callbackExecuted = false;
       try {
         const ctx = options.context as Record<string, unknown>;
         // Trigger context scoping if any meaningful Langfuse field is present
-        if (ctx.userId || ctx.sessionId || ctx.conversationId || ctx.requestId || ctx.traceName || ctx.metadata) {
+        if (
+          ctx.userId ||
+          ctx.sessionId ||
+          ctx.conversationId ||
+          ctx.requestId ||
+          ctx.traceName ||
+          ctx.metadata
+        ) {
           // Build customAttributes from top-level metadata string/number/boolean fields
-          let customAttributes: Record<string, string | number | boolean> | undefined;
+          let customAttributes:
+            | Record<string, string | number | boolean>
+            | undefined;
           if (ctx.metadata && typeof ctx.metadata === "object") {
             const metaObj = ctx.metadata as Record<string, unknown>;
             const attrs: Record<string, string | number | boolean> = {};
             for (const [k, v] of Object.entries(metaObj)) {
-              if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+              if (
+                typeof v === "string" ||
+                typeof v === "number" ||
+                typeof v === "boolean"
+              ) {
                 attrs[k] = v;
               }
             }
@@ -520,12 +623,20 @@ export class NeuroLink {
             setLangfuseContext(
               {
                 userId: typeof ctx.userId === "string" ? ctx.userId : null,
-                sessionId: typeof ctx.sessionId === "string" ? ctx.sessionId : null,
-                conversationId: typeof ctx.conversationId === "string" ? ctx.conversationId : null,
-                requestId: typeof ctx.requestId === "string" ? ctx.requestId : null,
-                traceName: typeof ctx.traceName === "string" ? ctx.traceName : null,
+                sessionId:
+                  typeof ctx.sessionId === "string" ? ctx.sessionId : null,
+                conversationId:
+                  typeof ctx.conversationId === "string"
+                    ? ctx.conversationId
+                    : null,
+                requestId:
+                  typeof ctx.requestId === "string" ? ctx.requestId : null,
+                traceName:
+                  typeof ctx.traceName === "string" ? ctx.traceName : null,
                 metadata:
-                  ctx.metadata && typeof ctx.metadata === "object" ? (ctx.metadata as Record<string, unknown>) : null,
+                  ctx.metadata && typeof ctx.metadata === "object"
+                    ? (ctx.metadata as Record<string, unknown>)
+                    : null,
                 ...(customAttributes !== undefined && { customAttributes }),
               },
               async () => {
@@ -553,6 +664,189 @@ export class NeuroLink {
       }
     }
     return await callback();
+  }
+
+  private createMetricsTraceContext(): {
+    traceId: string;
+    parentSpanId: string;
+  } {
+    return {
+      traceId: crypto.randomUUID().replace(/-/g, ""),
+      parentSpanId: crypto.randomUUID().replace(/-/g, "").substring(0, 16),
+    };
+  }
+
+  private enforceSessionBudget(maxBudgetUsd?: number): void {
+    if (
+      maxBudgetUsd === undefined ||
+      maxBudgetUsd <= 0 ||
+      this._sessionCostUsd < maxBudgetUsd
+    ) {
+      return;
+    }
+
+    throw new NeuroLinkError({
+      code: "SESSION_BUDGET_EXCEEDED",
+      message: `Session budget exceeded: spent $${this._sessionCostUsd.toFixed(4)} of $${maxBudgetUsd.toFixed(4)} limit`,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.HIGH,
+      retriable: false,
+      context: {
+        spent: this._sessionCostUsd,
+        limit: maxBudgetUsd,
+      },
+    });
+  }
+
+  private assertInputText(
+    text: string | undefined,
+    message: string,
+  ): asserts text is string {
+    if (!text || typeof text !== "string") {
+      throw new Error(message);
+    }
+  }
+
+  private async applyAuthenticatedRequestContext(options: {
+    auth?: { token?: string };
+    context?: Record<string, unknown>;
+    requestContext?: Record<string, unknown>;
+  }): Promise<void> {
+    if (options.auth?.token) {
+      const { AuthError } = await import("./auth/errors.js");
+      await this.ensureAuthProvider();
+      if (!this.authProvider) {
+        throw AuthError.create(
+          "PROVIDER_ERROR",
+          "No auth provider configured. Set auth in constructor or via setAuthProvider() before using auth: { token }.",
+        );
+      }
+
+      let authResult: Awaited<
+        ReturnType<MastraAuthProvider["authenticateToken"]>
+      >;
+      try {
+        authResult = await withTimeout(
+          this.authProvider.authenticateToken(options.auth.token),
+          5000,
+          AuthError.create(
+            "PROVIDER_ERROR",
+            "Auth token validation timed out after 5000ms",
+          ),
+        );
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "feature" in error &&
+          (error as { feature: string }).feature === "Auth"
+        ) {
+          throw error;
+        }
+        throw AuthError.create(
+          "PROVIDER_ERROR",
+          `Auth token validation failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      if (!authResult.valid) {
+        throw AuthError.create(
+          "INVALID_TOKEN",
+          authResult.error || "Token validation failed",
+        );
+      }
+      if (!authResult.user) {
+        throw AuthError.create(
+          "INVALID_TOKEN",
+          "Token validated but no user identity returned",
+        );
+      }
+      if (!authResult.user.id) {
+        throw AuthError.create(
+          "INVALID_TOKEN",
+          "Token validated but user identity missing required 'id' field",
+        );
+      }
+
+      options.context = {
+        ...(options.context || {}),
+        userId: authResult.user.id,
+        userEmail: authResult.user.email,
+        userRoles: authResult.user.roles,
+      };
+    }
+
+    if (!options.requestContext) {
+      return;
+    }
+
+    const tokenDerivedFields =
+      options.auth?.token && this.authProvider
+        ? {
+            userId: options.context?.userId,
+            userEmail: options.context?.userEmail,
+            userRoles: options.context?.userRoles,
+          }
+        : {};
+    options.context = {
+      ...(options.context || {}),
+      ...options.requestContext,
+      ...tokenDerivedFields,
+    };
+  }
+
+  private applyGenerateLifecycleMiddleware(options: GenerateOptions): void {
+    if (!options.onFinish && !options.onError) {
+      return;
+    }
+
+    options.middleware = {
+      ...options.middleware,
+      middlewareConfig: {
+        ...options.middleware?.middlewareConfig,
+        lifecycle: {
+          ...options.middleware?.middlewareConfig?.lifecycle,
+          enabled: true,
+          config: {
+            ...options.middleware?.middlewareConfig?.lifecycle?.config,
+            ...(options.onFinish !== undefined
+              ? { onFinish: options.onFinish }
+              : {}),
+            ...(options.onError !== undefined
+              ? { onError: options.onError }
+              : {}),
+          },
+        },
+      },
+    };
+  }
+
+  private applyStreamLifecycleMiddleware(options: StreamOptions): void {
+    if (!options.onFinish && !options.onError && !options.onChunk) {
+      return;
+    }
+
+    options.middleware = {
+      ...options.middleware,
+      middlewareConfig: {
+        ...options.middleware?.middlewareConfig,
+        lifecycle: {
+          ...options.middleware?.middlewareConfig?.lifecycle,
+          enabled: true,
+          config: {
+            ...options.middleware?.middlewareConfig?.lifecycle?.config,
+            ...(options.onFinish !== undefined
+              ? { onFinish: options.onFinish }
+              : {}),
+            ...(options.onError !== undefined
+              ? { onError: options.onError }
+              : {}),
+            ...(options.onChunk !== undefined
+              ? { onChunk: options.onChunk }
+              : {}),
+          },
+        },
+      },
+    };
   }
 
   private initializeMemoryConfig(): boolean {
@@ -672,22 +966,50 @@ export class NeuroLink {
 
     // Read tool cache duration from environment variables, with a default
     const cacheDurationEnv = process.env.NEUROLINK_TOOL_CACHE_DURATION;
-    this.toolCacheDuration = cacheDurationEnv ? parseInt(cacheDurationEnv, 10) : 20000;
+    this.toolCacheDuration = cacheDurationEnv
+      ? parseInt(cacheDurationEnv, 10)
+      : 20000;
 
     const constructorStartTime = Date.now();
     const constructorHrTimeStart = process.hrtime.bigint();
     const constructorId = `neurolink-constructor-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
-    this.initializeProviderRegistry(constructorId, constructorStartTime, constructorHrTimeStart);
-    this.initializeConversationMemory(config, constructorId, constructorStartTime, constructorHrTimeStart);
-    this.initializeExternalServerManager(constructorId, constructorStartTime, constructorHrTimeStart);
-    this.initializeHITL(config, constructorId, constructorStartTime, constructorHrTimeStart);
+    this.initializeProviderRegistry(
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
+    this.initializeConversationMemory(
+      config,
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
+    this.initializeExternalServerManager(
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
+    this.initializeHITL(
+      config,
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
     this.initializeMCPEnhancements(config);
     this.registerFileTools();
     this.registerMemoryRetrievalTools();
-    this.initializeLangfuse(constructorId, constructorStartTime, constructorHrTimeStart);
+    this.initializeLangfuse(
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
     this.initializeMetricsListeners();
-    this.logConstructorComplete(constructorId, constructorStartTime, constructorHrTimeStart);
+    this.logConstructorComplete(
+      constructorId,
+      constructorStartTime,
+      constructorHrTimeStart,
+    );
 
     // Store auth config for lazy initialization
     if (config?.auth) {
@@ -737,15 +1059,20 @@ export class NeuroLink {
     constructorHrTimeStart: bigint,
   ): void {
     const registrySetupStartTime = process.hrtime.bigint();
-    logger.debug(`[NeuroLink] 🏗️ LOG_POINT_C002_PROVIDER_REGISTRY_SETUP_START`, {
-      logPoint: "C002_PROVIDER_REGISTRY_SETUP_START",
-      constructorId,
-      timestamp: new Date().toISOString(),
-      elapsedMs: Date.now() - constructorStartTime,
-      elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
-      registrySetupStartTimeNs: registrySetupStartTime.toString(),
-      message: "Starting ProviderRegistry configuration for security",
-    });
+    logger.debug(
+      `[NeuroLink] 🏗️ LOG_POINT_C002_PROVIDER_REGISTRY_SETUP_START`,
+      {
+        logPoint: "C002_PROVIDER_REGISTRY_SETUP_START",
+        constructorId,
+        timestamp: new Date().toISOString(),
+        elapsedMs: Date.now() - constructorStartTime,
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
+        registrySetupStartTimeNs: registrySetupStartTime.toString(),
+        message: "Starting ProviderRegistry configuration for security",
+      },
+    );
 
     ProviderRegistry.setOptions({ enableManualMCP: false });
   }
@@ -754,7 +1081,9 @@ export class NeuroLink {
    * Initialize conversation memory if enabled
    */
   private initializeConversationMemory(
-    config: { conversationMemory?: Partial<ConversationMemoryConfig> } | undefined,
+    config:
+      | { conversationMemory?: Partial<ConversationMemoryConfig> }
+      | undefined,
     constructorId: string,
     constructorStartTime: number,
     constructorHrTimeStart: bigint,
@@ -768,23 +1097,32 @@ export class NeuroLink {
 
       const memoryInitEndTime = process.hrtime.bigint();
       const memoryInitDurationNs = memoryInitEndTime - memoryInitStartTime;
-      logger.debug(`[NeuroLink] ✅ LOG_POINT_C006_MEMORY_INIT_FLAG_SET_SUCCESS`, {
-        logPoint: "C006_MEMORY_INIT_FLAG_SET_SUCCESS",
-        constructorId,
-        timestamp: new Date().toISOString(),
-        elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
-        memoryInitDurationNs: memoryInitDurationNs.toString(),
-        memoryInitDurationMs: Number(memoryInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
-        message: "Conversation memory initialization flag set successfully for lazy loading",
-      });
+      logger.debug(
+        `[NeuroLink] ✅ LOG_POINT_C006_MEMORY_INIT_FLAG_SET_SUCCESS`,
+        {
+          logPoint: "C006_MEMORY_INIT_FLAG_SET_SUCCESS",
+          constructorId,
+          timestamp: new Date().toISOString(),
+          elapsedMs: Date.now() - constructorStartTime,
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
+          memoryInitDurationNs: memoryInitDurationNs.toString(),
+          memoryInitDurationMs:
+            Number(memoryInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+          message:
+            "Conversation memory initialization flag set successfully for lazy loading",
+        },
+      );
     } else {
       logger.debug(`[NeuroLink] 🚫 LOG_POINT_C008_MEMORY_DISABLED`, {
         logPoint: "C008_MEMORY_DISABLED",
         constructorId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
         hasConfig: !!config,
         hasMemoryConfig: !!config?.conversationMemory,
         memoryEnabled: config?.conversationMemory?.enabled || false,
@@ -822,13 +1160,16 @@ export class NeuroLink {
         constructorId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
         hitlInitStartTimeNs: hitlInitStartTime.toString(),
         hitlConfig: {
           enabled: config.hitl.enabled,
           dangerousActions: config.hitl.dangerousActions || [],
           timeout: config.hitl.timeout || 30000,
-          allowArgumentModification: config.hitl.allowArgumentModification ?? true,
+          allowArgumentModification:
+            config.hitl.allowArgumentModification ?? true,
           auditLogging: config.hitl.auditLogging ?? false,
         },
         message: "Starting HITL (Human-in-the-Loop) initialization",
@@ -855,9 +1196,12 @@ export class NeuroLink {
           constructorId,
           timestamp: new Date().toISOString(),
           elapsedMs: Date.now() - constructorStartTime,
-          elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
           hitlInitDurationNs: hitlInitDurationNs.toString(),
-          hitlInitDurationMs: Number(hitlInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+          hitlInitDurationMs:
+            Number(hitlInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
           hasHitlManager: !!this.hitlManager,
           message: "HITL (Human-in-the-Loop) initialized successfully",
         });
@@ -865,7 +1209,8 @@ export class NeuroLink {
         logger.info(`[NeuroLink] HITL safety features enabled`, {
           dangerousActions: config.hitl.dangerousActions?.length || 0,
           timeout: config.hitl.timeout || 30000,
-          allowArgumentModification: config.hitl.allowArgumentModification ?? true,
+          allowArgumentModification:
+            config.hitl.allowArgumentModification ?? true,
           auditLogging: config.hitl.auditLogging ?? false,
         });
       } catch (error) {
@@ -877,9 +1222,12 @@ export class NeuroLink {
           constructorId,
           timestamp: new Date().toISOString(),
           elapsedMs: Date.now() - constructorStartTime,
-          elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
           hitlInitDurationNs: hitlInitDurationNs.toString(),
-          hitlInitDurationMs: Number(hitlInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+          hitlInitDurationMs:
+            Number(hitlInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
           error: error instanceof Error ? error.message : String(error),
           errorName: error instanceof Error ? error.name : "UnknownError",
           errorStack: error instanceof Error ? error.stack : undefined,
@@ -893,7 +1241,9 @@ export class NeuroLink {
         constructorId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
         hasConfig: !!config,
         hasHitlConfig: !!config?.hitl,
         hitlEnabled: config?.hitl?.enabled || false,
@@ -904,7 +1254,8 @@ export class NeuroLink {
             : !config.hitl.enabled
               ? "HITL_DISABLED"
               : "UNKNOWN",
-        message: "HITL (Human-in-the-Loop) not enabled - skipping initialization",
+        message:
+          "HITL (Human-in-the-Loop) not enabled - skipping initialization",
       });
     }
   }
@@ -938,13 +1289,15 @@ export class NeuroLink {
         maxWaitMs: mcpConfig.batcher.maxWaitMs ?? 100,
       });
       // Wire batcher to execute tools via the internal execution path (bypass batcher itself)
-      this.mcpToolBatcher.setToolExecutor(async (tool: string, args: unknown) => {
-        return this.executeToolInternal(tool, args, {
-          timeout: TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
-          maxRetries: RETRY_ATTEMPTS.DEFAULT,
-          retryDelayMs: RETRY_DELAYS.BASE_MS,
-        });
-      });
+      this.mcpToolBatcher.setToolExecutor(
+        async (tool: string, args: unknown) => {
+          return this.executeToolInternal(tool, args, {
+            timeout: TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
+            maxRetries: RETRY_ATTEMPTS.DEFAULT,
+            retryDelayMs: RETRY_DELAYS.BASE_MS,
+          });
+        },
+      );
       logger.debug("[NeuroLink] MCP tool call batcher initialized");
     }
 
@@ -976,51 +1329,60 @@ export class NeuroLink {
     const fileTools = createFileTools(this.fileRegistry);
 
     // Use void to handle async registration without blocking constructor
-    const registrations = Object.entries(fileTools).map(async ([toolName, toolDef]) => {
-      const toolId = `direct.${toolName}`;
-      const toolInfo: ToolInfo = {
-        name: toolName,
-        description: toolDef.description || `File tool: ${toolName}`,
-        inputSchema: {},
-        serverId: "direct",
-        category: "built-in" as MCPServerCategory,
-      };
+    const registrations = Object.entries(fileTools).map(
+      async ([toolName, toolDef]) => {
+        const toolId = `direct.${toolName}`;
+        const toolInfo: ToolInfo = {
+          name: toolName,
+          description: toolDef.description || `File tool: ${toolName}`,
+          inputSchema: {},
+          serverId: "direct",
+          category: "built-in" as MCPServerCategory,
+        };
 
-      await this.toolRegistry.registerTool(toolId, toolInfo, {
-        execute: async (params: unknown) => {
-          try {
-            const result = await (toolDef.execute as (params: unknown, ctx: unknown) => Promise<unknown>)(params, {
-              toolCallId: "file-tool",
-              messages: [],
-            });
-            return {
-              success: true,
-              data: result,
-              metadata: { toolName, serverId: "direct", executionTime: 0 },
-            };
-          } catch (error) {
-            // Known limitation: this non-throwing error path returns
-            // { success: false } without recording errorCategories in
-            // toolExecutionMetrics. These are internal file-tool failures
-            // (low frequency), so the risk of metric gaps is minimal.
-            // A full fix would require access to the metrics map here,
-            // which is not available in the registration closure.
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-              metadata: { toolName, serverId: "direct", executionTime: 0 },
-            };
-          }
-        },
-        description: toolDef.description,
-        inputSchema: {},
-      });
-    });
+        await this.toolRegistry.registerTool(toolId, toolInfo, {
+          execute: async (params: unknown) => {
+            try {
+              const result = await (
+                toolDef.execute as (
+                  params: unknown,
+                  ctx: unknown,
+                ) => Promise<unknown>
+              )(params, {
+                toolCallId: "file-tool",
+                messages: [],
+              });
+              return {
+                success: true,
+                data: result,
+                metadata: { toolName, serverId: "direct", executionTime: 0 },
+              };
+            } catch (error) {
+              // Known limitation: this non-throwing error path returns
+              // { success: false } without recording errorCategories in
+              // toolExecutionMetrics. These are internal file-tool failures
+              // (low frequency), so the risk of metric gaps is minimal.
+              // A full fix would require access to the metrics map here,
+              // which is not available in the registration closure.
+              return {
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+                metadata: { toolName, serverId: "direct", executionTime: 0 },
+              };
+            }
+          },
+          description: toolDef.description,
+          inputSchema: {},
+        });
+      },
+    );
 
     // Fire-and-forget: registrations complete before any generate/stream call
     // because those calls await initializeMCP() which is slower
     void Promise.all(registrations).then(() => {
-      logger.debug(`[NeuroLink] Registered ${Object.keys(fileTools).length} file reference tools`);
+      logger.debug(
+        `[NeuroLink] Registered ${Object.keys(fileTools).length} file reference tools`,
+      );
     });
   }
 
@@ -1048,7 +1410,12 @@ export class NeuroLink {
       void this.toolRegistry.registerTool(toolId, toolInfo, {
         execute: async (params: unknown) => {
           try {
-            const result = await (toolDef.execute as (params: unknown, ctx: unknown) => Promise<unknown>)(params, {
+            const result = await (
+              toolDef.execute as (
+                params: unknown,
+                ctx: unknown,
+              ) => Promise<unknown>
+            )(params, {
               toolCallId: "task-tool",
               messages: [],
             });
@@ -1070,7 +1437,9 @@ export class NeuroLink {
       });
     }
 
-    logger.debug(`[NeuroLink] Registered ${Object.keys(taskTools).length} task tools`);
+    logger.debug(
+      `[NeuroLink] Registered ${Object.keys(taskTools).length} task tools`,
+    );
   }
 
   /**
@@ -1086,10 +1455,14 @@ export class NeuroLink {
     const memConfig = this.conversationMemoryConfig?.conversationMemory;
     const hasRedisConfig =
       !!memConfig?.redisConfig ||
-      (memConfig && "redis" in memConfig && !!(memConfig as { redis?: unknown }).redis) ||
+      (memConfig &&
+        "redis" in memConfig &&
+        !!(memConfig as { redis?: unknown }).redis) ||
       process.env.STORAGE_TYPE === "redis";
     if (!memConfig?.enabled || !hasRedisConfig) {
-      logger.debug("[NeuroLink] Skipping memory retrieval tools — requires Redis conversation memory");
+      logger.debug(
+        "[NeuroLink] Skipping memory retrieval tools — requires Redis conversation memory",
+      );
       return;
     }
 
@@ -1105,7 +1478,8 @@ export class NeuroLink {
           if (!memoryManager || !("getSessionRaw" in memoryManager)) {
             return {
               success: false,
-              error: "Memory retrieval not available — Redis memory manager not initialized",
+              error:
+                "Memory retrieval not available — Redis memory manager not initialized",
               metadata: {
                 toolName: "retrieve_context",
                 serverId: "direct",
@@ -1118,14 +1492,23 @@ export class NeuroLink {
             memoryManager as import("./core/redisConversationMemoryManager.js").RedisConversationMemoryManager,
           );
           const result = await (
-            actualTools.retrieve_context.execute as (params: unknown, ctx: unknown) => Promise<unknown>
+            actualTools.retrieve_context.execute as (
+              params: unknown,
+              ctx: unknown,
+            ) => Promise<unknown>
           )(params, {
             toolCallId: "memory-retrieval",
             messages: [],
           });
           // Check if the tool itself reported an error
-          const hasError = result && typeof result === "object" && "error" in result && !("messages" in result);
-          const errorMsg = hasError ? (result as { error: string }).error : undefined;
+          const hasError =
+            result &&
+            typeof result === "object" &&
+            "error" in result &&
+            !("messages" in result);
+          const errorMsg = hasError
+            ? (result as { error: string }).error
+            : undefined;
           return {
             success: !hasError,
             data: result,
@@ -1140,38 +1523,40 @@ export class NeuroLink {
       },
     };
 
-    const registrations = Object.entries(tools).map(async ([toolName, toolDef]) => {
-      const toolId = `direct.${toolName}`;
-      const toolInfo: ToolInfo = {
-        name: toolName,
-        description: toolDef.description,
-        inputSchema: {},
-        serverId: "direct",
-        category: "built-in" as MCPServerCategory,
-      };
+    const registrations = Object.entries(tools).map(
+      async ([toolName, toolDef]) => {
+        const toolId = `direct.${toolName}`;
+        const toolInfo: ToolInfo = {
+          name: toolName,
+          description: toolDef.description,
+          inputSchema: {},
+          serverId: "direct",
+          category: "built-in" as MCPServerCategory,
+        };
 
-      await this.toolRegistry.registerTool(toolId, toolInfo, {
-        execute: async (params: unknown) => {
-          try {
-            return await toolDef.execute(params);
-          } catch (error) {
-            // Known limitation: this non-throwing error path returns
-            // { success: false } without recording errorCategories in
-            // toolExecutionMetrics. These are internal memory-tool failures
-            // (low frequency), so the risk of metric gaps is minimal.
-            // A full fix would require access to the metrics map here,
-            // which is not available in the registration closure.
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-              metadata: { toolName, serverId: "direct", executionTime: 0 },
-            };
-          }
-        },
-        description: toolDef.description,
-        inputSchema: {},
-      });
-    });
+        await this.toolRegistry.registerTool(toolId, toolInfo, {
+          execute: async (params: unknown) => {
+            try {
+              return await toolDef.execute(params);
+            } catch (error) {
+              // Known limitation: this non-throwing error path returns
+              // { success: false } without recording errorCategories in
+              // toolExecutionMetrics. These are internal memory-tool failures
+              // (low frequency), so the risk of metric gaps is minimal.
+              // A full fix would require access to the metrics map here,
+              // which is not available in the registration closure.
+              return {
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+                metadata: { toolName, serverId: "direct", executionTime: 0 },
+              };
+            }
+          },
+          description: toolDef.description,
+          inputSchema: {},
+        });
+      },
+    );
 
     void Promise.all(registrations).then(() => {
       logger.info("[NeuroLink] Memory retrieval tools registered");
@@ -1179,7 +1564,10 @@ export class NeuroLink {
   }
 
   /** Format memory context for prompt inclusion */
-  private formatMemoryContext(memoryContext: string, currentInput: string): string {
+  private formatMemoryContext(
+    memoryContext: string,
+    currentInput: string,
+  ): string {
     return `Context from previous conversations:
 
 ${memoryContext}
@@ -1190,7 +1578,10 @@ Current user's request: ${currentInput}`;
   /**
    * Format memory context from multiple users into a labeled block.
    */
-  private formatMultiUserMemoryContext(memories: Map<string, string>, currentInput: string): string {
+  private formatMultiUserMemoryContext(
+    memories: Map<string, string>,
+    currentInput: string,
+  ): string {
     const memoryBlocks: string[] = [];
     for (const [label, memory] of memories) {
       memoryBlocks.push(`[${label}]\n${memory}`);
@@ -1206,8 +1597,14 @@ Current user's request: ${currentInput}`;
    * Determine whether memory should be read (retrieved) for this call.
    * Respects both the global memory SDK config and per-call overrides.
    */
-  private shouldReadMemory(perCallMemory: { enabled?: boolean; read?: boolean } | undefined, userId: unknown): boolean {
-    if (!this.conversationMemoryConfig?.conversationMemory?.memory?.enabled || !userId) {
+  private shouldReadMemory(
+    perCallMemory: { enabled?: boolean; read?: boolean } | undefined,
+    userId: unknown,
+  ): boolean {
+    if (
+      !this.conversationMemoryConfig?.conversationMemory?.memory?.enabled ||
+      !userId
+    ) {
       return false;
     }
     if (perCallMemory?.enabled === false) {
@@ -1228,7 +1625,10 @@ Current user's request: ${currentInput}`;
     userId: unknown,
     content: string | undefined | null,
   ): boolean {
-    if (!this.conversationMemoryConfig?.conversationMemory?.memory?.enabled || !userId) {
+    if (
+      !this.conversationMemoryConfig?.conversationMemory?.memory?.enabled ||
+      !userId
+    ) {
       return false;
     }
     if (!content?.trim()) {
@@ -1258,7 +1658,9 @@ Current user's request: ${currentInput}`;
     }
 
     // Collect all user IDs to read (primary + additional users with read !== false)
-    const readableAdditional = (additionalUsers || []).filter((u) => u.read !== false);
+    const readableAdditional = (additionalUsers || []).filter(
+      (u) => u.read !== false,
+    );
 
     if (readableAdditional.length === 0) {
       // Single user — use original fast path
@@ -1322,10 +1724,14 @@ Current user's request: ${currentInput}`;
         // Collect all users to write: primary + additional users with write !== false
         const writeOps: Promise<string>[] = [client.add(userId, content)];
 
-        const writableAdditional = (additionalUsers || []).filter((u) => u.write !== false);
+        const writableAdditional = (additionalUsers || []).filter(
+          (u) => u.write !== false,
+        );
         for (const user of writableAdditional) {
           const addOptions =
-            user.prompt || user.maxWords ? { prompt: user.prompt, maxWords: user.maxWords } : undefined;
+            user.prompt || user.maxWords
+              ? { prompt: user.prompt, maxWords: user.maxWords }
+              : undefined;
           writeOps.push(client.add(user.userId, content, addOptions));
         }
 
@@ -1390,7 +1796,10 @@ Current user's request: ${currentInput}`;
       this.externalServerManager = new ExternalServerManager(
         {
           maxServers: 20,
-          defaultTimeout: Math.max(10000, Number(process.env.MCP_CLIENT_TIMEOUT) || 60000),
+          defaultTimeout: Math.max(
+            10000,
+            Number(process.env.MCP_CLIENT_TIMEOUT) || 60000,
+          ),
           enableAutoRestart: true,
           enablePerformanceMonitoring: true,
         },
@@ -1400,33 +1809,44 @@ Current user's request: ${currentInput}`;
       );
 
       const externalServerInitEndTime = process.hrtime.bigint();
-      const externalServerInitDurationNs = externalServerInitEndTime - externalServerInitStartTime;
+      const externalServerInitDurationNs =
+        externalServerInitEndTime - externalServerInitStartTime;
 
-      logger.debug(`[NeuroLink] ✅ LOG_POINT_C010_EXTERNAL_SERVER_INIT_SUCCESS`, {
-        logPoint: "C010_EXTERNAL_SERVER_INIT_SUCCESS",
-        constructorId,
-        timestamp: new Date().toISOString(),
-        elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
-        externalServerInitDurationNs: externalServerInitDurationNs.toString(),
-        externalServerInitDurationMs: Number(externalServerInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
-        hasExternalServerManager: !!this.externalServerManager,
-        message: "External server manager initialized successfully",
-      });
+      logger.debug(
+        `[NeuroLink] ✅ LOG_POINT_C010_EXTERNAL_SERVER_INIT_SUCCESS`,
+        {
+          logPoint: "C010_EXTERNAL_SERVER_INIT_SUCCESS",
+          constructorId,
+          timestamp: new Date().toISOString(),
+          elapsedMs: Date.now() - constructorStartTime,
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
+          externalServerInitDurationNs: externalServerInitDurationNs.toString(),
+          externalServerInitDurationMs:
+            Number(externalServerInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+          hasExternalServerManager: !!this.externalServerManager,
+          message: "External server manager initialized successfully",
+        },
+      );
 
       this.setupExternalServerEventHandlers(constructorId);
     } catch (error) {
       const externalServerInitErrorTime = process.hrtime.bigint();
-      const externalServerInitDurationNs = externalServerInitErrorTime - externalServerInitStartTime;
+      const externalServerInitDurationNs =
+        externalServerInitErrorTime - externalServerInitStartTime;
 
       logger.error(`[NeuroLink] ❌ LOG_POINT_C013_EXTERNAL_SERVER_INIT_ERROR`, {
         logPoint: "C013_EXTERNAL_SERVER_INIT_ERROR",
         constructorId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
         externalServerInitDurationNs: externalServerInitDurationNs.toString(),
-        externalServerInitDurationMs: Number(externalServerInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+        externalServerInitDurationMs:
+          Number(externalServerInitDurationNs) / NANOSECOND_TO_MS_DIVISOR,
         error: error instanceof Error ? error.message : String(error),
         errorName: error instanceof Error ? error.name : "UnknownError",
         errorStack: error instanceof Error ? error.stack : undefined,
@@ -1514,7 +1934,8 @@ Current user's request: ${currentInput}`;
 
       // Check if we should use external provider mode - bypass enabled check
       const useExternalProvider =
-        langfuseConfig?.autoDetectExternalProvider === true || langfuseConfig?.useExternalTracerProvider === true;
+        langfuseConfig?.autoDetectExternalProvider === true ||
+        langfuseConfig?.useExternalTracerProvider === true;
 
       if (langfuseConfig?.enabled || useExternalProvider) {
         logger.debug(`[NeuroLink] 📊 LOG_POINT_C019_LANGFUSE_INIT_START`, {
@@ -1522,7 +1943,9 @@ Current user's request: ${currentInput}`;
           constructorId,
           timestamp: new Date().toISOString(),
           elapsedMs: Date.now() - constructorStartTime,
-          elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
           langfuseInitStartTimeNs: langfuseInitStartTime.toString(),
           message: "Starting Langfuse observability initialization",
         });
@@ -1531,15 +1954,22 @@ Current user's request: ${currentInput}`;
         initializeOpenTelemetry(langfuseConfig);
 
         const healthStatus = getLangfuseHealthStatus();
-        const langfuseInitDurationNs = process.hrtime.bigint() - langfuseInitStartTime;
+        const langfuseInitDurationNs =
+          process.hrtime.bigint() - langfuseInitStartTime;
 
-        if (healthStatus.initialized && healthStatus.hasProcessor && healthStatus.isHealthy) {
+        if (
+          healthStatus.initialized &&
+          healthStatus.hasProcessor &&
+          healthStatus.isHealthy
+        ) {
           logger.debug(`[NeuroLink] ✅ LOG_POINT_C020_LANGFUSE_INIT_SUCCESS`, {
             logPoint: "C020_LANGFUSE_INIT_SUCCESS",
             constructorId,
             timestamp: new Date().toISOString(),
             elapsedMs: Date.now() - constructorStartTime,
-            elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+            elapsedNs: (
+              process.hrtime.bigint() - constructorHrTimeStart
+            ).toString(),
             langfuseInitDurationNs: langfuseInitDurationNs.toString(),
             langfuseInitDurationMs: Number(langfuseInitDurationNs) / 1_000_000,
             healthStatus,
@@ -1551,7 +1981,9 @@ Current user's request: ${currentInput}`;
             constructorId,
             timestamp: new Date().toISOString(),
             elapsedMs: Date.now() - constructorStartTime,
-            elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+            elapsedNs: (
+              process.hrtime.bigint() - constructorHrTimeStart
+            ).toString(),
             langfuseInitDurationNs: langfuseInitDurationNs.toString(),
             healthStatus,
             message: "Langfuse initialized but not healthy",
@@ -1563,19 +1995,25 @@ Current user's request: ${currentInput}`;
           constructorId,
           timestamp: new Date().toISOString(),
           elapsedMs: Date.now() - constructorStartTime,
-          elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
-          message: "Langfuse observability not enabled - skipping initialization",
+          elapsedNs: (
+            process.hrtime.bigint() - constructorHrTimeStart
+          ).toString(),
+          message:
+            "Langfuse observability not enabled - skipping initialization",
         });
       }
     } catch (error) {
-      const langfuseInitErrorDurationNs = process.hrtime.bigint() - langfuseInitStartTime;
+      const langfuseInitErrorDurationNs =
+        process.hrtime.bigint() - langfuseInitStartTime;
 
       logger.error(`[NeuroLink] ❌ LOG_POINT_C023_LANGFUSE_INIT_ERROR`, {
         logPoint: "C023_LANGFUSE_INIT_ERROR",
         constructorId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - constructorStartTime,
-        elapsedNs: (process.hrtime.bigint() - constructorHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - constructorHrTimeStart
+        ).toString(),
         langfuseInitDurationNs: langfuseInitErrorDurationNs.toString(),
         errorMessage: error instanceof Error ? error.message : String(error),
         errorStack: error instanceof Error ? error.stack : undefined,
@@ -1600,7 +2038,8 @@ Current user's request: ${currentInput}`;
       constructorId,
       timestamp: new Date().toISOString(),
       constructorDurationNs: constructorDurationNs.toString(),
-      constructorDurationMs: Number(constructorDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+      constructorDurationMs:
+        Number(constructorDurationNs) / NANOSECOND_TO_MS_DIVISOR,
       totalElapsedMs: Date.now() - constructorStartTime,
       finalState: {
         hasConversationMemory: !!this.conversationMemory,
@@ -1612,7 +2051,8 @@ Current user's request: ${currentInput}`;
       },
       finalMemoryUsage: process.memoryUsage(),
       finalCpuUsage: process.cpuUsage(),
-      message: "NeuroLink constructor completed successfully with all components initialized",
+      message:
+        "NeuroLink constructor completed successfully with all components initialized",
     });
   }
 
@@ -1668,13 +2108,22 @@ Current user's request: ${currentInput}`;
     const mcpInitStartTime = Date.now();
     const mcpInitHrTimeStart = process.hrtime.bigint();
 
-    const MemoryManager = await this.importPerformanceManager(mcpInitId, mcpInitStartTime, mcpInitHrTimeStart);
+    const MemoryManager = await this.importPerformanceManager(
+      mcpInitId,
+      mcpInitStartTime,
+      mcpInitHrTimeStart,
+    );
     const startMemory = MemoryManager
       ? MemoryManager.getMemoryUsageMB()
       : { heapUsed: 0, heapTotal: 0, rss: 0, external: 0 };
 
     try {
-      await this.performMCPInitialization(mcpInitId, mcpInitStartTime, mcpInitHrTimeStart, startMemory);
+      await this.performMCPInitialization(
+        mcpInitId,
+        mcpInitStartTime,
+        mcpInitHrTimeStart,
+        startMemory,
+      );
       this.mcpInitialized = true;
       this.logMCPInitComplete(startMemory, MemoryManager, mcpInitStartTime);
     } catch (error) {
@@ -1704,7 +2153,9 @@ Current user's request: ${currentInput}`;
     mcpInitId: string,
     mcpInitStartTime: number,
     mcpInitHrTimeStart: bigint,
-  ): Promise<typeof import("./utils/performance.js").MemoryManager | undefined> {
+  ): Promise<
+    typeof import("./utils/performance.js").MemoryManager | undefined
+  > {
     const performanceImportStartTime = process.hrtime.bigint();
 
     try {
@@ -1713,7 +2164,8 @@ Current user's request: ${currentInput}`;
       return MemoryManager;
     } catch (error) {
       const performanceImportErrorTime = process.hrtime.bigint();
-      const performanceImportDurationNs = performanceImportErrorTime - performanceImportStartTime;
+      const performanceImportDurationNs =
+        performanceImportErrorTime - performanceImportStartTime;
 
       logger.warn(`[NeuroLink] ⚠️ LOG_POINT_M005_PERFORMANCE_IMPORT_ERROR`, {
         logPoint: "M005_PERFORMANCE_IMPORT_ERROR",
@@ -1722,10 +2174,12 @@ Current user's request: ${currentInput}`;
         elapsedMs: Date.now() - mcpInitStartTime,
         elapsedNs: (process.hrtime.bigint() - mcpInitHrTimeStart).toString(),
         performanceImportDurationNs: performanceImportDurationNs.toString(),
-        performanceImportDurationMs: Number(performanceImportDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+        performanceImportDurationMs:
+          Number(performanceImportDurationNs) / NANOSECOND_TO_MS_DIVISOR,
         error: error instanceof Error ? error.message : String(error),
         errorName: error instanceof Error ? error.name : "UnknownError",
-        message: "MemoryManager import failed - continuing without performance tracking",
+        message:
+          "MemoryManager import failed - continuing without performance tracking",
       });
       return undefined;
     }
@@ -1759,7 +2213,11 @@ Current user's request: ${currentInput}`;
 
     await this.initializeToolRegistryInternal();
     await this.initializeProviderRegistryInternal();
-    await this.registerDirectToolsServerInternal(mcpInitId, mcpInitStartTime, mcpInitHrTimeStart);
+    await this.registerDirectToolsServerInternal(
+      mcpInitId,
+      mcpInitStartTime,
+      mcpInitHrTimeStart,
+    );
     await this.loadMCPConfigurationInternal();
   }
 
@@ -1772,7 +2230,10 @@ Current user's request: ${currentInput}`;
     await Promise.race([
       Promise.resolve(),
       new Promise<void>((_, reject) => {
-        setTimeout(() => reject(new Error("MCP initialization timeout")), initTimeout);
+        setTimeout(
+          () => reject(new Error("MCP initialization timeout")),
+          initTimeout,
+        );
       }),
     ]);
   }
@@ -1796,13 +2257,21 @@ Current user's request: ${currentInput}`;
 
     try {
       if (process.env.NEUROLINK_DISABLE_DIRECT_TOOLS === "true") {
-        mcpLogger.debug("Direct tools server are disabled via environment variable.");
+        mcpLogger.debug(
+          "Direct tools server are disabled via environment variable.",
+        );
       } else {
-        await this.toolRegistry.registerServer("neurolink-direct", directToolsServer);
+        await this.toolRegistry.registerServer(
+          "neurolink-direct",
+          directToolsServer,
+        );
 
-        mcpLogger.debug("[NeuroLink] Direct tools server registered successfully", {
-          serverId: "neurolink-direct",
-        });
+        mcpLogger.debug(
+          "[NeuroLink] Direct tools server registered successfully",
+          {
+            serverId: "neurolink-direct",
+          },
+        );
       }
     } catch (error) {
       const directToolsErrorTime = process.hrtime.bigint();
@@ -1815,7 +2284,8 @@ Current user's request: ${currentInput}`;
         elapsedMs: Date.now() - mcpInitStartTime,
         elapsedNs: (process.hrtime.bigint() - mcpInitHrTimeStart).toString(),
         directToolsDurationNs: directToolsDurationNs.toString(),
-        directToolsDurationMs: Number(directToolsDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+        directToolsDurationMs:
+          Number(directToolsDurationNs) / NANOSECOND_TO_MS_DIVISOR,
         error: error instanceof Error ? error.message : String(error),
         errorName: error instanceof Error ? error.name : "UnknownError",
         errorStack: error instanceof Error ? error.stack : undefined,
@@ -1834,10 +2304,11 @@ Current user's request: ${currentInput}`;
    */
   private async loadMCPConfigurationInternal(): Promise<void> {
     try {
-      const configResult = await this.externalServerManager.loadMCPConfiguration(
-        undefined, // Use default config path
-        { parallel: true }, // Enable parallel loading
-      );
+      const configResult =
+        await this.externalServerManager.loadMCPConfiguration(
+          undefined, // Use default config path
+          { parallel: true }, // Enable parallel loading
+        );
 
       mcpLogger.debug("[NeuroLink] MCP configuration loaded successfully", {
         serversLoaded: configResult.serversLoaded,
@@ -1851,7 +2322,10 @@ Current user's request: ${currentInput}`;
       }
     } catch (configError) {
       mcpLogger.warn("[NeuroLink] MCP configuration loading failed", {
-        error: configError instanceof Error ? configError.message : String(configError),
+        error:
+          configError instanceof Error
+            ? configError.message
+            : String(configError),
       });
     }
   }
@@ -1866,7 +2340,9 @@ Current user's request: ${currentInput}`;
       rss: number;
       external: number;
     },
-    MemoryManager: typeof import("./utils/performance.js").MemoryManager | undefined,
+    MemoryManager:
+      | typeof import("./utils/performance.js").MemoryManager
+      | undefined,
     mcpInitStartTime: number,
   ): void {
     const endMemory = MemoryManager
@@ -1892,7 +2368,9 @@ Current user's request: ${currentInput}`;
    * @param options - Original GenerateOptions
    * @returns Modified options with orchestrated provider marked in context, or empty object if validation fails
    */
-  private async applyOrchestration(options: GenerateOptions): Promise<Partial<GenerateOptions>> {
+  private async applyOrchestration(
+    options: GenerateOptions,
+  ): Promise<Partial<GenerateOptions>> {
     const startTime = Date.now();
 
     try {
@@ -1959,13 +2437,16 @@ Current user's request: ${currentInput}`;
 
           // Filter and validate models before comparison
           const validModels = models.filter(
-            (m): m is { name: string } => m && typeof m === "object" && typeof m.name === "string",
+            (m): m is { name: string } =>
+              m && typeof m === "object" && typeof m.name === "string",
           );
 
           const targetModel = route.model;
           if (targetModel) {
             // Check if the specific routed model is available
-            const modelIsAvailable = validModels.some((m) => m.name === targetModel);
+            const modelIsAvailable = validModels.some(
+              (m) => m.name === targetModel,
+            );
             if (!modelIsAvailable) {
               logger.debug("Orchestration provider validation failed", {
                 taskType: classification.type,
@@ -2000,7 +2481,10 @@ Current user's request: ${currentInput}`;
             taskType: classification.type,
             routedProvider: route.provider,
             routedModel: route.model,
-            reason: error instanceof Error ? error.message : "Ollama service check failed",
+            reason:
+              error instanceof Error
+                ? error.message
+                : "Ollama service check failed",
             orchestrationTime: `${Date.now() - startTime}ms`,
           });
           return {}; // Return empty object to preserve existing fallback behavior
@@ -2039,7 +2523,9 @@ Current user's request: ${currentInput}`;
    * @param options - Original StreamOptions
    * @returns Modified options with orchestrated provider marked in context, or empty object if validation fails
    */
-  private async applyStreamOrchestration(options: StreamOptions): Promise<Partial<StreamOptions>> {
+  private async applyStreamOrchestration(
+    options: StreamOptions,
+  ): Promise<Partial<StreamOptions>> {
     const startTime = Date.now();
 
     try {
@@ -2106,13 +2592,16 @@ Current user's request: ${currentInput}`;
 
           // Filter and validate models before comparison
           const validModels = models.filter(
-            (m): m is { name: string } => m && typeof m === "object" && typeof m.name === "string",
+            (m): m is { name: string } =>
+              m && typeof m === "object" && typeof m.name === "string",
           );
 
           const targetModel = route.model;
           if (targetModel) {
             // Check if the specific routed model is available
-            const modelIsAvailable = validModels.some((m) => m.name === targetModel);
+            const modelIsAvailable = validModels.some(
+              (m) => m.name === targetModel,
+            );
             if (!modelIsAvailable) {
               logger.debug("Stream orchestration provider validation failed", {
                 taskType: classification.type,
@@ -2147,7 +2636,10 @@ Current user's request: ${currentInput}`;
             taskType: classification.type,
             routedProvider: route.provider,
             routedModel: route.model,
-            reason: error instanceof Error ? error.message : "Ollama service check failed",
+            reason:
+              error instanceof Error
+                ? error.message
+                : "Ollama service check failed",
             orchestrationTime: `${Date.now() - startTime}ms`,
           });
           return {}; // Return empty object to preserve existing fallback behavior
@@ -2192,7 +2684,9 @@ Current user's request: ${currentInput}`;
    * @param optionsOrPrompt The prompt input, either as a string or a GenerateOptions object.
    * @returns The original prompt text as a string.
    */
-  private _extractOriginalPrompt(optionsOrPrompt: GenerateOptions | string): string {
+  private _extractOriginalPrompt(
+    optionsOrPrompt: GenerateOptions | string,
+  ): string {
     if (typeof optionsOrPrompt === "string") {
       return optionsOrPrompt;
     }
@@ -2203,7 +2697,9 @@ Current user's request: ${currentInput}`;
     };
     if (anyOptions.messages && anyOptions.messages.length > 0) {
       const lastMessage = anyOptions.messages[anyOptions.messages.length - 1];
-      return typeof lastMessage.content === "string" ? lastMessage.content : JSON.stringify(lastMessage.content);
+      return typeof lastMessage.content === "string"
+        ? lastMessage.content
+        : JSON.stringify(lastMessage.content);
     }
 
     // Handle input.text format
@@ -2322,7 +2818,8 @@ Current user's request: ${currentInput}`;
             endpoint: otelConfig.endpoint,
             serviceName: otelConfig.serviceName,
           }
-        : isOpenTelemetryInitialized() || process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+        : isOpenTelemetryInitialized() ||
+            process.env.OTEL_EXPORTER_OTLP_ENDPOINT
           ? {
               enabled: isOpenTelemetryInitialized(),
               endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
@@ -2411,12 +2908,19 @@ Current user's request: ${currentInput}`;
       if (langfuseConfig?.enabled) {
         initializeOpenTelemetry(langfuseConfig);
 
-        logger.debug("[NeuroLink] Langfuse observability initialized via public method");
+        logger.debug(
+          "[NeuroLink] Langfuse observability initialized via public method",
+        );
       } else {
-        logger.debug("[NeuroLink] Langfuse not enabled, skipping initialization");
+        logger.debug(
+          "[NeuroLink] Langfuse not enabled, skipping initialization",
+        );
       }
     } catch (error) {
-      logger.warn("[NeuroLink] Failed to initialize Langfuse observability:", error);
+      logger.warn(
+        "[NeuroLink] Failed to initialize Langfuse observability:",
+        error,
+      );
     }
   }
 
@@ -2447,7 +2951,11 @@ Current user's request: ${currentInput}`;
       // Shutdown TaskManager
       if (this._taskManager) {
         try {
-          await withTimeout(this._taskManager.shutdown(), 5000, new Error("TaskManager shutdown timed out"));
+          await withTimeout(
+            this._taskManager.shutdown(),
+            5000,
+            new Error("TaskManager shutdown timed out"),
+          );
         } catch (error) {
           logger.warn("[NeuroLink] TaskManager shutdown error:", error);
         } finally {
@@ -2461,7 +2969,10 @@ Current user's request: ${currentInput}`;
           await this.conversationMemory.close();
           logger.debug("[NeuroLink] Conversation memory shutdown completed");
         } catch (error) {
-          logger.warn("[NeuroLink] Conversation memory shutdown failed:", error);
+          logger.warn(
+            "[NeuroLink] Conversation memory shutdown failed:",
+            error,
+          );
         }
       }
 
@@ -2481,9 +2992,14 @@ Current user's request: ${currentInput}`;
       const data = args[0] as Record<string, unknown>;
       try {
         const result = data.result as Record<string, unknown> | undefined;
-        const usage = result?.usage as { input?: number; output?: number; total?: number } | undefined;
+        const usage = result?.usage as
+          | { input?: number; output?: number; total?: number }
+          | undefined;
         const analytics = result?.analytics as { cost?: number } | undefined;
-        const provider = (data.provider as string) || (result?.provider as string) || "unknown";
+        const provider =
+          (data.provider as string) ||
+          (result?.provider as string) ||
+          "unknown";
         const model = (result?.model as string) || "unknown";
         const responseTime = (data.responseTime as number) || 0;
         const traceCtx = this._metricsTraceContext;
@@ -2503,15 +3019,23 @@ Current user's request: ${currentInput}`;
           span.parentSpanId = undefined;
         }
         // Mark failed generations with ERROR status so metrics count them correctly
-        const spanStatus = data.success === false || data.error ? SpanStatus.ERROR : SpanStatus.OK;
-        span = SpanSerializer.endSpan(span, spanStatus, data.error ? String(data.error) : undefined);
+        const spanStatus =
+          data.success === false || data.error
+            ? SpanStatus.ERROR
+            : SpanStatus.OK;
+        span = SpanSerializer.endSpan(
+          span,
+          spanStatus,
+          data.error ? String(data.error) : undefined,
+        );
         span.durationMs = responseTime;
 
         if (usage) {
           span = SpanSerializer.enrichWithTokenUsage(span, {
             promptTokens: usage.input || 0,
             completionTokens: usage.output || 0,
-            totalTokens: usage.total || (usage.input || 0) + (usage.output || 0),
+            totalTokens:
+              usage.total || (usage.input || 0) + (usage.output || 0),
           });
         }
 
@@ -2524,8 +3048,10 @@ Current user's request: ${currentInput}`;
           const tokenTracker = this.metricsAggregator.getTokenTracker();
           const pricing = tokenTracker.getModelPricing(model);
           if (pricing) {
-            const inputCost = ((usage.input || 0) / 1_000_000) * pricing.inputPricePerMillion;
-            const outputCost = ((usage.output || 0) / 1_000_000) * pricing.outputPricePerMillion;
+            const inputCost =
+              ((usage.input || 0) / 1_000_000) * pricing.inputPricePerMillion;
+            const outputCost =
+              ((usage.output || 0) / 1_000_000) * pricing.outputPricePerMillion;
             const totalCost = inputCost + outputCost;
             if (totalCost > 0) {
               span = SpanSerializer.enrichWithCost(span, {
@@ -2541,7 +3067,10 @@ Current user's request: ${currentInput}`;
         const content = (result?.content as string) || (result?.text as string);
         if (content) {
           span = SpanSerializer.updateAttributes(span, {
-            output: content.length > 5000 ? content.substring(0, 5000) + "...[truncated]" : content,
+            output:
+              content.length > 5000
+                ? content.substring(0, 5000) + "...[truncated]"
+                : content,
           });
         }
 
@@ -2583,7 +3112,10 @@ Current user's request: ${currentInput}`;
         if (data.prompt) {
           const promptStr = String(data.prompt);
           span = SpanSerializer.updateAttributes(span, {
-            input: promptStr.length > 5000 ? promptStr.substring(0, 5000) + "...[truncated]" : promptStr,
+            input:
+              promptStr.length > 5000
+                ? promptStr.substring(0, 5000) + "...[truncated]"
+                : promptStr,
           });
         }
 
@@ -2591,17 +3123,23 @@ Current user's request: ${currentInput}`;
         const streamContent = data.content as string;
         if (streamContent) {
           span = SpanSerializer.updateAttributes(span, {
-            output: streamContent.length > 5000 ? streamContent.substring(0, 5000) + "...[truncated]" : streamContent,
+            output:
+              streamContent.length > 5000
+                ? streamContent.substring(0, 5000) + "...[truncated]"
+                : streamContent,
           });
         }
 
         // Enrich stream span with token usage if available
-        const usage = metadata?.usage as { input?: number; output?: number; total?: number } | undefined;
+        const usage = metadata?.usage as
+          | { input?: number; output?: number; total?: number }
+          | undefined;
         if (usage) {
           span = SpanSerializer.enrichWithTokenUsage(span, {
             promptTokens: usage.input || 0,
             completionTokens: usage.output || 0,
-            totalTokens: usage.total || (usage.input || 0) + (usage.output || 0),
+            totalTokens:
+              usage.total || (usage.input || 0) + (usage.output || 0),
           });
 
           // Compute cost from token usage
@@ -2609,8 +3147,11 @@ Current user's request: ${currentInput}`;
             const tokenTracker = this.metricsAggregator.getTokenTracker();
             const pricing = tokenTracker.getModelPricing(model);
             if (pricing) {
-              const inputCost = ((usage.input || 0) / 1_000_000) * pricing.inputPricePerMillion;
-              const outputCost = ((usage.output || 0) / 1_000_000) * pricing.outputPricePerMillion;
+              const inputCost =
+                ((usage.input || 0) / 1_000_000) * pricing.inputPricePerMillion;
+              const outputCost =
+                ((usage.output || 0) / 1_000_000) *
+                pricing.outputPricePerMillion;
               const totalCost = inputCost + outputCost;
               if (totalCost > 0) {
                 span = SpanSerializer.enrichWithCost(span, {
@@ -2634,10 +3175,13 @@ Current user's request: ${currentInput}`;
       const data = args[0] as Record<string, unknown>;
       try {
         // Handle both event formats: {toolName} (from emitToolEnd) and {tool} (from executeToolInternal)
-        const toolName = (data.toolName as string) || (data.tool as string) || "unknown";
-        const responseTime = (data.responseTime as number) || (data.duration as number) || 0;
+        const toolName =
+          (data.toolName as string) || (data.tool as string) || "unknown";
+        const responseTime =
+          (data.responseTime as number) || (data.duration as number) || 0;
         // success is explicit in one format; infer from error presence in the other
-        const success = data.success !== undefined ? (data.success as boolean) : !data.error;
+        const success =
+          data.success !== undefined ? (data.success as boolean) : !data.error;
         const traceCtx = this._metricsTraceContext;
 
         let span = SpanSerializer.createSpan(
@@ -2650,16 +3194,22 @@ Current user's request: ${currentInput}`;
           traceCtx?.parentSpanId,
           traceCtx?.traceId,
         );
-        span = SpanSerializer.endSpan(span, success ? SpanStatus.OK : SpanStatus.ERROR);
+        span = SpanSerializer.endSpan(
+          span,
+          success ? SpanStatus.OK : SpanStatus.ERROR,
+        );
         span.durationMs = responseTime;
 
         if (!success && data.error) {
-          span.statusMessage = (data.error as Error).message || String(data.error);
+          span.statusMessage =
+            (data.error as Error).message || String(data.error);
         }
 
         if (data.result) {
           try {
-            span.attributes["tool.result"] = JSON.stringify(data.result).substring(0, 500);
+            span.attributes["tool.result"] = JSON.stringify(
+              data.result,
+            ).substring(0, 500);
           } catch {
             // Non-blocking
           }
@@ -2808,459 +3358,487 @@ Current user's request: ${currentInput}`;
    * @see {@link stream} for streaming generation
    * @since 1.0.0
    */
-  async generate(optionsOrPrompt: GenerateOptions | string): Promise<GenerateResult> {
-    return tracers.sdk.startActiveSpan("neurolink.generate", { kind: SpanKind.INTERNAL }, async (generateSpan) => {
-      // Set metrics trace context for parent-child span linking.
-      // The generation span will be the root (no parentSpanId).
-      // Tool spans will be children of the root span via rootSpanId.
-      const metricsTraceId = crypto.randomUUID().replace(/-/g, "");
-      const metricsRootSpanId = crypto.randomUUID().replace(/-/g, "").substring(0, 16);
-      // Scope trace context to this request via AsyncLocalStorage
-      // so concurrent generate/stream calls don't race.
-      return metricsTraceContextStorage.run({ traceId: metricsTraceId, parentSpanId: metricsRootSpanId }, async () => {
-        try {
-          const originalPrompt = this._extractOriginalPrompt(optionsOrPrompt);
-          // Convert string prompt to full options
-          // Shallow-copy caller's object to avoid mutating their original reference
-          const options: GenerateOptions =
-            typeof optionsOrPrompt === "string" ? { input: { text: optionsOrPrompt } } : { ...optionsOrPrompt };
+  async generate(
+    optionsOrPrompt: GenerateOptions | string,
+  ): Promise<GenerateResult> {
+    return tracers.sdk.startActiveSpan(
+      "neurolink.generate",
+      { kind: SpanKind.INTERNAL },
+      (generateSpan) =>
+        this.executeGenerateWithMetricsContext(optionsOrPrompt, generateSpan),
+    );
+  }
 
-          // NL-004: Resolve model aliases/deprecations before processing
-          options.model = resolveModel(options.model, this.modelAliasConfig);
+  private async executeGenerateWithMetricsContext(
+    optionsOrPrompt: GenerateOptions | string,
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<GenerateResult> {
+    return metricsTraceContextStorage.run(
+      this.createMetricsTraceContext(),
+      () => this.executeGenerateRequest(optionsOrPrompt, generateSpan),
+    );
+  }
 
-          // MCP Enhancement: propagate disableToolCache to tool execution
-          this._disableToolCacheForCurrentRequest = !!options.disableToolCache;
+  private async executeGenerateRequest(
+    optionsOrPrompt: GenerateOptions | string,
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<GenerateResult> {
+    try {
+      const { options, originalPrompt } = await this.prepareGenerateRequest(
+        optionsOrPrompt,
+        generateSpan,
+      );
+      const earlyResult = await this.maybeHandleEarlyGenerateResult(
+        options,
+        generateSpan,
+      );
+      if (earlyResult) {
+        generateSpan.setStatus({ code: SpanStatusCode.OK });
+        return earlyResult;
+      }
 
-          // Set span attributes for observability
-          generateSpan.setAttribute("neurolink.provider", (options.provider as string) || "default");
-          generateSpan.setAttribute("neurolink.model", options.model || "default");
-          generateSpan.setAttribute(
-            "neurolink.input_length",
-            typeof optionsOrPrompt === "string" ? optionsOrPrompt.length : options.input?.text?.length || 0,
-          );
-          generateSpan.setAttribute("neurolink.has_tools", !!(options.tools && Object.keys(options.tools).length > 0));
+      const result = await this.setLangfuseContextFromOptions(options, () =>
+        this.runStandardGenerateRequest(options, originalPrompt, generateSpan),
+      );
+      generateSpan.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      generateSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      this.emitGenerateErrorEvent(optionsOrPrompt, error);
+      throw error;
+    } finally {
+      this._disableToolCacheForCurrentRequest = false;
+      generateSpan.end();
+    }
+  }
 
-          // Validate prompt
-          if (!options.input?.text || typeof options.input.text !== "string") {
-            throw new Error("Input text is required and must be a non-empty string");
-          }
+  private async prepareGenerateRequest(
+    optionsOrPrompt: GenerateOptions | string,
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<{
+    options: GenerateOptions;
+    originalPrompt: string | undefined;
+  }> {
+    const originalPrompt = this._extractOriginalPrompt(optionsOrPrompt);
+    const options: GenerateOptions =
+      typeof optionsOrPrompt === "string"
+        ? { input: { text: optionsOrPrompt } }
+        : { ...optionsOrPrompt };
 
-          // Check budget limit before making API call
-          if (
-            options.maxBudgetUsd !== undefined &&
-            options.maxBudgetUsd > 0 &&
-            this._sessionCostUsd >= options.maxBudgetUsd
-          ) {
-            throw new NeuroLinkError({
-              code: "SESSION_BUDGET_EXCEEDED",
-              message: `Session budget exceeded: spent $${this._sessionCostUsd.toFixed(4)} of $${options.maxBudgetUsd.toFixed(4)} limit`,
-              category: ErrorCategory.VALIDATION,
-              severity: ErrorSeverity.HIGH,
-              retriable: false,
-              context: {
-                spent: this._sessionCostUsd,
-                limit: options.maxBudgetUsd,
-              },
-            });
-          }
+    options.model = resolveModel(options.model, this.modelAliasConfig);
+    this._disableToolCacheForCurrentRequest = !!options.disableToolCache;
 
-          // Auto-inject lifecycle middleware when callbacks are provided
-          // (must happen before workflow/PPT early returns so those paths get middleware too)
-          if (options.onFinish || options.onError) {
-            options.middleware = {
-              ...options.middleware,
-              middlewareConfig: {
-                ...options.middleware?.middlewareConfig,
-                lifecycle: {
-                  ...options.middleware?.middlewareConfig?.lifecycle,
-                  enabled: true,
-                  config: {
-                    ...options.middleware?.middlewareConfig?.lifecycle?.config,
-                    ...(options.onFinish !== undefined ? { onFinish: options.onFinish } : {}),
-                    ...(options.onError !== undefined ? { onError: options.onError } : {}),
-                  },
-                },
-              },
-            };
-          }
+    generateSpan.setAttribute(
+      "neurolink.provider",
+      (options.provider as string) || "default",
+    );
+    generateSpan.setAttribute("neurolink.model", options.model || "default");
+    generateSpan.setAttribute(
+      "neurolink.input_length",
+      typeof optionsOrPrompt === "string"
+        ? optionsOrPrompt.length
+        : options.input?.text?.length || 0,
+    );
+    generateSpan.setAttribute(
+      "neurolink.has_tools",
+      !!(options.tools && Object.keys(options.tools).length > 0),
+    );
 
-          // Handle per-call auth token validation
-          if (options.auth?.token) {
-            const { AuthError } = await import("./auth/errors.js");
-            await this.ensureAuthProvider();
-            if (!this.authProvider) {
-              throw AuthError.create(
-                "PROVIDER_ERROR",
-                "No auth provider configured. Set auth in constructor or via setAuthProvider() before using auth: { token }.",
-              );
-            }
-            let authResult: Awaited<ReturnType<MastraAuthProvider["authenticateToken"]>>;
-            try {
-              authResult = await withTimeout(
-                this.authProvider.authenticateToken(options.auth.token),
-                5000,
-                AuthError.create("PROVIDER_ERROR", "Auth token validation timed out after 5000ms"),
-              );
-            } catch (err) {
-              // Rethrow auth errors as-is; wrap anything else
-              if (err instanceof Error && "feature" in err && (err as { feature: string }).feature === "Auth") {
-                throw err;
-              }
-              throw AuthError.create(
-                "PROVIDER_ERROR",
-                `Auth token validation failed: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            }
-            if (!authResult.valid) {
-              throw AuthError.create("INVALID_TOKEN", authResult.error || "Token validation failed");
-            }
-            // Fail closed: token valid but no user identity is a provider bug
-            if (!authResult.user) {
-              throw AuthError.create("INVALID_TOKEN", "Token validated but no user identity returned");
-            }
-            if (!authResult.user.id) {
-              throw AuthError.create("INVALID_TOKEN", "Token validated but user identity missing required 'id' field");
-            }
-            // Merge validated user into context
-            options.context = {
-              ...((options.context as Record<string, unknown>) || {}),
-              userId: authResult.user.id,
-              userEmail: authResult.user.email,
-              userRoles: authResult.user.roles,
-            };
-          }
+    this.assertInputText(
+      options.input?.text,
+      "Input text is required and must be a non-empty string",
+    );
+    this.enforceSessionBudget(options.maxBudgetUsd);
+    this.applyGenerateLifecycleMiddleware(options);
+    await this.applyAuthenticatedRequestContext(options);
 
-          // Handle pre-validated requestContext
-          if (options.requestContext) {
-            // When auth token was validated, token-derived identity fields
-            // MUST take precedence over requestContext to prevent privilege escalation.
-            const tokenDerivedFields =
-              options.auth?.token && this.authProvider
-                ? {
-                    userId: (options.context as Record<string, unknown> | undefined)?.userId,
-                    userEmail: (options.context as Record<string, unknown> | undefined)?.userEmail,
-                    userRoles: (options.context as Record<string, unknown> | undefined)?.userRoles,
-                  }
-                : {};
-            options.context = {
-              ...((options.context as Record<string, unknown>) || {}),
-              ...options.requestContext,
-              ...tokenDerivedFields,
-            };
-          }
+    return { options, originalPrompt };
+  }
 
-          // Check if workflow is requested
-          if (options.workflow || options.workflowConfig) {
-            return await this.generateWithWorkflow(options);
-          }
+  private async maybeHandleEarlyGenerateResult(
+    options: GenerateOptions,
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<GenerateResult | null> {
+    if (options.workflow || options.workflowConfig) {
+      return this.generateWithWorkflow(options);
+    }
+    if (options.output?.mode !== "ppt") {
+      return null;
+    }
 
-          // Check if PPT output mode is requested
-          if (options.output?.mode === "ppt") {
-            const pptResult = await this.generateWithPPT(options);
-            generateSpan.setAttribute("neurolink.output_length", pptResult.content?.length ?? 0);
-            if (pptResult.analytics) {
-              generateSpan.setAttribute("neurolink.tokens.input", pptResult.analytics.tokenUsage?.input ?? 0);
-              generateSpan.setAttribute("neurolink.tokens.output", pptResult.analytics.tokenUsage?.output ?? 0);
-              generateSpan.setAttribute("neurolink.cost", pptResult.analytics.cost ?? 0);
-            }
-            generateSpan.setStatus({ code: SpanStatusCode.OK });
-            return pptResult;
-          }
+    const pptResult = await this.generateWithPPT(options);
+    generateSpan.setAttribute(
+      "neurolink.output_length",
+      pptResult.content?.length ?? 0,
+    );
+    if (pptResult.analytics) {
+      generateSpan.setAttribute(
+        "neurolink.tokens.input",
+        pptResult.analytics.tokenUsage?.input ?? 0,
+      );
+      generateSpan.setAttribute(
+        "neurolink.tokens.output",
+        pptResult.analytics.tokenUsage?.output ?? 0,
+      );
+      generateSpan.setAttribute(
+        "neurolink.cost",
+        pptResult.analytics.cost ?? 0,
+      );
+    }
+    generateSpan.setStatus({ code: SpanStatusCode.OK });
+    return pptResult;
+  }
 
-          // Set session and user IDs from context for Langfuse spans and execute with proper async scoping
-          return await this.setLangfuseContextFromOptions(options, async () => {
-            const startTime = Date.now();
+  private async runStandardGenerateRequest(
+    options: GenerateOptions,
+    originalPrompt: string | undefined,
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<GenerateResult> {
+    const startTime = Date.now();
 
-            // Apply orchestration if enabled and no specific provider/model requested
-            if (this.enableOrchestration && !options.provider && !options.model) {
-              try {
-                const orchestratedOptions = await this.applyOrchestration(options);
-                logger.debug("Orchestration applied", {
-                  originalProvider: options.provider || "auto",
-                  orchestratedProvider: orchestratedOptions.provider,
-                  orchestratedModel: orchestratedOptions.model,
-                  prompt: options.input.text.substring(0, 100),
-                });
-
-                // Use orchestrated options
-                Object.assign(options, orchestratedOptions);
-
-                // Re-resolve model alias in case orchestration returned an alias
-                if (orchestratedOptions.model) {
-                  options.model = resolveModel(options.model, this.modelAliasConfig);
-                }
-              } catch (error) {
-                logger.warn("Orchestration failed, continuing with original options", {
-                  error: error instanceof Error ? error.message : String(error),
-                  originalProvider: options.provider || "auto",
-                });
-                // Continue with original options if orchestration fails
-              }
-            }
-
-            // Emit generation start event (NeuroLink format - keep existing)
-            this.emitter.emit("generation:start", {
-              provider: options.provider || "auto",
-              timestamp: startTime,
-            });
-
-            // ADD: Bedrock-compatible response:start event
-            this.emitter.emit("response:start");
-
-            // ADD: Bedrock-compatible message event
-            this.emitter.emit("message", `Starting ${options.provider || "auto"} text generation...`);
-
-            // Process factory configuration
-            const factoryResult = processFactoryOptions(options);
-
-            // Validate factory configuration if present
-            if (factoryResult.hasFactoryConfig && options.factoryConfig) {
-              const validation = validateFactoryConfig(options.factoryConfig);
-              if (!validation.isValid) {
-                logger.warn("Invalid factory configuration detected", {
-                  errors: validation.errors,
-                });
-                // Continue with warning rather than throwing - graceful degradation
-              }
-            }
-
-            // RAG Integration: If rag config is provided, prepare the RAG search tool
-            if (options.rag?.files?.length) {
-              try {
-                const { prepareRAGTool } = await import("./rag/ragIntegration.js");
-                const ragResult = await prepareRAGTool(options.rag, options.provider as string | undefined);
-
-                // Inject the RAG tool into the tools record
-                if (!options.tools) {
-                  options.tools = {};
-                }
-                (options.tools as Record<string, unknown>)[ragResult.toolName] = ragResult.tool;
-
-                // Inject RAG-aware system prompt so the AI uses the RAG tool first
-                const ragSystemInstruction = [
-                  `\n\nIMPORTANT: You have a tool called "${ragResult.toolName}" that searches through`,
-                  `${ragResult.filesLoaded} loaded document(s) containing ${ragResult.chunksIndexed} indexed chunks.`,
-                  `ALWAYS use the "${ragResult.toolName}" tool FIRST to answer the user's question before using any other tools.`,
-                  `This tool searches your local knowledge base of pre-loaded documents and is the primary source of truth.`,
-                  `Do NOT use websearchGrounding or any web search tools when the answer can be found in the loaded documents.`,
-                ].join(" ");
-                options.systemPrompt = (options.systemPrompt || "") + ragSystemInstruction;
-
-                logger.info("[RAG] Tool injected into generate()", {
-                  toolName: ragResult.toolName,
-                  filesLoaded: ragResult.filesLoaded,
-                  chunksIndexed: ragResult.chunksIndexed,
-                });
-              } catch (error) {
-                logger.warn("[RAG] Failed to prepare RAG tool, continuing without RAG", {
-                  error: error instanceof Error ? error.message : String(error),
-                });
-              }
-            }
-
-            // Memory retrieval for generate path
-            if (this.shouldReadMemory(options.memory, options.context?.userId) && options.context?.userId) {
-              try {
-                options.input.text = await this.retrieveMemory(
-                  options.input.text,
-                  options.context.userId as string,
-                  options.memory?.additionalUsers,
-                );
-                logger.debug("Memory retrieval successful (generate)");
-              } catch (error) {
-                logger.warn("Memory retrieval failed (generate):", error);
-              }
-            }
-
-            // 🔧 CRITICAL FIX: Convert to TextGenerationOptions while preserving the input object for multimodal support
-            const baseOptions: TextGenerationOptions = {
-              prompt: options.input.text,
-              provider: options.provider as AIProviderName,
-              model: options.model,
-              temperature: options.temperature,
-              maxTokens: options.maxTokens,
-              systemPrompt: options.systemPrompt,
-              schema: options.schema,
-              output: options.output,
-              tools: options.tools, // Includes RAG tools if rag config was provided
-              disableTools: options.disableTools,
-              toolFilter: options.toolFilter,
-              excludeTools: options.excludeTools,
-              maxSteps: options.maxSteps,
-              toolChoice: options.toolChoice,
-              prepareStep: options.prepareStep,
-              enableAnalytics: options.enableAnalytics,
-              enableEvaluation: options.enableEvaluation,
-              context: options.context as Record<string, JsonValue> | undefined,
-              evaluationDomain: options.evaluationDomain,
-              toolUsageContext: options.toolUsageContext,
-              input: options.input, // This includes text, images, and content arrays
-              region: options.region,
-              tts: options.tts,
-              fileRegistry: this.fileRegistry,
-              abortSignal: options.abortSignal,
-              skipToolPromptInjection: options.skipToolPromptInjection,
-              middleware: options.middleware,
-              // Pass through conversation messages for task continuation and external callers
-              conversationMessages: options.conversationMessages,
-            };
-
-            // Auto-map top-level sessionId/userId to context for convenience
-            // Tests and users may pass sessionId/userId as top-level options
-            const extraContext = options as Record<string, unknown>;
-            if (extraContext.sessionId || extraContext.userId) {
-              baseOptions.context = {
-                ...baseOptions.context,
-                ...(extraContext.sessionId && !baseOptions.context?.sessionId
-                  ? { sessionId: extraContext.sessionId as JsonValue }
-                  : {}),
-                ...(extraContext.userId && !baseOptions.context?.userId
-                  ? { userId: extraContext.userId as JsonValue }
-                  : {}),
-              };
-            }
-
-            // Apply factory enhancement using centralized utilities
-            const textOptions = enhanceTextGenerationOptions(baseOptions, factoryResult);
-
-            // Pass conversation memory config if available
-            if (this.conversationMemory) {
-              textOptions.conversationMemoryConfig = this.conversationMemory.config;
-              // Include original prompt for context summarization
-              textOptions.originalPrompt = originalPrompt;
-            }
-
-            // Detect and execute domain-specific tools
-            const { toolResults, enhancedPrompt } = await this.detectAndExecuteTools(
-              textOptions.prompt || options.input.text,
-              factoryResult.domainType,
-            );
-
-            // Update prompt with tool results if available
-            if (enhancedPrompt !== textOptions.prompt) {
-              textOptions.prompt = enhancedPrompt;
-              logger.debug("Enhanced prompt with tool results", {
-                originalLength: options.input.text.length,
-                enhancedLength: enhancedPrompt.length,
-                toolResults: toolResults.length,
-              });
-            }
-
-            const textResult = await this.generateTextInternal(textOptions);
-
-            // Emit generation completion event (NeuroLink format - enhanced with content)
-            this.emitter.emit("generation:end", {
-              provider: textResult.provider,
-              responseTime: Date.now() - startTime,
-              toolsUsed: textResult.toolsUsed,
-              timestamp: Date.now(),
-              result: textResult, // Enhanced: include full result
-              prompt: options.input?.text || (options as Record<string, unknown>).prompt,
-              temperature: textOptions.temperature,
-              maxTokens: textOptions.maxTokens,
-            });
-
-            // ADD: Bedrock-compatible response:end event with content
-            this.emitter.emit("response:end", textResult.content || "");
-
-            // ADD: Bedrock-compatible message event
-            this.emitter.emit("message", `Generation completed in ${Date.now() - startTime}ms`);
-
-            // Convert back to GenerateResult
-            const generateResult: GenerateResult = {
-              content: textResult.content,
-              finishReason: textResult.finishReason,
-              provider: textResult.provider,
-              model: textResult.model,
-              usage: textResult.usage
-                ? {
-                    input: textResult.usage.input || 0,
-                    output: textResult.usage.output || 0,
-                    total: textResult.usage.total || 0,
-                  }
-                : undefined,
-              responseTime: textResult.responseTime,
-              toolsUsed: textResult.toolsUsed,
-              toolExecutions: transformToolExecutions(textResult.toolExecutions),
-              enhancedWithTools: textResult.enhancedWithTools,
-              availableTools: transformAvailableTools(textResult.availableTools),
-              analytics: textResult.analytics,
-              // CRITICAL FIX: Include imageOutput for image generation models
-              imageOutput: textResult.imageOutput,
-              evaluation: textResult.evaluation
-                ? {
-                    ...textResult.evaluation,
-                    isOffTopic: textResult.evaluation.isOffTopic ?? false,
-                    alertSeverity: textResult.evaluation.alertSeverity ?? ("none" as const),
-                    reasoning: textResult.evaluation.reasoning ?? "No evaluation provided",
-                    evaluationModel: textResult.evaluation.evaluationModel ?? "unknown",
-                    evaluationTime: textResult.evaluation.evaluationTime ?? Date.now(),
-                    evaluationDomain:
-                      textResult.evaluation.evaluationDomain ??
-                      textOptions.evaluationDomain ??
-                      factoryResult.domainType,
-                  }
-                : undefined,
-              audio: textResult.audio,
-              video: textResult.video,
-              ppt: textResult.ppt,
-              // NL-007: Copy retry metadata from MCP generation path
-              ...(textResult.retries && { retries: textResult.retries }),
-            };
-
-            // Accumulate session cost for budget tracking
-            if (generateResult.analytics?.cost && generateResult.analytics.cost > 0) {
-              this._sessionCostUsd += generateResult.analytics.cost;
-            }
-
-            this.scheduleGenerateMemoryStorage(options, originalPrompt, generateResult);
-
-            // Set completion span attributes
-            generateSpan.setAttribute("neurolink.output_length", generateResult.content?.length || 0);
-            generateSpan.setAttribute("neurolink.tokens.input", generateResult.usage?.input || 0);
-            generateSpan.setAttribute("neurolink.tokens.output", generateResult.usage?.output || 0);
-            generateSpan.setAttribute("neurolink.finish_reason", generateResult.finishReason || "unknown");
-            generateSpan.setAttribute("neurolink.result_provider", generateResult.provider || "unknown");
-            generateSpan.setAttribute("neurolink.result_model", generateResult.model || "unknown");
-            // NL-007: Expose retry count in OTel span
-            generateSpan.setAttribute("generate.retry_count", generateResult.retries?.count || 0);
-
-            generateSpan.setStatus({ code: SpanStatusCode.OK });
-
-            return generateResult;
-          });
-        } catch (error) {
-          generateSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
-          });
-          // Emit generation:end on error so metrics listeners still record the failure.
-          // Note: variables declared inside try blocks are not accessible in error
-          // handlers, so we extract what we can from the original input.
-          const errProvider =
-            typeof optionsOrPrompt === "object"
-              ? (optionsOrPrompt as GenerateOptions).provider || "unknown"
-              : "unknown";
-          const errModel =
-            typeof optionsOrPrompt === "object" ? (optionsOrPrompt as GenerateOptions).model || "unknown" : "unknown";
-          try {
-            this.emitter.emit("generation:end", {
-              provider: errProvider,
-              model: errModel,
-              responseTime: 0,
-              error: error instanceof Error ? error.message : String(error),
-              success: false,
-            });
-          } catch (emitError: unknown) {
-            void emitError; // non-blocking — error event emission is best-effort
-          }
-          throw error;
-        } finally {
-          this._disableToolCacheForCurrentRequest = false;
-          generateSpan.end();
-        }
-      }); // end metricsTraceContextStorage.run
+    await this.maybeApplyGenerateOrchestration(options);
+    this.emitter.emit("generation:start", {
+      provider: options.provider || "auto",
+      timestamp: startTime,
     });
+    this.emitter.emit("response:start");
+    this.emitter.emit(
+      "message",
+      `Starting ${options.provider || "auto"} text generation...`,
+    );
+
+    const factoryResult = processFactoryOptions(options);
+    if (factoryResult.hasFactoryConfig && options.factoryConfig) {
+      const validation = validateFactoryConfig(options.factoryConfig);
+      if (!validation.isValid) {
+        logger.warn("Invalid factory configuration detected", {
+          errors: validation.errors,
+        });
+      }
+    }
+
+    await this.prepareGenerateAugmentations(options);
+    const textOptions = await this.buildGenerateTextOptions(
+      options,
+      originalPrompt,
+      factoryResult,
+    );
+    const textResult = await this.generateTextInternal(textOptions);
+
+    return this.finalizeGenerateRequestResult({
+      generateSpan,
+      options,
+      textOptions,
+      textResult,
+      factoryResult,
+      originalPrompt,
+      startTime,
+    });
+  }
+
+  private async maybeApplyGenerateOrchestration(
+    options: GenerateOptions,
+  ): Promise<void> {
+    if (!this.enableOrchestration || options.provider || options.model) {
+      return;
+    }
+
+    try {
+      const orchestratedOptions = await this.applyOrchestration(options);
+      logger.debug("Orchestration applied", {
+        originalProvider: options.provider || "auto",
+        orchestratedProvider: orchestratedOptions.provider,
+        orchestratedModel: orchestratedOptions.model,
+        prompt: options.input.text.substring(0, 100),
+      });
+      Object.assign(options, orchestratedOptions);
+      if (orchestratedOptions.model) {
+        options.model = resolveModel(options.model, this.modelAliasConfig);
+      }
+    } catch (error) {
+      logger.warn("Orchestration failed, continuing with original options", {
+        error: error instanceof Error ? error.message : String(error),
+        originalProvider: options.provider || "auto",
+      });
+    }
+  }
+
+  private async prepareGenerateAugmentations(
+    options: GenerateOptions,
+  ): Promise<void> {
+    if (options.rag?.files?.length) {
+      try {
+        const { prepareRAGTool } = await import("./rag/ragIntegration.js");
+        const ragResult = await prepareRAGTool(
+          options.rag,
+          options.provider as string | undefined,
+        );
+
+        if (!options.tools) {
+          options.tools = {};
+        }
+        (options.tools as Record<string, unknown>)[ragResult.toolName] =
+          ragResult.tool;
+        options.systemPrompt =
+          (options.systemPrompt || "") +
+          [
+            `\n\nIMPORTANT: You have a tool called "${ragResult.toolName}" that searches through`,
+            `${ragResult.filesLoaded} loaded document(s) containing ${ragResult.chunksIndexed} indexed chunks.`,
+            `ALWAYS use the "${ragResult.toolName}" tool FIRST to answer the user's question before using any other tools.`,
+            `This tool searches your local knowledge base of pre-loaded documents and is the primary source of truth.`,
+            `Do NOT use websearchGrounding or any web search tools when the answer can be found in the loaded documents.`,
+          ].join(" ");
+
+        logger.info("[RAG] Tool injected into generate()", {
+          toolName: ragResult.toolName,
+          filesLoaded: ragResult.filesLoaded,
+          chunksIndexed: ragResult.chunksIndexed,
+        });
+      } catch (error) {
+        logger.warn(
+          "[RAG] Failed to prepare RAG tool, continuing without RAG",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
+    if (
+      !this.shouldReadMemory(options.memory, options.context?.userId) ||
+      !options.context?.userId
+    ) {
+      return;
+    }
+
+    try {
+      options.input.text = await this.retrieveMemory(
+        options.input.text,
+        options.context.userId as string,
+        options.memory?.additionalUsers,
+      );
+      logger.debug("Memory retrieval successful (generate)");
+    } catch (error) {
+      logger.warn("Memory retrieval failed (generate):", error);
+    }
+  }
+
+  private async buildGenerateTextOptions(
+    options: GenerateOptions,
+    originalPrompt: string | undefined,
+    factoryResult: ReturnType<typeof processFactoryOptions>,
+  ): Promise<TextGenerationOptions> {
+    const baseOptions: TextGenerationOptions = {
+      prompt: options.input.text,
+      provider: options.provider as AIProviderName,
+      model: options.model,
+      temperature: options.temperature,
+      maxTokens: options.maxTokens,
+      systemPrompt: options.systemPrompt,
+      schema: options.schema,
+      output: options.output,
+      tools: options.tools,
+      disableTools: options.disableTools,
+      toolFilter: options.toolFilter,
+      excludeTools: options.excludeTools,
+      maxSteps: options.maxSteps,
+      toolChoice: options.toolChoice,
+      prepareStep: options.prepareStep,
+      enableAnalytics: options.enableAnalytics,
+      enableEvaluation: options.enableEvaluation,
+      context: options.context as Record<string, JsonValue> | undefined,
+      evaluationDomain: options.evaluationDomain,
+      toolUsageContext: options.toolUsageContext,
+      input: options.input,
+      region: options.region,
+      tts: options.tts,
+      fileRegistry: this.fileRegistry,
+      abortSignal: options.abortSignal,
+      skipToolPromptInjection: options.skipToolPromptInjection,
+      middleware: options.middleware,
+      conversationMessages: options.conversationMessages,
+    };
+
+    const extraContext = options as Record<string, unknown>;
+    if (extraContext.sessionId || extraContext.userId) {
+      baseOptions.context = {
+        ...baseOptions.context,
+        ...(extraContext.sessionId && !baseOptions.context?.sessionId
+          ? { sessionId: extraContext.sessionId as JsonValue }
+          : {}),
+        ...(extraContext.userId && !baseOptions.context?.userId
+          ? { userId: extraContext.userId as JsonValue }
+          : {}),
+      };
+    }
+
+    const textOptions = enhanceTextGenerationOptions(
+      baseOptions,
+      factoryResult,
+    );
+    if (this.conversationMemory) {
+      textOptions.conversationMemoryConfig = this.conversationMemory.config;
+      textOptions.originalPrompt = originalPrompt;
+    }
+
+    const { toolResults, enhancedPrompt } = await this.detectAndExecuteTools(
+      textOptions.prompt || options.input.text,
+      factoryResult.domainType,
+    );
+    if (enhancedPrompt !== textOptions.prompt) {
+      textOptions.prompt = enhancedPrompt;
+      logger.debug("Enhanced prompt with tool results", {
+        originalLength: options.input.text.length,
+        enhancedLength: enhancedPrompt.length,
+        toolResults: toolResults.length,
+      });
+    }
+
+    return textOptions;
+  }
+
+  private finalizeGenerateRequestResult(params: {
+    generateSpan: ReturnType<typeof tracers.sdk.startSpan>;
+    options: GenerateOptions;
+    textOptions: TextGenerationOptions;
+    textResult: TextGenerationResult;
+    factoryResult: ReturnType<typeof processFactoryOptions>;
+    originalPrompt: string | undefined;
+    startTime: number;
+  }): GenerateResult {
+    const {
+      generateSpan,
+      options,
+      textOptions,
+      textResult,
+      factoryResult,
+      originalPrompt,
+      startTime,
+    } = params;
+
+    this.emitter.emit("generation:end", {
+      provider: textResult.provider,
+      responseTime: Date.now() - startTime,
+      toolsUsed: textResult.toolsUsed,
+      timestamp: Date.now(),
+      result: textResult,
+      prompt:
+        options.input?.text || (options as Record<string, unknown>).prompt,
+      temperature: textOptions.temperature,
+      maxTokens: textOptions.maxTokens,
+    });
+    this.emitter.emit("response:end", textResult.content || "");
+    this.emitter.emit(
+      "message",
+      `Generation completed in ${Date.now() - startTime}ms`,
+    );
+
+    const generateResult: GenerateResult = {
+      content: textResult.content,
+      finishReason: textResult.finishReason,
+      provider: textResult.provider,
+      model: textResult.model,
+      usage: textResult.usage
+        ? {
+            input: textResult.usage.input || 0,
+            output: textResult.usage.output || 0,
+            total: textResult.usage.total || 0,
+          }
+        : undefined,
+      responseTime: textResult.responseTime,
+      toolsUsed: textResult.toolsUsed,
+      toolExecutions: transformToolExecutions(textResult.toolExecutions),
+      enhancedWithTools: textResult.enhancedWithTools,
+      availableTools: transformAvailableTools(textResult.availableTools),
+      analytics: textResult.analytics,
+      imageOutput: textResult.imageOutput,
+      evaluation: textResult.evaluation
+        ? {
+            ...textResult.evaluation,
+            isOffTopic: textResult.evaluation.isOffTopic ?? false,
+            alertSeverity:
+              textResult.evaluation.alertSeverity ?? ("none" as const),
+            reasoning:
+              textResult.evaluation.reasoning ?? "No evaluation provided",
+            evaluationModel: textResult.evaluation.evaluationModel ?? "unknown",
+            evaluationTime: textResult.evaluation.evaluationTime ?? Date.now(),
+            evaluationDomain:
+              textResult.evaluation.evaluationDomain ??
+              textOptions.evaluationDomain ??
+              factoryResult.domainType,
+          }
+        : undefined,
+      audio: textResult.audio,
+      video: textResult.video,
+      ppt: textResult.ppt,
+      ...(textResult.retries && { retries: textResult.retries }),
+    };
+
+    if (generateResult.analytics?.cost && generateResult.analytics.cost > 0) {
+      this._sessionCostUsd += generateResult.analytics.cost;
+    }
+    this.scheduleGenerateMemoryStorage(options, originalPrompt, generateResult);
+
+    generateSpan.setAttribute(
+      "neurolink.output_length",
+      generateResult.content?.length || 0,
+    );
+    generateSpan.setAttribute(
+      "neurolink.tokens.input",
+      generateResult.usage?.input || 0,
+    );
+    generateSpan.setAttribute(
+      "neurolink.tokens.output",
+      generateResult.usage?.output || 0,
+    );
+    generateSpan.setAttribute(
+      "neurolink.finish_reason",
+      generateResult.finishReason || "unknown",
+    );
+    generateSpan.setAttribute(
+      "neurolink.result_provider",
+      generateResult.provider || "unknown",
+    );
+    generateSpan.setAttribute(
+      "neurolink.result_model",
+      generateResult.model || "unknown",
+    );
+    generateSpan.setAttribute(
+      "generate.retry_count",
+      generateResult.retries?.count || 0,
+    );
+    generateSpan.setStatus({ code: SpanStatusCode.OK });
+
+    return generateResult;
+  }
+
+  private emitGenerateErrorEvent(
+    optionsOrPrompt: GenerateOptions | string,
+    error: unknown,
+  ): void {
+    const errProvider =
+      typeof optionsOrPrompt === "object"
+        ? optionsOrPrompt.provider || "unknown"
+        : "unknown";
+    const errModel =
+      typeof optionsOrPrompt === "object"
+        ? optionsOrPrompt.model || "unknown"
+        : "unknown";
+
+    try {
+      this.emitter.emit("generation:end", {
+        provider: errProvider,
+        model: errModel,
+        responseTime: 0,
+        error: error instanceof Error ? error.message : String(error),
+        success: false,
+      });
+    } catch (emitError: unknown) {
+      void emitError;
+    }
   }
 
   /**
@@ -3273,7 +3851,11 @@ Current user's request: ${currentInput}`;
   ): void {
     // Memory storage
     if (
-      this.shouldWriteMemory(options.memory, options.context?.userId, generateResult.content) &&
+      this.shouldWriteMemory(
+        options.memory,
+        options.context?.userId,
+        generateResult.content,
+      ) &&
       options.context?.userId
     ) {
       this.storeMemoryInBackground(
@@ -3288,12 +3870,16 @@ Current user's request: ${currentInput}`;
   /**
    * Handle PPT generation mode
    */
-  private async generateWithPPT(options: GenerateOptions): Promise<GenerateResult> {
+  private async generateWithPPT(
+    options: GenerateOptions,
+  ): Promise<GenerateResult> {
     const startTime = Date.now();
 
     // Dynamic import to avoid circular deps (same pattern as RAG)
-    const { generatePresentation } = await import("./features/ppt/presentationOrchestrator.js");
-    const { extractPPTContext, getEffectivePPTProvider } = await import("./features/ppt/utils.js");
+    const { generatePresentation } =
+      await import("./features/ppt/presentationOrchestrator.js");
+    const { extractPPTContext, getEffectivePPTProvider } =
+      await import("./features/ppt/utils.js");
 
     // Get provider instance for content planning
     const requestedProvider = (options.provider || "vertex") as AIProviderName;
@@ -3318,7 +3904,8 @@ Current user's request: ${currentInput}`;
     // Generate the presentation
     const pptResult = await generatePresentation({
       context: pptContext,
-      provider: effectiveProvider.provider as import("./types/providers.js").AIProvider,
+      provider:
+        effectiveProvider.provider as import("./types/providers.js").AIProvider,
       providerName: effectiveProvider.providerName,
       modelName: effectiveProvider.modelName,
       neurolink: this,
@@ -3340,7 +3927,9 @@ Current user's request: ${currentInput}`;
    * Generate with workflow engine integration
    * Returns both original and processed responses for AB testing
    */
-  private async generateWithWorkflow(options: GenerateOptions): Promise<GenerateResult> {
+  private async generateWithWorkflow(
+    options: GenerateOptions,
+  ): Promise<GenerateResult> {
     const workflowStartTime = Date.now();
 
     logger.debug("[NeuroLink] Executing workflow generation", {
@@ -3374,8 +3963,14 @@ Current user's request: ${currentInput}`;
           ?.filter((m) => m.role === "user" || m.role === "assistant")
           .map((m) => ({
             role: m.role as "user" | "assistant",
-            content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
-          })) ?? (options.conversationHistory as Array<{ role: "user" | "assistant"; content: string }> | undefined),
+            content:
+              typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content),
+          })) ??
+        (options.conversationHistory as
+          | Array<{ role: "user" | "assistant"; content: string }>
+          | undefined),
       timeout: options.timeout as number | undefined,
       verbose: false,
       metadata: options.context as Record<string, JsonValue> | undefined,
@@ -3387,8 +3982,12 @@ Current user's request: ${currentInput}`;
       content: workflowResult.content,
 
       // Provider info from selected response
-      provider: workflowResult.selectedResponse?.provider || workflowConfig.models[0]?.provider,
-      model: workflowResult.selectedResponse?.model || workflowConfig.models[0]?.model,
+      provider:
+        workflowResult.selectedResponse?.provider ||
+        workflowConfig.models[0]?.provider,
+      model:
+        workflowResult.selectedResponse?.model ||
+        workflowConfig.models[0]?.model,
 
       // Basic usage info
       usage: workflowResult.usage
@@ -3404,7 +4003,8 @@ Current user's request: ${currentInput}`;
 
       // Workflow-specific data
       workflow: {
-        originalResponse: workflowResult.originalContent || workflowResult.content, // Original unmodified best response
+        originalResponse:
+          workflowResult.originalContent || workflowResult.content, // Original unmodified best response
         processedResponse: workflowResult.content, // After conditioning (with metadata)
         ensembleResponses: workflowResult.ensembleResponses.map((r) => ({
           provider: r.provider,
@@ -3447,7 +4047,10 @@ Current user's request: ${currentInput}`;
    * Stream with workflow engine integration
    * Progressive streaming: yields preliminary response (first model) then final synthesis
    */
-  private async streamWithWorkflow(options: StreamOptions, startTime: number): Promise<StreamResult> {
+  private async streamWithWorkflow(
+    options: StreamOptions,
+    startTime: number,
+  ): Promise<StreamResult> {
     logger.debug("[NeuroLink] Executing workflow streaming (progressive)", {
       workflowId: options.workflow,
       hasInlineConfig: !!options.workflowConfig,
@@ -3469,7 +4072,8 @@ Current user's request: ${currentInput}`;
     }
 
     // Import streaming workflow runner
-    const { runWorkflowWithStreaming } = await import("./workflow/core/workflowRunner.js");
+    const { runWorkflowWithStreaming } =
+      await import("./workflow/core/workflowRunner.js");
 
     // Execute workflow with progressive streaming
     const workflowStream = runWorkflowWithStreaming(workflowConfig, {
@@ -3479,8 +4083,14 @@ Current user's request: ${currentInput}`;
           ?.filter((m) => m.role === "user" || m.role === "assistant")
           .map((m) => ({
             role: m.role as "user" | "assistant",
-            content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
-          })) ?? (options.conversationHistory as Array<{ role: "user" | "assistant"; content: string }> | undefined),
+            content:
+              typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content),
+          })) ??
+        (options.conversationHistory as
+          | Array<{ role: "user" | "assistant"; content: string }>
+          | undefined),
       timeout: options.timeout as number | undefined,
       verbose: false,
       metadata: options.context as Record<string, JsonValue> | undefined,
@@ -3488,7 +4098,9 @@ Current user's request: ${currentInput}`;
     });
 
     // Store final result for metadata
-    let finalResult: Partial<import("./workflow/types.js").WorkflowResult> | null = null;
+    let finalResult: Partial<
+      import("./workflow/types.js").WorkflowResult
+    > | null = null;
     let preliminaryTime = 0;
 
     // Create a generator that yields progressive chunks
@@ -3550,7 +4162,9 @@ Current user's request: ${currentInput}`;
 
       // After stream completes, update result with final workflow data
       if (finalResult) {
-        const result = finalResult as Partial<import("./workflow/types.js").WorkflowResult>;
+        const result = finalResult as Partial<
+          import("./workflow/types.js").WorkflowResult
+        >;
         const responseTime = Date.now() - startTime;
 
         // Update usage if available
@@ -3622,10 +4236,18 @@ Current user's request: ${currentInput}`;
    * BACKWARD COMPATIBILITY: Legacy generateText method
    * Internally calls generate() and converts result format
    */
-  async generateText(options: TextGenerationOptions): Promise<TextGenerationResult> {
+  async generateText(
+    options: TextGenerationOptions,
+  ): Promise<TextGenerationResult> {
     // Validate required parameters for backward compatibility
-    if (!options.prompt || typeof options.prompt !== "string" || options.prompt.trim() === "") {
-      throw new Error("GenerateText options must include prompt as a non-empty string");
+    if (
+      !options.prompt ||
+      typeof options.prompt !== "string" ||
+      options.prompt.trim() === ""
+    ) {
+      throw new Error(
+        "GenerateText options must include prompt as a non-empty string",
+      );
     }
 
     // NL-004: Resolve model aliases/deprecations before processing
@@ -3645,341 +4267,443 @@ Current user's request: ${currentInput}`;
    * 4. Fall back to direct provider generation
    * 5. Store conversation turn for future context
    */
-  private async generateTextInternal(options: TextGenerationOptions): Promise<TextGenerationResult> {
+  private async generateTextInternal(
+    options: TextGenerationOptions,
+  ): Promise<TextGenerationResult> {
     return tracers.sdk.startActiveSpan(
       "neurolink.generateTextInternal",
       { kind: SpanKind.INTERNAL },
-      async (internalSpan) => {
-        try {
-          const generateInternalId = `generate-internal-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-          const existingRequestId = (options.context as Record<string, unknown> | undefined)?.requestId;
-          const requestId =
-            typeof existingRequestId === "string" && existingRequestId
-              ? existingRequestId
-              : `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-          options.context = { ...options.context, requestId };
-          const generateInternalStartTime = Date.now();
-          const generateInternalHrTimeStart = process.hrtime.bigint();
-          const functionTag = "NeuroLink.generateTextInternal";
+      (internalSpan) =>
+        this.executeGenerateTextInternalWithSpan(options, internalSpan),
+    );
+  }
 
-          // Set span attributes for internal generation
-          internalSpan.setAttribute("neurolink.request_id", requestId);
-          internalSpan.setAttribute("neurolink.has_conversation_memory", !!this.conversationMemory);
-          internalSpan.setAttribute("neurolink.provider", (options.provider as string) || "auto");
-          internalSpan.setAttribute("neurolink.model", options.model || "default");
+  private async executeGenerateTextInternalWithSpan(
+    options: TextGenerationOptions,
+    internalSpan: ReturnType<typeof tracers.sdk.startSpan>,
+  ): Promise<TextGenerationResult> {
+    try {
+      const context = this.initializeGenerateTextInternalContext(options);
+      internalSpan.setAttribute("neurolink.request_id", context.requestId);
+      internalSpan.setAttribute(
+        "neurolink.has_conversation_memory",
+        !!this.conversationMemory,
+      );
+      internalSpan.setAttribute(
+        "neurolink.provider",
+        (options.provider as string) || "auto",
+      );
+      internalSpan.setAttribute("neurolink.model", options.model || "default");
 
-          this.logGenerateTextInternalStart(
-            generateInternalId,
-            generateInternalStartTime,
-            generateInternalHrTimeStart,
-            options,
-            functionTag,
-          );
-          this.emitGenerationStartEvents(options);
+      this.logGenerateTextInternalStart(
+        context.generateInternalId,
+        context.generateInternalStartTime,
+        context.generateInternalHrTimeStart,
+        options,
+        context.functionTag,
+      );
+      this.emitGenerationStartEvents(options);
 
-          try {
-            await this.initializeConversationMemoryForGeneration(
-              generateInternalId,
-              generateInternalStartTime,
-              generateInternalHrTimeStart,
-            );
-            const mcpResult = await this.attemptMCPGeneration(
-              options,
-              generateInternalId,
-              generateInternalStartTime,
-              generateInternalHrTimeStart,
-              functionTag,
-            );
+      return await this.runGenerateTextInternalFlow(
+        options,
+        internalSpan,
+        context,
+      );
+    } catch (error) {
+      internalSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      internalSpan.end();
+    }
+  }
 
-            if (mcpResult) {
-              logger.info(`[NeuroLink.generateTextInternal] generate() - COMPLETE SUCCESS (MCP path)`, {
-                provider: mcpResult.provider,
-                model: mcpResult.model,
-                responseTimeMs: Date.now() - generateInternalStartTime,
-                tokensUsed: mcpResult.usage?.total || 0,
-                toolsUsed: mcpResult.toolsUsed?.length || 0,
-                ...(mcpResult.usage?.cacheCreationTokens !== undefined && {
-                  cacheCreationTokens: mcpResult.usage.cacheCreationTokens,
-                }),
-                ...(mcpResult.usage?.cacheReadTokens !== undefined && {
-                  cacheReadTokens: mcpResult.usage.cacheReadTokens,
-                }),
-                ...(mcpResult.usage?.cacheSavingsPercent !== undefined && {
-                  cacheSavingsPercent: mcpResult.usage.cacheSavingsPercent,
-                }),
-              });
-              {
-                const memStoreStart = Date.now();
-                try {
-                  await storeConversationTurn(
-                    this.conversationMemory,
-                    options,
-                    mcpResult,
-                    new Date(generateInternalStartTime),
-                    requestId,
-                  );
-                  this.recordMemorySpan(
-                    "memory.store",
-                    { "memory.operation": "store", "memory.path": "mcp" },
-                    Date.now() - memStoreStart,
-                    SpanStatus.OK,
-                  );
-                } catch (memErr) {
-                  this.recordMemorySpan(
-                    "memory.store",
-                    { "memory.operation": "store", "memory.path": "mcp" },
-                    Date.now() - memStoreStart,
-                    SpanStatus.ERROR,
-                    memErr instanceof Error ? memErr.message : String(memErr),
-                  );
-                }
-              }
-              this.emitter.emit("response:end", mcpResult.content || "");
-              internalSpan.setAttribute("neurolink.path", "mcp");
-              internalSpan.setAttribute("neurolink.tokens.input", mcpResult.usage?.input || 0);
-              internalSpan.setAttribute("neurolink.tokens.output", mcpResult.usage?.output || 0);
-              internalSpan.setAttribute("neurolink.result_provider", mcpResult.provider || "unknown");
-              internalSpan.setStatus({ code: SpanStatusCode.OK });
-              return mcpResult;
-            }
+  private initializeGenerateTextInternalContext(
+    options: TextGenerationOptions,
+  ): {
+    generateInternalId: string;
+    generateInternalStartTime: number;
+    generateInternalHrTimeStart: bigint;
+    functionTag: string;
+    requestId: string;
+  } {
+    const generateInternalId = `generate-internal-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const existingRequestId = (
+      options.context as Record<string, unknown> | undefined
+    )?.requestId;
+    const requestId =
+      typeof existingRequestId === "string" && existingRequestId
+        ? existingRequestId
+        : `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    options.context = { ...options.context, requestId };
+    return {
+      generateInternalId,
+      generateInternalStartTime: Date.now(),
+      generateInternalHrTimeStart: process.hrtime.bigint(),
+      functionTag: "NeuroLink.generateTextInternal",
+      requestId,
+    };
+  }
 
-            if (options.abortSignal?.aborted) {
-              throw new DOMException("The operation was aborted", "AbortError");
-            }
+  private async runGenerateTextInternalFlow(
+    options: TextGenerationOptions,
+    internalSpan: ReturnType<typeof tracers.sdk.startSpan>,
+    context: {
+      generateInternalId: string;
+      generateInternalStartTime: number;
+      generateInternalHrTimeStart: bigint;
+      functionTag: string;
+      requestId: string;
+    },
+  ): Promise<TextGenerationResult> {
+    try {
+      await this.initializeConversationMemoryForGeneration(
+        context.generateInternalId,
+        context.generateInternalStartTime,
+        context.generateInternalHrTimeStart,
+      );
+      const mcpResult = await this.attemptMCPGeneration(
+        options,
+        context.generateInternalId,
+        context.generateInternalStartTime,
+        context.generateInternalHrTimeStart,
+        context.functionTag,
+      );
+      if (mcpResult) {
+        return this.finalizeGenerateTextInternalResult({
+          path: "mcp",
+          result: mcpResult,
+          options,
+          internalSpan,
+          requestId: context.requestId,
+          startTime: context.generateInternalStartTime,
+        });
+      }
 
-            // Save original messages for smart overflow recovery (Solution 6)
-            // directProviderGeneration may compact messages; if provider still rejects,
-            // the catch block needs the originals for a more effective retry
-            if (this.conversationMemory) {
-              const originalMessages = await getConversationMessages(this.conversationMemory, options);
-              (
-                options as TextGenerationOptions & {
-                  _originalConversationMessages?: unknown[];
-                }
-              )._originalConversationMessages = originalMessages ? [...originalMessages] : undefined;
-            }
+      if (options.abortSignal?.aborted) {
+        throw new DOMException("The operation was aborted", "AbortError");
+      }
 
-            const directResult = await this.directProviderGeneration(options);
-            logger.debug(`[${functionTag}] Direct generation successful`);
-            logger.info(`[NeuroLink.generateTextInternal] generate() - COMPLETE SUCCESS`, {
-              provider: directResult.provider,
-              model: directResult.model,
-              responseTimeMs: Date.now() - generateInternalStartTime,
-              tokensUsed: directResult.usage?.total || 0,
-              toolsUsed: directResult.toolsUsed?.length || 0,
-              ...(directResult.usage?.cacheCreationTokens !== undefined && {
-                cacheCreationTokens: directResult.usage.cacheCreationTokens,
-              }),
-              ...(directResult.usage?.cacheReadTokens !== undefined && {
-                cacheReadTokens: directResult.usage.cacheReadTokens,
-              }),
-              ...(directResult.usage?.cacheSavingsPercent !== undefined && {
-                cacheSavingsPercent: directResult.usage.cacheSavingsPercent,
-              }),
-            });
+      await this.captureOriginalConversationMessagesForRecovery(options);
+      const directResult = await this.directProviderGeneration(options);
+      logger.debug(`[${context.functionTag}] Direct generation successful`);
 
-            {
-              const memStoreStart = Date.now();
-              try {
-                await storeConversationTurn(
-                  this.conversationMemory,
-                  options,
-                  directResult,
-                  new Date(generateInternalStartTime),
-                  requestId,
-                );
-                this.recordMemorySpan(
-                  "memory.store",
-                  { "memory.operation": "store", "memory.path": "direct" },
-                  Date.now() - memStoreStart,
-                  SpanStatus.OK,
-                );
-              } catch (memErr) {
-                this.recordMemorySpan(
-                  "memory.store",
-                  { "memory.operation": "store", "memory.path": "direct" },
-                  Date.now() - memStoreStart,
-                  SpanStatus.ERROR,
-                  memErr instanceof Error ? memErr.message : String(memErr),
-                );
-              }
-            }
-            this.emitter.emit("response:end", directResult.content || "");
-            this.emitter.emit("message", `Text generation completed successfully`);
-            internalSpan.setAttribute("neurolink.path", "direct");
-            internalSpan.setAttribute("neurolink.tokens.input", directResult.usage?.input || 0);
-            internalSpan.setAttribute("neurolink.tokens.output", directResult.usage?.output || 0);
-            internalSpan.setAttribute("neurolink.result_provider", directResult.provider || "unknown");
+      return this.finalizeGenerateTextInternalResult({
+        path: "direct",
+        result: directResult,
+        options,
+        internalSpan,
+        requestId: context.requestId,
+        startTime: context.generateInternalStartTime,
+      });
+    } catch (error) {
+      const recoveredResult = await this.handleGenerateTextInternalFailure(
+        options,
+        context,
+        error,
+      );
+      if (recoveredResult) {
+        return recoveredResult;
+      }
+      throw error;
+    }
+  }
 
-            internalSpan.setStatus({ code: SpanStatusCode.OK });
-            return directResult;
-          } catch (error) {
-            // Check if this is a context overflow error - attempt recovery
-            if (isContextOverflowError(error) && this.conversationMemory) {
-              logger.warn(`[${functionTag}] Context overflow detected by provider, attempting smart recovery`, {
-                error: error instanceof Error ? error.message : String(error),
-                overflowProvider: getContextOverflowProvider(error),
-              });
+  private async captureOriginalConversationMessagesForRecovery(
+    options: TextGenerationOptions,
+  ): Promise<void> {
+    if (!this.conversationMemory) {
+      return;
+    }
 
-              try {
-                // IMPROVEMENT 1: Extract actual token count from provider error if available
-                const actualOverflow = parseProviderOverflowDetails(error);
+    const originalMessages = await getConversationMessages(
+      this.conversationMemory,
+      options,
+    );
+    (
+      options as TextGenerationOptions & {
+        _originalConversationMessages?: unknown[];
+      }
+    )._originalConversationMessages = originalMessages
+      ? [...originalMessages]
+      : undefined;
+  }
 
-                // IMPROVEMENT 2: Use ORIGINAL messages (not already-compacted ones)
-                const originalMessages =
-                  (
-                    options as TextGenerationOptions & {
-                      _originalConversationMessages?: unknown[];
-                    }
-                  )._originalConversationMessages ?? (await getConversationMessages(this.conversationMemory, options));
+  private async finalizeGenerateTextInternalResult(params: {
+    path: "mcp" | "direct";
+    result: TextGenerationResult;
+    options: TextGenerationOptions;
+    internalSpan: ReturnType<typeof tracers.sdk.startSpan>;
+    requestId: string;
+    startTime: number;
+  }): Promise<TextGenerationResult> {
+    const { path, result, options, internalSpan, requestId, startTime } =
+      params;
 
-                // IMPROVEMENT 3: Calculate precise reduction target
-                const recoveryBudget = checkContextBudget({
-                  provider: options.provider || "openai",
-                  model: options.model,
-                  maxTokens: options.maxTokens,
-                  currentPrompt: options.prompt,
-                  systemPrompt: options.systemPrompt,
-                });
-
-                // Use provider's reported token count if available (more accurate than our estimate)
-                const actualTokens = actualOverflow?.actualTokens ?? recoveryBudget.estimatedInputTokens;
-                const budgetTokens = actualOverflow?.budgetTokens ?? recoveryBudget.availableInputTokens;
-
-                // Target = 70% of budget (aggressive safety margin for recovery)
-                const compactionTarget = Math.floor(budgetTokens * 0.7);
-
-                // IMPROVEMENT 4: Calculate adaptive truncation fraction from actual numbers
-                const requiredReduction = actualTokens > 0 ? (actualTokens - compactionTarget) / actualTokens : 0.5;
-
-                const compactor = new ContextCompactor({
-                  enableSummarize: false, // Skip LLM call for recovery (speed)
-                  enablePrune: true,
-                  enableDeduplicate: true,
-                  enableTruncate: true,
-                  truncationFraction: Math.min(0.9, requiredReduction + 0.15),
-                });
-
-                const compactionResult = await compactor.compact(
-                  originalMessages as import("./types/conversation.js").ChatMessage[],
-                  compactionTarget,
-                  undefined,
-                  (options.context as Record<string, unknown>)?.requestId as string | undefined,
-                );
-
-                if (compactionResult.compacted) {
-                  const repairedResult = repairToolPairs(compactionResult.messages);
-
-                  // IMPROVEMENT 5: Verify BEFORE retrying
-                  const verifyBudget = checkContextBudget({
-                    provider: options.provider || "openai",
-                    model: options.model,
-                    maxTokens: options.maxTokens,
-                    systemPrompt: options.systemPrompt,
-                    currentPrompt: options.prompt,
-                    conversationMessages: repairedResult.messages as Array<{
-                      role: string;
-                      content: string;
-                    }>,
-                  });
-
-                  if (!verifyBudget.withinBudget) {
-                    logger.error(`[${functionTag}] Recovery compaction insufficient, aborting retry`, {
-                      estimatedTokens: verifyBudget.estimatedInputTokens,
-                      availableTokens: verifyBudget.availableInputTokens,
-                    });
-                    throw new ContextBudgetExceededError(
-                      `Context overflow recovery failed. Provider rejected at ~${actualTokens} tokens, ` +
-                        `recovery compaction achieved ${compactionResult.tokensAfter} tokens ` +
-                        `but budget is ${budgetTokens} tokens.`,
-                      {
-                        estimatedTokens: compactionResult.tokensAfter,
-                        availableTokens: budgetTokens,
-                        stagesUsed: compactionResult.stagesUsed,
-                        breakdown: verifyBudget.breakdown,
-                      },
-                    );
-                  }
-
-                  logger.info(`[${functionTag}] Smart recovery verified, retrying generation`, {
-                    tokensSaved: compactionResult.tokensSaved,
-                    compactionTarget,
-                    verifiedTokens: verifyBudget.estimatedInputTokens,
-                    verifiedBudget: verifyBudget.availableInputTokens,
-                  });
-
-                  // Single verified retry
-                  return await this.directProviderGeneration({
-                    ...options,
-                    conversationMessages: repairedResult.messages,
-                  } as TextGenerationOptions);
-                }
-              } catch (retryError) {
-                // If the retry error is our own ContextBudgetExceededError, re-throw it
-                if (retryError instanceof ContextBudgetExceededError) {
-                  throw retryError;
-                }
-                logger.error(`[${functionTag}] Recovery attempt failed`, {
-                  error: retryError instanceof Error ? retryError.message : String(retryError),
-                });
-              }
-            }
-
-            // If the generation was aborted (e.g., coding task short-circuit via AbortController),
-            // still store the conversation turn so that:
-            // 1. The Redis conversation entry is created (if first turn)
-            // 2. setImmediate triggers generateConversationTitle() for the session
-            // 3. The caller's syncTitleFromRedis() can find the SDK-generated title
-            if (isAbortError(error)) {
-              logger.info(`[${functionTag}] Generation aborted — storing conversation turn for title generation`, {
-                hasMemory: !!this.conversationMemory,
-                memoryType: this.conversationMemory?.constructor?.name || "NONE",
-                sessionId: (options.context as Record<string, unknown>)?.sessionId || "unknown",
-              });
-
-              try {
-                const abortedResult: TextGenerationResult = {
-                  content: "[generation was interrupted]",
-                  provider: options.provider || "unknown",
-                  model: options.model || "unknown",
-                  responseTime: Date.now() - generateInternalStartTime,
-                };
-                await withTimeout(
-                  storeConversationTurn(
-                    this.conversationMemory,
-                    options,
-                    abortedResult,
-                    new Date(generateInternalStartTime),
-                    requestId,
-                  ),
-                  5000, // 5 second timeout for Redis storage
-                );
-              } catch (storeError) {
-                logger.warn(`[${functionTag}] Failed to store conversation turn after abort`, {
-                  error: storeError instanceof Error ? storeError.message : String(storeError),
-                });
-              }
-            } else {
-              logger.error(`[${functionTag}] All generation methods failed`, {
-                error: error instanceof Error ? error.message : String(error),
-              });
-            }
-
-            this.emitter.emit("response:end", "");
-            this.emitter.emit("error", error instanceof Error ? error : new Error(String(error)));
-            throw error;
-          }
-        } catch (spanError) {
-          internalSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: spanError instanceof Error ? spanError.message : String(spanError),
-          });
-          throw spanError;
-        } finally {
-          internalSpan.end();
-        }
+    logger.info(
+      `[NeuroLink.generateTextInternal] generate() - COMPLETE SUCCESS${path === "mcp" ? " (MCP path)" : ""}`,
+      {
+        provider: result.provider,
+        model: result.model,
+        responseTimeMs: Date.now() - startTime,
+        tokensUsed: result.usage?.total || 0,
+        toolsUsed: result.toolsUsed?.length || 0,
+        ...(result.usage?.cacheCreationTokens !== undefined && {
+          cacheCreationTokens: result.usage.cacheCreationTokens,
+        }),
+        ...(result.usage?.cacheReadTokens !== undefined && {
+          cacheReadTokens: result.usage.cacheReadTokens,
+        }),
+        ...(result.usage?.cacheSavingsPercent !== undefined && {
+          cacheSavingsPercent: result.usage.cacheSavingsPercent,
+        }),
       },
     );
+
+    const memStoreStart = Date.now();
+    try {
+      await storeConversationTurn(
+        this.conversationMemory,
+        options,
+        result,
+        new Date(startTime),
+        requestId,
+      );
+      this.recordMemorySpan(
+        "memory.store",
+        { "memory.operation": "store", "memory.path": path },
+        Date.now() - memStoreStart,
+        SpanStatus.OK,
+      );
+    } catch (memoryError) {
+      this.recordMemorySpan(
+        "memory.store",
+        { "memory.operation": "store", "memory.path": path },
+        Date.now() - memStoreStart,
+        SpanStatus.ERROR,
+        memoryError instanceof Error
+          ? memoryError.message
+          : String(memoryError),
+      );
+    }
+
+    this.emitter.emit("response:end", result.content || "");
+    if (path === "direct") {
+      this.emitter.emit("message", "Text generation completed successfully");
+    }
+    internalSpan.setAttribute("neurolink.path", path);
+    internalSpan.setAttribute(
+      "neurolink.tokens.input",
+      result.usage?.input || 0,
+    );
+    internalSpan.setAttribute(
+      "neurolink.tokens.output",
+      result.usage?.output || 0,
+    );
+    internalSpan.setAttribute(
+      "neurolink.result_provider",
+      result.provider || "unknown",
+    );
+    internalSpan.setStatus({ code: SpanStatusCode.OK });
+
+    return result;
+  }
+
+  private async handleGenerateTextInternalFailure(
+    options: TextGenerationOptions,
+    context: {
+      generateInternalStartTime: number;
+      functionTag: string;
+      requestId: string;
+    },
+    error: unknown,
+  ): Promise<TextGenerationResult | null> {
+    const recoveredResult = await this.tryRecoverGenerateTextOverflow(
+      options,
+      context.functionTag,
+      error,
+    );
+    if (recoveredResult) {
+      return recoveredResult;
+    }
+
+    if (isAbortError(error)) {
+      logger.info(
+        `[${context.functionTag}] Generation aborted — storing conversation turn for title generation`,
+        {
+          hasMemory: !!this.conversationMemory,
+          memoryType: this.conversationMemory?.constructor?.name || "NONE",
+          sessionId:
+            (options.context as Record<string, unknown>)?.sessionId ||
+            "unknown",
+        },
+      );
+
+      try {
+        const abortedResult: TextGenerationResult = {
+          content: "[generation was interrupted]",
+          provider: options.provider || "unknown",
+          model: options.model || "unknown",
+          responseTime: Date.now() - context.generateInternalStartTime,
+        };
+        await withTimeout(
+          storeConversationTurn(
+            this.conversationMemory,
+            options,
+            abortedResult,
+            new Date(context.generateInternalStartTime),
+            context.requestId,
+          ),
+          5000,
+        );
+      } catch (storeError) {
+        logger.warn(
+          `[${context.functionTag}] Failed to store conversation turn after abort`,
+          {
+            error:
+              storeError instanceof Error
+                ? storeError.message
+                : String(storeError),
+          },
+        );
+      }
+    } else {
+      logger.error(`[${context.functionTag}] All generation methods failed`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    this.emitter.emit("response:end", "");
+    this.emitter.emit(
+      "error",
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return null;
+  }
+
+  private async tryRecoverGenerateTextOverflow(
+    options: TextGenerationOptions,
+    functionTag: string,
+    error: unknown,
+  ): Promise<TextGenerationResult | null> {
+    if (!isContextOverflowError(error) || !this.conversationMemory) {
+      return null;
+    }
+
+    logger.warn(
+      `[${functionTag}] Context overflow detected by provider, attempting smart recovery`,
+      {
+        error: error instanceof Error ? error.message : String(error),
+        overflowProvider: getContextOverflowProvider(error),
+      },
+    );
+
+    try {
+      const actualOverflow = parseProviderOverflowDetails(error);
+      const originalMessages =
+        (
+          options as TextGenerationOptions & {
+            _originalConversationMessages?: unknown[];
+          }
+        )._originalConversationMessages ??
+        (await getConversationMessages(this.conversationMemory, options));
+      const recoveryBudget = checkContextBudget({
+        provider: options.provider || "openai",
+        model: options.model,
+        maxTokens: options.maxTokens,
+        currentPrompt: options.prompt,
+        systemPrompt: options.systemPrompt,
+      });
+      const actualTokens =
+        actualOverflow?.actualTokens ?? recoveryBudget.estimatedInputTokens;
+      const budgetTokens =
+        actualOverflow?.budgetTokens ?? recoveryBudget.availableInputTokens;
+      const compactionTarget = Math.floor(budgetTokens * 0.7);
+      const requiredReduction =
+        actualTokens > 0
+          ? (actualTokens - compactionTarget) / actualTokens
+          : 0.5;
+
+      const compactor = new ContextCompactor({
+        enableSummarize: false,
+        enablePrune: true,
+        enableDeduplicate: true,
+        enableTruncate: true,
+        truncationFraction: Math.min(0.9, requiredReduction + 0.15),
+      });
+      const compactionResult = await compactor.compact(
+        originalMessages as import("./types/conversation.js").ChatMessage[],
+        compactionTarget,
+        undefined,
+        (options.context as Record<string, unknown>)?.requestId as
+          | string
+          | undefined,
+      );
+
+      if (!compactionResult.compacted) {
+        return null;
+      }
+
+      const repairedResult = repairToolPairs(compactionResult.messages);
+      const verifyBudget = checkContextBudget({
+        provider: options.provider || "openai",
+        model: options.model,
+        maxTokens: options.maxTokens,
+        systemPrompt: options.systemPrompt,
+        currentPrompt: options.prompt,
+        conversationMessages: repairedResult.messages as Array<{
+          role: string;
+          content: string;
+        }>,
+      });
+
+      if (!verifyBudget.withinBudget) {
+        logger.error(
+          `[${functionTag}] Recovery compaction insufficient, aborting retry`,
+          {
+            estimatedTokens: verifyBudget.estimatedInputTokens,
+            availableTokens: verifyBudget.availableInputTokens,
+          },
+        );
+        throw new ContextBudgetExceededError(
+          `Context overflow recovery failed. Provider rejected at ~${actualTokens} tokens, ` +
+            `recovery compaction achieved ${compactionResult.tokensAfter} tokens ` +
+            `but budget is ${budgetTokens} tokens.`,
+          {
+            estimatedTokens: compactionResult.tokensAfter,
+            availableTokens: budgetTokens,
+            stagesUsed: compactionResult.stagesUsed,
+            breakdown: verifyBudget.breakdown,
+          },
+        );
+      }
+
+      logger.info(
+        `[${functionTag}] Smart recovery verified, retrying generation`,
+        {
+          tokensSaved: compactionResult.tokensSaved,
+          compactionTarget,
+          verifiedTokens: verifyBudget.estimatedInputTokens,
+          verifiedBudget: verifyBudget.availableInputTokens,
+        },
+      );
+
+      return this.directProviderGeneration({
+        ...options,
+        conversationMessages: repairedResult.messages,
+      } as TextGenerationOptions);
+    } catch (retryError) {
+      if (retryError instanceof ContextBudgetExceededError) {
+        throw retryError;
+      }
+      logger.error(`[${functionTag}] Recovery attempt failed`, {
+        error:
+          retryError instanceof Error ? retryError.message : String(retryError),
+      });
+      return null;
+    }
   }
 
   /**
@@ -4004,7 +4728,10 @@ Current user's request: ${currentInput}`;
    */
   private emitGenerationStartEvents(options: TextGenerationOptions): void {
     this.emitter.emit("response:start");
-    this.emitter.emit("message", `Starting ${options.provider || "auto"} text generation (internal)...`);
+    this.emitter.emit(
+      "message",
+      `Starting ${options.provider || "auto"} text generation (internal)...`,
+    );
   }
 
   /**
@@ -4029,22 +4756,30 @@ Current user's request: ${currentInput}`;
 
     // Normal initialization for already created memory manager
     if (this.conversationMemory) {
-      logger.debug(`[NeuroLink] 🧠 LOG_POINT_G003_CONVERSATION_MEMORY_INIT_START`, {
-        logPoint: "G003_CONVERSATION_MEMORY_INIT_START",
-        generateInternalId,
-        timestamp: new Date().toISOString(),
-        elapsedMs: Date.now() - generateInternalStartTime,
-        elapsedNs: (process.hrtime.bigint() - generateInternalHrTimeStart).toString(),
-        message: "Starting conversation memory initialization",
-      });
+      logger.debug(
+        `[NeuroLink] 🧠 LOG_POINT_G003_CONVERSATION_MEMORY_INIT_START`,
+        {
+          logPoint: "G003_CONVERSATION_MEMORY_INIT_START",
+          generateInternalId,
+          timestamp: new Date().toISOString(),
+          elapsedMs: Date.now() - generateInternalStartTime,
+          elapsedNs: (
+            process.hrtime.bigint() - generateInternalHrTimeStart
+          ).toString(),
+          message: "Starting conversation memory initialization",
+        },
+      );
 
       try {
         await this.conversationMemory.initialize();
       } catch (err) {
-        logger.warn("[NEUROLINK] Redis memory init failed, falling back to in-memory", {
-          error: err instanceof Error ? err.message : String(err),
-          generateInternalId,
-        });
+        logger.warn(
+          "[NEUROLINK] Redis memory init failed, falling back to in-memory",
+          {
+            error: err instanceof Error ? err.message : String(err),
+            generateInternalId,
+          },
+        );
         const memCfg = this.conversationMemoryConfig?.conversationMemory;
         this.conversationMemory = new ConversationMemoryManager({
           enabled: true,
@@ -4055,18 +4790,25 @@ Current user's request: ${currentInput}`;
       }
 
       const conversationMemoryEndTime = process.hrtime.bigint();
-      const conversationMemoryDurationNs = conversationMemoryEndTime - conversationMemoryStartTime;
+      const conversationMemoryDurationNs =
+        conversationMemoryEndTime - conversationMemoryStartTime;
 
-      logger.debug(`[NeuroLink] ✅ LOG_POINT_G004_CONVERSATION_MEMORY_INIT_SUCCESS`, {
-        logPoint: "G004_CONVERSATION_MEMORY_INIT_SUCCESS",
-        generateInternalId,
-        timestamp: new Date().toISOString(),
-        elapsedMs: Date.now() - generateInternalStartTime,
-        elapsedNs: (process.hrtime.bigint() - generateInternalHrTimeStart).toString(),
-        conversationMemoryDurationNs: conversationMemoryDurationNs.toString(),
-        conversationMemoryDurationMs: Number(conversationMemoryDurationNs) / NANOSECOND_TO_MS_DIVISOR,
-        message: "Conversation memory initialization completed successfully",
-      });
+      logger.debug(
+        `[NeuroLink] ✅ LOG_POINT_G004_CONVERSATION_MEMORY_INIT_SUCCESS`,
+        {
+          logPoint: "G004_CONVERSATION_MEMORY_INIT_SUCCESS",
+          generateInternalId,
+          timestamp: new Date().toISOString(),
+          elapsedMs: Date.now() - generateInternalStartTime,
+          elapsedNs: (
+            process.hrtime.bigint() - generateInternalHrTimeStart
+          ).toString(),
+          conversationMemoryDurationNs: conversationMemoryDurationNs.toString(),
+          conversationMemoryDurationMs:
+            Number(conversationMemoryDurationNs) / NANOSECOND_TO_MS_DIVISOR,
+          message: "Conversation memory initialization completed successfully",
+        },
+      );
     }
   }
 
@@ -4080,7 +4822,10 @@ Current user's request: ${currentInput}`;
     generateInternalHrTimeStart: bigint,
     functionTag: string,
   ): Promise<TextGenerationResult | null> {
-    if (!options.disableTools && !(options.tts?.enabled && !options.tts?.useAiResponse)) {
+    if (
+      !options.disableTools &&
+      !(options.tts?.enabled && !options.tts?.useAiResponse)
+    ) {
       return await this.performMCPGenerationRetries(
         options,
         generateInternalId,
@@ -4112,52 +4857,76 @@ Current user's request: ${currentInput}`;
     const maxAttempts = maxMcpRetries + 1;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       if (options.abortSignal?.aborted) {
-        logger.debug(`[${functionTag}] Abort signal already fired before attempt ${attempt}, stopping retries`);
+        logger.debug(
+          `[${functionTag}] Abort signal already fired before attempt ${attempt}, stopping retries`,
+        );
         throw new DOMException("The operation was aborted", "AbortError");
       }
 
       try {
-        logger.debug(`[${functionTag}] Attempting MCP generation (attempt ${attempt}/${maxAttempts})...`);
+        logger.debug(
+          `[${functionTag}] Attempting MCP generation (attempt ${attempt}/${maxAttempts})...`,
+        );
         const mcpResult = await this.tryMCPGeneration(options);
 
-        if (mcpResult && (mcpResult.content || (mcpResult.toolExecutions && mcpResult.toolExecutions.length > 0))) {
-          logger.debug(`[${functionTag}] MCP generation successful on attempt ${attempt}`, {
-            contentLength: mcpResult.content?.length || 0,
-            toolsUsed: mcpResult.toolsUsed?.length || 0,
-            toolExecutions: mcpResult.toolExecutions?.length || 0,
-            retryCount,
-          });
+        if (
+          mcpResult &&
+          (mcpResult.content ||
+            (mcpResult.toolExecutions && mcpResult.toolExecutions.length > 0))
+        ) {
+          logger.debug(
+            `[${functionTag}] MCP generation successful on attempt ${attempt}`,
+            {
+              contentLength: mcpResult.content?.length || 0,
+              toolsUsed: mcpResult.toolsUsed?.length || 0,
+              toolExecutions: mcpResult.toolExecutions?.length || 0,
+              retryCount,
+            },
+          );
           // NL-007: Attach retry metadata to result
           if (retryCount > 0) {
             mcpResult.retries = { count: retryCount, errors: retryErrors };
           }
           return mcpResult;
         } else {
-          logger.debug(`[${functionTag}] MCP generation returned empty result on attempt ${attempt}`, {
-            hasResult: !!mcpResult,
-            hasContent: !!(mcpResult && mcpResult.content),
-            contentLength: mcpResult?.content?.length || 0,
-            toolExecutions: mcpResult?.toolExecutions?.length || 0,
-          });
+          logger.debug(
+            `[${functionTag}] MCP generation returned empty result on attempt ${attempt}`,
+            {
+              hasResult: !!mcpResult,
+              hasContent: !!(mcpResult && mcpResult.content),
+              contentLength: mcpResult?.content?.length || 0,
+              toolExecutions: mcpResult?.toolExecutions?.length || 0,
+            },
+          );
         }
       } catch (error) {
         // Immediately propagate AbortError — never retry aborted requests
         if (isAbortError(error)) {
-          logger.debug(`[${functionTag}] AbortError detected on attempt ${attempt}, stopping retries`);
+          logger.debug(
+            `[${functionTag}] AbortError detected on attempt ${attempt}, stopping retries`,
+          );
           throw error;
         }
 
         // NL-007: Record retry error for observability
         retryCount++;
         const errMsg = error instanceof Error ? error.message : String(error);
-        const errCode = error instanceof NeuroLinkError ? error.code : error instanceof Error ? error.name : "UNKNOWN";
+        const errCode =
+          error instanceof NeuroLinkError
+            ? error.code
+            : error instanceof Error
+              ? error.name
+              : "UNKNOWN";
         retryErrors.push({ code: errCode, message: errMsg.substring(0, 500) });
 
-        logger.debug(`[${functionTag}] MCP generation failed on attempt ${attempt}/${maxAttempts}`, {
-          error: errMsg,
-          willRetry: attempt < maxAttempts,
-          retryCount,
-        });
+        logger.debug(
+          `[${functionTag}] MCP generation failed on attempt ${attempt}/${maxAttempts}`,
+          {
+            error: errMsg,
+            willRetry: attempt < maxAttempts,
+            retryCount,
+          },
+        );
 
         // Check for non-retryable errors — skip remaining retries immediately
         // NoSuchToolError / InvalidToolArgumentsError from Vercel AI SDK are never
@@ -4174,16 +4943,23 @@ Current user's request: ${currentInput}`;
           isContextOverflowError(error) ||
           isToolError ||
           isNonRetryableProviderError(error) ||
-          (error instanceof Error && (error as Error & { isRetryable?: boolean }).isRetryable === false) ||
-          (error instanceof Error && (error as Error & { statusCode?: number }).statusCode === 400);
+          (error instanceof Error &&
+            (error as Error & { isRetryable?: boolean }).isRetryable ===
+              false) ||
+          (error instanceof Error &&
+            (error as Error & { statusCode?: number }).statusCode === 400);
 
         if (isNonRetryable) {
-          logger.debug(`[${functionTag}] Non-retryable error detected, skipping remaining retries`);
+          logger.debug(
+            `[${functionTag}] Non-retryable error detected, skipping remaining retries`,
+          );
           break;
         }
 
         if (attempt >= maxAttempts) {
-          logger.debug(`[${functionTag}] All MCP attempts exhausted, falling back to direct generation`);
+          logger.debug(
+            `[${functionTag}] All MCP attempts exhausted, falling back to direct generation`,
+          );
           break;
         }
 
@@ -4211,366 +4987,53 @@ Current user's request: ${currentInput}`;
   /**
    * Try MCP-enhanced generation (no fallback recursion)
    */
-  private async tryMCPGeneration(options: TextGenerationOptions): Promise<TextGenerationResult | null> {
+  private async tryMCPGeneration(
+    options: TextGenerationOptions,
+  ): Promise<TextGenerationResult | null> {
     if (options.abortSignal?.aborted) {
       throw new DOMException("The operation was aborted", "AbortError");
     }
 
     // 🚀 EXHAUSTIVE LOGGING POINT T001: TRY MCP GENERATION ENTRY
-    const requestId = ((options.context as Record<string, unknown>)?.requestId as string) || "unknown";
+    const requestId =
+      ((options.context as Record<string, unknown>)?.requestId as string) ||
+      "unknown";
     const tryMCPId = `try-mcp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const tryMCPStartTime = Date.now();
     const tryMCPHrTimeStart = process.hrtime.bigint();
     const functionTag = "NeuroLink.tryMCPGeneration";
 
     try {
-      // Initialize MCP if needed
-      await this.initializeMCP();
-
-      if (!this.mcpInitialized) {
-        logger.warn(`[NeuroLink] ⚠️ LOG_POINT_T004_MCP_NOT_AVAILABLE`, {
-          logPoint: "T004_MCP_NOT_AVAILABLE",
-          tryMCPId,
-          timestamp: new Date().toISOString(),
-          elapsedMs: Date.now() - tryMCPStartTime,
-          elapsedNs: (process.hrtime.bigint() - tryMCPHrTimeStart).toString(),
-          mcpInitialized: this.mcpInitialized,
-          mcpComponents: {
-            hasExternalServerManager: !!this.externalServerManager,
-            hasToolRegistry: !!this.toolRegistry,
-            hasProviderRegistry: !!AIProviderFactory,
-          },
-          fallbackReason: "MCP_NOT_INITIALIZED",
-          message: "MCP not available - returning null for fallback to direct generation",
-        });
-        return null; // Skip MCP if not available
-      }
-
-      // Context creation removed - was never used
-
-      // Determine provider
-      const providerName =
-        options.provider === "auto" || !options.provider ? await getBestProvider() : options.provider;
-
-      // Get available tools
-      let availableTools = await this.getAllAvailableTools();
-
-      // NL-001: Filter out tools with OPEN circuit breakers
-      const { tools: circuitBreakerFilteredTools, unavailableTools } = this.toolRegistry.getAvailableTools(
-        this.toolCircuitBreakers,
+      const generationContext = await this.prepareMCPGenerationContext(
+        options,
+        requestId,
+        tryMCPId,
+        tryMCPStartTime,
+        tryMCPHrTimeStart,
       );
-      // Intersect: keep only tools that pass both getAllAvailableTools and circuit breaker filtering
-      const cbFilteredNames = new Set(circuitBreakerFilteredTools.map((t) => t.name));
-      availableTools = availableTools.filter((t) => cbFilteredNames.has(t.name));
-
-      // Apply per-call tool filtering for system prompt tool descriptions
-      availableTools = this.applyToolInfoFiltering(availableTools, options);
-
-      const targetTool = availableTools.find(
-        (t) => t.name.includes("SuccessRateSRByTime") || t.name.includes("juspay-analytics"),
-      );
-      logger.debug("Available tools for AI prompt generation", {
-        toolsCount: availableTools.length,
-        toolNames: availableTools.map((t) => t.name),
-        unavailableToolsCount: unavailableTools.length,
-        unavailableTools: unavailableTools,
-        hasTargetTool: !!targetTool,
-        targetToolDetails: targetTool
-          ? {
-              name: targetTool.name,
-              description: targetTool.description,
-              server: targetTool.server,
-            }
-          : null,
-      });
-
-      // NL-001: Inject system note about unavailable tools
-      let circuitBreakerNote = "";
-      if (unavailableTools.length > 0) {
-        circuitBreakerNote = `\n\nNOTE: The following tools are temporarily unavailable due to repeated failures: ${unavailableTools.join(", ")}. Do not attempt to call these tools.`;
+      if (!generationContext) {
+        return null;
       }
 
-      // Create tool-aware system prompt (skip if skipToolPromptInjection is true)
-      const enhancedSystemPrompt = options.skipToolPromptInjection
-        ? (options.systemPrompt || "") + circuitBreakerNote
-        : this.createToolAwareSystemPrompt(options.systemPrompt, availableTools) + circuitBreakerNote;
-      logger.debug("Tool-aware system prompt created", {
+      const conversationMessages = await this.ensureMCPGenerationBudget(
+        options,
         requestId,
-        originalPromptLength: options.systemPrompt?.length || 0,
-        enhancedPromptLength: enhancedSystemPrompt.length,
-        skippedToolInjection: !!options.skipToolPromptInjection,
-        enhancedPromptPreview: enhancedSystemPrompt.substring(0, 80) + "...",
-      });
-
-      logger.debug("[Observability] System prompt metadata", {
-        requestId,
-        systemPromptLength: enhancedSystemPrompt.length,
-        systemPromptHash: enhancedSystemPrompt.length > 0 ? `sha256:${enhancedSystemPrompt.slice(0, 8)}...` : "empty",
-        hasCustomSystemPrompt: !!options.systemPrompt,
-      });
-
-      // Get conversation messages for context
-      let conversationMessages = await getConversationMessages(this.conversationMemory, options);
-
-      if (logger.shouldLog("debug")) {
-        try {
-          logger.debug("[Observability] Conversation history summary", {
-            requestId,
-            messageCount: conversationMessages?.length || 0,
-            messages: conversationMessages?.map((msg: { role: string; content: unknown }, i: number) => {
-              let contentLength: number;
-              if (typeof msg.content === "string") {
-                contentLength = msg.content.length;
-              } else {
-                try {
-                  contentLength = JSON.stringify(msg.content).length;
-                } catch {
-                  contentLength = 0;
-                }
-              }
-              return {
-                index: i,
-                role: msg.role,
-                contentLength,
-                contentPreview: typeof msg.content === "string" ? msg.content.substring(0, 200) : "[multimodal]",
-              };
-            }),
-          });
-        } catch {
-          // Ignore serialization errors in debug logging
-        }
-      }
-
-      logger.debug("[Observability] Available tools for LLM", {
-        requestId,
-        toolCount: availableTools?.length || 0,
-        toolNames: availableTools?.map((t: { name: string }) => t.name) || [],
-      });
-
-      // Pre-generation budget check
-      const budgetResult = checkContextBudget({
-        provider: providerName,
-        model: options.model,
-        maxTokens: options.maxTokens,
-        systemPrompt: enhancedSystemPrompt,
-        conversationMessages: conversationMessages as Array<{
-          role: string;
-          content: string;
-        }>,
-        currentPrompt: options.prompt,
-        toolDefinitions: availableTools,
-      });
-
-      logger.info("[TokenBudget] Token breakdown", {
-        requestId,
-        system: budgetResult.breakdown?.systemPrompt || 0,
-        history: budgetResult.breakdown?.conversationHistory || 0,
-        tools: budgetResult.breakdown?.toolDefinitions || 0,
-        currentPrompt: budgetResult.breakdown?.currentPrompt || 0,
-        files: budgetResult.breakdown?.fileAttachments || 0,
-        total: budgetResult.estimatedInputTokens,
-        budget: budgetResult.availableInputTokens,
-        usagePercent: Math.round(budgetResult.usageRatio * 1000) / 10,
-        conversationMessageCount: conversationMessages?.length || 0,
-        shouldCompact: budgetResult.shouldCompact,
-      });
-
-      const messageCount = conversationMessages?.length || 0;
-      const compactionSessionId = this.getCompactionSessionId(options);
-      if (
-        budgetResult.shouldCompact &&
-        this.conversationMemory &&
-        messageCount > (this.lastCompactionMessageCount.get(compactionSessionId) ?? 0)
-      ) {
-        logger.info("[NeuroLink] Context budget exceeded, triggering auto-compaction", {
-          usageRatio: budgetResult.usageRatio,
-          estimatedTokens: budgetResult.estimatedInputTokens,
-          availableTokens: budgetResult.availableInputTokens,
-        });
-
-        const compactor = new ContextCompactor({
-          provider: providerName,
-          summarizationProvider: this.conversationMemoryConfig?.conversationMemory?.summarizationProvider,
-          summarizationModel: this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
-        });
-
-        const compactionResult = await compactor.compact(
-          conversationMessages as import("./types/conversation.js").ChatMessage[],
-          budgetResult.availableInputTokens,
-          this.conversationMemoryConfig?.conversationMemory,
-          requestId,
-        );
-
-        if (compactionResult.compacted) {
-          const repairedResult = repairToolPairs(compactionResult.messages);
-          conversationMessages = repairedResult.messages;
-          this.lastCompactionMessageCount.set(compactionSessionId, conversationMessages.length);
-          logger.info("[NeuroLink] Context compacted successfully", {
-            stagesUsed: compactionResult.stagesUsed,
-            tokensSaved: compactionResult.tokensSaved,
-          });
-        }
-
-        // POST-COMPACTION BUDGET RE-CHECK (BUG-003 fix)
-        const postCompactBudget = checkContextBudget({
-          provider: providerName,
-          model: options.model,
-          maxTokens: options.maxTokens,
-          systemPrompt: enhancedSystemPrompt,
-          conversationMessages: conversationMessages as Array<{
-            role: string;
-            content: string;
-          }>,
-          currentPrompt: options.prompt,
-          toolDefinitions: availableTools,
-        });
-
-        if (!postCompactBudget.withinBudget) {
-          const overageRatio = postCompactBudget.usageRatio - 1.0;
-          logger.warn("[NeuroLink] Post-compaction still over budget, attempting emergency content truncation", {
-            requestId,
-            estimatedTokens: postCompactBudget.estimatedInputTokens,
-            availableTokens: postCompactBudget.availableInputTokens,
-            overagePercent: Math.round(overageRatio * 100),
-            stagesUsedInCompaction: compactionResult.stagesUsed,
-          });
-
-          // Emergency: truncate the content of the longest messages
-          conversationMessages = emergencyContentTruncation(
-            conversationMessages as import("./types/conversation.js").ChatMessage[],
-            postCompactBudget.availableInputTokens,
-            postCompactBudget.breakdown,
-            providerName,
-          );
-
-          // Final check after emergency truncation
-          const finalBudget = checkContextBudget({
-            provider: providerName,
-            model: options.model,
-            maxTokens: options.maxTokens,
-            systemPrompt: enhancedSystemPrompt,
-            conversationMessages: conversationMessages as Array<{
-              role: string;
-              content: string;
-            }>,
-            currentPrompt: options.prompt,
-            toolDefinitions: availableTools,
-          });
-
-          if (!finalBudget.withinBudget) {
-            throw new ContextBudgetExceededError(
-              `Context exceeds model budget after all compaction stages. ` +
-                `Estimated: ${finalBudget.estimatedInputTokens} tokens, ` +
-                `Budget: ${finalBudget.availableInputTokens} tokens. ` +
-                `Conversation is too large to fit in the model's context window.`,
-              {
-                estimatedTokens: finalBudget.estimatedInputTokens,
-                availableTokens: finalBudget.availableInputTokens,
-                stagesUsed: compactionResult.stagesUsed,
-                breakdown: finalBudget.breakdown,
-              },
-            );
-          }
-        }
-      }
-
-      // Create provider and generate (with confidence that context fits)
-      const provider = await AIProviderFactory.createProvider(
-        providerName as AIProviderName,
-        options.model,
-        !options.disableTools, // Pass disableTools as inverse of enableMCP
-        this as unknown as UnknownRecord, // Pass SDK instance
-        options.region, // Pass region parameter
+        generationContext.providerName,
+        generationContext.enhancedSystemPrompt,
+        generationContext.availableTools,
+        generationContext.conversationMessages,
       );
 
-      // Propagate trace context for parent-child span hierarchy
-      provider.setTraceContext(this._metricsTraceContext);
-
-      // ADD: Emit connection events for all providers (Bedrock-compatible)
-      this.emitter.emit("connected");
-      this.emitter.emit("message", `${providerName} provider initialized successfully`);
-
-      // Enable tool execution for the provider using BaseProvider method
-      provider.setupToolExecutor(
-        {
-          customTools: this.getCustomTools(),
-          executeTool: (toolName: string, params: unknown) =>
-            this.executeTool(toolName, params, {
-              disableToolCache: options.disableToolCache,
-            }),
-        },
+      return this.generateWithMCPProvider({
+        options,
+        requestId,
         functionTag,
-      );
-
-      logger.debug("[Observability] User input to LLM", {
-        requestId,
-        promptPreview: options.prompt?.substring(0, 200),
-        promptLength: options.prompt?.length || 0,
-        model: options.model,
-        maxTokens: options.maxTokens,
-        temperature: options.temperature,
-        maxSteps: options.maxSteps,
-        skipToolPromptInjection: options.skipToolPromptInjection,
+        tryMCPStartTime,
+        providerName: generationContext.providerName,
+        availableTools: generationContext.availableTools,
+        enhancedSystemPrompt: generationContext.enhancedSystemPrompt,
+        conversationMessages,
       });
-
-      const result = await provider.generate({
-        ...options,
-        systemPrompt: enhancedSystemPrompt,
-        conversationMessages, // Inject conversation history
-      });
-
-      const responseTime = Date.now() - tryMCPStartTime;
-
-      // Enhanced result validation - consider tool executions as valid results
-      const hasContent = result && result.content && result.content.trim().length > 0;
-      const hasToolExecutions = result && result.toolExecutions && result.toolExecutions.length > 0;
-
-      // Log detailed result analysis for debugging
-      mcpLogger.debug(`[${functionTag}] Result validation:`, {
-        hasResult: !!result,
-        hasContent,
-        hasToolExecutions,
-        contentLength: result?.content?.length || 0,
-        toolExecutionsCount: result?.toolExecutions?.length || 0,
-        toolsUsedCount: result?.toolsUsed?.length || 0,
-      });
-
-      // Accept result if it has content OR successful tool executions
-      if (!hasContent && !hasToolExecutions) {
-        mcpLogger.debug(`[${functionTag}] Result rejected: no content and no tool executions`);
-        return null; // Let caller fall back to direct generation
-      }
-
-      // Transform tool executions with enhanced preservation
-      const transformedToolExecutions = transformToolExecutionsForMCP(result.toolExecutions);
-
-      // Log transformation results
-      mcpLogger.debug(`[${functionTag}] Tool execution transformation:`, {
-        originalCount: result?.toolExecutions?.length || 0,
-        transformedCount: transformedToolExecutions.length,
-        transformedTools: transformedToolExecutions.map((te) => te.toolName),
-      });
-
-      // Return enhanced result with preserved tool information
-      return {
-        content: result.content || "", // Ensure content is never undefined
-        provider: providerName,
-        model: result.model,
-        usage: result.usage,
-        responseTime,
-        finishReason: result.finishReason,
-        toolsUsed: result.toolsUsed || [],
-        toolExecutions: transformedToolExecutions,
-        enhancedWithTools: Boolean(hasToolExecutions), // Mark as enhanced if tools were actually used
-        availableTools: transformToolsForMCP(transformToolsToExpectedFormat(availableTools)),
-        audio: result.audio,
-        video: result.video,
-        ppt: result.ppt,
-        imageOutput: result.imageOutput,
-        // Include analytics and evaluation from BaseProvider
-        analytics: result.analytics,
-        evaluation: result.evaluation,
-      };
     } catch (error) {
       // Immediately propagate AbortError — never swallow aborted requests
       if (isAbortError(error)) {
@@ -4589,9 +5052,12 @@ Current user's request: ${currentInput}`;
             (error.message.includes("NoSuchToolError") ||
               error.message.includes("Model tried to call unavailable tool"))));
       if (isToolError) {
-        mcpLogger.warn(`[${functionTag}] Non-retryable tool error, rethrowing`, {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        mcpLogger.warn(
+          `[${functionTag}] Non-retryable tool error, rethrowing`,
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
         throw error;
       }
 
@@ -4602,10 +5068,471 @@ Current user's request: ${currentInput}`;
     }
   }
 
+  private async prepareMCPGenerationContext(
+    options: TextGenerationOptions,
+    requestId: string,
+    tryMCPId: string,
+    tryMCPStartTime: number,
+    tryMCPHrTimeStart: bigint,
+  ): Promise<{
+    providerName: string;
+    availableTools: ToolInfo[];
+    enhancedSystemPrompt: string;
+    conversationMessages: ChatMessage[];
+  } | null> {
+    await this.initializeMCP();
+
+    if (!this.mcpInitialized) {
+      logger.warn(`[NeuroLink] ⚠️ LOG_POINT_T004_MCP_NOT_AVAILABLE`, {
+        logPoint: "T004_MCP_NOT_AVAILABLE",
+        tryMCPId,
+        timestamp: new Date().toISOString(),
+        elapsedMs: Date.now() - tryMCPStartTime,
+        elapsedNs: (process.hrtime.bigint() - tryMCPHrTimeStart).toString(),
+        mcpInitialized: this.mcpInitialized,
+        mcpComponents: {
+          hasExternalServerManager: !!this.externalServerManager,
+          hasToolRegistry: !!this.toolRegistry,
+          hasProviderRegistry: !!AIProviderFactory,
+        },
+        fallbackReason: "MCP_NOT_INITIALIZED",
+        message:
+          "MCP not available - returning null for fallback to direct generation",
+      });
+      return null;
+    }
+
+    const providerName =
+      options.provider === "auto" || !options.provider
+        ? await getBestProvider()
+        : options.provider;
+    let availableTools = await this.getAllAvailableTools();
+    const { tools: circuitBreakerFilteredTools, unavailableTools } =
+      this.toolRegistry.getAvailableTools(this.toolCircuitBreakers);
+    const cbFilteredNames = new Set(
+      circuitBreakerFilteredTools.map((tool) => tool.name),
+    );
+    availableTools = availableTools.filter((tool) =>
+      cbFilteredNames.has(tool.name),
+    );
+    availableTools = this.applyToolInfoFiltering(availableTools, options);
+
+    const targetTool = availableTools.find(
+      (tool) =>
+        tool.name.includes("SuccessRateSRByTime") ||
+        tool.name.includes("juspay-analytics"),
+    );
+    logger.debug("Available tools for AI prompt generation", {
+      toolsCount: availableTools.length,
+      toolNames: availableTools.map((tool) => tool.name),
+      unavailableToolsCount: unavailableTools.length,
+      unavailableTools,
+      hasTargetTool: !!targetTool,
+      targetToolDetails: targetTool
+        ? {
+            name: targetTool.name,
+            description: targetTool.description,
+            server: targetTool.server,
+          }
+        : null,
+    });
+
+    const circuitBreakerNote =
+      unavailableTools.length > 0
+        ? `\n\nNOTE: The following tools are temporarily unavailable due to repeated failures: ${unavailableTools.join(", ")}. Do not attempt to call these tools.`
+        : "";
+    const enhancedSystemPrompt = options.skipToolPromptInjection
+      ? (options.systemPrompt || "") + circuitBreakerNote
+      : this.createToolAwareSystemPrompt(options.systemPrompt, availableTools) +
+        circuitBreakerNote;
+    logger.debug("Tool-aware system prompt created", {
+      requestId,
+      originalPromptLength: options.systemPrompt?.length || 0,
+      enhancedPromptLength: enhancedSystemPrompt.length,
+      skippedToolInjection: !!options.skipToolPromptInjection,
+      enhancedPromptPreview: enhancedSystemPrompt.substring(0, 80) + "...",
+    });
+
+    logger.debug("[Observability] System prompt metadata", {
+      requestId,
+      systemPromptLength: enhancedSystemPrompt.length,
+      systemPromptHash:
+        enhancedSystemPrompt.length > 0
+          ? `sha256:${enhancedSystemPrompt.slice(0, 8)}...`
+          : "empty",
+      hasCustomSystemPrompt: !!options.systemPrompt,
+    });
+
+    const conversationMessages = (await getConversationMessages(
+      this.conversationMemory,
+      options,
+    )) as ChatMessage[];
+    this.logMCPConversationSummary(requestId, conversationMessages);
+
+    logger.debug("[Observability] Available tools for LLM", {
+      requestId,
+      toolCount: availableTools.length,
+      toolNames: availableTools.map((tool) => tool.name),
+    });
+
+    return {
+      providerName,
+      availableTools,
+      enhancedSystemPrompt,
+      conversationMessages,
+    };
+  }
+
+  private logMCPConversationSummary(
+    requestId: string,
+    conversationMessages: ChatMessage[],
+  ): void {
+    if (!logger.shouldLog("debug")) {
+      return;
+    }
+
+    try {
+      logger.debug("[Observability] Conversation history summary", {
+        requestId,
+        messageCount: conversationMessages.length,
+        messages: conversationMessages.map((message, index) => {
+          let contentLength: number;
+          if (typeof message.content === "string") {
+            contentLength = message.content.length;
+          } else {
+            try {
+              contentLength = JSON.stringify(message.content).length;
+            } catch {
+              contentLength = 0;
+            }
+          }
+
+          return {
+            index,
+            role: message.role,
+            contentLength,
+            contentPreview:
+              typeof message.content === "string"
+                ? message.content.substring(0, 200)
+                : "[multimodal]",
+          };
+        }),
+      });
+    } catch {
+      // Ignore serialization errors in debug logging
+    }
+  }
+
+  private async ensureMCPGenerationBudget(
+    options: TextGenerationOptions,
+    requestId: string,
+    providerName: string,
+    enhancedSystemPrompt: string,
+    availableTools: ToolInfo[],
+    conversationMessages: ChatMessage[],
+  ): Promise<ChatMessage[]> {
+    const budgetResult = checkContextBudget({
+      provider: providerName,
+      model: options.model,
+      maxTokens: options.maxTokens,
+      systemPrompt: enhancedSystemPrompt,
+      conversationMessages: conversationMessages as Array<{
+        role: string;
+        content: string;
+      }>,
+      currentPrompt: options.prompt,
+      toolDefinitions: availableTools,
+    });
+
+    logger.info("[TokenBudget] Token breakdown", {
+      requestId,
+      system: budgetResult.breakdown?.systemPrompt || 0,
+      history: budgetResult.breakdown?.conversationHistory || 0,
+      tools: budgetResult.breakdown?.toolDefinitions || 0,
+      currentPrompt: budgetResult.breakdown?.currentPrompt || 0,
+      files: budgetResult.breakdown?.fileAttachments || 0,
+      total: budgetResult.estimatedInputTokens,
+      budget: budgetResult.availableInputTokens,
+      usagePercent: Math.round(budgetResult.usageRatio * 1000) / 10,
+      conversationMessageCount: conversationMessages.length,
+      shouldCompact: budgetResult.shouldCompact,
+    });
+
+    const compactionSessionId = this.getCompactionSessionId(options);
+    const lastCompactionCount =
+      this.lastCompactionMessageCount.get(compactionSessionId) ?? 0;
+    if (
+      !budgetResult.shouldCompact ||
+      !this.conversationMemory ||
+      conversationMessages.length <= lastCompactionCount
+    ) {
+      return conversationMessages;
+    }
+
+    return this.compactMCPConversationForBudget({
+      options,
+      requestId,
+      providerName,
+      enhancedSystemPrompt,
+      availableTools,
+      conversationMessages,
+      availableInputTokens: budgetResult.availableInputTokens,
+      usageRatio: budgetResult.usageRatio,
+      estimatedInputTokens: budgetResult.estimatedInputTokens,
+      compactionSessionId,
+    });
+  }
+
+  private async compactMCPConversationForBudget(context: {
+    options: TextGenerationOptions;
+    requestId: string;
+    providerName: string;
+    enhancedSystemPrompt: string;
+    availableTools: ToolInfo[];
+    conversationMessages: ChatMessage[];
+    availableInputTokens: number;
+    usageRatio: number;
+    estimatedInputTokens: number;
+    compactionSessionId: string;
+  }): Promise<ChatMessage[]> {
+    const {
+      options,
+      requestId,
+      providerName,
+      enhancedSystemPrompt,
+      availableTools,
+      conversationMessages,
+      availableInputTokens,
+      usageRatio,
+      estimatedInputTokens,
+      compactionSessionId,
+    } = context;
+    logger.info(
+      "[NeuroLink] Context budget exceeded, triggering auto-compaction",
+      {
+        usageRatio,
+        estimatedTokens: estimatedInputTokens,
+        availableTokens: availableInputTokens,
+      },
+    );
+
+    const compactor = new ContextCompactor({
+      provider: providerName,
+      summarizationProvider:
+        this.conversationMemoryConfig?.conversationMemory
+          ?.summarizationProvider,
+      summarizationModel:
+        this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
+    });
+
+    const compactionResult = await compactor.compact(
+      conversationMessages,
+      availableInputTokens,
+      this.conversationMemoryConfig?.conversationMemory,
+      requestId,
+    );
+
+    let compactedMessages = conversationMessages;
+    if (compactionResult.compacted) {
+      const repairedResult = repairToolPairs(compactionResult.messages);
+      compactedMessages = repairedResult.messages;
+      this.lastCompactionMessageCount.set(
+        compactionSessionId,
+        compactedMessages.length,
+      );
+      logger.info("[NeuroLink] Context compacted successfully", {
+        stagesUsed: compactionResult.stagesUsed,
+        tokensSaved: compactionResult.tokensSaved,
+      });
+    }
+
+    const postCompactBudget = checkContextBudget({
+      provider: providerName,
+      model: options.model,
+      maxTokens: options.maxTokens,
+      systemPrompt: enhancedSystemPrompt,
+      conversationMessages: compactedMessages as Array<{
+        role: string;
+        content: string;
+      }>,
+      currentPrompt: options.prompt,
+      toolDefinitions: availableTools,
+    });
+
+    if (postCompactBudget.withinBudget) {
+      return compactedMessages;
+    }
+
+    const overageRatio = postCompactBudget.usageRatio - 1.0;
+    logger.warn(
+      "[NeuroLink] Post-compaction still over budget, attempting emergency content truncation",
+      {
+        requestId,
+        estimatedTokens: postCompactBudget.estimatedInputTokens,
+        availableTokens: postCompactBudget.availableInputTokens,
+        overagePercent: Math.round(overageRatio * 100),
+        stagesUsedInCompaction: compactionResult.stagesUsed,
+      },
+    );
+
+    compactedMessages = emergencyContentTruncation(
+      compactedMessages,
+      postCompactBudget.availableInputTokens,
+      postCompactBudget.breakdown,
+      providerName,
+    );
+
+    const finalBudget = checkContextBudget({
+      provider: providerName,
+      model: options.model,
+      maxTokens: options.maxTokens,
+      systemPrompt: enhancedSystemPrompt,
+      conversationMessages: compactedMessages as Array<{
+        role: string;
+        content: string;
+      }>,
+      currentPrompt: options.prompt,
+      toolDefinitions: availableTools,
+    });
+
+    if (!finalBudget.withinBudget) {
+      throw new ContextBudgetExceededError(
+        `Context exceeds model budget after all compaction stages. ` +
+          `Estimated: ${finalBudget.estimatedInputTokens} tokens, ` +
+          `Budget: ${finalBudget.availableInputTokens} tokens. ` +
+          `Conversation is too large to fit in the model's context window.`,
+        {
+          estimatedTokens: finalBudget.estimatedInputTokens,
+          availableTokens: finalBudget.availableInputTokens,
+          stagesUsed: compactionResult.stagesUsed,
+          breakdown: finalBudget.breakdown,
+        },
+      );
+    }
+
+    return compactedMessages;
+  }
+
+  private async generateWithMCPProvider(context: {
+    options: TextGenerationOptions;
+    requestId: string;
+    functionTag: string;
+    tryMCPStartTime: number;
+    providerName: string;
+    availableTools: ToolInfo[];
+    enhancedSystemPrompt: string;
+    conversationMessages: ChatMessage[];
+  }): Promise<TextGenerationResult | null> {
+    const {
+      options,
+      requestId,
+      functionTag,
+      tryMCPStartTime,
+      providerName,
+      availableTools,
+      enhancedSystemPrompt,
+      conversationMessages,
+    } = context;
+    const provider = await AIProviderFactory.createProvider(
+      providerName as AIProviderName,
+      options.model,
+      !options.disableTools,
+      this as unknown as UnknownRecord,
+      options.region,
+    );
+
+    provider.setTraceContext(this._metricsTraceContext);
+    this.emitter.emit("connected");
+    this.emitter.emit(
+      "message",
+      `${providerName} provider initialized successfully`,
+    );
+    provider.setupToolExecutor(
+      {
+        customTools: this.getCustomTools(),
+        executeTool: (toolName: string, params: unknown) =>
+          this.executeTool(toolName, params, {
+            disableToolCache: options.disableToolCache,
+          }),
+      },
+      functionTag,
+    );
+
+    logger.debug("[Observability] User input to LLM", {
+      requestId,
+      promptPreview: options.prompt?.substring(0, 200),
+      promptLength: options.prompt?.length || 0,
+      model: options.model,
+      maxTokens: options.maxTokens,
+      temperature: options.temperature,
+      maxSteps: options.maxSteps,
+      skipToolPromptInjection: options.skipToolPromptInjection,
+    });
+
+    const result = await provider.generate({
+      ...options,
+      systemPrompt: enhancedSystemPrompt,
+      conversationMessages,
+    });
+    const responseTime = Date.now() - tryMCPStartTime;
+    const hasContent = !!(result?.content && result.content.trim().length > 0);
+    const hasToolExecutions = !!(
+      result?.toolExecutions && result.toolExecutions.length > 0
+    );
+
+    mcpLogger.debug(`[${functionTag}] Result validation:`, {
+      hasResult: !!result,
+      hasContent,
+      hasToolExecutions,
+      contentLength: result?.content?.length || 0,
+      toolExecutionsCount: result?.toolExecutions?.length || 0,
+      toolsUsedCount: result?.toolsUsed?.length || 0,
+    });
+
+    if (!hasContent && !hasToolExecutions) {
+      mcpLogger.debug(
+        `[${functionTag}] Result rejected: no content and no tool executions`,
+      );
+      return null;
+    }
+
+    const transformedToolExecutions = transformToolExecutionsForMCP(
+      result.toolExecutions,
+    );
+    mcpLogger.debug(`[${functionTag}] Tool execution transformation:`, {
+      originalCount: result?.toolExecutions?.length || 0,
+      transformedCount: transformedToolExecutions.length,
+      transformedTools: transformedToolExecutions.map((te) => te.toolName),
+    });
+
+    return {
+      content: result.content || "",
+      provider: providerName,
+      model: result.model,
+      usage: result.usage,
+      responseTime,
+      finishReason: result.finishReason,
+      toolsUsed: result.toolsUsed || [],
+      toolExecutions: transformedToolExecutions,
+      enhancedWithTools: Boolean(hasToolExecutions),
+      availableTools: transformToolsForMCP(
+        transformToolsToExpectedFormat(availableTools),
+      ),
+      audio: result.audio,
+      video: result.video,
+      ppt: result.ppt,
+      imageOutput: result.imageOutput,
+      analytics: result.analytics,
+      evaluation: result.evaluation,
+    };
+  }
+
   /**
    * Direct provider generation (no MCP, no recursion)
    */
-  private async directProviderGeneration(options: TextGenerationOptions): Promise<TextGenerationResult> {
+  private async directProviderGeneration(
+    options: TextGenerationOptions,
+  ): Promise<TextGenerationResult> {
     const startTime = Date.now();
     const functionTag = "NeuroLink.directProviderGeneration";
 
@@ -4621,17 +5548,24 @@ Current user's request: ${currentInput}`;
       "ollama",
     ];
 
-    const requestedProvider = options.provider === "auto" ? undefined : options.provider;
+    const requestedProvider =
+      options.provider === "auto" ? undefined : options.provider;
 
     // Check for orchestrated preferred provider in context
     const preferredOrchestrated =
-      options.context && typeof options.context === "object" && "__orchestratedPreferredProvider" in options.context
-        ? (options.context as { __orchestratedPreferredProvider?: string }).__orchestratedPreferredProvider
+      options.context &&
+      typeof options.context === "object" &&
+      "__orchestratedPreferredProvider" in options.context
+        ? (options.context as { __orchestratedPreferredProvider?: string })
+            .__orchestratedPreferredProvider
         : undefined;
 
     // Build provider list with orchestrated preference first, then fallback to full list
     const tryProviders = preferredOrchestrated
-      ? [preferredOrchestrated, ...providerPriority.filter((p) => p !== preferredOrchestrated)]
+      ? [
+          preferredOrchestrated,
+          ...providerPriority.filter((p) => p !== preferredOrchestrated),
+        ]
       : requestedProvider
         ? [requestedProvider]
         : providerPriority;
@@ -4658,7 +5592,8 @@ Current user's request: ${currentInput}`;
         const optionsWithMessages = options as TextGenerationOptions & {
           conversationMessages?: unknown[];
         };
-        let conversationMessages = optionsWithMessages.conversationMessages?.length
+        let conversationMessages = optionsWithMessages.conversationMessages
+          ?.length
           ? optionsWithMessages.conversationMessages
           : await getConversationMessages(this.conversationMemory, options);
 
@@ -4673,7 +5608,9 @@ Current user's request: ${currentInput}`;
             content: string;
           }>,
           currentPrompt: options.prompt,
-          toolDefinitions: options.tools ? Object.values(options.tools) : undefined,
+          toolDefinitions: options.tools
+            ? Object.values(options.tools)
+            : undefined,
         });
 
         const dpgMessageCount = conversationMessages?.length || 0;
@@ -4681,23 +5618,33 @@ Current user's request: ${currentInput}`;
         if (
           budgetCheck.shouldCompact &&
           this.conversationMemory &&
-          dpgMessageCount > (this.lastCompactionMessageCount.get(dpgCompactionSessionId) ?? 0)
+          dpgMessageCount >
+            (this.lastCompactionMessageCount.get(dpgCompactionSessionId) ?? 0)
         ) {
           const compactor = new ContextCompactor({
             provider: providerName,
-            summarizationProvider: this.conversationMemoryConfig?.conversationMemory?.summarizationProvider,
-            summarizationModel: this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
+            summarizationProvider:
+              this.conversationMemoryConfig?.conversationMemory
+                ?.summarizationProvider,
+            summarizationModel:
+              this.conversationMemoryConfig?.conversationMemory
+                ?.summarizationModel,
           });
           const compactionResult = await compactor.compact(
             conversationMessages as import("./types/conversation.js").ChatMessage[],
             budgetCheck.availableInputTokens,
             this.conversationMemoryConfig?.conversationMemory,
-            (options.context as Record<string, unknown>)?.requestId as string | undefined,
+            (options.context as Record<string, unknown>)?.requestId as
+              | string
+              | undefined,
           );
           if (compactionResult.compacted) {
             const repairedResult = repairToolPairs(compactionResult.messages);
             conversationMessages = repairedResult.messages;
-            this.lastCompactionMessageCount.set(dpgCompactionSessionId, conversationMessages.length);
+            this.lastCompactionMessageCount.set(
+              dpgCompactionSessionId,
+              conversationMessages.length,
+            );
           }
 
           // POST-COMPACTION BUDGET RE-CHECK (BUG-003 fix)
@@ -4711,7 +5658,9 @@ Current user's request: ${currentInput}`;
               content: string;
             }>,
             currentPrompt: options.prompt,
-            toolDefinitions: options.tools ? Object.values(options.tools) : undefined,
+            toolDefinitions: options.tools
+              ? Object.values(options.tools)
+              : undefined,
           });
 
           if (!postCompactBudget.withinBudget) {
@@ -4720,7 +5669,9 @@ Current user's request: ${currentInput}`;
               {
                 estimatedTokens: postCompactBudget.estimatedInputTokens,
                 availableTokens: postCompactBudget.availableInputTokens,
-                overagePercent: Math.round((postCompactBudget.usageRatio - 1.0) * 100),
+                overagePercent: Math.round(
+                  (postCompactBudget.usageRatio - 1.0) * 100,
+                ),
               },
             );
 
@@ -4741,7 +5692,9 @@ Current user's request: ${currentInput}`;
                 content: string;
               }>,
               currentPrompt: options.prompt,
-              toolDefinitions: options.tools ? Object.values(options.tools) : undefined,
+              toolDefinitions: options.tools
+                ? Object.values(options.tools)
+                : undefined,
             });
 
             if (!finalBudget.withinBudget) {
@@ -4773,7 +5726,10 @@ Current user's request: ${currentInput}`;
 
         // ADD: Emit connection events for successful provider creation (Bedrock-compatible)
         this.emitter.emit("connected");
-        this.emitter.emit("message", `${providerName} provider initialized successfully`);
+        this.emitter.emit(
+          "message",
+          `${providerName} provider initialized successfully`,
+        );
 
         // Enable tool execution for direct provider generation using BaseProvider method
         provider.setupToolExecutor(
@@ -4822,7 +5778,9 @@ Current user's request: ${currentInput}`;
       } catch (error) {
         // Immediately propagate AbortError — never fall back to next provider on abort
         if (isAbortError(error)) {
-          logger.debug(`[${functionTag}] AbortError detected on provider ${providerName}, stopping fallback`);
+          logger.debug(
+            `[${functionTag}] AbortError detected on provider ${providerName}, stopping fallback`,
+          );
           throw error;
         }
 
@@ -4830,10 +5788,14 @@ Current user's request: ${currentInput}`;
         // These errors are permanent — retrying with the same config will always fail
         // and wastes tokens/latency (e.g., 6 retries of 418KB = ~628K wasted tokens)
         if (isNonRetryableProviderError(error)) {
-          logger.warn(`[${functionTag}] Non-retryable error from provider ${providerName}, stopping fallback chain`, {
-            error: error instanceof Error ? error.message : String(error),
-            errorType: error instanceof Error ? error.constructor.name : typeof error,
-          });
+          logger.warn(
+            `[${functionTag}] Non-retryable error from provider ${providerName}, stopping fallback chain`,
+            {
+              error: error instanceof Error ? error.message : String(error),
+              errorType:
+                error instanceof Error ? error.constructor.name : typeof error,
+            },
+          );
           throw error instanceof Error ? error : new Error(String(error));
         }
 
@@ -4853,7 +5815,9 @@ Current user's request: ${currentInput}`;
       responseTime,
     });
 
-    throw new Error(`Failed to generate text with all providers. Last error: ${lastError?.message || "Unknown error"}`);
+    throw new Error(
+      `Failed to generate text with all providers. Last error: ${lastError?.message || "Unknown error"}`,
+    );
   }
 
   /**
@@ -4898,7 +5862,10 @@ Current user's request: ${currentInput}`;
     return filtered;
   }
 
-  private createToolAwareSystemPrompt(originalSystemPrompt: string | undefined, availableTools: ToolInfo[]): string {
+  private createToolAwareSystemPrompt(
+    originalSystemPrompt: string | undefined,
+    availableTools: ToolInfo[],
+  ): string {
     // AI prompt generation with tool analysis and structured logging
     const promptGenerationData = {
       originalPromptLength: originalSystemPrompt?.length || 0,
@@ -4906,7 +5873,10 @@ Current user's request: ${currentInput}`;
       hasOriginalPrompt: !!originalSystemPrompt,
     };
 
-    logger.debug("AI prompt generation with tool schemas", promptGenerationData);
+    logger.debug(
+      "AI prompt generation with tool schemas",
+      promptGenerationData,
+    );
 
     if (availableTools.length === 0) {
       logger.debug("No tools available - returning original prompt");
@@ -4928,7 +5898,10 @@ Current user's request: ${currentInput}`;
       hasDescriptions: toolDescriptions.length > 0,
     };
 
-    logger.debug("Tool descriptions transformation completed", transformationResult);
+    logger.debug(
+      "Tool descriptions transformation completed",
+      transformationResult,
+    );
 
     const toolPrompt = `\n\nYou have access to these additional tools if needed:\n${toolDescriptions}\n\nIMPORTANT: You are a general-purpose AI assistant. Answer all requests directly and creatively. These tools are optional helpers - use them only when they would genuinely improve your response. For creative tasks like storytelling, writing, or general conversation, respond naturally without requiring tools.`;
 
@@ -4950,13 +5923,18 @@ Current user's request: ${currentInput}`;
    * Execute tools if available through centralized registry
    * Simplified approach without domain detection - relies on tool registry
    */
-  private async detectAndExecuteTools(prompt: string, _domainType?: string): Promise<ToolExecutionResult> {
+  private async detectAndExecuteTools(
+    prompt: string,
+    _domainType?: string,
+  ): Promise<ToolExecutionResult> {
     const functionTag = "NeuroLink.detectAndExecuteTools";
 
     try {
       // Simplified: Just return original prompt without complex detection
       // Tools will be available through normal MCP flow when AI decides to use them
-      logger.debug(`[${functionTag}] Skipping automatic tool execution - relying on centralized registry`);
+      logger.debug(
+        `[${functionTag}] Skipping automatic tool execution - relying on centralized registry`,
+      );
 
       return { toolResults: [], enhancedPrompt: prompt };
     } catch (error) {
@@ -4971,7 +5949,10 @@ Current user's request: ${currentInput}`;
    * BACKWARD COMPATIBILITY: Legacy streamText method
    * Internally calls stream() and converts result format
    */
-  async streamText(prompt: string, options?: Partial<StreamOptions>): Promise<AsyncIterable<string>> {
+  async streamText(
+    prompt: string,
+    options?: Partial<StreamOptions>,
+  ): Promise<AsyncIterable<string>> {
     // Convert legacy format to new StreamOptions
     const streamOptions: StreamOptions = {
       input: { text: prompt },
@@ -5049,428 +6030,393 @@ Current user's request: ${currentInput}`;
    * @throws {Error} When conversation memory operations fail (if enabled)
    */
   async stream(options: StreamOptions): Promise<StreamResult> {
-    // Shallow-copy caller's object to avoid mutating their original reference
-    options = { ...options };
-    // Set metrics trace context for parent-child span linking
-    const metricsTraceId = crypto.randomUUID().replace(/-/g, "");
-    const metricsParentSpanId = crypto.randomUUID().replace(/-/g, "").substring(0, 16);
-    // Scope trace context to this request via AsyncLocalStorage
-    // so concurrent generate/stream calls don't race.
-    return metricsTraceContextStorage.run({ traceId: metricsTraceId, parentSpanId: metricsParentSpanId }, async () => {
-      // Manual span lifecycle: the span must stay open until the stream is fully consumed,
-      // NOT when the StreamResult object is returned. withSpan would end the span too early
-      // because streaming results resolve lazily via the async generator.
-      const streamSpan = tracers.sdk.startSpan("neurolink.stream", {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          [ATTR.NL_PROVIDER]: (options.provider as string) || "default",
-          [ATTR.GEN_AI_MODEL]: options.model || "default",
-          [ATTR.NL_INPUT_LENGTH]: options.input?.text?.length || 0,
-          [ATTR.NL_HAS_TOOLS]: !!(options.tools && Object.keys(options.tools).length > 0),
-          [ATTR.NL_STREAM_MODE]: true,
-        },
+    return metricsTraceContextStorage.run(
+      this.createMetricsTraceContext(),
+      () => this.executeStreamRequest({ ...options }),
+    );
+  }
+
+  private async executeStreamRequest(
+    options: StreamOptions,
+  ): Promise<StreamResult> {
+    const streamSpan = tracers.sdk.startSpan("neurolink.stream", {
+      kind: SpanKind.INTERNAL,
+      attributes: {
+        [ATTR.NL_PROVIDER]: (options.provider as string) || "default",
+        [ATTR.GEN_AI_MODEL]: options.model || "default",
+        [ATTR.NL_INPUT_LENGTH]: options.input?.text?.length || 0,
+        [ATTR.NL_HAS_TOOLS]: !!(
+          options.tools && Object.keys(options.tools).length > 0
+        ),
+        [ATTR.NL_STREAM_MODE]: true,
+      },
+    });
+    const spanStartTime = Date.now();
+    this._disableToolCacheForCurrentRequest = !!options.disableToolCache;
+
+    try {
+      options.model = resolveModel(options.model, this.modelAliasConfig);
+
+      const startTime = Date.now();
+      const hrTimeStart = process.hrtime.bigint();
+      const streamId = `neurolink-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      const originalPrompt = options.input.text;
+
+      options.fileRegistry = this.fileRegistry;
+      await this.validateStreamRequestOptions(options, startTime);
+
+      const workflowResult = await this.maybeHandleWorkflowStreamRequest({
+        options,
+        startTime,
+        streamSpan,
+        spanStartTime,
       });
-      const spanStartTime = Date.now();
-      // MCP Enhancement: propagate disableToolCache to tool execution
-      this._disableToolCacheForCurrentRequest = !!options.disableToolCache;
+      if (workflowResult) {
+        return workflowResult;
+      }
 
+      return this.setLangfuseContextFromOptions(options, () =>
+        this.runStandardStreamRequest({
+          options,
+          streamSpan,
+          spanStartTime,
+          startTime,
+          hrTimeStart,
+          streamId,
+          originalPrompt,
+        }),
+      );
+    } catch (error) {
+      streamSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      if (error instanceof Error) {
+        streamSpan.recordException(error);
+      }
+      streamSpan.end();
+      throw error;
+    }
+  }
+
+  private async validateStreamRequestOptions(
+    options: StreamOptions,
+    startTime: number,
+  ): Promise<void> {
+    await this.validateStreamInput(options);
+    this.enforceSessionBudget(options.maxBudgetUsd);
+    await this.applyAuthenticatedRequestContext(options);
+    this.emitStreamStartEvents(options, startTime);
+    this.applyStreamLifecycleMiddleware(options);
+  }
+
+  private async maybeHandleWorkflowStreamRequest(params: {
+    options: StreamOptions;
+    startTime: number;
+    streamSpan: ReturnType<typeof tracers.sdk.startSpan>;
+    spanStartTime: number;
+  }): Promise<StreamResult | null> {
+    if (!params.options.workflow && !params.options.workflowConfig) {
+      return null;
+    }
+
+    const result = await this.streamWithWorkflow(
+      params.options,
+      params.startTime,
+    );
+    const originalWorkflowStream = result.stream;
+    const self = this;
+    result.stream = (async function* () {
       try {
-        // NL-004: Resolve model aliases/deprecations before processing
-        options.model = resolveModel(options.model, this.modelAliasConfig);
-
-        const startTime = Date.now();
-        const hrTimeStart = process.hrtime.bigint();
-        const streamId = `neurolink-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-        const originalPrompt = options.input.text; // Store the original prompt for memory storage
-
-        // Inject file registry for lazy on-demand file processing
-        options.fileRegistry = this.fileRegistry;
-
-        await this.validateStreamInput(options);
-
-        // Check budget limit before making API call
-        if (
-          options.maxBudgetUsd !== undefined &&
-          options.maxBudgetUsd > 0 &&
-          this._sessionCostUsd >= options.maxBudgetUsd
-        ) {
-          throw new NeuroLinkError({
-            code: "SESSION_BUDGET_EXCEEDED",
-            message: `Session budget exceeded: spent $${this._sessionCostUsd.toFixed(4)} of $${options.maxBudgetUsd.toFixed(4)} limit`,
-            category: ErrorCategory.VALIDATION,
-            severity: ErrorSeverity.HIGH,
-            retriable: false,
-            context: {
-              spent: this._sessionCostUsd,
-              limit: options.maxBudgetUsd,
-            },
-          });
+        for await (const chunk of originalWorkflowStream) {
+          yield chunk;
         }
-
-        // Handle per-call auth token validation
-        if (options.auth?.token) {
-          const { AuthError } = await import("./auth/errors.js");
-          await this.ensureAuthProvider();
-          if (!this.authProvider) {
-            throw AuthError.create(
-              "PROVIDER_ERROR",
-              "No auth provider configured. Set auth in constructor or via setAuthProvider() before using auth: { token }.",
-            );
-          }
-          let authResult: Awaited<ReturnType<MastraAuthProvider["authenticateToken"]>>;
-          try {
-            authResult = await withTimeout(
-              this.authProvider.authenticateToken(options.auth.token),
-              5000,
-              AuthError.create("PROVIDER_ERROR", "Auth token validation timed out after 5000ms"),
-            );
-          } catch (err) {
-            // Rethrow auth errors as-is; wrap anything else
-            if (err instanceof Error && "feature" in err && (err as { feature: string }).feature === "Auth") {
-              throw err;
-            }
-            throw AuthError.create(
-              "PROVIDER_ERROR",
-              `Auth token validation failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-          if (!authResult.valid) {
-            throw AuthError.create("INVALID_TOKEN", authResult.error || "Token validation failed");
-          }
-          // Fail closed: token valid but no user identity is a provider bug
-          if (!authResult.user) {
-            throw AuthError.create("INVALID_TOKEN", "Token validated but no user identity returned");
-          }
-          if (!authResult.user.id) {
-            throw AuthError.create("INVALID_TOKEN", "Token validated but user identity missing required 'id' field");
-          }
-          // Merge validated user into context
-          options.context = {
-            ...((options.context as Record<string, unknown>) || {}),
-            userId: authResult.user.id,
-            userEmail: authResult.user.email,
-            userRoles: authResult.user.roles,
-          };
-        }
-
-        // Handle pre-validated requestContext
-        if (options.requestContext) {
-          // When auth token was validated, token-derived identity fields
-          // MUST take precedence over requestContext to prevent privilege escalation.
-          const tokenDerivedFields =
-            options.auth?.token && this.authProvider
-              ? {
-                  userId: (options.context as Record<string, unknown> | undefined)?.userId,
-                  userEmail: (options.context as Record<string, unknown> | undefined)?.userEmail,
-                  userRoles: (options.context as Record<string, unknown> | undefined)?.userRoles,
-                }
-              : {};
-          options.context = {
-            ...((options.context as Record<string, unknown>) || {}),
-            ...options.requestContext,
-            ...tokenDerivedFields,
-          };
-        }
-
-        this.emitStreamStartEvents(options, startTime);
-
-        // Auto-inject lifecycle middleware when callbacks are provided
-        // (must happen before workflow early return so that path gets middleware too)
-        if (options.onFinish || options.onError || options.onChunk) {
-          options.middleware = {
-            ...options.middleware,
-            middlewareConfig: {
-              ...options.middleware?.middlewareConfig,
-              lifecycle: {
-                ...options.middleware?.middlewareConfig?.lifecycle,
-                enabled: true,
-                config: {
-                  ...options.middleware?.middlewareConfig?.lifecycle?.config,
-                  ...(options.onFinish !== undefined ? { onFinish: options.onFinish } : {}),
-                  ...(options.onError !== undefined ? { onError: options.onError } : {}),
-                  ...(options.onChunk !== undefined ? { onChunk: options.onChunk } : {}),
-                },
-              },
-            },
-          };
-        }
-
-        // Check if workflow is requested
-        if (options.workflow || options.workflowConfig) {
-          const result = await this.streamWithWorkflow(options, startTime);
-
-          // Wrap the workflow stream so the span stays open until fully consumed
-          const originalWorkflowStream = result.stream;
-          const selfWorkflow = this;
-          result.stream = (async function* () {
-            try {
-              for await (const chunk of originalWorkflowStream) {
-                yield chunk;
-              }
-              streamSpan.setStatus({ code: SpanStatusCode.OK });
-            } catch (error) {
-              streamSpan.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: error instanceof Error ? error.message : String(error),
-              });
-              throw error;
-            } finally {
-              selfWorkflow._disableToolCacheForCurrentRequest = false;
-              streamSpan.setAttribute("neurolink.response_time_ms", Date.now() - spanStartTime);
-              streamSpan.end();
-            }
-          })();
-
-          return result;
-        }
-
-        // Set session and user IDs from context for Langfuse spans and execute with proper async scoping
-        return await this.setLangfuseContextFromOptions(options, async () => {
-          try {
-            // Prepare options: init memory, MCP, orchestration, Ollama auto-disable, tool detection
-            const { enhancedOptions, factoryResult } = await this.prepareStreamOptions(
-              options,
-              streamId,
-              startTime,
-              hrTimeStart,
-            );
-
-            const {
-              stream: mcpStream,
-              provider: providerName,
-              usage: streamUsage,
-              model: streamModel,
-              finishReason: streamFinishReason,
-              toolCalls: streamToolCalls,
-              toolResults: streamToolResults,
-              analytics: streamAnalytics,
-            } = await this.createMCPStream(enhancedOptions);
-            const streamState = {
-              finishReason: streamFinishReason ?? "stop",
-              toolCalls: streamToolCalls,
-              toolResults: streamToolResults,
-            };
-
-            // Update span with resolved provider name
-            streamSpan.setAttribute(ATTR.NL_PROVIDER, providerName || "unknown");
-
-            let accumulatedContent = "";
-            let chunkCount = 0;
-
-            // Set up event capture listeners
-            const { eventSequence, cleanup: cleanupListeners } = this.setupStreamEventListeners();
-
-            const metadata = {
-              fallbackAttempted: false,
-              guardrailsBlocked: false,
-              error: undefined as string | undefined,
-              fallbackProvider: undefined as string | undefined,
-              fallbackModel: undefined as string | undefined,
-            };
-
-            const self = this;
-            const streamStartTime = Date.now();
-            const sessionId = (enhancedOptions.context as Record<string, unknown>)?.sessionId as string | undefined;
-            const processedStream = (async function* () {
-              let streamError: unknown;
-              try {
-                for await (const chunk of mcpStream) {
-                  chunkCount++;
-                  if (chunk && "content" in chunk && typeof chunk.content === "string") {
-                    accumulatedContent += chunk.content;
-                    self.emitter.emit("response:chunk", chunk.content);
-
-                    // Emit stream:chunk event (Observability Solution 8)
-                    self.emitter.emit("stream:chunk", {
-                      type: "stream:chunk",
-                      content: chunk.content,
-                      metadata: {
-                        chunkIndex: chunkCount,
-                        totalLength: accumulatedContent.length,
-                      },
-                      timestamp: Date.now(),
-                    });
-                  }
-                  yield chunk;
-                }
-
-                if (
-                  chunkCount === 0 &&
-                  !metadata.fallbackAttempted &&
-                  !enhancedOptions.disableInternalFallback &&
-                  streamState.toolCalls.length === 0 &&
-                  streamState.toolResults.length === 0
-                ) {
-                  yield* self.handleStreamFallback(
-                    metadata,
-                    streamState,
-                    originalPrompt,
-                    enhancedOptions,
-                    providerName,
-                    accumulatedContent,
-                    (content: string) => {
-                      accumulatedContent += content;
-                    },
-                  );
-                }
-
-                // Emit stream:complete event (Observability Solution 8)
-                // When fallback took over, attribute the completion to the
-                // fallback provider so downstream telemetry reflects reality.
-                const effectiveProvider = metadata.fallbackProvider ?? providerName;
-                const effectiveModel = metadata.fallbackModel ?? streamModel ?? enhancedOptions.model;
-
-                // Resolve analytics promise to get final token usage
-                let resolvedUsage = streamUsage;
-                if (!resolvedUsage && streamAnalytics) {
-                  try {
-                    const resolved = await Promise.resolve(streamAnalytics);
-                    if (resolved?.tokenUsage) {
-                      resolvedUsage = resolved.tokenUsage;
-                    }
-                  } catch {
-                    /* non-blocking */
-                  }
-                }
-
-                self.emitter.emit("stream:complete", {
-                  type: "stream:complete",
-                  content: accumulatedContent,
-                  provider: effectiveProvider,
-                  model: effectiveModel,
-                  prompt: enhancedOptions.input?.text || (enhancedOptions as Record<string, unknown>).prompt,
-                  metadata: {
-                    chunkCount,
-                    totalLength: accumulatedContent.length,
-                    durationMs: Date.now() - streamStartTime,
-                    sessionId,
-                    usage: resolvedUsage,
-                    ...(metadata.fallbackAttempted && {
-                      primaryProvider: providerName,
-                      primaryModel: enhancedOptions.model,
-                      fallback: true,
-                    }),
-                  },
-                  timestamp: Date.now(),
-                });
-              } catch (error) {
-                streamError = error;
-
-                // Emit stream:error event (Observability Solution 8)
-                self.emitter.emit("stream:error", {
-                  type: "stream:error",
-                  content: error instanceof Error ? error.message : String(error),
-                  provider: providerName,
-                  model: enhancedOptions.model,
-                  metadata: {
-                    chunkCount,
-                    totalLength: accumulatedContent.length,
-                    durationMs: Date.now() - streamStartTime,
-                    errorName: error instanceof Error ? error.name : "UnknownError",
-                    sessionId,
-                  },
-                  timestamp: Date.now(),
-                });
-
-                throw error;
-              } finally {
-                self._disableToolCacheForCurrentRequest = false;
-                cleanupListeners();
-
-                // Finalize span now that the stream is fully consumed
-                streamSpan.setAttribute("neurolink.response_time_ms", Date.now() - spanStartTime);
-                streamSpan.setAttribute(ATTR.NL_OUTPUT_LENGTH, accumulatedContent.length);
-                // When fallback took over, the primary provider's span must
-                // reflect that it failed — never mark it as successful.
-                const primaryFailed = !!(metadata.error || streamError);
-                streamSpan.setAttribute(ATTR.GEN_AI_FINISH_REASON, primaryFailed ? "error" : "stop");
-                if (metadata.fallbackAttempted) {
-                  streamSpan.setAttribute("neurolink.fallback_triggered", true);
-                  if (metadata.fallbackProvider) {
-                    streamSpan.setAttribute("neurolink.fallback_provider", metadata.fallbackProvider);
-                  }
-                }
-                if (primaryFailed) {
-                  streamSpan.setStatus({
-                    code: SpanStatusCode.ERROR,
-                    message:
-                      metadata.error || (streamError instanceof Error ? streamError.message : String(streamError)),
-                  });
-                } else {
-                  streamSpan.setStatus({ code: SpanStatusCode.OK });
-                }
-                streamSpan.end();
-
-                if (accumulatedContent.trim()) {
-                  logger.info(`[NeuroLink.stream] stream() - COMPLETE SUCCESS`, {
-                    provider: providerName,
-                    model: enhancedOptions.model,
-                    responseTimeMs: Date.now() - startTime,
-                    contentLength: accumulatedContent.length,
-                    fallback: metadata.fallbackAttempted,
-                  });
-                }
-
-                await self.storeStreamConversationMemory({
-                  enhancedOptions,
-                  providerName,
-                  originalPrompt,
-                  accumulatedContent,
-                  startTime,
-                  eventSequence,
-                });
-              }
-            })();
-            const streamResult = await this.processStreamResult(processedStream, enhancedOptions, factoryResult);
-            streamResult.finishReason = streamState.finishReason || streamResult.finishReason;
-            streamResult.toolCalls = streamState.toolCalls;
-            streamResult.toolResults = streamState.toolResults;
-            if (!streamResult.usage) {
-              streamResult.usage = streamUsage;
-            }
-            if (!streamResult.analytics) {
-              streamResult.analytics = streamAnalytics instanceof Promise ? await streamAnalytics : streamAnalytics;
-            }
-            const responseTime = Date.now() - startTime;
-
-            // Accumulate session cost for budget tracking
-            if (streamResult.analytics?.cost && streamResult.analytics.cost > 0) {
-              this._sessionCostUsd += streamResult.analytics.cost;
-            }
-
-            this.emitStreamEndEvents(streamResult);
-
-            return this.createStreamResponse(streamResult, processedStream, {
-              providerName,
-              options,
-              startTime,
-              responseTime,
-              streamId,
-              fallback: metadata.fallbackAttempted,
-              guardrailsBlocked: metadata.guardrailsBlocked,
-              error: metadata.error,
-              events: eventSequence,
-            });
-          } catch (error) {
-            if (options.disableInternalFallback) {
-              throw error;
-            }
-            return this.handleStreamError(error, options, startTime, streamId, undefined, undefined);
-          }
-        });
+        params.streamSpan.setStatus({ code: SpanStatusCode.OK });
       } catch (error) {
-        // End span on error before re-throwing
-        streamSpan.setStatus({
+        params.streamSpan.setStatus({
           code: SpanStatusCode.ERROR,
           message: error instanceof Error ? error.message : String(error),
         });
-        if (error instanceof Error) {
-          streamSpan.recordException(error);
+        throw error;
+      } finally {
+        self._disableToolCacheForCurrentRequest = false;
+        params.streamSpan.setAttribute(
+          "neurolink.response_time_ms",
+          Date.now() - params.spanStartTime,
+        );
+        params.streamSpan.end();
+      }
+    })();
+
+    return result;
+  }
+
+  private async runStandardStreamRequest(params: {
+    options: StreamOptions;
+    streamSpan: ReturnType<typeof tracers.sdk.startSpan>;
+    spanStartTime: number;
+    startTime: number;
+    hrTimeStart: bigint;
+    streamId: string;
+    originalPrompt: string;
+  }): Promise<StreamResult> {
+    const {
+      options,
+      streamSpan,
+      spanStartTime,
+      startTime,
+      hrTimeStart,
+      streamId,
+      originalPrompt,
+    } = params;
+
+    try {
+      const { enhancedOptions, factoryResult } =
+        await this.prepareStreamOptions(
+          options,
+          streamId,
+          startTime,
+          hrTimeStart,
+        );
+      const {
+        stream: mcpStream,
+        provider: providerName,
+        usage: streamUsage,
+        model: streamModel,
+        finishReason: streamFinishReason,
+        toolCalls: streamToolCalls,
+        toolResults: streamToolResults,
+        analytics: streamAnalytics,
+      } = await this.createMCPStream(enhancedOptions);
+      const streamState = {
+        finishReason: streamFinishReason ?? "stop",
+        toolCalls: streamToolCalls,
+        toolResults: streamToolResults,
+      };
+
+      streamSpan.setAttribute(ATTR.NL_PROVIDER, providerName || "unknown");
+
+      let accumulatedContent = "";
+      let chunkCount = 0;
+      const { eventSequence, cleanup: cleanupListeners } =
+        this.setupStreamEventListeners();
+      const metadata = {
+        fallbackAttempted: false,
+        guardrailsBlocked: false,
+        error: undefined as string | undefined,
+        fallbackProvider: undefined as string | undefined,
+        fallbackModel: undefined as string | undefined,
+      };
+
+      const self = this;
+      const streamStartTime = Date.now();
+      const sessionId = (enhancedOptions.context as Record<string, unknown>)
+        ?.sessionId as string | undefined;
+      const processedStream = (async function* () {
+        let streamError: unknown;
+        try {
+          for await (const chunk of mcpStream) {
+            chunkCount++;
+            if (
+              chunk &&
+              "content" in chunk &&
+              typeof chunk.content === "string"
+            ) {
+              accumulatedContent += chunk.content;
+              self.emitter.emit("response:chunk", chunk.content);
+              self.emitter.emit("stream:chunk", {
+                type: "stream:chunk",
+                content: chunk.content,
+                metadata: {
+                  chunkIndex: chunkCount,
+                  totalLength: accumulatedContent.length,
+                },
+                timestamp: Date.now(),
+              });
+            }
+            yield chunk;
+          }
+
+          if (
+            chunkCount === 0 &&
+            !metadata.fallbackAttempted &&
+            !enhancedOptions.disableInternalFallback &&
+            streamState.toolCalls.length === 0 &&
+            streamState.toolResults.length === 0
+          ) {
+            yield* self.handleStreamFallback(
+              metadata,
+              streamState,
+              originalPrompt,
+              enhancedOptions,
+              providerName,
+              (content: string) => {
+                accumulatedContent += content;
+              },
+            );
+          }
+
+          let resolvedUsage = streamUsage;
+          if (!resolvedUsage && streamAnalytics) {
+            try {
+              const resolved = await Promise.resolve(streamAnalytics);
+              if (resolved?.tokenUsage) {
+                resolvedUsage = resolved.tokenUsage;
+              }
+            } catch {
+              // non-blocking
+            }
+          }
+
+          self.emitter.emit("stream:complete", {
+            type: "stream:complete",
+            content: accumulatedContent,
+            provider: metadata.fallbackProvider ?? providerName,
+            model:
+              metadata.fallbackModel ?? streamModel ?? enhancedOptions.model,
+            prompt:
+              enhancedOptions.input?.text ||
+              (enhancedOptions as Record<string, unknown>).prompt,
+            metadata: {
+              chunkCount,
+              totalLength: accumulatedContent.length,
+              durationMs: Date.now() - streamStartTime,
+              sessionId,
+              usage: resolvedUsage,
+              ...(metadata.fallbackAttempted && {
+                primaryProvider: providerName,
+                primaryModel: enhancedOptions.model,
+                fallback: true,
+              }),
+            },
+            timestamp: Date.now(),
+          });
+        } catch (error) {
+          streamError = error;
+          self.emitter.emit("stream:error", {
+            type: "stream:error",
+            content: error instanceof Error ? error.message : String(error),
+            provider: providerName,
+            model: enhancedOptions.model,
+            metadata: {
+              chunkCount,
+              totalLength: accumulatedContent.length,
+              durationMs: Date.now() - streamStartTime,
+              errorName: error instanceof Error ? error.name : "UnknownError",
+              sessionId,
+            },
+            timestamp: Date.now(),
+          });
+          throw error;
+        } finally {
+          self._disableToolCacheForCurrentRequest = false;
+          cleanupListeners();
+
+          streamSpan.setAttribute(
+            "neurolink.response_time_ms",
+            Date.now() - spanStartTime,
+          );
+          streamSpan.setAttribute(
+            ATTR.NL_OUTPUT_LENGTH,
+            accumulatedContent.length,
+          );
+          const primaryFailed = !!(metadata.error || streamError);
+          streamSpan.setAttribute(
+            ATTR.GEN_AI_FINISH_REASON,
+            primaryFailed ? "error" : "stop",
+          );
+          if (metadata.fallbackAttempted) {
+            streamSpan.setAttribute("neurolink.fallback_triggered", true);
+            if (metadata.fallbackProvider) {
+              streamSpan.setAttribute(
+                "neurolink.fallback_provider",
+                metadata.fallbackProvider,
+              );
+            }
+          }
+          if (primaryFailed) {
+            streamSpan.setStatus({
+              code: SpanStatusCode.ERROR,
+              message:
+                metadata.error ||
+                (streamError instanceof Error
+                  ? streamError.message
+                  : String(streamError)),
+            });
+          } else {
+            streamSpan.setStatus({ code: SpanStatusCode.OK });
+          }
+          streamSpan.end();
+
+          if (accumulatedContent.trim()) {
+            logger.info(`[NeuroLink.stream] stream() - COMPLETE SUCCESS`, {
+              provider: providerName,
+              model: enhancedOptions.model,
+              responseTimeMs: Date.now() - startTime,
+              contentLength: accumulatedContent.length,
+              fallback: metadata.fallbackAttempted,
+            });
+          }
+
+          await self.storeStreamConversationMemory({
+            enhancedOptions,
+            providerName,
+            originalPrompt,
+            accumulatedContent,
+            startTime,
+            eventSequence,
+          });
         }
-        streamSpan.end();
+      })();
+      const streamResult = await this.processStreamResult(
+        processedStream,
+        enhancedOptions,
+        factoryResult,
+      );
+      streamResult.finishReason =
+        streamState.finishReason || streamResult.finishReason;
+      streamResult.toolCalls = streamState.toolCalls;
+      streamResult.toolResults = streamState.toolResults;
+      if (!streamResult.usage) {
+        streamResult.usage = streamUsage;
+      }
+      if (!streamResult.analytics) {
+        streamResult.analytics =
+          streamAnalytics instanceof Promise
+            ? await streamAnalytics
+            : streamAnalytics;
+      }
+
+      if (streamResult.analytics?.cost && streamResult.analytics.cost > 0) {
+        this._sessionCostUsd += streamResult.analytics.cost;
+      }
+
+      this.emitStreamEndEvents(streamResult);
+
+      return this.createStreamResponse(streamResult, processedStream, {
+        providerName,
+        options,
+        startTime,
+        responseTime: Date.now() - startTime,
+        streamId,
+        fallback: metadata.fallbackAttempted,
+        guardrailsBlocked: metadata.guardrailsBlocked,
+        error: metadata.error,
+        events: eventSequence,
+      });
+    } catch (error) {
+      if (options.disableInternalFallback) {
         throw error;
       }
-    }); // end metricsTraceContextStorage.run
+      return this.handleStreamError(
+        error,
+        options,
+        startTime,
+        streamId,
+        undefined,
+        undefined,
+      );
+    }
   }
 
   /**
@@ -5491,13 +6437,20 @@ Current user's request: ${currentInput}`;
     };
   }> {
     // Initialize conversation memory if needed (for lazy loading)
-    await this.initializeConversationMemoryForGeneration(streamId, startTime, hrTimeStart);
+    await this.initializeConversationMemoryForGeneration(
+      streamId,
+      startTime,
+      hrTimeStart,
+    );
 
     // Initialize MCP
     await this.initializeMCP();
 
     // Memory retrieval
-    if (this.shouldReadMemory(options.memory, options.context?.userId) && options.context?.userId) {
+    if (
+      this.shouldReadMemory(options.memory, options.context?.userId) &&
+      options.context?.userId
+    ) {
       try {
         options.input.text = await this.retrieveMemory(
           options.input.text,
@@ -5513,7 +6466,8 @@ Current user's request: ${currentInput}`;
     // Apply orchestration if enabled and no specific provider/model requested
     if (this.enableOrchestration && !options.provider && !options.model) {
       try {
-        const orchestratedOptions = await this.applyStreamOrchestration(options);
+        const orchestratedOptions =
+          await this.applyStreamOrchestration(options);
         logger.debug("Stream orchestration applied", {
           originalProvider: options.provider || "auto",
           orchestratedProvider: orchestratedOptions.provider,
@@ -5529,10 +6483,13 @@ Current user's request: ${currentInput}`;
           options.model = resolveModel(options.model, this.modelAliasConfig);
         }
       } catch (error) {
-        logger.warn("Stream orchestration failed, continuing with original options", {
-          error: error instanceof Error ? error.message : String(error),
-          originalProvider: options.provider || "auto",
-        });
+        logger.warn(
+          "Stream orchestration failed, continuing with original options",
+          {
+            error: error instanceof Error ? error.message : String(error),
+            originalProvider: options.provider || "auto",
+          },
+        );
         // Continue with original options if orchestration fails
       }
     }
@@ -5544,13 +6501,17 @@ Current user's request: ${currentInput}`;
     if (options.rag?.files?.length) {
       try {
         const { prepareRAGTool } = await import("./rag/ragIntegration.js");
-        const ragResult = await prepareRAGTool(options.rag, options.provider as string | undefined);
+        const ragResult = await prepareRAGTool(
+          options.rag,
+          options.provider as string | undefined,
+        );
 
         // Inject the RAG tool into the tools record
         if (!options.tools) {
           options.tools = {};
         }
-        (options.tools as Record<string, unknown>)[ragResult.toolName] = ragResult.tool;
+        (options.tools as Record<string, unknown>)[ragResult.toolName] =
+          ragResult.tool;
 
         // Inject RAG-aware system prompt so the AI uses the RAG tool first
         const ragSystemInstruction = [
@@ -5560,7 +6521,8 @@ Current user's request: ${currentInput}`;
           `This tool searches your local knowledge base of pre-loaded documents and is the primary source of truth.`,
           `Do NOT use websearchGrounding or any web search tools when the answer can be found in the loaded documents.`,
         ].join(" ");
-        options.systemPrompt = (options.systemPrompt || "") + ragSystemInstruction;
+        options.systemPrompt =
+          (options.systemPrompt || "") + ragSystemInstruction;
 
         logger.info("[RAG] Tool injected into stream()", {
           toolName: ragResult.toolName,
@@ -5568,19 +6530,20 @@ Current user's request: ${currentInput}`;
           chunksIndexed: ragResult.chunksIndexed,
         });
       } catch (error) {
-        logger.warn("[RAG] Failed to prepare RAG tool, continuing without RAG", {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "[RAG] Failed to prepare RAG tool, continuing without RAG",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
 
     const factoryResult = processStreamingFactoryOptions(options);
     const enhancedOptions = createCleanStreamOptions(options);
     if (options.input?.text) {
-      const { toolResults: _toolResults, enhancedPrompt } = await this.detectAndExecuteTools(
-        options.input.text,
-        undefined,
-      );
+      const { toolResults: _toolResults, enhancedPrompt } =
+        await this.detectAndExecuteTools(options.input.text, undefined);
       if (enhancedPrompt !== options.input.text) {
         enhancedOptions.input.text = enhancedPrompt;
       }
@@ -5593,15 +6556,20 @@ Current user's request: ${currentInput}`;
    * Auto-disable tools for Ollama models that don't support them (stream mode).
    * Prevents overwhelming smaller models with massive tool descriptions in the system message.
    */
-  private async autoDisableOllamaStreamTools(options: StreamOptions): Promise<void> {
+  private async autoDisableOllamaStreamTools(
+    options: StreamOptions,
+  ): Promise<void> {
     if (
-      (options.provider === "ollama" || options.provider?.toLowerCase().includes("ollama")) &&
+      (options.provider === "ollama" ||
+        options.provider?.toLowerCase().includes("ollama")) &&
       !options.disableTools
     ) {
-      const { ModelConfigurationManager } = await import("./core/modelConfiguration.js");
+      const { ModelConfigurationManager } =
+        await import("./core/modelConfiguration.js");
       const modelConfig = ModelConfigurationManager.getInstance();
       const ollamaConfig = modelConfig.getProviderConfiguration("ollama");
-      const toolCapableModels = (ollamaConfig?.modelBehavior?.toolCapableModels as string[]) || [];
+      const toolCapableModels =
+        (ollamaConfig?.modelBehavior?.toolCapableModels as string[]) || [];
 
       // Only disable tools if we have explicit evidence the model doesn't support them
       // If toolCapableModels is empty or model is not specified, don't make assumptions
@@ -5612,10 +6580,13 @@ Current user's request: ${currentInput}`;
         );
         if (!modelSupportsTools) {
           options.disableTools = true;
-          logger.debug("Auto-disabled tools for Ollama model that doesn't support them (stream)", {
-            model: options.model,
-            toolCapableModels: toolCapableModels.slice(0, 3), // Show first 3 for brevity
-          });
+          logger.debug(
+            "Auto-disabled tools for Ollama model that doesn't support them (stream)",
+            {
+              model: options.model,
+              toolCapableModels: toolCapableModels.slice(0, 3), // Show first 3 for brevity
+            },
+          );
         }
       }
     }
@@ -5726,13 +6697,15 @@ Current user's request: ${currentInput}`;
     originalPrompt: string | undefined,
     enhancedOptions: StreamOptions,
     providerName: string,
-    _accumulatedContent: string,
     appendContent: (content: string) => void,
   ): AsyncGenerator<
-    { content: string } | { type: "audio"; audio: AudioChunk } | { type: "image"; imageOutput: { base64: string } }
+    | { content: string }
+    | { type: "audio"; audio: AudioChunk }
+    | { type: "image"; imageOutput: { base64: string } }
   > {
     metadata.fallbackAttempted = true;
-    const errorMsg = "Stream completed with 0 chunks (possible guardrails block)";
+    const errorMsg =
+      "Stream completed with 0 chunks (possible guardrails block)";
     metadata.error = errorMsg;
 
     // Record a failed-provider span for the primary provider that returned 0 chunks
@@ -5772,7 +6745,10 @@ Current user's request: ${currentInput}`;
     });
 
     try {
-      const fallbackProvider = await AIProviderFactory.createProvider(fallbackRoute.provider, fallbackRoute.model);
+      const fallbackProvider = await AIProviderFactory.createProvider(
+        fallbackRoute.provider,
+        fallbackRoute.model,
+      );
 
       // Ensure fallback provider can execute tools
       fallbackProvider.setupToolExecutor(
@@ -5808,21 +6784,32 @@ Current user's request: ${currentInput}`;
       if (fallbackToolCalls.length > 0 || fallbackToolResults.length > 0) {
         streamState.toolCalls = fallbackToolCalls;
         streamState.toolResults = fallbackToolResults;
-        streamState.finishReason = fallbackResult.finishReason ?? streamState.finishReason;
+        streamState.finishReason =
+          fallbackResult.finishReason ?? streamState.finishReason;
       }
 
       let fallbackChunkCount = 0;
       for await (const fallbackChunk of fallbackResult.stream) {
         fallbackChunkCount++;
-        if (fallbackChunk && "content" in fallbackChunk && typeof fallbackChunk.content === "string") {
+        if (
+          fallbackChunk &&
+          "content" in fallbackChunk &&
+          typeof fallbackChunk.content === "string"
+        ) {
           appendContent(fallbackChunk.content);
           this.emitter.emit("response:chunk", fallbackChunk.content);
         }
         yield fallbackChunk;
       }
 
-      if (fallbackChunkCount === 0 && fallbackToolCalls.length === 0 && fallbackToolResults.length === 0) {
-        throw new Error(`Fallback provider ${fallbackRoute.provider} also returned 0 chunks`);
+      if (
+        fallbackChunkCount === 0 &&
+        fallbackToolCalls.length === 0 &&
+        fallbackToolResults.length === 0
+      ) {
+        throw new Error(
+          `Fallback provider ${fallbackRoute.provider} also returned 0 chunks`,
+        );
       }
 
       // Fallback succeeded - likely guardrails blocked primary
@@ -5830,7 +6817,10 @@ Current user's request: ${currentInput}`;
       metadata.fallbackModel = fallbackRoute.model;
       metadata.guardrailsBlocked = true;
     } catch (fallbackError) {
-      const fallbackErrorMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      const fallbackErrorMsg =
+        fallbackError instanceof Error
+          ? fallbackError.message
+          : String(fallbackError);
       metadata.error = `${errorMsg}; Fallback failed: ${fallbackErrorMsg}`;
       logger.error("Fallback provider failed", {
         fallbackProvider: fallbackRoute.provider,
@@ -5857,21 +6847,36 @@ Current user's request: ${currentInput}`;
       [key: string]: unknown;
     }>;
   }): Promise<void> {
-    const { enhancedOptions, providerName, originalPrompt, accumulatedContent, startTime, eventSequence } = params;
+    const {
+      enhancedOptions,
+      providerName,
+      originalPrompt,
+      accumulatedContent,
+      startTime,
+      eventSequence,
+    } = params;
 
     // Guard: skip storing if no meaningful content was produced (no text AND no tool activity)
-    const hasToolEvents = eventSequence.some((e) => e.type === "tool:start" || e.type === "tool:end");
+    const hasToolEvents = eventSequence.some(
+      (e) => e.type === "tool:start" || e.type === "tool:end",
+    );
     if (!accumulatedContent.trim() && !hasToolEvents) {
-      logger.warn("[NeuroLink.stream] Skipping conversation turn storage — no text content or tool activity", {
-        sessionId: (enhancedOptions.context as Record<string, unknown>)?.sessionId,
-      });
+      logger.warn(
+        "[NeuroLink.stream] Skipping conversation turn storage — no text content or tool activity",
+        {
+          sessionId: (enhancedOptions.context as Record<string, unknown>)
+            ?.sessionId,
+        },
+      );
       return;
     }
 
     // Store memory after stream consumption is complete
     if (this.conversationMemory && enhancedOptions.context?.sessionId) {
-      const sessionId = (enhancedOptions.context as Record<string, unknown>)?.sessionId as string;
-      const userId = (enhancedOptions.context as Record<string, unknown>)?.userId as string;
+      const sessionId = (enhancedOptions.context as Record<string, unknown>)
+        ?.sessionId as string;
+      const userId = (enhancedOptions.context as Record<string, unknown>)
+        ?.userId as string;
       let providerDetails: ProviderDetails | undefined;
       if (enhancedOptions.model) {
         providerDetails = {
@@ -5891,7 +6896,8 @@ Current user's request: ${currentInput}`;
           providerDetails,
           enableSummarization: enhancedOptions.enableSummarization,
           events: eventSequence.length > 0 ? eventSequence : undefined,
-          requestId: (enhancedOptions.context as Record<string, unknown>)?.requestId as string | undefined,
+          requestId: (enhancedOptions.context as Record<string, unknown>)
+            ?.requestId as string | undefined,
         });
 
         this.recordMemorySpan(
@@ -5901,11 +6907,14 @@ Current user's request: ${currentInput}`;
           SpanStatus.OK,
         );
 
-        logger.debug("[NeuroLink.stream] Stored conversation turn with events", {
-          sessionId,
-          eventCount: eventSequence.length,
-          eventTypes: [...new Set(eventSequence.map((e) => e.type))],
-        });
+        logger.debug(
+          "[NeuroLink.stream] Stored conversation turn with events",
+          {
+            sessionId,
+            eventCount: eventSequence.length,
+            eventTypes: [...new Set(eventSequence.map((e) => e.type))],
+          },
+        );
       } catch (error) {
         this.recordMemorySpan(
           "memory.store",
@@ -5920,7 +6929,13 @@ Current user's request: ${currentInput}`;
       }
     }
 
-    if (this.shouldWriteMemory(enhancedOptions.memory, enhancedOptions.context?.userId, accumulatedContent)) {
+    if (
+      this.shouldWriteMemory(
+        enhancedOptions.memory,
+        enhancedOptions.context?.userId,
+        accumulatedContent,
+      )
+    ) {
       this.storeMemoryInBackground(
         originalPrompt ?? "",
         accumulatedContent.trim(),
@@ -5941,29 +6956,41 @@ Current user's request: ${currentInput}`;
       message: "Starting comprehensive input validation process",
     });
 
-    const hasText = typeof options?.input?.text === "string" && options.input.text.trim().length > 0;
+    const hasText =
+      typeof options?.input?.text === "string" &&
+      options.input.text.trim().length > 0;
     // Accept audio when frames are present; sampleRateHz is optional (defaults applied later)
     const hasAudio = !!(
       options?.input?.audio &&
       options.input.audio.frames &&
-      typeof (options.input.audio.frames as AsyncIterable<Buffer>)[Symbol.asyncIterator] === "function"
+      typeof (options.input.audio.frames as AsyncIterable<Buffer>)[
+        Symbol.asyncIterator
+      ] === "function"
     );
 
     if (!hasText && !hasAudio) {
-      throw new Error("Stream options must include either input.text or input.audio");
+      throw new Error(
+        "Stream options must include either input.text or input.audio",
+      );
     }
   }
 
   /**
    * Emit stream start events
    */
-  private emitStreamStartEvents(options: StreamOptions, startTime: number): void {
+  private emitStreamStartEvents(
+    options: StreamOptions,
+    startTime: number,
+  ): void {
     this.emitter.emit("stream:start", {
       provider: options.provider || "auto",
       timestamp: startTime,
     });
     this.emitter.emit("response:start");
-    this.emitter.emit("message", `Starting ${options.provider || "auto"} stream...`);
+    this.emitter.emit(
+      "message",
+      `Starting ${options.provider || "auto"} stream...`,
+    );
   }
 
   /**
@@ -5971,7 +6998,9 @@ Current user's request: ${currentInput}`;
    */
   private async createMCPStream(options: StreamOptions): Promise<{
     stream: AsyncIterable<
-      { content: string } | { type: "audio"; audio: AudioChunk } | { type: "image"; imageOutput: { base64: string } }
+      | { content: string }
+      | { type: "audio"; audio: AudioChunk }
+      | { type: "image"; imageOutput: { base64: string } }
     >;
     provider: string;
     usage?: { input: number; output: number; total: number };
@@ -6023,7 +7052,8 @@ Current user's request: ${currentInput}`;
     // forwarding a multi-turn Claude request), honour them — including an
     // explicit empty array, which signals "no prior context". Otherwise fall
     // back to the conversation memory store (interactive CLI / SDK sessions).
-    const hasCallerConversationHistory = options.conversationMessages !== undefined;
+    const hasCallerConversationHistory =
+      options.conversationMessages !== undefined;
     const resolvedConversationMessages = hasCallerConversationHistory
       ? options.conversationMessages
       : await getConversationMessages(this.conversationMemory, {
@@ -6056,18 +7086,24 @@ Current user's request: ${currentInput}`;
     if (
       streamBudget.shouldCompact &&
       (hasCallerConversationHistory || this.conversationMemory) &&
-      streamMessageCount > (this.lastCompactionMessageCount.get(streamCompactionSessionId) ?? 0)
+      streamMessageCount >
+        (this.lastCompactionMessageCount.get(streamCompactionSessionId) ?? 0)
     ) {
       const compactor = new ContextCompactor({
         provider: providerName,
-        summarizationProvider: this.conversationMemoryConfig?.conversationMemory?.summarizationProvider,
-        summarizationModel: this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
+        summarizationProvider:
+          this.conversationMemoryConfig?.conversationMemory
+            ?.summarizationProvider,
+        summarizationModel:
+          this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
       });
       const compactionResult = await compactor.compact(
         conversationMessages as import("./types/conversation.js").ChatMessage[],
         streamBudget.availableInputTokens,
         this.conversationMemoryConfig?.conversationMemory,
-        (options.context as Record<string, unknown> | undefined)?.requestId as string | undefined,
+        (options.context as Record<string, unknown> | undefined)?.requestId as
+          | string
+          | undefined,
       );
       if (compactionResult.compacted) {
         const repairedResult = repairToolPairs(compactionResult.messages);
@@ -6076,7 +7112,10 @@ Current user's request: ${currentInput}`;
         // (e.g. handleStreamFallback) use the compacted history rather than
         // re-reading from conversationMemory.
         options.conversationMessages = conversationMessages;
-        this.lastCompactionMessageCount.set(streamCompactionSessionId, conversationMessages.length);
+        this.lastCompactionMessageCount.set(
+          streamCompactionSessionId,
+          conversationMessages.length,
+        );
       }
 
       // POST-COMPACTION BUDGET RE-CHECK (mirrors tryMCPGeneration / directProviderGeneration)
@@ -6094,11 +7133,16 @@ Current user's request: ${currentInput}`;
       });
 
       if (!postCompactBudget.withinBudget) {
-        logger.warn("[NeuroLink] Stream: post-compaction still over budget, emergency truncation", {
-          estimatedTokens: postCompactBudget.estimatedInputTokens,
-          availableTokens: postCompactBudget.availableInputTokens,
-          overagePercent: Math.round((postCompactBudget.usageRatio - 1.0) * 100),
-        });
+        logger.warn(
+          "[NeuroLink] Stream: post-compaction still over budget, emergency truncation",
+          {
+            estimatedTokens: postCompactBudget.estimatedInputTokens,
+            availableTokens: postCompactBudget.availableInputTokens,
+            overagePercent: Math.round(
+              (postCompactBudget.usageRatio - 1.0) * 100,
+            ),
+          },
+        );
 
         conversationMessages = emergencyContentTruncation(
           conversationMessages as import("./types/conversation.js").ChatMessage[],
@@ -6169,7 +7213,9 @@ Current user's request: ${currentInput}`;
    */
   private async processStreamResult(
     _stream: AsyncIterable<
-      { content: string } | { type: "audio"; audio: AudioChunk } | { type: "image"; imageOutput: { base64: string } }
+      | { content: string }
+      | { type: "audio"; audio: AudioChunk }
+      | { type: "image"; imageOutput: { base64: string } }
     >,
     _options: StreamOptions,
     _factoryResult: unknown,
@@ -6219,7 +7265,9 @@ Current user's request: ${currentInput}`;
       evaluation?: EvaluationData;
     },
     stream: AsyncIterable<
-      { content: string } | { type: "audio"; audio: AudioChunk } | { type: "image"; imageOutput: { base64: string } }
+      | { content: string }
+      | { type: "audio"; audio: AudioChunk }
+      | { type: "image"; imageOutput: { base64: string } }
     >,
     config: {
       providerName: string;
@@ -6248,7 +7296,8 @@ Current user's request: ${currentInput}`;
       toolResults: streamResult.toolResults,
       analytics: streamResult.analytics,
       evaluation: streamResult.evaluation,
-      events: config.events && config.events.length > 0 ? config.events : undefined,
+      events:
+        config.events && config.events.length > 0 ? config.events : undefined,
       metadata: {
         streamId: config.streamId,
         startTime: config.startTime,
@@ -6287,7 +7336,8 @@ Current user's request: ${currentInput}`;
         parentSpanId: traceCtx?.parentSpanId,
       });
       failedSpan = SpanSerializer.endSpan(failedSpan, SpanStatus.ERROR);
-      failedSpan.statusMessage = error instanceof Error ? error.message : String(error);
+      failedSpan.statusMessage =
+        error instanceof Error ? error.message : String(error);
       failedSpan.durationMs = Date.now() - startTime;
       this.metricsAggregator.recordSpan(failedSpan);
       getMetricsAggregator().recordSpan(failedSpan);
@@ -6298,7 +7348,10 @@ Current user's request: ${currentInput}`;
     const originalPrompt = options.input.text;
     const responseTime = Date.now() - startTime;
     const providerName = await getBestProvider(options.provider);
-    const provider = await AIProviderFactory.createProvider(providerName, options.model);
+    const provider = await AIProviderFactory.createProvider(
+      providerName,
+      options.model,
+    );
     const fallbackStreamResult = await provider.stream({
       input: { text: options.input.text },
       model: options.model,
@@ -6313,7 +7366,11 @@ Current user's request: ${currentInput}`;
     const fallbackProcessedStream = (async function* (self: NeuroLink) {
       try {
         for await (const chunk of fallbackStreamResult.stream) {
-          if (chunk && "content" in chunk && typeof chunk.content === "string") {
+          if (
+            chunk &&
+            "content" in chunk &&
+            typeof chunk.content === "string"
+          ) {
             fallbackAccumulatedContent += chunk.content;
             // Emit chunk event
             self.emitter.emit("response:chunk", chunk.content);
@@ -6322,19 +7379,29 @@ Current user's request: ${currentInput}`;
         }
       } finally {
         if (fallbackAccumulatedContent.trim()) {
-          logger.info(`[NeuroLink.handleStreamError] stream() - COMPLETE SUCCESS (fallback)`, {
-            provider: providerName,
-            model: options.model,
-            responseTimeMs: Date.now() - startTime,
-            contentLength: fallbackAccumulatedContent.length,
-          });
+          logger.info(
+            `[NeuroLink.handleStreamError] stream() - COMPLETE SUCCESS (fallback)`,
+            {
+              provider: providerName,
+              model: options.model,
+              responseTimeMs: Date.now() - startTime,
+              contentLength: fallbackAccumulatedContent.length,
+            },
+          );
         }
 
         // Store memory after fallback stream consumption is complete
         // Guard: skip storing if fallback accumulated content is empty
-        if (self.conversationMemory && enhancedOptions?.context?.sessionId && fallbackAccumulatedContent.trim()) {
-          const sessionId = (enhancedOptions?.context as Record<string, unknown>)?.sessionId as string;
-          const userId = (enhancedOptions?.context as Record<string, unknown>)?.userId as string;
+        if (
+          self.conversationMemory &&
+          enhancedOptions?.context?.sessionId &&
+          fallbackAccumulatedContent.trim()
+        ) {
+          const sessionId = (
+            enhancedOptions?.context as Record<string, unknown>
+          )?.sessionId as string;
+          const userId = (enhancedOptions?.context as Record<string, unknown>)
+            ?.userId as string;
           let providerDetails: ProviderDetails | undefined;
           if (options.model) {
             providerDetails = {
@@ -6354,8 +7421,13 @@ Current user's request: ${currentInput}`;
               providerDetails,
               enableSummarization: enhancedOptions?.enableSummarization,
               requestId:
-                ((enhancedOptions?.context as Record<string, unknown> | undefined)?.requestId as string | undefined) ||
-                ((options.context as Record<string, unknown> | undefined)?.requestId as string | undefined),
+                ((
+                  enhancedOptions?.context as
+                    | Record<string, unknown>
+                    | undefined
+                )?.requestId as string | undefined) ||
+                ((options.context as Record<string, unknown> | undefined)
+                  ?.requestId as string | undefined),
             });
             self.recordMemorySpan(
               "memory.store",
@@ -6590,7 +7662,11 @@ Current user's request: ${currentInput}`;
    * @param startTime - Timestamp when execution started
    * @returns executionId for tracking this specific execution
    */
-  emitToolStart(toolName: string, input: unknown, startTime: number = Date.now()): string {
+  emitToolStart(
+    toolName: string,
+    input: unknown,
+    startTime: number = Date.now(),
+  ): string {
     const executionId = `${toolName}-${startTime}-${Math.random().toString(36).substr(2, 9)}`;
 
     // Create execution context for tracking
@@ -6653,7 +7729,9 @@ Current user's request: ${currentInput}`;
       context = this.activeToolExecutions.get(executionId);
     } else {
       // Find by tool name (fallback for executions without ID tracking)
-      context = Array.from(this.activeToolExecutions.values()).find((ctx) => ctx.tool === toolName && !ctx.endTime);
+      context = Array.from(this.activeToolExecutions.values()).find(
+        (ctx) => ctx.tool === toolName && !ctx.endTime,
+      );
     }
 
     const finalExecutionId =
@@ -6740,7 +7818,11 @@ Current user's request: ${currentInput}`;
    * @param name - Unique name for the tool
    * @param tool - Tool in MCPExecutableTool format (unified MCP protocol type)
    */
-  registerTool(name: string, tool: MCPExecutableTool, options?: ToolRegistrationOptions): void {
+  registerTool(
+    name: string,
+    tool: MCPExecutableTool,
+    options?: ToolRegistrationOptions,
+  ): void {
     this.invalidateToolCache(); // Invalidate cache when a tool is registered
     // Emit tool registration start event
     this.emitter.emit("tools-register:start", {
@@ -6810,9 +7892,13 @@ Current user's request: ${currentInput}`;
         convertedTool.execute = async (...args: unknown[]) => {
           const timeoutSignal = AbortSignal.timeout(toolTimeout);
           // Compose with any parent abortSignal from ToolExecutionOptions
-          const execOptions = args[1] as { abortSignal?: AbortSignal } | undefined;
+          const execOptions = args[1] as
+            | { abortSignal?: AbortSignal }
+            | undefined;
           const parentSignal = execOptions?.abortSignal;
-          const composedSignal = parentSignal ? AbortSignal.any([parentSignal, timeoutSignal]) : timeoutSignal;
+          const composedSignal = parentSignal
+            ? AbortSignal.any([parentSignal, timeoutSignal])
+            : timeoutSignal;
 
           // Replace the abortSignal in execution options
           const augmentedContext = {
@@ -6829,7 +7915,12 @@ Current user's request: ${currentInput}`;
                   if (timeoutSignal.aborted) {
                     reject(ErrorFactory.toolTimeout(toolName, toolTimeout));
                   } else {
-                    reject(new DOMException("The operation was aborted", "AbortError"));
+                    reject(
+                      new DOMException(
+                        "The operation was aborted",
+                        "AbortError",
+                      ),
+                    );
                   }
                 },
                 { once: true },
@@ -6840,7 +7931,12 @@ Current user's request: ${currentInput}`;
       }
 
       // SMART DEFAULTS: Use utility to eliminate boilerplate creation
-      const mcpServerInfo = createCustomToolServerInfo(name, convertedTool, options?.timeout, options?.maxRetries);
+      const mcpServerInfo = createCustomToolServerInfo(
+        name,
+        convertedTool,
+        options?.timeout,
+        options?.maxRetries,
+      );
 
       // Register with toolRegistry using MCPServerInfo directly
       this.toolRegistry.registerServer(mcpServerInfo);
@@ -6879,7 +7975,9 @@ Current user's request: ${currentInput}`;
    * @returns Current context or undefined if not set
    */
   getToolContext(): Record<string, unknown> | undefined {
-    return this.toolExecutionContext ? { ...this.toolExecutionContext } : undefined;
+    return this.toolExecutionContext
+      ? { ...this.toolExecutionContext }
+      : undefined;
   }
 
   /**
@@ -6897,7 +7995,11 @@ Current user's request: ${currentInput}`;
    * Object format (existing): { toolName: MCPExecutableTool, ... }
    * Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }, ...]
    */
-  registerTools(tools: Record<string, MCPExecutableTool> | Array<{ name: string; tool: MCPExecutableTool }>): void {
+  registerTools(
+    tools:
+      | Record<string, MCPExecutableTool>
+      | Array<{ name: string; tool: MCPExecutableTool }>,
+  ): void {
     if (Array.isArray(tools)) {
       // Handle array format (Lighthouse compatible)
       for (const { name, tool } of tools) {
@@ -6934,9 +8036,13 @@ Current user's request: ${currentInput}`;
    * @param middleware - The middleware function to register
    * @returns this (for chaining)
    */
-  useToolMiddleware(middleware: import("./mcp/toolIntegration.js").ToolMiddleware): this {
+  useToolMiddleware(
+    middleware: import("./mcp/toolIntegration.js").ToolMiddleware,
+  ): this {
     this.mcpToolMiddlewares.push(middleware);
-    logger.debug(`[NeuroLink] Registered tool middleware (total: ${this.mcpToolMiddlewares.length})`);
+    logger.debug(
+      `[NeuroLink] Registered tool middleware (total: ${this.mcpToolMiddlewares.length})`,
+    );
     return this;
   }
 
@@ -7007,7 +8113,8 @@ Current user's request: ${currentInput}`;
 
     await withTimeout(
       (
-        this.conversationMemory as import("./core/redisConversationMemoryManager.js").RedisConversationMemoryManager
+        this
+          .conversationMemory as import("./core/redisConversationMemoryManager.js").RedisConversationMemoryManager
       ).updateAgenticLoopReport(sessionId, userId, report),
       5000,
     );
@@ -7019,7 +8126,9 @@ Current user's request: ${currentInput}`;
    */
   getCustomTools(): Map<string, MCPExecutableTool> {
     // Get tools from toolRegistry with smart category detection
-    const customTools = this.toolRegistry.getToolsByCategory(detectCategory({ isCustomTool: true }));
+    const customTools = this.toolRegistry.getToolsByCategory(
+      detectCategory({ isCustomTool: true }),
+    );
     const toolMap = new Map<string, MCPExecutableTool>();
 
     for (const tool of customTools) {
@@ -7031,15 +8140,23 @@ Current user's request: ${currentInput}`;
         hasParameters: !!tool.parameters,
         parametersType: typeof tool.parameters,
         parametersKeys:
-          tool.parameters && typeof tool.parameters === "object" ? Object.keys(tool.parameters) : "NOT_OBJECT",
+          tool.parameters && typeof tool.parameters === "object"
+            ? Object.keys(tool.parameters)
+            : "NOT_OBJECT",
         hasInputSchema: !!tool.inputSchema,
         inputSchemaType: typeof tool.inputSchema,
         inputSchemaKeys:
-          tool.inputSchema && typeof tool.inputSchema === "object" ? Object.keys(tool.inputSchema) : "NOT_OBJECT",
+          tool.inputSchema && typeof tool.inputSchema === "object"
+            ? Object.keys(tool.inputSchema)
+            : "NOT_OBJECT",
         hasEffectiveSchema: !!effectiveSchema,
         effectiveSchemaType: typeof effectiveSchema,
-        effectiveSchemaHasProperties: !!(effectiveSchema as Record<string, unknown>)?.properties,
-        effectiveSchemaHasRequired: !!(effectiveSchema as Record<string, unknown>)?.required,
+        effectiveSchemaHasProperties: !!(
+          effectiveSchema as Record<string, unknown>
+        )?.properties,
+        effectiveSchemaHasRequired: !!(
+          effectiveSchema as Record<string, unknown>
+        )?.required,
         originalInputSchema: tool.inputSchema,
         phase: "AFTER_SCHEMA_FIX",
         timestamp: Date.now(),
@@ -7058,7 +8175,10 @@ Current user's request: ${currentInput}`;
         execute: async (params: unknown, context?: unknown) => {
           // CONTEXT MERGING: Combine all available contexts for maximum information
           const storedContext = this.toolExecutionContext || {};
-          const runtimeContext = context && isNonNullObject(context) ? (context as Record<string, unknown>) : {};
+          const runtimeContext =
+            context && isNonNullObject(context)
+              ? (context as Record<string, unknown>)
+              : {};
 
           // Merge contexts with runtime context taking precedence
           // This ensures we have the richest possible context for tool execution
@@ -7066,7 +8186,10 @@ Current user's request: ${currentInput}`;
             ...storedContext, // Base context from setToolContext (session, tokens, etc.)
             ...runtimeContext, // Runtime context from AI model (if any)
             // Ensure we always have at least a sessionId for tracing
-            sessionId: runtimeContext.sessionId || storedContext.sessionId || `fallback-${Date.now()}`,
+            sessionId:
+              runtimeContext.sessionId ||
+              storedContext.sessionId ||
+              `fallback-${Date.now()}`,
           };
 
           // Enhanced logging for context debugging
@@ -7075,12 +8198,17 @@ Current user's request: ${currentInput}`;
             storedContextKeys: Object.keys(storedContext),
             runtimeContextKeys: Object.keys(runtimeContext),
             finalContextKeys: Object.keys(executionContext),
-            hasJuspayToken: !!(executionContext as Record<string, unknown>).juspayToken,
+            hasJuspayToken: !!(executionContext as Record<string, unknown>)
+              .juspayToken,
             hasShopId: !!(executionContext as Record<string, unknown>).shopId,
             sessionId: executionContext.sessionId,
           });
 
-          return await this.toolRegistry.executeTool(tool.name, params, executionContext as Record<string, unknown>);
+          return await this.toolRegistry.executeTool(
+            tool.name,
+            params,
+            executionContext as Record<string, unknown>,
+          );
         },
       });
     }
@@ -7101,14 +8229,22 @@ Current user's request: ${currentInput}`;
     for (const [toolName, toolDef] of Object.entries(fileTools)) {
       if (!toolMap.has(toolName)) {
         const toolDefRecord = toolDef as Record<string, unknown>;
-        const toolParams = toolDefRecord.inputSchema ?? toolDefRecord.parameters;
+        const toolParams =
+          toolDefRecord.inputSchema ?? toolDefRecord.parameters;
         toolMap.set(toolName, {
           name: toolName,
           description: toolDef.description || `File tool: ${toolName}`,
           inputSchema:
-            typeof toolParams === "object" && toolParams !== null ? toolParams : { type: "object", properties: {} },
+            typeof toolParams === "object" && toolParams !== null
+              ? toolParams
+              : { type: "object", properties: {} },
           execute: async (params: unknown) => {
-            return await (toolDef.execute as (params: unknown, ctx: unknown) => Promise<unknown>)(params, {
+            return await (
+              toolDef.execute as (
+                params: unknown,
+                ctx: unknown,
+              ) => Promise<unknown>
+            )(params, {
               toolCallId: `file-tool-${Date.now()}`,
               messages: [],
             });
@@ -7126,10 +8262,15 @@ Current user's request: ${currentInput}`;
    * @param serverId - Unique identifier for the server
    * @param serverInfo - Server configuration
    */
-  async addInMemoryMCPServer(serverId: string, serverInfo: MCPServerInfo): Promise<void> {
+  async addInMemoryMCPServer(
+    serverId: string,
+    serverInfo: MCPServerInfo,
+  ): Promise<void> {
     this.invalidateToolCache(); // Invalidate cache when a server is added
     try {
-      mcpLogger.debug(`[NeuroLink] Registering in-memory MCP server: ${serverId}`);
+      mcpLogger.debug(
+        `[NeuroLink] Registering in-memory MCP server: ${serverId}`,
+      );
 
       // Initialize tools array if not provided
       if (!serverInfo.tools) {
@@ -7139,13 +8280,19 @@ Current user's request: ${currentInput}`;
       // ZERO CONVERSIONS: Pass MCPServerInfo directly to toolRegistry
       await this.toolRegistry.registerServer(serverInfo);
 
-      mcpLogger.info(`[NeuroLink] Successfully registered in-memory server: ${serverId}`, {
-        category: serverInfo.metadata?.category,
-        provider: serverInfo.metadata?.provider,
-        version: serverInfo.metadata?.version,
-      });
+      mcpLogger.info(
+        `[NeuroLink] Successfully registered in-memory server: ${serverId}`,
+        {
+          category: serverInfo.metadata?.category,
+          provider: serverInfo.metadata?.provider,
+          version: serverInfo.metadata?.version,
+        },
+      );
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] Failed to register in-memory server ${serverId}:`, error);
+      mcpLogger.error(
+        `[NeuroLink] Failed to register in-memory server ${serverId}:`,
+        error,
+      );
       throw error;
     }
   }
@@ -7233,410 +8380,624 @@ Current user's request: ${currentInput}`;
       };
     },
   ): Promise<T> {
-    const functionTag = "NeuroLink.executeTool";
-    const executionStartTime = Date.now();
-
-    // === MCP ENHANCEMENT: RequestBatcher — batch programmatic tool calls ===
-    // LIMITATION: When the request batcher is enabled, per-tool timeout and retry
-    // settings (from registration options or call-site options) are NOT applied.
-    // The batcher uses its own hardcoded defaults for timeout and retry behavior.
-    // Use `bypassBatcher: true` to ensure per-tool timeout/retry is respected.
-    // Additionally, note that executeToolInternal's safe-tool retry logic may still
-    // trigger even when maxRetries is set to 0, since it operates independently.
     if (this.mcpToolBatcher && !options?.bypassBatcher) {
       return this.mcpToolBatcher.execute(toolName, params) as Promise<T>;
     }
 
-    // Determine tool type for span attributes
-    const externalTools = this.externalServerManager.getAllTools();
-    const externalTool = externalTools.find((tool) => tool.name === toolName);
-    const toolType = externalTool ? "mcp" : this.getCustomTools().has(toolName) ? "custom" : "external";
-
-    // Compute truncated input size for the span
-    const inputStr = typeof params === "string" ? params : params ? JSON.stringify(params) : "";
-    const inputSize = inputStr.length;
-    const truncatedInput = inputStr.length > 2048 ? inputStr.substring(0, 2048) : inputStr;
-
+    const executionContext = this.createToolExecutionContext(
+      toolName,
+      params,
+      options,
+    );
     return tracers.mcp.startActiveSpan(
       "neurolink.tool.execute",
       {
         attributes: {
           "tool.name": toolName,
-          "tool.type": toolType,
-          "tool.input_size": inputSize,
-          "tool.input_preview": truncatedInput,
+          "tool.type": executionContext.toolType,
+          "tool.input_size": executionContext.inputSize,
+          "tool.input_preview": executionContext.truncatedInput,
         },
       },
-      async (toolSpan) => {
-        try {
-          // Debug: Log tool execution attempt
-          logger.debug(`[${functionTag}] Tool execution requested:`, {
-            toolName,
-            params: isNonNullObject(params) ? transformParamsForLogging(params) : params,
-            hasExternalManager: !!this.externalServerManager,
-          });
+      (toolSpan) =>
+        this.executeToolWithSpan<T>(
+          toolName,
+          params,
+          options,
+          executionContext,
+          toolSpan,
+        ),
+    ) as Promise<T>;
+  }
 
-          // 🔧 PARAMETER TRACE: Log tool execution details for debugging
-          logger.debug(`Tool execution detailed analysis`, {
-            toolName,
-            executionStartTime,
-            paramsAnalysis: {
-              type: typeof params,
-              isNull: params === null,
-              isUndefined: params === undefined,
-              isEmpty: params && typeof params === "object" && Object.keys(params as object).length === 0,
-              keys: params && typeof params === "object" ? Object.keys(params as object) : "NOT_OBJECT",
-              keysLength: params && typeof params === "object" ? Object.keys(params as object).length : 0,
-            },
-            isTargetTool: toolName === "juspay-analytics_SuccessRateSRByTime",
-            options,
-            hasExternalManager: !!this.externalServerManager,
-          });
-
-          // Emit tool start event (NeuroLink format - keep existing)
-          this.emitter.emit("tool:start", {
-            toolName,
-            timestamp: executionStartTime,
-            input: params, // Enhanced: add input parameters
-          });
-
-          // NL-004: Use composite key (serverId.toolName) to avoid cross-server collisions
-          // Fetch toolInfo early so per-tool timeout is available for finalOptions
-          const toolInfo = this.toolRegistry.getToolInfo(toolName);
-
-          // Set default options — per-tool values from registration take precedence over global defaults.
-          // When not explicitly set at registration, global defaults are preserved for backward compatibility.
-          const registeredTimeout = toolInfo?.tool?.timeoutMs;
-          const registeredMaxRetries = toolInfo?.tool?.maxRetries;
-          const finalOptions = {
-            timeout: options?.timeout ?? registeredTimeout ?? TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
-            maxRetries: options?.maxRetries ?? registeredMaxRetries ?? RETRY_ATTEMPTS.DEFAULT,
-            retryDelayMs: options?.retryDelayMs || RETRY_DELAYS.BASE_MS,
-            authContext: options?.authContext,
-            disableToolCache: options?.disableToolCache,
+  private createToolExecutionContext(
+    toolName: string,
+    params: unknown,
+    options:
+      | {
+          timeout?: number;
+          maxRetries?: number;
+          retryDelayMs?: number;
+          disableToolCache?: boolean;
+          bypassBatcher?: boolean;
+          authContext?: {
+            userId?: string;
+            sessionId?: string;
+            user?: Record<string, unknown>;
+            [key: string]: unknown;
           };
-
-          // Track memory usage for tool execution
-          const { MemoryManager } = await import("./utils/performance.js");
-          const startMemory = MemoryManager.getMemoryUsageMB();
-          const breakerServerId = externalTool?.serverId || toolInfo?.tool?.serverId || "unknown";
-          const breakerKey = `${breakerServerId}.${toolName}`;
-
-          // Get or create circuit breaker for this tool
-          if (!this.toolCircuitBreakers.has(breakerKey)) {
-            this.toolCircuitBreakers.set(
-              breakerKey,
-              new CircuitBreaker(CIRCUIT_BREAKER.FAILURE_THRESHOLD, CIRCUIT_BREAKER_RESET_MS),
-            );
-          }
-          const circuitBreaker = this.toolCircuitBreakers.get(breakerKey);
-
-          // Initialize metrics for this tool if not exists
-          if (!this.toolExecutionMetrics.has(toolName)) {
-            this.toolExecutionMetrics.set(toolName, {
-              totalExecutions: 0,
-              successfulExecutions: 0,
-              failedExecutions: 0,
-              averageExecutionTime: 0,
-              lastExecutionTime: 0,
-              errorCategories: {},
-            });
-          }
-          const metrics = this.toolExecutionMetrics.get(toolName);
-          if (metrics) {
-            metrics.totalExecutions++;
-          }
-
-          try {
-            mcpLogger.debug(`[${functionTag}] Executing tool: ${toolName}`, {
-              toolName,
-              params,
-              options: finalOptions,
-              circuitBreakerState: circuitBreaker?.getState(),
-            });
-
-            // Execute with circuit breaker, timeout, and retry logic
-            if (!circuitBreaker) {
-              throw new Error(`Circuit breaker not initialized for tool: ${toolName}`);
-            }
-            const result: T = await circuitBreaker.execute(async () => {
-              return await withRetry(
-                async () => {
-                  return await withTimeout(
-                    this.executeToolInternal<T>(toolName, params, finalOptions),
-                    finalOptions.timeout,
-                    ErrorFactory.toolTimeout(toolName, finalOptions.timeout),
-                  );
-                },
-                {
-                  maxAttempts: finalOptions.maxRetries + 1, // +1 for initial attempt
-                  delayMs: finalOptions.retryDelayMs,
-                  isRetriable: isRetriableError,
-                  onRetry: (attempt, error) => {
-                    mcpLogger.warn(`[${functionTag}] Retrying tool execution (attempt ${attempt})`, {
-                      toolName,
-                      error: error.message,
-                      attempt,
-                    });
-                  },
-                },
-              );
-            });
-
-            // Update success metrics
-            const executionTime = Date.now() - executionStartTime;
-            if (metrics) {
-              metrics.successfulExecutions++;
-              metrics.lastExecutionTime = executionTime;
-              metrics.averageExecutionTime =
-                (metrics.averageExecutionTime * (metrics.successfulExecutions - 1) + executionTime) /
-                metrics.successfulExecutions;
-            }
-
-            // Track memory usage
-            const endMemory = MemoryManager.getMemoryUsageMB();
-            const memoryDelta = endMemory.heapUsed - startMemory.heapUsed;
-
-            if (memoryDelta > 20) {
-              mcpLogger.warn(`Tool '${toolName}' used excessive memory: ${memoryDelta}MB`, {
-                toolName,
-                memoryDelta,
-                executionTime,
-              });
-            }
-
-            mcpLogger.debug(`[${functionTag}] Tool executed successfully`, {
-              toolName,
-              executionTime,
-              memoryDelta,
-              circuitBreakerState: circuitBreaker?.getState(),
-            });
-
-            // Set span success attributes
-            // Check if result has isError flag (MCP tool error result)
-            // Also detect toolRegistry-wrapped errors that return { success: false }
-            const resultObj = result && typeof result === "object" ? (result as Record<string, unknown>) : undefined;
-            const isToolError =
-              (resultObj && "isError" in resultObj && resultObj.isError === true) ||
-              (resultObj && "success" in resultObj && resultObj.success === false);
-
-            // NL-001: Count isError:true results as circuit breaker failures
-            // This ensures tools that return error results (not just thrown errors) are tracked
-            // TODO(NL-009): This records a failure AFTER the circuit breaker already recorded
-            // success inside `circuitBreaker.execute()`. The correct fix is to check `isToolError`
-            // inside the execute callback and throw before returning, so the breaker never sees
-            // success. Deferred because moving the check inside the callback requires restructuring
-            // the retry/timeout wrapper chain and is high-risk for a hot-path change.
-            if (isToolError && circuitBreaker) {
-              // Record a failure by executing a rejected promise through the breaker
-              try {
-                await circuitBreaker.execute(async () => {
-                  throw new Error(`Tool ${toolName} returned isError:true`);
-                });
-              } catch {
-                // Expected — we intentionally triggered the failure recording
-              }
-              mcpLogger.debug(`[${functionTag}] Circuit breaker failure recorded for isError result`, {
-                toolName,
-                circuitBreakerState: circuitBreaker.getState(),
-                circuitBreakerFailures: circuitBreaker.getFailureCount(),
-              });
-            }
-
-            // NL-002 + NL-003: Format and capture MCP error results
-            if (isToolError) {
-              const resultObj = result as Record<string, unknown>;
-              const contentArr = resultObj.content as Array<{ type?: string; text?: string }> | undefined;
-              const errorText =
-                contentArr
-                  ?.filter((c) => c.type === "text" && c.text)
-                  .map((c) => c.text)
-                  .join(" ") || (typeof resultObj.error === "string" ? resultObj.error : "Unknown error");
-              const errorCategory = classifyMcpErrorMessage(errorText);
-              const prefix = `[TOOL_ERROR: ${toolName} failed (${errorCategory})] `;
-
-              // NL-002: Clone content array to avoid mutating shared objects, then prefix error
-              if (contentArr && Array.isArray(contentArr)) {
-                const clonedContent = contentArr.map((c) => ({ ...c }));
-                for (const content of clonedContent) {
-                  if (content.type === "text" && content.text) {
-                    content.text = prefix + content.text;
-                    break; // Only prefix the first text content
-                  }
-                }
-                resultObj.content = clonedContent;
-              }
-
-              // NL-003: Capture error details in span attributes for telemetry
-              toolSpan.setAttribute("tool.error.message", errorText.substring(0, 500));
-              toolSpan.setAttribute("tool.error.category", errorCategory);
-              toolSpan.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: `MCP tool returned isError: ${errorText.substring(0, 200)}`,
-              });
-
-              if (metrics) {
-                metrics.failedExecutions++;
-                const prevSuccessful = metrics.successfulExecutions;
-                metrics.successfulExecutions = Math.max(0, metrics.successfulExecutions - 1);
-                // Recompute averageExecutionTime: back out this execution's duration
-                // which was incorrectly included as a success
-                if (prevSuccessful > 1) {
-                  metrics.averageExecutionTime =
-                    (metrics.averageExecutionTime * prevSuccessful - executionTime) / (prevSuccessful - 1);
-                } else {
-                  // No remaining successful executions, reset to 0
-                  metrics.averageExecutionTime = 0;
-                }
-                const mappedCategory = mcpCategoryToErrorCategory(errorCategory);
-                metrics.errorCategories[mappedCategory] = (metrics.errorCategories[mappedCategory] || 0) + 1;
-              }
-            }
-
-            // Emit tool end event AFTER isError check so success flag is correct
-            this.emitToolEndEvent(toolName, executionStartTime, !isToolError, result);
-
-            toolSpan.setAttribute("tool.result.status", isToolError ? "error" : "success");
-            toolSpan.setAttribute("tool.duration_ms", executionTime);
-
-            return result;
-          } catch (error) {
-            // Update failure metrics
-            if (metrics) {
-              metrics.failedExecutions++;
-            }
-            const executionTime = Date.now() - executionStartTime;
-
-            // Circuit breaker open: return a structured non-retryable isError result
-            // so the AI model understands the tool is temporarily unavailable.
-            // Log at warn (not error) since this is expected circuit breaker behavior.
-            if (error instanceof CircuitBreakerOpenError) {
-              mcpLogger.warn(`[${functionTag}] Tool blocked by circuit breaker: ${toolName}`, {
-                toolName,
-                breakerState: error.breakerState,
-                retryAfter: error.retryAfter,
-                retryAfterMs: error.retryAfterMs,
-                failureCount: error.failureCount,
-                executionTime,
-              });
-
-              if (metrics) {
-                const category = ErrorCategory.EXECUTION;
-                metrics.errorCategories[category] = (metrics.errorCategories[category] || 0) + 1;
-              }
-
-              // Emit tool end event for circuit breaker open
-              this.emitToolEndEvent(toolName, executionStartTime, false, undefined);
-
-              toolSpan.setAttribute("tool.result.status", "circuit_breaker_open");
-              toolSpan.setAttribute("tool.duration_ms", executionTime);
-              toolSpan.setAttribute("tool.circuit_breaker.state", error.breakerState);
-              toolSpan.setAttribute("tool.circuit_breaker.retry_after_ms", error.retryAfterMs);
-              toolSpan.setAttribute("tool.circuit_breaker.failure_count", error.failureCount);
-              toolSpan.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: `Circuit breaker open for ${toolName}: ${error.message}`,
-              });
-
-              // Return an isError tool result so the AI can inform the user
-              // instead of throwing, which would cause a generic retry
-              return {
-                isError: true,
-                content: [
-                  {
-                    type: "text" as const,
-                    text:
-                      `TOOL TEMPORARILY UNAVAILABLE: "${toolName}" has been disabled after ` +
-                      `${error.failureCount} failures. ` +
-                      `This is a circuit breaker protection — do NOT retry this tool. ` +
-                      `It will become available again after ${Math.ceil(error.retryAfterMs / 1000)} seconds ` +
-                      `(at ${error.retryAfter}). ` +
-                      `Instead, inform the user that the operation failed and suggest trying again later.`,
-                  },
-                ],
-              } as T;
-            }
-
-            // Create structured error
-            let structuredError: NeuroLinkError;
-
-            if (error instanceof NeuroLinkError) {
-              structuredError = error;
-            } else if (error instanceof Error) {
-              // Categorize the error based on the message
-              if (error.message.includes("timeout")) {
-                structuredError = ErrorFactory.toolTimeout(toolName, finalOptions.timeout);
-              } else if (error.message.includes("not found")) {
-                const availableTools = await this.getAllAvailableTools();
-                structuredError = ErrorFactory.toolNotFound(
-                  toolName,
-                  extractToolNames(availableTools.map((t) => ({ name: t.name }))),
-                );
-              } else if (error.message.includes("validation") || error.message.includes("parameter")) {
-                structuredError = ErrorFactory.invalidParameters(toolName, error, params);
-              } else if (error.message.includes("network") || error.message.includes("connection")) {
-                structuredError = ErrorFactory.networkError(toolName, error);
-              } else {
-                structuredError = ErrorFactory.toolExecutionFailed(toolName, error);
-              }
-            } else {
-              structuredError = ErrorFactory.toolExecutionFailed(toolName, new Error(String(error)));
-            }
-
-            if (metrics) {
-              const category = structuredError.category || ErrorCategory.EXECUTION;
-              metrics.errorCategories[category] = (metrics.errorCategories[category] || 0) + 1;
-            }
-
-            // Emit tool end event BEFORE the error event.
-            // Node.js EventEmitter throws on unhandled 'error' events,
-            // which would prevent tool:end from being emitted.
-            this.emitToolEndEvent(toolName, executionStartTime, false, undefined, structuredError);
-
-            // Centralized error event emission
-            this.emitter.emit("error", structuredError);
-
-            // Add execution context to structured error
-            structuredError = new NeuroLinkError({
-              ...structuredError,
-              context: {
-                ...structuredError.context,
-                executionTime,
-                params,
-                options: finalOptions,
-                circuitBreakerState: circuitBreaker?.getState(),
-                circuitBreakerFailures: circuitBreaker?.getFailureCount(),
-                metrics: { ...metrics },
-              },
-            });
-
-            // Log structured error
-            logStructuredError(structuredError);
-
-            // Record error on span
-            toolSpan.setAttribute("tool.result.status", "error");
-            toolSpan.setAttribute("tool.duration_ms", executionTime);
-            toolSpan.recordException(structuredError);
-            toolSpan.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: structuredError.message,
-            });
-
-            throw structuredError;
-          }
-        } catch (outerError) {
-          // If the error was not already recorded on the span (from inner catch), record it
-          if (!(outerError instanceof NeuroLinkError)) {
-            const errMsg = outerError instanceof Error ? outerError.message : String(outerError);
-            toolSpan.recordException(outerError instanceof Error ? outerError : new Error(errMsg));
-            toolSpan.setStatus({ code: SpanStatusCode.ERROR, message: errMsg });
-          }
-          throw outerError;
-        } finally {
-          toolSpan.end();
         }
+      | undefined,
+  ): {
+    functionTag: string;
+    executionStartTime: number;
+    externalTool:
+      | ReturnType<NeuroLink["externalServerManager"]["getAllTools"]>[number]
+      | undefined;
+    toolType: "mcp" | "custom" | "external";
+    inputSize: number;
+    truncatedInput: string;
+    options: typeof options;
+  } {
+    const externalTool = this.externalServerManager
+      .getAllTools()
+      .find((tool) => tool.name === toolName);
+    const toolType = externalTool
+      ? "mcp"
+      : this.getCustomTools().has(toolName)
+        ? "custom"
+        : "external";
+    const inputStr =
+      typeof params === "string"
+        ? params
+        : params
+          ? JSON.stringify(params)
+          : "";
+
+    return {
+      functionTag: "NeuroLink.executeTool",
+      executionStartTime: Date.now(),
+      externalTool,
+      toolType,
+      inputSize: inputStr.length,
+      truncatedInput:
+        inputStr.length > 2048 ? inputStr.substring(0, 2048) : inputStr,
+      options,
+    };
+  }
+
+  private async executeToolWithSpan<T>(
+    toolName: string,
+    params: unknown,
+    options:
+      | {
+          timeout?: number;
+          maxRetries?: number;
+          retryDelayMs?: number;
+          disableToolCache?: boolean;
+          bypassBatcher?: boolean;
+          authContext?: {
+            userId?: string;
+            sessionId?: string;
+            user?: Record<string, unknown>;
+            [key: string]: unknown;
+          };
+        }
+      | undefined,
+    executionContext: ReturnType<NeuroLink["createToolExecutionContext"]>,
+    toolSpan: ReturnType<typeof tracers.mcp.startSpan>,
+  ): Promise<T> {
+    try {
+      const prepared = await this.prepareToolExecutionState(
+        toolName,
+        params,
+        options,
+        executionContext,
+      );
+      return await this.runPreparedToolExecution(
+        toolName,
+        params,
+        prepared,
+        executionContext,
+        toolSpan,
+      );
+    } catch (outerError) {
+      if (!(outerError instanceof NeuroLinkError)) {
+        const errMsg =
+          outerError instanceof Error ? outerError.message : String(outerError);
+        toolSpan.recordException(
+          outerError instanceof Error ? outerError : new Error(errMsg),
+        );
+        toolSpan.setStatus({ code: SpanStatusCode.ERROR, message: errMsg });
+      }
+      throw outerError;
+    } finally {
+      toolSpan.end();
+    }
+  }
+
+  private async prepareToolExecutionState(
+    toolName: string,
+    params: unknown,
+    options:
+      | {
+          timeout?: number;
+          maxRetries?: number;
+          retryDelayMs?: number;
+          disableToolCache?: boolean;
+          bypassBatcher?: boolean;
+          authContext?: {
+            userId?: string;
+            sessionId?: string;
+            user?: Record<string, unknown>;
+            [key: string]: unknown;
+          };
+        }
+      | undefined,
+    executionContext: ReturnType<NeuroLink["createToolExecutionContext"]>,
+  ): Promise<{
+    finalOptions: {
+      timeout: number;
+      maxRetries: number;
+      retryDelayMs: number;
+      authContext:
+        | {
+            userId?: string;
+            sessionId?: string;
+            user?: Record<string, unknown>;
+            [key: string]: unknown;
+          }
+        | undefined;
+      disableToolCache: boolean | undefined;
+    };
+    startMemory: {
+      rss: number;
+      heapTotal: number;
+      heapUsed: number;
+      external: number;
+    };
+    circuitBreaker: CircuitBreaker;
+    breakerKey: string;
+    metrics: {
+      totalExecutions: number;
+      successfulExecutions: number;
+      failedExecutions: number;
+      averageExecutionTime: number;
+      lastExecutionTime: number;
+      errorCategories: Record<string, number>;
+    };
+  }> {
+    logger.debug(
+      `[${executionContext.functionTag}] Tool execution requested:`,
+      {
+        toolName,
+        params: isNonNullObject(params)
+          ? transformParamsForLogging(params)
+          : params,
+        hasExternalManager: !!this.externalServerManager,
       },
     );
+    logger.debug(`Tool execution detailed analysis`, {
+      toolName,
+      executionStartTime: executionContext.executionStartTime,
+      paramsAnalysis: {
+        type: typeof params,
+        isNull: params === null,
+        isUndefined: params === undefined,
+        isEmpty:
+          params &&
+          typeof params === "object" &&
+          Object.keys(params as object).length === 0,
+        keys:
+          params && typeof params === "object"
+            ? Object.keys(params as object)
+            : "NOT_OBJECT",
+        keysLength:
+          params && typeof params === "object"
+            ? Object.keys(params as object).length
+            : 0,
+      },
+      isTargetTool: toolName === "juspay-analytics_SuccessRateSRByTime",
+      options,
+      hasExternalManager: !!this.externalServerManager,
+    });
+    this.emitter.emit("tool:start", {
+      toolName,
+      timestamp: executionContext.executionStartTime,
+      input: params,
+    });
+
+    const toolInfo = this.toolRegistry.getToolInfo(toolName);
+    const finalOptions = {
+      timeout:
+        options?.timeout ??
+        toolInfo?.tool?.timeoutMs ??
+        TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
+      maxRetries:
+        options?.maxRetries ??
+        toolInfo?.tool?.maxRetries ??
+        RETRY_ATTEMPTS.DEFAULT,
+      retryDelayMs: options?.retryDelayMs || RETRY_DELAYS.BASE_MS,
+      authContext: options?.authContext,
+      disableToolCache: options?.disableToolCache,
+    };
+
+    const { MemoryManager } = await import("./utils/performance.js");
+    const startMemory = MemoryManager.getMemoryUsageMB();
+    const breakerServerId =
+      executionContext.externalTool?.serverId ||
+      toolInfo?.tool?.serverId ||
+      "unknown";
+    const breakerKey = `${breakerServerId}.${toolName}`;
+
+    let circuitBreaker = this.toolCircuitBreakers.get(breakerKey);
+    if (!circuitBreaker) {
+      circuitBreaker = new CircuitBreaker(
+        CIRCUIT_BREAKER.FAILURE_THRESHOLD,
+        CIRCUIT_BREAKER_RESET_MS,
+      );
+      this.toolCircuitBreakers.set(breakerKey, circuitBreaker);
+    }
+
+    let metrics = this.toolExecutionMetrics.get(toolName);
+    if (!metrics) {
+      metrics = {
+        totalExecutions: 0,
+        successfulExecutions: 0,
+        failedExecutions: 0,
+        averageExecutionTime: 0,
+        lastExecutionTime: 0,
+        errorCategories: {},
+      };
+      this.toolExecutionMetrics.set(toolName, metrics);
+    }
+    metrics.totalExecutions++;
+
+    return {
+      finalOptions,
+      startMemory,
+      circuitBreaker,
+      breakerKey,
+      metrics,
+    };
+  }
+
+  private async runPreparedToolExecution<T>(
+    toolName: string,
+    params: unknown,
+    prepared: Awaited<ReturnType<NeuroLink["prepareToolExecutionState"]>>,
+    executionContext: ReturnType<NeuroLink["createToolExecutionContext"]>,
+    toolSpan: ReturnType<typeof tracers.mcp.startSpan>,
+  ): Promise<T> {
+    try {
+      mcpLogger.debug(
+        `[${executionContext.functionTag}] Executing tool: ${toolName}`,
+        {
+          toolName,
+          params,
+          options: prepared.finalOptions,
+          circuitBreakerState: prepared.circuitBreaker.getState(),
+        },
+      );
+
+      const result: T = await prepared.circuitBreaker.execute(async () => {
+        return withRetry(
+          async () =>
+            withTimeout(
+              this.executeToolInternal<T>(
+                toolName,
+                params,
+                prepared.finalOptions,
+              ),
+              prepared.finalOptions.timeout,
+              ErrorFactory.toolTimeout(toolName, prepared.finalOptions.timeout),
+            ),
+          {
+            maxAttempts: prepared.finalOptions.maxRetries + 1,
+            delayMs: prepared.finalOptions.retryDelayMs,
+            isRetriable: isRetriableError,
+            onRetry: (attempt, error) => {
+              mcpLogger.warn(
+                `[${executionContext.functionTag}] Retrying tool execution (attempt ${attempt})`,
+                {
+                  toolName,
+                  error: error.message,
+                  attempt,
+                },
+              );
+            },
+          },
+        );
+      });
+
+      return await this.handleSuccessfulToolExecution(
+        toolName,
+        result,
+        prepared,
+        executionContext,
+        toolSpan,
+      );
+    } catch (error) {
+      return this.handleFailedToolExecution(
+        toolName,
+        params,
+        error,
+        prepared,
+        executionContext,
+        toolSpan,
+      );
+    }
+  }
+
+  private async handleSuccessfulToolExecution<T>(
+    toolName: string,
+    result: T,
+    prepared: Awaited<ReturnType<NeuroLink["prepareToolExecutionState"]>>,
+    executionContext: ReturnType<NeuroLink["createToolExecutionContext"]>,
+    toolSpan: ReturnType<typeof tracers.mcp.startSpan>,
+  ): Promise<T> {
+    const executionTime = Date.now() - executionContext.executionStartTime;
+    prepared.metrics.successfulExecutions++;
+    prepared.metrics.lastExecutionTime = executionTime;
+    prepared.metrics.averageExecutionTime =
+      (prepared.metrics.averageExecutionTime *
+        (prepared.metrics.successfulExecutions - 1) +
+        executionTime) /
+      prepared.metrics.successfulExecutions;
+
+    const { MemoryManager } = await import("./utils/performance.js");
+    const endMemory = MemoryManager.getMemoryUsageMB();
+    const memoryDelta = endMemory.heapUsed - prepared.startMemory.heapUsed;
+    if (memoryDelta > 20) {
+      mcpLogger.warn(
+        `Tool '${toolName}' used excessive memory: ${memoryDelta}MB`,
+        {
+          toolName,
+          memoryDelta,
+          executionTime,
+        },
+      );
+    }
+
+    mcpLogger.debug(
+      `[${executionContext.functionTag}] Tool executed successfully`,
+      {
+        toolName,
+        executionTime,
+        memoryDelta,
+        circuitBreakerState: prepared.circuitBreaker.getState(),
+      },
+    );
+
+    const resultObj =
+      result && typeof result === "object"
+        ? (result as Record<string, unknown>)
+        : undefined;
+    const isToolError =
+      (resultObj && "isError" in resultObj && resultObj.isError === true) ||
+      (resultObj && "success" in resultObj && resultObj.success === false);
+
+    if (isToolError) {
+      try {
+        await prepared.circuitBreaker.execute(async () => {
+          throw new Error(`Tool ${toolName} returned isError:true`);
+        });
+      } catch {
+        // Expected — intentionally records the failure
+      }
+      mcpLogger.debug(
+        `[${executionContext.functionTag}] Circuit breaker failure recorded for isError result`,
+        {
+          toolName,
+          circuitBreakerState: prepared.circuitBreaker.getState(),
+          circuitBreakerFailures: prepared.circuitBreaker.getFailureCount(),
+        },
+      );
+
+      const contentArr = resultObj?.content as
+        | Array<{ type?: string; text?: string }>
+        | undefined;
+      const errorText =
+        contentArr
+          ?.filter((content) => content.type === "text" && content.text)
+          .map((content) => content.text)
+          .join(" ") ||
+        (typeof resultObj?.error === "string"
+          ? resultObj.error
+          : "Unknown error");
+      const errorCategory = classifyMcpErrorMessage(errorText);
+      const prefix = `[TOOL_ERROR: ${toolName} failed (${errorCategory})] `;
+
+      if (resultObj && Array.isArray(contentArr)) {
+        const clonedContent = contentArr.map((content) => ({ ...content }));
+        for (const content of clonedContent) {
+          if (content.type === "text" && content.text) {
+            content.text = prefix + content.text;
+            break;
+          }
+        }
+        resultObj.content = clonedContent;
+      }
+
+      toolSpan.setAttribute("tool.error.message", errorText.substring(0, 500));
+      toolSpan.setAttribute("tool.error.category", errorCategory);
+      toolSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `MCP tool returned isError: ${errorText.substring(0, 200)}`,
+      });
+
+      prepared.metrics.failedExecutions++;
+      const prevSuccessful = prepared.metrics.successfulExecutions;
+      prepared.metrics.successfulExecutions = Math.max(
+        0,
+        prepared.metrics.successfulExecutions - 1,
+      );
+      prepared.metrics.averageExecutionTime =
+        prevSuccessful > 1
+          ? (prepared.metrics.averageExecutionTime * prevSuccessful -
+              executionTime) /
+            (prevSuccessful - 1)
+          : 0;
+      const mappedCategory = mcpCategoryToErrorCategory(errorCategory);
+      prepared.metrics.errorCategories[mappedCategory] =
+        (prepared.metrics.errorCategories[mappedCategory] || 0) + 1;
+    }
+
+    this.emitToolEndEvent(
+      toolName,
+      executionContext.executionStartTime,
+      !isToolError,
+      result,
+    );
+    toolSpan.setAttribute(
+      "tool.result.status",
+      isToolError ? "error" : "success",
+    );
+    toolSpan.setAttribute("tool.duration_ms", executionTime);
+
+    return result;
+  }
+
+  private async handleFailedToolExecution<T>(
+    toolName: string,
+    params: unknown,
+    error: unknown,
+    prepared: Awaited<ReturnType<NeuroLink["prepareToolExecutionState"]>>,
+    executionContext: ReturnType<NeuroLink["createToolExecutionContext"]>,
+    toolSpan: ReturnType<typeof tracers.mcp.startSpan>,
+  ): Promise<T> {
+    prepared.metrics.failedExecutions++;
+    const executionTime = Date.now() - executionContext.executionStartTime;
+
+    if (error instanceof CircuitBreakerOpenError) {
+      mcpLogger.warn(
+        `[${executionContext.functionTag}] Tool blocked by circuit breaker: ${toolName}`,
+        {
+          toolName,
+          breakerState: error.breakerState,
+          retryAfter: error.retryAfter,
+          retryAfterMs: error.retryAfterMs,
+          failureCount: error.failureCount,
+          executionTime,
+        },
+      );
+      prepared.metrics.errorCategories[ErrorCategory.EXECUTION] =
+        (prepared.metrics.errorCategories[ErrorCategory.EXECUTION] || 0) + 1;
+
+      this.emitToolEndEvent(
+        toolName,
+        executionContext.executionStartTime,
+        false,
+        undefined,
+      );
+      toolSpan.setAttribute("tool.result.status", "circuit_breaker_open");
+      toolSpan.setAttribute("tool.duration_ms", executionTime);
+      toolSpan.setAttribute("tool.circuit_breaker.state", error.breakerState);
+      toolSpan.setAttribute(
+        "tool.circuit_breaker.retry_after_ms",
+        error.retryAfterMs,
+      );
+      toolSpan.setAttribute(
+        "tool.circuit_breaker.failure_count",
+        error.failureCount,
+      );
+      toolSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `Circuit breaker open for ${toolName}: ${error.message}`,
+      });
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `TOOL TEMPORARILY UNAVAILABLE: "${toolName}" has been disabled after ` +
+              `${error.failureCount} failures. ` +
+              `This is a circuit breaker protection — do NOT retry this tool. ` +
+              `It will become available again after ${Math.ceil(error.retryAfterMs / 1000)} seconds ` +
+              `(at ${error.retryAfter}). ` +
+              `Instead, inform the user that the operation failed and suggest trying again later.`,
+          },
+        ],
+      } as T;
+    }
+
+    let structuredError: NeuroLinkError;
+    if (error instanceof NeuroLinkError) {
+      structuredError = error;
+    } else if (error instanceof Error) {
+      if (error.message.includes("timeout")) {
+        structuredError = ErrorFactory.toolTimeout(
+          toolName,
+          prepared.finalOptions.timeout,
+        );
+      } else if (error.message.includes("not found")) {
+        const availableTools = await this.getAllAvailableTools();
+        structuredError = ErrorFactory.toolNotFound(
+          toolName,
+          extractToolNames(availableTools.map((tool) => ({ name: tool.name }))),
+        );
+      } else if (
+        error.message.includes("validation") ||
+        error.message.includes("parameter")
+      ) {
+        structuredError = ErrorFactory.invalidParameters(
+          toolName,
+          error,
+          params,
+        );
+      } else if (
+        error.message.includes("network") ||
+        error.message.includes("connection")
+      ) {
+        structuredError = ErrorFactory.networkError(toolName, error);
+      } else {
+        structuredError = ErrorFactory.toolExecutionFailed(toolName, error);
+      }
+    } else {
+      structuredError = ErrorFactory.toolExecutionFailed(
+        toolName,
+        new Error(String(error)),
+      );
+    }
+
+    const category = structuredError.category || ErrorCategory.EXECUTION;
+    prepared.metrics.errorCategories[category] =
+      (prepared.metrics.errorCategories[category] || 0) + 1;
+
+    this.emitToolEndEvent(
+      toolName,
+      executionContext.executionStartTime,
+      false,
+      undefined,
+      structuredError,
+    );
+    this.emitter.emit("error", structuredError);
+
+    structuredError = new NeuroLinkError({
+      ...structuredError,
+      context: {
+        ...structuredError.context,
+        executionTime,
+        params,
+        options: prepared.finalOptions,
+        circuitBreakerState: prepared.circuitBreaker.getState(),
+        circuitBreakerFailures: prepared.circuitBreaker.getFailureCount(),
+        metrics: { ...prepared.metrics },
+      },
+    });
+
+    logStructuredError(structuredError);
+    toolSpan.setAttribute("tool.result.status", "error");
+    toolSpan.setAttribute("tool.duration_ms", executionTime);
+    toolSpan.recordException(structuredError);
+    toolSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: structuredError.message,
+    });
+
+    throw structuredError;
   }
 
   /**
@@ -7691,7 +9052,9 @@ Current user's request: ${currentInput}`;
     }
 
     // === MCP ENHANCEMENT: Middleware chain wrapper ===
-    const executeWithMiddleware = async (executeFn: () => Promise<T>): Promise<T> => {
+    const executeWithMiddleware = async (
+      executeFn: () => Promise<T>,
+    ): Promise<T> => {
       if (this.mcpToolMiddlewares.length === 0) {
         return executeFn();
       }
@@ -7727,7 +9090,9 @@ Current user's request: ${currentInput}`;
       const externalTools = this.externalServerManager.getAllTools();
 
       // === MCP ENHANCEMENT: ToolRouter for multi-server routing ===
-      const matchingTools = externalTools.filter((tool) => tool.name === toolName && tool.isAvailable);
+      const matchingTools = externalTools.filter(
+        (tool) => tool.name === toolName && tool.isAvailable,
+      );
 
       let externalTool: ExternalMCPToolInfo | undefined;
 
@@ -7741,13 +9106,21 @@ Current user's request: ${currentInput}`;
             inputSchema: {},
           };
           const decision: RoutingDecision = this.mcpToolRouter.route(mcpTool);
-          externalTool = matchingTools.find((t) => t.serverId === decision.serverId) || matchingTools[0];
-          logger.debug(`[${functionTag}] Router selected server: ${decision.serverId}`, {
-            strategy: decision.strategy,
-            confidence: decision.confidence,
-          });
+          externalTool =
+            matchingTools.find((t) => t.serverId === decision.serverId) ||
+            matchingTools[0];
+          logger.debug(
+            `[${functionTag}] Router selected server: ${decision.serverId}`,
+            {
+              strategy: decision.strategy,
+              confidence: decision.confidence,
+            },
+          );
         } catch (routerError) {
-          logger.warn(`[${functionTag}] Router failed, falling back to first match`, { error: routerError });
+          logger.warn(
+            `[${functionTag}] Router failed, falling back to first match`,
+            { error: routerError },
+          );
           externalTool = matchingTools[0];
         }
       } else {
@@ -7764,7 +9137,9 @@ Current user's request: ${currentInput}`;
 
       if (externalTool && externalTool.isAvailable) {
         try {
-          mcpLogger.debug(`[${functionTag}] Executing external MCP tool: ${toolName} from ${externalTool.serverId}`);
+          mcpLogger.debug(
+            `[${functionTag}] Executing external MCP tool: ${toolName} from ${externalTool.serverId}`,
+          );
 
           const result = await this.externalServerManager.executeTool(
             externalTool.serverId,
@@ -7773,11 +9148,14 @@ Current user's request: ${currentInput}`;
             { timeout: options.timeout },
           );
 
-          logger.debug(`[${functionTag}] External MCP tool execution successful:`, {
-            toolName,
-            serverId: externalTool.serverId,
-            resultType: typeof result,
-          });
+          logger.debug(
+            `[${functionTag}] External MCP tool execution successful:`,
+            {
+              toolName,
+              serverId: externalTool.serverId,
+              resultType: typeof result,
+            },
+          );
 
           return result as T;
         } catch (error) {
@@ -7810,18 +9188,29 @@ Current user's request: ${currentInput}`;
           finalContextKeys: Object.keys(context),
         });
 
-        const result = (await this.toolRegistry.executeTool(toolName, params, context)) as T;
+        const result = (await this.toolRegistry.executeTool(
+          toolName,
+          params,
+          context,
+        )) as T;
 
         // Check if result indicates a failure and emit error event
-        if (result && typeof result === "object" && "success" in result && result.success === false) {
-          const errorMessage = (result as { error?: string }).error || "Tool execution failed";
+        if (
+          result &&
+          typeof result === "object" &&
+          "success" in result &&
+          result.success === false
+        ) {
+          const errorMessage =
+            (result as { error?: string }).error || "Tool execution failed";
           const errorToEmit = new Error(errorMessage);
           this.emitter.emit("error", errorToEmit);
         }
 
         return result;
       } catch (error) {
-        const errorToEmit = error instanceof Error ? error : new Error(String(error));
+        const errorToEmit =
+          error instanceof Error ? error : new Error(String(error));
         this.emitter.emit("error", errorToEmit);
 
         // Check if tool was not found
@@ -7833,7 +9222,10 @@ Current user's request: ${currentInput}`;
           );
         }
 
-        throw ErrorFactory.toolExecutionFailed(toolName, error instanceof Error ? error : new Error(String(error)));
+        throw ErrorFactory.toolExecutionFailed(
+          toolName,
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     };
 
@@ -7858,8 +9250,15 @@ Current user's request: ${currentInput}`;
             execute: async () => ({}),
           } as import("./mcp/toolAnnotations.js").MCPServerTool)
         : undefined;
-      if (toolStubForRetry && isSafeToRetry(toolStubForRetry) && error instanceof Error && isRetriableError(error)) {
-        logger.debug(`[${functionTag}] Tool ${toolName} is safe to retry, attempting once more`);
+      if (
+        toolStubForRetry &&
+        isSafeToRetry(toolStubForRetry) &&
+        error instanceof Error &&
+        isRetriableError(error)
+      ) {
+        logger.debug(
+          `[${functionTag}] Tool ${toolName} is safe to retry, attempting once more`,
+        );
         try {
           const retryResult = await executeWithMiddleware(executeCore);
 
@@ -7882,7 +9281,9 @@ Current user's request: ${currentInput}`;
    * Get tool annotations for execution decisions (cache, retry).
    * Checks cached tool list first, falls back to inference from tool name.
    */
-  private getToolAnnotationsForExecution(toolName: string): MCPToolAnnotations | undefined {
+  private getToolAnnotationsForExecution(
+    toolName: string,
+  ): MCPToolAnnotations | undefined {
     // Check tool cache for stored annotations
     if (this.toolCache?.tools) {
       const tool = this.toolCache.tools.find((t) => t.name === toolName);
@@ -7908,7 +9309,10 @@ Current user's request: ${currentInput}`;
 
   async getAllAvailableTools(): Promise<ToolInfo[]> {
     // Return from cache if available and not stale
-    if (this.toolCache && Date.now() - this.toolCache.timestamp < this.toolCacheDuration) {
+    if (
+      this.toolCache &&
+      Date.now() - this.toolCache.timestamp < this.toolCacheDuration
+    ) {
       logger.debug("Returning available tools from cache");
       return this.toolCache.tools;
     }
@@ -7931,7 +9335,8 @@ Current user's request: ${currentInput}`;
         toolRegistrySize: 0, // Not accessible as size property
         toolRegistryType: this.toolRegistry?.constructor?.name || "NOT_SET",
         hasExternalServerManager: !!this.externalServerManager,
-        externalServerManagerType: this.externalServerManager?.constructor?.name || "NOT_SET",
+        externalServerManagerType:
+          this.externalServerManager?.constructor?.name || "NOT_SET",
       },
 
       // 🌐 MCP state
@@ -7957,14 +9362,17 @@ Current user's request: ${currentInput}`;
       for (const tool of mcpToolsRaw) {
         if (!allTools.has(tool.name)) {
           const optimizedTool = optimizeToolForCollection(tool, {
-            serverId: tool.serverId === "direct" ? "neurolink-direct" : tool.serverId,
+            serverId:
+              tool.serverId === "direct" ? "neurolink-direct" : tool.serverId,
           });
           allTools.set(tool.name, optimizedTool);
         }
       }
 
       // 2. Add custom tools from this NeuroLink instance
-      const customToolsRaw = this.toolRegistry.getToolsByCategory(detectCategory({ isCustomTool: true }));
+      const customToolsRaw = this.toolRegistry.getToolsByCategory(
+        detectCategory({ isCustomTool: true }),
+      );
       for (const tool of customToolsRaw) {
         if (!allTools.has(tool.name)) {
           const optimizedTool = optimizeToolForCollection(tool, {
@@ -7981,7 +9389,8 @@ Current user's request: ${currentInput}`;
       }
 
       // 3. Add tools from in-memory MCP servers
-      const inMemoryToolsRaw = this.toolRegistry.getToolsByCategory("in-memory");
+      const inMemoryToolsRaw =
+        this.toolRegistry.getToolsByCategory("in-memory");
       for (const tool of inMemoryToolsRaw) {
         if (!allTools.has(tool.name)) {
           const optimizedTool = optimizeToolForCollection(tool, {
@@ -8000,7 +9409,10 @@ Current user's request: ${currentInput}`;
         if (!allTools.has(tool.name)) {
           const optimizedTool = optimizeToolForCollection(tool as ToolInfo, {
             category: detectCategory({
-              existingCategory: typeof tool.metadata?.category === "string" ? tool.metadata.category : undefined,
+              existingCategory:
+                typeof tool.metadata?.category === "string"
+                  ? tool.metadata.category
+                  : undefined,
               isExternal: true,
               serverId: tool.serverId,
             }),
@@ -8025,7 +9437,9 @@ Current user's request: ${currentInput}`;
       const memoryDelta = endMemory.heapUsed - startMemory.heapUsed;
 
       if (memoryDelta > MEMORY_THRESHOLDS.LOW_USAGE_MB) {
-        mcpLogger.debug(`🔍 Tool listing used ${memoryDelta}MB memory (large tool registry detected)`);
+        mcpLogger.debug(
+          `🔍 Tool listing used ${memoryDelta}MB memory (large tool registry detected)`,
+        );
         // Optimized collection patterns should reduce memory usage significantly
         if (uniqueTools.length > PERFORMANCE_THRESHOLDS.LARGE_TOOL_COLLECTION) {
           mcpLogger.debug(
@@ -8070,7 +9484,9 @@ Current user's request: ${currentInput}`;
    * Get comprehensive status of all AI providers
    * Primary method for provider health checking and diagnostics
    */
-  async getProviderStatus(options?: { quiet?: boolean }): Promise<ProviderStatus[]> {
+  async getProviderStatus(options?: {
+    quiet?: boolean;
+  }): Promise<ProviderStatus[]> {
     // Track memory and timing for provider status checks
     const { MemoryManager } = await import("./utils/performance.js");
     const startMemory = MemoryManager.getMemoryUsageMB();
@@ -8144,16 +9560,20 @@ Current user's request: ${currentInput}`;
 
               // Runtime-safe guard: ensure models is an array with valid objects
               if (!Array.isArray(models)) {
-                logger.warn("Ollama API returned invalid models format in testProvider", {
-                  responseData,
-                  modelsType: typeof models,
-                });
+                logger.warn(
+                  "Ollama API returned invalid models format in testProvider",
+                  {
+                    responseData,
+                    modelsType: typeof models,
+                  },
+                );
                 throw new Error("Invalid models format from Ollama API");
               }
 
               // Filter and validate models before comparison
               const validModels = models.filter(
-                (m): m is { name: string } => m && typeof m === "object" && typeof m.name === "string",
+                (m): m is { name: string } =>
+                  m && typeof m === "object" && typeof m.name === "string",
               );
 
               if (validModels.length > 0) {
@@ -8181,7 +9601,10 @@ Current user's request: ${currentInput}`;
                 status: "failed" as const,
                 configured: false,
                 authenticated: false,
-                error: error instanceof Error ? error.message : "Ollama service not running",
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Ollama service not running",
                 responseTime: Date.now() - startTime,
               };
             }
@@ -8191,7 +9614,10 @@ Current user's request: ${currentInput}`;
           const testTimeout = 5000;
           const testPromise = this.testProviderConnection(providerName);
           const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error("Provider test timeout (5s)")), testTimeout);
+            setTimeout(
+              () => reject(new Error("Provider test timeout (5s)")),
+              testTimeout,
+            );
           });
 
           await Promise.race([testPromise, timeoutPromise]);
@@ -8204,7 +9630,8 @@ Current user's request: ${currentInput}`;
             responseTime: Date.now() - startTime,
           };
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
           return {
             provider: providerName,
             status: "failed" as const,
@@ -8225,7 +9652,9 @@ Current user's request: ${currentInput}`;
     const memoryDelta = endMemory.heapUsed - startMemory.heapUsed;
 
     if (!options?.quiet && memoryDelta > 20) {
-      mcpLogger.debug(`🔍 Memory usage: +${memoryDelta}MB (consider cleanup for large operations)`);
+      mcpLogger.debug(
+        `🔍 Memory usage: +${memoryDelta}MB (consider cleanup for large operations)`,
+      );
     }
 
     // Suggest garbage collection for large memory increases
@@ -8256,7 +9685,10 @@ Current user's request: ${currentInput}`;
   private async testProviderConnection(providerName: string): Promise<void> {
     const { AIProviderFactory } = await import("./core/factory.js");
 
-    const provider = await AIProviderFactory.createProvider(providerName as AIProviderName, null);
+    const provider = await AIProviderFactory.createProvider(
+      providerName as AIProviderName,
+      null,
+    );
 
     await provider.generate({
       prompt: "test",
@@ -8325,7 +9757,10 @@ Current user's request: ${currentInput}`;
         inMemoryServerInfos.length +
         builtInServerInfos.length +
         autoDiscoveredServerInfos.length;
-      const availableServers = externalStats.connectedServers + inMemoryServerInfos.length + builtInServerInfos.length; // in-memory and built-in always available
+      const availableServers =
+        externalStats.connectedServers +
+        inMemoryServerInfos.length +
+        builtInServerInfos.length; // in-memory and built-in always available
       const totalTools = allTools.length + externalStats.totalTools;
 
       return {
@@ -8335,7 +9770,9 @@ Current user's request: ${currentInput}`;
         autoDiscoveredCount: autoDiscoveredServerInfos.length,
         totalTools,
         autoDiscoveredServers: autoDiscoveredServerInfos,
-        customToolsCount: this.toolRegistry.getToolsByCategory(detectCategory({ isCustomTool: true })).length,
+        customToolsCount: this.toolRegistry.getToolsByCategory(
+          detectCategory({ isCustomTool: true }),
+        ).length,
         inMemoryServersCount: inMemoryServerInfos.length,
         externalMCPServersCount: externalMCPServers.length,
         externalMCPConnectedCount: externalStats.connectedServers,
@@ -8350,7 +9787,9 @@ Current user's request: ${currentInput}`;
         autoDiscoveredCount: 0,
         totalTools: 0,
         autoDiscoveredServers: [],
-        customToolsCount: this.toolRegistry.getToolsByCategory(detectCategory({ isCustomTool: true })).length,
+        customToolsCount: this.toolRegistry.getToolsByCategory(
+          detectCategory({ isCustomTool: true }),
+        ).length,
         inMemoryServersCount: 0,
         externalMCPServersCount: 0,
         externalMCPConnectedCount: 0,
@@ -8398,12 +9837,18 @@ Current user's request: ${currentInput}`;
       // Test external MCP servers
       const externalServer = this.externalServerManager.getServer(serverId);
       if (externalServer) {
-        return externalServer.status === "connected" && externalServer.client !== null;
+        return (
+          externalServer.status === "connected" &&
+          externalServer.client !== null
+        );
       }
 
       return false;
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] Error testing MCP server ${serverId}:`, error);
+      mcpLogger.error(
+        `[NeuroLink] Error testing MCP server ${serverId}:`,
+        error,
+      );
       return false;
     }
   }
@@ -8419,10 +9864,13 @@ Current user's request: ${currentInput}`;
     const { ProviderHealthChecker } = await import("./utils/providerHealth.js");
 
     try {
-      const health = await ProviderHealthChecker.checkProviderHealth(providerName as AIProviderName, {
-        includeConnectivityTest: false,
-        cacheResults: false,
-      });
+      const health = await ProviderHealthChecker.checkProviderHealth(
+        providerName as AIProviderName,
+        {
+          includeConnectivityTest: false,
+          cacheResults: false,
+        },
+      );
       return health.isConfigured && health.hasApiKey;
     } catch (error) {
       logger.warn(`Provider env var check failed for ${providerName}`, {
@@ -8460,7 +9908,10 @@ Current user's request: ${currentInput}`;
   }> {
     const { ProviderHealthChecker } = await import("./utils/providerHealth.js");
 
-    const health = await ProviderHealthChecker.checkProviderHealth(providerName as AIProviderName, options);
+    const health = await ProviderHealthChecker.checkProviderHealth(
+      providerName as AIProviderName,
+      options,
+    );
 
     return {
       provider: health.provider,
@@ -8504,7 +9955,8 @@ Current user's request: ${currentInput}`;
   > {
     const { ProviderHealthChecker } = await import("./utils/providerHealth.js");
 
-    const healthStatuses = await ProviderHealthChecker.checkAllProvidersHealth(options);
+    const healthStatuses =
+      await ProviderHealthChecker.checkAllProvidersHealth(options);
 
     return healthStatuses.map((health) => ({
       provider: health.provider,
@@ -8546,13 +9998,19 @@ Current user's request: ${currentInput}`;
     const recommendations: string[] = [];
 
     if (summary.healthy === 0) {
-      recommendations.push("No providers are healthy. Check your environment configuration.");
+      recommendations.push(
+        "No providers are healthy. Check your environment configuration.",
+      );
     } else if (summary.healthy < 2) {
-      recommendations.push("Consider configuring additional providers for better reliability.");
+      recommendations.push(
+        "Consider configuring additional providers for better reliability.",
+      );
     }
 
     if (summary.hasIssues > 0) {
-      recommendations.push("Some providers have configuration issues. Run checkAllProvidersHealth() for details.");
+      recommendations.push(
+        "Some providers have configuration issues. Run checkAllProvidersHealth() for details.",
+      );
     }
 
     return {
@@ -8606,7 +10064,9 @@ Current user's request: ${currentInput}`;
         ...toolMetrics,
         errorCategories: { ...toolMetrics.errorCategories },
         successRate:
-          toolMetrics.totalExecutions > 0 ? toolMetrics.successfulExecutions / toolMetrics.totalExecutions : 0,
+          toolMetrics.totalExecutions > 0
+            ? toolMetrics.successfulExecutions / toolMetrics.totalExecutions
+            : 0,
       };
     }
 
@@ -8618,9 +10078,13 @@ Current user's request: ${currentInput}`;
    * Models in the alias map will be warned, redirected, or blocked based on their action.
    * @param config - Model alias configuration with aliases map
    */
-  setModelAliasConfig(config: import("./types/generateTypes.js").ModelAliasConfig): void {
+  setModelAliasConfig(
+    config: import("./types/generateTypes.js").ModelAliasConfig,
+  ): void {
     this.modelAliasConfig = config;
-    logger.info(`[ModelAlias] Configured ${Object.keys(config.aliases).length} model aliases`);
+    logger.info(
+      `[ModelAlias] Configured ${Object.keys(config.aliases).length} model aliases`,
+    );
   }
 
   /**
@@ -8644,7 +10108,10 @@ Current user's request: ${currentInput}`;
       }
     > = {};
 
-    for (const [toolName, circuitBreaker] of this.toolCircuitBreakers.entries()) {
+    for (const [
+      toolName,
+      circuitBreaker,
+    ] of this.toolCircuitBreakers.entries()) {
       status[toolName] = {
         state: circuitBreaker.getState(),
         failureCount: circuitBreaker.getFailureCount(),
@@ -8664,7 +10131,10 @@ Current user's request: ${currentInput}`;
       // Create a new circuit breaker (effectively resets it)
       this.toolCircuitBreakers.set(
         toolName,
-        new CircuitBreaker(CIRCUIT_BREAKER.FAILURE_THRESHOLD, CIRCUIT_BREAKER_RESET_MS),
+        new CircuitBreaker(
+          CIRCUIT_BREAKER.FAILURE_THRESHOLD,
+          CIRCUIT_BREAKER_RESET_MS,
+        ),
       );
       mcpLogger.info(`Circuit breaker reset for tool: ${toolName}`);
     }
@@ -8750,7 +10220,9 @@ Current user's request: ${currentInput}`;
           ? metrics.successfulExecutions / metrics.totalExecutions
           : 0
         : 0;
-      const isHealthy = (!circuitBreaker || circuitBreaker.getState() === "closed") && successRate >= 0.8;
+      const isHealthy =
+        (!circuitBreaker || circuitBreaker.getState() === "closed") &&
+        successRate >= 0.8;
 
       if (isHealthy) {
         healthyCount++;
@@ -8761,7 +10233,9 @@ Current user's request: ${currentInput}`;
 
       if (circuitBreaker && circuitBreaker.getState() === "open") {
         issues.push("Circuit breaker is open due to repeated failures");
-        recommendations.push("Check tool implementation and fix underlying issues");
+        recommendations.push(
+          "Check tool implementation and fix underlying issues",
+        );
       }
 
       if (successRate < 0.8 && metrics && metrics.totalExecutions > 0) {
@@ -8778,15 +10252,21 @@ Current user's request: ${currentInput}`;
         const categories = metrics.errorCategories;
         if (categories[ErrorCategory.TIMEOUT] > 0) {
           issues.push(`Timeout errors: ${categories[ErrorCategory.TIMEOUT]}`);
-          recommendations.push("Consider increasing the tool timeout configuration");
+          recommendations.push(
+            "Consider increasing the tool timeout configuration",
+          );
         }
         if (categories[ErrorCategory.VALIDATION] > 0) {
-          issues.push(`Validation errors: ${categories[ErrorCategory.VALIDATION]}`);
+          issues.push(
+            `Validation errors: ${categories[ErrorCategory.VALIDATION]}`,
+          );
           recommendations.push("Review input schemas and parameter validation");
         }
         if (categories[ErrorCategory.NETWORK] > 0) {
           issues.push(`Network errors: ${categories[ErrorCategory.NETWORK]}`);
-          recommendations.push("Check network connectivity and endpoint availability");
+          recommendations.push(
+            "Check network connectivity and endpoint availability",
+          );
         }
       }
 
@@ -8798,7 +10278,9 @@ Current user's request: ${currentInput}`;
           successRate,
           averageExecutionTime: metrics?.averageExecutionTime || 0,
           lastExecutionTime: metrics?.lastExecutionTime || 0,
-          errorCategories: metrics?.errorCategories ? { ...metrics.errorCategories } : {},
+          errorCategories: metrics?.errorCategories
+            ? { ...metrics.errorCategories }
+            : {},
         },
         circuitBreaker: {
           state: circuitBreaker?.getState() || "closed",
@@ -8828,7 +10310,11 @@ Current user's request: ${currentInput}`;
   async ensureConversationMemoryInitialized(): Promise<boolean> {
     try {
       const initId = `manual-init-${Date.now()}`;
-      await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+      await this.initializeConversationMemoryForGeneration(
+        initId,
+        Date.now(),
+        process.hrtime.bigint(),
+      );
       return !!this.conversationMemory;
     } catch (error) {
       logger.error("Failed to initialize conversation memory", {
@@ -8844,7 +10330,11 @@ Current user's request: ${currentInput}`;
   async getConversationStats() {
     // First ensure memory is initialized
     const initId = `stats-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -8867,7 +10357,11 @@ Current user's request: ${currentInput}`;
   async getConversationHistory(sessionId: string): Promise<ChatMessage[]> {
     // First ensure memory is initialized
     const initId = `history-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -8892,7 +10386,8 @@ Current user's request: ${currentInput}`;
 
     try {
       // Use the existing buildContextMessages method to get the complete history
-      const messages = await this.conversationMemory.buildContextMessages(sessionId);
+      const messages =
+        await this.conversationMemory.buildContextMessages(sessionId);
 
       logger.debug("Retrieved conversation history", {
         sessionId,
@@ -8918,7 +10413,11 @@ Current user's request: ${currentInput}`;
   async clearConversationSession(sessionId: string): Promise<boolean> {
     // First ensure memory is initialized
     const initId = `clear-session-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -8940,7 +10439,11 @@ Current user's request: ${currentInput}`;
   async clearAllConversations(): Promise<void> {
     // First ensure memory is initialized
     const initId = `clear-all-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -8982,7 +10485,9 @@ Current user's request: ${currentInput}`;
     currentTime?: Date,
   ): Promise<void> {
     // Check if tools are not empty
-    const hasToolData = (toolCalls && toolCalls.length > 0) || (toolResults && toolResults.length > 0);
+    const hasToolData =
+      (toolCalls && toolCalls.length > 0) ||
+      (toolResults && toolResults.length > 0);
 
     if (!hasToolData) {
       logger.debug("Tool execution storage skipped", {
@@ -8994,10 +10499,17 @@ Current user's request: ${currentInput}`;
     }
 
     // Type guard to ensure it's Redis conversation memory manager
-    const redisMemory = this.conversationMemory as RedisConversationMemoryManager;
+    const redisMemory = this
+      .conversationMemory as RedisConversationMemoryManager;
 
     try {
-      await redisMemory.storeToolExecution(sessionId, userId, toolCalls, toolResults, currentTime);
+      await redisMemory.storeToolExecution(
+        sessionId,
+        userId,
+        toolCalls,
+        toolResults,
+        currentTime,
+      );
     } catch (error) {
       logger.warn("Failed to store tool executions", {
         sessionId,
@@ -9015,7 +10527,9 @@ Current user's request: ${currentInput}`;
   isToolExecutionStorageAvailable(): boolean {
     const isRedisStorage = process.env.STORAGE_TYPE === "redis";
     const hasRedisConversationMemory =
-      this.conversationMemory && this.conversationMemory.constructor.name === "RedisConversationMemoryManager";
+      this.conversationMemory &&
+      this.conversationMemory.constructor.name ===
+        "RedisConversationMemoryManager";
 
     return !!(isRedisStorage && hasRedisConversationMemory);
   }
@@ -9026,9 +10540,16 @@ Current user's request: ${currentInput}`;
    * @param sessionId - The session ID to retrieve messages for
    * @returns Array of ChatMessage objects, or empty array if session doesn't exist
    */
-  async getSessionMessages(sessionId: string, userId?: string): Promise<ChatMessage[]> {
+  async getSessionMessages(
+    sessionId: string,
+    userId?: string,
+  ): Promise<ChatMessage[]> {
     const initId = `get-msgs-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -9060,9 +10581,17 @@ Current user's request: ${currentInput}`;
    * @param messages - The new messages array
    * @param userId - Optional user ID for scoped Redis key lookup
    */
-  async setSessionMessages(sessionId: string, messages: ChatMessage[], userId?: string): Promise<void> {
+  async setSessionMessages(
+    sessionId: string,
+    messages: ChatMessage[],
+    userId?: string,
+  ): Promise<void> {
     const initId = `set-msgs-init-${Date.now()}`;
-    await this.initializeConversationMemoryForGeneration(initId, Date.now(), process.hrtime.bigint());
+    await this.initializeConversationMemoryForGeneration(
+      initId,
+      Date.now(),
+      process.hrtime.bigint(),
+    );
 
     if (!this.conversationMemory) {
       throw new NeuroLinkError({
@@ -9085,7 +10614,11 @@ Current user's request: ${currentInput}`;
       });
     }
 
-    await this.conversationMemory.setSessionMessages(sessionId, messages, userId);
+    await this.conversationMemory.setSessionMessages(
+      sessionId,
+      messages,
+      userId,
+    );
   }
 
   /**
@@ -9138,27 +10671,37 @@ Current user's request: ${currentInput}`;
         transport: config.transport,
       });
 
-      const result = await this.externalServerManager.addServer(serverId, config);
+      const result = await this.externalServerManager.addServer(
+        serverId,
+        config,
+      );
 
       if (result.success) {
-        mcpLogger.info(`[NeuroLink] External MCP server added successfully: ${serverId}`, {
-          toolsDiscovered: result.metadata?.toolsDiscovered || 0,
-          duration: result.duration,
-        });
+        mcpLogger.info(
+          `[NeuroLink] External MCP server added successfully: ${serverId}`,
+          {
+            toolsDiscovered: result.metadata?.toolsDiscovered || 0,
+            duration: result.duration,
+          },
+        );
 
         // === MCP ENHANCEMENT: Lazy-init ToolRouter when 2+ servers exist ===
         if (this.mcpEnhancementsConfig?.router?.enabled !== false) {
           const servers = this.externalServerManager.listServers();
           if (servers.length >= 2 && !this.mcpToolRouter) {
             this.mcpToolRouter = new ToolRouter({
-              strategy: this.mcpEnhancementsConfig?.router?.strategy ?? "least-loaded",
-              enableAffinity: this.mcpEnhancementsConfig?.router?.enableAffinity ?? false,
+              strategy:
+                this.mcpEnhancementsConfig?.router?.strategy ?? "least-loaded",
+              enableAffinity:
+                this.mcpEnhancementsConfig?.router?.enableAffinity ?? false,
             });
             // Register all existing servers
             for (const server of servers) {
               this.mcpToolRouter.registerServer(server.id || serverId);
             }
-            logger.debug("[NeuroLink] ToolRouter auto-initialized (2+ external servers)");
+            logger.debug(
+              "[NeuroLink] ToolRouter auto-initialized (2+ external servers)",
+            );
           } else if (this.mcpToolRouter) {
             this.mcpToolRouter.registerServer(serverId);
           }
@@ -9172,14 +10715,20 @@ Current user's request: ${currentInput}`;
           timestamp: Date.now(),
         });
       } else {
-        mcpLogger.error(`[NeuroLink] Failed to add external MCP server: ${serverId}`, {
-          error: result.error,
-        });
+        mcpLogger.error(
+          `[NeuroLink] Failed to add external MCP server: ${serverId}`,
+          {
+            error: result.error,
+          },
+        );
       }
 
       return result;
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] Error adding external MCP server: ${serverId}`, error);
+      mcpLogger.error(
+        `[NeuroLink] Error adding external MCP server: ${serverId}`,
+        error,
+      );
       throw error;
     }
   }
@@ -9190,7 +10739,9 @@ Current user's request: ${currentInput}`;
    * @param serverId - ID of the server to remove
    * @returns Operation result
    */
-  async removeExternalMCPServer(serverId: string): Promise<ExternalMCPOperationResult<void>> {
+  async removeExternalMCPServer(
+    serverId: string,
+  ): Promise<ExternalMCPOperationResult<void>> {
     this.invalidateToolCache(); // Invalidate cache when an external server is removed
     try {
       mcpLogger.info(`[NeuroLink] Removing external MCP server: ${serverId}`);
@@ -9198,7 +10749,9 @@ Current user's request: ${currentInput}`;
       const result = await this.externalServerManager.removeServer(serverId);
 
       if (result.success) {
-        mcpLogger.info(`[NeuroLink] External MCP server removed successfully: ${serverId}`);
+        mcpLogger.info(
+          `[NeuroLink] External MCP server removed successfully: ${serverId}`,
+        );
 
         // Emit server removed event
         this.emitter.emit("externalMCP:serverRemoved", {
@@ -9206,14 +10759,20 @@ Current user's request: ${currentInput}`;
           timestamp: Date.now(),
         });
       } else {
-        mcpLogger.error(`[NeuroLink] Failed to remove external MCP server: ${serverId}`, {
-          error: result.error,
-        });
+        mcpLogger.error(
+          `[NeuroLink] Failed to remove external MCP server: ${serverId}`,
+          {
+            error: result.error,
+          },
+        );
       }
 
       return result;
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] Error removing external MCP server: ${serverId}`, error);
+      mcpLogger.error(
+        `[NeuroLink] Error removing external MCP server: ${serverId}`,
+        error,
+      );
       throw error;
     }
   }
@@ -9251,7 +10810,9 @@ Current user's request: ${currentInput}`;
    * @param serverId - ID of the server
    * @returns Server instance or undefined if not found
    */
-  getExternalMCPServer(serverId: string): ExternalMCPServerInstance | undefined {
+  getExternalMCPServer(
+    serverId: string,
+  ): ExternalMCPServerInstance | undefined {
     return this.externalServerManager.getServer(serverId);
   }
 
@@ -9270,14 +10831,26 @@ Current user's request: ${currentInput}`;
     options?: { timeout?: number },
   ): Promise<unknown> {
     try {
-      mcpLogger.debug(`[NeuroLink] Executing external MCP tool: ${toolName} on ${serverId}`);
+      mcpLogger.debug(
+        `[NeuroLink] Executing external MCP tool: ${toolName} on ${serverId}`,
+      );
 
-      const result = await this.externalServerManager.executeTool(serverId, toolName, parameters, options);
+      const result = await this.externalServerManager.executeTool(
+        serverId,
+        toolName,
+        parameters,
+        options,
+      );
 
-      mcpLogger.debug(`[NeuroLink] External MCP tool executed successfully: ${toolName}`);
+      mcpLogger.debug(
+        `[NeuroLink] External MCP tool executed successfully: ${toolName}`,
+      );
       return result;
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] External MCP tool execution failed: ${toolName}`, error);
+      mcpLogger.error(
+        `[NeuroLink] External MCP tool execution failed: ${toolName}`,
+        error,
+      );
       throw error;
     }
   }
@@ -9304,9 +10877,14 @@ Current user's request: ${currentInput}`;
    * @param config - Server configuration to test
    * @returns Test result with connection status
    */
-  async testExternalMCPConnection(config: MCPServerInfo): Promise<BatchOperationResult> {
+  async testExternalMCPConnection(
+    config: MCPServerInfo,
+  ): Promise<BatchOperationResult> {
     try {
-      const { MCPClientFactory } = await withTimeout(import("./mcp/mcpClientFactory.js"), 10000);
+      const { MCPClientFactory } = await withTimeout(
+        import("./mcp/mcpClientFactory.js"),
+        10000,
+      );
 
       const testResult = await MCPClientFactory.testConnection(config, 10000);
 
@@ -9349,9 +10927,14 @@ Current user's request: ${currentInput}`;
       this.unregisterAllExternalMCPToolsFromRegistry();
       // Then shutdown the external server manager
       await this.externalServerManager.shutdown();
-      mcpLogger.info("[NeuroLink] All external MCP servers shut down successfully");
+      mcpLogger.info(
+        "[NeuroLink] All external MCP servers shut down successfully",
+      );
     } catch (error) {
-      mcpLogger.error("[NeuroLink] Error shutting down external MCP servers:", error);
+      mcpLogger.error(
+        "[NeuroLink] Error shutting down external MCP servers:",
+        error,
+      );
       throw error;
     }
   }
@@ -9403,7 +10986,9 @@ Current user's request: ${currentInput}`;
    * });
    * ```
    */
-  async registerElicitationHandler(handler: (request: unknown) => Promise<unknown>): Promise<void> {
+  async registerElicitationHandler(
+    handler: (request: unknown) => Promise<unknown>,
+  ): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const elicitationManager = (await this.getElicitationManager()) as any;
     elicitationManager.registerHandler(handler);
@@ -9519,7 +11104,10 @@ Current user's request: ${currentInput}`;
       enableLogging?: boolean;
     },
   ) {
-    const agentExposure = await withTimeout(import("./mcp/agentExposure.js"), 10000);
+    const agentExposure = await withTimeout(
+      import("./mcp/agentExposure.js"),
+      10000,
+    );
     return agentExposure.exposeAgentAsTool(agent, options);
   }
 
@@ -9558,7 +11146,10 @@ Current user's request: ${currentInput}`;
       enableLogging?: boolean;
     },
   ) {
-    const agentExposure = await withTimeout(import("./mcp/agentExposure.js"), 10000);
+    const agentExposure = await withTimeout(
+      import("./mcp/agentExposure.js"),
+      10000,
+    );
     return agentExposure.exposeWorkflowAsTool(workflow, options);
   }
 
@@ -9663,25 +11254,25 @@ Current user's request: ${currentInput}`;
    * ```
    */
   async getToolAnnotations(toolName: string) {
-    const { inferAnnotations, mergeAnnotations, getAnnotationSummary } = await withTimeout(
-      import("./mcp/toolAnnotations.js"),
-      10000,
-    );
+    const { inferAnnotations, mergeAnnotations, getAnnotationSummary } =
+      await withTimeout(import("./mcp/toolAnnotations.js"), 10000);
     const toolInfo = this.toolRegistry.getToolInfo(toolName);
     if (!toolInfo) {
       return null;
     }
     // Check for explicit annotations set on the tool first
-    const explicitAnnotations = (toolInfo.tool as Record<string, unknown>).annotations as
-      | Record<string, unknown>
-      | undefined;
+    const explicitAnnotations = (toolInfo.tool as Record<string, unknown>)
+      .annotations as Record<string, unknown> | undefined;
     // Infer annotations from the tool name/description as fallback
     const inferredAnnotations = inferAnnotations({
       name: toolInfo.tool.name,
       description: toolInfo.tool.description ?? "",
     });
     // Merge: inferred first, then explicit overrides (explicit takes precedence)
-    const annotations = mergeAnnotations(inferredAnnotations, explicitAnnotations);
+    const annotations = mergeAnnotations(
+      inferredAnnotations,
+      explicitAnnotations,
+    );
     return {
       annotations,
       summary: getAnnotationSummary(annotations),
@@ -9704,20 +11295,33 @@ Current user's request: ${currentInput}`;
           description: tool.description,
           execute: async (params: Record<string, unknown>) => {
             try {
-              mcpLogger.debug(`[NeuroLink] Executing external MCP tool via AI SDK: ${tool.name}`, { params });
+              mcpLogger.debug(
+                `[NeuroLink] Executing external MCP tool via AI SDK: ${tool.name}`,
+                { params },
+              );
               const result = await this.externalServerManager.executeTool(
                 tool.serverId,
                 tool.name,
                 params as JsonObject,
                 { timeout: 30000 },
               );
-              mcpLogger.debug(`[NeuroLink] External MCP tool execution result: ${tool.name}`, {
-                success: !!result,
-                hasData: !!(result && typeof result === "object" && "content" in result),
-              });
+              mcpLogger.debug(
+                `[NeuroLink] External MCP tool execution result: ${tool.name}`,
+                {
+                  success: !!result,
+                  hasData: !!(
+                    result &&
+                    typeof result === "object" &&
+                    "content" in result
+                  ),
+                },
+              );
               return result;
             } catch (error) {
-              mcpLogger.error(`[NeuroLink] External MCP tool execution failed: ${tool.name}`, error);
+              mcpLogger.error(
+                `[NeuroLink] External MCP tool execution failed: ${tool.name}`,
+                error,
+              );
               throw error;
             }
           },
@@ -9733,7 +11337,9 @@ Current user's request: ${currentInput}`;
       }
     }
 
-    mcpLogger.info(`[NeuroLink] Converted ${Object.keys(aiSDKTools).length} external MCP tools to AI SDK format`);
+    mcpLogger.info(
+      `[NeuroLink] Converted ${Object.keys(aiSDKTools).length} external MCP tools to AI SDK format`,
+    );
     return aiSDKTools;
   }
 
@@ -9757,7 +11363,9 @@ Current user's request: ${currentInput}`;
 
       for (const tool of externalTools) {
         this.toolRegistry.removeTool(tool.name);
-        mcpLogger.debug(`[NeuroLink] Unregistered external MCP tool from main registry: ${tool.name}`);
+        mcpLogger.debug(
+          `[NeuroLink] Unregistered external MCP tool from main registry: ${tool.name}`,
+        );
       }
     } catch (error) {
       mcpLogger.error(
@@ -9773,9 +11381,14 @@ Current user's request: ${currentInput}`;
   private unregisterExternalMCPToolFromRegistry(toolName: string): void {
     try {
       this.toolRegistry.removeTool(toolName);
-      mcpLogger.debug(`[NeuroLink] Unregistered external MCP tool from main registry: ${toolName}`);
+      mcpLogger.debug(
+        `[NeuroLink] Unregistered external MCP tool from main registry: ${toolName}`,
+      );
     } catch (error) {
-      mcpLogger.error(`[NeuroLink] Failed to unregister external MCP tool ${toolName} from registry:`, error);
+      mcpLogger.error(
+        `[NeuroLink] Failed to unregister external MCP tool ${toolName} from registry:`,
+        error,
+      );
     }
   }
 
@@ -9790,10 +11403,13 @@ Current user's request: ${currentInput}`;
   ): Promise<void> {
     try {
       // Import the integration module
-      const { initializeConversationMemory } = await import("./core/conversationMemoryInitializer.js");
+      const { initializeConversationMemory } =
+        await import("./core/conversationMemoryInitializer.js");
 
       // Use the integration module to create the appropriate memory manager
-      const memoryManager = await initializeConversationMemory(this.conversationMemoryConfig);
+      const memoryManager = await initializeConversationMemory(
+        this.conversationMemoryConfig,
+      );
       // Assign to conversationMemory with proper type to handle both memory manager types
       this.conversationMemory = memoryManager;
 
@@ -9805,7 +11421,9 @@ Current user's request: ${currentInput}`;
         generateInternalId,
         timestamp: new Date().toISOString(),
         elapsedMs: Date.now() - generateInternalStartTime,
-        elapsedNs: (process.hrtime.bigint() - generateInternalHrTimeStart).toString(),
+        elapsedNs: (
+          process.hrtime.bigint() - generateInternalHrTimeStart
+        ).toString(),
         error: error instanceof Error ? error.message : String(error),
         errorName: error instanceof Error ? error.name : "UnknownError",
         errorStack: error instanceof Error ? error.stack : undefined,
@@ -9826,9 +11444,14 @@ Current user's request: ${currentInput}`;
         this.toolRegistry.removeTool(tool.name);
       }
 
-      mcpLogger.debug(`[NeuroLink] Unregistered ${externalTools.length} external MCP tools from main registry`);
+      mcpLogger.debug(
+        `[NeuroLink] Unregistered ${externalTools.length} external MCP tools from main registry`,
+      );
     } catch (error) {
-      mcpLogger.error("[NeuroLink] Failed to unregister all external MCP tools from registry:", error);
+      mcpLogger.error(
+        "[NeuroLink] Failed to unregister all external MCP tools from registry:",
+        error,
+      );
     }
   }
 
@@ -9880,7 +11503,9 @@ Current user's request: ${currentInput}`;
       | "summarization"
       | "customerSupport"
       | "codeGeneration",
-  ): Promise<import("./evaluation/pipeline/evaluationPipeline.js").EvaluationPipeline> {
+  ): Promise<
+    import("./evaluation/pipeline/evaluationPipeline.js").EvaluationPipeline
+  > {
     const { EvaluationPipeline, getPreset } = await withTimeout(
       import("./evaluation/pipeline/index.js"),
       10000,
@@ -9900,9 +11525,15 @@ Current user's request: ${currentInput}`;
     const pipeline = new EvaluationPipeline(config);
     // Note: withTimeout races the promise but does not abort in-flight LLM calls.
     // Full AbortController propagation into pipeline/scorer internals is planned.
-    await withTimeout(pipeline.initialize(), 30000, ErrorFactory.evaluationTimeout("pipeline initialization", 30000));
+    await withTimeout(
+      pipeline.initialize(),
+      30000,
+      ErrorFactory.evaluationTimeout("pipeline initialization", 30000),
+    );
 
-    logger.debug(`[NeuroLink] Created evaluation pipeline: ${config.name ?? "custom"}`);
+    logger.debug(
+      `[NeuroLink] Created evaluation pipeline: ${config.name ?? "custom"}`,
+    );
 
     return pipeline;
   }
@@ -9977,7 +11608,9 @@ Current user's request: ${currentInput}`;
       /** Overall evaluation timeout in milliseconds */
       timeoutMs?: number;
     },
-  ): Promise<import("./evaluation/pipeline/evaluationPipeline.js").PipelineResult> {
+  ): Promise<
+    import("./evaluation/pipeline/evaluationPipeline.js").PipelineResult
+  > {
     const { EvaluationPipeline, getPreset } = await withTimeout(
       import("./evaluation/pipeline/index.js"),
       10000,
@@ -9988,7 +11621,9 @@ Current user's request: ${currentInput}`;
 
     // Fail fast on conflicting or empty evaluator selection
     if (options?.pipeline && options?.scorers) {
-      throw new Error("Cannot specify both 'pipeline' and 'scorers' options. Use one or the other.");
+      throw new Error(
+        "Cannot specify both 'pipeline' and 'scorers' options. Use one or the other.",
+      );
     }
     if (options?.scorers && options.scorers.length === 0) {
       throw new Error(
@@ -10022,7 +11657,11 @@ Current user's request: ${currentInput}`;
     }
 
     const pipeline = new EvaluationPipeline(config);
-    await withTimeout(pipeline.initialize(), 30000, ErrorFactory.evaluationTimeout("pipeline initialization", 30000));
+    await withTimeout(
+      pipeline.initialize(),
+      30000,
+      ErrorFactory.evaluationTimeout("pipeline initialization", 30000),
+    );
 
     const executionTimeoutMs = options?.timeoutMs ?? 60000;
     const result = await withTimeout(
@@ -10117,7 +11756,10 @@ Current user's request: ${currentInput}`;
     // Validate input
     const validation = scorer.validateInput(input);
     if (!validation.valid) {
-      throw ErrorFactory.evaluationValidationFailed(scorerId, validation.errors);
+      throw ErrorFactory.evaluationValidationFailed(
+        scorerId,
+        validation.errors,
+      );
     }
 
     // Execute scoring
@@ -10277,7 +11919,10 @@ Current user's request: ${currentInput}`;
         await shutdownOpenTelemetry();
         logger.debug("[NeuroLink] OpenTelemetry shutdown successfully");
       } catch (error) {
-        const err = error instanceof Error ? error : new Error(`OpenTelemetry shutdown error: ${String(error)}`);
+        const err =
+          error instanceof Error
+            ? error
+            : new Error(`OpenTelemetry shutdown error: ${String(error)}`);
         cleanupErrors.push(err);
         logger.warn("[NeuroLink] Error shutting down OpenTelemetry:", error);
       }
@@ -10287,11 +11932,19 @@ Current user's request: ${currentInput}`;
         try {
           logger.debug("[NeuroLink] Shutting down external MCP servers...");
           await this.externalServerManager.shutdown();
-          logger.debug("[NeuroLink] External MCP servers shutdown successfully");
+          logger.debug(
+            "[NeuroLink] External MCP servers shutdown successfully",
+          );
         } catch (error) {
-          const err = error instanceof Error ? error : new Error(`External server shutdown error: ${String(error)}`);
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(`External server shutdown error: ${String(error)}`);
           cleanupErrors.push(err);
-          logger.warn("[NeuroLink] Error shutting down external MCP servers:", error);
+          logger.warn(
+            "[NeuroLink] Error shutting down external MCP servers:",
+            error,
+          );
         }
       }
 
@@ -10303,7 +11956,10 @@ Current user's request: ${currentInput}`;
           logger.clearEventEmitter();
           logger.debug("[NeuroLink] Event listeners removed successfully");
         } catch (error) {
-          const err = error instanceof Error ? error : new Error(`Event emitter cleanup error: ${String(error)}`);
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(`Event emitter cleanup error: ${String(error)}`);
           cleanupErrors.push(err);
           logger.warn("[NeuroLink] Error removing event listeners:", error);
         }
@@ -10312,11 +11968,16 @@ Current user's request: ${currentInput}`;
       // 4. Clear all circuit breakers
       if (this.toolCircuitBreakers && this.toolCircuitBreakers.size > 0) {
         try {
-          logger.debug(`[NeuroLink] Clearing ${this.toolCircuitBreakers.size} circuit breakers...`);
+          logger.debug(
+            `[NeuroLink] Clearing ${this.toolCircuitBreakers.size} circuit breakers...`,
+          );
           this.toolCircuitBreakers.clear();
           logger.debug("[NeuroLink] Circuit breakers cleared successfully");
         } catch (error) {
-          const err = error instanceof Error ? error : new Error(`Circuit breaker cleanup error: ${String(error)}`);
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(`Circuit breaker cleanup error: ${String(error)}`);
           cleanupErrors.push(err);
           logger.warn("[NeuroLink] Error clearing circuit breakers:", error);
         }
@@ -10360,7 +12021,10 @@ Current user's request: ${currentInput}`;
 
         logger.debug("[NeuroLink] Maps and caches cleared successfully");
       } catch (error) {
-        const err = error instanceof Error ? error : new Error(`Cache cleanup error: ${String(error)}`);
+        const err =
+          error instanceof Error
+            ? error
+            : new Error(`Cache cleanup error: ${String(error)}`);
         cleanupErrors.push(err);
         logger.warn("[NeuroLink] Error clearing caches:", error);
       }
@@ -10369,7 +12033,11 @@ Current user's request: ${currentInput}`;
       if (this._taskManager) {
         try {
           logger.debug("[NeuroLink] Shutting down TaskManager...");
-          await withTimeout(this._taskManager.shutdown(), 5000, new Error("TaskManager shutdown timed out"));
+          await withTimeout(
+            this._taskManager.shutdown(),
+            5000,
+            new Error("TaskManager shutdown timed out"),
+          );
         } catch (error) {
           logger.warn("[NeuroLink] TaskManager shutdown error:", error);
         } finally {
@@ -10385,7 +12053,10 @@ Current user's request: ${currentInput}`;
         this.conversationMemoryNeedsInit = false;
         logger.debug("[NeuroLink] Initialization state reset successfully");
       } catch (error) {
-        const err = error instanceof Error ? error : new Error(`State reset error: ${String(error)}`);
+        const err =
+          error instanceof Error
+            ? error
+            : new Error(`State reset error: ${String(error)}`);
         cleanupErrors.push(err);
         logger.warn("[NeuroLink] Error resetting state:", error);
       }
@@ -10394,9 +12065,12 @@ Current user's request: ${currentInput}`;
       if (cleanupErrors.length === 0) {
         logger.debug("[NeuroLink] ✅ Resource disposal completed successfully");
       } else {
-        logger.warn(`[NeuroLink] ⚠️ Resource disposal completed with ${cleanupErrors.length} errors`, {
-          errors: cleanupErrors.map((e) => e.message),
-        });
+        logger.warn(
+          `[NeuroLink] ⚠️ Resource disposal completed with ${cleanupErrors.length} errors`,
+          {
+            errors: cleanupErrors.map((e) => e.message),
+          },
+        );
       }
     } catch (error) {
       logger.error("[NeuroLink] Critical error during disposal:", error);
@@ -10421,12 +12095,16 @@ Current user's request: ${currentInput}`;
    * Manually trigger context compaction for a session.
    * Runs the full 4-stage compaction pipeline.
    */
-  async compactSession(sessionId: string, config?: CompactionConfig): Promise<CompactionResult | null> {
+  async compactSession(
+    sessionId: string,
+    config?: CompactionConfig,
+  ): Promise<CompactionResult | null> {
     if (!this.conversationMemory) {
       return null;
     }
 
-    const messages = await this.conversationMemory.buildContextMessages(sessionId);
+    const messages =
+      await this.conversationMemory.buildContextMessages(sessionId);
     if (!messages || messages.length === 0) {
       return null;
     }
@@ -10434,9 +12112,12 @@ Current user's request: ${currentInput}`;
     const compactor = new ContextCompactor({
       ...config,
       summarizationProvider:
-        config?.summarizationProvider ?? this.conversationMemoryConfig?.conversationMemory?.summarizationProvider,
+        config?.summarizationProvider ??
+        this.conversationMemoryConfig?.conversationMemory
+          ?.summarizationProvider,
       summarizationModel:
-        config?.summarizationModel ?? this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
+        config?.summarizationModel ??
+        this.conversationMemoryConfig?.conversationMemory?.summarizationModel,
     });
     // Use actual context window to determine target, not arbitrary heuristic
     const budgetInfo = checkContextBudget({
@@ -10448,7 +12129,11 @@ Current user's request: ${currentInput}`;
     });
     // Target 60% of available input tokens — leave room for new messages
     const targetTokens = Math.floor(budgetInfo.availableInputTokens * 0.6);
-    const result = await compactor.compact(messages, targetTokens, this.conversationMemoryConfig?.conversationMemory);
+    const result = await compactor.compact(
+      messages,
+      targetTokens,
+      this.conversationMemoryConfig?.conversationMemory,
+    );
 
     if (result.compacted) {
       repairToolPairs(result.messages);
@@ -10476,7 +12161,8 @@ Current user's request: ${currentInput}`;
       return null;
     }
 
-    const messages = await this.conversationMemory.buildContextMessages(sessionId);
+    const messages =
+      await this.conversationMemory.buildContextMessages(sessionId);
     if (!messages || messages.length === 0) {
       return null;
     }
@@ -10502,12 +12188,18 @@ Current user's request: ${currentInput}`;
   /**
    * Check if a session needs compaction.
    */
-  needsCompaction(sessionId: string, provider?: string, model?: string): boolean {
+  needsCompaction(
+    sessionId: string,
+    provider?: string,
+    model?: string,
+  ): boolean {
     if (!this.conversationMemory) {
       return false;
     }
 
-    const session = (this.conversationMemory as ConversationMemoryManager).getSession?.(sessionId);
+    const session = (
+      this.conversationMemory as ConversationMemoryManager
+    ).getSession?.(sessionId);
     if (!session) {
       return false;
     }
@@ -10540,12 +12232,17 @@ Current user's request: ${currentInput}`;
     await this.initializeAuthProviderFromConfig(config);
   }
 
-  private async initializeAuthProviderFromConfig(config: NeuroLinkAuthConfig): Promise<void> {
+  private async initializeAuthProviderFromConfig(
+    config: NeuroLinkAuthConfig,
+  ): Promise<void> {
     let provider: MastraAuthProvider;
     let providerType: string;
 
     // Duck-type check: direct MastraAuthProvider instance
-    if ("authenticateToken" in config && typeof (config as MastraAuthProvider).authenticateToken === "function") {
+    if (
+      "authenticateToken" in config &&
+      typeof (config as MastraAuthProvider).authenticateToken === "function"
+    ) {
       provider = config as MastraAuthProvider;
       providerType = provider.type;
     } else if ("provider" in config) {
@@ -10556,8 +12253,12 @@ Current user's request: ${currentInput}`;
         type: AuthProviderType;
         config: AuthProviderConfig;
       };
-      const { AuthProviderFactory } = await import("./auth/AuthProviderFactory.js");
-      provider = await AuthProviderFactory.createProvider(typedConfig.type, typedConfig.config);
+      const { AuthProviderFactory } =
+        await import("./auth/AuthProviderFactory.js");
+      provider = await AuthProviderFactory.createProvider(
+        typedConfig.type,
+        typedConfig.config,
+      );
       providerType = typedConfig.type;
     }
 
@@ -10593,7 +12294,8 @@ Current user's request: ${currentInput}`;
       } finally {
         if (
           this.authInitPromise &&
-          (this.pendingAuthConfig === undefined || this.pendingAuthConfig === pendingAuthConfig)
+          (this.pendingAuthConfig === undefined ||
+            this.pendingAuthConfig === pendingAuthConfig)
         ) {
           this.authInitPromise = undefined;
         }

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -92,14 +92,6 @@ async function createGoogleGenAIClient(apiKey: string): Promise<GenAIClient> {
   return new Ctor({ apiKey });
 }
 
-// Environment variable setup
-if (
-  !process.env.GOOGLE_GENERATIVE_AI_API_KEY &&
-  process.env.GOOGLE_AI_API_KEY
-) {
-  process.env.GOOGLE_GENERATIVE_AI_API_KEY = process.env.GOOGLE_AI_API_KEY;
-}
-
 /**
  * Google AI Studio provider implementation using BaseProvider
  * Migrated from original GoogleAIStudio class to new factory pattern

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -7,7 +7,7 @@ import {
   createVertexAnthropic,
   type GoogleVertexAnthropicProviderSettings,
 } from "@ai-sdk/google-vertex/anthropic";
-import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+import { type Span, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import {
   embed,
   embedMany,
@@ -1073,360 +1073,114 @@ export class GoogleVertexProvider extends BaseProvider {
     options: StreamOptions,
     analysisSchema?: ZodType | Schema<unknown>,
   ): Promise<StreamResult> {
-    // Check if this is a Gemini 3 model with tools - use native SDK for thought_signature
-    const gemini3CheckModelName = this.resolveAlias(
+    const modelName = this.resolveAlias(
       options.model || this.modelName || getDefaultVertexModel(),
     );
+    const nativeGemini3Result = await this.maybeExecuteNativeGemini3ToolStream(
+      options,
+      analysisSchema,
+      modelName,
+    );
+    if (nativeGemini3Result) {
+      return nativeGemini3Result;
+    }
+    return this.executeAISDKStream(options, analysisSchema, modelName);
+  }
 
-    // Structured output (analysisSchema, JSON format, or schema) is incompatible with tools on Gemini.
-    // Compute once and reuse in both the native Gemini 3 gate and the streamText fallback path.
+  private async maybeExecuteNativeGemini3ToolStream(
+    options: StreamOptions,
+    analysisSchema: ZodType | Schema<unknown> | undefined,
+    modelName: string,
+  ): Promise<StreamResult | null> {
     const wantsStructuredOutput =
       analysisSchema || options.output?.format === "json" || options.schema;
-
-    // Check for tools from options AND from SDK (MCP tools)
-    // Need to check early if we should route to native SDK
-    const gemini3CheckShouldUseTools =
+    const shouldUseTools =
       !options.disableTools && this.supportsTools() && !wantsStructuredOutput;
     const optionTools = options.tools || {};
-    const sdkTools = gemini3CheckShouldUseTools ? await this.getAllTools() : {};
+    const sdkTools = shouldUseTools ? await this.getAllTools() : {};
     const combinedToolCount =
       Object.keys(optionTools).length + Object.keys(sdkTools).length;
-    const hasTools = gemini3CheckShouldUseTools && combinedToolCount > 0;
+    const hasTools = shouldUseTools && combinedToolCount > 0;
 
-    if (isGemini3Model(gemini3CheckModelName) && hasTools) {
-      // Process CSV files before routing to native SDK (bypasses normal message builder)
-      const processedOptions = await this.processCSVFilesForNativeSDK(options);
-
-      // Merge SDK tools into options for native SDK path
-      const mergedOptions = {
-        ...processedOptions,
-        tools: { ...sdkTools, ...optionTools },
-      };
-
-      logger.info(
-        "[GoogleVertex] Routing Gemini 3 to native SDK for tool calling",
-        {
-          model: gemini3CheckModelName,
-          optionToolCount: Object.keys(optionTools).length,
-          sdkToolCount: Object.keys(sdkTools).length,
-          totalToolCount: combinedToolCount,
-        },
-      );
-      return this.executeNativeGemini3Stream(mergedOptions);
+    if (!isGemini3Model(modelName) || !hasTools) {
+      return null;
     }
 
-    // Initialize stream execution tracking
+    const processedOptions = await this.processCSVFilesForNativeSDK(options);
+    const mergedOptions = {
+      ...processedOptions,
+      tools: { ...sdkTools, ...optionTools },
+    };
+
+    logger.info(
+      "[GoogleVertex] Routing Gemini 3 to native SDK for tool calling",
+      {
+        model: modelName,
+        optionToolCount: Object.keys(optionTools).length,
+        sdkToolCount: Object.keys(sdkTools).length,
+        totalToolCount: combinedToolCount,
+      },
+    );
+    return this.executeNativeGemini3Stream(mergedOptions);
+  }
+
+  private async executeAISDKStream(
+    options: StreamOptions,
+    analysisSchema: ZodType | Schema<unknown> | undefined,
+    modelName: string,
+  ): Promise<StreamResult> {
     const functionTag = "GoogleVertexProvider.executeStream";
-    let chunkCount = 0;
-
-    // Setup timeout controller
-    const timeout = this.getTimeout(options);
-
+    const tracking = {
+      chunkCount: 0,
+      collectedToolCalls: [] as ToolCall[],
+      collectedToolResults: [] as ToolResult[],
+    };
     const timeoutController = createTimeoutController(
-      timeout,
+      this.getTimeout(options),
       this.providerName,
       "stream",
     );
 
     try {
-      // Validate stream options
       this.validateStreamOptionsOnly(options);
-
-      // Build message array from options with multimodal support
-      // Using protected helper from BaseProvider to eliminate code duplication
       const messages = await this.buildMessagesForStream(options);
-
-      const model = await this.getAISDKModelWithMiddleware(options); // This is where network connection happens!
-
-      // Get all available tools (direct + MCP + external + user-provided RAG tools) for streaming
-      const shouldUseTools = !options.disableTools && this.supportsTools();
-      const baseStreamTools = shouldUseTools ? await this.getAllTools() : {};
-      const rawTools = shouldUseTools
-        ? { ...baseStreamTools, ...(options.tools || {}) }
-        : {};
-      // Only sanitize for Gemini models (not Anthropic/Claude models routed through Vertex)
-      const isAnthropic = isAnthropicModel(gemini3CheckModelName);
-      let tools: Record<string, Tool> | undefined;
-      if (Object.keys(rawTools).length > 0 && !isAnthropic) {
-        const sanitized = sanitizeToolsForGemini(rawTools);
-        if (sanitized.dropped.length > 0) {
-          logger.warn(
-            `[GoogleVertex] Dropped ${sanitized.dropped.length} incompatible tool(s): ${sanitized.dropped.join(", ")}`,
-          );
-        }
-        tools =
-          Object.keys(sanitized.tools).length > 0 ? sanitized.tools : undefined;
-      } else if (isAnthropic && Object.keys(rawTools).length > 0) {
-        // Anthropic models don't need Gemini sanitization — pass tools through
-        tools = rawTools;
-      } else {
-        tools = undefined;
-      }
-
-      logger.debug(`${functionTag}: Tools for streaming`, {
+      const model = await this.getAISDKModelWithMiddleware(options);
+      const { shouldUseTools, tools, isAnthropic } =
+        await this.resolveAISDKStreamTools(options, modelName, functionTag);
+      const streamOptions = this.buildAISDKStreamOptions({
+        options,
+        analysisSchema,
+        functionTag,
+        modelName,
+        model,
+        messages,
+        tools,
         shouldUseTools,
-        baseToolCount: Object.keys(baseStreamTools).length,
-        externalToolCount: Object.keys(options.tools || {}).length,
-        toolCount: Object.keys(tools ?? {}).length,
-        toolNames: Object.keys(tools ?? {}),
+        isAnthropic,
+        timeoutController,
+        tracking,
+      });
+      const result = this.startObservedAISDKStream(
+        streamOptions,
+        model,
+        modelName,
+        options,
+      );
+
+      this.observeAISDKStreamResult(result, {
+        model,
+        modelName,
+        options,
+        timeoutController,
       });
 
-      // Model-specific maxTokens handling
-      const modelName = this.resolveAlias(
-        options.model || this.modelName || getDefaultVertexModel(),
-      );
-
-      // Use cached model configuration to determine maxTokens handling for streaming performance
-      // This avoids hardcoded model-specific logic and repeated config lookups
-      const shouldSetMaxTokens = this.shouldSetMaxTokensCached(modelName);
-      const maxTokens = shouldSetMaxTokens
-        ? options.maxTokens // No default limit
-        : undefined;
-
-      const collectedToolCalls: ToolCall[] = [];
-      const collectedToolResults: ToolResult[] = [];
-
-      // Build complete stream options with proper typing
-      let streamOptions: Parameters<typeof streamText>[0] = {
-        model: model,
-        messages: messages,
-        temperature: options.temperature,
-        ...(maxTokens && { maxTokens }),
-        maxRetries: 0, // NL11: Disable AI SDK's invisible internal retries; we handle retries with OTel instrumentation
-        ...(shouldUseTools &&
-          tools &&
-          Object.keys(tools).length > 0 && {
-            tools,
-            toolChoice: resolveToolChoice(options, tools, shouldUseTools),
-            stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
-          }),
-        abortSignal: composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        ),
-        experimental_telemetry:
-          this.telemetryHandler.getTelemetryConfig(options),
-        // Gemini 3: use thinkingLevel via providerOptions (Vertex AI)
-        // Gemini 2.5: use thinkingBudget via providerOptions
-        ...(options.thinkingConfig?.enabled && {
-          providerOptions: {
-            vertex: {
-              thinkingConfig: {
-                ...(options.thinkingConfig.thinkingLevel && {
-                  thinkingLevel: options.thinkingConfig.thinkingLevel,
-                }),
-                ...(options.thinkingConfig.budgetTokens &&
-                  !options.thinkingConfig.thinkingLevel && {
-                    thinkingBudget: options.thinkingConfig.budgetTokens,
-                  }),
-                includeThoughts: true,
-              },
-            },
-          },
-        }),
-
-        onError: (event: { error: unknown }) => {
-          const error = event.error;
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          logger.error(`${functionTag}: Stream error`, {
-            provider: this.providerName,
-            modelName: this.modelName,
-            error: errorMessage,
-            chunkCount,
-          });
-        },
-
-        onFinish: (event: {
-          finishReason: string;
-          usage: Record<string, unknown>;
-          text?: string;
-        }) => {
-          logger.debug(`${functionTag}: Stream finished`, {
-            finishReason: event.finishReason,
-            totalChunks: chunkCount,
-          });
-        },
-
-        onChunk: () => {
-          chunkCount++;
-        },
-
-        onStepFinish: ({ toolCalls, toolResults }) => {
-          logger.info("Tool execution completed", { toolResults, toolCalls });
-
-          for (const toolCall of toolCalls) {
-            collectedToolCalls.push({
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              args:
-                (toolCall as { args?: Record<string, unknown> }).args ??
-                (toolCall as { input?: Record<string, unknown> }).input ??
-                (toolCall as { parameters?: Record<string, unknown> })
-                  .parameters ??
-                {},
-            });
-          }
-
-          for (const toolResult of toolResults) {
-            const rawToolResult = toolResult as {
-              output?: unknown;
-              result?: unknown;
-              error?: string;
-              toolCallId?: string;
-            };
-            collectedToolResults.push({
-              toolName: toolResult.toolName,
-              status: rawToolResult.error ? "failure" : "success",
-              output:
-                ((rawToolResult.output ??
-                  rawToolResult.result) as ToolResult["output"]) ?? undefined,
-              error: rawToolResult.error,
-              id: rawToolResult.toolCallId ?? toolResult.toolName,
-            });
-          }
-
-          // Handle tool execution storage
-          this.handleToolExecutionStorage(
-            toolCalls,
-            toolResults,
-            options,
-            new Date(),
-          ).catch((error: unknown) => {
-            logger.warn(
-              "[GoogleVertexProvider] Failed to store tool executions",
-              {
-                provider: this.providerName,
-                error: error instanceof Error ? error.message : String(error),
-              },
-            );
-          });
-        },
-      };
-
-      if (analysisSchema) {
-        try {
-          // Gemini cannot use tools and JSON schema simultaneously
-          if (!isAnthropic) {
-            delete streamOptions.tools;
-            delete streamOptions.toolChoice;
-            delete streamOptions.stopWhen;
-          }
-          streamOptions = {
-            ...streamOptions,
-            experimental_output: Output.object({
-              schema: analysisSchema,
-            }),
-          };
-        } catch (error) {
-          logger.warn("Schema application failed, continuing without schema", {
-            error: String(error),
-          });
-        }
-      }
-
-      // Wrap streamText in an OTel span to capture provider-level latency and token usage
-      const streamSpan = streamTracer.startSpan(
-        "neurolink.provider.streamText",
-        {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            "gen_ai.system": "vertex",
-            "gen_ai.request.model": getModelId(
-              model,
-              this.modelName || "unknown",
-            ),
-          },
-        },
-      );
-
-      let result: ReturnType<typeof streamText>;
-      try {
-        result = streamText(streamOptions);
-      } catch (err) {
-        streamSpan.recordException(
-          err instanceof Error ? err : new Error(String(err)),
-        );
-        streamSpan.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err instanceof Error ? err.message : String(err),
-        });
-        streamSpan.end();
-        throw err;
-      }
-
-      // Collect token usage and finish reason asynchronously when the stream completes,
-      // then end the span. This avoids blocking the stream consumer.
-      Promise.resolve(result.usage)
-        .then((usage) => {
-          streamSpan.setAttribute(
-            "gen_ai.usage.input_tokens",
-            usage.inputTokens || 0,
-          );
-          streamSpan.setAttribute(
-            "gen_ai.usage.output_tokens",
-            usage.outputTokens || 0,
-          );
-          const effectiveModel =
-            options.model ||
-            getModelId(model, this.modelName || getDefaultVertexModel());
-          const cost = calculateCost(this.providerName, effectiveModel, {
-            input: usage.inputTokens || 0,
-            output: usage.outputTokens || 0,
-            total: (usage.inputTokens || 0) + (usage.outputTokens || 0),
-          });
-          if (cost && cost > 0) {
-            streamSpan.setAttribute("neurolink.cost", cost);
-          }
-        })
-        .catch(() => {
-          // Usage may not be available if the stream is aborted
-        });
-      Promise.resolve(result.finishReason)
-        .then((reason) => {
-          streamSpan.setAttribute(
-            "gen_ai.response.finish_reason",
-            reason || "unknown",
-          );
-        })
-        .catch(() => {
-          // Finish reason may not be available if the stream is aborted
-        });
-      Promise.resolve(result.text)
-        .then(() => {
-          streamSpan.end();
-        })
-        .catch((err: unknown) => {
-          streamSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err instanceof Error ? err.message : String(err),
-          });
-          streamSpan.end();
-        });
-
-      // Defer timeout cleanup until the stream completes or errors.
-      // Guard against NoOutputGeneratedError becoming an unhandled rejection.
-      Promise.resolve(result.text)
-        .catch((err: unknown) => {
-          logger.debug(
-            "Stream text promise rejected (expected for empty streams)",
-            {
-              error: err instanceof Error ? err.message : String(err),
-            },
-          );
-        })
-        .finally(() => timeoutController?.cleanup());
-
-      // Transform string stream to content object stream using BaseProvider method
-      const transformedStream = this.createTextStream(result);
-
       return {
-        stream: transformedStream,
+        stream: this.createTextStream(result),
         provider: this.providerName,
         model: this.modelName,
         ...(shouldUseTools && {
-          toolCalls: collectedToolCalls,
-          toolResults: collectedToolResults,
+          toolCalls: tracking.collectedToolCalls,
+          toolResults: tracking.collectedToolResults,
         }),
       };
     } catch (error) {
@@ -1435,10 +1189,361 @@ export class GoogleVertexProvider extends BaseProvider {
         provider: this.providerName,
         modelName: this.modelName,
         error: String(error),
-        chunkCount,
+        chunkCount: tracking.chunkCount,
       });
       throw this.handleProviderError(error);
     }
+  }
+
+  private async resolveAISDKStreamTools(
+    options: StreamOptions,
+    modelName: string,
+    functionTag: string,
+  ): Promise<{
+    shouldUseTools: boolean;
+    tools: Record<string, Tool> | undefined;
+    isAnthropic: boolean;
+    baseToolCount: number;
+  }> {
+    const shouldUseTools = !options.disableTools && this.supportsTools();
+    const baseStreamTools = shouldUseTools ? await this.getAllTools() : {};
+    const rawTools = shouldUseTools
+      ? { ...baseStreamTools, ...(options.tools || {}) }
+      : {};
+    const isAnthropic = isAnthropicModel(modelName);
+    let tools: Record<string, Tool> | undefined;
+
+    if (Object.keys(rawTools).length > 0 && !isAnthropic) {
+      const sanitized = sanitizeToolsForGemini(rawTools);
+      if (sanitized.dropped.length > 0) {
+        logger.warn(
+          `[GoogleVertex] Dropped ${sanitized.dropped.length} incompatible tool(s): ${sanitized.dropped.join(", ")}`,
+        );
+      }
+      tools =
+        Object.keys(sanitized.tools).length > 0 ? sanitized.tools : undefined;
+    } else if (isAnthropic && Object.keys(rawTools).length > 0) {
+      tools = rawTools;
+    } else {
+      tools = undefined;
+    }
+
+    logger.debug(`${functionTag}: Tools for streaming`, {
+      shouldUseTools,
+      baseToolCount: Object.keys(baseStreamTools).length,
+      externalToolCount: Object.keys(options.tools || {}).length,
+      toolCount: Object.keys(tools ?? {}).length,
+      toolNames: Object.keys(tools ?? {}),
+    });
+
+    return {
+      shouldUseTools,
+      tools,
+      isAnthropic,
+      baseToolCount: Object.keys(baseStreamTools).length,
+    };
+  }
+
+  private buildAISDKStreamOptions(params: {
+    options: StreamOptions;
+    analysisSchema: ZodType | Schema<unknown> | undefined;
+    functionTag: string;
+    modelName: string;
+    model: LanguageModel;
+    messages: Awaited<
+      ReturnType<GoogleVertexProvider["buildMessagesForStream"]>
+    >;
+    tools: Record<string, Tool> | undefined;
+    shouldUseTools: boolean;
+    isAnthropic: boolean;
+    timeoutController: ReturnType<typeof createTimeoutController>;
+    tracking: {
+      chunkCount: number;
+      collectedToolCalls: ToolCall[];
+      collectedToolResults: ToolResult[];
+    };
+  }): Parameters<typeof streamText>[0] {
+    const {
+      options,
+      analysisSchema,
+      functionTag,
+      modelName,
+      model,
+      messages,
+      tools,
+      shouldUseTools,
+      isAnthropic,
+      timeoutController,
+      tracking,
+    } = params;
+    const shouldSetMaxTokens = this.shouldSetMaxTokensCached(modelName);
+    const maxTokens = shouldSetMaxTokens ? options.maxTokens : undefined;
+
+    let streamOptions: Parameters<typeof streamText>[0] = {
+      model,
+      messages,
+      temperature: options.temperature,
+      ...(maxTokens && { maxTokens }),
+      maxRetries: 0,
+      ...(shouldUseTools &&
+        tools &&
+        Object.keys(tools).length > 0 && {
+          tools,
+          toolChoice: resolveToolChoice(options, tools, shouldUseTools),
+          stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
+        }),
+      abortSignal: composeAbortSignals(
+        options.abortSignal,
+        timeoutController?.controller.signal,
+      ),
+      experimental_telemetry: this.telemetryHandler.getTelemetryConfig(options),
+      ...(options.thinkingConfig?.enabled && {
+        providerOptions: {
+          vertex: {
+            thinkingConfig: {
+              ...(options.thinkingConfig.thinkingLevel && {
+                thinkingLevel: options.thinkingConfig.thinkingLevel,
+              }),
+              ...(options.thinkingConfig.budgetTokens &&
+                !options.thinkingConfig.thinkingLevel && {
+                  thinkingBudget: options.thinkingConfig.budgetTokens,
+                }),
+              includeThoughts: true,
+            },
+          },
+        },
+      }),
+      onError: (event: { error: unknown }) => {
+        const errorMessage =
+          event.error instanceof Error
+            ? event.error.message
+            : String(event.error);
+        logger.error(`${functionTag}: Stream error`, {
+          provider: this.providerName,
+          modelName: this.modelName,
+          error: errorMessage,
+          chunkCount: tracking.chunkCount,
+        });
+      },
+      onFinish: (event: {
+        finishReason: string;
+        usage: Record<string, unknown>;
+        text?: string;
+      }) => {
+        logger.debug(`${functionTag}: Stream finished`, {
+          finishReason: event.finishReason,
+          totalChunks: tracking.chunkCount,
+        });
+      },
+      onChunk: () => {
+        tracking.chunkCount++;
+      },
+      onStepFinish: ({ toolCalls, toolResults }) => {
+        this.captureAISDKStreamToolStep(
+          options,
+          toolCalls as Array<{
+            toolCallId: string;
+            toolName: string;
+            args?: Record<string, unknown>;
+            input?: Record<string, unknown>;
+            parameters?: Record<string, unknown>;
+          }>,
+          toolResults,
+          tracking,
+        );
+      },
+    };
+
+    if (!analysisSchema) {
+      return streamOptions;
+    }
+
+    try {
+      if (!isAnthropic) {
+        delete streamOptions.tools;
+        delete streamOptions.toolChoice;
+        delete streamOptions.stopWhen;
+      }
+      streamOptions = {
+        ...streamOptions,
+        experimental_output: Output.object({ schema: analysisSchema }),
+      };
+    } catch (error) {
+      logger.warn("Schema application failed, continuing without schema", {
+        error: String(error),
+      });
+    }
+
+    return streamOptions;
+  }
+
+  private captureAISDKStreamToolStep(
+    options: StreamOptions,
+    toolCalls: Array<{
+      toolCallId: string;
+      toolName: string;
+      args?: Record<string, unknown>;
+      input?: Record<string, unknown>;
+      parameters?: Record<string, unknown>;
+    }>,
+    toolResults: Array<{
+      toolName: string;
+      output?: unknown;
+      result?: unknown;
+      error?: string;
+      toolCallId?: string;
+    }>,
+    tracking: {
+      collectedToolCalls: ToolCall[];
+      collectedToolResults: ToolResult[];
+    },
+  ): void {
+    logger.info("Tool execution completed", { toolResults, toolCalls });
+
+    for (const toolCall of toolCalls) {
+      tracking.collectedToolCalls.push({
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        args: toolCall.args ?? toolCall.input ?? toolCall.parameters ?? {},
+      });
+    }
+
+    for (const toolResult of toolResults) {
+      tracking.collectedToolResults.push({
+        toolName: toolResult.toolName,
+        status: toolResult.error ? "failure" : "success",
+        output:
+          ((toolResult.output ?? toolResult.result) as ToolResult["output"]) ??
+          undefined,
+        error: toolResult.error,
+        id: toolResult.toolCallId ?? toolResult.toolName,
+      });
+    }
+
+    this.handleToolExecutionStorage(
+      toolCalls,
+      toolResults,
+      options,
+      new Date(),
+    ).catch((error: unknown) => {
+      logger.warn("[GoogleVertexProvider] Failed to store tool executions", {
+        provider: this.providerName,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private startObservedAISDKStream(
+    streamOptions: Parameters<typeof streamText>[0],
+    model: LanguageModel,
+    modelName: string,
+    options: StreamOptions,
+  ): ReturnType<typeof streamText> {
+    const streamSpan = streamTracer.startSpan("neurolink.provider.streamText", {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        "gen_ai.system": "vertex",
+        "gen_ai.request.model": getModelId(model, this.modelName || "unknown"),
+      },
+    });
+
+    try {
+      const result = streamText(streamOptions);
+      this.attachAISDKStreamObservers(
+        result,
+        streamSpan,
+        model,
+        modelName,
+        options,
+      );
+      return result;
+    } catch (error) {
+      streamSpan.recordException(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      streamSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      streamSpan.end();
+      throw error;
+    }
+  }
+
+  private attachAISDKStreamObservers(
+    result: ReturnType<typeof streamText>,
+    streamSpan: Span,
+    model: LanguageModel,
+    modelName: string,
+    options: StreamOptions,
+  ): void {
+    Promise.resolve(result.usage)
+      .then((usage) => {
+        streamSpan.setAttribute(
+          "gen_ai.usage.input_tokens",
+          usage.inputTokens || 0,
+        );
+        streamSpan.setAttribute(
+          "gen_ai.usage.output_tokens",
+          usage.outputTokens || 0,
+        );
+        const effectiveModel =
+          options.model ||
+          getModelId(model, modelName || getDefaultVertexModel());
+        const cost = calculateCost(this.providerName, effectiveModel, {
+          input: usage.inputTokens || 0,
+          output: usage.outputTokens || 0,
+          total: (usage.inputTokens || 0) + (usage.outputTokens || 0),
+        });
+        if (cost && cost > 0) {
+          streamSpan.setAttribute("neurolink.cost", cost);
+        }
+      })
+      .catch(() => undefined);
+    Promise.resolve(result.finishReason)
+      .then((reason) => {
+        streamSpan.setAttribute(
+          "gen_ai.response.finish_reason",
+          reason || "unknown",
+        );
+      })
+      .catch(() => undefined);
+    Promise.resolve(result.text)
+      .then(() => {
+        streamSpan.end();
+      })
+      .catch((error: unknown) => {
+        streamSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        streamSpan.end();
+      });
+  }
+
+  private observeAISDKStreamResult(
+    result: ReturnType<typeof streamText>,
+    params: {
+      model: LanguageModel;
+      modelName: string;
+      options: StreamOptions;
+      timeoutController: ReturnType<typeof createTimeoutController>;
+    },
+  ): void {
+    void params.model;
+    void params.modelName;
+    void params.options;
+
+    Promise.resolve(result.text)
+      .catch((error: unknown) => {
+        logger.debug(
+          "Stream text promise rejected (expected for empty streams)",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      })
+      .finally(() => params.timeoutController?.cleanup());
   }
 
   /**
@@ -1641,309 +1746,294 @@ export class GoogleVertexProvider extends BaseProvider {
           [ATTR.NL_PROVIDER]: this.providerName,
         },
       },
-      async (span) => {
-        const client = await this.createVertexGenAIClient(options.region);
-        const effectiveLocation =
-          options.region || this.location || getVertexLocation();
-
-        logger.debug("[GoogleVertex] Using native @google/genai for Gemini 3", {
-          model: modelName,
-          hasTools: !!options.tools && Object.keys(options.tools).length > 0,
-          project: this.projectId,
-          location: effectiveLocation,
-        });
-
-        // Build contents from input with multimodal support
-        const multimodalInput = options.input as {
-          text: string;
-          pdfFiles?: Array<Buffer | string>;
-          images?: Array<Buffer | string>;
-        };
-        const contents = this.buildNativeContentParts(
-          options.input.text,
-          multimodalInput,
-          "native stream",
-        );
-
-        // Convert tools to native format
-        let hasToolsInput =
-          options.tools &&
-          Object.keys(options.tools).length > 0 &&
-          !options.disableTools;
-
-        // Guard: Gemini cannot use tools + JSON schema simultaneously
-        const streamOptions = options as TextGenerationOptions;
-        const wantsJsonOutput =
-          streamOptions.output?.format === "json" || streamOptions.schema;
-        if (wantsJsonOutput && hasToolsInput) {
-          logger.warn(
-            "[GoogleVertex] Gemini does not support tools and JSON schema output simultaneously. Disabling tools for this request.",
-          );
-          hasToolsInput = false;
-        }
-
-        let toolsConfig: NativeToolsConfig | undefined;
-        let executeMap = new Map<string, Tool["execute"]>();
-
-        if (hasToolsInput) {
-          const result = buildNativeToolDeclarations(
-            options.tools as Record<string, Tool>,
-          );
-          toolsConfig = result.toolsConfig;
-          executeMap = result.executeMap;
-
-          logger.debug("[GoogleVertex] Converted tools for native SDK", {
-            toolCount: toolsConfig[0].functionDeclarations.length,
-            toolNames: toolsConfig[0].functionDeclarations.map((t) => t.name),
-          });
-        }
-
-        // Build config — systemInstruction stays in config for Gemini 3.x.
-        // The @google/genai SDK maps config.systemInstruction to the HTTP-level
-        // system_instruction field, which is the correct mechanism for all
-        // Gemini 3.x models (including global endpoint).  Older workaround
-        // that moved systemInstruction into user/model content messages caused
-        // "Please use a valid role: user, model" on Gemini 3.1+ preview models.
-        const config = buildNativeConfig(options, toolsConfig);
-
-        // Add JSON output format support for native SDK stream
-        if (streamOptions.output?.format === "json" || streamOptions.schema) {
-          config.responseMimeType = "application/json";
-
-          if (streamOptions.schema) {
-            const rawSchema = convertZodToJsonSchema(
-              streamOptions.schema as ZodUnknownSchema,
-            ) as Record<string, unknown>;
-            const inlinedSchema = inlineJsonSchema(rawSchema);
-            if (inlinedSchema.$schema) {
-              delete inlinedSchema.$schema;
-            }
-            config.responseSchema = inlinedSchema;
-
-            logger.debug(
-              "[GoogleVertex] Added responseSchema for JSON output (stream)",
-              {
-                schemaKeys: Object.keys(inlinedSchema),
-              },
-            );
-          }
-        }
-
-        const startTime = Date.now();
-        const timeout = this.getTimeout(options);
-        const timeoutController = createTimeoutController(
-          timeout,
-          this.providerName,
-          "stream",
-        );
-        const composedSignal = composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        );
-        const maxSteps = computeMaxStepsShared(options.maxSteps);
-        // Inject conversation history so the native path has multi-turn context
-        const currentContents = this.prependConversationHistory(
-          [...contents] as Array<{ role: string; parts: unknown[] }>,
-          (options as TextGenerationOptions).conversationMessages as
-            | Array<{ role: string; content: string }>
-            | undefined,
-        );
-        // Create a push-based text channel so the caller receives tokens as
-        // they arrive from the network rather than after full buffering.
-        const channel = createTextChannel();
-
-        // Shared mutable state updated by the background agentic loop.
-        const allToolCalls: Array<{
-          toolName: string;
-          args: Record<string, unknown>;
-        }> = [];
-
-        // Shared metadata object mutated by the background loop so that
-        // responseTime and totalToolExecutions reflect final values.
-        const metadata = {
-          streamId: `native-vertex-${Date.now()}`,
-          startTime,
-          responseTime: 0,
-          totalToolExecutions: 0,
-        };
-
-        // analyticsResolvers lets the background loop settle the analytics
-        // promise once token counts are known (after the loop completes).
-        let analyticsResolve!: (value: AnalyticsData) => void;
-        let analyticsReject!: (reason: unknown) => void;
-        const analyticsPromise = new Promise<AnalyticsData>((res, rej) => {
-          analyticsResolve = res;
-          analyticsReject = rej;
-        });
-
-        // Run the agentic loop in the background without awaiting it here,
-        // so we can return the StreamResult (with channel.iterable) immediately.
-        const loopPromise = (async () => {
-          let lastStepText = "";
-          let totalInputTokens = 0;
-          let totalOutputTokens = 0;
-          let step = 0;
-          let completedWithFinalAnswer = false;
-          const failedTools = new Map<
-            string,
-            { count: number; lastError: string }
-          >();
-
-          try {
-            // Agentic loop for tool calling
-            while (step < maxSteps) {
-              if (composedSignal?.aborted) {
-                throw composedSignal.reason instanceof Error
-                  ? composedSignal.reason
-                  : new Error("Request aborted");
-              }
-              step++;
-              logger.debug(
-                `[GoogleVertex] Native SDK step ${step}/${maxSteps}`,
-              );
-
-              try {
-                const rawStream = await client.models.generateContentStream({
-                  model: modelName,
-                  contents: currentContents,
-                  config,
-                  ...(composedSignal
-                    ? { httpOptions: { signal: composedSignal } }
-                    : {}),
-                });
-
-                // For every step, use incremental collection so text parts
-                // are pushed to the channel as they arrive.  For intermediate
-                // steps (those that produce function calls) we still need the
-                // complete rawResponseParts for pushModelResponseToHistory,
-                // which collectStreamChunksIncremental provides at stream end.
-                const chunkResult = await collectStreamChunksIncremental(
-                  rawStream,
-                  channel,
-                );
-                totalInputTokens += chunkResult.inputTokens;
-                totalOutputTokens += chunkResult.outputTokens;
-
-                const stepText = extractTextFromParts(
-                  chunkResult.rawResponseParts,
-                );
-
-                // If no function calls, this was the final step — channel
-                // already received all text parts incrementally.
-                if (chunkResult.stepFunctionCalls.length === 0) {
-                  completedWithFinalAnswer = true;
-                  break;
-                }
-
-                lastStepText = stepText;
-
-                // Record tool call events on the span
-                for (const fc of chunkResult.stepFunctionCalls) {
-                  span.addEvent("gen_ai.tool_call", {
-                    "tool.name": fc.name as string,
-                    "tool.step": step,
-                  });
-                }
-
-                logger.debug(
-                  `[GoogleVertex] Executing ${chunkResult.stepFunctionCalls.length} function calls`,
-                );
-
-                pushModelResponseToHistory(
-                  currentContents,
-                  chunkResult.rawResponseParts,
-                  chunkResult.stepFunctionCalls,
-                );
-
-                const functionResponses = await executeNativeToolCalls(
-                  "[GoogleVertex]",
-                  chunkResult.stepFunctionCalls,
-                  executeMap,
-                  failedTools,
-                  allToolCalls,
-                  { abortSignal: composedSignal },
-                );
-
-                // Function/tool responses must use role: "user" — the
-                // @google/genai SDK's validateHistory() only accepts "user"
-                // and "model" roles (matching automaticFunctionCalling).
-                currentContents.push({
-                  role: "user",
-                  parts: functionResponses as unknown[],
-                });
-              } catch (error) {
-                logger.error("[GoogleVertex] Native SDK error", error);
-                throw this.handleProviderError(error);
-              }
-            }
-
-            // Handle max-steps termination: if the model was still calling
-            // tools when we hit the limit, push a synthetic final message.
-            if (step >= maxSteps && !completedWithFinalAnswer) {
-              const fallback = handleMaxStepsTermination(
-                "[GoogleVertex]",
-                step,
-                maxSteps,
-                "", // finalText is empty — model didn't stop on its own
-                lastStepText,
-              );
-              if (fallback) {
-                channel.push(fallback);
-              }
-            }
-
-            const responseTime = Date.now() - startTime;
-
-            // Propagate final values to the shared metadata object so that
-            // the already-returned StreamResult reflects accurate telemetry.
-            metadata.responseTime = responseTime;
-            metadata.totalToolExecutions = allToolCalls.length;
-
-            // Set token usage and finish reason on the span
-            span.setAttribute(ATTR.GEN_AI_INPUT_TOKENS, totalInputTokens);
-            span.setAttribute(ATTR.GEN_AI_OUTPUT_TOKENS, totalOutputTokens);
-            span.setAttribute(
-              ATTR.GEN_AI_FINISH_REASON,
-              step >= maxSteps && !completedWithFinalAnswer
-                ? "max_steps"
-                : "stop",
-            );
-
-            analyticsResolve({
-              provider: this.providerName,
-              model: modelName,
-              tokenUsage: {
-                input: totalInputTokens,
-                output: totalOutputTokens,
-                total: totalInputTokens + totalOutputTokens,
-              },
-              requestDuration: responseTime,
-              timestamp: new Date().toISOString(),
-            });
-
-            channel.close();
-          } catch (err) {
-            channel.error(err);
-            analyticsReject(err);
-          } finally {
-            timeoutController?.cleanup();
-          }
-        })();
-
-        // Suppress unhandled-rejection warnings on loopPromise — errors are
-        // forwarded to the channel and will surface when the caller iterates.
-        loopPromise.catch(() => undefined);
-
-        return {
-          stream: channel.iterable,
-          provider: this.providerName,
-          model: modelName,
-          toolCalls: allToolCalls,
-          analytics: analyticsPromise,
-          metadata,
-        };
-      },
+      (span) =>
+        this.executeNativeGemini3StreamWithSpan(options, modelName, span),
     );
+  }
+
+  private async executeNativeGemini3StreamWithSpan(
+    options: StreamOptions,
+    modelName: string,
+    span: Span,
+  ): Promise<StreamResult> {
+    const client = await this.createVertexGenAIClient(options.region);
+    const effectiveLocation =
+      options.region || this.location || getVertexLocation();
+
+    logger.debug("[GoogleVertex] Using native @google/genai for Gemini 3", {
+      model: modelName,
+      hasTools: !!options.tools && Object.keys(options.tools).length > 0,
+      project: this.projectId,
+      location: effectiveLocation,
+    });
+
+    const multimodalInput = options.input as {
+      text: string;
+      pdfFiles?: Array<Buffer | string>;
+      images?: Array<Buffer | string>;
+    };
+    const contents = this.buildNativeContentParts(
+      options.input.text,
+      multimodalInput,
+      "native stream",
+    );
+
+    let hasToolsInput =
+      !!options.tools &&
+      Object.keys(options.tools).length > 0 &&
+      !options.disableTools;
+    const streamOptions = options as TextGenerationOptions;
+    const wantsJsonOutput =
+      streamOptions.output?.format === "json" || streamOptions.schema;
+    if (wantsJsonOutput && hasToolsInput) {
+      logger.warn(
+        "[GoogleVertex] Gemini does not support tools and JSON schema output simultaneously. Disabling tools for this request.",
+      );
+      hasToolsInput = false;
+    }
+
+    let toolsConfig: NativeToolsConfig | undefined;
+    let executeMap = new Map<string, Tool["execute"]>();
+    if (hasToolsInput) {
+      const toolDeclarationResult = buildNativeToolDeclarations(
+        options.tools as Record<string, Tool>,
+      );
+      toolsConfig = toolDeclarationResult.toolsConfig;
+      executeMap = toolDeclarationResult.executeMap;
+
+      logger.debug("[GoogleVertex] Converted tools for native SDK", {
+        toolCount: toolsConfig[0].functionDeclarations.length,
+        toolNames: toolsConfig[0].functionDeclarations.map((tool) => tool.name),
+      });
+    }
+
+    const config = buildNativeConfig(options, toolsConfig);
+    if (wantsJsonOutput) {
+      config.responseMimeType = "application/json";
+      if (streamOptions.schema) {
+        const rawSchema = convertZodToJsonSchema(
+          streamOptions.schema as ZodUnknownSchema,
+        ) as Record<string, unknown>;
+        const inlinedSchema = inlineJsonSchema(rawSchema);
+        if (inlinedSchema.$schema) {
+          delete inlinedSchema.$schema;
+        }
+        config.responseSchema = inlinedSchema;
+        logger.debug(
+          "[GoogleVertex] Added responseSchema for JSON output (stream)",
+          {
+            schemaKeys: Object.keys(inlinedSchema),
+          },
+        );
+      }
+    }
+
+    const startTime = Date.now();
+    const timeoutController = createTimeoutController(
+      this.getTimeout(options),
+      this.providerName,
+      "stream",
+    );
+    const composedSignal = composeAbortSignals(
+      options.abortSignal,
+      timeoutController?.controller.signal,
+    );
+    const maxSteps = computeMaxStepsShared(options.maxSteps);
+    const currentContents = this.prependConversationHistory(
+      [...contents] as Array<{ role: string; parts: unknown[] }>,
+      (options as TextGenerationOptions).conversationMessages as
+        | Array<{ role: string; content: string }>
+        | undefined,
+    );
+    const channel = createTextChannel();
+    const allToolCalls: Array<{
+      toolName: string;
+      args: Record<string, unknown>;
+    }> = [];
+    const metadata = {
+      streamId: `native-vertex-${Date.now()}`,
+      startTime,
+      responseTime: 0,
+      totalToolExecutions: 0,
+    };
+    let analyticsResolve!: (value: AnalyticsData) => void;
+    let analyticsReject!: (reason: unknown) => void;
+    const analyticsPromise = new Promise<AnalyticsData>((resolve, reject) => {
+      analyticsResolve = resolve;
+      analyticsReject = reject;
+    });
+
+    const loopPromise = this.runNativeGemini3StreamLoop({
+      client,
+      modelName,
+      span,
+      config,
+      currentContents,
+      executeMap,
+      channel,
+      allToolCalls,
+      metadata,
+      analyticsResolve,
+      analyticsReject,
+      startTime,
+      timeoutController,
+      composedSignal,
+      maxSteps,
+    });
+    loopPromise.catch(() => undefined);
+
+    return {
+      stream: channel.iterable,
+      provider: this.providerName,
+      model: modelName,
+      toolCalls: allToolCalls,
+      analytics: analyticsPromise,
+      metadata,
+    };
+  }
+
+  private async runNativeGemini3StreamLoop(params: {
+    client: GenAIClient;
+    modelName: string;
+    span: Span;
+    config: ReturnType<typeof buildNativeConfig>;
+    currentContents: Array<{ role: string; parts: unknown[] }>;
+    executeMap: Map<string, Tool["execute"]>;
+    channel: ReturnType<typeof createTextChannel>;
+    allToolCalls: Array<{ toolName: string; args: Record<string, unknown> }>;
+    metadata: {
+      streamId: string;
+      startTime: number;
+      responseTime: number;
+      totalToolExecutions: number;
+    };
+    analyticsResolve: (value: AnalyticsData) => void;
+    analyticsReject: (reason: unknown) => void;
+    startTime: number;
+    timeoutController: ReturnType<typeof createTimeoutController>;
+    composedSignal: AbortSignal | undefined;
+    maxSteps: number;
+  }): Promise<void> {
+    let lastStepText = "";
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let step = 0;
+    let completedWithFinalAnswer = false;
+    const failedTools = new Map<string, { count: number; lastError: string }>();
+
+    try {
+      while (step < params.maxSteps) {
+        if (params.composedSignal?.aborted) {
+          throw params.composedSignal.reason instanceof Error
+            ? params.composedSignal.reason
+            : new Error("Request aborted");
+        }
+        step++;
+        logger.debug(
+          `[GoogleVertex] Native SDK step ${step}/${params.maxSteps}`,
+        );
+
+        try {
+          const rawStream = await params.client.models.generateContentStream({
+            model: params.modelName,
+            contents: params.currentContents,
+            config: params.config,
+            ...(params.composedSignal
+              ? { httpOptions: { signal: params.composedSignal } }
+              : {}),
+          });
+          const chunkResult = await collectStreamChunksIncremental(
+            rawStream,
+            params.channel,
+          );
+          totalInputTokens += chunkResult.inputTokens;
+          totalOutputTokens += chunkResult.outputTokens;
+
+          const stepText = extractTextFromParts(chunkResult.rawResponseParts);
+          if (chunkResult.stepFunctionCalls.length === 0) {
+            completedWithFinalAnswer = true;
+            break;
+          }
+
+          lastStepText = stepText;
+          for (const functionCall of chunkResult.stepFunctionCalls) {
+            params.span.addEvent("gen_ai.tool_call", {
+              "tool.name": functionCall.name as string,
+              "tool.step": step,
+            });
+          }
+
+          logger.debug(
+            `[GoogleVertex] Executing ${chunkResult.stepFunctionCalls.length} function calls`,
+          );
+          pushModelResponseToHistory(
+            params.currentContents,
+            chunkResult.rawResponseParts,
+            chunkResult.stepFunctionCalls,
+          );
+
+          const functionResponses = await executeNativeToolCalls(
+            "[GoogleVertex]",
+            chunkResult.stepFunctionCalls,
+            params.executeMap,
+            failedTools,
+            params.allToolCalls,
+            { abortSignal: params.composedSignal },
+          );
+          params.currentContents.push({
+            role: "user",
+            parts: functionResponses as unknown[],
+          });
+        } catch (error) {
+          logger.error("[GoogleVertex] Native SDK error", error);
+          throw this.handleProviderError(error);
+        }
+      }
+
+      if (step >= params.maxSteps && !completedWithFinalAnswer) {
+        const fallback = handleMaxStepsTermination(
+          "[GoogleVertex]",
+          step,
+          params.maxSteps,
+          "",
+          lastStepText,
+        );
+        if (fallback) {
+          params.channel.push(fallback);
+        }
+      }
+
+      const responseTime = Date.now() - params.startTime;
+      params.metadata.responseTime = responseTime;
+      params.metadata.totalToolExecutions = params.allToolCalls.length;
+      params.span.setAttribute(ATTR.GEN_AI_INPUT_TOKENS, totalInputTokens);
+      params.span.setAttribute(ATTR.GEN_AI_OUTPUT_TOKENS, totalOutputTokens);
+      params.span.setAttribute(
+        ATTR.GEN_AI_FINISH_REASON,
+        step >= params.maxSteps && !completedWithFinalAnswer
+          ? "max_steps"
+          : "stop",
+      );
+
+      params.analyticsResolve({
+        provider: this.providerName,
+        model: params.modelName,
+        tokenUsage: {
+          input: totalInputTokens,
+          output: totalOutputTokens,
+          total: totalInputTokens + totalOutputTokens,
+        },
+        requestDuration: responseTime,
+        timestamp: new Date().toISOString(),
+      });
+
+      params.channel.close();
+    } catch (error) {
+      params.channel.error(error);
+      params.analyticsReject(error);
+    } finally {
+      params.timeoutController?.cleanup();
+    }
   }
 
   /**

--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -1,6 +1,13 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
-import { type LanguageModel, NoOutputGeneratedError, Output, type Schema, streamText, type Tool } from "ai";
+import {
+  type LanguageModel,
+  NoOutputGeneratedError,
+  Output,
+  type Schema,
+  streamText,
+  type Tool,
+} from "ai";
 import type { ZodType } from "zod";
 import type { AIProviderName } from "../constants/enums.js";
 import { BaseProvider } from "../core/baseProvider.js";
@@ -16,12 +23,22 @@ import {
   ProviderError,
   RateLimitError,
 } from "../types/errors.js";
-import type { StreamOptions, StreamResult, StreamTextResult, ToolCall, ToolResult } from "../types/streamTypes.js";
+import type {
+  StreamOptions,
+  StreamResult,
+  StreamTextResult,
+  ToolCall,
+  ToolResult,
+} from "../types/streamTypes.js";
 import { isAbortError } from "../utils/errorHandling.js";
 import { logger } from "../utils/logger.js";
 import { calculateCost } from "../utils/pricing.js";
 import { getProviderModel } from "../utils/providerConfig.js";
-import { composeAbortSignals, createTimeoutController, TimeoutError } from "../utils/timeout.js";
+import {
+  composeAbortSignals,
+  createTimeoutController,
+  TimeoutError,
+} from "../utils/timeout.js";
 import { resolveToolChoice } from "../utils/toolChoice.js";
 import { getModelId } from "./providerTypeUtils.js";
 
@@ -106,19 +123,29 @@ export class LiteLLMProvider extends BaseProvider {
 
   public formatProviderError(error: unknown): Error {
     if (error instanceof TimeoutError) {
-      return new NetworkError(`Request timed out: ${error.message}`, this.providerName);
+      return new NetworkError(
+        `Request timed out: ${error.message}`,
+        this.providerName,
+      );
     }
 
     // Check for timeout by error name and message as fallback
     const errorRecord = error as UnknownRecord;
     if (
       errorRecord?.name === "TimeoutError" ||
-      (typeof errorRecord?.message === "string" && errorRecord.message.toLowerCase().includes("timeout"))
+      (typeof errorRecord?.message === "string" &&
+        errorRecord.message.toLowerCase().includes("timeout"))
     ) {
-      return new NetworkError(`Request timed out: ${errorRecord?.message || "Unknown timeout"}`, this.providerName);
+      return new NetworkError(
+        `Request timed out: ${errorRecord?.message || "Unknown timeout"}`,
+        this.providerName,
+      );
     }
     if (typeof errorRecord?.message === "string") {
-      if (errorRecord.message.includes("ECONNREFUSED") || errorRecord.message.includes("Failed to fetch")) {
+      if (
+        errorRecord.message.includes("ECONNREFUSED") ||
+        errorRecord.message.includes("Failed to fetch")
+      ) {
         return new NetworkError(
           "LiteLLM proxy server not available. Please start the LiteLLM proxy server at " +
             `${process.env.LITELLM_BASE_URL || "http://localhost:4000"}`,
@@ -126,7 +153,10 @@ export class LiteLLMProvider extends BaseProvider {
         );
       }
 
-      if (errorRecord.message.includes("API_KEY_INVALID") || errorRecord.message.includes("Invalid API key")) {
+      if (
+        errorRecord.message.includes("API_KEY_INVALID") ||
+        errorRecord.message.includes("Invalid API key")
+      ) {
         return new AuthenticationError(
           "Invalid LiteLLM configuration. Please check your LITELLM_API_KEY environment variable.",
           this.providerName,
@@ -134,7 +164,10 @@ export class LiteLLMProvider extends BaseProvider {
       }
 
       if (errorRecord.message.toLowerCase().includes("rate limit")) {
-        return new RateLimitError("LiteLLM rate limit exceeded. Please try again later.", this.providerName);
+        return new RateLimitError(
+          "LiteLLM rate limit exceeded. Please try again later.",
+          this.providerName,
+        );
       }
 
       if (
@@ -149,7 +182,10 @@ export class LiteLLMProvider extends BaseProvider {
       }
     }
 
-    return new ProviderError(`LiteLLM error: ${errorRecord?.message || "Unknown error"}`, this.providerName);
+    return new ProviderError(
+      `LiteLLM error: ${errorRecord?.message || "Unknown error"}`,
+      this.providerName,
+    );
   }
 
   /**
@@ -172,7 +208,11 @@ export class LiteLLMProvider extends BaseProvider {
     const startTime = Date.now();
     let chunkCount = 0; // Track chunk count for debugging
     const timeout = this.getTimeout(options);
-    const timeoutController = createTimeoutController(timeout, this.providerName, "stream");
+    const timeoutController = createTimeoutController(
+      timeout,
+      this.providerName,
+      "stream",
+    );
 
     try {
       // Build message array from options with multimodal support
@@ -183,7 +223,9 @@ export class LiteLLMProvider extends BaseProvider {
 
       // Get tools - options.tools is pre-merged by BaseProvider.stream()
       const shouldUseTools = !options.disableTools && this.supportsTools();
-      const tools = shouldUseTools ? (options.tools as Record<string, Tool>) || (await this.getAllTools()) : {};
+      const tools = shouldUseTools
+        ? (options.tools as Record<string, Tool>) || (await this.getAllTools())
+        : {};
 
       logger.debug(`LiteLLM: Tools for streaming`, {
         shouldUseTools,
@@ -193,14 +235,18 @@ export class LiteLLMProvider extends BaseProvider {
 
       // Model-specific maxTokens handling - Gemini 2.5 models have issues with maxTokens
       const modelName = this.modelName || getDefaultLiteLLMModel();
-      const isGemini25Model = modelName.includes("gemini-2.5") || modelName.includes("gemini/2.5");
+      const isGemini25Model =
+        modelName.includes("gemini-2.5") || modelName.includes("gemini/2.5");
       const maxTokens = isGemini25Model ? undefined : options.maxTokens;
 
       if (isGemini25Model && options.maxTokens) {
-        logger.debug(`LiteLLM: Skipping maxTokens for Gemini 2.5 model (known compatibility issue)`, {
-          modelName,
-          requestedMaxTokens: options.maxTokens,
-        });
+        logger.debug(
+          `LiteLLM: Skipping maxTokens for Gemini 2.5 model (known compatibility issue)`,
+          {
+            modelName,
+            requestedMaxTokens: options.maxTokens,
+          },
+        );
       }
 
       // Build complete stream options with proper typing - matching Vertex pattern
@@ -215,12 +261,17 @@ export class LiteLLMProvider extends BaseProvider {
             toolChoice: resolveToolChoice(options, tools, shouldUseTools),
             maxSteps: options.maxSteps || DEFAULT_MAX_STEPS,
           }),
-        abortSignal: composeAbortSignals(options.abortSignal, timeoutController?.controller.signal),
-        experimental_telemetry: this.telemetryHandler.getTelemetryConfig(options),
+        abortSignal: composeAbortSignals(
+          options.abortSignal,
+          timeoutController?.controller.signal,
+        ),
+        experimental_telemetry:
+          this.telemetryHandler.getTelemetryConfig(options),
 
         onError: (event: { error: unknown }) => {
           const error = event.error;
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
           logger.error(`LiteLLM: Stream error`, {
             provider: this.providerName,
             modelName: this.modelName,
@@ -229,7 +280,11 @@ export class LiteLLMProvider extends BaseProvider {
           });
         },
 
-        onFinish: (event: { finishReason: string; usage: Record<string, unknown>; text?: string }) => {
+        onFinish: (event: {
+          finishReason: string;
+          usage: Record<string, unknown>;
+          text?: string;
+        }) => {
           logger.debug(`LiteLLM: Stream finished`, {
             finishReason: event.finishReason,
             totalChunks: chunkCount,
@@ -250,7 +305,8 @@ export class LiteLLMProvider extends BaseProvider {
               args:
                 (toolCall as { args?: Record<string, unknown> }).args ??
                 (toolCall as { input?: Record<string, unknown> }).input ??
-                (toolCall as { parameters?: Record<string, unknown> }).parameters ??
+                (toolCall as { parameters?: Record<string, unknown> })
+                  .parameters ??
                 {},
             });
           }
@@ -265,13 +321,20 @@ export class LiteLLMProvider extends BaseProvider {
             collectedToolResults.push({
               toolName: toolResult.toolName,
               status: rawToolResult.error ? "failure" : "success",
-              output: ((rawToolResult.output ?? rawToolResult.result) as ToolResult["output"]) ?? undefined,
+              output:
+                ((rawToolResult.output ??
+                  rawToolResult.result) as ToolResult["output"]) ?? undefined,
               error: rawToolResult.error,
               id: rawToolResult.toolCallId ?? toolResult.toolName,
             });
           }
 
-          this.handleToolExecutionStorage(toolCalls, toolResults, options, new Date()).catch((error: unknown) => {
+          this.handleToolExecutionStorage(
+            toolCalls,
+            toolResults,
+            options,
+            new Date(),
+          ).catch((error: unknown) => {
             logger.warn("[LiteLLMProvider] Failed to store tool executions", {
               provider: this.providerName,
               error: error instanceof Error ? error.message : String(error),
@@ -297,13 +360,19 @@ export class LiteLLMProvider extends BaseProvider {
       }
 
       // Wrap streamText in an OTel span to capture provider-level latency, token usage, and cost
-      const streamSpan = streamTracer.startSpan("neurolink.provider.streamText", {
-        kind: SpanKind.CLIENT,
-        attributes: {
-          "gen_ai.system": "litellm",
-          "gen_ai.request.model": getModelId(model, this.modelName || "unknown"),
+      const streamSpan = streamTracer.startSpan(
+        "neurolink.provider.streamText",
+        {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            "gen_ai.system": "litellm",
+            "gen_ai.request.model": getModelId(
+              model,
+              this.modelName || "unknown",
+            ),
+          },
         },
-      });
+      );
 
       let result: ReturnType<typeof streamText>;
       const collectedToolCalls: ToolCall[] = [];
@@ -313,7 +382,10 @@ export class LiteLLMProvider extends BaseProvider {
       } catch (streamError) {
         streamSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: streamError instanceof Error ? streamError.message : String(streamError),
+          message:
+            streamError instanceof Error
+              ? streamError.message
+              : String(streamError),
         });
         streamSpan.end();
         throw streamError;
@@ -323,8 +395,14 @@ export class LiteLLMProvider extends BaseProvider {
       // then end the span. This avoids blocking the stream consumer.
       Promise.resolve(result.usage)
         .then((usage) => {
-          streamSpan.setAttribute("gen_ai.usage.input_tokens", usage.inputTokens || 0);
-          streamSpan.setAttribute("gen_ai.usage.output_tokens", usage.outputTokens || 0);
+          streamSpan.setAttribute(
+            "gen_ai.usage.input_tokens",
+            usage.inputTokens || 0,
+          );
+          streamSpan.setAttribute(
+            "gen_ai.usage.output_tokens",
+            usage.outputTokens || 0,
+          );
           const cost = calculateCost(this.providerName, this.modelName, {
             input: usage.inputTokens || 0,
             output: usage.outputTokens || 0,
@@ -339,7 +417,10 @@ export class LiteLLMProvider extends BaseProvider {
         });
       Promise.resolve(result.finishReason)
         .then((reason) => {
-          streamSpan.setAttribute("gen_ai.response.finish_reason", reason || "unknown");
+          streamSpan.setAttribute(
+            "gen_ai.response.finish_reason",
+            reason || "unknown",
+          );
         })
         .catch(() => {
           // Finish reason may not be available if the stream is aborted
@@ -358,60 +439,7 @@ export class LiteLLMProvider extends BaseProvider {
 
       timeoutController?.cleanup();
 
-      // Transform stream to content object stream using fullStream (handles both text and tool calls)
-      // Note: fullStream includes tool results, textStream only has text
-      const transformedStream = (async function* () {
-        try {
-          // Try fullStream first (handles both text and tool calls), fallback to textStream
-          const streamToUse = result.fullStream || result.textStream;
-
-          for await (const chunk of streamToUse) {
-            // Handle different chunk types from fullStream
-            if (chunk && typeof chunk === "object") {
-              // Check for error chunks first (critical error handling)
-              if ("type" in chunk && chunk.type === "error") {
-                const errorChunk = chunk as {
-                  type: "error";
-                  error: Record<string, unknown>;
-                };
-                logger.error(`LiteLLM: Error chunk received:`, {
-                  errorType: errorChunk.type,
-                  errorDetails: errorChunk.error,
-                });
-                throw new Error(
-                  `LiteLLM streaming error: ${(errorChunk.error as Record<string, unknown>)?.message || "Unknown error"}`,
-                );
-              }
-
-              if ("textDelta" in chunk) {
-                // Text delta from fullStream
-                const textDelta = (chunk as { textDelta: string }).textDelta;
-                if (textDelta) {
-                  yield { content: textDelta };
-                }
-              } else if ("type" in chunk && chunk.type === "tool-call" && "toolCallId" in chunk) {
-                // Tool call event - log for debugging
-                const toolCallId = String(chunk.toolCallId);
-                const toolName = "toolName" in chunk ? String(chunk.toolName) : "unknown";
-                logger.debug("LiteLLM: Tool call", {
-                  toolCallId,
-                  toolName,
-                });
-              }
-            } else if (typeof chunk === "string") {
-              // Direct string chunk from textStream fallback
-              yield { content: chunk };
-            }
-          }
-        } catch (streamError) {
-          // AI SDK v6 throws NoOutputGeneratedError when the stream produced no output.
-          if (NoOutputGeneratedError.isInstance(streamError)) {
-            logger.warn("LiteLLM: Stream produced no output (NoOutputGeneratedError)");
-            return;
-          }
-          throw streamError;
-        }
-      })();
+      const transformedStream = this.createLiteLLMTransformedStream(result);
 
       // Create analytics promise that resolves after stream completion
       const analyticsPromise = streamAnalyticsCollector.createAnalytics(
@@ -420,7 +448,9 @@ export class LiteLLMProvider extends BaseProvider {
         result as StreamTextResult,
         Date.now() - startTime,
         {
-          requestId: (options as { requestId?: string }).requestId ?? `litellm-stream-${Date.now()}`,
+          requestId:
+            (options as { requestId?: string }).requestId ??
+            `litellm-stream-${Date.now()}`,
           streamingMode: true,
         },
       );
@@ -445,6 +475,61 @@ export class LiteLLMProvider extends BaseProvider {
     }
   }
 
+  private async *createLiteLLMTransformedStream(
+    result: ReturnType<typeof streamText>,
+  ): AsyncGenerator<{ content: string }> {
+    try {
+      const streamToUse = result.fullStream || result.textStream;
+
+      for await (const chunk of streamToUse) {
+        if (chunk && typeof chunk === "object") {
+          if ("type" in chunk && chunk.type === "error") {
+            const errorChunk = chunk as {
+              type: "error";
+              error: Record<string, unknown>;
+            };
+            logger.error(`LiteLLM: Error chunk received:`, {
+              errorType: errorChunk.type,
+              errorDetails: errorChunk.error,
+            });
+            throw this.formatProviderError(
+              new Error(
+                `LiteLLM streaming error: ${(errorChunk.error as Record<string, unknown>)?.message || "Unknown error"}`,
+              ),
+            );
+          }
+
+          if ("textDelta" in chunk) {
+            const textDelta = (chunk as { textDelta: string }).textDelta;
+            if (textDelta) {
+              yield { content: textDelta };
+            }
+          } else if (
+            "type" in chunk &&
+            chunk.type === "tool-call" &&
+            "toolCallId" in chunk
+          ) {
+            logger.debug("LiteLLM: Tool call", {
+              toolCallId: String(chunk.toolCallId),
+              toolName:
+                "toolName" in chunk ? String(chunk.toolName) : "unknown",
+            });
+          }
+        } else if (typeof chunk === "string") {
+          yield { content: chunk };
+        }
+      }
+    } catch (streamError) {
+      if (NoOutputGeneratedError.isInstance(streamError)) {
+        logger.warn(
+          "LiteLLM: Stream produced no output (NoOutputGeneratedError)",
+        );
+        return;
+      }
+      throw streamError;
+    }
+  }
+
   /**
    * Generate an embedding for a single text input
    * Uses the LiteLLM proxy with OpenAI-compatible embedding API
@@ -453,7 +538,10 @@ export class LiteLLMProvider extends BaseProvider {
     const { embed: aiEmbed } = await import("ai");
     const { createOpenAI } = await import("@ai-sdk/openai");
     const config = getLiteLLMConfig();
-    const embeddingModelName = modelName || process.env.LITELLM_EMBEDDING_MODEL || "gemini-embedding-001";
+    const embeddingModelName =
+      modelName ||
+      process.env.LITELLM_EMBEDDING_MODEL ||
+      "gemini-embedding-001";
 
     const customOpenAI = createOpenAI({
       baseURL: config.baseURL,
@@ -474,7 +562,10 @@ export class LiteLLMProvider extends BaseProvider {
     const { embedMany: aiEmbedMany } = await import("ai");
     const { createOpenAI } = await import("@ai-sdk/openai");
     const config = getLiteLLMConfig();
-    const embeddingModelName = modelName || process.env.LITELLM_EMBEDDING_MODEL || "gemini-embedding-001";
+    const embeddingModelName =
+      modelName ||
+      process.env.LITELLM_EMBEDDING_MODEL ||
+      "gemini-embedding-001";
 
     const customOpenAI = createOpenAI({
       baseURL: config.baseURL,
@@ -498,7 +589,8 @@ export class LiteLLMProvider extends BaseProvider {
     // Check if cached models are still valid
     if (
       LiteLLMProvider.modelsCache.length > 0 &&
-      now - LiteLLMProvider.modelsCacheTime < LiteLLMProvider.MODELS_CACHE_DURATION
+      now - LiteLLMProvider.modelsCacheTime <
+        LiteLLMProvider.MODELS_CACHE_DURATION
     ) {
       logger.debug(`[${functionTag}] Using cached models`, {
         cacheAge: Math.round((now - LiteLLMProvider.modelsCacheTime) / 1000),
@@ -521,13 +613,18 @@ export class LiteLLMProvider extends BaseProvider {
         return dynamicModels;
       }
     } catch (error) {
-      logger.warn(`[${functionTag}] Failed to fetch models from API, using fallback`, {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        `[${functionTag}] Failed to fetch models from API, using fallback`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
 
     // Fallback to hardcoded list if API fetch fails
-    const fallbackModels = process.env.LITELLM_FALLBACK_MODELS?.split(",").map((m) => m.trim()) || [
+    const fallbackModels = process.env.LITELLM_FALLBACK_MODELS?.split(",")
+      .map((m) => m.trim())
+      .filter((m) => m.length > 0) || [
       "openai/gpt-4o", // minimal safe baseline
       "anthropic/claude-3-haiku",
       "meta-llama/llama-3.1-8b-instruct",
@@ -585,7 +682,9 @@ export class LiteLLMProvider extends BaseProvider {
               ? (model as { id: string }).id
               : undefined,
           )
-          .filter((id: string | undefined) => typeof id === "string" && id.length > 0)
+          .filter(
+            (id: string | undefined) => typeof id === "string" && id.length > 0,
+          )
           .sort();
 
         logger.debug(`[${functionTag}] Successfully parsed models`, {
@@ -601,7 +700,10 @@ export class LiteLLMProvider extends BaseProvider {
       clearTimeout(timeoutId);
 
       if (isAbortError(error)) {
-        throw new NetworkError("Request timed out after 5 seconds", this.providerName);
+        throw new NetworkError(
+          "Request timed out after 5 seconds",
+          this.providerName,
+        );
       }
 
       throw error;

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -69,7 +69,23 @@ const getOllamaTimeout = (): number => {
   return parseInt(process.env.OLLAMA_TIMEOUT || "240000", 10);
 };
 
-async function createOllamaHttpError(response: Response): Promise<Error> {
+type OllamaHttpError = ProviderError & {
+  statusCode: number;
+  statusText: string;
+  responseBody: string;
+};
+
+function isOllamaHttpError(error: unknown): error is OllamaHttpError {
+  return (
+    error instanceof ProviderError &&
+    typeof (error as { statusCode?: unknown }).statusCode === "number" &&
+    typeof (error as { responseBody?: unknown }).responseBody === "string"
+  );
+}
+
+async function createOllamaHttpError(
+  response: Response,
+): Promise<OllamaHttpError> {
   let responseBody = "";
   try {
     responseBody = (await response.text()).trim();
@@ -78,9 +94,14 @@ async function createOllamaHttpError(response: Response): Promise<Error> {
   }
 
   const suffix = responseBody ? ` - ${responseBody.slice(0, 500)}` : "";
-  return new Error(
+  const error = new ProviderError(
     `Ollama API error: ${response.status} ${response.statusText}${suffix}`,
-  );
+    "ollama",
+  ) as OllamaHttpError;
+  error.statusCode = response.status;
+  error.statusText = response.statusText;
+  error.responseBody = responseBody;
+  return error;
 }
 
 // Create proxy-aware fetch instance
@@ -2037,9 +2058,13 @@ export class OllamaProvider extends BaseProvider {
     }
 
     const errMsg = (error as Error).message ?? "";
+    const httpStatus = isOllamaHttpError(error) ? error.statusCode : undefined;
+    const responseBody = isOllamaHttpError(error) ? error.responseBody : "";
     if (
-      errMsg.includes("404") &&
-      (errMsg.toLowerCase().includes("model") ||
+      httpStatus === 404 &&
+      (responseBody.toLowerCase().includes("model") ||
+        responseBody.toLowerCase().includes("not found") ||
+        errMsg.toLowerCase().includes("model") ||
         errMsg.toLowerCase().includes("not found"))
     ) {
       return new InvalidModelError(
@@ -2048,7 +2073,7 @@ export class OllamaProvider extends BaseProvider {
       );
     }
 
-    if (errMsg.includes("404")) {
+    if (httpStatus === 404) {
       return new ProviderError(
         `❌ Ollama Endpoint Returned HTTP 404\n\nThe configured base URL (${this.baseUrl}) did not serve the expected Ollama endpoint for model '${this.modelName}'. This is usually a configuration or API-mode mismatch rather than a missing model.\n\n🔧 Check:\n1. Verify the base URL: ${this.baseUrl}\n2. For native Ollama mode, confirm /api/generate exists\n3. For OpenAI-compatible mode, confirm /v1/chat/completions exists\n4. If the model is missing, the response body should explicitly say so`,
         this.providerName,

--- a/src/lib/providers/openAI.ts
+++ b/src/lib/providers/openAI.ts
@@ -394,6 +394,25 @@ export class OpenAIProvider extends BaseProvider {
       // Build message array from options with multimodal support
       // Using protected helper from BaseProvider to eliminate code duplication
       const messages = await this.buildMessagesForStream(options);
+      let resolvedToolChoice = resolveToolChoice(
+        options,
+        tools,
+        shouldUseTools,
+      );
+
+      // Guard: if toolChoice names a specific tool that was filtered out, fall back to "auto"
+      if (
+        resolvedToolChoice !== null &&
+        typeof resolvedToolChoice === "object" &&
+        "toolName" in resolvedToolChoice &&
+        typeof resolvedToolChoice.toolName === "string" &&
+        !tools[resolvedToolChoice.toolName]
+      ) {
+        logger.warn(
+          `OpenAI: toolChoice references tool "${resolvedToolChoice.toolName}" which was removed during filtering; falling back to "auto"`,
+        );
+        resolvedToolChoice = "auto";
+      }
 
       // Debug the actual request being sent to OpenAI
       logger.debug(`OpenAI: streamText request parameters:`, {
@@ -402,8 +421,7 @@ export class OpenAIProvider extends BaseProvider {
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         toolsCount: Object.keys(tools).length,
-        toolChoice:
-          shouldUseTools && Object.keys(tools).length > 0 ? "auto" : "none",
+        toolChoice: resolvedToolChoice,
         maxSteps: options.maxSteps || DEFAULT_MAX_STEPS,
         firstToolExample:
           Object.keys(tools).length > 0
@@ -442,7 +460,7 @@ export class OpenAIProvider extends BaseProvider {
           maxRetries: 0, // NL11: Disable AI SDK's invisible internal retries; we handle retries with OTel instrumentation
           tools,
           stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
-          toolChoice: resolveToolChoice(options, tools, shouldUseTools),
+          toolChoice: resolvedToolChoice,
           abortSignal: composeAbortSignals(
             options.abortSignal,
             timeoutController?.controller.signal,
@@ -531,163 +549,11 @@ export class OpenAIProvider extends BaseProvider {
         resultType: typeof result,
       });
 
-      // Transform string stream to content object stream using fullStream
-      const transformedStream = async function* () {
-        try {
-          logger.debug(`OpenAI: Starting stream transformation`, {
-            hasTextStream: !!result.textStream,
-            hasFullStream: !!result.fullStream,
-            resultKeys: Object.keys(result),
-            toolsEnabled: shouldUseTools,
-            toolsCount: Object.keys(tools).length,
-          });
-
-          let chunkCount = 0;
-          let contentYielded = 0;
-          // Try fullStream first (handles both text and tool calls), fallback to textStream
-          const streamToUse = result.fullStream || result.textStream;
-          if (!streamToUse) {
-            logger.error("OpenAI: No stream available in result", {
-              resultKeys: Object.keys(result),
-            });
-            return;
-          }
-
-          logger.debug(`OpenAI: Stream source selected:`, {
-            usingFullStream: !!result.fullStream,
-            usingTextStream: !!result.textStream && !result.fullStream,
-            streamSourceType: result.fullStream ? "fullStream" : "textStream",
-          });
-
-          for await (const chunk of streamToUse) {
-            chunkCount++;
-            logger.debug(`OpenAI: Processing chunk ${chunkCount}:`, {
-              chunkType: typeof chunk,
-              chunkValue:
-                typeof chunk === "string"
-                  ? (chunk as string).substring(0, 50)
-                  : "not-string",
-              chunkKeys:
-                chunk && typeof chunk === "object"
-                  ? Object.keys(chunk)
-                  : "not-object",
-              hasText: chunk && typeof chunk === "object" && "text" in chunk,
-              hasTextDelta:
-                chunk && typeof chunk === "object" && "textDelta" in chunk,
-              hasType: chunk && typeof chunk === "object" && "type" in chunk,
-              chunkTypeValue:
-                chunk && typeof chunk === "object" && "type" in chunk
-                  ? (chunk as { type: unknown }).type
-                  : "no-type",
-            });
-
-            let contentToYield: string | null = null;
-
-            // Handle different chunk types from fullStream
-            if (chunk && typeof chunk === "object") {
-              // Log the full chunk structure for debugging (debug mode only)
-              if (process.env.NEUROLINK_DEBUG === "true") {
-                logger.debug(`OpenAI: Full chunk structure:`, {
-                  chunkKeys: Object.keys(chunk),
-                  fullChunk: JSON.stringify(chunk).substring(0, 500),
-                });
-              }
-
-              if ("type" in chunk && chunk.type === "error") {
-                // Handle error chunks when tools are enabled
-                const errorChunk = chunk as {
-                  type: "error";
-                  error: Record<string, unknown>;
-                };
-                logger.error(`OpenAI: Error chunk received:`, {
-                  errorType: errorChunk.type,
-                  errorDetails: errorChunk.error,
-                  fullChunk: JSON.stringify(chunk),
-                });
-
-                // Throw a more descriptive error for tool-related issues
-                const errorMessage =
-                  errorChunk.error &&
-                  typeof errorChunk.error === "object" &&
-                  "message" in errorChunk.error
-                    ? String(errorChunk.error.message)
-                    : "OpenAI API error when tools are enabled";
-                throw new Error(
-                  `OpenAI streaming error with tools: ${errorMessage}. Try disabling tools with --disableTools`,
-                );
-              } else if (
-                "type" in chunk &&
-                chunk.type === "text-delta" &&
-                "textDelta" in chunk
-              ) {
-                // Text delta from fullStream
-                contentToYield = chunk.textDelta as string;
-                logger.debug(`OpenAI: Found text-delta:`, {
-                  textDelta: contentToYield,
-                });
-              } else if ("text" in chunk) {
-                // Direct text chunk
-                contentToYield = chunk.text as string;
-                logger.debug(`OpenAI: Found direct text:`, {
-                  text: contentToYield,
-                });
-              } else {
-                // Log unhandled chunks in debug mode only
-                if (process.env.NEUROLINK_DEBUG === "true") {
-                  logger.debug(`OpenAI: Unhandled object chunk:`, {
-                    chunkKeys: Object.keys(chunk),
-                    chunkType: chunk.type || "no-type",
-                    fullChunk: JSON.stringify(chunk).substring(0, 500),
-                  });
-                }
-              }
-            } else if (typeof chunk === "string") {
-              // Direct string chunk from textStream
-              contentToYield = chunk;
-              logger.debug(`OpenAI: Found string chunk:`, {
-                content: contentToYield,
-              });
-            } else {
-              logger.warn(`OpenAI: Unhandled chunk type:`, {
-                type: typeof chunk,
-                value: String(chunk).substring(0, 100),
-              });
-            }
-
-            if (contentToYield) {
-              contentYielded++;
-              logger.debug(`OpenAI: Yielding content ${contentYielded}:`, {
-                content: contentToYield.substring(0, 50),
-                length: contentToYield.length,
-              });
-              yield { content: contentToYield };
-            }
-          }
-
-          logger.debug(`OpenAI: Stream transformation completed`, {
-            totalChunks: chunkCount,
-            contentYielded,
-            success: contentYielded > 0,
-          });
-
-          if (contentYielded === 0) {
-            logger.warn(
-              `OpenAI: No content was yielded from stream despite processing ${chunkCount} chunks`,
-            );
-          }
-        } catch (streamError) {
-          // AI SDK v6 throws NoOutputGeneratedError when the stream produced no output.
-          // Treat as an empty stream rather than crashing with an unhandled rejection.
-          if (NoOutputGeneratedError.isInstance(streamError)) {
-            logger.warn(
-              "OpenAI: Stream produced no output (NoOutputGeneratedError)",
-            );
-            return;
-          }
-          logger.error(`OpenAI: Stream transformation error:`, streamError);
-          throw streamError;
-        }
-      };
+      const transformedStream = this.createOpenAITransformedStream(
+        result,
+        shouldUseTools,
+        tools,
+      );
 
       // Create analytics promise that resolves after stream completion
       const analyticsPromise = streamAnalyticsCollector.createAnalytics(
@@ -702,7 +568,7 @@ export class OpenAIProvider extends BaseProvider {
       );
 
       return {
-        stream: transformedStream(),
+        stream: transformedStream,
         provider: this.providerName,
         model: this.modelName,
         analytics: analyticsPromise,
@@ -715,6 +581,166 @@ export class OpenAIProvider extends BaseProvider {
       timeoutController?.cleanup();
       throw this.handleProviderError(error);
     }
+  }
+
+  private async *createOpenAITransformedStream(
+    result: ReturnType<typeof streamText>,
+    shouldUseTools: boolean,
+    tools: Record<string, Tool>,
+  ): AsyncGenerator<{ content: string }> {
+    try {
+      logger.debug(`OpenAI: Starting stream transformation`, {
+        hasTextStream: !!result.textStream,
+        hasFullStream: !!result.fullStream,
+        resultKeys: Object.keys(result),
+        toolsEnabled: shouldUseTools,
+        toolsCount: Object.keys(tools).length,
+      });
+
+      let chunkCount = 0;
+      let contentYielded = 0;
+      const streamToUse = result.fullStream || result.textStream;
+      if (!streamToUse) {
+        logger.error("OpenAI: No stream available in result", {
+          resultKeys: Object.keys(result),
+        });
+        return;
+      }
+
+      logger.debug(`OpenAI: Stream source selected:`, {
+        usingFullStream: !!result.fullStream,
+        usingTextStream: !!result.textStream && !result.fullStream,
+        streamSourceType: result.fullStream ? "fullStream" : "textStream",
+      });
+
+      for await (const chunk of streamToUse) {
+        chunkCount++;
+        logger.debug(`OpenAI: Processing chunk ${chunkCount}:`, {
+          chunkType: typeof chunk,
+          chunkValue:
+            typeof chunk === "string"
+              ? (chunk as string).substring(0, 50)
+              : "not-string",
+          chunkKeys:
+            chunk && typeof chunk === "object"
+              ? Object.keys(chunk)
+              : "not-object",
+          hasText: chunk && typeof chunk === "object" && "text" in chunk,
+          hasTextDelta:
+            chunk && typeof chunk === "object" && "textDelta" in chunk,
+          hasType: chunk && typeof chunk === "object" && "type" in chunk,
+          chunkTypeValue:
+            chunk && typeof chunk === "object" && "type" in chunk
+              ? (chunk as { type: unknown }).type
+              : "no-type",
+        });
+
+        const contentToYield = this.extractOpenAIChunkContent(chunk);
+        if (contentToYield) {
+          contentYielded++;
+          logger.debug(`OpenAI: Yielding content ${contentYielded}:`, {
+            content: contentToYield.substring(0, 50),
+            length: contentToYield.length,
+          });
+          yield { content: contentToYield };
+        }
+      }
+
+      logger.debug(`OpenAI: Stream transformation completed`, {
+        totalChunks: chunkCount,
+        contentYielded,
+        success: contentYielded > 0,
+      });
+
+      if (contentYielded === 0) {
+        logger.warn(
+          `OpenAI: No content was yielded from stream despite processing ${chunkCount} chunks`,
+        );
+      }
+    } catch (streamError) {
+      if (NoOutputGeneratedError.isInstance(streamError)) {
+        logger.warn(
+          "OpenAI: Stream produced no output (NoOutputGeneratedError)",
+        );
+        return;
+      }
+      logger.error(`OpenAI: Stream transformation error:`, streamError);
+      throw streamError;
+    }
+  }
+
+  private extractOpenAIChunkContent(chunk: unknown): string | null {
+    if (chunk && typeof chunk === "object") {
+      if (process.env.NEUROLINK_DEBUG === "true") {
+        logger.debug(`OpenAI: Full chunk structure:`, {
+          chunkKeys: Object.keys(chunk),
+          fullChunk: JSON.stringify(chunk).substring(0, 500),
+        });
+      }
+
+      if ("type" in chunk && chunk.type === "error") {
+        const errorChunk = chunk as {
+          type: "error";
+          error: Record<string, unknown>;
+        };
+        logger.error(`OpenAI: Error chunk received:`, {
+          errorType: errorChunk.type,
+          errorDetails: errorChunk.error,
+          fullChunk: JSON.stringify(chunk),
+        });
+
+        const errorMessage =
+          errorChunk.error &&
+          typeof errorChunk.error === "object" &&
+          "message" in errorChunk.error
+            ? String(errorChunk.error.message)
+            : "OpenAI API error when tools are enabled";
+        throw new Error(
+          `OpenAI streaming error with tools: ${errorMessage}. Try disabling tools with --disableTools`,
+        );
+      }
+
+      if (
+        "type" in chunk &&
+        chunk.type === "text-delta" &&
+        "textDelta" in chunk
+      ) {
+        const textDelta = chunk.textDelta as string;
+        logger.debug(`OpenAI: Found text-delta:`, { textDelta });
+        return textDelta;
+      }
+
+      if ("text" in chunk) {
+        const text = chunk.text as string;
+        logger.debug(`OpenAI: Found direct text:`, { text });
+        return text;
+      }
+
+      if (process.env.NEUROLINK_DEBUG === "true") {
+        logger.debug(`OpenAI: Unhandled object chunk:`, {
+          chunkKeys: Object.keys(chunk),
+          chunkType:
+            "type" in chunk
+              ? String((chunk as { type?: unknown }).type)
+              : "no-type",
+          fullChunk: JSON.stringify(chunk).substring(0, 500),
+        });
+      }
+      return null;
+    }
+
+    if (typeof chunk === "string") {
+      logger.debug(`OpenAI: Found string chunk:`, {
+        content: chunk,
+      });
+      return chunk;
+    }
+
+    logger.warn(`OpenAI: Unhandled chunk type:`, {
+      type: typeof chunk,
+      value: String(chunk).substring(0, 100),
+    });
+    return null;
   }
 
   /**

--- a/src/lib/proxy/claudeFormat.ts
+++ b/src/lib/proxy/claudeFormat.ts
@@ -137,14 +137,17 @@ export function parseClaudeRequest(body: ClaudeRequest): ParsedClaudeRequest {
         } else if (block.type === "tool_use") {
           // Preserve assistant tool_use blocks so multi-turn tool
           // conversations retain the full call/result chain.
-          const inputStr = block.input !== undefined ? JSON.stringify(block.input) : "{}";
+          const inputStr =
+            block.input !== undefined ? JSON.stringify(block.input) : "{}";
           textParts.push(`[tool_use:${block.id}:${block.name}] ${inputStr}`);
         } else if (block.type === "tool_result") {
           const resultContent =
             typeof block.content === "string"
               ? block.content
               : Array.isArray(block.content)
-                ? block.content.map((b) => (b.type === "text" ? b.text : `[${b.type}]`)).join("\n")
+                ? block.content
+                    .map((b) => (b.type === "text" ? b.text : `[${b.type}]`))
+                    .join("\n")
                 : "";
           textParts.push(`[tool_result:${block.tool_use_id}] ${resultContent}`);
         } else if (block.type) {
@@ -152,7 +155,8 @@ export function parseClaudeRequest(body: ClaudeRequest): ParsedClaudeRequest {
           // so they are visible in translated history instead of silently dropped.
           const { type, ...rest } = block;
           const preview = JSON.stringify(rest);
-          const truncated = preview.length > 200 ? preview.slice(0, 200) + "…" : preview;
+          const truncated =
+            preview.length > 200 ? preview.slice(0, 200) + "…" : preview;
           textParts.push(`[${type}: ${truncated}]`);
         }
       }
@@ -203,12 +207,15 @@ export function parseClaudeRequest(body: ClaudeRequest): ParsedClaudeRequest {
   let thinkingConfig: ParsedClaudeRequest["thinkingConfig"];
   if (body.thinking) {
     // Claude thinking types: "enabled" (fixed budget), "adaptive" (auto budget), "disabled"
-    const isEnabled = body.thinking.type === "enabled" || body.thinking.type === "adaptive";
+    const isEnabled =
+      body.thinking.type === "enabled" || body.thinking.type === "adaptive";
     thinkingConfig = {
       enabled: isEnabled,
       budgetTokens: body.thinking.budget_tokens,
       // Pass the raw type so providers can map "adaptive" appropriately
-      ...(body.thinking.type === "adaptive" ? { thinkingLevel: "medium" as const } : {}),
+      ...(body.thinking.type === "adaptive"
+        ? { thinkingLevel: "medium" as const }
+        : {}),
     };
   }
 
@@ -261,10 +268,15 @@ function mapStopReason(finishReason: string | undefined): string | null {
 /**
  * Serialize a NeuroLink GenerateResult into a Claude Messages API response.
  */
-export function serializeClaudeResponse(result: InternalResult, requestModel: string): ClaudeResponse {
+export function serializeClaudeResponse(
+  result: InternalResult,
+  requestModel: string,
+): ClaudeResponse {
   const content: ClaudeContentBlock[] = [];
   const inferredFinishReason =
-    result.toolCalls && result.toolCalls.length > 0 && (!result.finishReason || result.finishReason === "stop")
+    result.toolCalls &&
+    result.toolCalls.length > 0 &&
+    (!result.finishReason || result.finishReason === "stop")
       ? "tool_use"
       : result.finishReason;
 
@@ -354,7 +366,11 @@ function errorTypeFromStatus(status: number): string {
 /**
  * Build a Claude-compatible error envelope.
  */
-export function buildClaudeError(status: number, message: string, errorType?: string): ClaudeErrorResponse {
+export function buildClaudeError(
+  status: number,
+  message: string,
+  errorType?: string,
+): ClaudeErrorResponse {
   return {
     type: "error",
     error: {
@@ -650,7 +666,9 @@ export class ClaudeStreamSerializer {
 
     this.outputTokens = outputTokens ?? this.outputTokens;
     const resolvedFinishReason =
-      this.sawToolUseBlock && (!finishReason || finishReason === "stop") ? "tool_use" : finishReason;
+      this.sawToolUseBlock && (!finishReason || finishReason === "stop")
+        ? "tool_use"
+        : finishReason;
 
     // Close any open content block
     yield* this.closeCurrentBlock();

--- a/src/lib/proxy/oauthFetch.ts
+++ b/src/lib/proxy/oauthFetch.ts
@@ -12,17 +12,437 @@
  */
 
 import {
+  buildStableClaudeCodeBillingHeader,
   CLAUDE_CLI_USER_AGENT,
   CLAUDE_CODE_OAUTH_BETAS,
-  MCP_TOOL_PREFIX,
-  buildStableClaudeCodeBillingHeader,
   getOrCreateClaudeCodeIdentity,
+  MCP_TOOL_PREFIX,
 } from "../auth/anthropicOAuth.js";
 import { logger } from "../utils/logger.js";
+import { createProxyFetch } from "./proxyFetch.js";
 
 // Re-export constants for consumers that previously imported them alongside
 // the function from `providers/anthropic.ts`.
 export { CLAUDE_CLI_USER_AGENT, MCP_TOOL_PREFIX };
+
+function resolveOAuthRequestUrl(input: RequestInfo | URL): URL | null {
+  try {
+    if (typeof input === "string" || input instanceof URL) {
+      return new URL(input.toString());
+    }
+    if (input instanceof Request) {
+      return new URL(input.url);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function mergeRequestHeaders(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Headers {
+  const requestHeaders = new Headers();
+
+  if (input instanceof Request) {
+    input.headers.forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+  }
+
+  if (!init?.headers) {
+    return requestHeaders;
+  }
+
+  if (init.headers instanceof Headers) {
+    init.headers.forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+    return requestHeaders;
+  }
+
+  if (Array.isArray(init.headers)) {
+    for (const [key, value] of init.headers) {
+      if (typeof value !== "undefined") {
+        requestHeaders.set(key, String(value));
+      }
+    }
+    return requestHeaders;
+  }
+
+  for (const [key, value] of Object.entries(init.headers)) {
+    if (typeof value !== "undefined") {
+      requestHeaders.set(key, String(value));
+    }
+  }
+
+  return requestHeaders;
+}
+
+function applyOAuthHeaders(
+  requestHeaders: Headers,
+  getToken: () => string,
+  includeOptionalBetas: boolean,
+  skipBodyTransform: boolean,
+): void {
+  const existingBetas = (requestHeaders.get("anthropic-beta") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const requiredBetas = ["oauth-2025-04-20"];
+
+  if (!skipBodyTransform) {
+    requiredBetas.push(
+      ...(includeOptionalBetas
+        ? CLAUDE_CODE_OAUTH_BETAS.filter((beta) => beta !== "oauth-2025-04-20")
+        : []),
+    );
+  }
+
+  requestHeaders.set("authorization", `Bearer ${getToken()}`);
+  requestHeaders.set(
+    "anthropic-beta",
+    [...new Set([...existingBetas, ...requiredBetas])].join(","),
+  );
+  requestHeaders.delete("x-api-key");
+
+  if (skipBodyTransform) {
+    return;
+  }
+
+  requestHeaders.set("user-agent", CLAUDE_CLI_USER_AGENT);
+  requestHeaders.set("anthropic-version", "2023-06-01");
+  requestHeaders.set("accept", "application/json");
+  requestHeaders.set("anthropic-dangerous-direct-browser-access", "true");
+  requestHeaders.set("x-app", "cli");
+  requestHeaders.set("connection", "keep-alive");
+  requestHeaders.set("x-stainless-retry-count", "0");
+  requestHeaders.set("x-stainless-runtime-version", "v24.3.0");
+  requestHeaders.set("x-stainless-package-version", "0.74.0");
+  requestHeaders.set("x-stainless-runtime", "node");
+  requestHeaders.set("x-stainless-lang", "js");
+  requestHeaders.set(
+    "x-stainless-arch",
+    process.arch === "x64" ? "x64" : process.arch,
+  );
+  requestHeaders.set(
+    "x-stainless-os",
+    process.platform === "darwin"
+      ? "MacOS"
+      : process.platform === "win32"
+        ? "Windows"
+        : "Linux",
+  );
+  requestHeaders.set("x-stainless-timeout", "600");
+}
+
+async function resolveOAuthRequestBody(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<{
+  sourceRequest?: Request;
+  method?: string;
+  body: BodyInit | undefined;
+}> {
+  const sourceRequest = input instanceof Request ? input : undefined;
+  const method = init?.method ?? sourceRequest?.method;
+  let body = init?.body;
+
+  if (
+    body === undefined &&
+    sourceRequest &&
+    method !== "GET" &&
+    method !== "HEAD"
+  ) {
+    const contentType = sourceRequest.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      body = (await sourceRequest.clone().text()) || undefined;
+    } else {
+      body = sourceRequest.clone().body ?? undefined;
+    }
+  }
+
+  return { sourceRequest, method, body: body ?? undefined };
+}
+
+function transformOAuthJsonBody(
+  body: string,
+  requestHeaders: Headers,
+  getToken: () => string,
+  enableMcpPrefix: boolean,
+): string {
+  const parsed = JSON.parse(body);
+
+  if (enableMcpPrefix) {
+    if (parsed.tools && Array.isArray(parsed.tools)) {
+      parsed.tools = parsed.tools.map(
+        (tool: { name?: string; [key: string]: unknown }) => ({
+          ...tool,
+          name: tool.name ? `${MCP_TOOL_PREFIX}${tool.name}` : tool.name,
+        }),
+      );
+    }
+
+    if (parsed.messages && Array.isArray(parsed.messages)) {
+      parsed.messages = parsed.messages.map(
+        (msg: { content?: unknown; [key: string]: unknown }) => {
+          if (msg.content && Array.isArray(msg.content)) {
+            msg.content = msg.content.map((block: unknown) => {
+              const b = block as {
+                type?: string;
+                name?: string;
+                [key: string]: unknown;
+              };
+              if (b.type === "tool_use" && b.name) {
+                return {
+                  ...b,
+                  name: `${MCP_TOOL_PREFIX}${b.name}`,
+                };
+              }
+              return block;
+            });
+          }
+          return msg;
+        },
+      );
+    }
+  }
+
+  if (
+    parsed.tool_choice?.type === "any" ||
+    parsed.tool_choice?.type === "tool"
+  ) {
+    delete parsed.thinking;
+  }
+
+  const agentBlock = {
+    type: "text",
+    text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+  };
+
+  // Normalise `system` to an array and APPEND billing + agent blocks.
+  // IMPORTANT: We append (not prepend) to preserve the client's cache
+  // prefix chain. Anthropic's prompt caching uses prefix matching — if
+  // we insert anything before the client's system blocks, we invalidate
+  // all cached content (tools, system prompt, message history).
+  //
+  // Claude Code sends a billing block with a `cch=<hash>` value that
+  // changes on every request. We remove any existing billing/agent
+  // blocks from their positions and always append our stable
+  // Claude-Code-shaped versions at the end.
+  if (parsed.system) {
+    if (typeof parsed.system === "string") {
+      parsed.system = [{ type: "text", text: parsed.system }];
+    }
+    if (Array.isArray(parsed.system)) {
+      // Find and remove existing billing/agent blocks from wherever
+      // the client placed them (typically at system[0])
+      const billingIdx = parsed.system.findIndex(
+        (b: { text?: string }) =>
+          typeof b.text === "string" &&
+          b.text.includes("x-anthropic-billing-header"),
+      );
+      const agentIdx = parsed.system.findIndex(
+        (b: { text?: string }) =>
+          typeof b.text === "string" && b.text.includes("Claude Agent SDK"),
+      );
+      const billingBlock = {
+        type: "text",
+        text: buildStableClaudeCodeBillingHeader(
+          parsed.system[billingIdx]?.text,
+        ),
+      };
+
+      // Remove in reverse index order so indices stay valid
+      const indicesToRemove = [billingIdx, agentIdx]
+        .filter((i) => i >= 0)
+        .sort((a, b) => b - a);
+      for (const idx of indicesToRemove) {
+        parsed.system.splice(idx, 1);
+      }
+
+      // Always append deterministic billing + agent blocks at the end
+      parsed.system = [...parsed.system, billingBlock, agentBlock];
+    }
+  } else {
+    const billingBlock = {
+      type: "text",
+      text: buildStableClaudeCodeBillingHeader(),
+    };
+    parsed.system = [billingBlock, agentBlock];
+  }
+
+  const token = getToken();
+  const stableId =
+    parsed.metadata?.user_id ?? token.substring(0, Math.min(20, token.length));
+  const identity = getOrCreateClaudeCodeIdentity(stableId, {
+    existingUserId: parsed.metadata?.user_id,
+    preferredSessionId:
+      requestHeaders.get("x-claude-code-session-id") ?? undefined,
+  });
+  parsed.metadata = {
+    ...parsed.metadata,
+    user_id: identity.metadataUserId,
+  };
+  requestHeaders.set("x-claude-code-session-id", identity.sessionId);
+
+  return JSON.stringify(parsed);
+}
+
+async function injectOtelHeaders(requestHeaders: Headers): Promise<void> {
+  try {
+    const { propagation: otelPropagation, context: otelContext } =
+      await import("@opentelemetry/api");
+    const carrier: Record<string, string> = {};
+    otelPropagation.inject(otelContext.active(), carrier);
+    for (const [key, value] of Object.entries(carrier)) {
+      if (!requestHeaders.has(key)) {
+        requestHeaders.set(key, value);
+      }
+    }
+  } catch {
+    // OTel not available — skip silently
+  }
+}
+
+function rewriteMcpPrefixedStreamingResponse(response: Response): Response {
+  if (!response.body) {
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const responseHeaders = new Headers(response.headers);
+  responseHeaders.delete("content-length");
+  let carry = "";
+
+  const stream = new ReadableStream({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        if (carry) {
+          controller.enqueue(
+            encoder.encode(
+              carry.replace(/"name"\s*:\s*"mcp_([^"]+)"/g, '"name": "$1"'),
+            ),
+          );
+          carry = "";
+        }
+        controller.close();
+        return;
+      }
+
+      const chunkText = decoder.decode(value, { stream: true });
+      const combined = carry + chunkText;
+      const partialMatch = combined.match(/"name"\s*:\s*"mcp_[^"]*$/);
+      let safeText: string;
+
+      if (partialMatch && partialMatch.index !== undefined) {
+        safeText = combined.slice(0, partialMatch.index);
+        carry = combined.slice(partialMatch.index);
+      } else {
+        const lastQuote = combined.lastIndexOf('"');
+        const safeLen = lastQuote >= 0 ? lastQuote + 1 : combined.length;
+        safeText = combined.slice(0, safeLen);
+        carry = combined.slice(safeLen);
+      }
+
+      const replaced = safeText.replace(
+        /"name"\s*:\s*"mcp_([^"]+)"/g,
+        '"name": "$1"',
+      );
+      if (replaced) {
+        controller.enqueue(encoder.encode(replaced));
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+async function executeOAuthFetch(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  getToken: () => string,
+  includeOptionalBetas: boolean,
+  enableMcpPrefix: boolean,
+  skipBodyTransform: boolean,
+): Promise<Response> {
+  const requestUrl = resolveOAuthRequestUrl(input);
+  if (
+    requestUrl &&
+    requestUrl.pathname === "/v1/messages" &&
+    !requestUrl.searchParams.has("beta")
+  ) {
+    requestUrl.searchParams.set("beta", "true");
+  }
+
+  const requestHeaders = mergeRequestHeaders(input, init);
+  applyOAuthHeaders(
+    requestHeaders,
+    getToken,
+    includeOptionalBetas,
+    skipBodyTransform,
+  );
+
+  logger.debug("[createOAuthFetch] Making OAuth request:", {
+    url: requestUrl?.toString() || input.toString(),
+    hasAuthorization: requestHeaders.has("authorization"),
+    authType: "Bearer",
+    anthropicBeta: requestHeaders.get("anthropic-beta"),
+    userAgent: requestHeaders.get("user-agent"),
+  });
+
+  const {
+    sourceRequest,
+    method,
+    body: initialBody,
+  } = await resolveOAuthRequestBody(input, init);
+  let body = initialBody;
+
+  if (body && typeof body === "string" && !skipBodyTransform) {
+    try {
+      body = transformOAuthJsonBody(
+        body,
+        requestHeaders,
+        getToken,
+        enableMcpPrefix,
+      );
+    } catch {
+      // Ignore JSON parse errors — pass body through unchanged
+    }
+  }
+
+  requestHeaders.delete("content-length");
+  await injectOtelHeaders(requestHeaders);
+
+  const proxyFetch = createProxyFetch();
+  const response = await proxyFetch(
+    requestUrl?.toString() ||
+      (input instanceof Request ? input.url : input.toString()),
+    {
+      ...init,
+      method,
+      body,
+      signal: init?.signal ?? sourceRequest?.signal,
+      headers: requestHeaders,
+    },
+  );
+
+  return enableMcpPrefix
+    ? rewriteMcpPrefixedStreamingResponse(response)
+    : response;
+}
 
 // ---------------------------------------------------------------------------
 // Main factory
@@ -58,387 +478,13 @@ export function createOAuthFetch(
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
-  ): Promise<Response> => {
-    // Build the URL
-    let requestUrl: URL | null = null;
-
-    try {
-      if (typeof input === "string" || input instanceof URL) {
-        requestUrl = new URL(input.toString());
-      } else if (input instanceof Request) {
-        requestUrl = new URL(input.url);
-      }
-    } catch {
-      requestUrl = null;
-    }
-
-    // Add ?beta=true to /v1/messages endpoint
-    if (
-      requestUrl &&
-      requestUrl.pathname === "/v1/messages" &&
-      !requestUrl.searchParams.has("beta")
-    ) {
-      requestUrl.searchParams.set("beta", "true");
-    }
-
-    // Build new headers
-    const requestHeaders = new Headers();
-
-    // Copy headers from Request object if present
-    if (input instanceof Request) {
-      input.headers.forEach((value, key) => {
-        requestHeaders.set(key, value);
-      });
-    }
-
-    // Copy headers from init if present
-    if (init?.headers) {
-      if (init.headers instanceof Headers) {
-        init.headers.forEach((value, key) => {
-          requestHeaders.set(key, value);
-        });
-      } else if (Array.isArray(init.headers)) {
-        for (const [key, value] of init.headers) {
-          if (typeof value !== "undefined") {
-            requestHeaders.set(key, String(value));
-          }
-        }
-      } else {
-        for (const [key, value] of Object.entries(init.headers)) {
-          if (typeof value !== "undefined") {
-            requestHeaders.set(key, String(value));
-          }
-        }
-      }
-    }
-
-    // ------------------------------------------------------------------
-    // Beta headers — preserve existing client betas and merge in required ones.
-    // In passthrough mode, Claude Code sends its own betas that MUST be kept
-    // (e.g., context-management-2025-06-27). We only add oauth if missing.
-    // ------------------------------------------------------------------
-    const existingBetas = (requestHeaders.get("anthropic-beta") ?? "")
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-
-    const requiredBetas = ["oauth-2025-04-20"];
-
-    // Only add our betas if not already present in client's headers
-    if (!skipBodyTransform) {
-      // Direct NeuroLink usage — set full beta list
-      requiredBetas.push(
-        ...(includeOptionalBetas
-          ? CLAUDE_CODE_OAUTH_BETAS.filter(
-              (beta) => beta !== "oauth-2025-04-20",
-            )
-          : []),
-      );
-    }
-
-    const allBetas = [...new Set([...existingBetas, ...requiredBetas])];
-    const mergedBetas = allBetas.join(",");
-
-    // Set OAuth authorization (Bearer token, NOT x-api-key)
-    // Call getToken() each time so refreshed tokens are used automatically.
-    requestHeaders.set("authorization", `Bearer ${getToken()}`);
-    requestHeaders.set("anthropic-beta", mergedBetas);
-    if (!skipBodyTransform) {
-      // Only override user-agent for direct NeuroLink usage
-      requestHeaders.set("user-agent", CLAUDE_CLI_USER_AGENT);
-      requestHeaders.set("anthropic-version", "2023-06-01");
-      requestHeaders.set("accept", "application/json");
-    }
-    requestHeaders.delete("x-api-key");
-
-    // Identity / fingerprint headers (skip in passthrough — client sends its own)
-    if (!skipBodyTransform) {
-      requestHeaders.set("anthropic-dangerous-direct-browser-access", "true");
-      requestHeaders.set("x-app", "cli");
-      requestHeaders.set("connection", "keep-alive");
-
-      // Stainless SDK headers
-      requestHeaders.set("x-stainless-retry-count", "0");
-      requestHeaders.set("x-stainless-runtime-version", "v24.3.0");
-      requestHeaders.set("x-stainless-package-version", "0.74.0");
-      requestHeaders.set("x-stainless-runtime", "node");
-      requestHeaders.set("x-stainless-lang", "js");
-      requestHeaders.set(
-        "x-stainless-arch",
-        process.arch === "x64" ? "x64" : process.arch,
-      );
-      requestHeaders.set(
-        "x-stainless-os",
-        process.platform === "darwin"
-          ? "MacOS"
-          : process.platform === "win32"
-            ? "Windows"
-            : "Linux",
-      );
-      requestHeaders.set("x-stainless-timeout", "600");
-    }
-
-    logger.debug("[createOAuthFetch] Making OAuth request:", {
-      url: requestUrl?.toString() || input.toString(),
-      hasAuthorization: requestHeaders.has("authorization"),
-      authType: "Bearer",
-      anthropicBeta: requestHeaders.get("anthropic-beta"),
-      userAgent: requestHeaders.get("user-agent"),
-    });
-
-    // ------------------------------------------------------------------
-    // Body transformations (skipped in passthrough/proxy mode)
-    // ------------------------------------------------------------------
-    const sourceRequest = input instanceof Request ? input : undefined;
-    const method = init?.method ?? sourceRequest?.method;
-    let body = init?.body;
-    if (
-      body === undefined &&
-      sourceRequest &&
-      method !== "GET" &&
-      method !== "HEAD"
-    ) {
-      // Read the body as text (not ReadableStream) so that the JSON transforms
-      // below can parse and modify it. A ReadableStream would bypass the
-      // `typeof body === "string"` branch and skip all cloaking transforms.
-      const contentType = sourceRequest.headers.get("content-type") ?? "";
-      if (contentType.includes("application/json")) {
-        body = (await sourceRequest.clone().text()) || undefined;
-      } else {
-        body = sourceRequest.clone().body ?? undefined;
-      }
-    }
-    if (body && typeof body === "string" && !skipBodyTransform) {
-      try {
-        const parsed = JSON.parse(body);
-
-        // --- mcp_ prefix (only when explicitly enabled) ----------------
-        if (enableMcpPrefix) {
-          if (parsed.tools && Array.isArray(parsed.tools)) {
-            parsed.tools = parsed.tools.map(
-              (tool: { name?: string; [key: string]: unknown }) => ({
-                ...tool,
-                name: tool.name ? `${MCP_TOOL_PREFIX}${tool.name}` : tool.name,
-              }),
-            );
-          }
-
-          if (parsed.messages && Array.isArray(parsed.messages)) {
-            parsed.messages = parsed.messages.map(
-              (msg: { content?: unknown; [key: string]: unknown }) => {
-                if (msg.content && Array.isArray(msg.content)) {
-                  msg.content = msg.content.map((block: unknown) => {
-                    const b = block as {
-                      type?: string;
-                      name?: string;
-                      [key: string]: unknown;
-                    };
-                    if (b.type === "tool_use" && b.name) {
-                      return {
-                        ...b,
-                        name: `${MCP_TOOL_PREFIX}${b.name}`,
-                      };
-                    }
-                    return block;
-                  });
-                }
-                return msg;
-              },
-            );
-          }
-        }
-
-        // --- Disable thinking when tool_choice is forced ---------------
-        if (
-          parsed.tool_choice?.type === "any" ||
-          parsed.tool_choice?.type === "tool"
-        ) {
-          delete parsed.thinking;
-        }
-
-        const agentBlock = {
-          type: "text",
-          text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-        };
-
-        // Normalise `system` to an array and APPEND billing + agent blocks.
-        // IMPORTANT: We append (not prepend) to preserve the client's cache
-        // prefix chain. Anthropic's prompt caching uses prefix matching — if
-        // we insert anything before the client's system blocks, we invalidate
-        // all cached content (tools, system prompt, message history).
-        //
-        // Claude Code sends a billing block with a `cch=<hash>` value that
-        // changes on every request. We remove any existing billing/agent
-        // blocks from their positions and always append our stable
-        // Claude-Code-shaped versions at the end.
-        if (parsed.system) {
-          if (typeof parsed.system === "string") {
-            parsed.system = [{ type: "text", text: parsed.system }];
-          }
-          if (Array.isArray(parsed.system)) {
-            // Find and remove existing billing/agent blocks from wherever
-            // the client placed them (typically at system[0])
-            const billingIdx = parsed.system.findIndex(
-              (b: { text?: string }) =>
-                typeof b.text === "string" &&
-                b.text.includes("x-anthropic-billing-header"),
-            );
-            const agentIdx = parsed.system.findIndex(
-              (b: { text?: string }) =>
-                typeof b.text === "string" &&
-                b.text.includes("Claude Agent SDK"),
-            );
-            const billingBlock = {
-              type: "text",
-              text: buildStableClaudeCodeBillingHeader(
-                parsed.system[billingIdx]?.text,
-              ),
-            };
-
-            // Remove in reverse index order so indices stay valid
-            const indicesToRemove = [billingIdx, agentIdx]
-              .filter((i) => i >= 0)
-              .sort((a, b) => b - a);
-            for (const idx of indicesToRemove) {
-              parsed.system.splice(idx, 1);
-            }
-
-            // Always append deterministic billing + agent blocks at the end
-            parsed.system = [...parsed.system, billingBlock, agentBlock];
-          }
-        } else {
-          const billingBlock = {
-            type: "text",
-            text: buildStableClaudeCodeBillingHeader(),
-          };
-          parsed.system = [billingBlock, agentBlock];
-        }
-
-        // --- Inject Claude-Code-shaped identity into metadata ----------
-        // Prefer existing metadata.user_id (refresh-stable) over the access
-        // token prefix, which changes on every token rotation.
-        const stableId =
-          parsed.metadata?.user_id ??
-          getToken().substring(0, Math.min(20, getToken().length));
-        const identity = getOrCreateClaudeCodeIdentity(stableId, {
-          existingUserId: parsed.metadata?.user_id,
-          preferredSessionId:
-            requestHeaders.get("x-claude-code-session-id") ?? undefined,
-        });
-        parsed.metadata = {
-          ...parsed.metadata,
-          user_id: identity.metadataUserId,
-        };
-        requestHeaders.set("x-claude-code-session-id", identity.sessionId);
-
-        body = JSON.stringify(parsed);
-      } catch {
-        // Ignore JSON parse errors — pass body through unchanged
-      }
-    }
-
-    // Remove any inherited content-length — the body may have been transformed
-    // above, so the original length is stale. Let fetch/undici recalculate it.
-    requestHeaders.delete("content-length");
-
-    // Inject OTel traceparent so the proxy can link to this trace
-    try {
-      const { propagation: otelPropagation, context: otelContext } =
-        await import("@opentelemetry/api");
-      const carrier: Record<string, string> = {};
-      otelPropagation.inject(otelContext.active(), carrier);
-      for (const [key, value] of Object.entries(carrier)) {
-        if (!requestHeaders.has(key)) {
-          requestHeaders.set(key, value);
-        }
-      }
-    } catch {
-      // OTel not available — skip silently
-    }
-
-    // Make the request
-    const response = await fetch(
-      requestUrl?.toString() ||
-        (input instanceof Request ? input.url : input.toString()),
-      {
-        ...init,
-        method,
-        body,
-        signal: init?.signal ?? sourceRequest?.signal,
-        headers: requestHeaders,
-      },
+  ): Promise<Response> =>
+    executeOAuthFetch(
+      input,
+      init,
+      getToken,
+      includeOptionalBetas,
+      enableMcpPrefix,
+      skipBodyTransform,
     );
-
-    // Transform streaming response to rename tools back (remove mcp_ prefix).
-    // Uses a dynamically-sized carry buffer that holds any incomplete JSON
-    // token spanning a chunk boundary (e.g. a partial `"name": "mcp_..."`).
-    if (enableMcpPrefix && response.body) {
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      const encoder = new TextEncoder();
-      const responseHeaders = new Headers(response.headers);
-      responseHeaders.delete("content-length");
-      let carry = "";
-
-      const stream = new ReadableStream({
-        async pull(controller) {
-          const { done, value } = await reader.read();
-          if (done) {
-            // Flush any remaining carry
-            if (carry) {
-              const flushed = carry.replace(
-                /"name"\s*:\s*"mcp_([^"]+)"/g,
-                '"name": "$1"',
-              );
-              controller.enqueue(encoder.encode(flushed));
-              carry = "";
-            }
-            controller.close();
-            return;
-          }
-
-          const chunkText = decoder.decode(value, { stream: true });
-          const combined = carry + chunkText;
-          // Detect a trailing partial `"name":\s*"mcp_...` that hasn't closed
-          // yet (no closing quote for the value). We must keep the entire
-          // partial field in carry so the regex can match it once the next
-          // chunk completes it.
-          const partialMatch = combined.match(/"name"\s*:\s*"mcp_[^"]*$/);
-          let safeText: string;
-          if (partialMatch && partialMatch.index !== undefined) {
-            // Partial mcp_ name field at end — carry the entire partial field
-            safeText = combined.slice(0, partialMatch.index);
-            carry = combined.slice(partialMatch.index);
-          } else {
-            // No partial mcp_ field — safe to process everything.
-            // Still carry trailing content after the last quote to avoid
-            // splitting other JSON tokens.
-            const lastQuote = combined.lastIndexOf('"');
-            const safeLen = lastQuote >= 0 ? lastQuote + 1 : combined.length;
-            safeText = combined.slice(0, safeLen);
-            carry = combined.slice(safeLen);
-          }
-          // Apply the mcp_ stripping regex on the safe portion
-          const replaced = safeText.replace(
-            /"name"\s*:\s*"mcp_([^"]+)"/g,
-            '"name": "$1"',
-          );
-          if (replaced) {
-            controller.enqueue(encoder.encode(replaced));
-          }
-        },
-        async cancel(reason) {
-          await reader.cancel(reason);
-        },
-      });
-
-      return new Response(stream, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
-    return response;
-  };
 }

--- a/src/lib/proxy/proxyConfig.ts
+++ b/src/lib/proxy/proxyConfig.ts
@@ -586,7 +586,11 @@ export async function loadProxyConfig(
   const accounts: Record<string, ProxyAccountConfig[]> = {};
 
   const rawAccounts = raw.accounts as Record<string, unknown[]> | undefined;
-  if (rawAccounts && typeof rawAccounts === "object") {
+  if (
+    rawAccounts &&
+    typeof rawAccounts === "object" &&
+    !Array.isArray(rawAccounts)
+  ) {
     for (const [provider, list] of Object.entries(rawAccounts)) {
       accounts[provider] = list.map((item) =>
         applyAccountDefaults(item as Partial<ProxyAccountConfig>),

--- a/src/lib/proxy/proxyFetch.ts
+++ b/src/lib/proxy/proxyFetch.ts
@@ -10,6 +10,7 @@ import { tracers } from "../telemetry/tracers.js";
 import type { ProxyAgent } from "undici";
 import { shouldBypassProxy } from "./utils/noProxyUtils.js";
 import type { ParsedProxyConfig } from "../types/index.js";
+import { createHash } from "node:crypto";
 
 type LangfuseContext = {
   sessionId?: string | null;
@@ -35,7 +36,28 @@ async function getLangfuseContext(): Promise<LangfuseContext | undefined> {
  * - The NeuroLink proxy to link proxy spans as children of the calling SDK's trace
  * - Conversation-level session/user attribution on proxy spans
  */
-async function injectTraceContext(init?: RequestInit): Promise<RequestInit> {
+function mergeTraceHeaders(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Headers {
+  const existingHeaders = new Headers(
+    input instanceof Request ? input.headers : undefined,
+  );
+
+  if (init?.headers) {
+    const initHeaders = new Headers(init.headers);
+    for (const [key, value] of initHeaders.entries()) {
+      existingHeaders.set(key, value);
+    }
+  }
+
+  return existingHeaders;
+}
+
+async function injectTraceContext(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<RequestInit> {
   const carrier: Record<string, string> = {};
   propagation.inject(context.active(), carrier);
 
@@ -55,7 +77,7 @@ async function injectTraceContext(init?: RequestInit): Promise<RequestInit> {
     return init ?? {};
   }
 
-  const existingHeaders = new Headers(init?.headers);
+  const existingHeaders = mergeTraceHeaders(input, init);
   for (const [key, value] of Object.entries(carrier)) {
     if (!existingHeaders.has(key)) {
       existingHeaders.set(key, value);
@@ -387,6 +409,303 @@ async function createProxyAgent(proxyUrl: string): Promise<ProxyAgent> {
   }
 }
 
+type ProxyEnvironmentSnapshot = {
+  httpsProxy?: string;
+  httpProxy?: string;
+  allProxy?: string;
+  socksProxy?: string;
+  noProxy?: string;
+};
+
+function sanitizeProxyUrl(url: string | undefined): string {
+  return maskProxyUrl(url) ?? "NOT_SET";
+}
+
+function getTargetUrl(input: RequestInfo | URL): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.href
+      : (input as Request).url;
+}
+
+function createDirectFetchHandler(): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const enrichedInit = await injectTraceContext(input, init);
+    const reqId = `req-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+    const startTs = Date.now();
+    const url = getTargetUrl(input);
+
+    if (logger.shouldLog("debug")) {
+      const { size: bodySize, type: bodyType } = parseBody(enrichedInit?.body);
+      logger.debug("[Observability] HTTP request to LLM provider", {
+        requestId: reqId,
+        url,
+        method: enrichedInit?.method || "POST",
+        bodySize,
+        bodyType,
+      });
+    }
+
+    try {
+      const response = await fetchWithRetry(input, enrichedInit);
+
+      if (logger.shouldLog("debug")) {
+        const {
+          parsed: responseBody,
+          size: responseSize,
+          type: responseType,
+          headers: responseHeaders,
+        } = await readResponseBody(response);
+        logger.debug("[Observability] HTTP response from LLM provider", {
+          requestId: reqId,
+          url,
+          status: response.status,
+          statusText: response.statusText,
+          durationMs: Date.now() - startTs,
+          contentLength: responseSize,
+          hasContent: !!responseBody,
+          bodyType: responseType,
+          responseHeaders,
+        });
+      }
+
+      return response;
+    } catch (error: unknown) {
+      logger.debug("[Observability] HTTP request failed", {
+        requestId: reqId,
+        url,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - startTs,
+      });
+      throw error;
+    }
+  };
+}
+
+async function executeProxiedFetch(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  proxyEnv: ProxyEnvironmentSnapshot,
+): Promise<Response> {
+  const { httpsProxy, httpProxy, allProxy, socksProxy, noProxy } = proxyEnv;
+  init = await injectTraceContext(input, init);
+  const requestId = `req-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  const requestStartTime = Date.now();
+  const targetUrl = getTargetUrl(input);
+
+  if (logger.shouldLog("debug")) {
+    const { size: bodySize, type: bodyType } = parseBody(init?.body);
+    logger.debug("[Observability] HTTP request to LLM provider", {
+      requestId,
+      url: targetUrl,
+      method: init?.method || "POST",
+      bodySize,
+      bodyType,
+    });
+  }
+
+  logger.debug(`[Proxy Fetch] ENHANCED REQUEST START`, {
+    requestId,
+    targetUrl,
+    timestamp: new Date().toISOString(),
+    httpProxy: sanitizeProxyUrl(httpProxy),
+    httpsProxy: sanitizeProxyUrl(httpsProxy),
+    allProxy: sanitizeProxyUrl(allProxy),
+    socksProxy: sanitizeProxyUrl(socksProxy),
+    noProxy: noProxy || "NOT_SET",
+    initMethod: init?.method || "GET",
+  });
+
+  // Clone the request before any proxy attempt so that if the proxy path
+  // consumes the body stream and then fails, the fallback still has an intact
+  // body to send.
+  const requestClone = input instanceof Request ? input.clone() : null;
+
+  try {
+    const proxyUrl = selectProxyUrl(targetUrl);
+
+    if (proxyUrl) {
+      const url = new URL(targetUrl);
+      logger.debug(`[Proxy Fetch] 🔗 ENHANCED URL ANALYSIS`, {
+        requestId,
+        targetUrl,
+        urlHostname: url.hostname,
+        urlProtocol: url.protocol,
+        urlPort: url.port,
+        selectedProxyUrl: sanitizeProxyUrl(proxyUrl),
+        timestamp: new Date().toISOString(),
+      });
+      logger.debug(`[Proxy Fetch] 🎯 ENHANCED PROXY AGENT CREATION`, {
+        requestId,
+        proxyUrl: sanitizeProxyUrl(proxyUrl),
+        targetHostname: url.hostname,
+        targetProtocol: url.protocol,
+        aboutToCreateProxyAgent: true,
+        timestamp: new Date().toISOString(),
+      });
+
+      const globalWithCache = globalThis as unknown as {
+        __NL_PROXY_AGENT_CACHE__?: Map<string, ProxyAgent>;
+      };
+      if (!globalWithCache.__NL_PROXY_AGENT_CACHE__) {
+        globalWithCache.__NL_PROXY_AGENT_CACHE__ = new Map();
+      }
+      const agentCache: Map<string, ProxyAgent> =
+        globalWithCache.__NL_PROXY_AGENT_CACHE__;
+      const cacheKey = createHash("sha256")
+        .update(maskProxyUrl(proxyUrl) ?? proxyUrl)
+        .digest("hex");
+      const dispatcher =
+        agentCache.get(cacheKey) || (await createProxyAgent(proxyUrl));
+      agentCache.set(cacheKey, dispatcher);
+
+      logger.debug(`[Proxy Fetch] ✅ ENHANCED PROXY AGENT CREATED`, {
+        requestId,
+        hasDispatcher: !!dispatcher,
+        dispatcherType: typeof dispatcher,
+        dispatcherConstructor: dispatcher?.constructor?.name || "unknown",
+        timestamp: new Date().toISOString(),
+      });
+
+      let fetchInput: string | URL;
+      let fetchInit = { ...init };
+
+      if (input instanceof Request) {
+        fetchInput = input.url;
+        fetchInit = {
+          method: input.method,
+          headers: input.headers,
+          body: input.body,
+          ...init,
+        };
+      } else {
+        fetchInput = input;
+      }
+
+      const undici = await import("undici");
+      const response = await undici.fetch(fetchInput, {
+        ...fetchInit,
+        dispatcher,
+      } as unknown as import("undici").RequestInit);
+
+      if (logger.shouldLog("debug")) {
+        const {
+          parsed: responseBody,
+          size: responseSize,
+          type: responseType,
+          headers: responseHeaders,
+        } = await readResponseBody(response as unknown as Response);
+        logger.debug("[Observability] HTTP response from LLM provider", {
+          requestId,
+          url: targetUrl,
+          status: response?.status,
+          statusText: response?.statusText,
+          durationMs: Date.now() - requestStartTime,
+          contentLength: responseSize,
+          hasContent: !!responseBody,
+          bodyType: responseType,
+          proxied: true,
+          responseHeaders,
+        });
+      }
+
+      logger.debug(`[Proxy Fetch] ENHANCED PROXY SUCCESS`, {
+        requestId,
+        responseStatus: response?.status,
+        responseOk: response?.ok,
+        proxyUsed: true,
+        timestamp: new Date().toISOString(),
+      });
+
+      return response as unknown as Response;
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    logger.debug("[Observability] HTTP request failed", {
+      requestId,
+      url: targetUrl,
+      error: errorMessage,
+      durationMs: Date.now() - requestStartTime,
+    });
+    logger.debug(`[Proxy Fetch] ENHANCED ERROR ANALYSIS`, {
+      requestId,
+      error: errorMessage,
+      errorType: error instanceof Error ? error.constructor.name : typeof error,
+      willFallback: true,
+      timestamp: new Date().toISOString(),
+    });
+    logger.warn(
+      `[Proxy Fetch] Enhanced proxy failed (${errorMessage}), falling back to direct connection`,
+    );
+  }
+
+  logger.debug(`[Proxy Fetch] ENHANCED FALLBACK TO STANDARD FETCH`, {
+    requestId,
+    fallbackReason: "No proxy configured or proxy failed",
+    timestamp: new Date().toISOString(),
+  });
+
+  // Use the cloned request for the fallback so that the body stream is not
+  // already consumed from the proxy attempt above.
+  const fallbackInput: RequestInfo | URL = (
+    input instanceof Request ? (requestClone ?? input) : input
+  ) as RequestInfo | URL;
+
+  try {
+    const response = await fetchWithRetry(fallbackInput, init);
+
+    if (logger.shouldLog("debug")) {
+      const {
+        parsed: responseBody,
+        size: responseSize,
+        type: responseType,
+        headers: responseHeaders,
+      } = await readResponseBody(response);
+      logger.debug("[Observability] HTTP response from LLM provider", {
+        requestId,
+        url: targetUrl,
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - requestStartTime,
+        contentLength: responseSize,
+        hasContent: !!responseBody,
+        bodyType: responseType,
+        proxied: false,
+        responseHeaders,
+      });
+    }
+
+    return response;
+  } catch (fallbackError: unknown) {
+    const fallbackMessage =
+      fallbackError instanceof Error
+        ? fallbackError.message
+        : String(fallbackError);
+
+    logger.debug("[Observability] HTTP request failed", {
+      requestId,
+      url: targetUrl,
+      error: fallbackMessage,
+      durationMs: Date.now() - requestStartTime,
+    });
+    throw fallbackError;
+  }
+}
+
+function createProxiedFetchHandler(
+  proxyEnv: ProxyEnvironmentSnapshot,
+): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => executeProxiedFetch(input, init, proxyEnv);
+}
+
 // ==================== ENHANCED PROXY FETCH FUNCTION ====================
 
 /**
@@ -400,12 +719,15 @@ export function createProxyFetch(): typeof fetch {
   const allProxy = process.env.ALL_PROXY || process.env.all_proxy;
   const socksProxy = process.env.SOCKS_PROXY || process.env.socks_proxy;
   const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  const proxyEnv: ProxyEnvironmentSnapshot = {
+    httpsProxy,
+    httpProxy,
+    allProxy,
+    socksProxy,
+    noProxy,
+  };
 
   // ENHANCED LOGGING: Capture ALL proxy-related environment variables — credentials redacted
-  // Reuse module-level maskProxyUrl, defaulting to "NOT_SET" for undefined values
-  const sanitizeProxyUrl = (url: string | undefined): string =>
-    maskProxyUrl(url) ?? "NOT_SET";
-
   if (logger.shouldLog("debug")) {
     const allProxyRelatedEnvVars = Object.keys(process.env)
       .filter((key) => key.toLowerCase().includes("proxy"))
@@ -434,68 +756,7 @@ export function createProxyFetch(): typeof fetch {
     logger.debug(
       "[Proxy Fetch] No proxy environment variables found - using standard fetch",
     );
-    return async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      // Inject OTel traceparent so the proxy can link to this trace
-      const enrichedInit = await injectTraceContext(init);
-      const reqId = `req-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
-      const startTs = Date.now();
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.href
-            : (input as Request).url;
-
-      if (logger.shouldLog("debug")) {
-        const { size: bodySize, type: bodyType } = parseBody(
-          enrichedInit?.body,
-        );
-        logger.debug("[Observability] HTTP request to LLM provider", {
-          requestId: reqId,
-          url,
-          method: enrichedInit?.method || "POST",
-          bodySize,
-          bodyType,
-        });
-      }
-
-      try {
-        const response = await fetchWithRetry(input, enrichedInit);
-
-        if (logger.shouldLog("debug")) {
-          const {
-            parsed: responseBody,
-            size: responseSize,
-            type: responseType,
-            headers: responseHeaders,
-          } = await readResponseBody(response);
-          logger.debug("[Observability] HTTP response from LLM provider", {
-            requestId: reqId,
-            url,
-            status: response.status,
-            statusText: response.statusText,
-            durationMs: Date.now() - startTs,
-            contentLength: responseSize,
-            hasContent: !!responseBody,
-            bodyType: responseType,
-            responseHeaders,
-          });
-        }
-
-        return response;
-      } catch (error: unknown) {
-        logger.debug("[Observability] HTTP request failed", {
-          requestId: reqId,
-          url,
-          error: error instanceof Error ? error.message : String(error),
-          durationMs: Date.now() - startTs,
-        });
-        throw error;
-      }
-    };
+    return createDirectFetchHandler();
   }
 
   logger.debug(
@@ -507,226 +768,7 @@ export function createProxyFetch(): typeof fetch {
   logger.debug(`[Proxy Fetch] SOCKS_PROXY: ${sanitizeProxyUrl(socksProxy)}`);
   logger.debug(`[Proxy Fetch] NO_PROXY: ${noProxy || "not set"}`);
 
-  // Return enhanced proxy-aware fetch function
-  return async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    // Inject OTel traceparent so the proxy can link to this trace
-    init = await injectTraceContext(init);
-    const requestId = `req-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
-    const requestStartTime = Date.now();
-
-    // Determine target URL
-    const targetUrl =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.href
-          : (input as Request).url;
-
-    // Request logging with sensitive header redaction — gated behind debug check
-    if (logger.shouldLog("debug")) {
-      const { size: bodySize, type: bodyType } = parseBody(init?.body);
-      logger.debug("[Observability] HTTP request to LLM provider", {
-        requestId,
-        url: targetUrl,
-        method: init?.method || "POST",
-        bodySize,
-        bodyType,
-      });
-    }
-
-    logger.debug(`[Proxy Fetch] ENHANCED REQUEST START`, {
-      requestId,
-      targetUrl,
-      timestamp: new Date().toISOString(),
-      httpProxy: sanitizeProxyUrl(httpProxy),
-      httpsProxy: sanitizeProxyUrl(httpsProxy),
-      allProxy: sanitizeProxyUrl(allProxy),
-      socksProxy: sanitizeProxyUrl(socksProxy),
-      initMethod: init?.method || "GET",
-    });
-
-    try {
-      // Enhanced proxy selection with NO_PROXY bypass and multiple protocols
-      const proxyUrl = selectProxyUrl(targetUrl);
-
-      if (proxyUrl) {
-        const url = new URL(targetUrl);
-
-        const sanitizedProxy = sanitizeProxyUrl(proxyUrl);
-        logger.debug(`[Proxy Fetch] 🔗 ENHANCED URL ANALYSIS`, {
-          requestId,
-          targetUrl,
-          urlHostname: url.hostname,
-          urlProtocol: url.protocol,
-          urlPort: url.port,
-          selectedProxyUrl: sanitizedProxy,
-          timestamp: new Date().toISOString(),
-        });
-
-        logger.debug(`[Proxy Fetch] 🎯 ENHANCED PROXY AGENT CREATION`, {
-          requestId,
-          proxyUrl: sanitizedProxy,
-          targetHostname: url.hostname,
-          targetProtocol: url.protocol,
-          aboutToCreateProxyAgent: true,
-          timestamp: new Date().toISOString(),
-        });
-
-        // Create/reuse proxy agent (HTTP/HTTPS/SOCKS)
-        const agentCache: Map<string, ProxyAgent> =
-          (
-            globalThis as unknown as {
-              __NL_PROXY_AGENT_CACHE__?: Map<string, ProxyAgent>;
-            }
-          ).__NL_PROXY_AGENT_CACHE__ ??
-          ((
-            globalThis as unknown as {
-              __NL_PROXY_AGENT_CACHE__: Map<string, ProxyAgent>;
-            }
-          ).__NL_PROXY_AGENT_CACHE__ = new Map());
-        const cacheKey = maskProxyUrl(proxyUrl) ?? proxyUrl; // mask credentials in cache key
-        const dispatcher =
-          agentCache.get(cacheKey) || (await createProxyAgent(proxyUrl));
-        agentCache.set(cacheKey, dispatcher);
-
-        logger.debug(`[Proxy Fetch] ✅ ENHANCED PROXY AGENT CREATED`, {
-          requestId,
-          hasDispatcher: !!dispatcher,
-          dispatcherType: typeof dispatcher,
-          dispatcherConstructor: dispatcher?.constructor?.name || "unknown",
-          timestamp: new Date().toISOString(),
-        });
-
-        // Handle Request objects by extracting URL and merging properties
-        let fetchInput: string | URL;
-        let fetchInit = { ...init };
-
-        if (input instanceof Request) {
-          fetchInput = input.url;
-          fetchInit = {
-            method: input.method,
-            headers: input.headers,
-            body: input.body,
-            ...init, // Allow init to override Request properties
-          };
-        } else {
-          fetchInput = input;
-        }
-
-        // Use undici fetch with enhanced dispatcher (supports HTTP/HTTPS/SOCKS)
-        const undici = await import("undici");
-        const response = await undici.fetch(fetchInput, {
-          ...fetchInit,
-          dispatcher: dispatcher,
-        } as unknown as import("undici").RequestInit);
-
-        if (logger.shouldLog("debug")) {
-          const {
-            parsed: responseBody,
-            size: responseSize,
-            type: responseType,
-            headers: responseHeaders,
-          } = await readResponseBody(response as unknown as Response);
-          logger.debug("[Observability] HTTP response from LLM provider", {
-            requestId,
-            url: targetUrl,
-            status: response?.status,
-            statusText: response?.statusText,
-            durationMs: Date.now() - requestStartTime,
-            contentLength: responseSize,
-            hasContent: !!responseBody,
-            bodyType: responseType,
-            proxied: true,
-            responseHeaders,
-          });
-        }
-
-        logger.debug(`[Proxy Fetch] ENHANCED PROXY SUCCESS`, {
-          requestId,
-          responseStatus: response?.status,
-          responseOk: response?.ok,
-          proxyUsed: true,
-          timestamp: new Date().toISOString(),
-        });
-
-        return response as unknown as Response;
-      }
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
-      logger.debug("[Observability] HTTP request failed", {
-        requestId,
-        url: targetUrl,
-        error: errorMessage,
-        durationMs: Date.now() - requestStartTime,
-      });
-
-      logger.debug(`[Proxy Fetch] ENHANCED ERROR ANALYSIS`, {
-        requestId,
-        error: errorMessage,
-        errorType:
-          error instanceof Error ? error.constructor.name : typeof error,
-        willFallback: true,
-        timestamp: new Date().toISOString(),
-      });
-
-      logger.warn(
-        `[Proxy Fetch] Enhanced proxy failed (${errorMessage}), falling back to direct connection`,
-      );
-    }
-
-    // Fallback to standard fetch
-    logger.debug(`[Proxy Fetch] ENHANCED FALLBACK TO STANDARD FETCH`, {
-      requestId,
-      fallbackReason: "No proxy configured or proxy failed",
-      timestamp: new Date().toISOString(),
-    });
-
-    try {
-      const response = await fetchWithRetry(input, init);
-
-      if (logger.shouldLog("debug")) {
-        const {
-          parsed: responseBody,
-          size: responseSize,
-          type: responseType,
-          headers: responseHeaders,
-        } = await readResponseBody(response);
-        logger.debug("[Observability] HTTP response from LLM provider", {
-          requestId,
-          url: targetUrl,
-          status: response.status,
-          statusText: response.statusText,
-          durationMs: Date.now() - requestStartTime,
-          contentLength: responseSize,
-          hasContent: !!responseBody,
-          bodyType: responseType,
-          proxied: false,
-          responseHeaders,
-        });
-      }
-
-      return response;
-    } catch (fallbackError: unknown) {
-      const fallbackMessage =
-        fallbackError instanceof Error
-          ? fallbackError.message
-          : String(fallbackError);
-
-      logger.debug("[Observability] HTTP request failed", {
-        requestId,
-        url: targetUrl,
-        error: fallbackMessage,
-        durationMs: Date.now() - requestStartTime,
-      });
-
-      throw fallbackError;
-    }
-  };
+  return createProxiedFetchHandler(proxyEnv);
 }
 
 /**

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -45,6 +45,9 @@ const MAX_RESOLVE_ATTEMPTS = 10;
 
 /** Maximum body chunk size emitted to OTLP logs. */
 const BODY_OTLP_CHUNK_SIZE = 16_000;
+/** Maximum redacted body bytes persisted per capture entry. */
+const MAX_CAPTURED_BODY_BYTES = 1024 * 1024;
+const BODY_TRUNCATION_MARKER = "\n...[TRUNCATED]";
 
 const gzip = promisify(gzipCallback);
 
@@ -323,6 +326,7 @@ type StoredBodyArtifact = {
   redactedBodyBytes?: number;
   storedFileBytes?: number;
   redactedBody?: string;
+  bodyTruncated?: boolean;
 };
 
 function serializeBody(body: unknown): string | undefined {
@@ -351,10 +355,157 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function truncateUtf8String(
+  input: string,
+  maxBytes: number,
+  marker: string = BODY_TRUNCATION_MARKER,
+): { value: string; bytes: number; truncated: boolean } {
+  const inputBytes = utf8ByteLength(input);
+  if (inputBytes <= maxBytes) {
+    return { value: input, bytes: inputBytes, truncated: false };
+  }
+
+  const markerBytes = utf8ByteLength(marker);
+  if (maxBytes <= markerBytes) {
+    return { value: marker, bytes: markerBytes, truncated: true };
+  }
+
+  let value = "";
+  let bytes = 0;
+  for (const char of input) {
+    const charBytes = utf8ByteLength(char);
+    if (bytes + charBytes + markerBytes > maxBytes) {
+      break;
+    }
+    value += char;
+    bytes += charBytes;
+  }
+
+  const truncatedValue = `${value}${marker}`;
+  return {
+    value: truncatedValue,
+    bytes: utf8ByteLength(truncatedValue),
+    truncated: true,
+  };
+}
+
+function splitUtf8StringByBytes(input: string, maxBytes: number): string[] {
+  if (!input) {
+    return [""];
+  }
+
+  const chunks: string[] = [];
+  let currentChunk = "";
+  let currentBytes = 0;
+
+  for (const char of input) {
+    const charBytes = utf8ByteLength(char);
+    if (currentChunk && currentBytes + charBytes > maxBytes) {
+      chunks.push(currentChunk);
+      currentChunk = char;
+      currentBytes = charBytes;
+      continue;
+    }
+
+    currentChunk += char;
+    currentBytes += charBytes;
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+function prepareRedactedBody(body: unknown): {
+  value?: string;
+  bytes?: number;
+  truncated: boolean;
+} {
+  const redacted = redactBody(body);
+  if (redacted === undefined) {
+    return { truncated: false };
+  }
+
+  return truncateUtf8String(redacted, MAX_CAPTURED_BODY_BYTES);
+}
+
+type ManagedLogFile = {
+  path: string;
+  mtime: number;
+  size: number;
+};
+
+function collectManagedLogFiles(rootDir: string): ManagedLogFile[] {
+  const managedFiles: ManagedLogFile[] = [];
+
+  const walk = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+        continue;
+      }
+
+      const isTopLevelProxyLog =
+        directory === rootDir &&
+        /^proxy(?:-attempts|-debug)?-.*\.jsonl$/.test(entry.name);
+      const isBodyArtifact =
+        entry.name.endsWith(".json.gz") &&
+        entryPath.includes(`${join(rootDir, "bodies")}`);
+
+      if (!isTopLevelProxyLog && !isBodyArtifact) {
+        continue;
+      }
+
+      try {
+        const stat = statSync(entryPath);
+        managedFiles.push({
+          path: entryPath,
+          mtime: stat.mtimeMs,
+          size: stat.size,
+        });
+      } catch {
+        // Non-fatal
+      }
+    }
+  };
+
+  walk(rootDir);
+  return managedFiles;
+}
+
+function pruneEmptyDirectories(directory: string, stopAt: string): void {
+  if (!existsSync(directory)) {
+    return;
+  }
+
+  try {
+    const entries = readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        pruneEmptyDirectories(join(directory, entry.name), stopAt);
+      }
+    }
+
+    if (directory !== stopAt && readdirSync(directory).length === 0) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  } catch {
+    // Non-fatal
+  }
+}
+
 async function writeBodyArtifact(
   entry: ProxyBodyCaptureEntry,
   redactedHeaders: Record<string, string> | undefined,
   redactedBody: string | undefined,
+  bodyTruncated: boolean,
 ): Promise<StoredBodyArtifact> {
   if (!logDir || redactedBody === undefined) {
     return {};
@@ -396,9 +547,10 @@ async function writeBodyArtifact(
   return {
     bodyPath,
     bodySha256: sha256(redactedBody),
-    redactedBodyBytes: Buffer.byteLength(redactedBody, "utf8"),
+    redactedBodyBytes: utf8ByteLength(redactedBody),
     storedFileBytes: compressed.byteLength,
     redactedBody,
+    bodyTruncated,
   };
 }
 
@@ -413,16 +565,14 @@ function emitOtlpBodyLogRecord(
       }
 
       const otelLogger = provider.getLogger("neurolink-proxy-bodies", "1.0.0");
-      const totalChunks = Math.max(
-        1,
-        Math.ceil(stored.redactedBody.length / BODY_OTLP_CHUNK_SIZE),
+      const chunks = splitUtf8StringByBytes(
+        stored.redactedBody,
+        BODY_OTLP_CHUNK_SIZE,
       );
+      const totalChunks = Math.max(1, chunks.length);
 
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-        const chunk = stored.redactedBody.slice(
-          chunkIndex * BODY_OTLP_CHUNK_SIZE,
-          (chunkIndex + 1) * BODY_OTLP_CHUNK_SIZE,
-        );
+        const chunk = chunks[chunkIndex] ?? "";
 
         otelLogger.emit({
           severityNumber:
@@ -458,6 +608,9 @@ function emitOtlpBodyLogRecord(
             ...(stored.redactedBodyBytes !== undefined && {
               "body.bytes": stored.redactedBodyBytes,
             }),
+            ...(stored.bodyTruncated !== undefined && {
+              "body.truncated": stored.bodyTruncated,
+            }),
             ...(entry.traceId && { "trace.id": entry.traceId }),
             ...(entry.spanId && { "span.id": entry.spanId }),
             ...(entry.metadata && {
@@ -486,13 +639,15 @@ export async function logBodyCapture(
       ? { traceId: entry.traceId, spanId: entry.spanId }
       : bridge.getCurrentTraceContext();
   const redactedHeaders = redactHeaders(entry.headers);
+  const preparedBody = prepareRedactedBody(entry.body);
 
   let stored: StoredBodyArtifact = {};
   try {
     stored = await writeBodyArtifact(
       entry,
       redactedHeaders,
-      redactBody(entry.body),
+      preparedBody.value,
+      preparedBody.truncated,
     );
   } catch {
     // Best-effort artifact persistence; continue with in-memory metadata only.
@@ -517,8 +672,9 @@ export async function logBodyCapture(
     bodyPath: stored.bodyPath,
     bodySha256: stored.bodySha256,
     observedBodyBytes: entry.bodySize,
-    redactedBodyBytes: stored.redactedBodyBytes,
+    redactedBodyBytes: stored.redactedBodyBytes ?? preparedBody.bytes,
     storedFileBytes: stored.storedFileBytes,
+    bodyTruncated: stored.bodyTruncated ?? preparedBody.truncated,
     metadata: entry.metadata,
   };
 
@@ -657,23 +813,9 @@ export function cleanupLogs(
 
   try {
     const activeLogDir = logDir;
-    const files = readdirSync(logDir)
-      .filter(
-        (f) =>
-          (f.startsWith("proxy-") || f.startsWith("proxy-attempts-")) &&
-          f.endsWith(".jsonl"),
-      )
-      .map((f) => {
-        const filePath = join(activeLogDir, f);
-        const stat = statSync(filePath);
-        return {
-          name: f,
-          path: filePath,
-          mtime: stat.mtimeMs,
-          size: stat.size,
-        };
-      })
-      .sort((a, b) => a.mtime - b.mtime); // oldest first
+    const files = collectManagedLogFiles(activeLogDir).sort(
+      (a, b) => a.mtime - b.mtime,
+    ); // oldest first
 
     const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
     let deletedCount = 0;
@@ -693,34 +835,12 @@ export function cleanupLogs(
 
     const bodiesDir = join(logDir, "bodies");
     if (existsSync(bodiesDir)) {
-      for (const entry of readdirSync(bodiesDir)) {
-        const bodyPath = join(bodiesDir, entry);
-        try {
-          if (statSync(bodyPath).mtimeMs < cutoff) {
-            rmSync(bodyPath, { recursive: true, force: true });
-          }
-        } catch {
-          // Non-fatal
-        }
-      }
-    }
-
-    // Include body artifacts in total size calculation
-    const bodiesDirForSize = join(logDir, "bodies");
-    let bodiesSize = 0;
-    if (existsSync(bodiesDirForSize)) {
-      for (const entry of readdirSync(bodiesDirForSize)) {
-        try {
-          bodiesSize += statSync(join(bodiesDirForSize, entry)).size;
-        } catch {
-          // Non-fatal
-        }
-      }
+      pruneEmptyDirectories(bodiesDir, bodiesDir);
     }
 
     // Pass 2: if total size exceeds maxSizeMb, delete oldest until under limit
     const maxBytes = maxSizeMb * 1024 * 1024;
-    let totalSize = remaining.reduce((sum, f) => sum + f.size, 0) + bodiesSize;
+    let totalSize = remaining.reduce((sum, f) => sum + f.size, 0);
 
     while (totalSize > maxBytes && remaining.length > 0) {
       const oldest = remaining.shift();
@@ -731,6 +851,10 @@ export function cleanupLogs(
       totalSize -= oldest.size;
       deletedCount++;
       freedBytes += oldest.size;
+    }
+
+    if (existsSync(bodiesDir)) {
+      pruneEmptyDirectories(bodiesDir, bodiesDir);
     }
 
     if (deletedCount > 0) {

--- a/src/lib/proxy/sseInterceptor.ts
+++ b/src/lib/proxy/sseInterceptor.ts
@@ -192,11 +192,36 @@ function createAccumulator(captureRawText: boolean): TelemetryAccumulator {
   };
 }
 
-function truncateString(input: string, maxBytes: number): string {
-  if (input.length <= maxBytes) {
+function utf8ByteLength(input: string): number {
+  return Buffer.byteLength(input, "utf8");
+}
+
+function truncateUtf8String(input: string, maxBytes: number): string {
+  if (utf8ByteLength(input) <= maxBytes) {
     return input;
   }
-  return `${input.slice(0, maxBytes)}${TRUNCATION_MARKER}`;
+
+  const markerBytes = utf8ByteLength(TRUNCATION_MARKER);
+  if (maxBytes <= 0 || maxBytes < markerBytes) {
+    return "";
+  }
+
+  let output = "";
+  let usedBytes = 0;
+  for (const char of input) {
+    const charBytes = utf8ByteLength(char);
+    if (usedBytes + charBytes + markerBytes > maxBytes) {
+      break;
+    }
+    output += char;
+    usedBytes += charBytes;
+  }
+
+  return `${output}${TRUNCATION_MARKER}`;
+}
+
+function truncateString(input: string, maxBytes: number): string {
+  return truncateUtf8String(input, maxBytes);
 }
 
 function appendCappedFragment(
@@ -205,19 +230,20 @@ function appendCappedFragment(
   currentBytes: number,
   maxBytes: number,
 ): { value: string; nextBytes: number } {
+  const fragmentBytes = utf8ByteLength(fragment);
   if (currentBytes >= maxBytes) {
     return {
       value:
         current && current.endsWith(TRUNCATION_MARKER)
           ? current
           : `${current ?? ""}${TRUNCATION_MARKER}`,
-      nextBytes: currentBytes + fragment.length,
+      nextBytes: currentBytes + fragmentBytes,
     };
   }
 
   const remainingBytes = maxBytes - currentBytes;
-  const nextBytes = currentBytes + fragment.length;
-  if (fragment.length <= remainingBytes) {
+  const nextBytes = currentBytes + fragmentBytes;
+  if (fragmentBytes <= remainingBytes) {
     return {
       value: `${current ?? ""}${fragment}`,
       nextBytes,
@@ -225,7 +251,7 @@ function appendCappedFragment(
   }
 
   return {
-    value: `${current ?? ""}${fragment.slice(0, remainingBytes)}${TRUNCATION_MARKER}`,
+    value: `${current ?? ""}${truncateUtf8String(fragment, remainingBytes)}`,
     nextBytes,
   };
 }
@@ -242,15 +268,20 @@ function appendRawTextChunk(acc: TelemetryAccumulator, chunk: string): void {
     return;
   }
 
-  if (chunk.length <= remainingBytes) {
+  const chunkBytes = utf8ByteLength(chunk);
+  if (chunkBytes <= remainingBytes) {
     acc.rawTextChunks.push(chunk);
-    acc.rawTextBytes += chunk.length;
+    acc.rawTextBytes += chunkBytes;
     return;
   }
 
-  acc.rawTextChunks.push(chunk.slice(0, remainingBytes), TRUNCATION_MARKER);
+  acc.rawTextChunks.push(truncateUtf8String(chunk, remainingBytes));
   acc.rawTextBytes = MAX_RAW_TEXT_BYTES;
   acc.rawTextTruncated = true;
+}
+
+function getBlockContentBytes(block: SSEContentBlock): number {
+  return utf8ByteLength(block.text ?? block.thinking ?? block.toolInput ?? "");
 }
 
 function finalize(acc: TelemetryAccumulator): SSETelemetry {
@@ -325,7 +356,7 @@ function processContentBlockStart(
   }
 
   acc.contentBlocks.push(entry);
-  acc.blockByteCounts.set(index, 0);
+  acc.blockByteCounts.set(index, getBlockContentBytes(entry));
 }
 
 function processContentBlockDelta(

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-depth */
 /**
  * Claude-Compatible Proxy Routes
  *
@@ -11,6 +10,7 @@
  * Without a router, models are passed through to the Anthropic provider.
  */
 
+import { randomUUID } from "node:crypto";
 import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -21,7 +21,10 @@ import {
   getOrCreateClaudeCodeIdentity,
   parseClaudeCodeUserId,
 } from "../../auth/anthropicOAuth.js";
-import { parseQuotaHeaders, saveAccountQuota } from "../../proxy/accountQuota.js";
+import {
+  parseQuotaHeaders,
+  saveAccountQuota,
+} from "../../proxy/accountQuota.js";
 import {
   buildClaudeError,
   ClaudeStreamSerializer,
@@ -32,9 +35,18 @@ import {
 import type { ModelRouter } from "../../proxy/modelRouter.js";
 import { ProxyTracer } from "../../proxy/proxyTracer.js";
 import { createRawStreamCapture } from "../../proxy/rawStreamCapture.js";
-import { logBodyCapture, logRequest, logRequestAttempt, logStreamError } from "../../proxy/requestLogger.js";
+import {
+  logBodyCapture,
+  logRequest,
+  logRequestAttempt,
+  logStreamError,
+} from "../../proxy/requestLogger.js";
 import { createSSEInterceptor } from "../../proxy/sseInterceptor.js";
-import { needsRefresh, persistTokens, refreshToken } from "../../proxy/tokenRefresh.js";
+import {
+  needsRefresh,
+  persistTokens,
+  refreshToken,
+} from "../../proxy/tokenRefresh.js";
 import {
   recordAttempt,
   recordAttemptError,
@@ -43,9 +55,22 @@ import {
   recordFinalSuccess,
 } from "../../proxy/usageStats.js";
 import type {
+  AnthropicAttemptLogger,
+  AnthropicAuthRetryResult,
+  AnthropicLoopState,
+  AnthropicNonOkResult,
+  AnthropicSuccessResult,
+  AnthropicUpstreamBodyBuilder,
+  AnthropicUpstreamFetchResult,
+  ClaudeFinalRequestLogger,
+  ClaudeLoggedErrorBuilder,
   ClaudeRequest,
+  ClaudeRequestRuntimeContext,
   InternalResult,
+  LoadedClaudeAccountContext,
   ParsedClaudeRequest,
+  PreparedAnthropicAccountAttempt,
+  ProxyBodyCaptureLogger,
   ProxyPassthroughAccount,
   RuntimeAccountState,
 } from "../../types/index.js";
@@ -138,7 +163,10 @@ type ClaudeSnapshot = {
   body?: ClaudeSnapshotBody;
 };
 
-const snapshotCache = new Map<string, { snapshot: ClaudeSnapshot; loadedAt: number }>();
+const snapshotCache = new Map<
+  string,
+  { snapshot: ClaudeSnapshot; loadedAt: number }
+>();
 const SNAPSHOT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const SNAPSHOT_STABLE_HEADERS = new Set([
   "accept",
@@ -171,10 +199,18 @@ function getSnapshotSafeLabel(accountLabel: string): string {
 }
 
 function getSnapshotPath(accountLabel: string): string {
-  return join(homedir(), ".neurolink", "header-snapshots", `anthropic_${getSnapshotSafeLabel(accountLabel)}.json`);
+  return join(
+    homedir(),
+    ".neurolink",
+    "header-snapshots",
+    `anthropic_${getSnapshotSafeLabel(accountLabel)}.json`,
+  );
 }
 
-function applySnapshotHeaders(headers: Record<string, string>, snapshot: ClaudeSnapshot | null): void {
+function applySnapshotHeaders(
+  headers: Record<string, string>,
+  snapshot: ClaudeSnapshot | null,
+): void {
   if (!snapshot?.headers) {
     return;
   }
@@ -194,7 +230,9 @@ function applySnapshotHeaders(headers: Record<string, string>, snapshot: ClaudeS
   }
 }
 
-async function loadClaudeSnapshot(accountLabel: string): Promise<ClaudeSnapshot | null> {
+async function loadClaudeSnapshot(
+  accountLabel: string,
+): Promise<ClaudeSnapshot | null> {
   try {
     const safeLabel = getSnapshotSafeLabel(accountLabel);
     const cached = snapshotCache.get(safeLabel);
@@ -226,10 +264,14 @@ async function loadClaudeSnapshot(accountLabel: string): Promise<ClaudeSnapshot 
           ? snapshot.capturedAt
           : new Date(0).toISOString(),
       source: "claude-code",
-      headers: "headers" in snapshot && snapshot.headers ? snapshot.headers : {},
+      headers:
+        "headers" in snapshot && snapshot.headers ? snapshot.headers : {},
       ...(snapshot.body ? { body: snapshot.body } : {}),
     };
-    if (Object.keys(normalized.headers).length === 0 && Object.keys(normalized.body ?? {}).length === 0) {
+    if (
+      Object.keys(normalized.headers).length === 0 &&
+      Object.keys(normalized.body ?? {}).length === 0
+    ) {
       return null;
     }
 
@@ -280,10 +322,14 @@ function extractSnapshotBody(body: unknown): ClaudeSnapshotBody | undefined {
       ? [{ type: "text", text: parsed.system }]
       : [];
   const billingHeader = systemBlocks.find(
-    (block) => typeof block?.text === "string" && block.text.includes("x-anthropic-billing-header"),
+    (block) =>
+      typeof block?.text === "string" &&
+      block.text.includes("x-anthropic-billing-header"),
   )?.text;
   const agentBlock = systemBlocks.find(
-    (block) => typeof block?.text === "string" && block.text.includes("Claude Agent SDK"),
+    (block) =>
+      typeof block?.text === "string" &&
+      block.text.includes("Claude Agent SDK"),
   )?.text;
 
   if (!identity && !billingHeader && !agentBlock) {
@@ -298,7 +344,10 @@ function extractSnapshotBody(body: unknown): ClaudeSnapshotBody | undefined {
   };
 }
 
-function isLikelyClaudeClient(headers: Record<string, string>, snapshotBody?: ClaudeSnapshotBody): boolean {
+function isLikelyClaudeClient(
+  headers: Record<string, string>,
+  snapshotBody?: ClaudeSnapshotBody,
+): boolean {
   return (
     typeof headers["x-claude-code-session-id"] === "string" ||
     headers["user-agent"]?.startsWith("claude-cli/") ||
@@ -308,22 +357,29 @@ function isLikelyClaudeClient(headers: Record<string, string>, snapshotBody?: Cl
   );
 }
 
-function snapshotsMatch(existing: ClaudeSnapshot | null, next: ClaudeSnapshot): boolean {
+function snapshotsMatch(
+  existing: ClaudeSnapshot | null,
+  next: ClaudeSnapshot,
+): boolean {
   if (!existing) {
     return false;
   }
 
   return (
-    JSON.stringify(existing.headers ?? {}) === JSON.stringify(next.headers ?? {}) &&
+    JSON.stringify(existing.headers ?? {}) ===
+      JSON.stringify(next.headers ?? {}) &&
     JSON.stringify(existing.body ?? {}) === JSON.stringify(next.body ?? {})
   );
 }
 
-async function persistClaudeSnapshot(accountLabel: string, snapshot: ClaudeSnapshot): Promise<void> {
+async function persistClaudeSnapshot(
+  accountLabel: string,
+  snapshot: ClaudeSnapshot,
+): Promise<void> {
   const snapshotPath = getSnapshotPath(accountLabel);
   const dirPath = join(homedir(), ".neurolink", "header-snapshots");
   await mkdir(dirPath, { recursive: true });
-  const tmpPath = `${snapshotPath}.tmp`;
+  const tmpPath = `${snapshotPath}.${process.pid}.${randomUUID()}.tmp`;
   await writeFile(tmpPath, JSON.stringify(snapshot, null, 2), { mode: 0o600 });
   await rename(tmpPath, snapshotPath);
   snapshotCache.set(getSnapshotSafeLabel(accountLabel), {
@@ -395,7 +451,9 @@ function polyfillOAuthBody(
     // version/entrypoint shape when present, but stabilize the volatile cch.
     const agentBlock = {
       type: "text",
-      text: snapshot?.body?.agentBlock || "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+      text:
+        snapshot?.body?.agentBlock ||
+        "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
     };
 
     // Normalise system to array and APPEND billing + agent blocks.
@@ -418,18 +476,25 @@ function polyfillOAuthBody(
         // Find and remove existing billing/agent blocks from wherever
         // the client placed them (typically at system[0])
         const billingIdx = parsed.system.findIndex(
-          (b: { text?: string }) => typeof b.text === "string" && b.text.includes("x-anthropic-billing-header"),
+          (b: { text?: string }) =>
+            typeof b.text === "string" &&
+            b.text.includes("x-anthropic-billing-header"),
         );
         const agentIdx = parsed.system.findIndex(
-          (b: { text?: string }) => typeof b.text === "string" && b.text.includes("Claude Agent SDK"),
+          (b: { text?: string }) =>
+            typeof b.text === "string" && b.text.includes("Claude Agent SDK"),
         );
         const billingBlock = {
           type: "text",
-          text: buildStableClaudeCodeBillingHeader(parsed.system[billingIdx]?.text ?? snapshot?.body?.billingHeader),
+          text: buildStableClaudeCodeBillingHeader(
+            parsed.system[billingIdx]?.text ?? snapshot?.body?.billingHeader,
+          ),
         };
 
         // Remove in reverse index order so indices stay valid
-        const indicesToRemove = [billingIdx, agentIdx].filter((i) => i >= 0).sort((a, b) => b - a);
+        const indicesToRemove = [billingIdx, agentIdx]
+          .filter((i) => i >= 0)
+          .sort((a, b) => b - a);
         for (const idx of indicesToRemove) {
           parsed.system.splice(idx, 1);
         }
@@ -448,9 +513,13 @@ function polyfillOAuthBody(
     }
 
     // Inject Claude-Code-shaped metadata.user_id (required for OAuth).
-    const tokenPrefix = accountToken.substring(0, Math.min(20, accountToken.length));
+    const tokenPrefix = accountToken.substring(
+      0,
+      Math.min(20, accountToken.length),
+    );
     const identity = getOrCreateClaudeCodeIdentity(tokenPrefix, {
-      existingUserId: parsed.metadata?.user_id ?? snapshot?.body?.metadataUserId,
+      existingUserId:
+        parsed.metadata?.user_id ?? snapshot?.body?.metadataUserId,
       preferredSessionId: preferredSessionId ?? snapshot?.body?.sessionId,
     });
     parsed.metadata = {
@@ -496,7 +565,9 @@ async function tryLoadLegacyAccount(
   }
 
   if (!legacyRefresh) {
-    logger.always("[proxy] skipping legacy account (expired, no refresh token)");
+    logger.always(
+      "[proxy] skipping legacy account (expired, no refresh token)",
+    );
     return undefined;
   }
 
@@ -508,7 +579,9 @@ async function tryLoadLegacyAccount(
   };
   const ok = await refreshToken(tmp);
   if (!ok.success) {
-    logger.always(`[proxy] skipping legacy account (expired, refresh failed: ${ok.error?.slice(0, 200) ?? "unknown"})`);
+    logger.always(
+      `[proxy] skipping legacy account (expired, refresh failed: ${ok.error?.slice(0, 200) ?? "unknown"})`,
+    );
     return undefined;
   }
 
@@ -529,7 +602,3857 @@ async function tryLoadLegacyAccount(
   };
 }
 
-export type { ClaudeProxyDeps } from "../../types/index.js";
+async function handleTranslatedClaudeRequest(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  route: { provider: string; model: string };
+  modelRouter?: ModelRouter;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    route,
+    modelRouter,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+  } = args;
+  tracer?.setMode("full");
+  const parsed = parseClaudeRequest(body);
+  const attempts = buildProxyTranslationAttempts(
+    {
+      provider: route.provider,
+      model: route.model,
+    },
+    modelRouter,
+    parsed,
+  );
+
+  if (body.stream) {
+    return handleTranslatedClaudeStreamRequest({
+      ctx,
+      body,
+      attempts,
+      parsed,
+      tracer,
+      requestStartTime,
+    });
+  }
+
+  return handleTranslatedClaudeJsonRequest({
+    ctx,
+    body,
+    attempts,
+    parsed,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+  });
+}
+
+async function handleTranslatedClaudeStreamRequest(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  attempts: ProxyTranslationAttempt[];
+  parsed: ParsedClaudeRequest;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+}): Promise<Response> {
+  const { ctx, body, attempts, parsed, tracer, requestStartTime } = args;
+  const serializer = new ClaudeStreamSerializer(body.model, 0);
+  const KEEPALIVE_INTERVAL_MS = 15_000;
+  const encoder = new TextEncoder();
+  let translationKeepAliveTimer: ReturnType<typeof setInterval> | undefined;
+  let translationCancelled = false;
+  let translationSucceeded = false;
+  let translatedModel: string | undefined;
+  let finalStreamError = "No translation providers succeeded";
+  let upstreamIterator: AsyncIterator<unknown> | undefined;
+
+  const translationStream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const frame of serializer.start()) {
+        controller.enqueue(encoder.encode(frame));
+      }
+
+      translationKeepAliveTimer = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": keep-alive\n\n"));
+        } catch {
+          // Controller already closed.
+        }
+      }, KEEPALIVE_INTERVAL_MS);
+
+      try {
+        for (
+          let attemptIndex = 0;
+          attemptIndex < attempts.length;
+          attemptIndex++
+        ) {
+          const attempt = attempts[attemptIndex];
+          if (attemptIndex > 0) {
+            logger.always(`[proxy] fallback → ${attempt.label}`);
+          }
+
+          let collectedText = "";
+          try {
+            const options = buildProxyFallbackOptions(
+              parsed,
+              attempt.provider
+                ? {
+                    provider: attempt.provider,
+                    model: attempt.model,
+                  }
+                : {},
+            );
+            const streamResult = await ctx.neurolink.stream(
+              options as Parameters<typeof ctx.neurolink.stream>[0],
+            );
+            const iterable = streamResult.stream as AsyncIterable<unknown>;
+            upstreamIterator = iterable[Symbol.asyncIterator]();
+
+            while (true) {
+              if (translationCancelled) {
+                break;
+              }
+              const { value: chunk, done } = await upstreamIterator.next();
+              if (done || translationCancelled) {
+                break;
+              }
+              const text = extractText(chunk);
+              if (text) {
+                collectedText += text;
+                for (const frame of serializer.pushDelta(text)) {
+                  controller.enqueue(encoder.encode(frame));
+                }
+              }
+            }
+
+            const toolCalls = streamResult.toolCalls ?? [];
+            if (!hasTranslatedOutput(collectedText, toolCalls)) {
+              finalStreamError = `Translated provider ${attempt.label} returned no content or tool calls`;
+              logger.debug(
+                `[proxy] translation attempt ${attempt.label} returned no content or tool calls`,
+              );
+              continue;
+            }
+
+            if (!translationCancelled && toolCalls.length) {
+              for (const toolCall of toolCalls) {
+                const toolName =
+                  (toolCall as { toolName?: string }).toolName ??
+                  (toolCall as { name?: string }).name ??
+                  "unknown";
+                for (const frame of serializer.pushToolUse(
+                  generateToolUseId(),
+                  toolName,
+                  extractToolArgs(toolCall),
+                )) {
+                  controller.enqueue(encoder.encode(frame));
+                }
+              }
+            }
+
+            if (!translationCancelled) {
+              const reason = streamResult.finishReason ?? "end_turn";
+              const resolvedUsage = extractUsageFromStreamResult(
+                streamResult.usage,
+              );
+              for (const frame of serializer.finish(
+                resolvedUsage.output,
+                reason,
+              )) {
+                controller.enqueue(encoder.encode(frame));
+              }
+            }
+
+            translatedModel = streamResult.model;
+            translationSucceeded = true;
+            return;
+          } catch (streamErr) {
+            if (translationCancelled) {
+              return;
+            }
+            finalStreamError =
+              streamErr instanceof Error
+                ? streamErr.message
+                : String(streamErr);
+            if (collectedText.trim().length > 0) {
+              logger.always(
+                `[proxy] mid-stream error (translation mode): ${finalStreamError}`,
+              );
+              const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
+              controller.enqueue(encoder.encode(errorEvent));
+              return;
+            }
+            logger.debug(
+              `[proxy] translation attempt ${attempt.label} failed: ${finalStreamError}`,
+            );
+          }
+        }
+
+        if (!translationCancelled) {
+          logger.always(
+            `[proxy] mid-stream error (translation mode): ${finalStreamError}`,
+          );
+          const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
+          controller.enqueue(encoder.encode(errorEvent));
+        }
+      } finally {
+        if (translationKeepAliveTimer) {
+          clearInterval(translationKeepAliveTimer);
+        }
+        if (!translationCancelled) {
+          controller.close();
+        }
+        if (tracer && translatedModel && translatedModel !== body.model) {
+          tracer.setModelSubstitution(body.model, translatedModel);
+        }
+        if (!translationSucceeded) {
+          tracer?.setError("generation_error", finalStreamError.slice(0, 500));
+        }
+        tracer?.end(200, Date.now() - requestStartTime);
+      }
+    },
+    cancel() {
+      translationCancelled = true;
+      if (translationKeepAliveTimer) {
+        clearInterval(translationKeepAliveTimer);
+        translationKeepAliveTimer = undefined;
+      }
+      if (upstreamIterator?.return) {
+        upstreamIterator.return(undefined).catch((cancelErr) => {
+          logger.debug(
+            `[proxy] upstream cancel error: ${cancelErr instanceof Error ? cancelErr.message : String(cancelErr)}`,
+          );
+        });
+      }
+    },
+  });
+
+  return new Response(translationStream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    },
+  });
+}
+
+async function handleTranslatedClaudeJsonRequest(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  attempts: ProxyTranslationAttempt[];
+  parsed: ParsedClaudeRequest;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    attempts,
+    parsed,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+  } = args;
+  let lastAttemptError = "No translation providers succeeded";
+
+  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+    const attempt = attempts[attemptIndex];
+    if (attemptIndex > 0) {
+      logger.always(`[proxy] fallback → ${attempt.label}`);
+    }
+
+    try {
+      const options = buildProxyFallbackOptions(
+        parsed,
+        attempt.provider
+          ? {
+              provider: attempt.provider,
+              model: attempt.model,
+            }
+          : {},
+      );
+      const streamResult = await ctx.neurolink.stream(
+        options as Parameters<typeof ctx.neurolink.stream>[0],
+      );
+      let collectedText = "";
+      for await (const chunk of streamResult.stream) {
+        const text = extractText(chunk);
+        if (text) {
+          collectedText += text;
+        }
+      }
+      if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
+        lastAttemptError = `Translated provider ${attempt.label} returned no content or tool calls`;
+        logger.debug(
+          `[proxy] translation attempt ${attempt.label} returned no content or tool calls`,
+        );
+        continue;
+      }
+
+      const internal: InternalResult = {
+        content: collectedText,
+        model: streamResult.model,
+        finishReason: streamResult.finishReason ?? "end_turn",
+        reasoning: undefined,
+        usage: streamResult.usage
+          ? extractUsageFromStreamResult(streamResult.usage)
+          : undefined,
+        toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
+      };
+      if (tracer && streamResult.model && streamResult.model !== body.model) {
+        tracer.setModelSubstitution(body.model, streamResult.model);
+      }
+      tracer?.end(200, Date.now() - requestStartTime);
+      const clientResponse = serializeClaudeResponse(internal, body.model);
+      const clientResponseText = JSON.stringify(clientResponse);
+      logProxyBody({
+        phase: "client_response",
+        headers: { "content-type": "application/json" },
+        body: clientResponseText,
+        bodySize: Buffer.byteLength(clientResponseText, "utf8"),
+        contentType: "application/json",
+        responseStatus: 200,
+        durationMs: Date.now() - requestStartTime,
+      });
+      return clientResponse;
+    } catch (attemptError) {
+      lastAttemptError =
+        attemptError instanceof Error
+          ? attemptError.message
+          : String(attemptError);
+      logger.debug(
+        `[proxy] translation attempt ${attempt.label} failed: ${lastAttemptError}`,
+      );
+    }
+  }
+
+  throw new Error(lastAttemptError);
+}
+
+async function handleClaudePassthroughRequest(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  clientRequestBody: string;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    clientRequestBody,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+  } = args;
+  tracer?.setMode("passthrough-cli");
+  const bodyStr = clientRequestBody;
+  const toolCount = Array.isArray(body.tools) ? body.tools.length : 0;
+  const upstreamHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(ctx.headers)) {
+    if (!BLOCKED_UPSTREAM_HEADERS.has(key.toLowerCase()) && value) {
+      upstreamHeaders[key] = value;
+    }
+  }
+  if (!upstreamHeaders["content-type"]) {
+    upstreamHeaders["content-type"] = "application/json";
+  }
+
+  const upstreamSpan = tracer?.startUpstreamAttempt({
+    account: "passthrough",
+    attempt: 1,
+    polyfillHeaders: false,
+    polyfillBody: false,
+    upstreamUrl: "https://api.anthropic.com/v1/messages?beta=true",
+  });
+  tracer?.logUpstreamRequestHeaders(upstreamHeaders);
+  tracer?.logUpstreamRequestBody(bodyStr);
+  logProxyBody({
+    phase: "upstream_request",
+    headers: upstreamHeaders,
+    body: bodyStr,
+    bodySize: Buffer.byteLength(bodyStr, "utf8"),
+    contentType: upstreamHeaders["content-type"] ?? "application/json",
+    account: "passthrough",
+    accountType: "passthrough",
+    attempt: 1,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch("https://api.anthropic.com/v1/messages?beta=true", {
+      method: "POST",
+      headers: upstreamHeaders,
+      body: bodyStr,
+      signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
+    });
+  } catch (fetchErr) {
+    const errMsg =
+      fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+    tracer?.setError("network_error", errMsg);
+    upstreamSpan?.end();
+    tracer?.end(502, Date.now() - requestStartTime);
+    logRequest({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream: body.stream ?? false,
+      toolCount,
+      account: "passthrough",
+      accountType: "passthrough",
+      responseStatus: 502,
+      responseTimeMs: Date.now() - requestStartTime,
+      errorType: "network_error",
+      errorMessage: errMsg,
+    });
+    const errorBody = buildClaudeError(
+      502,
+      `Passthrough fetch failed: ${errMsg}`,
+    );
+    const errorBodyText = JSON.stringify(errorBody);
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "application/json" },
+      body: errorBodyText,
+      bodySize: Buffer.byteLength(errorBodyText, "utf8"),
+      contentType: "application/json",
+      account: "passthrough",
+      accountType: "passthrough",
+      attempt: 1,
+      responseStatus: 502,
+      durationMs: Date.now() - requestStartTime,
+    });
+    return errorBody;
+  }
+
+  const upstreamResponseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    upstreamResponseHeaders[key] = value;
+  });
+  tracer?.logUpstreamResponseHeaders(upstreamResponseHeaders);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    tracer?.logUpstreamResponseBody(errorText);
+    logProxyBody({
+      phase: "upstream_response",
+      headers: upstreamResponseHeaders,
+      body: errorText,
+      bodySize: Buffer.byteLength(errorText, "utf8"),
+      contentType:
+        upstreamResponseHeaders["content-type"] ?? "application/json",
+      account: "passthrough",
+      accountType: "passthrough",
+      attempt: 1,
+      responseStatus: response.status,
+      durationMs: Date.now() - requestStartTime,
+    });
+    logProxyBody({
+      phase: "client_response",
+      headers: upstreamResponseHeaders,
+      body: errorText,
+      bodySize: Buffer.byteLength(errorText, "utf8"),
+      contentType:
+        upstreamResponseHeaders["content-type"] ?? "application/json",
+      account: "passthrough",
+      accountType: "passthrough",
+      attempt: 1,
+      responseStatus: response.status,
+      durationMs: Date.now() - requestStartTime,
+    });
+    upstreamSpan?.end();
+    tracer?.setError("api_error", errorText.slice(0, 500));
+    tracer?.end(response.status, Date.now() - requestStartTime);
+    try {
+      return JSON.parse(errorText);
+    } catch {
+      return buildClaudeError(response.status, errorText);
+    }
+  }
+
+  if (body.stream && response.body) {
+    return handleClaudePassthroughStreamResponse({
+      ctx,
+      body,
+      bodyStr,
+      response,
+      tracer,
+      requestStartTime,
+      toolCount,
+      upstreamSpan,
+      upstreamResponseHeaders,
+      logProxyBody,
+    });
+  }
+
+  return handleClaudePassthroughJsonResponse({
+    ctx,
+    body,
+    bodyStr,
+    response,
+    tracer,
+    requestStartTime,
+    toolCount,
+    upstreamSpan,
+    upstreamResponseHeaders,
+    logProxyBody,
+  });
+}
+
+async function handleClaudePassthroughStreamResponse(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  bodyStr: string;
+  response: Response;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  toolCount: number;
+  upstreamSpan?: ReturnType<ProxyTracer["startUpstreamAttempt"]>;
+  upstreamResponseHeaders: Record<string, string>;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<Response> {
+  const {
+    ctx,
+    body,
+    bodyStr,
+    response,
+    tracer,
+    requestStartTime,
+    toolCount,
+    upstreamSpan,
+    upstreamResponseHeaders,
+    logProxyBody,
+  } = args;
+  const responseHeaders = { ...upstreamResponseHeaders };
+  const { stream: clientCaptureStream, capture: clientCapture } =
+    createRawStreamCapture();
+  const responseBody = response.body;
+  if (!responseBody) {
+    throw new Error("Expected passthrough stream response body");
+  }
+  let streamSource: ReadableStream<Uint8Array> = responseBody;
+
+  if (tracer) {
+    try {
+      const { stream: interceptor, telemetry } = createSSEInterceptor({
+        captureRawText: true,
+      });
+      streamSource = streamSource.pipeThrough(interceptor);
+      const capturedTracer = tracer;
+      const capturedUpstreamSpan = upstreamSpan;
+      const capturedResponse = response;
+      const capturedRequestBytes = bodyStr.length;
+
+      Promise.all([telemetry, clientCapture])
+        .then(([data, clientBody]) => {
+          capturedTracer.setUsage({
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          });
+          capturedTracer.logStreamEvents(data.events);
+
+          const rateLimit5h = parseFloat(
+            capturedResponse.headers.get(
+              "anthropic-ratelimit-unified-5h-utilization",
+            ) ?? "",
+          );
+          const rateLimit7d = parseFloat(
+            capturedResponse.headers.get(
+              "anthropic-ratelimit-unified-7d-utilization",
+            ) ?? "",
+          );
+          const usageUpdate: Parameters<typeof capturedTracer.setUsage>[0] = {
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          };
+          if (!isNaN(rateLimit5h)) {
+            usageUpdate.rateLimitAfter5h = rateLimit5h;
+          }
+          if (!isNaN(rateLimit7d)) {
+            usageUpdate.rateLimitAfter7d = rateLimit7d;
+          }
+          if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
+            capturedTracer.setUsage(usageUpdate);
+          }
+
+          capturedTracer.logUpstreamResponseBody(data.rawText ?? "");
+          capturedTracer.recordMetrics();
+          capturedTracer.recordBodySizes(
+            capturedRequestBytes,
+            data.totalBytesReceived,
+          );
+          capturedUpstreamSpan?.end();
+          capturedTracer.end(200, Date.now() - requestStartTime);
+
+          const traceCtx = capturedTracer.getTraceContext();
+          logRequest({
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            method: ctx.method,
+            path: ctx.path,
+            model: body.model,
+            stream: true,
+            toolCount,
+            account: "passthrough",
+            accountType: "passthrough",
+            responseStatus: 200,
+            responseTimeMs: Date.now() - requestStartTime,
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+            traceId: traceCtx.traceId,
+            spanId: traceCtx.spanId,
+          });
+          logProxyBody({
+            phase: "upstream_response",
+            headers: responseHeaders,
+            body: data.rawText ?? "",
+            bodySize: data.totalBytesReceived,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: "passthrough",
+            accountType: "passthrough",
+            attempt: 1,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+          logProxyBody({
+            phase: "client_response",
+            headers: responseHeaders,
+            body: clientBody.text,
+            bodySize: clientBody.totalBytes,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: "passthrough",
+            accountType: "passthrough",
+            attempt: 1,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+        })
+        .catch((error) => {
+          capturedTracer.setError(
+            "stream_error",
+            error instanceof Error ? error.message : String(error),
+          );
+          capturedUpstreamSpan?.end();
+          capturedTracer.end(500, Date.now() - requestStartTime);
+
+          const traceCtx = capturedTracer.getTraceContext();
+          logRequest({
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            method: ctx.method,
+            path: ctx.path,
+            model: body.model,
+            stream: true,
+            toolCount,
+            account: "passthrough",
+            accountType: "passthrough",
+            responseStatus: 500,
+            responseTimeMs: Date.now() - requestStartTime,
+            errorType: "stream_error",
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+            traceId: traceCtx.traceId,
+            spanId: traceCtx.spanId,
+          });
+        });
+    } catch {
+      // Streaming capture is best-effort.
+    }
+  } else {
+    clientCapture
+      .then((clientBody) => {
+        logProxyBody({
+          phase: "upstream_response",
+          headers: responseHeaders,
+          body: clientBody.text,
+          bodySize: clientBody.totalBytes,
+          contentType: responseHeaders["content-type"] ?? "text/event-stream",
+          account: "passthrough",
+          accountType: "passthrough",
+          attempt: 1,
+          responseStatus: 200,
+          durationMs: Date.now() - requestStartTime,
+        });
+        logProxyBody({
+          phase: "client_response",
+          headers: responseHeaders,
+          body: clientBody.text,
+          bodySize: clientBody.totalBytes,
+          contentType: responseHeaders["content-type"] ?? "text/event-stream",
+          account: "passthrough",
+          accountType: "passthrough",
+          attempt: 1,
+          responseStatus: 200,
+          durationMs: Date.now() - requestStartTime,
+        });
+      })
+      .catch(() => {
+        // Non-fatal
+      });
+  }
+
+  const clientStream = streamSource.pipeThrough(clientCaptureStream);
+  return new Response(clientStream, {
+    status: response.status,
+    headers: responseHeaders,
+  });
+}
+
+async function handleClaudePassthroughJsonResponse(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  bodyStr: string;
+  response: Response;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  toolCount: number;
+  upstreamSpan?: ReturnType<ProxyTracer["startUpstreamAttempt"]>;
+  upstreamResponseHeaders: Record<string, string>;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    bodyStr,
+    response,
+    tracer,
+    requestStartTime,
+    toolCount,
+    upstreamSpan,
+    upstreamResponseHeaders,
+    logProxyBody,
+  } = args;
+  const responseText = await response.text();
+  tracer?.logUpstreamResponseBody(responseText);
+  logProxyBody({
+    phase: "upstream_response",
+    headers: upstreamResponseHeaders,
+    body: responseText,
+    bodySize: Buffer.byteLength(responseText, "utf8"),
+    contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
+    account: "passthrough",
+    accountType: "passthrough",
+    attempt: 1,
+    responseStatus: response.status,
+    durationMs: Date.now() - requestStartTime,
+  });
+  logProxyBody({
+    phase: "client_response",
+    headers: upstreamResponseHeaders,
+    body: responseText,
+    bodySize: Buffer.byteLength(responseText, "utf8"),
+    contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
+    account: "passthrough",
+    accountType: "passthrough",
+    attempt: 1,
+    responseStatus: response.status,
+    durationMs: Date.now() - requestStartTime,
+  });
+
+  const responseJson = JSON.parse(responseText);
+  if (tracer && responseJson && typeof responseJson === "object") {
+    const usage = (responseJson as Record<string, unknown>).usage as
+      | Record<string, number>
+      | undefined;
+    if (usage) {
+      tracer.setUsage({
+        inputTokens: usage.input_tokens ?? 0,
+        outputTokens: usage.output_tokens ?? 0,
+        cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+      });
+
+      const rateLimit5h = parseFloat(
+        response.headers.get("anthropic-ratelimit-unified-5h-utilization") ??
+          "",
+      );
+      const rateLimit7d = parseFloat(
+        response.headers.get("anthropic-ratelimit-unified-7d-utilization") ??
+          "",
+      );
+      if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
+        const usageWithRates: Parameters<typeof tracer.setUsage>[0] = {
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+        };
+        if (!isNaN(rateLimit5h)) {
+          usageWithRates.rateLimitAfter5h = rateLimit5h;
+        }
+        if (!isNaN(rateLimit7d)) {
+          usageWithRates.rateLimitAfter7d = rateLimit7d;
+        }
+        tracer.setUsage(usageWithRates);
+      }
+    }
+    tracer.recordMetrics();
+    const responseJsonStr = JSON.stringify(responseJson);
+    tracer.recordBodySizes(bodyStr.length, responseJsonStr.length);
+    upstreamSpan?.end();
+    tracer.end(response.status, Date.now() - requestStartTime);
+
+    const traceCtx = tracer.getTraceContext();
+    logRequest({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream: false,
+      toolCount,
+      account: "passthrough",
+      accountType: "passthrough",
+      responseStatus: response.status,
+      responseTimeMs: Date.now() - requestStartTime,
+      inputTokens: usage?.input_tokens,
+      outputTokens: usage?.output_tokens,
+      cacheCreationTokens: usage?.cache_creation_input_tokens,
+      cacheReadTokens: usage?.cache_read_input_tokens,
+      traceId: traceCtx.traceId,
+      spanId: traceCtx.spanId,
+    });
+  } else {
+    upstreamSpan?.end();
+    tracer?.end(response.status, Date.now() - requestStartTime);
+    logRequest({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream: false,
+      toolCount,
+      account: "passthrough",
+      accountType: "passthrough",
+      responseStatus: response.status,
+      responseTimeMs: Date.now() - requestStartTime,
+    });
+  }
+
+  return responseJson;
+}
+
+async function loadClaudeProxyAccounts(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  accountStrategy: "round-robin" | "fill-first";
+  buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+}): Promise<LoadedClaudeAccountContext | { response: unknown }> {
+  const {
+    ctx,
+    body,
+    tracer,
+    requestStartTime,
+    accountStrategy,
+    buildLoggedClaudeError,
+  } = args;
+  const fs = await import("fs");
+  const os = await import("os");
+  const accounts: ProxyPassthroughAccount[] = [];
+  const legacyCredPath = `${(os as typeof import("os")).homedir()}/.neurolink/anthropic-credentials.json`;
+  const { tokenStore } = await import("../../auth/tokenStore.js");
+
+  if (!startupPruneDone) {
+    await tokenStore.pruneExpired();
+    startupPruneDone = true;
+  }
+
+  const compoundKeys = await tokenStore.listByPrefix("anthropic:");
+  for (const key of compoundKeys) {
+    if (await tokenStore.isDisabled(key)) {
+      const existingState = getOrCreateRuntimeState(key);
+      const tokens = await tokenStore.loadTokens(key);
+      const hasTrackedTokens =
+        existingState.lastToken !== undefined && existingState.lastToken !== "";
+      const tokenChanged =
+        tokens &&
+        hasTrackedTokens &&
+        (existingState.lastToken !== tokens.accessToken ||
+          existingState.lastRefreshToken !== tokens.refreshToken);
+      if (tokenChanged) {
+        await tokenStore.markEnabled(key);
+        logger.always(
+          `[proxy] account=${key.split(":")[1] ?? key} re-enabled (credentials changed)`,
+        );
+        existingState.permanentlyDisabled = false;
+        existingState.coolingUntil = undefined;
+        existingState.backoffLevel = 0;
+        existingState.consecutiveRefreshFailures = 0;
+      } else {
+        logger.debug(
+          `[proxy] skipping disabled account=${key.split(":")[1] ?? key}`,
+        );
+        existingState.permanentlyDisabled = true;
+        continue;
+      }
+    }
+
+    const tokens = await tokenStore.loadTokens(key);
+    if (!tokens) {
+      continue;
+    }
+
+    let accessToken = tokens.accessToken;
+    let refreshTok = tokens.refreshToken;
+    let expiresAt = tokens.expiresAt;
+    const isExpired = expiresAt ? expiresAt < Date.now() : false;
+
+    if (isExpired) {
+      const label = key.split(":")[1] ?? key;
+      const existingState = getOrCreateRuntimeState(key);
+      if (existingState.permanentlyDisabled) {
+        continue;
+      }
+
+      if (!refreshTok) {
+        logger.always(
+          `[proxy] skipping account=${label} (expired, no refresh token)`,
+        );
+        await disableAccountUntilReauth(
+          { key, label, token: accessToken, type: "oauth" },
+          existingState,
+        );
+        continue;
+      }
+
+      const tempAccount = {
+        token: accessToken,
+        refreshToken: refreshTok,
+        expiresAt,
+        label,
+      };
+      const refreshed = await refreshToken(tempAccount);
+      if (!refreshed.success) {
+        logger.always(
+          `[proxy] skipping account=${label} (expired, refresh failed: ${refreshed.error?.slice(0, 200) ?? "unknown"})`,
+        );
+        await disableAccountUntilReauth(
+          { key, label, token: accessToken, type: "oauth" },
+          existingState,
+        );
+        continue;
+      }
+
+      accessToken = tempAccount.token;
+      refreshTok = tempAccount.refreshToken;
+      expiresAt = tempAccount.expiresAt;
+      await tokenStore.saveTokens(key, {
+        accessToken,
+        refreshToken: refreshTok,
+        expiresAt: expiresAt ?? Date.now() + 3600_000,
+        tokenType: "Bearer",
+      });
+      logger.always(
+        `[proxy] refreshed expired account=${key.split(":")[1] ?? key} at startup`,
+      );
+    }
+
+    const accountType: "oauth" | "api_key" =
+      tokens.tokenType === "Bearer" ? "oauth" : "api_key";
+
+    accounts.push({
+      key,
+      label: key.split(":")[1] ?? key,
+      token: accessToken,
+      refreshToken: refreshTok,
+      expiresAt,
+      type: accountType,
+      persistTarget: { providerKey: key },
+    });
+  }
+
+  if (accounts.length === 0) {
+    try {
+      const creds = JSON.parse(
+        (fs as typeof import("fs")).readFileSync(legacyCredPath, "utf8"),
+      ) as {
+        oauth?: {
+          accessToken?: string;
+          refreshToken?: string;
+          expiresAt?: number;
+        };
+      };
+      const legacyAccount = await tryLoadLegacyAccount(creds, legacyCredPath);
+      if (legacyAccount) {
+        accounts.push(legacyAccount);
+      }
+    } catch {
+      // file absent or invalid
+    }
+  }
+
+  if (process.env.ANTHROPIC_API_KEY && accounts.length === 0) {
+    accounts.push({
+      key: "anthropic:env",
+      label: "env",
+      token: process.env.ANTHROPIC_API_KEY,
+      type: "api_key",
+    });
+  }
+
+  if (accounts.length === 0) {
+    tracer?.setError("authentication_error", "No Anthropic credentials found");
+    tracer?.end(401, Date.now() - requestStartTime);
+    return {
+      response: buildLoggedClaudeError(401, "No Anthropic credentials found"),
+    };
+  }
+
+  for (const account of accounts) {
+    const state = getOrCreateRuntimeState(account.key);
+    const tokenChanged =
+      state.lastToken !== account.token ||
+      state.lastRefreshToken !== account.refreshToken;
+    if (tokenChanged) {
+      if (state.permanentlyDisabled) {
+        logger.always(
+          `[proxy] account=${account.label} credentials changed, re-enabling`,
+        );
+      }
+      state.coolingUntil = undefined;
+      state.backoffLevel = 0;
+      state.consecutiveRefreshFailures = 0;
+      state.permanentlyDisabled = false;
+    }
+    state.lastToken = account.token;
+    state.lastRefreshToken = account.refreshToken;
+  }
+
+  const enabledAccounts = accounts.filter((account) => {
+    return !getOrCreateRuntimeState(account.key).permanentlyDisabled;
+  });
+  if (enabledAccounts.length === 0) {
+    const reauthMsg = formatReauthMessage(
+      accounts.map((account) => account.label),
+    );
+    tracer?.setError("authentication_error", reauthMsg);
+    tracer?.end(401, Date.now() - requestStartTime);
+    return { response: buildLoggedClaudeError(401, reauthMsg) };
+  }
+
+  const orderedAccounts = [...enabledAccounts];
+  if (
+    accountStrategy === "round-robin" &&
+    orderedAccounts.length !== lastKnownAccountCount
+  ) {
+    primaryAccountIndex = 0;
+    lastKnownAccountCount = orderedAccounts.length;
+  }
+  if (orderedAccounts.length > 1) {
+    const idx = primaryAccountIndex % orderedAccounts.length;
+    if (accountStrategy === "round-robin") {
+      primaryAccountIndex = (primaryAccountIndex + 1) % orderedAccounts.length;
+    }
+    if (idx > 0) {
+      const head = orderedAccounts.splice(0, idx);
+      orderedAccounts.push(...head);
+    }
+  }
+
+  const normalizedAnthropicBody = normalizeClaudeRequestForAnthropic(body);
+  const bodyStr = JSON.stringify(normalizedAnthropicBody);
+  const requestStart = Date.now();
+  const toolCount = Array.isArray(body.tools) ? body.tools.length : 0;
+  const url = "https://api.anthropic.com/v1/messages?beta=true";
+  const clientHeaders = ctx.headers ?? {};
+  const clientSnapshotBody = extractSnapshotBody(body);
+
+  return {
+    accounts,
+    enabledAccounts,
+    orderedAccounts,
+    bodyStr,
+    requestStart,
+    toolCount,
+    url,
+    clientHeaders,
+    isClaudeClientRequest: isLikelyClaudeClient(
+      clientHeaders,
+      clientSnapshotBody,
+    ),
+  };
+}
+
+async function executeClaudeFallbackTranslation(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  options: Parameters<ServerContext["neurolink"]["stream"]>[0];
+  providerLabel: string;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+    logFinalRequest,
+    options,
+    providerLabel,
+  } = args;
+  if (body.stream) {
+    const streamResult = await ctx.neurolink.stream(options);
+    const serializer = new ClaudeStreamSerializer(body.model, 0);
+
+    async function* sseGenerator(): AsyncIterable<string> {
+      for (const frame of serializer.start()) {
+        yield frame;
+      }
+      let collectedText = "";
+      for await (const chunk of streamResult.stream) {
+        const text = extractText(chunk);
+        if (text) {
+          collectedText += text;
+          for (const frame of serializer.pushDelta(text)) {
+            yield frame;
+          }
+        }
+      }
+      const toolCalls = streamResult.toolCalls ?? [];
+      if (!hasTranslatedOutput(collectedText, toolCalls)) {
+        throw new Error(
+          `Translated provider ${providerLabel} returned no content or tool calls`,
+        );
+      }
+      if (toolCalls.length) {
+        for (const toolCall of toolCalls) {
+          const toolName =
+            (toolCall as { toolName?: string }).toolName ??
+            (toolCall as { name?: string }).name ??
+            "unknown";
+          for (const frame of serializer.pushToolUse(
+            generateToolUseId(),
+            toolName,
+            extractToolArgs(toolCall),
+          )) {
+            yield frame;
+          }
+        }
+      }
+      const reason = streamResult.finishReason ?? "end_turn";
+      const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
+      for (const frame of serializer.finish(resolvedUsage.output, reason)) {
+        yield frame;
+      }
+    }
+
+    tracer?.end(200, Date.now() - requestStartTime);
+    recordFinalSuccess();
+    logFinalRequest(200, "", providerLabel);
+    return sseGenerator();
+  }
+
+  const streamResult = await ctx.neurolink.stream(options);
+  let collectedText = "";
+  for await (const chunk of streamResult.stream) {
+    const text = extractText(chunk);
+    if (text) {
+      collectedText += text;
+    }
+  }
+  if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
+    throw new Error(
+      `Translated provider ${providerLabel} returned no content or tool calls`,
+    );
+  }
+
+  const internal: InternalResult = {
+    content: collectedText,
+    model: streamResult.model,
+    finishReason: streamResult.finishReason ?? "end_turn",
+    reasoning: undefined,
+    usage: streamResult.usage
+      ? extractUsageFromStreamResult(streamResult.usage)
+      : undefined,
+    toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
+  };
+  tracer?.end(200, Date.now() - requestStartTime);
+  recordFinalSuccess();
+  const clientResponse = serializeClaudeResponse(internal, body.model);
+  logFinalRequest(200, "", providerLabel, undefined, undefined, {
+    inputTokens: internal.usage?.input,
+    outputTokens: internal.usage?.output,
+  });
+  const clientResponseText = JSON.stringify(clientResponse);
+  logProxyBody({
+    phase: "client_response",
+    headers: { "content-type": "application/json" },
+    body: clientResponseText,
+    bodySize: Buffer.byteLength(clientResponseText, "utf8"),
+    contentType: "application/json",
+    responseStatus: 200,
+    durationMs: Date.now() - requestStartTime,
+  });
+  return clientResponse;
+}
+
+async function tryConfiguredClaudeFallbackChain(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  modelRouter?: ModelRouter;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<unknown | null> {
+  const {
+    ctx,
+    body,
+    modelRouter,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  const parsedFallbackRequest = parseClaudeRequest(body);
+  const chain = modelRouter?.getFallbackChain() ?? [];
+
+  for (const fallback of chain) {
+    if (
+      shouldSkipTranslationTarget(
+        fallback.provider,
+        fallback.model,
+        parsedFallbackRequest,
+      )
+    ) {
+      logger.debug(
+        `[proxy] skipping fallback ${fallback.provider}/${fallback.model}: incompatible with request shape`,
+      );
+      continue;
+    }
+
+    const availability =
+      await ProviderHealthChecker.checkFallbackProviderAvailability(
+        fallback.provider,
+        fallback.model,
+      );
+    if (!availability.available) {
+      logger.debug(
+        `[proxy] skipping fallback ${fallback.provider}/${fallback.model}: ${availability.reason ?? "provider unavailable"}`,
+      );
+      continue;
+    }
+
+    try {
+      logger.always(
+        `[proxy] fallback → ${fallback.provider}/${fallback.model}`,
+      );
+      const options = buildProxyFallbackOptions(parsedFallbackRequest, {
+        provider: fallback.provider,
+        model: fallback.model,
+      });
+      return await executeClaudeFallbackTranslation({
+        ctx,
+        body,
+        tracer,
+        requestStartTime,
+        logProxyBody,
+        logFinalRequest,
+        options: options as Parameters<ServerContext["neurolink"]["stream"]>[0],
+        providerLabel: fallback.provider,
+      });
+    } catch (fallbackErr) {
+      logger.debug(
+        `[proxy] fallback ${fallback.provider}/${fallback.model} failed: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
+      );
+    }
+  }
+
+  return null;
+}
+
+async function tryAutoClaudeFallback(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<unknown | null> {
+  const { ctx, body, tracer, requestStartTime, logProxyBody, logFinalRequest } =
+    args;
+  try {
+    logger.always("[proxy] fallback → auto-provider");
+    const parsed = parseClaudeRequest(body);
+    const options = buildProxyFallbackOptions(parsed);
+    return await executeClaudeFallbackTranslation({
+      ctx,
+      body,
+      tracer,
+      requestStartTime,
+      logProxyBody,
+      logFinalRequest,
+      options: options as Parameters<ServerContext["neurolink"]["stream"]>[0],
+      providerLabel: "auto-provider",
+    });
+  } catch (fallbackErr) {
+    logger.debug(
+      `[proxy] fallback auto-provider failed: ${
+        fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+      }`,
+    );
+    return null;
+  }
+}
+
+function buildClaudeAnthropicFailureResponse(args: {
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  authFailureMessage: string | null;
+  invalidRequestFailure: {
+    status: number;
+    body: string;
+    contentType?: string;
+  } | null;
+  sawNetworkError: boolean;
+  sawTransientFailure: boolean;
+  sawRateLimit: boolean;
+  lastError: unknown;
+  orderedAccounts: ProxyPassthroughAccount[];
+  buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): unknown {
+  const {
+    tracer,
+    requestStartTime,
+    authFailureMessage,
+    invalidRequestFailure,
+    sawNetworkError,
+    sawTransientFailure,
+    sawRateLimit,
+    lastError,
+    orderedAccounts,
+    buildLoggedClaudeError,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  if (authFailureMessage && !sawRateLimit) {
+    tracer?.setError("authentication_error", authFailureMessage);
+    tracer?.end(401, Date.now() - requestStartTime);
+    return buildLoggedClaudeError(401, authFailureMessage);
+  }
+
+  if (invalidRequestFailure) {
+    tracer?.setError(
+      "invalid_request_error",
+      summarizeErrorMessage(invalidRequestFailure.body),
+    );
+    tracer?.end(invalidRequestFailure.status, Date.now() - requestStartTime);
+    recordFinalError(invalidRequestFailure.status);
+    try {
+      const parsedError = JSON.parse(invalidRequestFailure.body);
+      logFinalRequest(
+        invalidRequestFailure.status,
+        "",
+        "final",
+        "invalid_request_error",
+        summarizeErrorMessage(invalidRequestFailure.body),
+      );
+      logProxyBody({
+        phase: "client_response",
+        headers: {
+          "content-type":
+            invalidRequestFailure.contentType ?? "application/json",
+        },
+        body: invalidRequestFailure.body,
+        bodySize: Buffer.byteLength(invalidRequestFailure.body, "utf8"),
+        contentType: invalidRequestFailure.contentType ?? "application/json",
+        responseStatus: invalidRequestFailure.status,
+        durationMs: Date.now() - requestStartTime,
+      });
+      return parsedError;
+    } catch {
+      return buildLoggedClaudeError(
+        invalidRequestFailure.status,
+        summarizeErrorMessage(invalidRequestFailure.body),
+        "invalid_request_error",
+      );
+    }
+  }
+
+  if ((sawNetworkError || sawTransientFailure) && !sawRateLimit) {
+    const msg = `All Anthropic accounts failed due to transient upstream/network errors. Last error: ${
+      lastError instanceof Error
+        ? lastError.message
+        : String(lastError ?? "unknown")
+    }`;
+    tracer?.setError("transient_error", msg.slice(0, 500));
+    tracer?.end(502, Date.now() - requestStartTime);
+    return buildLoggedClaudeError(502, msg);
+  }
+
+  if (!sawRateLimit) {
+    const msg = `All Anthropic accounts failed. Last error: ${
+      lastError instanceof Error
+        ? lastError.message
+        : String(lastError ?? "unknown")
+    }`;
+    tracer?.setError("all_accounts_failed", msg.slice(0, 500));
+    tracer?.end(502, Date.now() - requestStartTime);
+    return buildLoggedClaudeError(502, msg);
+  }
+
+  const earliestRecovery = orderedAccounts.reduce((min, account) => {
+    const coolingUntil = getOrCreateRuntimeState(account.key).coolingUntil;
+    return coolingUntil ? Math.min(min, coolingUntil) : min;
+  }, Infinity);
+  const retryAfterSec = Number.isFinite(earliestRecovery)
+    ? Math.max(1, Math.ceil((earliestRecovery - Date.now()) / 1000))
+    : 60;
+  logger.always(
+    `[proxy] all accounts rate-limited, retry in ${retryAfterSec}s`,
+  );
+  const errorBody = buildClaudeError(
+    429,
+    `All accounts rate-limited. Earliest recovery in ${retryAfterSec}s.`,
+    "overloaded_error",
+  );
+  tracer?.setError(
+    "rate_limit_error",
+    `All accounts rate-limited. Retry in ${retryAfterSec}s.`,
+  );
+  tracer?.end(429, Date.now() - requestStartTime);
+  recordFinalError(429);
+  logFinalRequest(
+    429,
+    "",
+    "final",
+    "rate_limit_error",
+    `All accounts rate-limited. Retry in ${retryAfterSec}s.`,
+  );
+  const errorBodyText = JSON.stringify(errorBody);
+  logProxyBody({
+    phase: "client_response",
+    headers: {
+      "content-type": "application/json",
+      "retry-after": String(retryAfterSec),
+    },
+    body: errorBodyText,
+    bodySize: Buffer.byteLength(errorBodyText, "utf8"),
+    contentType: "application/json",
+    responseStatus: 429,
+    durationMs: Date.now() - requestStartTime,
+  });
+  return new Response(errorBodyText, {
+    status: 429,
+    headers: {
+      "content-type": "application/json",
+      "retry-after": String(retryAfterSec),
+    },
+  });
+}
+
+async function handleAnthropicSuccessfulResponse(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  response: Response;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<AnthropicSuccessResult> {
+  const {
+    ctx,
+    body,
+    account,
+    accountState,
+    response,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  accountState.backoffLevel = 0;
+  accountState.coolingUntil = undefined;
+  accountState.consecutiveRefreshFailures = 0;
+  logger.always(`[proxy] ← ${response.status} account=${account.label}`);
+
+  const quota = parseQuotaHeaders(response.headers);
+  if (quota) {
+    saveAccountQuota(account.label, quota).catch(() => {
+      // Non-fatal: quota persistence is best-effort
+    });
+  }
+
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+  tracer?.logUpstreamResponseHeaders(responseHeaders);
+
+  if (body.stream) {
+    return handleAnthropicStreamingSuccessResponse({
+      ctx,
+      body,
+      account,
+      accountState,
+      response,
+      responseHeaders,
+      tracer,
+      requestStartTime,
+      fetchStartMs,
+      attemptNumber,
+      finalBodyStr,
+      upstreamSpan,
+      logProxyBody,
+      logFinalRequest,
+    });
+  }
+
+  return handleAnthropicJsonSuccessResponse({
+    account,
+    response,
+    responseHeaders,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  });
+}
+
+async function handleAnthropicStreamingSuccessResponse(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  response: Response;
+  responseHeaders: Record<string, string>;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<AnthropicSuccessResult> {
+  const {
+    ctx,
+    body,
+    account,
+    accountState,
+    response,
+    responseHeaders,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  if (!response.body) {
+    upstreamSpan?.end();
+    tracer?.setError("stream_error", "No response body from upstream");
+    tracer?.end(502, Date.now() - requestStartTime);
+    recordFinalError(502, account.label, account.type);
+    logFinalRequest(
+      502,
+      account.label,
+      account.type,
+      "stream_error",
+      "No response body from upstream",
+    );
+    const clientError = buildClaudeError(502, "No response body from upstream");
+    const clientErrorBody = JSON.stringify(clientError);
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "application/json" },
+      body: clientErrorBody,
+      bodySize: Buffer.byteLength(clientErrorBody, "utf8"),
+      contentType: "application/json",
+      account: account.label,
+      accountType: account.type,
+      attempt: attemptNumber,
+      responseStatus: 502,
+      durationMs: Date.now() - requestStartTime,
+    });
+    return { response: clientError };
+  }
+
+  const reader = response.body.getReader();
+  const firstChunk = await reader.read();
+  if (firstChunk.done || !firstChunk.value || firstChunk.value.length === 0) {
+    reader.cancel();
+    accountState.coolingUntil = Date.now() + 10_000;
+    recordCooldown(
+      account.label,
+      account.type,
+      accountState.coolingUntil,
+      accountState.backoffLevel,
+    );
+    logger.always(
+      `[proxy] ← empty stream from account=${account.label}, trying next`,
+    );
+    tracer?.recordRetry(account.label, "empty_stream");
+    upstreamSpan?.end();
+    return { retryNextAccount: true };
+  }
+
+  let mainStreamClosed = false;
+  const remainingStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(firstChunk.value);
+    },
+    async pull(controller) {
+      if (mainStreamClosed) {
+        return;
+      }
+      try {
+        const { done, value } = await reader.read();
+        if (mainStreamClosed) {
+          return;
+        }
+        if (done) {
+          mainStreamClosed = true;
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (streamErr) {
+        const errMsg =
+          streamErr instanceof Error ? streamErr.message : String(streamErr);
+        logger.always(
+          `[proxy] mid-stream error account=${account.label}: ${errMsg}`,
+        );
+        logStreamError({
+          timestamp: new Date().toISOString(),
+          requestId: ctx.requestId,
+          account: account.label,
+          model: body.model,
+          errorMessage: errMsg,
+          durationMs: Date.now() - fetchStartMs,
+        });
+        if (!mainStreamClosed) {
+          mainStreamClosed = true;
+          const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
+          controller.enqueue(new TextEncoder().encode(errorEvent));
+          controller.close();
+        }
+      }
+    },
+    cancel() {
+      mainStreamClosed = true;
+      reader.cancel();
+    },
+  });
+
+  const result = attachAnthropicSuccessStreamTelemetry({
+    account,
+    response,
+    responseHeaders,
+    remainingStream,
+    tracer,
+    requestStartTime,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  });
+  return { response: result };
+}
+
+function attachAnthropicSuccessStreamTelemetry(args: {
+  account: ProxyPassthroughAccount;
+  response: Response;
+  responseHeaders: Record<string, string>;
+  remainingStream: ReadableStream<Uint8Array>;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Response {
+  const {
+    account,
+    response,
+    responseHeaders,
+    remainingStream,
+    tracer,
+    requestStartTime,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  const { stream: clientCaptureStream, capture: clientCapture } =
+    createRawStreamCapture();
+  let streamSource: ReadableStream<Uint8Array> = remainingStream;
+
+  if (tracer) {
+    try {
+      const { stream: interceptor, telemetry } = createSSEInterceptor({
+        captureRawText: true,
+      });
+      streamSource = streamSource.pipeThrough(interceptor);
+      const capturedTracer = tracer;
+      const capturedUpstreamSpan = upstreamSpan;
+      const capturedResponse = response;
+      const capturedRequestBytes = finalBodyStr.length;
+      const capturedAccountLabel = account.label;
+
+      Promise.all([telemetry, clientCapture])
+        .then(([data, clientBody]) => {
+          capturedTracer.setUsage({
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          });
+          capturedTracer.logStreamEvents(data.events);
+          const rateLimit5h = parseFloat(
+            capturedResponse.headers.get(
+              "anthropic-ratelimit-unified-5h-utilization",
+            ) ?? "",
+          );
+          const rateLimit7d = parseFloat(
+            capturedResponse.headers.get(
+              "anthropic-ratelimit-unified-7d-utilization",
+            ) ?? "",
+          );
+          const usageUpdate: Parameters<typeof capturedTracer.setUsage>[0] = {
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          };
+          if (!isNaN(rateLimit5h)) {
+            usageUpdate.rateLimitAfter5h = rateLimit5h;
+          }
+          if (!isNaN(rateLimit7d)) {
+            usageUpdate.rateLimitAfter7d = rateLimit7d;
+          }
+          if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
+            capturedTracer.setUsage(usageUpdate);
+          }
+
+          capturedTracer.logUpstreamResponseBody(data.rawText ?? "");
+          capturedTracer.recordMetrics();
+          capturedTracer.recordBodySizes(
+            capturedRequestBytes,
+            data.totalBytesReceived,
+          );
+          capturedUpstreamSpan?.end();
+          capturedTracer.end(200, Date.now() - requestStartTime);
+          recordFinalSuccess(capturedAccountLabel, account.type);
+          logFinalRequest(
+            200,
+            capturedAccountLabel,
+            account.type,
+            undefined,
+            undefined,
+            {
+              inputTokens: data.usage.inputTokens,
+              outputTokens: data.usage.outputTokens,
+              cacheCreationTokens: data.usage.cacheCreationInputTokens,
+              cacheReadTokens: data.usage.cacheReadInputTokens,
+            },
+          );
+          logProxyBody({
+            phase: "upstream_response",
+            headers: responseHeaders,
+            body: data.rawText ?? "",
+            bodySize: data.totalBytesReceived,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: capturedAccountLabel,
+            accountType: account.type,
+            attempt: attemptNumber,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+          logProxyBody({
+            phase: "client_response",
+            headers: responseHeaders,
+            body: clientBody.text,
+            bodySize: clientBody.totalBytes,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: capturedAccountLabel,
+            accountType: account.type,
+            attempt: attemptNumber,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+        })
+        .catch((error) => {
+          capturedTracer.setError(
+            "stream_error",
+            error instanceof Error ? error.message : String(error),
+          );
+          capturedUpstreamSpan?.end();
+          capturedTracer.end(500, Date.now() - requestStartTime);
+          recordFinalError(500, capturedAccountLabel, account.type);
+          logFinalRequest(
+            500,
+            capturedAccountLabel,
+            account.type,
+            "stream_error",
+            error instanceof Error ? error.message : String(error),
+          );
+        });
+    } catch {
+      // Interceptor attachment failed after stream setup; response handling continues.
+    }
+  } else {
+    upstreamSpan?.end();
+    try {
+      const { stream: noTracerInterceptor, telemetry: noTracerTelemetry } =
+        createSSEInterceptor({
+          captureRawText: true,
+        });
+      streamSource = streamSource.pipeThrough(noTracerInterceptor);
+      const capturedAccountLabel = account.label;
+      Promise.all([noTracerTelemetry, clientCapture])
+        .then(([data, clientBody]) => {
+          recordFinalSuccess(capturedAccountLabel, account.type);
+          logFinalRequest(
+            200,
+            capturedAccountLabel,
+            account.type,
+            undefined,
+            undefined,
+            {
+              inputTokens: data.usage.inputTokens,
+              outputTokens: data.usage.outputTokens,
+              cacheCreationTokens: data.usage.cacheCreationInputTokens,
+              cacheReadTokens: data.usage.cacheReadInputTokens,
+            },
+          );
+          logProxyBody({
+            phase: "upstream_response",
+            headers: responseHeaders,
+            body: data.rawText ?? "",
+            bodySize: data.totalBytesReceived,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: capturedAccountLabel,
+            accountType: account.type,
+            attempt: attemptNumber,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+          logProxyBody({
+            phase: "client_response",
+            headers: responseHeaders,
+            body: clientBody.text,
+            bodySize: clientBody.totalBytes,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: capturedAccountLabel,
+            accountType: account.type,
+            attempt: attemptNumber,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+        })
+        .catch(() => {
+          recordFinalSuccess(account.label, account.type);
+          logFinalRequest(response.status, account.label, account.type);
+        });
+    } catch {
+      clientCapture
+        .then((clientBody) => {
+          logProxyBody({
+            phase: "client_response",
+            headers: responseHeaders,
+            body: clientBody.text,
+            bodySize: clientBody.totalBytes,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: account.label,
+            accountType: account.type,
+            attempt: attemptNumber,
+            responseStatus: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
+        })
+        .catch(() => {
+          // Non-fatal
+        });
+      recordFinalSuccess(account.label, account.type);
+      logFinalRequest(response.status, account.label, account.type);
+    }
+  }
+
+  const clientStream = streamSource.pipeThrough(clientCaptureStream);
+  const clientResponseHeaders: Record<string, string> = {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  };
+  for (const headerName of [
+    "retry-after",
+    "anthropic-ratelimit-requests-remaining",
+    "anthropic-ratelimit-requests-limit",
+    "anthropic-ratelimit-tokens-remaining",
+    "anthropic-ratelimit-tokens-limit",
+  ]) {
+    const value = response.headers.get(headerName);
+    if (value) {
+      clientResponseHeaders[headerName] = value;
+    }
+  }
+
+  return new Response(clientStream, {
+    status: response.status,
+    headers: clientResponseHeaders,
+  });
+}
+
+async function handleAnthropicJsonSuccessResponse(args: {
+  account: ProxyPassthroughAccount;
+  response: Response;
+  responseHeaders: Record<string, string>;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<AnthropicSuccessResult> {
+  const {
+    account,
+    response,
+    responseHeaders,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  const responseText = await response.text();
+  tracer?.logUpstreamResponseBody(responseText);
+  logProxyBody({
+    phase: "upstream_response",
+    headers: responseHeaders,
+    body: responseText,
+    bodySize: Buffer.byteLength(responseText, "utf8"),
+    contentType: responseHeaders["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+    responseStatus: response.status,
+    durationMs: Date.now() - fetchStartMs,
+  });
+  logProxyBody({
+    phase: "client_response",
+    headers: responseHeaders,
+    body: responseText,
+    bodySize: Buffer.byteLength(responseText, "utf8"),
+    contentType: responseHeaders["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+    responseStatus: response.status,
+    durationMs: Date.now() - requestStartTime,
+  });
+  const responseJson = JSON.parse(responseText);
+
+  if (tracer && responseJson && typeof responseJson === "object") {
+    const usage = (responseJson as Record<string, unknown>).usage as
+      | Record<string, number>
+      | undefined;
+    if (usage) {
+      tracer.setUsage({
+        inputTokens: usage.input_tokens ?? 0,
+        outputTokens: usage.output_tokens ?? 0,
+        cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+      });
+
+      const rateLimit5h = parseFloat(
+        response.headers.get("anthropic-ratelimit-unified-5h-utilization") ??
+          "",
+      );
+      const rateLimit7d = parseFloat(
+        response.headers.get("anthropic-ratelimit-unified-7d-utilization") ??
+          "",
+      );
+      if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
+        const usageWithRates: Parameters<typeof tracer.setUsage>[0] = {
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+        };
+        if (!isNaN(rateLimit5h)) {
+          usageWithRates.rateLimitAfter5h = rateLimit5h;
+        }
+        if (!isNaN(rateLimit7d)) {
+          usageWithRates.rateLimitAfter7d = rateLimit7d;
+        }
+        tracer.setUsage(usageWithRates);
+      }
+    }
+    tracer.recordMetrics();
+    const responseJsonStr = JSON.stringify(responseJson);
+    tracer.recordBodySizes(finalBodyStr.length, responseJsonStr.length);
+    upstreamSpan?.end();
+    tracer.end(response.status, Date.now() - requestStartTime);
+    recordFinalSuccess(account.label, account.type);
+    logFinalRequest(
+      response.status,
+      account.label,
+      account.type,
+      undefined,
+      undefined,
+      {
+        inputTokens: usage?.input_tokens,
+        outputTokens: usage?.output_tokens,
+        cacheCreationTokens: usage?.cache_creation_input_tokens,
+        cacheReadTokens: usage?.cache_read_input_tokens,
+      },
+    );
+  } else {
+    upstreamSpan?.end();
+    const noTracerUsage =
+      responseJson && typeof responseJson === "object"
+        ? ((responseJson as Record<string, unknown>).usage as
+            | Record<string, number>
+            | undefined)
+        : undefined;
+    recordFinalSuccess(account.label, account.type);
+    logFinalRequest(
+      response.status,
+      account.label,
+      account.type,
+      undefined,
+      undefined,
+      {
+        inputTokens: noTracerUsage?.input_tokens,
+        outputTokens: noTracerUsage?.output_tokens,
+        cacheCreationTokens: noTracerUsage?.cache_creation_input_tokens,
+        cacheReadTokens: noTracerUsage?.cache_read_input_tokens,
+      },
+    );
+  }
+
+  return { response: responseJson };
+}
+
+async function handleAnthropicSuccessfulRetryResponse(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  account: ProxyPassthroughAccount;
+  retryResp: Response;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+}): Promise<Response | unknown> {
+  const {
+    ctx,
+    body,
+    account,
+    retryResp,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  const retryQuota = parseQuotaHeaders(retryResp.headers);
+  if (retryQuota) {
+    saveAccountQuota(account.label, retryQuota).catch((error) => {
+      logger.debug("[proxy] Failed to persist account quota after auth retry", {
+        account: account.label,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  if (body.stream && retryResp.body) {
+    const retryReader = retryResp.body.getReader();
+    let retryStreamClosed = false;
+    const retryStream = new ReadableStream({
+      async pull(controller) {
+        if (retryStreamClosed) {
+          return;
+        }
+        try {
+          const { done, value } = await retryReader.read();
+          if (retryStreamClosed) {
+            return;
+          }
+          if (done) {
+            retryStreamClosed = true;
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+        } catch (streamErr) {
+          const errMsg =
+            streamErr instanceof Error ? streamErr.message : String(streamErr);
+          logger.always(
+            `[proxy] mid-stream error (auth-retry) account=${account.label}: ${errMsg}`,
+          );
+          logStreamError({
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            account: account.label,
+            model: body.model,
+            errorMessage: errMsg,
+            durationMs: Date.now() - fetchStartMs,
+          });
+          if (!retryStreamClosed) {
+            retryStreamClosed = true;
+            const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
+            controller.enqueue(new TextEncoder().encode(errorEvent));
+            controller.close();
+          }
+        }
+      },
+      cancel() {
+        retryStreamClosed = true;
+        retryReader.cancel();
+      },
+    });
+
+    let retryClientStream: ReadableStream<Uint8Array> = retryStream;
+    if (tracer) {
+      try {
+        const { stream: retryInterceptor, telemetry: retryTelemetry } =
+          createSSEInterceptor();
+        retryClientStream = retryStream.pipeThrough(retryInterceptor);
+        const capturedTracer = tracer;
+        const capturedUpstreamSpan = upstreamSpan;
+        const capturedRetryResp = retryResp;
+        const capturedRetryRequestBytes = finalBodyStr.length;
+        const capturedAccountLabel = account.label;
+        retryTelemetry
+          .then((data) => {
+            capturedTracer.setUsage({
+              inputTokens: data.usage.inputTokens,
+              outputTokens: data.usage.outputTokens,
+              cacheCreationTokens: data.usage.cacheCreationInputTokens,
+              cacheReadTokens: data.usage.cacheReadInputTokens,
+            });
+            capturedTracer.logStreamEvents(data.events);
+            capturedTracer.logUpstreamResponseHeaders(
+              Object.fromEntries([...capturedRetryResp.headers.entries()]),
+            );
+            capturedTracer.recordMetrics();
+            capturedTracer.recordBodySizes(
+              capturedRetryRequestBytes,
+              data.totalBytesReceived,
+            );
+            capturedUpstreamSpan?.end();
+            capturedTracer.end(200, Date.now() - requestStartTime);
+            recordFinalSuccess(capturedAccountLabel, account.type);
+            logFinalRequest(
+              200,
+              capturedAccountLabel,
+              account.type,
+              undefined,
+              undefined,
+              {
+                inputTokens: data.usage.inputTokens,
+                outputTokens: data.usage.outputTokens,
+                cacheCreationTokens: data.usage.cacheCreationInputTokens,
+                cacheReadTokens: data.usage.cacheReadInputTokens,
+              },
+            );
+          })
+          .catch((error) => {
+            capturedTracer.setError(
+              "stream_error",
+              error instanceof Error ? error.message : String(error),
+            );
+            capturedUpstreamSpan?.end();
+            capturedTracer.end(500, Date.now() - requestStartTime);
+            recordFinalError(500, capturedAccountLabel, account.type);
+            logFinalRequest(
+              500,
+              capturedAccountLabel,
+              account.type,
+              "stream_error",
+              error instanceof Error ? error.message : String(error),
+            );
+          });
+      } catch {
+        retryClientStream = retryStream;
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    };
+    for (const headerName of [
+      "retry-after",
+      "anthropic-ratelimit-requests-remaining",
+      "anthropic-ratelimit-requests-limit",
+      "anthropic-ratelimit-tokens-remaining",
+      "anthropic-ratelimit-tokens-limit",
+    ]) {
+      const value = retryResp.headers.get(headerName);
+      if (value) {
+        responseHeaders[headerName] = value;
+      }
+    }
+    return new Response(retryClientStream, {
+      status: retryResp.status,
+      headers: responseHeaders,
+    });
+  }
+
+  const retryRespHeaders = Object.fromEntries([...retryResp.headers.entries()]);
+  const retryText = await retryResp.text();
+  tracer?.logUpstreamResponseHeaders(retryRespHeaders);
+  tracer?.logUpstreamResponseBody(retryText);
+  logProxyBody({
+    phase: "upstream_response",
+    headers: retryRespHeaders,
+    body: retryText,
+    bodySize: Buffer.byteLength(retryText, "utf8"),
+    contentType: retryRespHeaders["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+    responseStatus: retryResp.status,
+    durationMs: Date.now() - fetchStartMs,
+  });
+  logProxyBody({
+    phase: "client_response",
+    headers: retryRespHeaders,
+    body: retryText,
+    bodySize: Buffer.byteLength(retryText, "utf8"),
+    contentType: retryRespHeaders["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+    responseStatus: retryResp.status,
+    durationMs: Date.now() - requestStartTime,
+  });
+
+  const retryJson = JSON.parse(retryText);
+  if (tracer && retryJson && typeof retryJson === "object") {
+    const retryUsage = (retryJson as Record<string, unknown>).usage as
+      | Record<string, number>
+      | undefined;
+    if (retryUsage) {
+      tracer.setUsage({
+        inputTokens: retryUsage.input_tokens ?? 0,
+        outputTokens: retryUsage.output_tokens ?? 0,
+        cacheCreationTokens: retryUsage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: retryUsage.cache_read_input_tokens ?? 0,
+      });
+    }
+    tracer.recordMetrics();
+    const retryJsonStr = JSON.stringify(retryJson);
+    tracer.recordBodySizes(finalBodyStr.length, retryJsonStr.length);
+    upstreamSpan?.end();
+    tracer.end(retryResp.status, Date.now() - requestStartTime);
+    recordFinalSuccess(account.label, account.type);
+    logFinalRequest(
+      retryResp.status,
+      account.label,
+      account.type,
+      undefined,
+      undefined,
+      {
+        inputTokens: retryUsage?.input_tokens,
+        outputTokens: retryUsage?.output_tokens,
+        cacheCreationTokens: retryUsage?.cache_creation_input_tokens,
+        cacheReadTokens: retryUsage?.cache_read_input_tokens,
+      },
+    );
+  } else {
+    upstreamSpan?.end();
+    recordFinalSuccess(account.label, account.type);
+    logFinalRequest(retryResp.status, account.label, account.type);
+  }
+
+  return retryJson;
+}
+
+async function handleAnthropicAuthRetry(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  headers: Record<string, string>;
+  buildUpstreamBody: (token: string) => { bodyStr: string; sessionId?: string };
+  enabledAccounts: ProxyPassthroughAccount[];
+  orderedAccounts: ProxyPassthroughAccount[];
+  response: Response;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  finalBodyStr: string;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+  logAttempt: (
+    status: number,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  lastError: unknown;
+  authFailureMessage: string | null;
+  sawRateLimit: boolean;
+  sawTransientFailure: boolean;
+  sawNetworkError: boolean;
+}): Promise<AnthropicAuthRetryResult> {
+  const {
+    ctx,
+    body,
+    account,
+    accountState,
+    headers,
+    buildUpstreamBody,
+    enabledAccounts,
+    orderedAccounts,
+    response: _response,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    finalBodyStr,
+    upstreamSpan,
+    logAttempt,
+    logProxyBody,
+    logFinalRequest,
+    lastError,
+    authFailureMessage,
+    sawRateLimit,
+    sawTransientFailure,
+    sawNetworkError,
+  } = args;
+  recordAttemptError(account.label, account.type, 401);
+  let currentLastError = lastError;
+  let currentAuthFailureMessage = authFailureMessage;
+  let currentSawRateLimit = sawRateLimit;
+  let currentSawTransientFailure = sawTransientFailure;
+  let currentSawNetworkError = sawNetworkError;
+  let currentUpstreamSpan = upstreamSpan;
+  let authRetrySucceeded = false;
+  let authRetryError = "received 401 from Anthropic";
+
+  for (let authRetry = 0; authRetry < MAX_AUTH_RETRIES; authRetry++) {
+    logger.always(
+      `[proxy] ← 401 account=${account.label} refreshing (attempt ${authRetry + 1}/${MAX_AUTH_RETRIES})`,
+    );
+    const refreshSucceeded = await refreshToken(account);
+    if (!refreshSucceeded.success) {
+      accountState.consecutiveRefreshFailures += 1;
+      authRetryError = `refresh failed for account=${account.label} attempt ${authRetry + 1}/${MAX_AUTH_RETRIES}: ${refreshSucceeded.error?.slice(0, 200) ?? "unknown"}`;
+      currentLastError = authRetryError;
+      logger.always(
+        `[proxy] ⚠ account=${account.label} refresh failed on attempt ${authRetry + 1}`,
+      );
+      if (
+        accountState.consecutiveRefreshFailures >=
+        MAX_CONSECUTIVE_REFRESH_FAILURES
+      ) {
+        await disableAccountUntilReauth(account, accountState);
+        currentAuthFailureMessage = formatReauthMessage(account.label);
+        break;
+      }
+      if (authRetry < MAX_AUTH_RETRIES - 1) {
+        await sleep(2000);
+      }
+      continue;
+    }
+
+    if (account.persistTarget) {
+      await persistTokens(account.persistTarget, account);
+    }
+    headers.authorization = `Bearer ${account.token}`;
+
+    try {
+      const retryResp = await fetch(
+        "https://api.anthropic.com/v1/messages?beta=true",
+        {
+          method: "POST",
+          headers,
+          body: buildUpstreamBody(account.token).bodyStr,
+          signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
+        },
+      );
+      if (retryResp.ok) {
+        authRetrySucceeded = true;
+        accountState.consecutiveRefreshFailures = 0;
+        accountState.backoffLevel = 0;
+        accountState.coolingUntil = undefined;
+        logger.always(
+          `[proxy] ← 200 account=${account.label} (after ${authRetry + 1} refresh(es))`,
+        );
+        const successResponse = await handleAnthropicSuccessfulRetryResponse({
+          ctx,
+          body,
+          account,
+          retryResp,
+          tracer,
+          requestStartTime,
+          fetchStartMs,
+          attemptNumber,
+          finalBodyStr,
+          upstreamSpan: currentUpstreamSpan,
+          logProxyBody,
+          logFinalRequest,
+        });
+        return {
+          response: successResponse,
+          continueLoop: false,
+          lastError: currentLastError,
+          authFailureMessage: currentAuthFailureMessage,
+          sawRateLimit: currentSawRateLimit,
+          sawTransientFailure: currentSawTransientFailure,
+          sawNetworkError: currentSawNetworkError,
+          upstreamSpan: undefined,
+        };
+      }
+
+      const retryStatus = retryResp.status;
+      const retryBody = await retryResp.text();
+      authRetryError = `retry ${authRetry + 1}/${MAX_AUTH_RETRIES} failed with status ${retryStatus}`;
+      currentLastError = retryBody;
+      logger.debug(
+        `[proxy] retry ${authRetry + 1} failed: ${retryStatus} ${retryBody.substring(0, 120)}`,
+      );
+      recordAttemptError(account.label, account.type, retryStatus);
+
+      if (retryStatus === 429) {
+        currentSawRateLimit = true;
+        const retryAfter = retryResp.headers.get("retry-after");
+        const parsedRetryAfter = parseInt(retryAfter ?? "", 10);
+        const cooldownMs = Number.isNaN(parsedRetryAfter)
+          ? 60_000
+          : Math.max(1, parsedRetryAfter) * 1000;
+        accountState.coolingUntil = Date.now() + cooldownMs;
+        advancePrimaryIfCurrent(
+          account.key,
+          enabledAccounts.length,
+          orderedAccounts[0]?.key,
+        );
+        recordCooldown(
+          account.label,
+          account.type,
+          accountState.coolingUntil,
+          accountState.backoffLevel,
+        );
+        break;
+      }
+
+      if (retryStatus === 401 || retryStatus === 402 || retryStatus === 403) {
+        if (authRetry < MAX_AUTH_RETRIES - 1) {
+          await sleep(1000);
+        }
+        continue;
+      }
+
+      if (isTransientHttpFailure(retryStatus, retryBody)) {
+        currentSawTransientFailure = true;
+        break;
+      }
+
+      logAttempt(retryStatus, "api_error", summarizeErrorMessage(retryBody));
+      recordFinalError(retryStatus, account.label, account.type);
+      try {
+        logFinalRequest(
+          retryStatus,
+          account.label,
+          account.type,
+          "api_error",
+          summarizeErrorMessage(retryBody),
+        );
+        return {
+          response: JSON.parse(retryBody),
+          continueLoop: false,
+          lastError: currentLastError,
+          authFailureMessage: currentAuthFailureMessage,
+          sawRateLimit: currentSawRateLimit,
+          sawTransientFailure: currentSawTransientFailure,
+          sawNetworkError: currentSawNetworkError,
+          upstreamSpan: currentUpstreamSpan,
+        };
+      } catch {
+        logFinalRequest(
+          retryStatus,
+          account.label,
+          account.type,
+          "api_error",
+          summarizeErrorMessage(retryBody),
+        );
+        return {
+          response: buildClaudeError(retryStatus, retryBody),
+          continueLoop: false,
+          lastError: currentLastError,
+          authFailureMessage: currentAuthFailureMessage,
+          sawRateLimit: currentSawRateLimit,
+          sawTransientFailure: currentSawTransientFailure,
+          sawNetworkError: currentSawNetworkError,
+          upstreamSpan: currentUpstreamSpan,
+        };
+      }
+    } catch (retryFetchErr) {
+      currentSawNetworkError = true;
+      recordAttemptError(account.label, account.type, 502);
+      const message =
+        retryFetchErr instanceof Error
+          ? retryFetchErr.message
+          : String(retryFetchErr);
+      authRetryError = `network error on retry ${authRetry + 1}: ${message}`;
+      currentLastError = authRetryError;
+      logger.debug(`[proxy] ${authRetryError}`);
+      break;
+    }
+  }
+
+  if (!authRetrySucceeded) {
+    if (!accountState.permanentlyDisabled) {
+      if (
+        !accountState.coolingUntil ||
+        accountState.coolingUntil <= Date.now()
+      ) {
+        accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
+      }
+      recordCooldown(
+        account.label,
+        account.type,
+        accountState.coolingUntil,
+        accountState.backoffLevel,
+      );
+    }
+    currentLastError = authRetryError;
+    logger.always(
+      `[proxy] ⚠ account=${account.label} auth retries exhausted, cooldown=5min`,
+    );
+    logAttempt(401, "authentication_error", authRetryError);
+    tracer?.setError("authentication_error", authRetryError);
+    tracer?.recordRetry(account.label, "auth_exhausted");
+    currentUpstreamSpan?.end();
+    currentUpstreamSpan = undefined;
+  }
+
+  return {
+    continueLoop: true,
+    lastError: currentLastError,
+    authFailureMessage: currentAuthFailureMessage,
+    sawRateLimit: currentSawRateLimit,
+    sawTransientFailure: currentSawTransientFailure,
+    sawNetworkError: currentSawNetworkError,
+    upstreamSpan: currentUpstreamSpan,
+  };
+}
+
+function buildAnthropicTerminalErrorResponse(args: {
+  responseStatus: number;
+  account: ProxyPassthroughAccount;
+  errBody: string;
+  errRespHeaders: Record<string, string>;
+  requestStartTime: number;
+  attemptNumber: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  errorType: "not_found_error" | "api_error";
+}): Response | unknown {
+  const {
+    responseStatus,
+    account,
+    errBody,
+    errRespHeaders,
+    requestStartTime,
+    attemptNumber,
+    logProxyBody,
+    logFinalRequest,
+    errorType,
+  } = args;
+  try {
+    const parsedError = JSON.parse(errBody);
+    logFinalRequest(
+      responseStatus,
+      account.label,
+      account.type,
+      errorType,
+      summarizeErrorMessage(errBody),
+    );
+    logProxyBody({
+      phase: "client_response",
+      headers: {
+        "content-type": errRespHeaders["content-type"] ?? "application/json",
+      },
+      body: errBody,
+      bodySize: Buffer.byteLength(errBody, "utf8"),
+      contentType: errRespHeaders["content-type"] ?? "application/json",
+      account: account.label,
+      accountType: account.type,
+      attempt: attemptNumber,
+      responseStatus,
+      durationMs: Date.now() - requestStartTime,
+    });
+    return parsedError;
+  } catch {
+    logFinalRequest(
+      responseStatus,
+      account.label,
+      account.type,
+      errorType,
+      summarizeErrorMessage(errBody),
+    );
+    const clientError = buildClaudeError(responseStatus, errBody);
+    const clientErrorBody = JSON.stringify(clientError);
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "application/json" },
+      body: clientErrorBody,
+      bodySize: Buffer.byteLength(clientErrorBody, "utf8"),
+      contentType: "application/json",
+      account: account.label,
+      accountType: account.type,
+      attempt: attemptNumber,
+      responseStatus,
+      durationMs: Date.now() - requestStartTime,
+    });
+    return clientError;
+  }
+}
+
+async function handleAnthropicNonOkResponse(args: {
+  response: Response;
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  fetchStartMs: number;
+  attemptNumber: number;
+  logAttempt: (
+    status: number,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: (
+    status: number,
+    accountLabel: string,
+    accountType: string,
+    errorType?: string,
+    errorMessage?: string,
+    extra?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ) => void;
+  lastError: unknown;
+  authFailureMessage: string | null;
+  sawTransientFailure: boolean;
+  invalidRequestFailure: {
+    status: number;
+    body: string;
+    contentType?: string;
+  } | null;
+  maxConsecutiveRefreshFailures: number;
+}): Promise<AnthropicNonOkResult> {
+  const {
+    response,
+    account,
+    accountState,
+    tracer,
+    requestStartTime,
+    fetchStartMs,
+    attemptNumber,
+    logAttempt,
+    logProxyBody,
+    logFinalRequest,
+    lastError,
+    authFailureMessage,
+    sawTransientFailure,
+    invalidRequestFailure,
+    maxConsecutiveRefreshFailures,
+  } = args;
+  let currentLastError = lastError;
+  let currentAuthFailureMessage = authFailureMessage;
+  let currentSawTransientFailure = sawTransientFailure;
+  let currentInvalidRequestFailure = invalidRequestFailure;
+
+  const errBody = await response.text();
+  const errRespHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    errRespHeaders[key] = value;
+  });
+  tracer?.logUpstreamResponseHeaders(errRespHeaders);
+  tracer?.logUpstreamResponseBody(errBody);
+  logProxyBody({
+    phase: "upstream_response",
+    headers: errRespHeaders,
+    body: errBody,
+    bodySize: Buffer.byteLength(errBody, "utf8"),
+    contentType: errRespHeaders["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+    responseStatus: response.status,
+    durationMs: Date.now() - fetchStartMs,
+  });
+
+  if (isInvalidRequestError(response.status, errBody)) {
+    logger.always(
+      `[proxy] ← ${response.status} upstream invalid_request_error`,
+    );
+    logAttempt(
+      response.status,
+      "invalid_request_error",
+      summarizeErrorMessage(errBody),
+    );
+    tracer?.setError("invalid_request_error", summarizeErrorMessage(errBody));
+    currentInvalidRequestFailure = {
+      status: response.status,
+      body: errBody,
+      contentType: errRespHeaders["content-type"],
+    };
+    currentLastError = summarizeErrorMessage(errBody);
+    return {
+      continueLoop: false,
+      lastError: currentLastError,
+      authFailureMessage: currentAuthFailureMessage,
+      sawTransientFailure: currentSawTransientFailure,
+      invalidRequestFailure: currentInvalidRequestFailure,
+      upstreamSpan: undefined,
+    };
+  }
+
+  if (
+    (response.status === 401 ||
+      response.status === 402 ||
+      response.status === 403) &&
+    account.type === "oauth" &&
+    !account.refreshToken
+  ) {
+    recordAttemptError(account.label, account.type, response.status);
+    accountState.consecutiveRefreshFailures += 1;
+    accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
+    recordCooldown(
+      account.label,
+      account.type,
+      accountState.coolingUntil,
+      accountState.backoffLevel,
+    );
+    if (
+      accountState.consecutiveRefreshFailures >= maxConsecutiveRefreshFailures
+    ) {
+      await disableAccountUntilReauth(account, accountState);
+    }
+    currentAuthFailureMessage = formatReauthMessage(account.label);
+    logger.always(
+      `[proxy] ← ${response.status} account=${account.label} cooldown=5min`,
+    );
+    currentLastError = errBody;
+    logAttempt(
+      response.status,
+      "authentication_error",
+      summarizeErrorMessage(errBody),
+    );
+    tracer?.setError("authentication_error", summarizeErrorMessage(errBody));
+    tracer?.recordRetry(account.label, "auth_no_refresh");
+    return {
+      continueLoop: true,
+      lastError: currentLastError,
+      authFailureMessage: currentAuthFailureMessage,
+      sawTransientFailure: currentSawTransientFailure,
+      invalidRequestFailure: currentInvalidRequestFailure,
+      upstreamSpan: undefined,
+    };
+  }
+
+  if (
+    (response.status === 401 ||
+      response.status === 402 ||
+      response.status === 403) &&
+    account.type === "api_key"
+  ) {
+    recordAttemptError(account.label, account.type, response.status);
+    currentAuthFailureMessage =
+      "Authentication failed for Anthropic API key credentials. Update ANTHROPIC_API_KEY or re-login with OAuth.";
+    accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
+    recordCooldown(
+      account.label,
+      account.type,
+      accountState.coolingUntil,
+      accountState.backoffLevel,
+    );
+    logger.always(
+      `[proxy] ← ${response.status} account=${account.label} cooldown=5min`,
+    );
+    currentLastError = errBody;
+    logAttempt(
+      response.status,
+      "authentication_error",
+      summarizeErrorMessage(errBody),
+    );
+    tracer?.setError("authentication_error", summarizeErrorMessage(errBody));
+    tracer?.recordRetry(account.label, "auth_api_key");
+    return {
+      continueLoop: true,
+      lastError: currentLastError,
+      authFailureMessage: currentAuthFailureMessage,
+      sawTransientFailure: currentSawTransientFailure,
+      invalidRequestFailure: currentInvalidRequestFailure,
+      upstreamSpan: undefined,
+    };
+  }
+
+  if (response.status === 404) {
+    recordFinalError(response.status, account.label, account.type);
+    logger.always(`[proxy] ← 404 account=${account.label}`);
+    logAttempt(404, "not_found_error", summarizeErrorMessage(errBody));
+    tracer?.setError("not_found_error", summarizeErrorMessage(errBody));
+    tracer?.end(404, Date.now() - requestStartTime);
+    return {
+      response: buildAnthropicTerminalErrorResponse({
+        responseStatus: 404,
+        account,
+        errBody,
+        errRespHeaders,
+        requestStartTime,
+        attemptNumber,
+        logProxyBody,
+        logFinalRequest,
+        errorType: "not_found_error",
+      }),
+      continueLoop: false,
+      lastError: currentLastError,
+      authFailureMessage: currentAuthFailureMessage,
+      sawTransientFailure: currentSawTransientFailure,
+      invalidRequestFailure: currentInvalidRequestFailure,
+      upstreamSpan: undefined,
+    };
+  }
+
+  if (isTransientHttpFailure(response.status, errBody)) {
+    recordAttemptError(account.label, account.type, response.status);
+    currentSawTransientFailure = true;
+    logger.always(
+      `[proxy] ← ${response.status} account=${account.label} (transient, rotating)`,
+    );
+    currentLastError = errBody;
+    logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
+    tracer?.setError("transient_error", summarizeErrorMessage(errBody));
+    tracer?.recordRetry(account.label, "transient");
+    return {
+      continueLoop: true,
+      lastError: currentLastError,
+      authFailureMessage: currentAuthFailureMessage,
+      sawTransientFailure: currentSawTransientFailure,
+      invalidRequestFailure: currentInvalidRequestFailure,
+      upstreamSpan: undefined,
+    };
+  }
+
+  recordFinalError(response.status, account.label, account.type);
+  logger.always(`[proxy] ← ${response.status} account=${account.label}`);
+  logger.debug(`[claude-proxy] error body: ${errBody.substring(0, 200)}`);
+  logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
+  tracer?.setError("api_error", summarizeErrorMessage(errBody));
+  tracer?.end(response.status, Date.now() - requestStartTime);
+  return {
+    response: buildAnthropicTerminalErrorResponse({
+      responseStatus: response.status,
+      account,
+      errBody,
+      errRespHeaders,
+      requestStartTime,
+      attemptNumber,
+      logProxyBody,
+      logFinalRequest,
+      errorType: "api_error",
+    }),
+    continueLoop: false,
+    lastError: currentLastError,
+    authFailureMessage: currentAuthFailureMessage,
+    sawTransientFailure: currentSawTransientFailure,
+    invalidRequestFailure: currentInvalidRequestFailure,
+    upstreamSpan: undefined,
+  };
+}
+
+function createClaudeRequestRuntimeContext(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  clientRequestBody: string;
+}): ClaudeRequestRuntimeContext {
+  const { ctx, body, clientRequestBody } = args;
+  let tracer: ProxyTracer | undefined;
+  try {
+    tracer = ProxyTracer.startRequest(
+      {
+        requestId: ctx.requestId,
+        method: ctx.method,
+        path: ctx.path,
+        model: body.model,
+        stream: body.stream ?? false,
+        toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
+        sessionId:
+          ctx.headers["x-neurolink-session-id"] ??
+          ctx.headers["x-claude-code-session-id"] ??
+          undefined,
+        userAgent: ctx.headers["user-agent"] ?? undefined,
+      },
+      ctx.headers,
+    );
+    const receiveSpan = tracer.startReceive();
+    tracer.logRequestHeaders(ctx.headers);
+    tracer.logRequestBody(clientRequestBody);
+    receiveSpan.end();
+  } catch {
+    tracer = undefined;
+  }
+
+  const requestStartTime = Date.now();
+  const logProxyBody: ProxyBodyCaptureLogger = (capture) => {
+    const traceCtx = tracer?.getTraceContext();
+    void logBodyCapture({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      model: body.model,
+      stream: body.stream ?? false,
+      ...capture,
+      ...(traceCtx
+        ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
+        : {}),
+    });
+  };
+  const logFinalRequest: ClaudeFinalRequestLogger = (
+    status,
+    accountLabel,
+    accountType,
+    errorType,
+    errorMessage,
+    extra,
+  ) => {
+    const traceCtx = tracer?.getTraceContext();
+    logRequest({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream: !!body.stream,
+      toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
+      account: accountLabel,
+      accountType,
+      responseStatus: status,
+      responseTimeMs: Date.now() - requestStartTime,
+      ...(errorType ? { errorType } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
+      ...(extra?.inputTokens !== undefined
+        ? { inputTokens: extra.inputTokens }
+        : {}),
+      ...(extra?.outputTokens !== undefined
+        ? { outputTokens: extra.outputTokens }
+        : {}),
+      ...(extra?.cacheCreationTokens !== undefined
+        ? { cacheCreationTokens: extra.cacheCreationTokens }
+        : {}),
+      ...(extra?.cacheReadTokens !== undefined
+        ? { cacheReadTokens: extra.cacheReadTokens }
+        : {}),
+      ...(traceCtx
+        ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
+        : {}),
+    });
+  };
+  const buildLoggedClaudeError: ClaudeLoggedErrorBuilder = (
+    status,
+    message,
+    errorType,
+    extra,
+  ) => {
+    const errorBody = buildClaudeError(status, message, errorType);
+    const errorBodyText = JSON.stringify(errorBody);
+    recordFinalError(status, extra?.account, extra?.accountType);
+    logFinalRequest(
+      status,
+      extra?.account ?? "",
+      extra?.accountType ?? "final",
+      errorType,
+      message,
+    );
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "application/json" },
+      body: errorBodyText,
+      bodySize: Buffer.byteLength(errorBodyText, "utf8"),
+      contentType: "application/json",
+      responseStatus: status,
+      durationMs: Date.now() - requestStartTime,
+      ...extra,
+    });
+    return errorBody;
+  };
+
+  logProxyBody({
+    phase: "client_request",
+    headers: ctx.headers,
+    body: clientRequestBody,
+    bodySize: Buffer.byteLength(clientRequestBody, "utf8"),
+    contentType: ctx.headers["content-type"] ?? "application/json",
+  });
+
+  return {
+    tracer,
+    requestStartTime,
+    logProxyBody,
+    logFinalRequest,
+    buildLoggedClaudeError,
+  };
+}
+
+function createAnthropicAttemptLogger(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  toolCount: number;
+  requestStart: number;
+  tracer?: ProxyTracer;
+  account: ProxyPassthroughAccount;
+  attemptNumber: number;
+}): AnthropicAttemptLogger {
+  const { ctx, body, toolCount, requestStart, tracer, account, attemptNumber } =
+    args;
+  return (status, errorType, errorMessage, extra) => {
+    const traceCtx = tracer?.getTraceContext();
+    logRequestAttempt({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      attempt: attemptNumber,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream: !!body.stream,
+      toolCount,
+      account: account.label,
+      accountType: account.type,
+      responseStatus: status,
+      responseTimeMs: Date.now() - requestStart,
+      ...(errorType ? { errorType } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
+      ...(extra?.inputTokens !== undefined
+        ? { inputTokens: extra.inputTokens }
+        : {}),
+      ...(extra?.outputTokens !== undefined
+        ? { outputTokens: extra.outputTokens }
+        : {}),
+      ...(extra?.cacheCreationTokens !== undefined
+        ? { cacheCreationTokens: extra.cacheCreationTokens }
+        : {}),
+      ...(extra?.cacheReadTokens !== undefined
+        ? { cacheReadTokens: extra.cacheReadTokens }
+        : {}),
+      ...(traceCtx
+        ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
+        : {}),
+    });
+  };
+}
+
+async function prepareAnthropicAccountAttempt(args: {
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  bodyStr: string;
+  clientHeaders: Record<string, string | undefined>;
+  isClaudeClientRequest: boolean;
+  url: string;
+  tracer?: ProxyTracer;
+  attemptNumber: number;
+  currentLastError: unknown;
+  currentAuthFailureMessage: string | null;
+  logAttempt: AnthropicAttemptLogger;
+  logProxyBody: ProxyBodyCaptureLogger;
+}): Promise<PreparedAnthropicAccountAttempt> {
+  const {
+    account,
+    accountState,
+    bodyStr,
+    clientHeaders,
+    isClaudeClientRequest,
+    url,
+    tracer,
+    attemptNumber,
+    currentLastError,
+    currentAuthFailureMessage,
+    logAttempt,
+    logProxyBody,
+  } = args;
+  let lastError = currentLastError;
+  let authFailureMessage = currentAuthFailureMessage;
+
+  if (needsRefresh(account)) {
+    const refreshed = await refreshToken(account);
+    if (refreshed.success) {
+      if (account.persistTarget) {
+        await persistTokens(account.persistTarget, account);
+      }
+      accountState.consecutiveRefreshFailures = 0;
+    } else {
+      accountState.consecutiveRefreshFailures += 1;
+      lastError = `token refresh failed for account=${account.label}: ${refreshed.error?.slice(0, 200) ?? "unknown"}`;
+      logger.debug(
+        `[proxy] preflight refresh failed account=${account.label} failures=${accountState.consecutiveRefreshFailures}`,
+      );
+      if (
+        accountState.consecutiveRefreshFailures >=
+        MAX_CONSECUTIVE_REFRESH_FAILURES
+      ) {
+        await disableAccountUntilReauth(account, accountState);
+        authFailureMessage = formatReauthMessage(account.label);
+        logAttempt(401, "authentication_error", String(lastError));
+        return {
+          continueLoop: true,
+          lastError,
+          authFailureMessage,
+        };
+      }
+    }
+  }
+
+  const isOAuth = account.type === "oauth";
+  const filteredHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(clientHeaders)) {
+    if (typeof v === "string") {
+      filteredHeaders[k] = v;
+    }
+  }
+  const snapshot = isOAuth
+    ? await maybeRefreshClaudeSnapshot(
+        account.label,
+        account.key,
+        filteredHeaders,
+        bodyStr,
+      )
+    : null;
+  const headers: Record<string, string> = {};
+  for (const [headerKey, headerValue] of Object.entries(clientHeaders)) {
+    const lower = headerKey.toLowerCase();
+    if (
+      typeof headerValue === "string" &&
+      !BLOCKED_UPSTREAM_HEADERS.has(lower)
+    ) {
+      headers[lower] = headerValue;
+    }
+  }
+
+  headers["content-type"] = "application/json";
+  if (isOAuth) {
+    headers.authorization = `Bearer ${account.token}`;
+    delete headers["x-api-key"];
+    applySnapshotHeaders(headers, snapshot);
+  } else {
+    headers["x-api-key"] = account.token;
+    delete headers.authorization;
+  }
+
+  if (!headers["user-agent"]) {
+    headers["user-agent"] = CLAUDE_CLI_USER_AGENT;
+  }
+  if (!headers["anthropic-version"]) {
+    headers["anthropic-version"] = "2023-06-01";
+  }
+  if (!headers["anthropic-dangerous-direct-browser-access"]) {
+    headers["anthropic-dangerous-direct-browser-access"] = "true";
+  }
+  if (!headers["x-app"]) {
+    headers["x-app"] = "cli";
+  }
+  if (!headers.accept) {
+    headers.accept = "application/json";
+  }
+
+  if (isOAuth) {
+    const betaSeed = isClaudeClientRequest
+      ? (headers["anthropic-beta"] ?? "")
+      : (clientHeaders["anthropic-beta"] ?? "");
+    const existing = new Set(
+      betaSeed
+        .split(",")
+        .map((value: string) => value.trim())
+        .filter(Boolean),
+    );
+    for (const beta of isClaudeClientRequest
+      ? CLAUDE_CODE_OAUTH_BETAS
+      : NON_CLAUDE_OAUTH_BETAS) {
+      existing.add(beta);
+    }
+    headers["anthropic-beta"] = [...existing].join(",");
+  } else {
+    const cleaned = (headers["anthropic-beta"] ?? "")
+      .split(",")
+      .map((value: string) => value.trim())
+      .filter(
+        (value: string) =>
+          value && !CLAUDE_CODE_OAUTH_BETAS.includes(value as never),
+      )
+      .join(",");
+    if (cleaned) {
+      headers["anthropic-beta"] = cleaned;
+    } else {
+      delete headers["anthropic-beta"];
+    }
+  }
+
+  const buildUpstreamBody: AnthropicUpstreamBodyBuilder = (token) =>
+    isOAuth
+      ? polyfillOAuthBody(
+          bodyStr,
+          token,
+          snapshot,
+          headers["x-claude-code-session-id"],
+        )
+      : { bodyStr };
+  const polyfilledBody = buildUpstreamBody(account.token);
+  if (
+    isOAuth &&
+    polyfilledBody.sessionId &&
+    !headers["x-claude-code-session-id"]
+  ) {
+    headers["x-claude-code-session-id"] = polyfilledBody.sessionId;
+  }
+  const finalBodyStr = polyfilledBody.bodyStr;
+
+  logger.always(`[proxy] → account=${account.label} (${account.type})`);
+  recordAttempt(account.label, account.type);
+  const fetchStartMs = Date.now();
+  let upstreamSpan: import("@opentelemetry/api").Span | undefined;
+  if (tracer) {
+    upstreamSpan = tracer.startUpstreamAttempt({
+      attempt: attemptNumber,
+      account: account.label,
+      polyfillHeaders: isOAuth,
+      polyfillBody: isOAuth,
+      upstreamUrl: url,
+    });
+    tracer.logUpstreamRequestHeaders(headers);
+    tracer.logUpstreamRequestBody(finalBodyStr);
+    Object.assign(headers, tracer.getTraceHeaders());
+  }
+  logProxyBody({
+    phase: "upstream_request",
+    headers,
+    body: finalBodyStr,
+    bodySize: Buffer.byteLength(finalBodyStr, "utf8"),
+    contentType: headers["content-type"] ?? "application/json",
+    account: account.label,
+    accountType: account.type,
+    attempt: attemptNumber,
+  });
+
+  return {
+    continueLoop: false,
+    lastError,
+    authFailureMessage,
+    headers,
+    buildUpstreamBody,
+    finalBodyStr,
+    fetchStartMs,
+    upstreamSpan,
+  };
+}
+
+async function fetchAnthropicAccountResponse(args: {
+  url: string;
+  headers: Record<string, string>;
+  finalBodyStr: string;
+  account: ProxyPassthroughAccount;
+  accountState: RuntimeAccountState;
+  enabledAccounts: ProxyPassthroughAccount[];
+  orderedAccounts: ProxyPassthroughAccount[];
+  tracer?: ProxyTracer;
+  logAttempt: AnthropicAttemptLogger;
+  currentLastError: unknown;
+  currentSawRateLimit: boolean;
+  currentSawNetworkError: boolean;
+  upstreamSpan?: import("@opentelemetry/api").Span;
+}): Promise<AnthropicUpstreamFetchResult> {
+  const {
+    url,
+    headers,
+    finalBodyStr,
+    account,
+    accountState,
+    enabledAccounts,
+    orderedAccounts,
+    tracer,
+    logAttempt,
+    currentLastError,
+    currentSawRateLimit,
+    currentSawNetworkError,
+    upstreamSpan,
+  } = args;
+  let lastError = currentLastError;
+  let sawRateLimit = currentSawRateLimit;
+  let sawNetworkError = currentSawNetworkError;
+  const currentUpstreamSpan = upstreamSpan;
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: finalBodyStr,
+      signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
+    });
+  } catch (fetchErr) {
+    if (!isRetryableNetworkError(fetchErr)) {
+      throw fetchErr;
+    }
+    sawNetworkError = true;
+    recordAttemptError(account.label, account.type, 502);
+    const errorCode = getErrorCode(fetchErr) ?? "unknown";
+    const errorMessage =
+      fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+    lastError = errorMessage;
+    logger.always(
+      `[proxy] fetch error account=${account.label} code=${errorCode} (rotating): ${errorMessage}`,
+    );
+    logAttempt(502, "network_error", errorMessage);
+    tracer?.setError("network_error", errorMessage);
+    tracer?.recordRetry(account.label, "network_error");
+    currentUpstreamSpan?.end();
+    return {
+      continueLoop: true,
+      lastError,
+      sawRateLimit,
+      sawNetworkError,
+      upstreamSpan: undefined,
+    };
+  }
+
+  if (response.status === 429) {
+    sawRateLimit = true;
+    const retryAfter = response.headers.get("retry-after");
+    let cooldownMs = 0;
+    if (retryAfter) {
+      const seconds = parseInt(retryAfter, 10);
+      if (!Number.isNaN(seconds)) {
+        cooldownMs = seconds * 1000;
+      } else {
+        const date = new Date(retryAfter);
+        if (!Number.isNaN(date.getTime())) {
+          cooldownMs = Math.max(date.getTime() - Date.now(), 1000);
+        }
+      }
+    }
+
+    const level = accountState.backoffLevel;
+    const baseCooldown =
+      cooldownMs > 0 ? cooldownMs : RATE_LIMIT_BACKOFF_BASE_MS;
+    const backoffMs = Math.min(
+      baseCooldown * 2 ** level,
+      RATE_LIMIT_BACKOFF_CAP_MS,
+    );
+    accountState.coolingUntil = Date.now() + backoffMs;
+    accountState.backoffLevel += 1;
+    advancePrimaryIfCurrent(
+      account.key,
+      enabledAccounts.length,
+      orderedAccounts[0]?.key,
+    );
+    recordAttemptError(account.label, account.type, 429);
+    recordCooldown(
+      account.label,
+      account.type,
+      accountState.coolingUntil,
+      accountState.backoffLevel,
+    );
+    lastError = await response.text();
+    logger.always(
+      `[proxy] ← 429 account=${account.label} backoff-level=${accountState.backoffLevel} cooldown=${Math.round(backoffMs / 1000)}s`,
+    );
+    logAttempt(429, "rate_limit_error", String(lastError));
+    tracer?.setError("rate_limit_error", String(lastError).slice(0, 500));
+    tracer?.recordRetry(account.label, "rate_limit");
+    currentUpstreamSpan?.end();
+    return {
+      continueLoop: true,
+      lastError,
+      sawRateLimit,
+      sawNetworkError,
+      upstreamSpan: undefined,
+    };
+  }
+
+  return {
+    continueLoop: false,
+    response,
+    lastError,
+    sawRateLimit,
+    sawNetworkError,
+    upstreamSpan: currentUpstreamSpan,
+  };
+}
+
+async function handleAnthropicRoutedClaudeRequest(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest;
+  modelRouter?: ModelRouter;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  accountStrategy: "round-robin" | "fill-first";
+  buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
+}): Promise<unknown> {
+  const {
+    ctx,
+    body,
+    modelRouter,
+    tracer,
+    requestStartTime,
+    accountStrategy,
+    buildLoggedClaudeError,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  const loadedAccounts = await loadClaudeProxyAccounts({
+    ctx,
+    body,
+    tracer,
+    requestStartTime,
+    accountStrategy,
+    buildLoggedClaudeError,
+  });
+  if ("response" in loadedAccounts) {
+    return loadedAccounts.response;
+  }
+
+  const {
+    accounts,
+    enabledAccounts,
+    orderedAccounts,
+    bodyStr,
+    requestStart,
+    toolCount,
+    url,
+    clientHeaders,
+    isClaudeClientRequest,
+  } = loadedAccounts;
+  const loopState: AnthropicLoopState = {
+    lastError: undefined,
+    sawRateLimit: false,
+    sawNetworkError: false,
+    sawTransientFailure: false,
+    invalidRequestFailure: null,
+    authFailureMessage: null,
+    attemptNumber: 0,
+  };
+  const acctSelectionSpan = tracer?.startAccountSelection();
+
+  for (const account of orderedAccounts) {
+    const accountState = getOrCreateRuntimeState(account.key);
+    if (accountState.coolingUntil && accountState.coolingUntil > Date.now()) {
+      continue;
+    }
+
+    loopState.attemptNumber += 1;
+    if (tracer && loopState.attemptNumber === 1 && acctSelectionSpan) {
+      tracer.setAccountSelection({
+        strategy: accountStrategy,
+        accountsTotal: accounts.length,
+        accountsHealthy: enabledAccounts.length,
+        selectedAccount: account.label,
+        accountType: account.type,
+      });
+      acctSelectionSpan.end();
+    }
+
+    const logAttempt = createAnthropicAttemptLogger({
+      ctx,
+      body,
+      toolCount,
+      requestStart,
+      tracer,
+      account,
+      attemptNumber: loopState.attemptNumber,
+    });
+    const preparedAttempt = await prepareAnthropicAccountAttempt({
+      account,
+      accountState,
+      bodyStr,
+      clientHeaders,
+      isClaudeClientRequest,
+      url,
+      tracer,
+      attemptNumber: loopState.attemptNumber,
+      currentLastError: loopState.lastError,
+      currentAuthFailureMessage: loopState.authFailureMessage,
+      logAttempt,
+      logProxyBody,
+    });
+    loopState.lastError = preparedAttempt.lastError;
+    loopState.authFailureMessage = preparedAttempt.authFailureMessage;
+    if (
+      preparedAttempt.continueLoop ||
+      !preparedAttempt.headers ||
+      !preparedAttempt.buildUpstreamBody ||
+      !preparedAttempt.finalBodyStr ||
+      preparedAttempt.fetchStartMs === undefined
+    ) {
+      continue;
+    }
+
+    const fetchResult = await fetchAnthropicAccountResponse({
+      url,
+      headers: preparedAttempt.headers,
+      finalBodyStr: preparedAttempt.finalBodyStr,
+      account,
+      accountState,
+      enabledAccounts,
+      orderedAccounts,
+      tracer,
+      logAttempt,
+      currentLastError: loopState.lastError,
+      currentSawRateLimit: loopState.sawRateLimit,
+      currentSawNetworkError: loopState.sawNetworkError,
+      upstreamSpan: preparedAttempt.upstreamSpan,
+    });
+    loopState.lastError = fetchResult.lastError;
+    loopState.sawRateLimit = fetchResult.sawRateLimit;
+    loopState.sawNetworkError = fetchResult.sawNetworkError;
+    if (fetchResult.continueLoop || !fetchResult.response) {
+      continue;
+    }
+
+    let upstreamSpan = fetchResult.upstreamSpan;
+    const response = fetchResult.response;
+    if (
+      response.status === 401 &&
+      account.type === "oauth" &&
+      account.refreshToken
+    ) {
+      const authRetryResult = await handleAnthropicAuthRetry({
+        ctx,
+        body,
+        account,
+        accountState,
+        headers: preparedAttempt.headers,
+        buildUpstreamBody: preparedAttempt.buildUpstreamBody,
+        enabledAccounts,
+        orderedAccounts,
+        response,
+        tracer,
+        requestStartTime,
+        fetchStartMs: preparedAttempt.fetchStartMs,
+        attemptNumber: loopState.attemptNumber,
+        finalBodyStr: preparedAttempt.finalBodyStr,
+        upstreamSpan,
+        logAttempt,
+        logProxyBody,
+        logFinalRequest,
+        lastError: loopState.lastError,
+        authFailureMessage: loopState.authFailureMessage,
+        sawRateLimit: loopState.sawRateLimit,
+        sawTransientFailure: loopState.sawTransientFailure,
+        sawNetworkError: loopState.sawNetworkError,
+      });
+      loopState.lastError = authRetryResult.lastError;
+      loopState.authFailureMessage = authRetryResult.authFailureMessage;
+      loopState.sawRateLimit = authRetryResult.sawRateLimit;
+      loopState.sawTransientFailure = authRetryResult.sawTransientFailure;
+      loopState.sawNetworkError = authRetryResult.sawNetworkError;
+      upstreamSpan = authRetryResult.upstreamSpan;
+      if (authRetryResult.response !== undefined) {
+        return authRetryResult.response;
+      }
+      if (authRetryResult.continueLoop) {
+        continue;
+      }
+    }
+
+    if (!response.ok) {
+      const nonOkResult = await handleAnthropicNonOkResponse({
+        response,
+        account,
+        accountState,
+        tracer,
+        requestStartTime,
+        fetchStartMs: preparedAttempt.fetchStartMs,
+        attemptNumber: loopState.attemptNumber,
+        logAttempt,
+        logProxyBody,
+        logFinalRequest,
+        lastError: loopState.lastError,
+        authFailureMessage: loopState.authFailureMessage,
+        sawTransientFailure: loopState.sawTransientFailure,
+        invalidRequestFailure: loopState.invalidRequestFailure,
+        maxConsecutiveRefreshFailures: MAX_CONSECUTIVE_REFRESH_FAILURES,
+      });
+      loopState.lastError = nonOkResult.lastError;
+      loopState.authFailureMessage = nonOkResult.authFailureMessage;
+      loopState.sawTransientFailure = nonOkResult.sawTransientFailure;
+      loopState.invalidRequestFailure = nonOkResult.invalidRequestFailure;
+      if (nonOkResult.response !== undefined) {
+        return nonOkResult.response;
+      }
+      if (nonOkResult.continueLoop) {
+        continue;
+      }
+      break;
+    }
+
+    const successResult = await handleAnthropicSuccessfulResponse({
+      ctx,
+      body,
+      account,
+      accountState,
+      response,
+      tracer,
+      requestStartTime,
+      fetchStartMs: preparedAttempt.fetchStartMs,
+      attemptNumber: loopState.attemptNumber,
+      finalBodyStr: preparedAttempt.finalBodyStr,
+      upstreamSpan,
+      logProxyBody,
+      logFinalRequest,
+    });
+    if ("retryNextAccount" in successResult) {
+      continue;
+    }
+    return successResult.response;
+  }
+
+  if (loopState.attemptNumber === 0) {
+    acctSelectionSpan?.end();
+  }
+
+  const configuredFallbackResponse = await tryConfiguredClaudeFallbackChain({
+    ctx,
+    body,
+    modelRouter,
+    tracer,
+    requestStartTime,
+    logProxyBody,
+    logFinalRequest,
+  });
+  if (configuredFallbackResponse) {
+    return configuredFallbackResponse;
+  }
+
+  const configuredChain = modelRouter?.getFallbackChain() ?? [];
+  if (configuredChain.length === 0 && !loopState.sawRateLimit) {
+    const autoFallbackResponse = await tryAutoClaudeFallback({
+      ctx,
+      body,
+      tracer,
+      requestStartTime,
+      logProxyBody,
+      logFinalRequest,
+    });
+    if (autoFallbackResponse) {
+      return autoFallbackResponse;
+    }
+  }
+
+  return buildClaudeAnthropicFailureResponse({
+    tracer,
+    requestStartTime,
+    authFailureMessage: loopState.authFailureMessage,
+    invalidRequestFailure: loopState.invalidRequestFailure,
+    sawNetworkError: loopState.sawNetworkError,
+    sawTransientFailure: loopState.sawTransientFailure,
+    sawRateLimit: loopState.sawRateLimit,
+    lastError: loopState.lastError,
+    orderedAccounts,
+    buildLoggedClaudeError,
+    logProxyBody,
+    logFinalRequest,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Route factory
@@ -545,7 +4468,6 @@ export type { ClaudeProxyDeps } from "../../types/index.js";
  * @param basePath    - Base path prefix (default: "" since Claude API uses /v1/...).
  * @returns RouteGroup with Claude-compatible endpoints.
  */
-// eslint-disable-next-line max-lines-per-function
 export function createClaudeProxyRoutes(
   modelRouter?: ModelRouter,
   basePath: string = "",
@@ -565,8 +4487,14 @@ export function createClaudeProxyRoutes(
           const body = ctx.body as ClaudeRequest | undefined;
 
           // 1. Validate
-          if (typeof body?.model !== "string" || !Array.isArray(body?.messages)) {
-            return buildClaudeError(400, "Missing required fields: model, messages");
+          if (
+            typeof body?.model !== "string" ||
+            !Array.isArray(body?.messages)
+          ) {
+            return buildClaudeError(
+              400,
+              "Missing required fields: model, messages",
+            );
           }
 
           // 2. Resolve model via router (or pass through to anthropic)
@@ -587,2585 +4515,78 @@ export function createClaudeProxyRoutes(
           };
           const clientRequestBody = JSON.stringify(body);
 
-          // ── OTel tracing ──────────────────────────────────────
-          let tracer: ProxyTracer | undefined;
-          try {
-            tracer = ProxyTracer.startRequest(
-              {
-                requestId: ctx.requestId,
-                method: ctx.method,
-                path: ctx.path,
-                model: body.model,
-                stream: body.stream ?? false,
-                toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
-                sessionId:
-                  ctx.headers["x-neurolink-session-id"] ?? ctx.headers["x-claude-code-session-id"] ?? undefined,
-                userAgent: ctx.headers["user-agent"] ?? undefined,
-              },
-              ctx.headers,
-            );
-            const receiveSpan = tracer.startReceive();
-            tracer.logRequestHeaders(ctx.headers);
-            tracer.logRequestBody(clientRequestBody);
-            receiveSpan.end();
-          } catch {
-            // Graceful degradation — continue without tracing
-            tracer = undefined;
-          }
-          const requestStartTime = Date.now();
-          const logProxyBody = (
-            capture: Omit<
-              Parameters<typeof logBodyCapture>[0],
-              "timestamp" | "requestId" | "model" | "stream" | "traceId" | "spanId"
-            >,
-          ): void => {
-            const traceCtx = tracer?.getTraceContext();
-            void logBodyCapture({
-              timestamp: new Date().toISOString(),
-              requestId: ctx.requestId,
-              model: body.model,
-              stream: body.stream ?? false,
-              ...capture,
-              ...(traceCtx ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId } : {}),
-            });
-          };
-          const logFinalRequest = (
-            status: number,
-            accountLabel: string,
-            accountType: string,
-            errorType?: string,
-            errorMessage?: string,
-            extra?: {
-              inputTokens?: number;
-              outputTokens?: number;
-              cacheCreationTokens?: number;
-              cacheReadTokens?: number;
-            },
-          ): void => {
-            const traceCtx = tracer?.getTraceContext();
-            logRequest({
-              timestamp: new Date().toISOString(),
-              requestId: ctx.requestId,
-              method: ctx.method,
-              path: ctx.path,
-              model: body.model,
-              stream: !!body.stream,
-              toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
-              account: accountLabel,
-              accountType,
-              responseStatus: status,
-              responseTimeMs: Date.now() - requestStartTime,
-              ...(errorType ? { errorType } : {}),
-              ...(errorMessage ? { errorMessage } : {}),
-              ...(extra?.inputTokens !== undefined ? { inputTokens: extra.inputTokens } : {}),
-              ...(extra?.outputTokens !== undefined ? { outputTokens: extra.outputTokens } : {}),
-              ...(extra?.cacheCreationTokens !== undefined ? { cacheCreationTokens: extra.cacheCreationTokens } : {}),
-              ...(extra?.cacheReadTokens !== undefined ? { cacheReadTokens: extra.cacheReadTokens } : {}),
-              ...(traceCtx ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId } : {}),
-            });
-          };
-          logProxyBody({
-            phase: "client_request",
-            headers: ctx.headers,
-            body: clientRequestBody,
-            bodySize: Buffer.byteLength(clientRequestBody, "utf8"),
-            contentType: ctx.headers["content-type"] ?? "application/json",
+          // 3. Create request runtime context (tracer, loggers, error builder)
+          const {
+            tracer,
+            requestStartTime,
+            logProxyBody,
+            logFinalRequest,
+            buildLoggedClaudeError,
+          } = createClaudeRequestRuntimeContext({
+            ctx,
+            body,
+            clientRequestBody,
           });
-          const buildLoggedClaudeError = (
-            status: number,
-            message: string,
-            errorType?: string,
-            extra?: {
-              account?: string;
-              accountType?: string;
-              attempt?: number;
-            },
-          ) => {
-            const errorBody = buildClaudeError(status, message, errorType);
-            const errorBodyText = JSON.stringify(errorBody);
-            recordFinalError(status, extra?.account, extra?.accountType);
-            logFinalRequest(status, extra?.account ?? "", extra?.accountType ?? "final", errorType, message);
-            logProxyBody({
-              phase: "client_response",
-              headers: { "content-type": "application/json" },
-              body: errorBodyText,
-              bodySize: Buffer.byteLength(errorBodyText, "utf8"),
-              contentType: "application/json",
-              responseStatus: status,
-              durationMs: Date.now() - requestStartTime,
-              ...extra,
-            });
-            return errorBody;
-          };
 
           try {
-            // 3. Route based on target provider
+            // 4. Route based on target provider
             if (route.provider === null) {
-              tracer?.setError("not_found_error", `Model '${body.model}' is not a Claude model.`);
+              tracer?.setError(
+                "not_found_error",
+                `Model '${body.model}' is not a Claude model.`,
+              );
               tracer?.end(404, Date.now() - requestStartTime);
               return buildLoggedClaudeError(
                 404,
-                `Model '${body.model}' is not a Claude model. ` + `Use a model router to route it to another provider.`,
+                `Model '${body.model}' is not a Claude model. Use a model router to route it to another provider.`,
               );
             }
-            const isClaudeTarget = route.provider === "anthropic";
 
-            if (isClaudeTarget) {
-              // --- PASSTHROUGH MODE (Claude -> Claude) -------------------
+            if (route.provider === "anthropic") {
               tracer?.setMode("passthrough");
 
-              // ── CLI --passthrough: raw transparent forwarding ──────
               if (passthroughMode) {
-                tracer?.setMode("passthrough-cli");
-                const bodyStr = clientRequestBody;
-                const toolCount = Array.isArray(body.tools) ? body.tools.length : 0;
-
-                // Forward client headers as-is, filtering blocked ones
-                const upstreamHeaders: Record<string, string> = {};
-                for (const [key, value] of Object.entries(ctx.headers)) {
-                  if (!BLOCKED_UPSTREAM_HEADERS.has(key.toLowerCase()) && value) {
-                    upstreamHeaders[key] = value;
-                  }
-                }
-                // Ensure content-type is set
-                if (!upstreamHeaders["content-type"]) {
-                  upstreamHeaders["content-type"] = "application/json";
-                }
-
-                const upstreamSpan = tracer?.startUpstreamAttempt({
-                  account: "passthrough",
-                  attempt: 1,
-                  polyfillHeaders: false,
-                  polyfillBody: false,
-                  upstreamUrl: "https://api.anthropic.com/v1/messages?beta=true",
-                });
-                tracer?.logUpstreamRequestHeaders(upstreamHeaders);
-                tracer?.logUpstreamRequestBody(bodyStr);
-                logProxyBody({
-                  phase: "upstream_request",
-                  headers: upstreamHeaders,
-                  body: bodyStr,
-                  bodySize: Buffer.byteLength(bodyStr, "utf8"),
-                  contentType: upstreamHeaders["content-type"] ?? "application/json",
-                  account: "passthrough",
-                  accountType: "passthrough",
-                  attempt: 1,
-                });
-
-                let response: Response;
-                try {
-                  response = await fetch("https://api.anthropic.com/v1/messages?beta=true", {
-                    method: "POST",
-                    headers: upstreamHeaders,
-                    body: bodyStr,
-                    signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
-                  });
-                } catch (fetchErr) {
-                  const errMsg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
-                  tracer?.setError("network_error", errMsg);
-                  upstreamSpan?.end();
-                  tracer?.end(502, Date.now() - requestStartTime);
-                  logRequest({
-                    timestamp: new Date().toISOString(),
-                    requestId: ctx.requestId,
-                    method: ctx.method,
-                    path: ctx.path,
-                    model: body.model,
-                    stream: body.stream ?? false,
-                    toolCount,
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    responseStatus: 502,
-                    responseTimeMs: Date.now() - requestStartTime,
-                    errorType: "network_error",
-                    errorMessage: errMsg,
-                  });
-                  const errorBody = buildClaudeError(502, `Passthrough fetch failed: ${errMsg}`);
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: { "content-type": "application/json" },
-                    body: JSON.stringify(errorBody),
-                    bodySize: Buffer.byteLength(JSON.stringify(errorBody), "utf8"),
-                    contentType: "application/json",
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    attempt: 1,
-                    responseStatus: 502,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return errorBody;
-                }
-
-                const upstreamResponseHeaders: Record<string, string> = {};
-                response.headers.forEach((v, k) => {
-                  upstreamResponseHeaders[k] = v;
-                });
-                tracer?.logUpstreamResponseHeaders(upstreamResponseHeaders);
-
-                if (!response.ok) {
-                  const errorText = await response.text();
-                  tracer?.logUpstreamResponseBody(errorText);
-                  logProxyBody({
-                    phase: "upstream_response",
-                    headers: upstreamResponseHeaders,
-                    body: errorText,
-                    bodySize: Buffer.byteLength(errorText, "utf8"),
-                    contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    attempt: 1,
-                    responseStatus: response.status,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: upstreamResponseHeaders,
-                    body: errorText,
-                    bodySize: Buffer.byteLength(errorText, "utf8"),
-                    contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    attempt: 1,
-                    responseStatus: response.status,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  upstreamSpan?.end();
-                  tracer?.setError("api_error", errorText.slice(0, 500));
-                  tracer?.end(response.status, Date.now() - requestStartTime);
-                  try {
-                    return JSON.parse(errorText);
-                  } catch {
-                    return buildClaudeError(response.status, errorText);
-                  }
-                }
-
-                // Streaming response
-                if (body.stream && response.body) {
-                  const responseHeaders = { ...upstreamResponseHeaders };
-                  const { stream: clientCaptureStream, capture: clientCapture } = createRawStreamCapture();
-                  let streamSource: ReadableStream<Uint8Array> = response.body;
-                  if (tracer) {
-                    try {
-                      const { stream: interceptor, telemetry } = createSSEInterceptor({ captureRawText: true });
-                      streamSource = streamSource.pipeThrough(interceptor);
-
-                      const capturedTracer = tracer;
-                      const capturedUpstreamSpan = upstreamSpan;
-                      const capturedResponse = response;
-                      const capturedRequestBytes = bodyStr.length;
-
-                      Promise.all([telemetry, clientCapture])
-                        .then(([data, clientBody]) => {
-                          capturedTracer.setUsage({
-                            inputTokens: data.usage.inputTokens,
-                            outputTokens: data.usage.outputTokens,
-                            cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                            cacheReadTokens: data.usage.cacheReadInputTokens,
-                          });
-                          capturedTracer.logStreamEvents(data.events);
-
-                          const rateLimit5h = parseFloat(
-                            capturedResponse.headers.get("anthropic-ratelimit-unified-5h-utilization") ?? "",
-                          );
-                          const rateLimit7d = parseFloat(
-                            capturedResponse.headers.get("anthropic-ratelimit-unified-7d-utilization") ?? "",
-                          );
-                          const usageUpdate: Parameters<typeof capturedTracer.setUsage>[0] = {
-                            inputTokens: data.usage.inputTokens,
-                            outputTokens: data.usage.outputTokens,
-                            cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                            cacheReadTokens: data.usage.cacheReadInputTokens,
-                          };
-                          if (!isNaN(rateLimit5h)) {
-                            usageUpdate.rateLimitAfter5h = rateLimit5h;
-                          }
-                          if (!isNaN(rateLimit7d)) {
-                            usageUpdate.rateLimitAfter7d = rateLimit7d;
-                          }
-                          if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
-                            capturedTracer.setUsage(usageUpdate);
-                          }
-
-                          capturedTracer.logUpstreamResponseBody(data.rawText ?? "");
-                          capturedTracer.recordMetrics();
-                          capturedTracer.recordBodySizes(capturedRequestBytes, data.totalBytesReceived);
-                          capturedUpstreamSpan?.end();
-                          capturedTracer.end(200, Date.now() - requestStartTime);
-
-                          const traceCtx = capturedTracer.getTraceContext();
-                          logRequest({
-                            timestamp: new Date().toISOString(),
-                            requestId: ctx.requestId,
-                            method: ctx.method,
-                            path: ctx.path,
-                            model: body.model,
-                            stream: true,
-                            toolCount,
-                            account: "passthrough",
-                            accountType: "passthrough",
-                            responseStatus: 200,
-                            responseTimeMs: Date.now() - requestStartTime,
-                            inputTokens: data.usage.inputTokens,
-                            outputTokens: data.usage.outputTokens,
-                            cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                            cacheReadTokens: data.usage.cacheReadInputTokens,
-                            traceId: traceCtx.traceId,
-                            spanId: traceCtx.spanId,
-                          });
-                          logProxyBody({
-                            phase: "upstream_response",
-                            headers: responseHeaders,
-                            body: data.rawText ?? "",
-                            bodySize: data.totalBytesReceived,
-                            contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                            account: "passthrough",
-                            accountType: "passthrough",
-                            attempt: 1,
-                            responseStatus: 200,
-                            durationMs: Date.now() - requestStartTime,
-                          });
-                          logProxyBody({
-                            phase: "client_response",
-                            headers: responseHeaders,
-                            body: clientBody.text,
-                            bodySize: clientBody.totalBytes,
-                            contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                            account: "passthrough",
-                            accountType: "passthrough",
-                            attempt: 1,
-                            responseStatus: 200,
-                            durationMs: Date.now() - requestStartTime,
-                          });
-                        })
-                        .catch((err) => {
-                          capturedTracer.setError("stream_error", err instanceof Error ? err.message : String(err));
-                          capturedUpstreamSpan?.end();
-                          capturedTracer.end(500, Date.now() - requestStartTime);
-
-                          const traceCtx = capturedTracer.getTraceContext();
-                          logRequest({
-                            timestamp: new Date().toISOString(),
-                            requestId: ctx.requestId,
-                            method: ctx.method,
-                            path: ctx.path,
-                            model: body.model,
-                            stream: true,
-                            toolCount,
-                            account: "passthrough",
-                            accountType: "passthrough",
-                            responseStatus: 500,
-                            responseTimeMs: Date.now() - requestStartTime,
-                            errorType: "stream_error",
-                            errorMessage: err instanceof Error ? err.message : String(err),
-                            traceId: traceCtx.traceId,
-                            spanId: traceCtx.spanId,
-                          });
-                        });
-                    } catch {
-                      // Streaming capture is best-effort; request completion is handled elsewhere.
-                    }
-                  } else {
-                    clientCapture
-                      .then((clientBody) => {
-                        logProxyBody({
-                          phase: "upstream_response",
-                          headers: responseHeaders,
-                          body: clientBody.text,
-                          bodySize: clientBody.totalBytes,
-                          contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                          account: "passthrough",
-                          accountType: "passthrough",
-                          attempt: 1,
-                          responseStatus: 200,
-                          durationMs: Date.now() - requestStartTime,
-                        });
-                        logProxyBody({
-                          phase: "client_response",
-                          headers: responseHeaders,
-                          body: clientBody.text,
-                          bodySize: clientBody.totalBytes,
-                          contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                          account: "passthrough",
-                          accountType: "passthrough",
-                          attempt: 1,
-                          responseStatus: 200,
-                          durationMs: Date.now() - requestStartTime,
-                        });
-                      })
-                      .catch(() => {
-                        // Non-fatal
-                      });
-                  }
-
-                  const clientStream = streamSource.pipeThrough(clientCaptureStream);
-                  return new Response(clientStream, {
-                    status: response.status,
-                    headers: responseHeaders,
-                  });
-                }
-
-                // Non-streaming response
-                const responseText = await response.text();
-                tracer?.logUpstreamResponseBody(responseText);
-                logProxyBody({
-                  phase: "upstream_response",
-                  headers: upstreamResponseHeaders,
-                  body: responseText,
-                  bodySize: Buffer.byteLength(responseText, "utf8"),
-                  contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
-                  account: "passthrough",
-                  accountType: "passthrough",
-                  attempt: 1,
-                  responseStatus: response.status,
-                  durationMs: Date.now() - requestStartTime,
-                });
-                logProxyBody({
-                  phase: "client_response",
-                  headers: upstreamResponseHeaders,
-                  body: responseText,
-                  bodySize: Buffer.byteLength(responseText, "utf8"),
-                  contentType: upstreamResponseHeaders["content-type"] ?? "application/json",
-                  account: "passthrough",
-                  accountType: "passthrough",
-                  attempt: 1,
-                  responseStatus: response.status,
-                  durationMs: Date.now() - requestStartTime,
-                });
-                const responseJson = JSON.parse(responseText);
-                if (tracer && responseJson && typeof responseJson === "object") {
-                  const usage = (responseJson as Record<string, unknown>).usage as Record<string, number> | undefined;
-                  if (usage) {
-                    tracer.setUsage({
-                      inputTokens: usage.input_tokens ?? 0,
-                      outputTokens: usage.output_tokens ?? 0,
-                      cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-                      cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-                    });
-
-                    const rateLimit5h = parseFloat(
-                      response.headers.get("anthropic-ratelimit-unified-5h-utilization") ?? "",
-                    );
-                    const rateLimit7d = parseFloat(
-                      response.headers.get("anthropic-ratelimit-unified-7d-utilization") ?? "",
-                    );
-                    if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
-                      const usageWithRates: Parameters<typeof tracer.setUsage>[0] = {
-                        inputTokens: usage.input_tokens ?? 0,
-                        outputTokens: usage.output_tokens ?? 0,
-                        cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-                        cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-                      };
-                      if (!isNaN(rateLimit5h)) {
-                        usageWithRates.rateLimitAfter5h = rateLimit5h;
-                      }
-                      if (!isNaN(rateLimit7d)) {
-                        usageWithRates.rateLimitAfter7d = rateLimit7d;
-                      }
-                      tracer.setUsage(usageWithRates);
-                    }
-                  }
-                  tracer.recordMetrics();
-                  const responseJsonStr = JSON.stringify(responseJson);
-                  tracer.recordBodySizes(bodyStr.length, responseJsonStr.length);
-                  upstreamSpan?.end();
-                  tracer.end(response.status, Date.now() - requestStartTime);
-
-                  const traceCtx = tracer.getTraceContext();
-                  logRequest({
-                    timestamp: new Date().toISOString(),
-                    requestId: ctx.requestId,
-                    method: ctx.method,
-                    path: ctx.path,
-                    model: body.model,
-                    stream: false,
-                    toolCount,
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    responseStatus: response.status,
-                    responseTimeMs: Date.now() - requestStartTime,
-                    inputTokens: usage?.input_tokens,
-                    outputTokens: usage?.output_tokens,
-                    cacheCreationTokens: usage?.cache_creation_input_tokens,
-                    cacheReadTokens: usage?.cache_read_input_tokens,
-                    traceId: traceCtx.traceId,
-                    spanId: traceCtx.spanId,
-                  });
-                } else {
-                  upstreamSpan?.end();
-                  tracer?.end(response.status, Date.now() - requestStartTime);
-                  logRequest({
-                    timestamp: new Date().toISOString(),
-                    requestId: ctx.requestId,
-                    method: ctx.method,
-                    path: ctx.path,
-                    model: body.model,
-                    stream: false,
-                    toolCount,
-                    account: "passthrough",
-                    accountType: "passthrough",
-                    responseStatus: response.status,
-                    responseTimeMs: Date.now() - requestStartTime,
-                  });
-                }
-                return responseJson;
-              }
-              // ── END CLI --passthrough ─────────────────────────────
-
-              const fs = await import("fs");
-              const os = await import("os");
-              const accounts: ProxyPassthroughAccount[] = [];
-              const legacyCredPath = `${(os as typeof import("os")).homedir()}/.neurolink/anthropic-credentials.json`;
-
-              // 1. Compound keys from TokenStore
-              // Skip accounts with expired tokens and no refresh token.
-              // For expired tokens WITH a refresh token, attempt ONE refresh
-              // before adding — if it fails, skip the account entirely.
-              const { tokenStore } = await import("../../auth/tokenStore.js");
-
-              // Decision 10D: Auto-prune dead entries once on first request (startup)
-              if (!startupPruneDone) {
-                await tokenStore.pruneExpired();
-                startupPruneDone = true;
-              }
-
-              const compoundKeys = await tokenStore.listByPrefix("anthropic:");
-              for (const key of compoundKeys) {
-                // Decision 10D + Hot-reload: Skip disabled accounts UNLESS credentials changed
-                if (await tokenStore.isDisabled(key)) {
-                  const existingState = getOrCreateRuntimeState(key);
-                  // Check if credentials were refreshed/re-authed since disable.
-                  // On cold start, lastToken is empty — don't treat that as a
-                  // credential change; only compare on subsequent reloads.
-                  const tokens = await tokenStore.loadTokens(key);
-                  const hasTrackedTokens = existingState.lastToken !== undefined && existingState.lastToken !== "";
-                  const tokenChanged =
-                    tokens &&
-                    hasTrackedTokens &&
-                    (existingState.lastToken !== tokens.accessToken ||
-                      existingState.lastRefreshToken !== tokens.refreshToken);
-                  if (tokenChanged) {
-                    // Credentials changed — auto-enable and use this account
-                    await tokenStore.markEnabled(key);
-                    logger.always(`[proxy] account=${key.split(":")[1] ?? key} re-enabled (credentials changed)`);
-                    existingState.permanentlyDisabled = false;
-                    existingState.coolingUntil = undefined;
-                    existingState.backoffLevel = 0;
-                    existingState.consecutiveRefreshFailures = 0;
-                  } else {
-                    logger.debug(`[proxy] skipping disabled account=${key.split(":")[1] ?? key}`);
-                    existingState.permanentlyDisabled = true;
-                    continue;
-                  }
-                }
-
-                const tokens = await tokenStore.loadTokens(key);
-                if (!tokens) {
-                  continue;
-                }
-
-                let accessToken = tokens.accessToken;
-                let refreshTok = tokens.refreshToken;
-                let expiresAt = tokens.expiresAt;
-
-                // Check if token is expired
-                const isExpired = expiresAt ? expiresAt < Date.now() : false;
-
-                if (isExpired) {
-                  const label = key.split(":")[1] ?? key;
-                  // Check if already marked dead from a previous request
-                  const existingState = getOrCreateRuntimeState(key);
-                  if (existingState.permanentlyDisabled) {
-                    // Already known dead — skip silently (no log spam)
-                    continue;
-                  }
-
-                  if (!refreshTok) {
-                    logger.always(`[proxy] skipping account=${label} (expired, no refresh token)`);
-                    await disableAccountUntilReauth({ key, label, token: accessToken, type: "oauth" }, existingState);
-                    continue;
-                  }
-                  // Try ONE refresh before adding
-                  const tempAccount = {
-                    token: accessToken,
-                    refreshToken: refreshTok,
-                    expiresAt,
-                    label,
-                  };
-                  const refreshed = await refreshToken(tempAccount);
-                  if (!refreshed.success) {
-                    logger.always(
-                      `[proxy] skipping account=${label} (expired, refresh failed: ${refreshed.error?.slice(0, 200) ?? "unknown"})`,
-                    );
-                    await disableAccountUntilReauth({ key, label, token: accessToken, type: "oauth" }, existingState);
-                    continue;
-                  }
-                  // Refresh succeeded — use new token and persist
-                  accessToken = tempAccount.token;
-                  refreshTok = tempAccount.refreshToken;
-                  expiresAt = tempAccount.expiresAt;
-                  await tokenStore.saveTokens(key, {
-                    accessToken,
-                    refreshToken: refreshTok,
-                    expiresAt: expiresAt ?? Date.now() + 3600_000,
-                    tokenType: "Bearer",
-                  });
-                  logger.always(`[proxy] refreshed expired account=${key.split(":")[1] ?? key} at startup`);
-                }
-
-                // Detect whether this is an API key or an OAuth token.
-                // Use the stored tokenType (set at auth time) rather than a
-                // prefix heuristic — both API keys (sk-ant-api03-…) and OAuth
-                // access tokens (sk-ant-oat01-…) share the "sk-ant-" prefix.
-                const accountType: "oauth" | "api_key" = tokens.tokenType === "Bearer" ? "oauth" : "api_key";
-
-                accounts.push({
-                  key,
-                  label: key.split(":")[1] ?? key,
-                  token: accessToken,
-                  refreshToken: refreshTok,
-                  expiresAt,
-                  type: accountType,
-                  persistTarget: { providerKey: key },
+                return handleClaudePassthroughRequest({
+                  ctx,
+                  body,
+                  clientRequestBody,
+                  tracer,
+                  requestStartTime,
+                  logProxyBody,
                 });
               }
 
-              // 2. Legacy credentials file (only if no usable compound account was loaded)
-              if (accounts.length === 0) {
-                try {
-                  const creds = JSON.parse((fs as typeof import("fs")).readFileSync(legacyCredPath, "utf8")) as {
-                    oauth?: {
-                      accessToken?: string;
-                      refreshToken?: string;
-                      expiresAt?: number;
-                    };
-                  };
-                  const legacyAccount = await tryLoadLegacyAccount(creds, legacyCredPath);
-                  if (legacyAccount) {
-                    accounts.push(legacyAccount);
-                  }
-                } catch {
-                  // no-op: file absent or invalid
-                }
-              }
-
-              // 3. Env var — only use as fallback when no OAuth accounts are available.
-              if (process.env.ANTHROPIC_API_KEY && accounts.length === 0) {
-                accounts.push({
-                  key: "anthropic:env",
-                  label: "env",
-                  token: process.env.ANTHROPIC_API_KEY,
-                  type: "api_key",
-                });
-              }
-
-              if (accounts.length === 0) {
-                tracer?.setError("authentication_error", "No Anthropic credentials found");
-                tracer?.end(401, Date.now() - requestStartTime);
-                return buildLoggedClaudeError(401, "No Anthropic credentials found");
-              }
-
-              // Sync in-memory runtime state with current token material.
-              for (const account of accounts) {
-                const state = getOrCreateRuntimeState(account.key);
-                const tokenChanged =
-                  state.lastToken !== account.token || state.lastRefreshToken !== account.refreshToken;
-                if (tokenChanged) {
-                  if (state.permanentlyDisabled) {
-                    logger.always(`[proxy] account=${account.label} credentials changed, re-enabling`);
-                  }
-                  state.coolingUntil = undefined;
-                  state.backoffLevel = 0;
-                  state.consecutiveRefreshFailures = 0;
-                  state.permanentlyDisabled = false;
-                }
-                state.lastToken = account.token;
-                state.lastRefreshToken = account.refreshToken;
-              }
-
-              const enabledAccounts = accounts.filter((account) => {
-                return !getOrCreateRuntimeState(account.key).permanentlyDisabled;
-              });
-
-              if (enabledAccounts.length === 0) {
-                const reauthMsg = formatReauthMessage(accounts.map((account) => account.label));
-                tracer?.setError("authentication_error", reauthMsg);
-                tracer?.end(401, Date.now() - requestStartTime);
-                return buildLoggedClaudeError(401, reauthMsg);
-              }
-
-              // Order accounts based on the configured strategy.
-              // - fill-first: always start with the primary account;
-              //   only fall over when the primary is cooling down (429/401).
-              // - round-robin: rotate the starting index on every request
-              //   so traffic is spread evenly across accounts.
-              const orderedAccounts = [...enabledAccounts];
-              // Reset round-robin index when account list size changes
-              // (e.g. a new account was authenticated while the proxy was running).
-              // Only applies to round-robin; fill-first uses primaryAccountIndex
-              // as a sticky primary and should not be disrupted.
-              if (accountStrategy === "round-robin" && orderedAccounts.length !== lastKnownAccountCount) {
-                primaryAccountIndex = 0;
-                lastKnownAccountCount = orderedAccounts.length;
-              }
-              if (orderedAccounts.length > 1) {
-                if (accountStrategy === "round-robin") {
-                  // Advance the index on every request for even distribution
-                  const idx = primaryAccountIndex % orderedAccounts.length;
-                  primaryAccountIndex = (primaryAccountIndex + 1) % orderedAccounts.length;
-                  if (idx > 0) {
-                    const head = orderedAccounts.splice(0, idx);
-                    orderedAccounts.push(...head);
-                  }
-                } else {
-                  // fill-first (default): clamp primaryAccountIndex
-                  const idx = primaryAccountIndex % orderedAccounts.length;
-                  if (idx > 0) {
-                    const head = orderedAccounts.splice(0, idx);
-                    orderedAccounts.push(...head);
-                  }
-                }
-              }
-
-              let lastError: unknown;
-              let sawRateLimit = false;
-              let sawNetworkError = false;
-              let sawTransientFailure = false;
-              let invalidRequestFailure: {
-                status: number;
-                body: string;
-                contentType?: string;
-              } | null = null;
-              let authFailureMessage: string | null = null;
-              const normalizedAnthropicBody = normalizeClaudeRequestForAnthropic(body);
-              const bodyStr = JSON.stringify(normalizedAnthropicBody);
-              const requestStart = Date.now();
-              const toolCount = Array.isArray(body.tools) ? body.tools.length : 0;
-              const url = "https://api.anthropic.com/v1/messages?beta=true";
-              const clientHeaders = ctx.headers ?? {};
-              const clientSnapshotBody = extractSnapshotBody(body);
-              const isClaudeClientRequest = isLikelyClaudeClient(clientHeaders, clientSnapshotBody);
-              let attemptNumber = 0;
-
-              // OTel: account selection span (covers the whole selection phase)
-              const acctSelectionSpan = tracer?.startAccountSelection();
-
-              for (const account of orderedAccounts) {
-                const accountState = getOrCreateRuntimeState(account.key);
-                if (accountState.coolingUntil && accountState.coolingUntil > Date.now()) {
-                  continue;
-                }
-
-                const logAttempt = (
-                  status: number,
-                  errorType?: string,
-                  errorMessage?: string,
-                  extra?: {
-                    inputTokens?: number;
-                    outputTokens?: number;
-                    cacheCreationTokens?: number;
-                    cacheReadTokens?: number;
-                  },
-                ): void => {
-                  const traceCtx = tracer?.getTraceContext();
-                  logRequestAttempt({
-                    timestamp: new Date().toISOString(),
-                    requestId: ctx.requestId,
-                    attempt: attemptNumber,
-                    method: ctx.method,
-                    path: ctx.path,
-                    model: body.model,
-                    stream: !!body.stream,
-                    toolCount,
-                    account: account.label,
-                    accountType: account.type,
-                    responseStatus: status,
-                    responseTimeMs: Date.now() - requestStart,
-                    ...(errorType ? { errorType } : {}),
-                    ...(errorMessage ? { errorMessage } : {}),
-                    ...(extra?.inputTokens !== undefined ? { inputTokens: extra.inputTokens } : {}),
-                    ...(extra?.outputTokens !== undefined ? { outputTokens: extra.outputTokens } : {}),
-                    ...(extra?.cacheCreationTokens !== undefined
-                      ? { cacheCreationTokens: extra.cacheCreationTokens }
-                      : {}),
-                    ...(extra?.cacheReadTokens !== undefined ? { cacheReadTokens: extra.cacheReadTokens } : {}),
-                    ...(traceCtx ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId } : {}),
-                  });
-                };
-
-                // OTel: record account selection and start upstream attempt span
-                attemptNumber++;
-                if (tracer) {
-                  // End the selection span on first actual attempt
-                  if (attemptNumber === 1 && acctSelectionSpan) {
-                    tracer.setAccountSelection({
-                      strategy: accountStrategy,
-                      accountsTotal: accounts.length,
-                      accountsHealthy: enabledAccounts.length,
-                      selectedAccount: account.label,
-                      accountType: account.type,
-                    });
-                    acctSelectionSpan.end();
-                  }
-                }
-                let upstreamSpan: import("@opentelemetry/api").Span | undefined;
-
-                // Auto-refresh expiring access tokens once before making the request.
-                if (needsRefresh(account)) {
-                  const refreshed = await refreshToken(account);
-                  if (refreshed.success) {
-                    if (account.persistTarget) {
-                      await persistTokens(account.persistTarget, account);
-                    }
-                    accountState.consecutiveRefreshFailures = 0;
-                  } else {
-                    accountState.consecutiveRefreshFailures += 1;
-                    lastError = `token refresh failed for account=${account.label}: ${refreshed.error?.slice(0, 200) ?? "unknown"}`;
-                    logger.debug(
-                      `[proxy] preflight refresh failed account=${account.label} failures=${accountState.consecutiveRefreshFailures}`,
-                    );
-                    if (accountState.consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
-                      await disableAccountUntilReauth(account, accountState);
-                      authFailureMessage = formatReauthMessage(account.label);
-                      logAttempt(401, "authentication_error", String(lastError));
-                      continue;
-                    }
-                  }
-                }
-
-                const isOAuth = account.type === "oauth";
-                const snapshot = isOAuth
-                  ? await maybeRefreshClaudeSnapshot(account.label, account.key, clientHeaders, bodyStr)
-                  : null;
-
-                // Decision 6: Passthrough client headers, fill gaps only.
-                // Start with a copy of incoming client headers, then set
-                // defaults for anything the client didn't send. Always
-                // override auth + content-type.
-                const headers: Record<string, string> = {};
-                for (const [hk, hv] of Object.entries(clientHeaders)) {
-                  const lower = hk.toLowerCase();
-                  if (typeof hv === "string" && !BLOCKED_UPSTREAM_HEADERS.has(lower)) {
-                    headers[lower] = hv;
-                  }
-                }
-
-                // Always set (override) — auth and content-type are proxy-controlled
-                headers["content-type"] = "application/json";
-                if (isOAuth) {
-                  headers["authorization"] = `Bearer ${account.token}`;
-                  delete headers["x-api-key"];
-                } else {
-                  headers["x-api-key"] = account.token;
-                  delete headers["authorization"];
-                }
-
-                // Apply header snapshot defaults for OAuth accounts
-                if (isOAuth) {
-                  applySnapshotHeaders(headers, snapshot);
-                }
-
-                // Hard defaults for anything still missing
-                if (!headers["user-agent"]) {
-                  headers["user-agent"] = CLAUDE_CLI_USER_AGENT;
-                }
-                if (!headers["anthropic-version"]) {
-                  headers["anthropic-version"] = "2023-06-01";
-                }
-                if (!headers["anthropic-dangerous-direct-browser-access"]) {
-                  headers["anthropic-dangerous-direct-browser-access"] = "true";
-                }
-                if (!headers["x-app"]) {
-                  headers["x-app"] = "cli";
-                }
-                if (!headers["accept"]) {
-                  headers["accept"] = "application/json";
-                }
-
-                // Manage anthropic-beta header based on auth type.
-                // OAuth requires specific betas; API-key must NOT carry them.
-                if (isOAuth) {
-                  const betaSeed = isClaudeClientRequest
-                    ? (headers["anthropic-beta"] ?? "")
-                    : (clientHeaders["anthropic-beta"] ?? "");
-                  const existing = new Set(
-                    betaSeed
-                      .split(",")
-                      .map((s: string) => s.trim())
-                      .filter(Boolean),
-                  );
-                  for (const beta of isClaudeClientRequest ? CLAUDE_CODE_OAUTH_BETAS : NON_CLAUDE_OAUTH_BETAS) {
-                    existing.add(beta);
-                  }
-                  headers["anthropic-beta"] = [...existing].join(",");
-                } else {
-                  // Strip OAuth-specific betas that may have leaked from client
-                  const cleaned = (headers["anthropic-beta"] ?? "")
-                    .split(",")
-                    .map((s: string) => s.trim())
-                    .filter((s: string) => s && !CLAUDE_CODE_OAUTH_BETAS.includes(s as never))
-                    .join(",");
-                  if (cleaned) {
-                    headers["anthropic-beta"] = cleaned;
-                  } else {
-                    delete headers["anthropic-beta"];
-                  }
-                }
-
-                // Polyfill request body for ALL OAuth accounts.
-                // Anthropic requires metadata.user_id and billing headers
-                // for OAuth — not just Claude Code clients.
-                const shouldPolyfillBody = isOAuth;
-                const buildUpstreamBody = (token: string) =>
-                  shouldPolyfillBody
-                    ? polyfillOAuthBody(bodyStr, token, snapshot, headers["x-claude-code-session-id"])
-                    : { bodyStr };
-                const polyfilledBody = buildUpstreamBody(account.token);
-                if (isOAuth && polyfilledBody.sessionId && !headers["x-claude-code-session-id"]) {
-                  headers["x-claude-code-session-id"] = polyfilledBody.sessionId;
-                }
-                const finalBodyStr = polyfilledBody.bodyStr;
-
-                logger.always(`[proxy] → account=${account.label} (${account.type})`);
-                recordAttempt(account.label, account.type);
-
-                // Log full request for debugging (written to ~/.neurolink/logs/proxy-debug-*.jsonl)
-                const fetchStartMs = Date.now();
-
-                // OTel: start upstream attempt span and inject trace headers
-                if (tracer) {
-                  upstreamSpan = tracer.startUpstreamAttempt({
-                    attempt: attemptNumber,
-                    account: account.label,
-                    polyfillHeaders: isOAuth,
-                    polyfillBody: isOAuth,
-                    upstreamUrl: url,
-                  });
-                  tracer.logUpstreamRequestHeaders(headers);
-                  tracer.logUpstreamRequestBody(finalBodyStr);
-                  const traceHeaders = tracer.getTraceHeaders();
-                  Object.assign(headers, traceHeaders);
-                }
-                logProxyBody({
-                  phase: "upstream_request",
-                  headers,
-                  body: finalBodyStr,
-                  bodySize: Buffer.byteLength(finalBodyStr, "utf8"),
-                  contentType: headers["content-type"] ?? "application/json",
-                  account: account.label,
-                  accountType: account.type,
-                  attempt: attemptNumber,
-                });
-
-                let response: Response;
-                try {
-                  response = await fetch(url, {
-                    method: "POST",
-                    headers,
-                    body: finalBodyStr,
-                    signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
-                  });
-                } catch (fetchErr) {
-                  if (!isRetryableNetworkError(fetchErr)) {
-                    throw fetchErr;
-                  }
-                  // Decision 8: Network errors — immediate rotation, no cooldown
-                  sawNetworkError = true;
-                  recordAttemptError(account.label, account.type, 502);
-                  const errorCode = getErrorCode(fetchErr) ?? "unknown";
-                  const errorMessage = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
-                  lastError = errorMessage;
-                  logger.always(
-                    `[proxy] fetch error account=${account.label} code=${errorCode} (rotating): ${errorMessage}`,
-                  );
-                  logAttempt(502, "network_error", errorMessage);
-                  tracer?.setError("network_error", errorMessage);
-                  tracer?.recordRetry(account.label, "network_error");
-                  upstreamSpan?.end();
-                  upstreamSpan = undefined;
-                  continue;
-                }
-
-                // Check 429 (with Retry-After + exponential backoff) → continue.
-                if (response.status === 429) {
-                  sawRateLimit = true;
-                  const retryAfter = response.headers.get("retry-after");
-                  let cooldownMs = 0;
-                  if (retryAfter) {
-                    const seconds = parseInt(retryAfter, 10);
-                    if (!Number.isNaN(seconds)) {
-                      cooldownMs = seconds * 1000;
-                    } else {
-                      const date = new Date(retryAfter);
-                      if (!Number.isNaN(date.getTime())) {
-                        cooldownMs = Math.max(date.getTime() - Date.now(), 1000);
-                      }
-                    }
-                  }
-                  const level = accountState.backoffLevel;
-                  const baseCooldown = cooldownMs > 0 ? cooldownMs : RATE_LIMIT_BACKOFF_BASE_MS;
-                  const backoffMs = Math.min(baseCooldown * 2 ** level, RATE_LIMIT_BACKOFF_CAP_MS);
-                  accountState.coolingUntil = Date.now() + backoffMs;
-                  accountState.backoffLevel += 1;
-                  advancePrimaryIfCurrent(account.key, enabledAccounts.length, orderedAccounts[0]?.key);
-                  recordAttemptError(account.label, account.type, 429);
-                  recordCooldown(account.label, account.type, accountState.coolingUntil, accountState.backoffLevel);
-                  lastError = await response.text();
-                  logger.always(
-                    `[proxy] ← 429 account=${account.label} backoff-level=${accountState.backoffLevel} cooldown=${Math.round(backoffMs / 1000)}s`,
-                  );
-                  logAttempt(429, "rate_limit_error", String(lastError));
-                  tracer?.setError("rate_limit_error", String(lastError).slice(0, 500));
-                  tracer?.recordRetry(account.label, "rate_limit");
-                  upstreamSpan?.end();
-                  upstreamSpan = undefined;
-                  continue;
-                }
-
-                // On 401 for refreshable OAuth: refresh token and retry before failing over.
-                if (response.status === 401 && account.type === "oauth" && account.refreshToken) {
-                  recordAttemptError(account.label, account.type, 401);
-                  let authRetrySucceeded = false;
-                  let authRetryError = "received 401 from Anthropic";
-
-                  for (let authRetry = 0; authRetry < MAX_AUTH_RETRIES; authRetry++) {
-                    logger.always(
-                      `[proxy] ← 401 account=${account.label} refreshing (attempt ${authRetry + 1}/${MAX_AUTH_RETRIES})`,
-                    );
-                    const refreshSucceeded = await refreshToken(account);
-                    if (!refreshSucceeded.success) {
-                      accountState.consecutiveRefreshFailures += 1;
-                      authRetryError = `refresh failed for account=${account.label} attempt ${authRetry + 1}/${MAX_AUTH_RETRIES}: ${refreshSucceeded.error?.slice(0, 200) ?? "unknown"}`;
-                      lastError = authRetryError;
-                      logger.always(`[proxy] ⚠ account=${account.label} refresh failed on attempt ${authRetry + 1}`);
-                      if (accountState.consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
-                        await disableAccountUntilReauth(account, accountState);
-                        authFailureMessage = formatReauthMessage(account.label);
-                        break;
-                      }
-                      if (authRetry < MAX_AUTH_RETRIES - 1) {
-                        await sleep(2000);
-                      }
-                      continue;
-                    }
-
-                    if (account.persistTarget) {
-                      await persistTokens(account.persistTarget, account);
-                    }
-                    headers.authorization = `Bearer ${account.token}`;
-
-                    try {
-                      const retryResp = await fetch(url, {
-                        method: "POST",
-                        headers,
-                        body: buildUpstreamBody(account.token).bodyStr,
-                        signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
-                      });
-                      if (retryResp.ok) {
-                        authRetrySucceeded = true;
-                        accountState.consecutiveRefreshFailures = 0;
-                        accountState.backoffLevel = 0;
-                        accountState.coolingUntil = undefined;
-                        logger.always(`[proxy] ← 200 account=${account.label} (after ${authRetry + 1} refresh(es))`);
-                        // Final success is recorded only once the response path
-                        // that reaches the client is fully determined.
-                        // Capture quota headers after successful auth-retry
-
-                        {
-                          const retryQuota = parseQuotaHeaders(retryResp.headers);
-                          if (retryQuota) {
-                            saveAccountQuota(account.label, retryQuota).catch(() => {});
-                          }
-                        }
-                        if (body.stream && retryResp.body) {
-                          const retryReader = retryResp.body.getReader();
-                          let retryStreamClosed = false;
-                          const retryStream = new ReadableStream({
-                            async pull(controller) {
-                              if (retryStreamClosed) {
-                                return;
-                              }
-                              try {
-                                const { done, value } = await retryReader.read();
-                                if (retryStreamClosed) {
-                                  return;
-                                }
-                                if (done) {
-                                  retryStreamClosed = true;
-                                  controller.close();
-                                  return;
-                                }
-                                controller.enqueue(value);
-                              } catch (streamErr) {
-                                const errMsg = streamErr instanceof Error ? streamErr.message : String(streamErr);
-                                logger.always(
-                                  `[proxy] mid-stream error (auth-retry) account=${account.label}: ${errMsg}`,
-                                );
-                                logStreamError({
-                                  timestamp: new Date().toISOString(),
-                                  requestId: ctx.requestId,
-                                  account: account.label,
-                                  model: body.model,
-                                  errorMessage: errMsg,
-                                  durationMs: Date.now() - fetchStartMs,
-                                });
-                                if (!retryStreamClosed) {
-                                  retryStreamClosed = true;
-                                  const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
-                                  controller.enqueue(new TextEncoder().encode(errorEvent));
-                                  controller.close();
-                                }
-                              }
-                            },
-                            cancel() {
-                              retryStreamClosed = true;
-                              retryReader.cancel();
-                            },
-                          });
-                          // OTel: pipe auth-retry stream through SSE interceptor
-                          let retryClientStream: ReadableStream<Uint8Array> = retryStream;
-                          if (tracer) {
-                            try {
-                              const { stream: retryInterceptor, telemetry: retryTelemetry } = createSSEInterceptor();
-                              retryClientStream = retryStream.pipeThrough(retryInterceptor);
-                              const capturedTracer2 = tracer;
-                              const capturedUpstreamSpan2 = upstreamSpan;
-                              const capturedRetryResp = retryResp;
-                              const capturedRetryRequestBytes = finalBodyStr.length;
-                              const capturedAccountLabel2 = account.label;
-                              retryTelemetry
-                                .then((data) => {
-                                  capturedTracer2.setUsage({
-                                    inputTokens: data.usage.inputTokens,
-                                    outputTokens: data.usage.outputTokens,
-                                    cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                                    cacheReadTokens: data.usage.cacheReadInputTokens,
-                                  });
-                                  capturedTracer2.logStreamEvents(data.events);
-                                  capturedTracer2.logUpstreamResponseHeaders(
-                                    Object.fromEntries([...capturedRetryResp.headers.entries()]),
-                                  );
-                                  capturedTracer2.recordMetrics();
-                                  capturedTracer2.recordBodySizes(capturedRetryRequestBytes, data.totalBytesReceived);
-                                  capturedUpstreamSpan2?.end();
-                                  capturedTracer2.end(200, Date.now() - requestStartTime);
-                                  recordFinalSuccess(capturedAccountLabel2, account.type);
-
-                                  // Deferred JSONL log with token usage (auth-retry streaming)
-                                  logFinalRequest(200, capturedAccountLabel2, account.type, undefined, undefined, {
-                                    inputTokens: data.usage.inputTokens,
-                                    outputTokens: data.usage.outputTokens,
-                                    cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                                    cacheReadTokens: data.usage.cacheReadInputTokens,
-                                  });
-                                })
-                                .catch((err) => {
-                                  capturedTracer2.setError(
-                                    "stream_error",
-                                    err instanceof Error ? err.message : String(err),
-                                  );
-                                  capturedUpstreamSpan2?.end();
-                                  capturedTracer2.end(500, Date.now() - requestStartTime);
-                                  recordFinalError(500, capturedAccountLabel2, account.type);
-                                  logFinalRequest(
-                                    500,
-                                    capturedAccountLabel2,
-                                    account.type,
-                                    "stream_error",
-                                    err instanceof Error ? err.message : String(err),
-                                  );
-                                });
-                            } catch {
-                              retryClientStream = retryStream;
-                            }
-                          }
-                          const responseHeaders: Record<string, string> = {
-                            "content-type": "text/event-stream",
-                            "cache-control": "no-cache",
-                            connection: "keep-alive",
-                          };
-                          for (const h of [
-                            "retry-after",
-                            "anthropic-ratelimit-requests-remaining",
-                            "anthropic-ratelimit-requests-limit",
-                            "anthropic-ratelimit-tokens-remaining",
-                            "anthropic-ratelimit-tokens-limit",
-                          ]) {
-                            const val = retryResp.headers.get(h);
-                            if (val) {
-                              responseHeaders[h] = val;
-                            }
-                          }
-                          return new Response(retryClientStream, {
-                            status: retryResp.status,
-                            headers: responseHeaders,
-                          });
-                        }
-                        // OTel: non-streaming auth-retry success
-                        const retryRespHeaders = Object.fromEntries([...retryResp.headers.entries()]);
-                        const retryText = await retryResp.text();
-                        tracer?.logUpstreamResponseHeaders(retryRespHeaders);
-                        tracer?.logUpstreamResponseBody(retryText);
-                        logProxyBody({
-                          phase: "upstream_response",
-                          headers: retryRespHeaders,
-                          body: retryText,
-                          bodySize: Buffer.byteLength(retryText, "utf8"),
-                          contentType: retryRespHeaders["content-type"] ?? "application/json",
-                          account: account.label,
-                          accountType: account.type,
-                          attempt: attemptNumber,
-                          responseStatus: retryResp.status,
-                          durationMs: Date.now() - fetchStartMs,
-                        });
-                        logProxyBody({
-                          phase: "client_response",
-                          headers: retryRespHeaders,
-                          body: retryText,
-                          bodySize: Buffer.byteLength(retryText, "utf8"),
-                          contentType: retryRespHeaders["content-type"] ?? "application/json",
-                          account: account.label,
-                          accountType: account.type,
-                          attempt: attemptNumber,
-                          responseStatus: retryResp.status,
-                          durationMs: Date.now() - requestStartTime,
-                        });
-                        const retryJson = JSON.parse(retryText);
-                        if (tracer && retryJson && typeof retryJson === "object") {
-                          const retryUsage = (retryJson as Record<string, unknown>).usage as
-                            | Record<string, number>
-                            | undefined;
-                          if (retryUsage) {
-                            tracer.setUsage({
-                              inputTokens: retryUsage.input_tokens ?? 0,
-                              outputTokens: retryUsage.output_tokens ?? 0,
-                              cacheCreationTokens: retryUsage.cache_creation_input_tokens ?? 0,
-                              cacheReadTokens: retryUsage.cache_read_input_tokens ?? 0,
-                            });
-                          }
-                          tracer.recordMetrics();
-                          const retryJsonStr = JSON.stringify(retryJson);
-                          tracer.recordBodySizes(finalBodyStr.length, retryJsonStr.length);
-                          upstreamSpan?.end();
-                          tracer.end(retryResp.status, Date.now() - requestStartTime);
-                          recordFinalSuccess(account.label, account.type);
-                          logFinalRequest(retryResp.status, account.label, account.type, undefined, undefined, {
-                            inputTokens: retryUsage?.input_tokens,
-                            outputTokens: retryUsage?.output_tokens,
-                            cacheCreationTokens: retryUsage?.cache_creation_input_tokens,
-                            cacheReadTokens: retryUsage?.cache_read_input_tokens,
-                          });
-                        } else {
-                          upstreamSpan?.end();
-                          recordFinalSuccess(account.label, account.type);
-                          logFinalRequest(retryResp.status, account.label, account.type);
-                        }
-                        return retryJson;
-                      }
-
-                      const retryStatus = retryResp.status;
-                      const retryBody = await retryResp.text();
-                      authRetryError = `retry ${authRetry + 1}/${MAX_AUTH_RETRIES} failed with status ${retryStatus}`;
-                      lastError = retryBody;
-                      logger.debug(
-                        `[proxy] retry ${authRetry + 1} failed: ${retryStatus} ${retryBody.substring(0, 120)}`,
-                      );
-                      recordAttemptError(account.label, account.type, retryStatus);
-
-                      if (retryStatus === 429) {
-                        sawRateLimit = true;
-                        const retryAfter = retryResp.headers.get("retry-after");
-                        const parsedRetryAfter = parseInt(retryAfter ?? "", 10);
-                        const cooldownMs = Number.isNaN(parsedRetryAfter)
-                          ? 60_000
-                          : Math.max(1, parsedRetryAfter) * 1000;
-                        accountState.coolingUntil = Date.now() + cooldownMs;
-                        advancePrimaryIfCurrent(account.key, enabledAccounts.length, orderedAccounts[0]?.key);
-                        recordCooldown(
-                          account.label,
-                          account.type,
-                          accountState.coolingUntil,
-                          accountState.backoffLevel,
-                        );
-                        break;
-                      }
-
-                      if (retryStatus === 401 || retryStatus === 402 || retryStatus === 403) {
-                        if (authRetry < MAX_AUTH_RETRIES - 1) {
-                          await sleep(1000);
-                        }
-                        continue;
-                      }
-
-                      if (isTransientHttpFailure(retryStatus, retryBody)) {
-                        // Decision 8: No cooldown for transient errors — rotate immediately
-                        sawTransientFailure = true;
-                        break;
-                      }
-
-                      logAttempt(retryStatus, "api_error", summarizeErrorMessage(retryBody));
-                      recordFinalError(retryStatus, account.label, account.type);
-                      try {
-                        logFinalRequest(
-                          retryStatus,
-                          account.label,
-                          account.type,
-                          "api_error",
-                          summarizeErrorMessage(retryBody),
-                        );
-                        return JSON.parse(retryBody);
-                      } catch {
-                        logFinalRequest(
-                          retryStatus,
-                          account.label,
-                          account.type,
-                          "api_error",
-                          summarizeErrorMessage(retryBody),
-                        );
-                        return buildClaudeError(retryStatus, retryBody);
-                      }
-                    } catch (retryFetchErr) {
-                      // Decision 8: No cooldown for network errors — rotate immediately
-                      sawNetworkError = true;
-                      recordAttemptError(account.label, account.type, 502);
-                      const message = retryFetchErr instanceof Error ? retryFetchErr.message : String(retryFetchErr);
-                      authRetryError = `network error on retry ${authRetry + 1}: ${message}`;
-                      lastError = authRetryError;
-                      logger.debug(`[proxy] ${authRetryError}`);
-                      break;
-                    }
-                  }
-
-                  if (!authRetrySucceeded) {
-                    if (!accountState.permanentlyDisabled) {
-                      if (!accountState.coolingUntil || accountState.coolingUntil <= Date.now()) {
-                        accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
-                      }
-                      recordCooldown(account.label, account.type, accountState.coolingUntil, accountState.backoffLevel);
-                    }
-                    lastError = authRetryError;
-                    logger.always(`[proxy] ⚠ account=${account.label} auth retries exhausted, cooldown=5min`);
-                    logAttempt(401, "authentication_error", authRetryError);
-                    tracer?.setError("authentication_error", authRetryError);
-                    tracer?.recordRetry(account.label, "auth_exhausted");
-                    upstreamSpan?.end();
-                    upstreamSpan = undefined;
-                    continue;
-                  }
-                }
-
-                if (!response.ok) {
-                  const errBody = await response.text();
-
-                  const errRespHeaders: Record<string, string> = {};
-                  response.headers.forEach((v, k) => {
-                    errRespHeaders[k] = v;
-                  });
-                  tracer?.logUpstreamResponseHeaders(errRespHeaders);
-                  tracer?.logUpstreamResponseBody(errBody);
-                  logProxyBody({
-                    phase: "upstream_response",
-                    headers: errRespHeaders,
-                    body: errBody,
-                    bodySize: Buffer.byteLength(errBody, "utf8"),
-                    contentType: errRespHeaders["content-type"] ?? "application/json",
-                    account: account.label,
-                    accountType: account.type,
-                    attempt: attemptNumber,
-                    responseStatus: response.status,
-                    durationMs: Date.now() - fetchStartMs,
-                  });
-
-                  // Upstream invalid_request_error responses are not retried on the
-                  // same Anthropic account, but may still be handed to fallback providers.
-                  if (isInvalidRequestError(response.status, errBody)) {
-                    logger.always(`[proxy] ← ${response.status} upstream invalid_request_error`);
-                    logAttempt(response.status, "invalid_request_error", summarizeErrorMessage(errBody));
-                    tracer?.setError("invalid_request_error", summarizeErrorMessage(errBody));
-                    invalidRequestFailure = {
-                      status: response.status,
-                      body: errBody,
-                      contentType: errRespHeaders["content-type"],
-                    };
-                    lastError = summarizeErrorMessage(errBody);
-                    upstreamSpan?.end();
-                    upstreamSpan = undefined;
-                    break;
-                  }
-
-                  // Auth failures for OAuth accounts without refresh token.
-                  if (
-                    (response.status === 401 || response.status === 402 || response.status === 403) &&
-                    account.type === "oauth" &&
-                    !account.refreshToken
-                  ) {
-                    recordAttemptError(account.label, account.type, response.status);
-                    accountState.consecutiveRefreshFailures += 1;
-                    accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
-                    recordCooldown(account.label, account.type, accountState.coolingUntil, accountState.backoffLevel);
-                    if (accountState.consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
-                      await disableAccountUntilReauth(account, accountState);
-                    }
-                    authFailureMessage = formatReauthMessage(account.label);
-                    logger.always(`[proxy] ← ${response.status} account=${account.label} cooldown=5min`);
-                    lastError = errBody;
-                    logAttempt(response.status, "authentication_error", summarizeErrorMessage(errBody));
-                    tracer?.setError("authentication_error", summarizeErrorMessage(errBody));
-                    tracer?.recordRetry(account.label, "auth_no_refresh");
-                    upstreamSpan?.end();
-                    upstreamSpan = undefined;
-                    continue;
-                  }
-
-                  // Auth failures for API-key accounts.
-                  if (
-                    (response.status === 401 || response.status === 402 || response.status === 403) &&
-                    account.type === "api_key"
-                  ) {
-                    recordAttemptError(account.label, account.type, response.status);
-                    authFailureMessage =
-                      "Authentication failed for Anthropic API key credentials. Update ANTHROPIC_API_KEY or re-login with OAuth.";
-                    accountState.coolingUntil = Date.now() + AUTH_COOLDOWN_MS;
-                    recordCooldown(account.label, account.type, accountState.coolingUntil, accountState.backoffLevel);
-                    logger.always(`[proxy] ← ${response.status} account=${account.label} cooldown=5min`);
-                    lastError = errBody;
-                    logAttempt(response.status, "authentication_error", summarizeErrorMessage(errBody));
-                    tracer?.setError("authentication_error", summarizeErrorMessage(errBody));
-                    tracer?.recordRetry(account.label, "auth_api_key");
-                    upstreamSpan?.end();
-                    upstreamSpan = undefined;
-                    continue;
-                  }
-
-                  // 404 is generally model/account specific; return immediately (no cooldown per Decision 8).
-                  if (response.status === 404) {
-                    recordFinalError(response.status, account.label, account.type);
-                    logger.always(`[proxy] ← 404 account=${account.label}`);
-                    logAttempt(404, "not_found_error", summarizeErrorMessage(errBody));
-                    tracer?.setError("not_found_error", summarizeErrorMessage(errBody));
-                    upstreamSpan?.end();
-                    tracer?.end(404, Date.now() - requestStartTime);
-                    try {
-                      const parsedError = JSON.parse(errBody);
-                      logFinalRequest(
-                        404,
-                        account.label,
-                        account.type,
-                        "not_found_error",
-                        summarizeErrorMessage(errBody),
-                      );
-                      logProxyBody({
-                        phase: "client_response",
-                        headers: {
-                          "content-type": errRespHeaders["content-type"] ?? "application/json",
-                        },
-                        body: errBody,
-                        bodySize: Buffer.byteLength(errBody, "utf8"),
-                        contentType: errRespHeaders["content-type"] ?? "application/json",
-                        account: account.label,
-                        accountType: account.type,
-                        attempt: attemptNumber,
-                        responseStatus: 404,
-                        durationMs: Date.now() - requestStartTime,
-                      });
-                      return parsedError;
-                    } catch {
-                      logFinalRequest(
-                        404,
-                        account.label,
-                        account.type,
-                        "not_found_error",
-                        summarizeErrorMessage(errBody),
-                      );
-                      const clientError = buildClaudeError(404, errBody);
-                      const clientErrorBody = JSON.stringify(clientError);
-                      logProxyBody({
-                        phase: "client_response",
-                        headers: { "content-type": "application/json" },
-                        body: clientErrorBody,
-                        bodySize: Buffer.byteLength(clientErrorBody, "utf8"),
-                        contentType: "application/json",
-                        account: account.label,
-                        accountType: account.type,
-                        attempt: attemptNumber,
-                        responseStatus: 404,
-                        durationMs: Date.now() - requestStartTime,
-                      });
-                      return clientError;
-                    }
-                  }
-
-                  // Decision 8: Transient upstream failures — immediate rotation, NO cooldown.
-                  if (isTransientHttpFailure(response.status, errBody)) {
-                    recordAttemptError(account.label, account.type, response.status);
-                    sawTransientFailure = true;
-                    // No cooldown for transient errors (502, 503, etc.) — rotate immediately
-                    logger.always(`[proxy] ← ${response.status} account=${account.label} (transient, rotating)`);
-                    lastError = errBody;
-                    logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
-                    tracer?.setError("transient_error", summarizeErrorMessage(errBody));
-                    tracer?.recordRetry(account.label, "transient");
-                    upstreamSpan?.end();
-                    upstreamSpan = undefined;
-                    continue;
-                  }
-
-                  // Other non-ok errors → return as-is.
-                  recordFinalError(response.status, account.label, account.type);
-                  logger.always(`[proxy] ← ${response.status} account=${account.label}`);
-                  logger.debug(`[claude-proxy] error body: ${errBody.substring(0, 200)}`);
-                  logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
-                  tracer?.setError("api_error", summarizeErrorMessage(errBody));
-                  upstreamSpan?.end();
-                  tracer?.end(response.status, Date.now() - requestStartTime);
-                  try {
-                    const parsedError = JSON.parse(errBody);
-                    logFinalRequest(
-                      response.status,
-                      account.label,
-                      account.type,
-                      "api_error",
-                      summarizeErrorMessage(errBody),
-                    );
-                    logProxyBody({
-                      phase: "client_response",
-                      headers: {
-                        "content-type": errRespHeaders["content-type"] ?? "application/json",
-                      },
-                      body: errBody,
-                      bodySize: Buffer.byteLength(errBody, "utf8"),
-                      contentType: errRespHeaders["content-type"] ?? "application/json",
-                      account: account.label,
-                      accountType: account.type,
-                      attempt: attemptNumber,
-                      responseStatus: response.status,
-                      durationMs: Date.now() - requestStartTime,
-                    });
-                    return parsedError;
-                  } catch {
-                    logFinalRequest(
-                      response.status,
-                      account.label,
-                      account.type,
-                      "api_error",
-                      summarizeErrorMessage(errBody),
-                    );
-                    const clientError = buildClaudeError(response.status, errBody);
-                    const clientErrorBody = JSON.stringify(clientError);
-                    logProxyBody({
-                      phase: "client_response",
-                      headers: { "content-type": "application/json" },
-                      body: clientErrorBody,
-                      bodySize: Buffer.byteLength(clientErrorBody, "utf8"),
-                      contentType: "application/json",
-                      account: account.label,
-                      accountType: account.type,
-                      attempt: attemptNumber,
-                      responseStatus: response.status,
-                      durationMs: Date.now() - requestStartTime,
-                    });
-                    return clientError;
-                  }
-                }
-
-                // Success path.
-                accountState.backoffLevel = 0;
-                accountState.coolingUntil = undefined;
-                accountState.consecutiveRefreshFailures = 0;
-                logger.always(`[proxy] ← ${response.status} account=${account.label}`);
-                // NOTE: logAttempt is deferred below so we can include token
-                // usage.  For streaming, the SSE interceptor callback logs it;
-                // for non-streaming, we log after JSON parsing.
-
-                // Capture quota/utilisation headers (fire-and-forget).
-                const quota = parseQuotaHeaders(response.headers);
-                if (quota) {
-                  saveAccountQuota(account.label, quota).catch(() => {
-                    // Non-fatal: quota persistence is best-effort
-                  });
-                }
-
-                const respHeaders: Record<string, string> = {};
-                response.headers.forEach((v, k) => {
-                  respHeaders[k] = v;
-                });
-                tracer?.logUpstreamResponseHeaders(respHeaders);
-
-                if (body.stream) {
-                  // Bootstrap retry: read first chunk to verify stream is valid.
-                  if (response.body) {
-                    const reader = response.body.getReader();
-                    const firstChunk = await reader.read();
-
-                    if (firstChunk.done || !firstChunk.value || firstChunk.value.length === 0) {
-                      // Empty stream — retry with next account.
-                      reader.cancel();
-                      accountState.coolingUntil = Date.now() + 10_000;
-                      recordCooldown(account.label, account.type, accountState.coolingUntil, accountState.backoffLevel);
-                      logger.always(`[proxy] ← empty stream from account=${account.label}, trying next`);
-                      tracer?.recordRetry(account.label, "empty_stream");
-                      upstreamSpan?.end();
-                      upstreamSpan = undefined;
-                      continue;
-                    }
-
-                    // Stream is valid — create a new ReadableStream with first chunk prepended.
-                    let mainStreamClosed = false;
-                    const remainingStream = new ReadableStream({
-                      start(controller) {
-                        controller.enqueue(firstChunk.value);
-                      },
-                      async pull(controller) {
-                        if (mainStreamClosed) {
-                          return;
-                        }
-                        try {
-                          const { done, value } = await reader.read();
-                          if (mainStreamClosed) {
-                            return;
-                          }
-                          if (done) {
-                            mainStreamClosed = true;
-                            controller.close();
-                            return;
-                          }
-                          controller.enqueue(value);
-                        } catch (streamErr) {
-                          const errMsg = streamErr instanceof Error ? streamErr.message : String(streamErr);
-                          logger.always(`[proxy] mid-stream error account=${account.label}: ${errMsg}`);
-                          logStreamError({
-                            timestamp: new Date().toISOString(),
-                            requestId: ctx.requestId,
-                            account: account.label,
-                            model: body.model,
-                            errorMessage: errMsg,
-                            durationMs: Date.now() - fetchStartMs,
-                          });
-                          // Send SSE error event so the client gets a meaningful error
-                          // instead of a raw connection drop
-                          if (!mainStreamClosed) {
-                            mainStreamClosed = true;
-                            const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
-                            controller.enqueue(new TextEncoder().encode(errorEvent));
-                            controller.close();
-                          }
-                        }
-                      },
-                      cancel() {
-                        mainStreamClosed = true;
-                        reader.cancel();
-                      },
-                    });
-
-                    // OTel: pipe stream through SSE interceptor for telemetry extraction.
-                    // The interceptor passes all bytes through unmodified and resolves
-                    // its telemetry promise when the stream finishes.
-                    const { stream: clientCaptureStream, capture: clientCapture } = createRawStreamCapture();
-                    let streamSource: ReadableStream<Uint8Array> = remainingStream;
-                    if (tracer) {
-                      try {
-                        const { stream: interceptor, telemetry } = createSSEInterceptor({ captureRawText: true });
-                        streamSource = streamSource.pipeThrough(interceptor);
-
-                        // Capture refs in const variables for the async closure —
-                        // loop variables (upstreamSpan, response) will change on next iteration,
-                        // and TypeScript needs the narrowed type for tracer.
-                        const capturedTracer = tracer;
-                        const capturedUpstreamSpan = upstreamSpan;
-                        const capturedResponse = response;
-                        const capturedRequestBytes = finalBodyStr.length;
-                        const capturedAccountLabel = account.label;
-
-                        Promise.all([telemetry, clientCapture])
-                          .then(([data, clientBody]) => {
-                            capturedTracer.setUsage({
-                              inputTokens: data.usage.inputTokens,
-                              outputTokens: data.usage.outputTokens,
-                              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                              cacheReadTokens: data.usage.cacheReadInputTokens,
-                            });
-                            capturedTracer.logStreamEvents(data.events);
-
-                            // Extract rate limits from response headers
-                            const rateLimit5h = parseFloat(
-                              capturedResponse.headers.get("anthropic-ratelimit-unified-5h-utilization") ?? "",
-                            );
-                            const rateLimit7d = parseFloat(
-                              capturedResponse.headers.get("anthropic-ratelimit-unified-7d-utilization") ?? "",
-                            );
-                            const usageUpdate: Parameters<typeof capturedTracer.setUsage>[0] = {
-                              inputTokens: data.usage.inputTokens,
-                              outputTokens: data.usage.outputTokens,
-                              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                              cacheReadTokens: data.usage.cacheReadInputTokens,
-                            };
-                            if (!isNaN(rateLimit5h)) {
-                              usageUpdate.rateLimitAfter5h = rateLimit5h;
-                            }
-                            if (!isNaN(rateLimit7d)) {
-                              usageUpdate.rateLimitAfter7d = rateLimit7d;
-                            }
-                            if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
-                              capturedTracer.setUsage(usageUpdate);
-                            }
-
-                            capturedTracer.logUpstreamResponseBody(data.rawText ?? "");
-                            capturedTracer.recordMetrics();
-                            capturedTracer.recordBodySizes(capturedRequestBytes, data.totalBytesReceived);
-                            capturedUpstreamSpan?.end();
-                            capturedTracer.end(200, Date.now() - requestStartTime);
-                            recordFinalSuccess(capturedAccountLabel, account.type);
-
-                            // Deferred JSONL log with token usage + traceId
-                            // (streaming: tokens only available after SSE stream finishes)
-                            logFinalRequest(200, capturedAccountLabel, account.type, undefined, undefined, {
-                              inputTokens: data.usage.inputTokens,
-                              outputTokens: data.usage.outputTokens,
-                              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                              cacheReadTokens: data.usage.cacheReadInputTokens,
-                            });
-                            logProxyBody({
-                              phase: "upstream_response",
-                              headers: respHeaders,
-                              body: data.rawText ?? "",
-                              bodySize: data.totalBytesReceived,
-                              contentType: respHeaders["content-type"] ?? "text/event-stream",
-                              account: capturedAccountLabel,
-                              accountType: account.type,
-                              attempt: attemptNumber,
-                              responseStatus: 200,
-                              durationMs: Date.now() - requestStartTime,
-                            });
-                            logProxyBody({
-                              phase: "client_response",
-                              headers: responseHeaders,
-                              body: clientBody.text,
-                              bodySize: clientBody.totalBytes,
-                              contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                              account: capturedAccountLabel,
-                              accountType: account.type,
-                              attempt: attemptNumber,
-                              responseStatus: 200,
-                              durationMs: Date.now() - requestStartTime,
-                            });
-                          })
-                          .catch((err) => {
-                            capturedTracer.setError("stream_error", err instanceof Error ? err.message : String(err));
-                            capturedUpstreamSpan?.end();
-                            capturedTracer.end(500, Date.now() - requestStartTime);
-                            recordFinalError(500, capturedAccountLabel, account.type);
-
-                            // Log the streaming error in JSONL
-                            logFinalRequest(
-                              500,
-                              capturedAccountLabel,
-                              account.type,
-                              "stream_error",
-                              err instanceof Error ? err.message : String(err),
-                            );
-                          });
-                      } catch {
-                        // Interceptor attachment failed after stream setup; response handling continues.
-                      }
-                    } else {
-                      // No tracer — still intercept stream for JSONL token logging
-                      upstreamSpan?.end();
-                      try {
-                        const { stream: noTracerInterceptor, telemetry: noTracerTelemetry } = createSSEInterceptor({
-                          captureRawText: true,
-                        });
-                        streamSource = streamSource.pipeThrough(noTracerInterceptor);
-                        const capturedAccountLabel = account.label;
-                        Promise.all([noTracerTelemetry, clientCapture])
-                          .then(([data, clientBody]) => {
-                            recordFinalSuccess(capturedAccountLabel, account.type);
-                            logFinalRequest(200, capturedAccountLabel, account.type, undefined, undefined, {
-                              inputTokens: data.usage.inputTokens,
-                              outputTokens: data.usage.outputTokens,
-                              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                              cacheReadTokens: data.usage.cacheReadInputTokens,
-                            });
-                            logProxyBody({
-                              phase: "upstream_response",
-                              headers: respHeaders,
-                              body: data.rawText ?? "",
-                              bodySize: data.totalBytesReceived,
-                              contentType: respHeaders["content-type"] ?? "text/event-stream",
-                              account: capturedAccountLabel,
-                              accountType: account.type,
-                              attempt: attemptNumber,
-                              responseStatus: 200,
-                              durationMs: Date.now() - requestStartTime,
-                            });
-                            logProxyBody({
-                              phase: "client_response",
-                              headers: responseHeaders,
-                              body: clientBody.text,
-                              bodySize: clientBody.totalBytes,
-                              contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                              account: capturedAccountLabel,
-                              accountType: account.type,
-                              attempt: attemptNumber,
-                              responseStatus: 200,
-                              durationMs: Date.now() - requestStartTime,
-                            });
-                          })
-                          .catch(() => {
-                            recordFinalSuccess(account.label, account.type);
-                            logFinalRequest(response.status, account.label, account.type);
-                          });
-                      } catch {
-                        // SSE interceptor creation failed — log without tokens
-                        clientCapture
-                          .then((clientBody) => {
-                            logProxyBody({
-                              phase: "client_response",
-                              headers: responseHeaders,
-                              body: clientBody.text,
-                              bodySize: clientBody.totalBytes,
-                              contentType: responseHeaders["content-type"] ?? "text/event-stream",
-                              account: account.label,
-                              accountType: account.type,
-                              attempt: attemptNumber,
-                              responseStatus: 200,
-                              durationMs: Date.now() - requestStartTime,
-                            });
-                          })
-                          .catch(() => {
-                            // Non-fatal
-                          });
-                        recordFinalSuccess(account.label, account.type);
-                        logFinalRequest(response.status, account.label, account.type);
-                      }
-                    }
-
-                    const clientStream = streamSource.pipeThrough(clientCaptureStream);
-                    // Forward rate limit headers from Anthropic.
-                    const responseHeaders: Record<string, string> = {
-                      "content-type": "text/event-stream",
-                      "cache-control": "no-cache",
-                      connection: "keep-alive",
-                    };
-                    for (const h of [
-                      "retry-after",
-                      "anthropic-ratelimit-requests-remaining",
-                      "anthropic-ratelimit-requests-limit",
-                      "anthropic-ratelimit-tokens-remaining",
-                      "anthropic-ratelimit-tokens-limit",
-                    ]) {
-                      const val = response.headers.get(h);
-                      if (val) {
-                        responseHeaders[h] = val;
-                      }
-                    }
-
-                    return new Response(clientStream, {
-                      status: response.status,
-                      headers: responseHeaders,
-                    });
-                  }
-                  upstreamSpan?.end();
-                  tracer?.setError("stream_error", "No response body from upstream");
-                  tracer?.end(502, Date.now() - requestStartTime);
-                  recordFinalError(502, account.label, account.type);
-                  logFinalRequest(502, account.label, account.type, "stream_error", "No response body from upstream");
-                  const clientError = buildClaudeError(502, "No response body from upstream");
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: { "content-type": "application/json" },
-                    body: JSON.stringify(clientError),
-                    bodySize: Buffer.byteLength(JSON.stringify(clientError), "utf8"),
-                    contentType: "application/json",
-                    account: account.label,
-                    accountType: account.type,
-                    attempt: attemptNumber,
-                    responseStatus: 502,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return clientError;
-                }
-
-                // Non-streaming: return JSON directly.
-                // OTel: extract usage from response JSON before returning.
-                const responseText = await response.text();
-                tracer?.logUpstreamResponseBody(responseText);
-                logProxyBody({
-                  phase: "upstream_response",
-                  headers: respHeaders,
-                  body: responseText,
-                  bodySize: Buffer.byteLength(responseText, "utf8"),
-                  contentType: respHeaders["content-type"] ?? "application/json",
-                  account: account.label,
-                  accountType: account.type,
-                  attempt: attemptNumber,
-                  responseStatus: response.status,
-                  durationMs: Date.now() - fetchStartMs,
-                });
-                logProxyBody({
-                  phase: "client_response",
-                  headers: respHeaders,
-                  body: responseText,
-                  bodySize: Buffer.byteLength(responseText, "utf8"),
-                  contentType: respHeaders["content-type"] ?? "application/json",
-                  account: account.label,
-                  accountType: account.type,
-                  attempt: attemptNumber,
-                  responseStatus: response.status,
-                  durationMs: Date.now() - requestStartTime,
-                });
-                const responseJson = JSON.parse(responseText);
-                if (tracer && responseJson && typeof responseJson === "object") {
-                  const usage = (responseJson as Record<string, unknown>).usage as Record<string, number> | undefined;
-                  if (usage) {
-                    tracer.setUsage({
-                      inputTokens: usage.input_tokens ?? 0,
-                      outputTokens: usage.output_tokens ?? 0,
-                      cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-                      cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-                    });
-
-                    // Extract rate limits from response headers
-                    const rateLimit5h = parseFloat(
-                      response.headers.get("anthropic-ratelimit-unified-5h-utilization") ?? "",
-                    );
-                    const rateLimit7d = parseFloat(
-                      response.headers.get("anthropic-ratelimit-unified-7d-utilization") ?? "",
-                    );
-                    if (!isNaN(rateLimit5h) || !isNaN(rateLimit7d)) {
-                      const usageWithRates: Parameters<typeof tracer.setUsage>[0] = {
-                        inputTokens: usage.input_tokens ?? 0,
-                        outputTokens: usage.output_tokens ?? 0,
-                        cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-                        cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-                      };
-                      if (!isNaN(rateLimit5h)) {
-                        usageWithRates.rateLimitAfter5h = rateLimit5h;
-                      }
-                      if (!isNaN(rateLimit7d)) {
-                        usageWithRates.rateLimitAfter7d = rateLimit7d;
-                      }
-                      tracer.setUsage(usageWithRates);
-                    }
-                  }
-                  tracer.recordMetrics();
-                  const responseJsonStr = JSON.stringify(responseJson);
-                  tracer.recordBodySizes(finalBodyStr.length, responseJsonStr.length);
-                  upstreamSpan?.end();
-                  tracer.end(response.status, Date.now() - requestStartTime);
-                  recordFinalSuccess(account.label, account.type);
-                  logFinalRequest(response.status, account.label, account.type, undefined, undefined, {
-                    inputTokens: usage?.input_tokens,
-                    outputTokens: usage?.output_tokens,
-                    cacheCreationTokens: usage?.cache_creation_input_tokens,
-                    cacheReadTokens: usage?.cache_read_input_tokens,
-                  });
-                } else {
-                  upstreamSpan?.end();
-                  // No tracer — still extract usage from response JSON for JSONL logging
-                  const noTracerUsage =
-                    responseJson && typeof responseJson === "object"
-                      ? ((responseJson as Record<string, unknown>).usage as Record<string, number> | undefined)
-                      : undefined;
-                  recordFinalSuccess(account.label, account.type);
-                  logFinalRequest(response.status, account.label, account.type, undefined, undefined, {
-                    inputTokens: noTracerUsage?.input_tokens,
-                    outputTokens: noTracerUsage?.output_tokens,
-                    cacheCreationTokens: noTracerUsage?.cache_creation_input_tokens,
-                    cacheReadTokens: noTracerUsage?.cache_read_input_tokens,
-                  });
-                }
-                return responseJson;
-              }
-
-              // OTel: end account selection span if all accounts were skipped
-              if (attemptNumber === 0) {
-                acctSelectionSpan?.end();
-              }
-
-              // All accounts exhausted — compute earliest recovery time.
-              const earliestRecovery = orderedAccounts.reduce((min, account) => {
-                const coolingUntil = getOrCreateRuntimeState(account.key).coolingUntil;
-                return coolingUntil ? Math.min(min, coolingUntil) : min;
-              }, Infinity);
-              const retryAfterSec = Number.isFinite(earliestRecovery)
-                ? Math.max(1, Math.ceil((earliestRecovery - Date.now()) / 1000))
-                : 60;
-
-              // Try fallback chain (alternative providers)
-              const chain = modelRouter?.getFallbackChain() ?? [];
-              for (const fallback of chain) {
-                const availability = await ProviderHealthChecker.checkFallbackProviderAvailability(
-                  fallback.provider,
-                  fallback.model,
-                );
-
-                if (!availability.available) {
-                  logger.debug(
-                    `[proxy] skipping fallback ${fallback.provider}/${fallback.model}: ${availability.reason ?? "provider unavailable"}`,
-                  );
-                  continue;
-                }
-
-                try {
-                  logger.always(`[proxy] fallback → ${fallback.provider}/${fallback.model}`);
-                  const parsed = parseClaudeRequest(body);
-                  const opts = buildProxyFallbackOptions(parsed, {
-                    provider: fallback.provider,
-                    model: fallback.model,
-                  });
-                  if (body.stream) {
-                    const streamResult = await ctx.neurolink.stream(
-                      opts as unknown as Parameters<typeof ctx.neurolink.stream>[0],
-                    );
-                    const serializer = new ClaudeStreamSerializer(body.model, 0);
-                    async function* sseGenerator(): AsyncIterable<string> {
-                      for (const frame of serializer.start()) {
-                        yield frame;
-                      }
-                      let collectedText = "";
-                      for await (const chunk of streamResult.stream) {
-                        const text = extractText(chunk);
-                        if (text) {
-                          collectedText += text;
-                          for (const frame of serializer.pushDelta(text)) {
-                            yield frame;
-                          }
-                        }
-                      }
-                      // Emit tool_use blocks if model wants to call tools
-                      const toolCalls = streamResult.toolCalls ?? [];
-                      if (!hasTranslatedOutput(collectedText, toolCalls)) {
-                        throw new Error(
-                          `Translated provider ${fallback.provider}/${fallback.model} returned no content or tool calls`,
-                        );
-                      }
-                      if (toolCalls.length) {
-                        for (const tc of toolCalls) {
-                          const toolName =
-                            (tc as { toolName?: string }).toolName ?? (tc as { name?: string }).name ?? "unknown";
-                          for (const frame of serializer.pushToolUse(
-                            generateToolUseId(),
-                            toolName,
-                            extractToolArgs(tc),
-                          )) {
-                            yield frame;
-                          }
-                        }
-                      }
-                      const reason = streamResult.finishReason ?? "end_turn";
-                      const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
-                      for (const frame of serializer.finish(resolvedUsage.output, reason)) {
-                        yield frame;
-                      }
-                    }
-                    tracer?.end(200, Date.now() - requestStartTime);
-                    recordFinalSuccess();
-                    logFinalRequest(200, "", fallback.provider);
-                    return sseGenerator();
-                  }
-                  const streamResult = await ctx.neurolink.stream(
-                    opts as unknown as Parameters<typeof ctx.neurolink.stream>[0],
-                  );
-                  let collectedText = "";
-                  for await (const chunk of streamResult.stream) {
-                    const text = extractText(chunk);
-                    if (text) {
-                      collectedText += text;
-                    }
-                  }
-                  if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
-                    throw new Error(
-                      `Translated provider ${fallback.provider}/${fallback.model} returned no content or tool calls`,
-                    );
-                  }
-                  const internal: InternalResult = {
-                    content: collectedText,
-                    model: streamResult.model,
-                    finishReason: streamResult.finishReason ?? "end_turn",
-                    reasoning: undefined,
-                    usage: streamResult.usage ? extractUsageFromStreamResult(streamResult.usage) : undefined,
-                    toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
-                  };
-                  tracer?.end(200, Date.now() - requestStartTime);
-                  recordFinalSuccess();
-                  const clientResponse = serializeClaudeResponse(internal, body.model);
-                  logFinalRequest(200, "", fallback.provider, undefined, undefined, {
-                    inputTokens: internal.usage?.input,
-                    outputTokens: internal.usage?.output,
-                  });
-                  const clientResponseText = JSON.stringify(clientResponse);
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: { "content-type": "application/json" },
-                    body: clientResponseText,
-                    bodySize: Buffer.byteLength(clientResponseText, "utf8"),
-                    contentType: "application/json",
-                    responseStatus: 200,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return clientResponse;
-                } catch (fallbackErr) {
-                  logger.debug(
-                    `[proxy] fallback ${fallback.provider}/${fallback.model} failed: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
-                  );
-                }
-              }
-
-              // If no explicit fallback chain is configured, try SDK auto-provider fallback.
-              // Skip auto-provider when all accounts are rate-limited — the client
-              // (e.g. Claude Code) understands 429 + Retry-After and will retry on
-              // its own. Silently routing to a different provider (e.g. OpenAI)
-              // produces confusing errors like "insufficient_quota".
-              if (chain.length === 0 && !sawRateLimit) {
-                try {
-                  logger.always("[proxy] fallback → auto-provider");
-                  const parsed = parseClaudeRequest(body);
-                  const opts = buildProxyFallbackOptions(parsed);
-                  if (body.stream) {
-                    const streamResult = await ctx.neurolink.stream(
-                      opts as unknown as Parameters<typeof ctx.neurolink.stream>[0],
-                    );
-                    const serializer = new ClaudeStreamSerializer(body.model, 0);
-                    async function* sseGenerator(): AsyncIterable<string> {
-                      for (const frame of serializer.start()) {
-                        yield frame;
-                      }
-                      let collectedText = "";
-                      for await (const chunk of streamResult.stream) {
-                        const text = extractText(chunk);
-                        if (text) {
-                          collectedText += text;
-                          for (const frame of serializer.pushDelta(text)) {
-                            yield frame;
-                          }
-                        }
-                      }
-                      // Emit tool_use blocks if model wants to call tools
-                      const toolCalls = streamResult.toolCalls ?? [];
-                      if (!hasTranslatedOutput(collectedText, toolCalls)) {
-                        throw new Error("Translated provider auto-provider returned no content or tool calls");
-                      }
-                      if (toolCalls.length) {
-                        for (const tc of toolCalls) {
-                          const toolName =
-                            (tc as { toolName?: string }).toolName ?? (tc as { name?: string }).name ?? "unknown";
-                          for (const frame of serializer.pushToolUse(
-                            generateToolUseId(),
-                            toolName,
-                            extractToolArgs(tc),
-                          )) {
-                            yield frame;
-                          }
-                        }
-                      }
-                      const reason = streamResult.finishReason ?? "end_turn";
-                      const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
-                      for (const frame of serializer.finish(resolvedUsage.output, reason)) {
-                        yield frame;
-                      }
-                    }
-                    tracer?.end(200, Date.now() - requestStartTime);
-                    recordFinalSuccess();
-                    logFinalRequest(200, "", "auto-provider");
-                    return sseGenerator();
-                  }
-                  const streamResult = await ctx.neurolink.stream(
-                    opts as unknown as Parameters<typeof ctx.neurolink.stream>[0],
-                  );
-                  let collectedText = "";
-                  for await (const chunk of streamResult.stream) {
-                    const text = extractText(chunk);
-                    if (text) {
-                      collectedText += text;
-                    }
-                  }
-                  if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
-                    throw new Error("Translated provider auto-provider returned no content or tool calls");
-                  }
-                  const internal: InternalResult = {
-                    content: collectedText,
-                    model: streamResult.model,
-                    finishReason: streamResult.finishReason ?? "end_turn",
-                    reasoning: undefined,
-                    usage: streamResult.usage ? extractUsageFromStreamResult(streamResult.usage) : undefined,
-                    toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
-                  };
-                  tracer?.end(200, Date.now() - requestStartTime);
-                  recordFinalSuccess();
-                  const clientResponse = serializeClaudeResponse(internal, body.model);
-                  logFinalRequest(200, "", "auto-provider", undefined, undefined, {
-                    inputTokens: internal.usage?.input,
-                    outputTokens: internal.usage?.output,
-                  });
-                  const clientResponseText = JSON.stringify(clientResponse);
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: { "content-type": "application/json" },
-                    body: clientResponseText,
-                    bodySize: Buffer.byteLength(clientResponseText, "utf8"),
-                    contentType: "application/json",
-                    responseStatus: 200,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return clientResponse;
-                } catch (fallbackErr) {
-                  logger.debug(
-                    `[proxy] fallback auto-provider failed: ${
-                      fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-                    }`,
-                  );
-                }
-              }
-
-              if (authFailureMessage && !sawRateLimit) {
-                tracer?.setError("authentication_error", authFailureMessage);
-                tracer?.end(401, Date.now() - requestStartTime);
-                return buildLoggedClaudeError(401, authFailureMessage);
-              }
-
-              if (invalidRequestFailure) {
-                tracer?.setError("invalid_request_error", summarizeErrorMessage(invalidRequestFailure.body));
-                tracer?.end(invalidRequestFailure.status, Date.now() - requestStartTime);
-                recordFinalError(invalidRequestFailure.status);
-                try {
-                  const parsedError = JSON.parse(invalidRequestFailure.body);
-                  logFinalRequest(
-                    invalidRequestFailure.status,
-                    "",
-                    "final",
-                    "invalid_request_error",
-                    summarizeErrorMessage(invalidRequestFailure.body),
-                  );
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: {
-                      "content-type": invalidRequestFailure.contentType ?? "application/json",
-                    },
-                    body: invalidRequestFailure.body,
-                    bodySize: Buffer.byteLength(invalidRequestFailure.body, "utf8"),
-                    contentType: invalidRequestFailure.contentType ?? "application/json",
-                    responseStatus: invalidRequestFailure.status,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return parsedError;
-                } catch {
-                  return buildLoggedClaudeError(
-                    invalidRequestFailure.status,
-                    summarizeErrorMessage(invalidRequestFailure.body),
-                    "invalid_request_error",
-                  );
-                }
-              }
-
-              if ((sawNetworkError || sawTransientFailure) && !sawRateLimit) {
-                const msg = `All Anthropic accounts failed due to transient upstream/network errors. Last error: ${
-                  lastError instanceof Error ? lastError.message : String(lastError ?? "unknown")
-                }`;
-                tracer?.setError("transient_error", msg.slice(0, 500));
-                tracer?.end(502, Date.now() - requestStartTime);
-                return buildLoggedClaudeError(502, msg);
-              }
-
-              if (!sawRateLimit) {
-                const msg = `All Anthropic accounts failed. Last error: ${
-                  lastError instanceof Error ? lastError.message : String(lastError ?? "unknown")
-                }`;
-                tracer?.setError("all_accounts_failed", msg.slice(0, 500));
-                tracer?.end(502, Date.now() - requestStartTime);
-                return buildLoggedClaudeError(502, msg);
-              }
-
-              // All accounts AND all fallbacks exhausted — return 429 with Retry-After
-              logger.always(`[proxy] all accounts rate-limited, retry in ${retryAfterSec}s`);
-              const errorBody = buildClaudeError(
-                429,
-                `All accounts rate-limited. Earliest recovery in ${retryAfterSec}s.`,
-                "overloaded_error",
-              );
-              tracer?.setError("rate_limit_error", `All accounts rate-limited. Retry in ${retryAfterSec}s.`);
-              tracer?.end(429, Date.now() - requestStartTime);
-              recordFinalError(429);
-              logFinalRequest(
-                429,
-                "",
-                "final",
-                "rate_limit_error",
-                `All accounts rate-limited. Retry in ${retryAfterSec}s.`,
-              );
-              const errorBodyText = JSON.stringify(errorBody);
-              logProxyBody({
-                phase: "client_response",
-                headers: {
-                  "content-type": "application/json",
-                  "retry-after": String(retryAfterSec),
-                },
-                body: errorBodyText,
-                bodySize: Buffer.byteLength(errorBodyText, "utf8"),
-                contentType: "application/json",
-                responseStatus: 429,
-                durationMs: Date.now() - requestStartTime,
-              });
-              return new Response(errorBodyText, {
-                status: 429,
-                headers: {
-                  "content-type": "application/json",
-                  "retry-after": String(retryAfterSec),
-                },
+              return handleAnthropicRoutedClaudeRequest({
+                ctx,
+                body,
+                modelRouter,
+                tracer,
+                requestStartTime,
+                accountStrategy,
+                buildLoggedClaudeError,
+                logProxyBody,
+                logFinalRequest,
               });
             } else {
-              // ─── TRANSLATION MODE (Claude → Other Provider) ───────
-              tracer?.setMode("full");
-              // Parse into NeuroLink format, call generate/stream, serialize back
-              const parsed = parseClaudeRequest(body);
-              const attempts = buildProxyTranslationAttempts(
-                {
+              return handleTranslatedClaudeRequest({
+                ctx,
+                body,
+                route: {
                   provider: route.provider,
                   model: route.model,
                 },
                 modelRouter,
-              );
-
-              if (body.stream) {
-                const serializer = new ClaudeStreamSerializer(body.model, 0);
-                const KEEPALIVE_INTERVAL_MS = 15_000; // 15 seconds
-
-                // Return a ReadableStream that emits SSE keep-alive comments
-                // every ~15s independently of upstream chunk arrival, so
-                // intermediaries don't drop the connection during stalls.
-                const encoder = new TextEncoder();
-                let translationKeepAliveTimer: ReturnType<typeof setInterval> | undefined;
-                let translationCancelled = false;
-                let translationSucceeded = false;
-                let translatedModel: string | undefined;
-                let finalStreamError = "No translation providers succeeded";
-                // Hold a reference to the upstream async iterator so
-                // we can abort it when the client disconnects.
-                let upstreamIterator: AsyncIterator<unknown> | undefined;
-                const translationStream = new ReadableStream<Uint8Array>({
-                  async start(controller) {
-                    // Emit start frames
-                    for (const frame of serializer.start()) {
-                      controller.enqueue(encoder.encode(frame));
-                    }
-
-                    // Keep-alive interval — fires even when upstream is stalled
-                    translationKeepAliveTimer = setInterval(() => {
-                      try {
-                        controller.enqueue(encoder.encode(": keep-alive\n\n"));
-                      } catch {
-                        // Controller already closed — ignore
-                      }
-                    }, KEEPALIVE_INTERVAL_MS);
-
-                    try {
-                      for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
-                        const attempt = attempts[attemptIndex];
-                        if (attemptIndex > 0) {
-                          logger.always(`[proxy] fallback → ${attempt.label}`);
-                        }
-
-                        let collectedText = "";
-                        try {
-                          const options = buildProxyFallbackOptions(
-                            parsed,
-                            attempt.provider
-                              ? {
-                                  provider: attempt.provider,
-                                  model: attempt.model,
-                                }
-                              : {},
-                          );
-                          const streamResult = await ctx.neurolink.stream(
-                            options as Parameters<typeof ctx.neurolink.stream>[0],
-                          );
-                          const iterable = streamResult.stream as AsyncIterable<unknown>;
-                          upstreamIterator = iterable[Symbol.asyncIterator]();
-
-                          while (true) {
-                            if (translationCancelled) {
-                              break;
-                            }
-                            const { value: chunk, done } = await upstreamIterator.next();
-                            if (done) {
-                              break;
-                            }
-                            if (translationCancelled) {
-                              break;
-                            }
-                            const text = extractText(chunk);
-                            if (text) {
-                              collectedText += text;
-                              for (const frame of serializer.pushDelta(text)) {
-                                controller.enqueue(encoder.encode(frame));
-                              }
-                            }
-                          }
-
-                          const toolCalls = streamResult.toolCalls ?? [];
-                          if (!hasTranslatedOutput(collectedText, toolCalls)) {
-                            finalStreamError = `Translated provider ${attempt.label} returned no content or tool calls`;
-                            logger.debug(
-                              `[proxy] translation attempt ${attempt.label} returned no content or tool calls`,
-                            );
-                            continue;
-                          }
-
-                          if (!translationCancelled && toolCalls.length) {
-                            for (const tc of toolCalls) {
-                              const toolName =
-                                (tc as { toolName?: string }).toolName ?? (tc as { name?: string }).name ?? "unknown";
-                              for (const frame of serializer.pushToolUse(
-                                generateToolUseId(),
-                                toolName,
-                                extractToolArgs(tc),
-                              )) {
-                                controller.enqueue(encoder.encode(frame));
-                              }
-                            }
-                          }
-
-                          if (!translationCancelled) {
-                            const reason = streamResult.finishReason ?? "end_turn";
-                            const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
-                            for (const frame of serializer.finish(resolvedUsage.output, reason)) {
-                              controller.enqueue(encoder.encode(frame));
-                            }
-                          }
-
-                          translatedModel = streamResult.model;
-                          translationSucceeded = true;
-                          return;
-                        } catch (streamErr) {
-                          if (translationCancelled) {
-                            return;
-                          }
-                          finalStreamError = streamErr instanceof Error ? streamErr.message : String(streamErr);
-                          if (collectedText.trim().length > 0) {
-                            logger.always(`[proxy] mid-stream error (translation mode): ${finalStreamError}`);
-                            const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
-                            controller.enqueue(encoder.encode(errorEvent));
-                            return;
-                          }
-                          logger.debug(`[proxy] translation attempt ${attempt.label} failed: ${finalStreamError}`);
-                        }
-                      }
-
-                      if (!translationCancelled) {
-                        logger.always(`[proxy] mid-stream error (translation mode): ${finalStreamError}`);
-                        const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
-                        controller.enqueue(encoder.encode(errorEvent));
-                      }
-                    } finally {
-                      if (translationKeepAliveTimer) {
-                        clearInterval(translationKeepAliveTimer);
-                      }
-                      if (!translationCancelled) {
-                        controller.close();
-                      }
-                      // OTel: record model substitution if proxy routed to a different model
-                      if (tracer && translatedModel && translatedModel !== body.model) {
-                        tracer.setModelSubstitution(body.model, translatedModel);
-                      }
-                      if (!translationSucceeded) {
-                        tracer?.setError("generation_error", finalStreamError.slice(0, 500));
-                      }
-                      tracer?.end(200, Date.now() - requestStartTime);
-                    }
-                  },
-                  cancel() {
-                    translationCancelled = true;
-                    if (translationKeepAliveTimer) {
-                      clearInterval(translationKeepAliveTimer);
-                      translationKeepAliveTimer = undefined;
-                    }
-                    // Propagate cancellation to the upstream provider stream
-                    if (upstreamIterator?.return) {
-                      upstreamIterator.return(undefined).catch((cancelErr) => {
-                        logger.debug(
-                          `[proxy] upstream cancel error: ${cancelErr instanceof Error ? cancelErr.message : String(cancelErr)}`,
-                        );
-                      });
-                    }
-                  },
-                });
-
-                return new Response(translationStream, {
-                  headers: {
-                    "content-type": "text/event-stream",
-                    "cache-control": "no-cache",
-                    connection: "keep-alive",
-                  },
-                });
-              }
-
-              let lastAttemptError = "No translation providers succeeded";
-              for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
-                const attempt = attempts[attemptIndex];
-                if (attemptIndex > 0) {
-                  logger.always(`[proxy] fallback → ${attempt.label}`);
-                }
-
-                try {
-                  const options = buildProxyFallbackOptions(
-                    parsed,
-                    attempt.provider
-                      ? {
-                          provider: attempt.provider,
-                          model: attempt.model,
-                        }
-                      : {},
-                  );
-                  const streamResult = await ctx.neurolink.stream(
-                    options as Parameters<typeof ctx.neurolink.stream>[0],
-                  );
-                  let collectedText = "";
-                  for await (const chunk of streamResult.stream) {
-                    const text = extractText(chunk);
-                    if (text) {
-                      collectedText += text;
-                    }
-                  }
-                  if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
-                    lastAttemptError = `Translated provider ${attempt.label} returned no content or tool calls`;
-                    logger.debug(`[proxy] translation attempt ${attempt.label} returned no content or tool calls`);
-                    continue;
-                  }
-
-                  const internal: InternalResult = {
-                    content: collectedText,
-                    model: streamResult.model,
-                    finishReason: streamResult.finishReason ?? "end_turn",
-                    reasoning: undefined,
-                    usage: streamResult.usage ? extractUsageFromStreamResult(streamResult.usage) : undefined,
-                    toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
-                  };
-                  // OTel: record model substitution if proxy routed to a different model
-                  if (tracer && streamResult.model && streamResult.model !== body.model) {
-                    tracer.setModelSubstitution(body.model, streamResult.model);
-                  }
-                  tracer?.end(200, Date.now() - requestStartTime);
-                  const clientResponse = serializeClaudeResponse(internal, body.model);
-                  const clientResponseText = JSON.stringify(clientResponse);
-                  logProxyBody({
-                    phase: "client_response",
-                    headers: { "content-type": "application/json" },
-                    body: clientResponseText,
-                    bodySize: Buffer.byteLength(clientResponseText, "utf8"),
-                    contentType: "application/json",
-                    responseStatus: 200,
-                    durationMs: Date.now() - requestStartTime,
-                  });
-                  return clientResponse;
-                } catch (attemptError) {
-                  lastAttemptError = attemptError instanceof Error ? attemptError.message : String(attemptError);
-                  logger.debug(`[proxy] translation attempt ${attempt.label} failed: ${lastAttemptError}`);
-                }
-              }
-
-              throw new Error(lastAttemptError);
+                tracer,
+                requestStartTime,
+                logProxyBody,
+              });
             }
           } catch (error) {
-            const errMsg = error instanceof Error ? error.message : String(error);
-            logger.error(`[claude-proxy] Generation error for ${body.model}: ${errMsg}`);
+            const errMsg =
+              error instanceof Error ? error.message : String(error);
+            logger.error(
+              `[claude-proxy] Generation error for ${body.model}: ${errMsg}`,
+            );
             tracer?.setError("generation_error", errMsg.slice(0, 500));
             tracer?.end(502, Date.now() - requestStartTime);
             return buildLoggedClaudeError(
@@ -3174,7 +4595,8 @@ export function createClaudeProxyRoutes(
             );
           }
         },
-        description: "Claude-compatible messages endpoint routed through NeuroLink",
+        description:
+          "Claude-compatible messages endpoint routed through NeuroLink",
         tags: ["claude-proxy", "messages"],
         streaming: { enabled: true, contentType: "text/event-stream" },
       },
@@ -3214,15 +4636,24 @@ export function createClaudeProxyRoutes(
         method: "POST",
         path: `${basePath}/v1/messages/count_tokens`,
         handler: async (ctx: ServerContext) => {
-          const body = ctx.body as { model?: string; messages?: Array<{ content: unknown }> } | undefined;
+          const body = ctx.body as
+            | { model?: string; messages?: Array<{ content: unknown }> }
+            | undefined;
 
           if (!body?.model || !body?.messages) {
-            return buildClaudeError(400, "Missing required fields: model, messages");
+            return buildClaudeError(
+              400,
+              "Missing required fields: model, messages",
+            );
           }
 
           // Simple estimation using character-to-token heuristic
           const text = body.messages
-            .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+            .map((m) =>
+              typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content),
+            )
             .join(" ");
 
           return { input_tokens: Math.ceil(text.length / 4) };
@@ -3310,7 +4741,10 @@ function getOrCreateRuntimeState(accountKey: string): RuntimeAccountState {
   return initial;
 }
 
-async function disableAccountUntilReauth(account: ProxyPassthroughAccount, state: RuntimeAccountState): Promise<void> {
+async function disableAccountUntilReauth(
+  account: ProxyPassthroughAccount,
+  state: RuntimeAccountState,
+): Promise<void> {
   state.permanentlyDisabled = true;
   state.coolingUntil = undefined;
   state.backoffLevel = 0;
@@ -3335,7 +4769,10 @@ function formatReauthMessage(labels: string | string[]): string {
   return `Account(s) require re-authentication: ${value}. Run: neurolink auth login anthropic --method oauth`;
 }
 
-function summarizeErrorMessage(message: string, maxLength: number = 180): string {
+function summarizeErrorMessage(
+  message: string,
+  maxLength: number = 180,
+): string {
   const compact = message.replace(/\s+/g, " ").trim();
   if (compact.length <= maxLength) {
     return compact;
@@ -3415,7 +4852,9 @@ function isRetryableNetworkError(error: unknown): boolean {
   );
 }
 
-const TRANSIENT_HTTP_STATUSES = new Set([408, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 529]);
+const TRANSIENT_HTTP_STATUSES = new Set([
+  408, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 529,
+]);
 
 type ParsedClaudeError = {
   errorType?: string;
@@ -3431,10 +4870,19 @@ export function parseClaudeErrorBody(errBody: string): ParsedClaudeError {
       type?: unknown;
       error?: { type?: unknown; message?: unknown };
     };
-    if (parsed && parsed.type === "error" && parsed.error && typeof parsed.error === "object") {
+    if (
+      parsed &&
+      parsed.type === "error" &&
+      parsed.error &&
+      typeof parsed.error === "object"
+    ) {
       return {
-        errorType: typeof parsed.error.type === "string" ? parsed.error.type : undefined,
-        message: typeof parsed.error.message === "string" ? parsed.error.message : undefined,
+        errorType:
+          typeof parsed.error.type === "string" ? parsed.error.type : undefined,
+        message:
+          typeof parsed.error.message === "string"
+            ? parsed.error.message
+            : undefined,
       };
     }
   } catch {
@@ -3446,15 +4894,23 @@ export function parseClaudeErrorBody(errBody: string): ParsedClaudeError {
 /**
  * Detect malformed request errors that should not trigger account/provider failover.
  */
-export function isInvalidRequestError(status: number, errBody: string): boolean {
+export function isInvalidRequestError(
+  status: number,
+  errBody: string,
+): boolean {
   if (status === 422) {
     return true;
   }
   const parsed = parseClaudeErrorBody(errBody);
-  return parsed.errorType === "invalid_request_error" || errBody.includes("invalid_request_error");
+  return (
+    parsed.errorType === "invalid_request_error" ||
+    errBody.includes("invalid_request_error")
+  );
 }
 
-function normalizeClaudeRequestForAnthropic(body: ClaudeRequest): ClaudeRequest {
+function normalizeClaudeRequestForAnthropic(
+  body: ClaudeRequest,
+): ClaudeRequest {
   return {
     ...body,
     messages: body.messages.map((msg) => {
@@ -3479,6 +4935,15 @@ export function buildProxyFallbackOptions(
 ): Record<string, unknown> {
   const historyMessages = parsed.conversationMessages.slice(0, -1);
   const toolNames = Object.keys(parsed.tools);
+  const images = shouldOmitImagesForTarget(overrides.provider, overrides.model)
+    ? []
+    : parsed.images;
+  const thinkingConfig = shouldOmitThinkingConfigForTarget(
+    overrides.provider,
+    overrides.model,
+  )
+    ? undefined
+    : parsed.thinkingConfig;
   const toolChoice = parsed.toolChoiceName
     ? { type: "tool" as const, toolName: parsed.toolChoiceName }
     : parsed.toolChoice;
@@ -3486,17 +4951,21 @@ export function buildProxyFallbackOptions(
   return {
     input: {
       text: parsed.prompt,
-      ...(parsed.images.length > 0 ? { images: parsed.images } : {}),
+      ...(images.length > 0 ? { images } : {}),
     },
     ...(overrides.provider ? { provider: overrides.provider } : {}),
     ...(overrides.model ? { model: overrides.model } : {}),
     systemPrompt: parsed.systemPrompt,
     maxTokens: parsed.maxTokens,
-    ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
+    ...(parsed.temperature !== undefined
+      ? { temperature: parsed.temperature }
+      : {}),
     ...(parsed.topP !== undefined ? { topP: parsed.topP } : {}),
     ...(parsed.topK !== undefined ? { topK: parsed.topK } : {}),
-    ...(parsed.stopSequences?.length ? { stopSequences: parsed.stopSequences } : {}),
-    ...(parsed.thinkingConfig ? { thinkingConfig: parsed.thinkingConfig } : {}),
+    ...(parsed.stopSequences?.length
+      ? { stopSequences: parsed.stopSequences }
+      : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
     ...(toolNames.length === 0 ? { disableTools: true } : {}),
     // Claude-compatible requests already declare the exact tool contract.
     // Filter out NeuroLink's built-in agent tools so translated fallbacks only
@@ -3508,16 +4977,19 @@ export function buildProxyFallbackOptions(
         }
       : {}),
     ...(toolChoice ? { toolChoice } : {}),
-    ...(historyMessages.length > 0 ? { conversationMessages: historyMessages } : {}),
+    ...(historyMessages.length > 0
+      ? { conversationMessages: historyMessages }
+      : {}),
     disableInternalFallback: true,
     skipToolPromptInjection: true,
     maxSteps: 1,
   };
 }
 
-function buildProxyTranslationAttempts(
+export function buildProxyTranslationAttempts(
   primary: { provider: string; model?: string },
   modelRouter?: ModelRouter,
+  parsed?: Pick<ParsedClaudeRequest, "images" | "thinkingConfig">,
 ): ProxyTranslationAttempt[] {
   const attempts: ProxyTranslationAttempt[] = [
     {
@@ -3529,7 +5001,15 @@ function buildProxyTranslationAttempts(
 
   const chain = modelRouter?.getFallbackChain() ?? [];
   for (const fallback of chain) {
-    if (fallback.provider === primary.provider && fallback.model === primary.model) {
+    if (
+      fallback.provider === primary.provider &&
+      fallback.model === primary.model
+    ) {
+      continue;
+    }
+    if (
+      shouldSkipTranslationTarget(fallback.provider, fallback.model, parsed)
+    ) {
       continue;
     }
 
@@ -3547,8 +5027,42 @@ function buildProxyTranslationAttempts(
   return attempts;
 }
 
-function hasTranslatedOutput(collectedText: string, toolCalls: unknown[] | undefined): boolean {
+function hasTranslatedOutput(
+  collectedText: string,
+  toolCalls: unknown[] | undefined,
+): boolean {
   return collectedText.trim().length > 0 || (toolCalls?.length ?? 0) > 0;
+}
+
+function shouldOmitImagesForTarget(provider?: string, model?: string): boolean {
+  // `open-large` in our LiteLLM setup handles text and tools, but returns an
+  // empty completion when binary images are forwarded. Claude Code already
+  // includes textual image markers in the prompt, so dropping only the binary
+  // image payload keeps the request usable instead of breaking fallback.
+  return provider === "litellm" && model === "open-large";
+}
+
+function shouldOmitThinkingConfigForTarget(
+  provider?: string,
+  model?: string,
+): boolean {
+  return provider === "vertex" && model === "gemini-2.5-flash";
+}
+
+function shouldSkipTranslationTarget(
+  provider?: string,
+  model?: string,
+  parsed?: Pick<ParsedClaudeRequest, "images" | "thinkingConfig">,
+): boolean {
+  if (
+    provider === "ollama" &&
+    model === "qwen2.5:0.5b" &&
+    (parsed?.images.length ?? 0) > 0
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function extractToolArgs(toolCall: unknown): unknown {
@@ -3566,7 +5080,10 @@ function extractToolArgs(toolCall: unknown): unknown {
  * Includes Cloudflare 52x statuses and Anthropic 400/api_error wrappers that
  * carry transient HTML responses (e.g. 520 pages) inside `error.message`.
  */
-export function isTransientHttpFailure(status: number, errBody: string): boolean {
+export function isTransientHttpFailure(
+  status: number,
+  errBody: string,
+): boolean {
   if (TRANSIENT_HTTP_STATUSES.has(status)) {
     return true;
   }

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -42,6 +42,92 @@ import { logger } from "../../../../utils/logger.js";
 
 const LOG_PREFIX = "[OpenTelemetry]";
 
+function createOtelResource(config: LangfuseConfig, serviceName: string) {
+  return resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_VERSION]: config.release || "v1.0.0",
+    "deployment.environment": config.environment || "dev",
+  });
+}
+
+function initializeOtlpMetricsAndLogs(
+  resource: ReturnType<typeof resourceFromAttributes>,
+  otlpEndpoint: string | undefined,
+  serviceName: string,
+): void {
+  if (!otlpEndpoint) {
+    return;
+  }
+
+  try {
+    const metricExporter = new OTLPMetricExporter({
+      url: `${otlpEndpoint}/v1/metrics`,
+    });
+    const metricReader = new PeriodicExportingMetricReader({
+      exporter: metricExporter,
+      exportIntervalMillis: 15000,
+      exportTimeoutMillis: 10000,
+    });
+    meterProvider = new MeterProvider({
+      resource,
+      readers: [metricReader],
+    });
+    metrics.setGlobalMeterProvider(meterProvider);
+    logger.info(
+      `${LOG_PREFIX} OTLP metric exporter added — MeterProvider registered globally`,
+      {
+        endpoint: `${otlpEndpoint}/v1/metrics`,
+        exportIntervalMs: 15000,
+        serviceName,
+        meterProviderType: meterProvider.constructor.name,
+      },
+    );
+  } catch (metricsError) {
+    logger.warn(
+      `${LOG_PREFIX} Failed to create OTLP metric exporter (non-fatal)`,
+      {
+        error:
+          metricsError instanceof Error
+            ? metricsError.message
+            : String(metricsError),
+        endpoint: otlpEndpoint,
+      },
+    );
+  }
+
+  try {
+    const logExporter = new OTLPLogExporter({
+      url: `${otlpEndpoint}/v1/logs`,
+    });
+    const logProcessor = new BatchLogRecordProcessor(logExporter, {
+      maxQueueSize: 2048,
+      maxExportBatchSize: 512,
+      scheduledDelayMillis: 2000,
+      exportTimeoutMillis: 30000,
+    });
+    loggerProvider = new LoggerProvider({
+      resource,
+      processors: [logProcessor],
+    });
+    logger.info(
+      `${LOG_PREFIX} OTLP log exporter added — LoggerProvider created`,
+      {
+        endpoint: `${otlpEndpoint}/v1/logs`,
+        serviceName,
+      },
+    );
+  } catch (logsError) {
+    logger.warn(
+      `${LOG_PREFIX} Failed to create OTLP log exporter (non-fatal)`,
+      {
+        error:
+          logsError instanceof Error ? logsError.message : String(logsError),
+        endpoint: otlpEndpoint,
+      },
+    );
+  }
+}
+
 /**
  * Extended context for Langfuse spans
  * Supports all Langfuse trace attributes for rich observability
@@ -516,6 +602,264 @@ class ContextEnricher implements SpanProcessor {
   }
 }
 
+function createLangfuseProcessor(
+  config: LangfuseConfig,
+): LangfuseSpanProcessor {
+  return new LangfuseSpanProcessor({
+    publicKey: config.publicKey,
+    secretKey: config.secretKey,
+    baseUrl: config.baseUrl || "https://cloud.langfuse.com",
+    environment: config.environment || "dev",
+    release: config.release || "v1.0.0",
+    shouldExportSpan: () => true,
+  });
+}
+
+function initializeExternalOpenTelemetryMode(
+  config: LangfuseConfig,
+  resource: ReturnType<typeof resourceFromAttributes>,
+  otlpEndpoint: string | undefined,
+  serviceName: string,
+  langfuseRequested: boolean,
+  hasLangfuseCreds: boolean,
+): void {
+  if (langfuseRequested && !hasLangfuseCreds) {
+    if (!otlpEndpoint) {
+      logger.warn(
+        `${LOG_PREFIX} External provider mode requested Langfuse but credentials are missing, and no OTLP endpoint is configured; skipping initialization`,
+        {
+          hasPublicKey: !!config?.publicKey,
+          hasSecretKey: !!config?.secretKey,
+        },
+      );
+      isInitialized = true;
+      isCredentialsValid = false;
+      return;
+    }
+
+    logger.warn(
+      `${LOG_PREFIX} External provider mode missing Langfuse credentials; continuing with OTLP-only metrics/logs`,
+      {
+        hasPublicKey: !!config?.publicKey,
+        hasSecretKey: !!config?.secretKey,
+        otlpEnabled: true,
+      },
+    );
+  }
+
+  try {
+    currentConfig = config;
+    isCredentialsValid = hasLangfuseCreds;
+    langfuseProcessor =
+      langfuseRequested && hasLangfuseCreds
+        ? createLangfuseProcessor(config)
+        : null;
+
+    usingExternalProvider = true;
+    isInitialized = true;
+    initializeOtlpMetricsAndLogs(resource, otlpEndpoint, serviceName);
+
+    try {
+      const globalProvider = trace.getTracerProvider();
+      const provider = globalProvider as unknown as {
+        addSpanProcessor?: (processor: SpanProcessor) => void;
+      };
+
+      if (globalProvider && typeof provider.addSpanProcessor === "function") {
+        provider.addSpanProcessor(new ContextEnricher());
+
+        const skipLangfuse =
+          config.skipLangfuseSpanProcessor === true || !langfuseProcessor;
+        if (!skipLangfuse && langfuseProcessor) {
+          provider.addSpanProcessor(langfuseProcessor);
+        }
+
+        logger.info(
+          `${LOG_PREFIX} Auto-registered processors with global TracerProvider`,
+          {
+            processors: skipLangfuse
+              ? ["ContextEnricher"]
+              : ["ContextEnricher", "LangfuseSpanProcessor"],
+            reason: "External provider mode with auto-registration",
+            skippedLangfuseSpanProcessor: skipLangfuse,
+          },
+        );
+        return;
+      }
+
+      logger.info(`${LOG_PREFIX} Using external TracerProvider mode`, {
+        reason: config.useExternalTracerProvider
+          ? "useExternalTracerProvider=true"
+          : "autoDetectExternalProvider=true (trusting host signal)",
+        instructions:
+          "Add span processors to your TracerProvider using getSpanProcessors()",
+      });
+      logger.info(`${LOG_PREFIX} Span processors ready for external use`, {
+        processors: langfuseProcessor
+          ? ["ContextEnricher", "LangfuseSpanProcessor"]
+          : ["ContextEnricher"],
+        usage: "import { getSpanProcessors } from '@juspay/neurolink'",
+      });
+    } catch (autoRegisterError) {
+      logger.warn(
+        `${LOG_PREFIX} Auto-registration failed, manual registration required`,
+        {
+          error:
+            autoRegisterError instanceof Error
+              ? autoRegisterError.message
+              : String(autoRegisterError),
+          instructions:
+            "Add span processors to your TracerProvider using getSpanProcessors()",
+        },
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `${LOG_PREFIX} Failed to create span processor for external mode`,
+      {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    );
+    isInitialized = true;
+  }
+}
+
+function initializeStandaloneOpenTelemetryMode(
+  config: LangfuseConfig,
+  resource: ReturnType<typeof resourceFromAttributes>,
+  otlpEndpoint: string | undefined,
+  serviceName: string,
+  langfuseRequested: boolean,
+  hasLangfuseCreds: boolean,
+): void {
+  if ((!langfuseRequested || !hasLangfuseCreds) && !otlpEndpoint) {
+    if (langfuseRequested && !hasLangfuseCreds) {
+      logger.warn(
+        `${LOG_PREFIX} Langfuse requested but credentials are missing, and no OTLP endpoint is configured; skipping initialization`,
+        {
+          hasPublicKey: !!config.publicKey,
+          hasSecretKey: !!config.secretKey,
+        },
+      );
+    } else {
+      logger.debug(
+        `${LOG_PREFIX} Langfuse disabled and OTLP endpoint missing, skipping initialization`,
+      );
+    }
+    isInitialized = true;
+    return;
+  }
+
+  if (langfuseRequested && !hasLangfuseCreds) {
+    logger.warn(
+      `${LOG_PREFIX} Langfuse requested but credentials are missing; continuing with OTLP-only telemetry`,
+      {
+        hasPublicKey: !!config.publicKey,
+        hasSecretKey: !!config.secretKey,
+        otlpEnabled: !!otlpEndpoint,
+      },
+    );
+  }
+
+  try {
+    currentConfig = config;
+    isCredentialsValid = hasLangfuseCreds;
+    langfuseProcessor =
+      langfuseRequested && hasLangfuseCreds
+        ? createLangfuseProcessor(config)
+        : null;
+
+    logger.debug(`${LOG_PREFIX} Standalone observability mode`, {
+      langfuseEnabled: !!langfuseProcessor,
+      otlpEnabled: !!otlpEndpoint,
+      baseUrl: config.baseUrl || "https://cloud.langfuse.com",
+      environment: config.environment || "dev",
+    });
+
+    const spanProcessors: SpanProcessor[] = [new ContextEnricher()];
+    if (langfuseProcessor) {
+      spanProcessors.push(langfuseProcessor);
+    }
+
+    if (otlpEndpoint) {
+      try {
+        const otlpExporter = new OTLPTraceExporter({
+          url: `${otlpEndpoint}/v1/traces`,
+        });
+        spanProcessors.push(
+          new BatchSpanProcessor(otlpExporter, {
+            maxQueueSize: 2048,
+            maxExportBatchSize: 512,
+            scheduledDelayMillis: 1000,
+            exportTimeoutMillis: 30000,
+          }),
+        );
+        logger.info(`${LOG_PREFIX} OTLP trace exporter added`, {
+          endpoint: `${otlpEndpoint}/v1/traces`,
+          serviceName,
+        });
+      } catch (otlpError) {
+        logger.warn(
+          `${LOG_PREFIX} Failed to create OTLP exporter (non-fatal)`,
+          {
+            error:
+              otlpError instanceof Error
+                ? otlpError.message
+                : String(otlpError),
+            endpoint: otlpEndpoint,
+          },
+        );
+      }
+    }
+
+    tracerProvider = new NodeTracerProvider({ resource, spanProcessors });
+    tracerProvider.register({
+      propagator: new W3CTraceContextPropagator(),
+    });
+    usingExternalProvider = false;
+    isInitialized = true;
+    initializeOtlpMetricsAndLogs(resource, otlpEndpoint, serviceName);
+
+    logger.info(`${LOG_PREFIX} Observability initialized`, {
+      baseUrl: config.baseUrl || "https://cloud.langfuse.com",
+      environment: config.environment || "dev",
+      release: config.release || "v1.0.0",
+      mode: "standalone",
+      langfuseEnabled: !!langfuseProcessor,
+      otlpEnabled: !!otlpEndpoint,
+      serviceName,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const isDuplicateError =
+      errorMessage.includes("duplicate registration") ||
+      errorMessage.includes("already registered") ||
+      errorMessage.includes("already set");
+
+    if (isDuplicateError) {
+      logger.warn(
+        `${LOG_PREFIX} TracerProvider already registered, switching to external mode`,
+        {
+          error: errorMessage,
+          recommendation:
+            "Set useExternalTracerProvider=true or autoDetectExternalProvider=true in config",
+        },
+      );
+
+      usingExternalProvider = true;
+      isInitialized = true;
+      return;
+    }
+
+    logger.error(`${LOG_PREFIX} Initialization failed`, {
+      error: errorMessage,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    throw error;
+  }
+}
+
 /**
  * Initialize OpenTelemetry with Langfuse span processor
  *
@@ -556,362 +900,32 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
   const shouldUseExternal =
     config?.useExternalTracerProvider === true ||
     config?.autoDetectExternalProvider === true;
-
-  if (shouldUseExternal) {
-    // Validate credentials even in external mode
-    if (!config?.publicKey || !config?.secretKey) {
-      logger.warn(
-        `${LOG_PREFIX} External provider mode but missing credentials, skipping initialization`,
-        {
-          hasPublicKey: !!config?.publicKey,
-          hasSecretKey: !!config?.secretKey,
-        },
-      );
-      isInitialized = true;
-      isCredentialsValid = false;
-      return;
-    }
-
-    try {
-      currentConfig = config;
-      isCredentialsValid = true;
-
-      // Create span processor for external provider mode
-      // shouldExportSpan: export all spans (v5 default filters to gen_ai spans only)
-      langfuseProcessor = new LangfuseSpanProcessor({
-        publicKey: config.publicKey,
-        secretKey: config.secretKey,
-        baseUrl: config.baseUrl || "https://cloud.langfuse.com",
-        environment: config.environment || "dev",
-        release: config.release || "v1.0.0",
-        shouldExportSpan: () => true,
-      });
-
-      usingExternalProvider = true;
-      isInitialized = true;
-
-      // Auto-register ContextEnricher with the global TracerProvider
-      // This ensures trace names are set even when host doesn't call getSpanProcessors()
-      try {
-        const globalProvider = trace.getTracerProvider();
-
-        // Check if it's a real provider with addSpanProcessor method (not the no-op default)
-        if (
-          globalProvider &&
-          typeof (globalProvider as unknown as { addSpanProcessor?: unknown })
-            .addSpanProcessor === "function"
-        ) {
-          const provider = globalProvider as unknown as {
-            addSpanProcessor: (processor: SpanProcessor) => void;
-          };
-
-          // Add ContextEnricher for trace name enrichment
-          provider.addSpanProcessor(new ContextEnricher());
-
-          // Only add LangfuseSpanProcessor if the host has not already registered one.
-          // When skipLangfuseSpanProcessor is true, the host (e.g. Curator) already
-          // registers its own LangfuseSpanProcessor via a DeferredSpanProcessor, so
-          // adding another one here would cause duplicate trace exports to Langfuse.
-          const skipLangfuse = config.skipLangfuseSpanProcessor === true;
-          if (!skipLangfuse) {
-            provider.addSpanProcessor(langfuseProcessor);
-          }
-
-          logger.info(
-            `${LOG_PREFIX} Auto-registered processors with global TracerProvider`,
-            {
-              processors: skipLangfuse
-                ? ["ContextEnricher"]
-                : ["ContextEnricher", "LangfuseSpanProcessor"],
-              reason: "External provider mode with auto-registration",
-              skippedLangfuseSpanProcessor: skipLangfuse,
-            },
-          );
-        } else {
-          // No real provider found - host will need to add processors manually
-          logger.info(`${LOG_PREFIX} Using external TracerProvider mode`, {
-            reason: config.useExternalTracerProvider
-              ? "useExternalTracerProvider=true"
-              : "autoDetectExternalProvider=true (trusting host signal)",
-            instructions:
-              "Add span processors to your TracerProvider using getSpanProcessors()",
-          });
-
-          logger.info(`${LOG_PREFIX} Span processors ready for external use`, {
-            processors: ["ContextEnricher", "LangfuseSpanProcessor"],
-            usage: "import { getSpanProcessors } from '@juspay/neurolink'",
-          });
-        }
-      } catch (autoRegisterError) {
-        // Auto-registration failed - fall back to manual registration
-        logger.warn(
-          `${LOG_PREFIX} Auto-registration failed, manual registration required`,
-          {
-            error:
-              autoRegisterError instanceof Error
-                ? autoRegisterError.message
-                : String(autoRegisterError),
-            instructions:
-              "Add span processors to your TracerProvider using getSpanProcessors()",
-          },
-        );
-      }
-
-      return;
-    } catch (error) {
-      logger.error(
-        `${LOG_PREFIX} Failed to create span processor for external mode`,
-        {
-          error: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-        },
-      );
-      isInitialized = true;
-      return;
-    }
-  }
-
   const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   const langfuseRequested = config?.enabled === true;
   const hasLangfuseCreds = !!config.publicKey && !!config.secretKey;
+  const serviceName = process.env.OTEL_SERVICE_NAME || "neurolink";
+  const resource = createOtelResource(config, serviceName);
 
-  // THEN: Check whether we have any standalone observability backend at all.
-  if ((!langfuseRequested || !hasLangfuseCreds) && !otlpEndpoint) {
-    if (langfuseRequested && !hasLangfuseCreds) {
-      logger.warn(
-        `${LOG_PREFIX} Langfuse requested but credentials are missing, and no OTLP endpoint is configured; skipping initialization`,
-        {
-          hasPublicKey: !!config.publicKey,
-          hasSecretKey: !!config.secretKey,
-        },
-      );
-    } else {
-      logger.debug(
-        `${LOG_PREFIX} Langfuse disabled and OTLP endpoint missing, skipping initialization`,
-      );
-    }
-    isInitialized = true;
+  if (shouldUseExternal) {
+    initializeExternalOpenTelemetryMode(
+      config,
+      resource,
+      otlpEndpoint,
+      serviceName,
+      langfuseRequested,
+      hasLangfuseCreds,
+    );
     return;
   }
 
-  if (langfuseRequested && !hasLangfuseCreds) {
-    logger.warn(
-      `${LOG_PREFIX} Langfuse requested but credentials are missing; continuing with OTLP-only telemetry`,
-      {
-        hasPublicKey: !!config.publicKey,
-        hasSecretKey: !!config.secretKey,
-        otlpEnabled: !!otlpEndpoint,
-      },
-    );
-  }
-
-  try {
-    currentConfig = config;
-    isCredentialsValid = hasLangfuseCreds;
-
-    // Step 1: Create LangfuseSpanProcessor only when Langfuse is explicitly enabled
-    // with real credentials. OTLP-only mode is valid and should not construct one.
-    if (langfuseRequested && hasLangfuseCreds) {
-      // shouldExportSpan: export all spans (v5 default filters to gen_ai spans only)
-      langfuseProcessor = new LangfuseSpanProcessor({
-        publicKey: config.publicKey,
-        secretKey: config.secretKey,
-        baseUrl: config.baseUrl || "https://cloud.langfuse.com",
-        environment: config.environment || "dev",
-        release: config.release || "v1.0.0",
-        shouldExportSpan: () => true,
-      });
-    } else {
-      langfuseProcessor = null;
-    }
-
-    logger.debug(`${LOG_PREFIX} Standalone observability mode`, {
-      langfuseEnabled: !!langfuseProcessor,
-      otlpEnabled: !!otlpEndpoint,
-      baseUrl: config.baseUrl || "https://cloud.langfuse.com",
-      environment: config.environment || "dev",
-    });
-
-    // Step 2: Create our own TracerProvider (standalone behavior)
-    // Use OTEL_SERVICE_NAME env var if available, otherwise "neurolink"
-    const serviceName = process.env.OTEL_SERVICE_NAME || "neurolink";
-    const resource = resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: serviceName,
-      [ATTR_SERVICE_VERSION]: config.release || "v1.0.0",
-      "deployment.environment": config.environment || "dev",
-    });
-
-    // Build span processor list
-    const spanProcessors: SpanProcessor[] = [new ContextEnricher()];
-    if (langfuseProcessor) {
-      spanProcessors.push(langfuseProcessor);
-    }
-
-    // Step 2b: If OTEL_EXPORTER_OTLP_ENDPOINT is set, also export via OTLP HTTP
-    // This allows sending traces to an OpenTelemetry Collector (e.g. for OpenObserve)
-    if (otlpEndpoint) {
-      try {
-        const otlpExporter = new OTLPTraceExporter({
-          url: `${otlpEndpoint}/v1/traces`,
-        });
-        const otlpBatchProcessor = new BatchSpanProcessor(otlpExporter, {
-          maxQueueSize: 2048,
-          maxExportBatchSize: 512,
-          scheduledDelayMillis: 1000,
-          exportTimeoutMillis: 30000,
-        });
-        spanProcessors.push(otlpBatchProcessor);
-        logger.info(`${LOG_PREFIX} OTLP trace exporter added`, {
-          endpoint: `${otlpEndpoint}/v1/traces`,
-          serviceName,
-        });
-      } catch (otlpError) {
-        logger.warn(
-          `${LOG_PREFIX} Failed to create OTLP exporter (non-fatal)`,
-          {
-            error:
-              otlpError instanceof Error
-                ? otlpError.message
-                : String(otlpError),
-            endpoint: otlpEndpoint,
-          },
-        );
-      }
-    }
-
-    tracerProvider = new NodeTracerProvider({
-      resource,
-      spanProcessors,
-    });
-
-    // Step 4: Register globally with explicit W3C propagator
-    // This ensures traceparent headers from calling SDKs are extracted correctly,
-    // even if another library registers a no-op propagator before us.
-    tracerProvider.register({
-      propagator: new W3CTraceContextPropagator(),
-    });
-    usingExternalProvider = false;
-    isInitialized = true;
-
-    // Step 5: If OTLP endpoint is set, also set up MeterProvider for metrics export
-    // This enables TelemetryService's metrics.getMeter() instruments to export via OTLP
-    if (otlpEndpoint) {
-      try {
-        const metricExporter = new OTLPMetricExporter({
-          url: `${otlpEndpoint}/v1/metrics`,
-        });
-        const metricReader = new PeriodicExportingMetricReader({
-          exporter: metricExporter,
-          exportIntervalMillis: 15000, // Export every 15 seconds
-          exportTimeoutMillis: 10000,
-        });
-        meterProvider = new MeterProvider({
-          resource,
-          readers: [metricReader],
-        });
-        // Register globally so TelemetryService's metrics.getMeter() picks it up
-        metrics.setGlobalMeterProvider(meterProvider);
-        logger.info(
-          `${LOG_PREFIX} OTLP metric exporter added — MeterProvider registered globally`,
-          {
-            endpoint: `${otlpEndpoint}/v1/metrics`,
-            exportIntervalMs: 15000,
-            serviceName,
-            meterProviderType: meterProvider.constructor.name,
-          },
-        );
-      } catch (metricsError) {
-        logger.warn(
-          `${LOG_PREFIX} Failed to create OTLP metric exporter (non-fatal)`,
-          {
-            error:
-              metricsError instanceof Error
-                ? metricsError.message
-                : String(metricsError),
-            endpoint: otlpEndpoint,
-          },
-        );
-      }
-
-      // Step 6: Set up LoggerProvider for OTLP log export
-      // This enables logRequest() to emit structured log records via OTLP
-      try {
-        const logExporter = new OTLPLogExporter({
-          url: `${otlpEndpoint}/v1/logs`,
-        });
-        const logProcessor = new BatchLogRecordProcessor(logExporter, {
-          maxQueueSize: 2048,
-          maxExportBatchSize: 512,
-          scheduledDelayMillis: 2000,
-          exportTimeoutMillis: 30000,
-        });
-        loggerProvider = new LoggerProvider({
-          resource,
-          processors: [logProcessor],
-        });
-        logger.info(
-          `${LOG_PREFIX} OTLP log exporter added — LoggerProvider created`,
-          {
-            endpoint: `${otlpEndpoint}/v1/logs`,
-            serviceName,
-          },
-        );
-      } catch (logsError) {
-        logger.warn(
-          `${LOG_PREFIX} Failed to create OTLP log exporter (non-fatal)`,
-          {
-            error:
-              logsError instanceof Error
-                ? logsError.message
-                : String(logsError),
-            endpoint: otlpEndpoint,
-          },
-        );
-      }
-    }
-
-    logger.info(`${LOG_PREFIX} Observability initialized`, {
-      baseUrl: config.baseUrl || "https://cloud.langfuse.com",
-      environment: config.environment || "dev",
-      release: config.release || "v1.0.0",
-      mode: "standalone",
-      langfuseEnabled: !!langfuseProcessor,
-      otlpEnabled: !!otlpEndpoint,
-      serviceName,
-    });
-  } catch (error) {
-    // Check if this is a duplicate registration error
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const isDuplicateError =
-      errorMessage.includes("duplicate registration") ||
-      errorMessage.includes("already registered") ||
-      errorMessage.includes("already set");
-
-    if (isDuplicateError) {
-      // Graceful handling: switch to external mode
-      logger.warn(
-        `${LOG_PREFIX} TracerProvider already registered, switching to external mode`,
-        {
-          error: errorMessage,
-          recommendation:
-            "Set useExternalTracerProvider=true or autoDetectExternalProvider=true in config",
-        },
-      );
-
-      usingExternalProvider = true;
-      isInitialized = true;
-
-      // Don't throw - processors are still usable
-      return;
-    }
-
-    // Other errors: log and re-throw
-    logger.error(`${LOG_PREFIX} Initialization failed`, {
-      error: errorMessage,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-    throw error;
-  }
+  initializeStandaloneOpenTelemetryMode(
+    config,
+    resource,
+    otlpEndpoint,
+    serviceName,
+    langfuseRequested,
+    hasLangfuseCreds,
+  );
 }
 
 /**

--- a/src/lib/tasks/backends/bullmqBackend.ts
+++ b/src/lib/tasks/backends/bullmqBackend.ts
@@ -90,37 +90,42 @@ export class BullMQBackend implements TaskBackend {
     const queue = this.getQueue();
     this.executors.set(task.id, executor);
 
-    const jobData = { taskId: task.id, task };
-    const schedule = task.schedule;
+    try {
+      const jobData = { taskId: task.id, task };
+      const schedule = task.schedule;
 
-    if (schedule.type === "cron") {
-      await queue.upsertJobScheduler(
-        task.id,
-        {
-          pattern: schedule.expression,
-          ...(schedule.timezone ? { tz: schedule.timezone } : {}),
-        },
-        { name: task.name, data: jobData },
-      );
-    } else if (schedule.type === "interval") {
-      await queue.upsertJobScheduler(
-        task.id,
-        { every: schedule.every },
-        { name: task.name, data: jobData },
-      );
-    } else if (schedule.type === "once") {
-      const at =
-        typeof schedule.at === "string" ? new Date(schedule.at) : schedule.at;
-      const delay = Math.max(0, at.getTime() - Date.now());
-      await queue.add(task.name, jobData, {
-        jobId: task.id,
-        delay,
-      });
+      if (schedule.type === "cron") {
+        await queue.upsertJobScheduler(
+          task.id,
+          {
+            pattern: schedule.expression,
+            ...(schedule.timezone ? { tz: schedule.timezone } : {}),
+          },
+          { name: task.name, data: jobData },
+        );
+      } else if (schedule.type === "interval") {
+        await queue.upsertJobScheduler(
+          task.id,
+          { every: schedule.every },
+          { name: task.name, data: jobData },
+        );
+      } else if (schedule.type === "once") {
+        const at =
+          typeof schedule.at === "string" ? new Date(schedule.at) : schedule.at;
+        const delay = Math.max(0, at.getTime() - Date.now());
+        await queue.add(task.name, jobData, {
+          jobId: task.id,
+          delay,
+        });
+      }
+    } catch (error) {
+      this.executors.delete(task.id);
+      throw error;
     }
 
     logger.info("[BullMQ] Task scheduled", {
       taskId: task.id,
-      type: schedule.type,
+      type: task.schedule.type,
     });
   }
 

--- a/src/lib/tasks/store/redisTaskStore.ts
+++ b/src/lib/tasks/store/redisTaskStore.ts
@@ -84,7 +84,7 @@ export class RedisTaskStore implements TaskStore {
   async save(task: Task): Promise<void> {
     const client = this.getClient();
     await client.hSet(TASKS_HASH, task.id, JSON.stringify(task));
-    this.applyRetentionTTL(task);
+    this.applyRetentionTTL(task, client);
   }
 
   async get(taskId: string): Promise<Task | null> {
@@ -126,7 +126,7 @@ export class RedisTaskStore implements TaskStore {
     };
 
     await client.hSet(TASKS_HASH, taskId, JSON.stringify(updated));
-    this.applyRetentionTTL(updated);
+    this.applyRetentionTTL(updated, client);
     return updated;
   }
 
@@ -227,7 +227,7 @@ export class RedisTaskStore implements TaskStore {
    * Set Redis TTL on terminal-state tasks so they auto-expire.
    * Active and paused tasks never expire.
    */
-  private applyRetentionTTL(task: Task): void {
+  private applyRetentionTTL(task: Task, client: RedisClient): void {
     // We don't set EXPIRE on the hash field directly (Redis doesn't support per-field TTL).
     // Instead, run logs and history keys get TTL. The task hash field itself must be
     // cleaned up via manual deletion or BullMQ's built-in job cleanup.
@@ -238,20 +238,34 @@ export class RedisTaskStore implements TaskStore {
     };
 
     const ttlMs = ttlMap[task.status];
-    if (ttlMs) {
-      const client = this.getClient();
-      const ttlSeconds = Math.ceil(ttlMs / 1000);
-      // Set TTL on associated keys
-      client.expire(taskRunsKey(task.id), ttlSeconds).catch((err) => {
-        logger.debug("[TaskStore:Redis] Failed to set TTL", {
-          error: String(err),
-        });
-      });
-      client.expire(taskHistoryKey(task.id), ttlSeconds).catch((err) => {
-        logger.debug("[TaskStore:Redis] Failed to set TTL", {
-          error: String(err),
-        });
-      });
+    if (!ttlMs || !client.isOpen) {
+      return;
     }
+
+    const ttlSeconds = Math.ceil(ttlMs / 1000);
+    // Set TTL on associated keys best-effort. A successful task write should not
+    // be surfaced as a failure just because the retention metadata could not be updated.
+    client.expire(taskRunsKey(task.id), ttlSeconds).catch((err) => {
+      logger.warn(
+        "[TaskStore:Redis] Failed to set TTL on task runs key — task data may outlive retention window",
+        {
+          taskId: task.id,
+          key: taskRunsKey(task.id),
+          ttlSeconds,
+          error: String(err),
+        },
+      );
+    });
+    client.expire(taskHistoryKey(task.id), ttlSeconds).catch((err) => {
+      logger.warn(
+        "[TaskStore:Redis] Failed to set TTL on task history key — task data may outlive retention window",
+        {
+          taskId: task.id,
+          key: taskHistoryKey(task.id),
+          ttlSeconds,
+          error: String(err),
+        },
+      );
+    });
   }
 }

--- a/src/lib/tasks/taskManager.ts
+++ b/src/lib/tasks/taskManager.ts
@@ -225,7 +225,32 @@ export class TaskManager {
     try {
       await backend.schedule(task, (t) => this.onTaskTick(t));
     } catch (err) {
-      await store.delete(task.id);
+      this.callbacks.delete(task.id);
+      try {
+        await store.delete(task.id);
+      } catch (cleanupError) {
+        // Deletion failed — task remains persisted as active. Attempt to mark it
+        // failed so it reaches a terminal state and operators can identify it.
+        logger.error(
+          "[TaskManager] Failed to clean up task after schedule error — task may remain persisted as active",
+          {
+            taskId: task.id,
+            scheduleError: String(err),
+            cleanupError: String(cleanupError),
+          },
+        );
+        try {
+          await store.update(task.id, { status: "failed" as TaskStatus });
+        } catch (terminalError) {
+          logger.error(
+            "[TaskManager] Failed to force task to terminal state — manual cleanup required",
+            {
+              taskId: task.id,
+              error: String(terminalError),
+            },
+          );
+        }
+      }
       throw err;
     }
 
@@ -288,13 +313,15 @@ export class TaskManager {
       }
     }
 
+    const shouldClearHistory =
+      updates.mode !== undefined && updates.mode !== "continuation";
+
     // Special-case: mode changes require sessionId handling
     if (updates.mode !== undefined) {
       if (updates.mode === "continuation" && !existing.sessionId) {
         taskUpdates.sessionId = `session_${nanoid(12)}`;
       } else if (updates.mode !== "continuation") {
         taskUpdates.sessionId = undefined;
-        await store.clearHistory(taskId);
       }
     }
 
@@ -302,8 +329,40 @@ export class TaskManager {
 
     // Re-schedule if schedule changed and task is active
     if (updates.schedule && updated.status === "active") {
+      const attemptedSchedule = updated.schedule;
       await backend.cancel(taskId);
-      await backend.schedule(updated, (t) => this.onTaskTick(t));
+      try {
+        await backend.schedule(updated, (t) => this.onTaskTick(t));
+      } catch (error) {
+        await this.restoreScheduledTask(existing, "update schedule rollback");
+        await this.rollbackTaskUpdate(taskId, existing, error);
+        throw TaskError.create(
+          "SCHEDULE_FAILED",
+          `Failed to update schedule for task ${taskId}`,
+          {
+            cause: error instanceof Error ? error : undefined,
+            details: {
+              taskId,
+              previousSchedule: existing.schedule,
+              attemptedSchedule,
+            },
+          },
+        );
+      }
+    }
+
+    if (shouldClearHistory) {
+      try {
+        await store.clearHistory(taskId);
+      } catch (error) {
+        logger.warn(
+          "[TaskManager] Failed to clear task history after mode update",
+          {
+            taskId,
+            error: String(error),
+          },
+        );
+      }
     }
 
     return updated;
@@ -338,7 +397,14 @@ export class TaskManager {
     }
 
     await backend.pause(taskId);
-    const updated = await store.update(taskId, { status: "paused" });
+
+    let updated: Task;
+    try {
+      updated = await store.update(taskId, { status: "paused" });
+    } catch (error) {
+      await this.restoreScheduledTask(task, "pause rollback");
+      throw error;
+    }
 
     this.emit("task:paused", updated);
     return updated;
@@ -361,7 +427,20 @@ export class TaskManager {
     }
 
     const updated = await store.update(taskId, { status: "active" });
-    await backend.schedule(updated, (t) => this.onTaskTick(t));
+
+    try {
+      await backend.schedule(updated, (t) => this.onTaskTick(t));
+    } catch (error) {
+      await this.rollbackTaskUpdate(taskId, task, error);
+      throw TaskError.create(
+        "SCHEDULE_FAILED",
+        `Failed to resume task ${taskId}`,
+        {
+          cause: error instanceof Error ? error : undefined,
+          details: { taskId, schedule: task.schedule },
+        },
+      );
+    }
 
     this.emit("task:resumed", updated);
     return updated;
@@ -409,6 +488,52 @@ export class TaskManager {
   }
 
   // ── Internal ──────────────────────────────────────────
+
+  private async restoreScheduledTask(
+    task: Task,
+    reason: string,
+  ): Promise<void> {
+    if (task.status !== "active") {
+      return;
+    }
+
+    try {
+      await this.getBackend().schedule(task, (t) => this.onTaskTick(t));
+      logger.warn("[TaskManager] Restored task schedule after rollback", {
+        taskId: task.id,
+        reason,
+      });
+    } catch (restoreError) {
+      logger.error(
+        "[TaskManager] Failed to restore task schedule during rollback",
+        {
+          taskId: task.id,
+          reason,
+          error: String(restoreError),
+        },
+      );
+    }
+  }
+
+  private async rollbackTaskUpdate(
+    taskId: string,
+    previousTask: Task,
+    error: unknown,
+  ): Promise<Task> {
+    try {
+      return await this.getStore().update(taskId, previousTask);
+    } catch (rollbackError) {
+      logger.error(
+        "[TaskManager] Failed to roll back task update — store and in-memory state may be diverged; manual reconciliation required",
+        {
+          taskId,
+          originalError: String(error),
+          rollbackError: String(rollbackError),
+        },
+      );
+      throw rollbackError;
+    }
+  }
 
   /**
    * Called by the backend on each scheduled tick.

--- a/src/lib/telemetry/telemetryService.ts
+++ b/src/lib/telemetry/telemetryService.ts
@@ -86,6 +86,7 @@ export class TelemetryService {
     try {
       const provider = trace.getTracerProvider() as {
         constructor?: { name?: string };
+        getDelegate?: () => { constructor?: { name?: string } } | null;
         _delegate?: { constructor?: { name?: string } };
       } | null;
 
@@ -93,16 +94,21 @@ export class TelemetryService {
         return false;
       }
 
-      const delegateName = provider._delegate?.constructor?.name || "";
-      if (delegateName && delegateName !== "NoopTracerProvider") {
+      const providerName = provider.constructor?.name || "";
+      if (
+        providerName &&
+        providerName !== "ProxyTracerProvider" &&
+        providerName !== "NoopTracerProvider"
+      ) {
         return true;
       }
 
-      const providerName = provider.constructor?.name || "";
-      return (
-        providerName !== "ProxyTracerProvider" &&
-        providerName !== "NoopTracerProvider"
-      );
+      const delegate =
+        typeof provider.getDelegate === "function"
+          ? provider.getDelegate()
+          : provider._delegate;
+      const delegateName = delegate?.constructor?.name || "";
+      return Boolean(delegateName && delegateName !== "NoopTracerProvider");
     } catch (error) {
       logger.warn("[Telemetry] Failed checking for external TracerProvider", {
         error: error instanceof Error ? error.message : String(error),

--- a/src/lib/types/proxyTypes.ts
+++ b/src/lib/types/proxyTypes.ts
@@ -14,6 +14,9 @@
  * - src/lib/server/routes/claudeProxyRoutes.ts (runtime state, deps)
  */
 
+import type { Span } from "@opentelemetry/api";
+import type { ProxyTracer } from "../proxy/proxyTracer.js";
+
 /**
  * Type describing the ModelRouter contract.
  * Defined here to avoid a circular dependency between types and implementation.
@@ -266,7 +269,7 @@ export type ParsedClaudeRequest = {
     string,
     {
       description?: string;
-      inputSchema?: unknown;
+      inputSchema: unknown;
       execute?: (...args: unknown[]) => unknown;
     }
   >;
@@ -410,6 +413,19 @@ export type TlsFingerprintOptions = {
 };
 
 // =============================================================================
+// PROXY MODE
+// =============================================================================
+
+/**
+ * Proxy operating mode:
+ * - "full"        — managed accounts, retry, rotation, polyfill (default)
+ * - "passthrough" — no polyfill/retry/rotation, but body is still parsed and re-serialized
+ * - "transparent" — zero-mutation byte relay: raw body forwarded as-is, minimal header filtering,
+ *                   SSE interceptor for cache metrics only (bytes pass through unmodified)
+ */
+export type ProxyMode = "full" | "passthrough" | "transparent";
+
+// =============================================================================
 // MODEL ROUTER TYPES (from modelRouter.ts)
 // =============================================================================
 
@@ -517,6 +533,151 @@ export type RequestAttemptLogEntry = {
   traceId?: string;
   /** OTel span ID for correlation with distributed traces */
   spanId?: string;
+};
+
+export type ProxyBodyCaptureInput = {
+  phase: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  bodySize?: number;
+  contentType?: string;
+  responseStatus?: number;
+  durationMs?: number;
+  account?: string;
+  accountType?: string;
+  attempt?: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type ProxyBodyCaptureLogger = (capture: ProxyBodyCaptureInput) => void;
+
+export type ClaudeFinalRequestLogger = (
+  status: number,
+  accountLabel: string,
+  accountType: string,
+  errorType?: string,
+  errorMessage?: string,
+  extra?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreationTokens?: number;
+    cacheReadTokens?: number;
+  },
+) => void;
+
+export type ClaudeLoggedErrorBuilder = (
+  status: number,
+  message: string,
+  errorType?: string,
+  extra?: {
+    account?: string;
+    accountType?: string;
+    attempt?: number;
+  },
+) => ClaudeErrorResponse;
+
+export type ClaudeRequestRuntimeContext = {
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
+  buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+};
+
+export type AnthropicAttemptLogger = (
+  status: number,
+  errorType?: string,
+  errorMessage?: string,
+  extra?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreationTokens?: number;
+    cacheReadTokens?: number;
+  },
+) => void;
+
+export type AnthropicLoopState = {
+  lastError: unknown;
+  sawRateLimit: boolean;
+  sawNetworkError: boolean;
+  sawTransientFailure: boolean;
+  invalidRequestFailure: {
+    status: number;
+    body: string;
+    contentType?: string;
+  } | null;
+  authFailureMessage: string | null;
+  attemptNumber: number;
+};
+
+export type AnthropicUpstreamBody = {
+  bodyStr: string;
+  sessionId?: string;
+};
+
+export type AnthropicUpstreamBodyBuilder = (
+  token: string,
+) => AnthropicUpstreamBody;
+
+export type LoadedClaudeAccountContext = {
+  accounts: ProxyPassthroughAccount[];
+  enabledAccounts: ProxyPassthroughAccount[];
+  orderedAccounts: ProxyPassthroughAccount[];
+  bodyStr: string;
+  requestStart: number;
+  toolCount: number;
+  url: string;
+  clientHeaders: Record<string, string | undefined>;
+  isClaudeClientRequest: boolean;
+};
+
+export type AnthropicSuccessResult =
+  | { retryNextAccount: true }
+  | { response: Response | unknown };
+
+export type AnthropicAuthRetryResult = {
+  response?: Response | unknown;
+  continueLoop: boolean;
+  lastError: unknown;
+  authFailureMessage: string | null;
+  sawRateLimit: boolean;
+  sawTransientFailure: boolean;
+  sawNetworkError: boolean;
+  upstreamSpan?: Span;
+};
+
+export type AnthropicNonOkResult = {
+  response?: Response | unknown;
+  continueLoop: boolean;
+  lastError: unknown;
+  authFailureMessage: string | null;
+  sawTransientFailure: boolean;
+  invalidRequestFailure: {
+    status: number;
+    body: string;
+    contentType?: string;
+  } | null;
+  upstreamSpan?: Span;
+};
+
+export type PreparedAnthropicAccountAttempt = {
+  continueLoop: boolean;
+  lastError: unknown;
+  authFailureMessage: string | null;
+  headers?: Record<string, string>;
+  buildUpstreamBody?: AnthropicUpstreamBodyBuilder;
+  finalBodyStr?: string;
+  fetchStartMs?: number;
+  upstreamSpan?: Span;
+};
+
+export type AnthropicUpstreamFetchResult = {
+  continueLoop: boolean;
+  response?: Response;
+  lastError: unknown;
+  sawRateLimit: boolean;
+  sawNetworkError: boolean;
+  upstreamSpan?: Span;
 };
 
 // =============================================================================

--- a/src/lib/types/streamTypes.ts
+++ b/src/lib/types/streamTypes.ts
@@ -2,7 +2,11 @@ import type { LanguageModel, StepResult, Tool, ToolChoice } from "ai";
 import type { AIProviderName } from "../constants/enums.js";
 import type { EvaluationData } from "../index.js";
 import type { RAGConfig } from "../rag/types.js";
-import type { AnalyticsData, ToolExecutionEvent, ToolExecutionSummary } from "../types/index.js";
+import type {
+  AnalyticsData,
+  ToolExecutionEvent,
+  ToolExecutionSummary,
+} from "../types/index.js";
 import type {
   MiddlewareFactoryOptions,
   OnChunkCallback,
@@ -59,7 +63,9 @@ export type StreamingOptions = {
 /**
  * Progress callback for streaming operations
  */
-export type ProgressCallback = (progress: StreamingProgressData) => void | Promise<void>;
+export type ProgressCallback = (
+  progress: StreamingProgressData,
+) => void | Promise<void>;
 
 /**
  * Type for tool execution calls (AI SDK compatible)
@@ -665,7 +671,15 @@ export type StreamTextResult = {
       }
     | undefined
   >;
-  finishReason: PromiseLike<"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown">;
+  finishReason: PromiseLike<
+    | "stop"
+    | "length"
+    | "content-filter"
+    | "tool-calls"
+    | "error"
+    | "other"
+    | "unknown"
+  >;
   /**
    * Tool results. Accepts both NeuroLink ToolResult[] and AI SDK TypedToolResult[],
    * since the analytics collector passes them through as `unknown` anyway.

--- a/src/lib/utils/providerHealth.ts
+++ b/src/lib/utils/providerHealth.ts
@@ -114,7 +114,11 @@ export class ProviderHealthChecker {
 
     try {
       // 1. Check environment configuration
-      await this.checkEnvironmentConfiguration(providerName, healthStatus);
+      await this.checkEnvironmentConfiguration(
+        providerName,
+        healthStatus,
+        timeout,
+      );
 
       // 2. Check API key validity (basic format validation)
       await this.checkApiKeyValidity(providerName, healthStatus);
@@ -187,6 +191,7 @@ export class ProviderHealthChecker {
   private static async checkEnvironmentConfiguration(
     providerName: AIProviderName,
     healthStatus: ProviderHealthStatusOptions,
+    timeout: number,
   ): Promise<void> {
     const requiredEnvVars = this.getRequiredEnvironmentVariables(providerName);
 
@@ -237,7 +242,7 @@ export class ProviderHealthChecker {
     }
 
     // Provider-specific configuration checks
-    await this.checkProviderSpecificConfig(providerName, healthStatus);
+    await this.checkProviderSpecificConfig(providerName, healthStatus, timeout);
   }
 
   /**
@@ -370,36 +375,39 @@ export class ProviderHealthChecker {
       return;
     }
 
+    const headers = {
+      "User-Agent": "NeuroLink-HealthCheck/1.0",
+      ...this.getConnectivityHeaders(providerName),
+    };
+
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-      const proxyFetch = createProxyFetch();
-      let response = await proxyFetch(endpoint, {
-        method: "HEAD",
-        signal: controller.signal,
-        headers: {
-          "User-Agent": "NeuroLink-HealthCheck/1.0",
-        },
-      });
-
-      // Fallback to GET if HEAD returns 405 (Method Not Allowed) for restrictive gateways
-      if (response.status === 405) {
-        response = await proxyFetch(endpoint, {
-          method: "GET",
+      try {
+        const proxyFetch = createProxyFetch();
+        let response = await proxyFetch(endpoint, {
+          method: "HEAD",
           signal: controller.signal,
-          headers: {
-            "User-Agent": "NeuroLink-HealthCheck/1.0",
-          },
+          headers,
         });
-      }
 
-      clearTimeout(timeoutId);
+        // Fallback to GET if HEAD returns 405 (Method Not Allowed) for restrictive gateways
+        if (response.status === 405) {
+          response = await proxyFetch(endpoint, {
+            method: "GET",
+            signal: controller.signal,
+            headers,
+          });
+        }
 
-      if (!response.ok) {
-        healthStatus.configurationIssues.push(
-          `Connectivity test failed: HTTP ${response.status}`,
-        );
+        if (!response.ok) {
+          healthStatus.configurationIssues.push(
+            `Connectivity test failed: HTTP ${response.status}`,
+          );
+        }
+      } finally {
+        clearTimeout(timeoutId);
       }
     } catch (error) {
       const errorMessage =
@@ -450,6 +458,18 @@ export class ProviderHealthChecker {
         );
       }
     }
+  }
+
+  private static getConnectivityHeaders(
+    providerName: AIProviderName,
+  ): Record<string, string> {
+    if (providerName === AIProviderName.LITELLM) {
+      return {
+        Authorization: `Bearer ${process.env.LITELLM_API_KEY || "sk-anything"}`,
+      };
+    }
+
+    return {};
   }
 
   /**
@@ -615,6 +635,7 @@ export class ProviderHealthChecker {
   private static async checkProviderSpecificConfig(
     providerName: AIProviderName,
     healthStatus: ProviderHealthStatusOptions,
+    timeout: number,
   ): Promise<void> {
     switch (providerName) {
       case AIProviderName.VERTEX:
@@ -627,10 +648,10 @@ export class ProviderHealthChecker {
         await this.checkAzureConfig(healthStatus);
         break;
       case AIProviderName.LITELLM:
-        await this.checkLiteLLMConfig(healthStatus);
+        await this.checkLiteLLMConfig(healthStatus, timeout);
         break;
       case AIProviderName.OLLAMA:
-        await this.checkOllamaConfig(healthStatus);
+        await this.checkOllamaConfig(healthStatus, timeout);
         break;
     }
   }
@@ -994,11 +1015,15 @@ export class ProviderHealthChecker {
     availableModels: string[],
     requestedModel: string,
   ): boolean {
+    const normalizedRequestedModel = requestedModel.trim();
+    const requiresExactMatch = /@/.test(normalizedRequestedModel);
+
     return availableModels.some(
       (model) =>
-        model === requestedModel ||
-        model.startsWith(`${requestedModel}:`) ||
-        requestedModel.startsWith(`${model}:`),
+        model === normalizedRequestedModel ||
+        (!requiresExactMatch &&
+          (model.startsWith(`${normalizedRequestedModel}:`) ||
+            model.startsWith(`${normalizedRequestedModel}@`))),
     );
   }
 
@@ -1085,6 +1110,7 @@ export class ProviderHealthChecker {
 
   private static async checkLiteLLMConfig(
     healthStatus: ProviderHealthStatusOptions,
+    timeout: number = this.DEFAULT_TIMEOUT,
   ): Promise<void> {
     const liteLLMBase = this.getLiteLLMBaseUrl();
     if (!liteLLMBase.startsWith("http")) {
@@ -1098,7 +1124,7 @@ export class ProviderHealthChecker {
 
     const availability = await this.checkLiteLLMAvailability({
       model: this.getConfiguredLiteLLMModel(),
-      timeout: 2000,
+      timeout,
     });
 
     if (!availability.available) {
@@ -1120,6 +1146,7 @@ export class ProviderHealthChecker {
    */
   private static async checkOllamaConfig(
     healthStatus: ProviderHealthStatusOptions,
+    timeout: number = this.DEFAULT_TIMEOUT,
   ): Promise<void> {
     const ollamaBase = this.getOllamaBaseUrl();
     if (!ollamaBase.startsWith("http")) {
@@ -1135,7 +1162,7 @@ export class ProviderHealthChecker {
 
     const availability = await this.checkOllamaAvailability({
       model: this.getConfiguredOllamaModel(),
-      timeout: 2000,
+      timeout,
     });
 
     if (!availability.available) {

--- a/src/lib/utils/providerUtils.ts
+++ b/src/lib/utils/providerUtils.ts
@@ -4,7 +4,6 @@
  */
 import { AIProviderFactory } from "../core/factory.js";
 import { logger } from "./logger.js";
-import type { UnknownRecord } from "../types/common.js";
 import type { ProviderError } from "../types/providers.js";
 import type { EnvVarValidationResult } from "../types/utilities.js";
 import { AIProviderName } from "../constants/enums.js";
@@ -87,7 +86,10 @@ export async function getBestProvider(
   }
 
   // Special case for Ollama - prioritize local when available
-  if (process.env.OLLAMA_BASE_URL && process.env.OLLAMA_MODEL) {
+  if (
+    (process.env.OLLAMA_BASE_URL || process.env.OLLAMA_API_BASE) &&
+    process.env.OLLAMA_MODEL
+  ) {
     try {
       if (await isProviderAvailable("ollama")) {
         logger.debug(`[getBestProvider] Prioritizing working local Ollama`);
@@ -101,7 +103,7 @@ export async function getBestProvider(
   /**
    * Provider priority order rationale:
    * - LiteLLM and Ollama are prioritized first for local/self-hosted deployments,
-   *   avoiding cloud quota/rate-limit issues during fallback scenarios.
+   *   avoiding unnecessary dependence on external providers during fallback scenarios.
    * - Vertex (Google Cloud AI) follows for enterprise-grade reliability.
    * - Google AI follows as second cloud priority for comprehensive Google AI ecosystem support.
    * - OpenAI maintains high priority due to its consistent reliability and broad model support.
@@ -109,8 +111,8 @@ export async function getBestProvider(
    * Please update this comment if the order is changed in the future, and document the rationale for maintainability.
    */
   const providers = [
-    "litellm", // Prioritize self-hosted/proxy (no rate limits)
-    "ollama", // Local models (no rate limits)
+    "litellm", // Prioritize self-hosted proxy deployments first
+    "ollama", // Local models when the configured runtime target is installed
     "vertex", // Google Cloud AI (enterprise)
     "google-ai", // Google AI ecosystem support
     "openai", // Reliable with broad model support
@@ -144,27 +146,22 @@ async function isProviderAvailable(providerName: string): Promise<boolean> {
     return false;
   }
 
+  if (providerName === "litellm") {
+    const availability =
+      await ProviderHealthChecker.checkFallbackProviderAvailability(
+        AIProviderName.LITELLM,
+        process.env.LITELLM_MODEL || "openai/gpt-4o-mini",
+      );
+    return availability.available;
+  }
+
   if (providerName === "ollama") {
-    try {
-      const response = await fetch("http://localhost:11434/api/tags", {
-        method: "GET",
-        signal: AbortSignal.timeout(2000),
-      });
-      if (response.ok) {
-        const { models } = await response.json();
-        const defaultOllamaModel = process.env.OLLAMA_MODEL || "llama3.1:8b";
-        // Check for exact match first, then prefix match (e.g. "gemma3:27b" matches "gemma3:27b-fp16")
-        return models.some(
-          (m: UnknownRecord) =>
-            m.name === defaultOllamaModel ||
-            (typeof m.name === "string" &&
-              m.name.startsWith(defaultOllamaModel.split(":")[0] + ":")),
-        );
-      }
-      return false;
-    } catch {
-      return false;
-    }
+    const availability =
+      await ProviderHealthChecker.checkFallbackProviderAvailability(
+        AIProviderName.OLLAMA,
+        process.env.OLLAMA_MODEL || "llama3.1:8b",
+      );
+    return availability.available;
   }
 
   try {

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -4366,6 +4366,8 @@ async function testCloakingRuntime(): Promise<boolean | null> {
   try {
     const { CloakingPipeline } =
       await import("../dist/lib/proxy/cloaking/index.js");
+    const { parseClaudeCodeUserId } =
+      await import("../dist/lib/auth/anthropicOAuth.js");
     const { createHeaderScrubber } =
       await import("../dist/lib/proxy/cloaking/plugins/headerScrubber.js");
     const { createSessionIdentity } =
@@ -4414,15 +4416,14 @@ async function testCloakingRuntime(): Promise<boolean | null> {
       logTest("Cloaking Runtime", "FAIL", "authorization header lost");
       return false;
     }
-    // Verify session identity injected
-    if (
-      !result.request.body?.metadata?.user_id ||
-      !(result.request.body.metadata.user_id as string).startsWith("user_")
-    ) {
+    // Verify Claude Code-style session identity injected
+    const metadataUserId = result.request.body?.metadata?.user_id;
+    const parsedIdentity = parseClaudeCodeUserId(metadataUserId);
+    if (!parsedIdentity || parsedIdentity.metadataUserId !== metadataUserId) {
       logTest(
         "Cloaking Runtime",
         "FAIL",
-        `Session ID not injected: ${result.request.body?.metadata?.user_id}`,
+        `Session identity not injected in Claude Code format: ${metadataUserId}`,
       );
       return false;
     }


### PR DESCRIPTION
## Summary

- **Decompose `claudeProxyRoutes.ts`**: Extract 20+ named handler functions (`handleTranslatedClaudeRequest`, `handleClaudePassthroughRequest`, `loadClaudeProxyAccounts`, `buildAnthropicTerminalErrorResponse`, `createAnthropicAttemptLogger`, `prepareAnthropicAccountAttempt`, etc.) to resolve `max-lines-per-function` lint violations
- **Decompose `neurolink.ts`**: Extract `executeGenerateWithMetricsContext`, `prepareGenerateRequest`, `buildGenerateTextOptions`, `maybeHandleEarlyGenerateResult`, and 8+ more private methods from the monolithic `generate()` method
- **Decompose `baseProvider.ts`**: Extract `runGenerateInActiveContext` private method, add `gen()` alias
- **Decompose `proxy.ts` CLI**: Extract `ensureProxyStartAllowed`, `loadProxyStartEnv`, `createProxyNeurolinkRuntime` composable helpers
- **Decompose `GoogleVertex`**: Extract `maybeExecuteNativeGemini3ToolStream` and `executeAISDKStream` private methods
- **Add `AIProviderFactory.resolveModelFromEnvironment`**: Per-provider env var model overrides (BEDROCK_MODEL, VERTEX_MODEL, AZURE_OPENAI_MODEL, etc.)
- **Refactor `MCPToolRegistry`**: Extract `resolveToolExecutionTarget` and `createExecutionContext` helpers
- **Refactor `oauthFetch`**: Extract `resolveOAuthRequestUrl` helper, clean up request flow
- **Fix `proxyFetch`**: Add `mergeTraceHeaders`, pass `input` to `injectTraceContext` to preserve request headers
- **Fix OpenAI**: Resolve `toolChoice` once before stream creation (avoid duplicate computation)
- **Fix `TaskManager`**: Cleanup callbacks before store delete, rollback on schedule failure, defer history clear after mode update
- **Add scorer definitions**: Built-in LLM scorer definitions in `ScorerRegistry` (hallucination, toxicity, and more)
- **New proxy types**: `ProxyBodyCaptureInput`, `ClaudeFinalRequestLogger`, `ClaudeLoggedErrorBuilder`
- **Security**: Ignore pre-existing lodash vulnerabilities in `@semantic-release` dev deps (no patch available upstream)

## Test plan

- [ ] All pre-commit hooks pass (type check, lint, format, build, security validation)
- [ ] `pnpm run check` — 0 errors, 0 warnings
- [ ] `pnpm run lint` — clean
- [ ] `pnpm run build` — successful full build
- [ ] Proxy CLI startup still works: `neurolink proxy start`
- [ ] `neurolink generate` and `neurolink stream` continue to function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated doc links and routes; added CLI installation prerequisites for proxy features; improved OpenObserve setup output display.

* **Bug Fixes**
  * Proxy now returns 400 errors for invalid request JSON; improved log file handling; fixed model matching behavior; tightened Ollama configuration checks.

* **New Features**
  * Proxy now tracks and reports operational mode; enhanced telemetry with UTF-8-aware truncation; improved task scheduling with better error recovery and rollback handling.

* **Improvements**
  * Better timeout enforcement; more robust error handling; refined configuration validation; improved authentication caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->