### PR TITLE
fix: curator production fixes — compaction, timeout, MCP events, Langfuse

### DIFF
--- a/src/lib/context/contextCompactor.ts
+++ b/src/lib/context/contextCompactor.ts
@@ -44,7 +44,7 @@ const DEFAULT_CONFIG: Required<CompactionConfig> = {
   enableSummarize: true,
   enableTruncate: true,
   pruneProtectTokens: 40_000,
-  pruneMinimumSavings: 20_000,
+  pruneMinimumSavings: 500,
   pruneProtectedTools: ["skill"],
   summarizationProvider: "vertex",
   summarizationModel: "gemini-2.5-flash",
@@ -225,7 +225,7 @@ export class ContextCompactor {
           targetTokens: targetTokens,
           provider: provider,
           adaptiveBuffer: 0.15,
-          maxIterations: 3,
+          maxIterations: 6,
         });
         if (truncResult.truncated) {
           currentMessages = truncResult.messages;

--- a/src/lib/context/stages/slidingWindowTruncator.ts
+++ b/src/lib/context/stages/slidingWindowTruncator.ts
@@ -7,7 +7,7 @@
  *
  * Features:
  * - Adaptive truncation (PERF-001): calculates fraction from actual overage
- *   instead of fixed 50%, with iterative refinement up to 3 passes.
+ *   instead of fixed 50%, with iterative refinement up to 6 passes.
  * - Small conversation handling (BUG-005): for <= 4 messages, truncates
  *   message content proportionally instead of returning no-op.
  */
@@ -214,8 +214,8 @@ export function truncateWithSlidingWindow(
           messagesRemoved: evenRemoveCount,
         };
       }
-      // Not enough -- increase fraction by 25% for next iteration
-      currentFraction = Math.min(0.95, currentFraction + 0.25);
+      // Not enough -- increase fraction by 10% for finer-grained escalation
+      currentFraction = Math.min(0.95, currentFraction + 0.1);
       continue;
     }
 

--- a/src/lib/core/modules/Utilities.ts
+++ b/src/lib/core/modules/Utilities.ts
@@ -27,7 +27,11 @@ import type { MiddlewareFactoryOptions } from "../../types/middlewareTypes.js";
 import type { ZodUnknownSchema } from "../../types/typeAliases.js";
 import { logger } from "../../utils/logger.js";
 import { getSafeMaxTokens } from "../../utils/tokenLimits.js";
-import { TimeoutError } from "../../utils/timeout.js";
+import {
+  TimeoutError,
+  getDefaultTimeout,
+  parseTimeout,
+} from "../../utils/timeout.js";
 import {
   validateStreamOptions as validateStreamOpts,
   validateTextGenerationOptions,
@@ -226,27 +230,45 @@ export class Utilities {
    * Supports number or string formats (e.g., '30s', '2m', '1h')
    */
   getTimeout(options: TextGenerationOptions | StreamOptions): number {
-    if (!options.timeout) {
-      return this.defaultTimeout;
+    // If caller specified a timeout, use it (supports number ms and string formats)
+    if (options.timeout !== undefined && options.timeout !== null) {
+      const parsed = parseTimeout(options.timeout);
+      if (parsed !== undefined) {
+        return parsed;
+      }
     }
 
-    if (typeof options.timeout === "number") {
-      return options.timeout;
+    // Use per-provider default (e.g., vertex=60s, ollama=5m) instead of global 30s.
+    // Always use "generate" operation here — streaming operations have their own
+    // longer timeout (DEFAULT_TIMEOUTS.streaming = 2m) applied by the streaming
+    // infrastructure in BaseProvider.stream(). Both TextGenerationOptions and
+    // StreamOptions share the same `input` property, so there is no reliable
+    // discriminator to detect streaming at this level.
+    const providerDefault = parseTimeout(
+      getDefaultTimeout(this.providerName, "generate"),
+    );
+    return providerDefault ?? this.defaultTimeout;
+  }
+
+  /**
+   * Get timeout scaled by estimated input token count.
+   * For large contexts (>100K tokens), increase timeout proportionally.
+   */
+  getContextAwareTimeout(
+    options: TextGenerationOptions | StreamOptions,
+    estimatedTokens?: number,
+  ): number {
+    const baseTimeout = this.getTimeout(options);
+
+    if (!estimatedTokens || estimatedTokens <= 100_000) {
+      return baseTimeout;
     }
 
-    // Parse string timeout (e.g., '30s', '2m', '1h')
-    const timeoutStr = options.timeout.toLowerCase();
-    const value = parseInt(timeoutStr);
-
-    if (timeoutStr.includes("h")) {
-      return value * 60 * 60 * 1000;
-    } else if (timeoutStr.includes("m")) {
-      return value * 60 * 1000;
-    } else if (timeoutStr.includes("s")) {
-      return value * 1000;
-    }
-
-    return this.defaultTimeout;
+    // Scale: >100K → 1.5x, >200K → 2x, >300K → 2.5x (capped at 4x)
+    // Use (estimatedTokens - 1) so exact multiples stay in the lower tier
+    // (e.g., 100_000 → 1x, 100_001 → 1.5x)
+    const scale = 1 + Math.floor((estimatedTokens - 1) / 100_000) * 0.5;
+    return Math.round(baseTimeout * Math.min(scale, 4));
   }
 
   /**

--- a/src/lib/mcp/externalServerManager.ts
+++ b/src/lib/mcp/externalServerManager.ts
@@ -256,11 +256,17 @@ export class ExternalServerManager extends EventEmitter {
 
     // Forward tool discovery events
     this.toolDiscovery.on("toolRegistered", (event) => {
-      this.emit("toolDiscovered", event);
+      this.emit("toolDiscovered", {
+        ...event,
+        serverName: this.getServerName(event.serverId),
+      });
     });
 
     this.toolDiscovery.on("toolUnregistered", (event) => {
-      this.emit("toolRemoved", event);
+      this.emit("toolRemoved", {
+        ...event,
+        serverName: this.getServerName(event.serverId),
+      });
     });
 
     // Handle process cleanup
@@ -291,6 +297,15 @@ export class ExternalServerManager extends EventEmitter {
    */
   getHITLManager(): HITLManager | undefined {
     return this.hitlManager;
+  }
+
+  /**
+   * Resolve the human-readable server name for an event payload.
+   * Falls back to serverId if the instance or config.name isn't available.
+   */
+  getServerName(serverId: string): string {
+    const instance = this.servers.get(serverId);
+    return instance?.config?.name || serverId;
   }
 
   /**
@@ -935,6 +950,9 @@ export class ExternalServerManager extends EventEmitter {
 
       mcpLogger.info(`[ExternalServerManager] Removing server: ${serverId}`);
 
+      // Capture name before deletion removes the instance
+      const serverName = this.getServerName(serverId);
+
       // Stop the server
       await this.stopServer(serverId);
 
@@ -944,6 +962,7 @@ export class ExternalServerManager extends EventEmitter {
       // Emit event
       this.emit("disconnected", {
         serverId,
+        serverName,
         reason: "Manually removed",
         timestamp: new Date(),
       } satisfies ExternalMCPServerEvents["disconnected"]);
@@ -1078,6 +1097,7 @@ export class ExternalServerManager extends EventEmitter {
       // Emit connected event
       this.emit("connected", {
         serverId,
+        serverName: this.getServerName(serverId),
         toolCount: instance.toolsMap.size,
         timestamp: new Date(),
       } satisfies ExternalMCPServerEvents["connected"]);
@@ -1221,6 +1241,7 @@ export class ExternalServerManager extends EventEmitter {
     // Emit status change event
     this.emit("statusChanged", {
       serverId,
+      serverName: this.getServerName(serverId),
       oldStatus,
       newStatus,
       timestamp: new Date(),
@@ -1251,6 +1272,7 @@ export class ExternalServerManager extends EventEmitter {
     // Emit failed event
     this.emit("failed", {
       serverId,
+      serverName: this.getServerName(serverId),
       error: error.message,
       timestamp: new Date(),
     } satisfies ExternalMCPServerEvents["failed"]);
@@ -1281,6 +1303,7 @@ export class ExternalServerManager extends EventEmitter {
     // Emit disconnected event
     this.emit("disconnected", {
       serverId,
+      serverName: this.getServerName(serverId),
       reason,
       timestamp: new Date(),
     } satisfies ExternalMCPServerEvents["disconnected"]);
@@ -1433,6 +1456,7 @@ export class ExternalServerManager extends EventEmitter {
       // Emit health check event
       this.emit("healthCheck", {
         serverId,
+        serverName: this.getServerName(serverId),
         health,
         timestamp: new Date(),
       } satisfies ExternalMCPServerEvents["healthCheck"]);

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -91,6 +91,7 @@ import {
   getLangfuseHealthStatus,
   initializeOpenTelemetry,
   isOpenTelemetryInitialized,
+  runWithCurrentLangfuseContext,
   setLangfuseContext,
   shutdownOpenTelemetry,
 } from "./services/server/ai/observability/instrumentation.js";
@@ -1715,7 +1716,10 @@ Current user's request: ${currentInput}`;
     userId: string,
     additionalUsers?: AdditionalMemoryUser[],
   ): void {
-    setImmediate(async () => {
+    // Preserve AsyncLocalStorage context across setImmediate boundary so that
+    // memory writes appear under the originating Langfuse trace instead of
+    // becoming orphan spans.
+    const wrappedMemoryWrite = runWithCurrentLangfuseContext(async () => {
       try {
         const client = this.ensureMemoryReady();
         if (!client) {
@@ -1738,11 +1742,21 @@ Current user's request: ${currentInput}`;
           writeOps.push(client.add(user.userId, content, addOptions));
         }
 
-        await Promise.all(writeOps);
+        // withTimeout races against Promise.all — if the timeout fires, the
+        // await resolves with an error but the underlying client.add() calls
+        // may still complete in the background. This is acceptable: the memory
+        // client API (Mem0) doesn't support AbortSignal, and these are
+        // fire-and-forget background writes where a stale completion is harmless.
+        await withTimeout(
+          Promise.all(writeOps),
+          30_000,
+          new Error("Background memory write timed out after 30s"),
+        );
       } catch (error) {
         logger.warn("Memory storage failed:", error);
       }
     });
+    setImmediate(wrappedMemoryWrite);
   }
 
   /**
@@ -5261,6 +5275,25 @@ Current user's request: ${currentInput}`;
       shouldCompact: budgetResult.shouldCompact,
     });
 
+    // Scale timeout for large contexts if caller didn't set one explicitly.
+    // Providers read options.timeout via getTimeout(), so setting it here
+    // propagates to any downstream provider call.
+    if (
+      options.timeout === undefined &&
+      budgetResult.estimatedInputTokens > 100_000
+    ) {
+      // >100K → 1.5x, >200K → 2x, >300K → 2.5x (capped at 4x) of 60s base
+      const scale =
+        1 + Math.floor((budgetResult.estimatedInputTokens - 1) / 100_000) * 0.5;
+      const scaledMs = Math.round(60_000 * Math.min(scale, 4));
+      options.timeout = scaledMs;
+      logger.info("[TokenBudget] Scaled timeout for large context", {
+        requestId,
+        estimatedTokens: budgetResult.estimatedInputTokens,
+        scaledTimeoutMs: scaledMs,
+      });
+    }
+
     const compactionSessionId = this.getCompactionSessionId(options);
     const lastCompactionCount =
       this.lastCompactionMessageCount.get(compactionSessionId) ?? 0;
@@ -5399,6 +5432,9 @@ Current user's request: ${currentInput}`;
     });
 
     if (!finalBudget.withinBudget) {
+      // Clear watermark so handleContextOverflow recovery can re-compact
+      this.lastCompactionMessageCount.delete(compactionSessionId);
+
       throw new ContextBudgetExceededError(
         `Context exceeds model budget after all compaction stages. ` +
           `Estimated: ${finalBudget.estimatedInputTokens} tokens, ` +
@@ -5701,6 +5737,9 @@ Current user's request: ${currentInput}`;
             });
 
             if (!finalBudget.withinBudget) {
+              // Clear watermark so handleContextOverflow recovery can re-compact
+              this.lastCompactionMessageCount.delete(dpgCompactionSessionId);
+
               throw new ContextBudgetExceededError(
                 `Context exceeds model budget after all compaction stages. ` +
                   `Estimated: ${finalBudget.estimatedInputTokens} tokens, ` +
@@ -7195,6 +7234,9 @@ Current user's request: ${currentInput}`;
         });
 
         if (!finalBudget.withinBudget) {
+          // Clear watermark so handleContextOverflow recovery can re-compact
+          this.lastCompactionMessageCount.delete(streamCompactionSessionId);
+
           throw new ContextBudgetExceededError(
             `Stream context exceeds model budget after all compaction stages. ` +
               `Estimated: ${finalBudget.estimatedInputTokens} tokens, ` +
@@ -10745,6 +10787,7 @@ Current user's request: ${currentInput}`;
         // Emit server added event
         this.emitter.emit("externalMCP:serverAdded", {
           serverId,
+          serverName: config.name || serverId,
           config,
           toolCount: result.metadata?.toolsDiscovered || 0,
           timestamp: Date.now(),
@@ -10781,6 +10824,9 @@ Current user's request: ${currentInput}`;
     try {
       mcpLogger.info(`[NeuroLink] Removing external MCP server: ${serverId}`);
 
+      // Capture the configured name before removal destroys the instance
+      const serverName = this.externalServerManager.getServerName(serverId);
+
       const result = await this.externalServerManager.removeServer(serverId);
 
       if (result.success) {
@@ -10791,6 +10837,7 @@ Current user's request: ${currentInput}`;
         // Emit server removed event
         this.emitter.emit("externalMCP:serverRemoved", {
           serverId,
+          serverName,
           timestamp: Date.now(),
         });
       } else {

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -668,8 +668,54 @@ function initializeExternalOpenTelemetryMode(
       if (globalProvider && typeof provider.addSpanProcessor === "function") {
         provider.addSpanProcessor(new ContextEnricher());
 
+        // Auto-detect: skip if consumer already registered a LangfuseSpanProcessor.
+        //
+        // Detection strategy (ordered by robustness):
+        // 1. `instanceof LangfuseSpanProcessor` — reliable when both sides use
+        //    the same @langfuse/otel package instance (same module identity).
+        // 2. Duck-type check for Langfuse-specific public member
+        //    (`langfuseClient` property) — survives minification.
+        // 3. `constructor.name === "LangfuseSpanProcessor"` — last resort,
+        //    brittle under minification or bundler renaming.
+        //
+        // NOTE: `_registeredSpanProcessors` is an internal OpenTelemetry field.
+        // If the OTel SDK removes or renames it, the array defaults to [] and
+        // `hasExistingLangfuse` is false — NeuroLink registers its own processor
+        // (same behavior as before this check). Consumers can always force skip
+        // via `skipLangfuseSpanProcessor: true`.
+        const existingProcessors =
+          (provider as { _registeredSpanProcessors?: unknown[] })
+            ._registeredSpanProcessors ?? [];
+        const hasExistingLangfuse = existingProcessors.some((p) => {
+          if (p === null || p === undefined || typeof p !== "object") {
+            return false;
+          }
+          // Prefer instanceof — works when same @langfuse/otel package is shared
+          if (p instanceof LangfuseSpanProcessor) {
+            return true;
+          }
+          // Duck-type: Langfuse processor exposes a langfuseClient property
+          if ("langfuseClient" in p) {
+            return true;
+          }
+          // Fallback: constructor name (brittle under minification)
+          return (
+            (p as { constructor?: { name?: string } }).constructor?.name ===
+            "LangfuseSpanProcessor"
+          );
+        });
+
         const skipLangfuse =
-          config.skipLangfuseSpanProcessor === true || !langfuseProcessor;
+          config.skipLangfuseSpanProcessor === true ||
+          !langfuseProcessor ||
+          hasExistingLangfuse;
+
+        if (hasExistingLangfuse && !config.skipLangfuseSpanProcessor) {
+          logger.info(
+            `${LOG_PREFIX} Auto-detected existing LangfuseSpanProcessor — skipping SDK registration to avoid duplicates`,
+          );
+        }
+
         if (!skipLangfuse && langfuseProcessor) {
           provider.addSpanProcessor(langfuseProcessor);
         }

--- a/src/lib/types/externalMcp.ts
+++ b/src/lib/types/externalMcp.ts
@@ -306,6 +306,7 @@ export type ExternalMCPServerEvents = {
   /** Server status changed */
   statusChanged: {
     serverId: string;
+    serverName: string;
     oldStatus: ExternalMCPServerStatus;
     newStatus: ExternalMCPServerStatus;
     timestamp: Date;
@@ -314,6 +315,7 @@ export type ExternalMCPServerEvents = {
   /** Server connected successfully */
   connected: {
     serverId: string;
+    serverName: string;
     toolCount: number;
     timestamp: Date;
   };
@@ -321,6 +323,7 @@ export type ExternalMCPServerEvents = {
   /** Server disconnected */
   disconnected: {
     serverId: string;
+    serverName: string;
     reason?: string;
     timestamp: Date;
   };
@@ -328,6 +331,7 @@ export type ExternalMCPServerEvents = {
   /** Server failed */
   failed: {
     serverId: string;
+    serverName: string;
     error: string;
     timestamp: Date;
   };
@@ -335,6 +339,7 @@ export type ExternalMCPServerEvents = {
   /** Tool discovered */
   toolDiscovered: {
     serverId: string;
+    serverName: string;
     toolName: string;
     toolInfo: ExternalMCPToolInfo;
     timestamp: Date;
@@ -343,6 +348,7 @@ export type ExternalMCPServerEvents = {
   /** Tool removed */
   toolRemoved: {
     serverId: string;
+    serverName: string;
     toolName: string;
     timestamp: Date;
   };
@@ -350,6 +356,7 @@ export type ExternalMCPServerEvents = {
   /** Health check completed */
   healthCheck: {
     serverId: string;
+    serverName: string;
     health: ExternalMCPServerHealth;
     timestamp: Date;
   };


### PR DESCRIPTION
## Summary

Fixes 6 production issues identified across 4 Curator monitoring cycles (2.27M telemetry rows, 10.3 GB, Mar 18 – Apr 8 2026) where the **root cause lives in the NeuroLink SDK**, not in Curator.

### Root Cause

Production telemetry from Curator (AI Slack assistant using NeuroLink as core engine) revealed six compounding issues:

1. **Token overflow — compaction pipeline ineffective** — \`pruneMinimumSavings: 20_000\` blocked Stage 1 from pruning tool outputs unless savings exceeded 20K tokens. In typical Curator conversations, stages 1-2 found nothing, stage 3 summarization failed silently, and stage 4 truncation used coarse 25%/iteration jumps (3 max). Evidence: 207K tokens vs 200K limit, compaction removed ~5 tokens, 3 wasted retry attempts per overflow.

2. **Compaction watermark prevented recovery** — After compaction failed and threw \`ContextBudgetExceededError\`, the \`lastCompactionMessageCount\` watermark was stale in **all three paths** (\`compactMCPConversationForBudget\`, \`directProviderGeneration\`, \`createMCPStream\`). Subsequent \`handleContextOverflow\` recovery calls saw "already compacted" and skipped re-compaction.

3. **Vertex AI timeout too short** — \`BaseProvider.defaultTimeout = 30000\` (30s) was hardcoded. \`DEFAULT_TIMEOUTS.providers.vertex = "60s"\` existed in \`timeout.ts\` as dead code — \`Utilities.getTimeout()\` never called \`getDefaultTimeout()\`. Gemini p90 latency for large contexts (69K-353K tokens) is 54.5s. Evidence: 21 timeout errors in 5-day period. Additionally, no dynamic scaling existed for large contexts.

4. **MCP events missing serverName** — All \`externalMCP:*\` events carried \`serverId\` but not \`serverName\`. The \`removeServer\` path was especially broken — it called \`getServerName()\` after \`servers.delete()\` had already destroyed the instance.

5. **Duplicate Langfuse spans** — When both NeuroLink and the consumer registered a \`LangfuseSpanProcessor\`, duplicate spans were exported. No auto-detection existed.

6. **AsyncLocalStorage context loss** — \`setImmediate()\` in \`storeMemoryInBackground\` lost AsyncLocalStorage context. Background memory writes appeared as orphaned root spans in Langfuse. Also lacked a timeout, so hung Redis connections could block indefinitely.

### Changes

**Context Compaction (FIX 1-2):**
- \`pruneMinimumSavings\` 20K → 500 so Stage 1 prunes tool outputs with modest savings
- Stage 4 truncation escalation: +25%/3 iterations → +10%/6 iterations (18%→28%→38%→48%→58%→68%)
- \`this.lastCompactionMessageCount.delete()\` before every \`ContextBudgetExceededError\` throw in all 3 paths (\`compactMCPConversationForBudget\`, \`directProviderGeneration\`, \`createMCPStream\`)
- slidingWindowTruncator doc comment updated from "3 passes" to "6 passes"

**Timeout (FIX 3):**
- \`Utilities.getTimeout()\` now calls \`getDefaultTimeout(providerName, "generate")\` returning per-provider values (vertex=60s, ollama=5m, bedrock=45s) instead of hardcoded 30s
- Timeout check uses \`!== undefined && !== null\` to honor zero/falsy values
- Comment explains why "generate" is always used (both \`TextGenerationOptions\` and \`StreamOptions\` share the \`input\` property — no reliable discriminator; streaming has its own timeout infrastructure)
- New \`getContextAwareTimeout()\` utility: >100K → 1.5x, >200K → 2x, >300K → 2.5x (capped at 4x). Uses \`(estimatedTokens - 1)\` divisor so exact boundaries stay in lower tier
- **Wired up in \`ensureMCPGenerationBudget\`**: after \`checkContextBudget\` returns \`estimatedInputTokens\`, sets \`options.timeout\` with scaled value if user didn't specify one — propagates to all downstream provider calls naturally via \`getTimeout(options)\`

**MCP Events (FIX 4):**
- \`serverName: string\` added to all 7 \`ExternalMCPServerEvents\` type payloads
- \`getServerName()\` helper made public (resolves \`instance.config.name || serverId\`)
- \`removeServer\` captures name **before** \`servers.delete()\`
- \`removeExternalMCPServer\` in neurolink.ts captures name via \`getServerName()\` **before** \`removeServer()\` destroys the instance

**Langfuse Observability (FIX 5-6):**
- Auto-detect existing \`LangfuseSpanProcessor\` with 3-tier detection: (1) \`instanceof LangfuseSpanProcessor\`, (2) duck-type \`langfuseClient\` property, (3) \`constructor.name\` fallback. Detailed comments explain fragility of \`_registeredSpanProcessors\` internal API and fallback behavior
- \`storeMemoryInBackground\` setImmediate wrapped with \`runWithCurrentLangfuseContext()\`
- \`Promise.all(writeOps)\` wrapped in \`withTimeout(…, 30_000)\` with comment explaining why underlying ops aren't cancelled (Mem0 client doesn't support AbortSignal; fire-and-forget background writes where stale completion is harmless)

### Verified — No Change Needed

- **Tool call corruption (FIX 6)** — Role filter at \`messageBuilder.ts:1392-1397\` and \`isValidRole\` guard at line 313 confirmed present.

### Files Changed

| File | What |
|------|------|
| \`src/lib/context/contextCompactor.ts\` | \`pruneMinimumSavings\` 20K→500, \`maxIterations\` 3→6 |
| \`src/lib/context/stages/slidingWindowTruncator.ts\` | Escalation +25%→+10%, doc "3 passes"→"6 passes" |
| \`src/lib/core/modules/Utilities.ts\` | \`getTimeout()\` per-provider defaults, null check, \`getContextAwareTimeout()\` with \`(n-1)\` divisor |
| \`src/lib/types/externalMcp.ts\` | \`serverName: string\` in all 7 event types |
| \`src/lib/mcp/externalServerManager.ts\` | Public \`getServerName()\`, all emit sites, capture name before \`servers.delete()\` |
| \`src/lib/neurolink.ts\` | Watermark delete in 3 paths, timeout scaling in \`ensureMCPGenerationBudget\`, \`serverName\` capture before removal, \`runWithCurrentLangfuseContext\` + \`withTimeout\` for memory |
| \`src/lib/services/server/ai/observability/instrumentation.ts\` | 3-tier Langfuse detection (\`instanceof\` → duck-type → constructor name) with fragility comments |
| \`docs/superpowers/plans/2026-04-09-curator-production-fixes.md\` | Updated plan with wiring step and corrected snippets |

### Test Plan

- [x] \`pnpm run check\` — 0 errors, 0 warnings across 3,746 files
- [x] \`pnpm run lint\` — passes (1 pre-existing warning for function length)
- [x] \`pnpm run build\` — full build succeeds (svelte-package + CLI + browser)
- [x] Pre-commit hooks pass
- [ ] Deploy to staging, send >100K token Curator conversation → verify timeout log shows scaled value
- [ ] Verify Vertex timeout errors drop (30s → 60s+ default)
- [ ] Verify MCP metrics show \`server=<name>\` instead of \`server=unknown\`
- [ ] Verify \`externalMCP:serverRemoved\` emits real name after removal
- [ ] Verify no duplicate Langfuse spans with default config
- [ ] Verify background memory writes appear under parent Langfuse trace
- [ ] Verify memory write timeout fires after 30s on hung Redis