### PR TITLE
fix(ci): pin npm to v10 to fix release workflow failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           echo "✅ ffmpeg installed successfully"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@10
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Problem

The release workflow fails with:

\`\`\`
npm error Cannot find module 'promise-retry'
\`\`\`

This happens at the **Upgrade npm for OIDC support** step which runs \`npm install -g npm@latest\`. On the GitHub-hosted runner with Node 22.22.2, the latest npm has a broken internal dependency in its own module tree — this is a runner infrastructure issue, not a code issue.

## Fix

Pin to `npm@10` (stable major for Node 22 LTS) instead of `@latest`. This avoids the broken npm version on the runner while still satisfying the OIDC provenance requirement.

## Affected

Both the `release` branch CI and any PR branches that trigger the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use a fixed npm version for improved consistency and stability in the release build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->