### PR TITLE
fix(release): remove npm downgrade that breaks OIDC token persistence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,6 @@ jobs:
           }
           echo "✅ ffmpeg installed successfully"
 
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@10
-
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Root Cause

6 versions (9.45.0 → 9.48.1) were tagged in git but never published to npm or GitHub Packages.

Two cascading failures:

1. **npm@latest → npm 11.x** broke on Node 22.22.2 with `MODULE_NOT_FOUND: promise-retry`
2. **Pinned npm@10** (commit 357ccf36) fixed that but overwrote Node's bundled npm with a standalone version that doesn't persist OIDC tokens between semantic-release's `verifyConditions` and `publish` steps → `ENEEDAUTH`

GitHub Packages also never ran because it's gated on the semantic-release step succeeding.

## Fix

Remove the `npm install -g npm@10` step entirely. Node 22 bundles npm 10.9.x which already supports OIDC provenance — no upgrade or downgrade needed.

## Impact

- Next `feat`/`fix`/`refactor` push to `release` will publish successfully
- The 6 missed versions (9.45.0 → 9.48.1) exist as git tags but are absent from npm — manual republish or a follow-up release will be needed to close the gap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Removed the automatic npm version upgrade step from the release workflow. The npm package manager will no longer be automatically updated to the latest version globally during the release process. All other deployment operations including dependency installation, building, semantic-release execution, and publishing to GitHub Packages remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->