### PR TITLE
fix(proxy): streaming fallback reliability and observability

### DIFF
--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -522,9 +522,9 @@ export class LiteLLMProvider extends BaseProvider {
     } catch (streamError) {
       if (NoOutputGeneratedError.isInstance(streamError)) {
         logger.warn(
-          "LiteLLM: Stream produced no output (NoOutputGeneratedError)",
+          "LiteLLM: Stream produced no output (NoOutputGeneratedError) — propagating to fallback chain",
         );
-        return;
+        throw streamError;
       }
       throw streamError;
     }

--- a/src/lib/proxy/proxyTracer.ts
+++ b/src/lib/proxy/proxyTracer.ts
@@ -59,6 +59,9 @@ type ProxyMetrics = {
   modelSubstitutionTotal: Counter;
   requestBodySize: Histogram;
   responseBodySize: Histogram;
+  fallbackAttemptsTotal: Counter;
+  fallbackSuccessTotal: Counter;
+  fallbackFailureTotal: Counter;
 };
 
 let _metrics: ProxyMetrics | null = null;
@@ -126,6 +129,21 @@ function getProxyMetrics(): ProxyMetrics {
     responseBodySize: meter.createHistogram("proxy_response_body_bytes", {
       description: "Response body size in bytes received from upstream",
       unit: "By",
+    }),
+    fallbackAttemptsTotal: meter.createCounter(
+      "proxy_fallback_attempts_total",
+      {
+        description: "Total fallback provider attempts",
+        unit: "{attempt}",
+      },
+    ),
+    fallbackSuccessTotal: meter.createCounter("proxy_fallback_success_total", {
+      description: "Total successful fallback provider responses",
+      unit: "{success}",
+    }),
+    fallbackFailureTotal: meter.createCounter("proxy_fallback_failure_total", {
+      description: "Total failed fallback provider responses",
+      unit: "{failure}",
     }),
   };
 
@@ -589,6 +607,25 @@ class ProxyTracer {
     });
   }
 
+  setFallbackInfo(info: {
+    triggered: boolean;
+    provider?: string;
+    model?: string;
+    attemptCount: number;
+    reason: string;
+  }): void {
+    if (!this.rootSpan) {
+      return;
+    }
+    this.rootSpan.setAttributes({
+      "proxy.fallback.triggered": info.triggered,
+      ...(info.provider ? { "proxy.fallback.provider": info.provider } : {}),
+      ...(info.model ? { "proxy.fallback.model": info.model } : {}),
+      "proxy.fallback.attempt_count": info.attemptCount,
+      "proxy.fallback.reason": info.reason,
+    });
+  }
+
   // -------------------------------------------------------------------------
   // Log payloads as span events
   // -------------------------------------------------------------------------
@@ -882,6 +919,30 @@ class ProxyTracer {
       {},
       trace.setSpan(context.active(), this.rootSpan),
     );
+  }
+}
+
+export function recordFallbackAttempt(attrs: {
+  provider: string;
+  model: string;
+  status: "success" | "failure";
+  errorMessage?: string;
+  durationMs: number;
+}): void {
+  try {
+    const m = getProxyMetrics();
+    const labels = { provider: attrs.provider, model: attrs.model };
+    m.fallbackAttemptsTotal.add(1, labels);
+    if (attrs.status === "success") {
+      m.fallbackSuccessTotal.add(1, labels);
+    } else {
+      m.fallbackFailureTotal.add(1, {
+        ...labels,
+        error: attrs.errorMessage?.slice(0, 100) ?? "unknown",
+      });
+    }
+  } catch {
+    // metrics are best-effort
   }
 }
 

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -32,7 +32,7 @@ import {
   serializeClaudeResponse,
 } from "../../proxy/claudeFormat.js";
 import type { ModelRouter } from "../../proxy/modelRouter.js";
-import { ProxyTracer } from "../../proxy/proxyTracer.js";
+import { ProxyTracer, recordFallbackAttempt } from "../../proxy/proxyTracer.js";
 import { createRawStreamCapture } from "../../proxy/rawStreamCapture.js";
 import {
   logBodyCapture,
@@ -1765,51 +1765,80 @@ async function executeClaudeFallbackTranslation(args: {
     const streamResult = await ctx.neurolink.stream(options);
     const serializer = new ClaudeStreamSerializer(body.model, 0);
 
-    async function* sseGenerator(): AsyncIterable<string> {
-      for (const frame of serializer.start()) {
-        yield frame;
-      }
-      let collectedText = "";
-      for await (const chunk of streamResult.stream) {
-        const text = extractText(chunk);
-        if (text) {
-          collectedText += text;
-          for (const frame of serializer.pushDelta(text)) {
-            yield frame;
-          }
+    // Eagerly consume stream so errors fire synchronously and the
+    // fallback loop in tryConfiguredClaudeFallbackChain can catch them.
+    const frames: string[] = [];
+    let collectedText = "";
+
+    for (const frame of serializer.start()) {
+      frames.push(frame);
+    }
+
+    for await (const chunk of streamResult.stream) {
+      const text = extractText(chunk);
+      if (text) {
+        collectedText += text;
+        for (const frame of serializer.pushDelta(text)) {
+          frames.push(frame);
         }
-      }
-      const toolCalls = streamResult.toolCalls ?? [];
-      if (!hasTranslatedOutput(collectedText, toolCalls)) {
-        throw new Error(
-          `Translated provider ${providerLabel} returned no content or tool calls`,
-        );
-      }
-      if (toolCalls.length) {
-        for (const toolCall of toolCalls) {
-          const toolName =
-            (toolCall as { toolName?: string }).toolName ??
-            (toolCall as { name?: string }).name ??
-            "unknown";
-          for (const frame of serializer.pushToolUse(
-            generateToolUseId(),
-            toolName,
-            extractToolArgs(toolCall),
-          )) {
-            yield frame;
-          }
-        }
-      }
-      const reason = streamResult.finishReason ?? "end_turn";
-      const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
-      for (const frame of serializer.finish(resolvedUsage.output, reason)) {
-        yield frame;
       }
     }
 
+    const toolCalls = streamResult.toolCalls ?? [];
+
+    if (!hasTranslatedOutput(collectedText, toolCalls)) {
+      throw new Error(
+        `Translated provider ${providerLabel} returned no content or tool calls`,
+      );
+    }
+
+    if (toolCalls.length) {
+      for (const toolCall of toolCalls) {
+        const toolName =
+          (toolCall as { toolName?: string }).toolName ??
+          (toolCall as { name?: string }).name ??
+          "unknown";
+        for (const frame of serializer.pushToolUse(
+          generateToolUseId(),
+          toolName,
+          extractToolArgs(toolCall),
+        )) {
+          frames.push(frame);
+        }
+      }
+    }
+
+    const reason = streamResult.finishReason ?? "end_turn";
+    const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
+    for (const frame of serializer.finish(resolvedUsage.output, reason)) {
+      frames.push(frame);
+    }
+
+    // Telemetry AFTER validation — not before like the old lazy path
     tracer?.end(200, Date.now() - requestStartTime);
     recordFinalSuccess();
-    logFinalRequest(200, "", providerLabel);
+    logFinalRequest(200, "", providerLabel, undefined, undefined, {
+      inputTokens: resolvedUsage.input,
+      outputTokens: resolvedUsage.output,
+    });
+
+    const bufferedBody = frames.join("");
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "text/event-stream" },
+      body: bufferedBody,
+      bodySize: Buffer.byteLength(bufferedBody, "utf8"),
+      contentType: "text/event-stream",
+      responseStatus: 200,
+      durationMs: Date.now() - requestStartTime,
+    });
+
+    // Return generator that yields pre-buffered frames
+    async function* sseGenerator(): AsyncIterable<string> {
+      for (const frame of frames) {
+        yield frame;
+      }
+    }
     return sseGenerator();
   }
 
@@ -1917,6 +1946,12 @@ async function tryConfiguredClaudeFallbackChain(args: {
     logger.always(`[proxy] skipping fallback ${label}: ${skipped.reason}`);
   }
 
+  tracer?.setFallbackInfo({
+    triggered: true,
+    attemptCount: fallbackPlan.attempts.slice(1).length,
+    reason: fallbackPolicyReason ?? "all_anthropic_accounts_exhausted",
+  });
+
   for (const fallback of fallbackPlan.attempts.slice(1)) {
     if (!fallback.provider || !fallback.model) {
       continue;
@@ -1933,6 +1968,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
       );
     }
 
+    const fallbackStart = Date.now();
     try {
       logger.always(
         `[proxy] fallback → ${fallback.provider}/${fallback.model}`,
@@ -1951,14 +1987,65 @@ async function tryConfiguredClaudeFallbackChain(args: {
         options: options as Parameters<ServerContext["neurolink"]["stream"]>[0],
         providerLabel: fallback.provider,
       });
+      recordFallbackAttempt({
+        provider: fallback.provider,
+        model: fallback.model,
+        status: "success",
+        durationMs: Date.now() - fallbackStart,
+      });
+      tracer?.setFallbackInfo({
+        triggered: true,
+        provider: fallback.provider,
+        model: fallback.model,
+        attemptCount: fallbackPlan.attempts.slice(1).length,
+        reason: "fallback_success",
+      });
       return {
         response,
         fallbackPolicyReason,
       };
     } catch (fallbackErr) {
+      const errMsg =
+        fallbackErr instanceof Error
+          ? fallbackErr.message
+          : String(fallbackErr);
+
+      let errorClass = "unknown";
+      if (
+        errMsg.includes("Rate limit") ||
+        errMsg.includes("rate_limit") ||
+        errMsg.includes("max_parallel_requests")
+      ) {
+        errorClass = "rate_limit";
+      } else if (
+        errMsg.includes("context length") ||
+        errMsg.includes("ContextWindowExceeded")
+      ) {
+        errorClass = "context_overflow";
+      } else if (
+        errMsg.includes("no content or tool calls") ||
+        errMsg.includes("NoOutputGenerated")
+      ) {
+        errorClass = "empty_response";
+      } else if (
+        errMsg.includes("thinking_level") ||
+        errMsg.includes("Field required")
+      ) {
+        errorClass = "schema_mismatch";
+      } else if (errMsg.includes("Resource exhausted")) {
+        errorClass = "provider_quota";
+      }
+
       logger.always(
-        `[proxy] fallback ${fallback.provider}/${fallback.model} failed: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
+        `[proxy] fallback ${fallback.provider}/${fallback.model} failed [${errorClass}]: ${errMsg}`,
       );
+      recordFallbackAttempt({
+        provider: fallback.provider,
+        model: fallback.model,
+        status: "failure",
+        errorMessage: `[${errorClass}] ${errMsg}`,
+        durationMs: Date.now() - fallbackStart,
+      });
     }
   }
 
@@ -5192,7 +5279,15 @@ function shouldOmitThinkingConfigForTarget(
   provider?: string,
   model?: string,
 ): boolean {
-  return provider === "vertex" && model === "gemini-2.5-flash";
+  if (provider === "litellm") {
+    return true;
+  }
+  if (provider !== "vertex") {
+    return false;
+  }
+  // Only Gemini 2.5+ and 3.x support thinking_level on Vertex.
+  const m = model?.toLowerCase() ?? "";
+  return !/gemini-(2\.5|3)/.test(m);
 }
 
 function extractToolArgs(toolCall: unknown): unknown {


### PR DESCRIPTION
## Summary

Fixes multiple issues causing Claude Code to hang when all Anthropic accounts are rate-limited and the proxy falls back to LiteLLM/Vertex providers.

### Root Cause

When all 3 Anthropic OAuth accounts are exhausted (429), the proxy enters `tryConfiguredClaudeFallbackChain` which iterates fallback providers (litellm/open-large, vertex/gemini-2.5-flash). Three bugs prevented this from working:

1. **Streaming fallback returned a lazy generator** — `executeClaudeFallbackTranslation` created an `AsyncGenerator` and returned it without consuming the stream. Errors only surfaced during iteration by the Hono adapter, long after the try/catch in the fallback loop had exited. The second provider was never tried.

2. **LiteLLM silently swallowed `NoOutputGeneratedError`** — When the model responded with tool calls only (no text), the Vercel AI SDK raised `NoOutputGeneratedError`. Our catch block silently returned an empty generator instead of propagating the error to the fallback chain.

3. **Vertex thinking config guard was too narrow** — `shouldOmitThinkingConfigForTarget` only matched `gemini-2.5-flash` exactly, causing `thinking_level is not supported` errors on other Vertex models.

### Changes

- **Eager buffering for streaming fallback** — The stream is now consumed and validated synchronously (matching the non-streaming path). If the provider returns no content, the error throws before the function returns, allowing the fallback loop to try the next provider.
- **Propagate `NoOutputGeneratedError`** — Changed from silent `return` to `throw` so the fallback chain continues.
- **Broadened `shouldOmitThinkingConfigForTarget`** — Now strips thinkingConfig for all Vertex models that don't support it (anything not `gemini-2.5*` or `gemini-3*`) and for all LiteLLM models.
- **Fallback OTEL metrics** — New counters `proxy_fallback_attempts_total`, `proxy_fallback_success_total`, `proxy_fallback_failure_total` labeled by provider and model.
- **Fallback span attributes** — Root `proxy.request` span now includes `proxy.fallback.triggered`, `proxy.fallback.provider`, `proxy.fallback.model`, `proxy.fallback.attempt_count`, `proxy.fallback.reason`.
- **Error classification** — Fallback errors are now classified as `rate_limit`, `context_overflow`, `empty_response`, `schema_mismatch`, `provider_quota`, or `unknown` in both stdout logs and OTEL metrics.

### Files Changed

| File | What |
|------|------|
| `src/lib/server/routes/claudeProxyRoutes.ts` | Eager buffering, thinking guard, metrics wiring, error classification |
| `src/lib/providers/litellm.ts` | Propagate NoOutputGeneratedError |
| `src/lib/proxy/proxyTracer.ts` | New fallback metrics, setFallbackInfo method, recordFallbackAttempt export |

### Test Plan

- [x] `pnpm run check` — 0 errors, 0 warnings across 3,746 files
- [x] `pnpm run lint` — passes (1 pre-existing warning for function length)
- [x] `pnpm run build` — full build succeeds (svelte-package + CLI + browser)
- [x] Pre-commit hooks pass (check, format, lint, validate, security, build)
- [ ] Deploy to local proxy and verify fallback logs show `[rate_limit]` / `[empty_response]` classification
- [ ] Verify OpenObserve shows `proxy_fallback_attempts_total` metric
- [ ] Trigger rate-limit exhaustion and verify second fallback provider is tried for streaming requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error propagation in streaming responses to ensure errors are properly reported to users

* **New Features**
  * Enhanced fallback mechanism with detailed attempt tracking, metrics, and intelligent error categorization
  * Expanded thinking configuration support for Vertex Gemini-2.5 and Gemini-3 models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->