### PR TITLE
fix(proxy): PID-scoped token store temp files and dynamic launchd PATH

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -13,7 +13,7 @@
 import type { CommandModule, Argv } from "yargs";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import {
@@ -2040,6 +2040,34 @@ function escapeXml(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * Build a PATH for the launchd plist that includes the current Node/pnpm
+ * bin directories so the guard process can find npm/pnpm for update checks.
+ */
+function buildLaunchdPath(): string {
+  const fallback = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin";
+  const nodeDir = dirname(process.execPath);
+  const segments = new Set<string>();
+
+  // Add the directory containing the Node binary that launched this process
+  if (nodeDir && nodeDir !== ".") {
+    segments.add(nodeDir);
+  }
+
+  // Add pnpm home if available (e.g., ~/.local/share/pnpm)
+  const pnpmHome = process.env.PNPM_HOME;
+  if (pnpmHome) {
+    segments.add(pnpmHome);
+  }
+
+  // Add the standard system paths
+  for (const p of fallback.split(":")) {
+    segments.add(p);
+  }
+
+  return [...segments].join(":");
+}
+
 function buildPlist(
   port: number,
   host: string,
@@ -2105,7 +2133,7 @@ ${configArgs}
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <string>${buildLaunchdPath()}</string>
     <key>HOME</key>
     <string>${homedir()}</string>
   </dict>

--- a/src/lib/auth/tokenStore.ts
+++ b/src/lib/auth/tokenStore.ts
@@ -185,7 +185,8 @@ export class TokenStore {
         : JSON.stringify(storageData, null, 2);
 
       // Write to temporary file first for atomic operation
-      const tempPath = `${this.storagePath}.tmp`;
+      // Use PID-scoped temp file to avoid cross-process race conditions
+      const tempPath = `${this.storagePath}.tmp.${process.pid}`;
       await writeFile(tempPath, content, "utf-8");
 
       // Set restrictive permissions before moving to final location
@@ -796,7 +797,8 @@ export class TokenStore {
         ? this.obfuscate(JSON.stringify(data))
         : JSON.stringify(data, null, 2);
 
-      const tmpPath = `${this.storagePath}.tmp`;
+      // Use PID-scoped temp file to avoid cross-process race conditions
+      const tmpPath = `${this.storagePath}.tmp.${process.pid}`;
       await writeFile(tmpPath, content, "utf-8");
       await chmod(tmpPath, TokenStore.FILE_PERMISSIONS);
       await rename(tmpPath, this.storagePath);


### PR DESCRIPTION
## Summary

- **Token store race condition:** `auth login` fails with `ENOENT` when the proxy is running because both processes write to the same `tokens.json.tmp` temp file. The proxy's concurrent token refresh renames it before the CLI can. Fix: scope temp files by PID (`tokens.json.tmp.<pid>`).
- **Launchd plist PATH:** The hardcoded PATH (`/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin`) doesn't include the pnpm-managed Node binary directory. The guard process can't find `npm`/`pnpm` for update checks, silently disabling auto-updates. Fix: `buildLaunchdPath()` captures `dirname(process.execPath)` and `PNPM_HOME` at install time.

## Files changed

| File | What changed |
|------|-------------|
| `src/lib/auth/tokenStore.ts` | Both `_saveTokensInternal()` and `saveStorageData()` now use `${storagePath}.tmp.${process.pid}` instead of shared `${storagePath}.tmp` |
| `src/cli/commands/proxy.ts` | Added `buildLaunchdPath()` that includes the current Node binary dir and `PNPM_HOME`; replaced hardcoded PATH in `buildPlist()` |

## Root cause details

**Token store:** The error was `ENOENT: no such file or directory, rename 'tokens.json.tmp' -> 'tokens.json'`. The in-process `AsyncMutex` doesn't protect cross-process writes. Two processes (proxy PID + CLI PID) both wrote to the same `.tmp` path — one renamed it away before the other could.

**Launchd PATH:** The guard process runs `npm view @juspay/neurolink version --json` for update checks. Under launchd, the hardcoded PATH found a broken Homebrew Node (`libicui18n.73.dylib` missing), so `checkForUpdate()` silently returned `{ latestVersion: currentVersion }`, disabling all auto-updates.

## Test plan

- [ ] Run `neurolink proxy start` and `neurolink auth login anthropic --method oauth` concurrently — verify no ENOENT error
- [ ] Run `neurolink proxy install` — verify the plist PATH includes the current Node binary directory
- [ ] Verify `launchctl print gui/<uid>/com.neurolink.proxy` shows the dynamic PATH after reinstall
- [ ] Run `neurolink proxy uninstall && neurolink proxy install` — verify guard update checks succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with various Node and development tool installations through enhanced PATH handling.
  * Enhanced reliability of token persistence during concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->