### PR TITLE
fix(ci): upgrade to npm 11 for native OIDC publish support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
           }
           echo "✅ ffmpeg installed successfully"
 
+      - name: Upgrade npm for native OIDC publish support
+        run: |
+          npx -y npm@11 install -g npm@11
+          echo "npm version: $(npm --version)"
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Summary

- Replaces `npm install -g npm@10` (removed in #932) with `npx -y npm@11 install -g npm@11`
- `@semantic-release/npm` v13 relies on npm's native OIDC publish support, which only exists in npm >= 11
- Direct `npm install -g npm@latest` crashes on Node 22.22.2 with `MODULE_NOT_FOUND: promise-retry`, so we use `npx` to bootstrap npm 11 in isolation first
- Every release from v9.45.0 through v9.48.1 failed to publish to npm with `ENEEDAUTH` because of this

## Root cause

| Run | npm version | Result |
|-----|------------|--------|
| Apr 3 (v9.44.1) | npm 11.x via `npm@latest` | Published successfully |
| Apr 4+ | npm 10.x via `npm@10` pin | ENEEDAUTH on every release |

## Test plan

- [ ] Merge and verify next `feat`/`fix` commit to `release` triggers successful npm publish
- [ ] Check npm registry for new version after CI completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use the latest npm version for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->