### PR TITLE
feat(proxy): add --dev flag for isolated local proxy instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .git
+.neurolink-dev/
 
 # Output
 .output

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -60,7 +60,18 @@ const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
 // STATE MANAGEMENT
 // =============================================================================
 
-const proxyStateManager = new StateFileManager<ProxyState>("proxy-state.json");
+let proxyStateManager = new StateFileManager<ProxyState>("proxy-state.json");
+
+/**
+ * Reinitialise the state manager with a custom base directory.
+ * Called when --dev redirects writable paths to .neurolink-dev/.
+ */
+function setProxyStateDir(baseDir: string): void {
+  proxyStateManager = new StateFileManager<ProxyState>(
+    "proxy-state.json",
+    baseDir,
+  );
+}
 
 function saveProxyState(state: ProxyState): void {
   proxyStateManager.save(state);
@@ -468,7 +479,7 @@ async function loadProxyStartEnv(
   }
 }
 
-async function createProxyNeurolinkRuntime() {
+async function createProxyNeurolinkRuntime(logsDir?: string) {
   process.env.NEUROLINK_SKIP_MCP = "true";
 
   const { NeuroLink } = await import("../../lib/neurolink.js");
@@ -476,7 +487,7 @@ async function createProxyNeurolinkRuntime() {
   const { initRequestLogger, cleanupLogs } =
     await import("../../lib/proxy/requestLogger.js");
 
-  initRequestLogger(true);
+  initRequestLogger(true, logsDir);
   cleanupLogs(7, 500);
 
   return { neurolink, cleanupLogs };
@@ -929,6 +940,7 @@ function registerProxyShutdownHandlers(params: {
   server: { close?: () => void };
   host: string;
   port: number;
+  isDev?: boolean;
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
 }): void {
@@ -946,7 +958,7 @@ function registerProxyShutdownHandlers(params: {
       // non-fatal — proxy shutdown must not block on OTel
     }
 
-    if (signal === "SIGINT") {
+    if (signal === "SIGINT" && !params.isDev) {
       try {
         const shutdownHost =
           params.host === "0.0.0.0" ? "localhost" : params.host;
@@ -992,7 +1004,11 @@ async function startProxyRuntime(params: {
     port: params.port,
     hostname: params.host,
   });
-  const guardPid = spawnFailOpenGuard(params.host, params.port, process.pid);
+  // Skip the fail-open guard in dev mode — it monitors the proxy and clears
+  // global Claude settings on exit, which is exactly what we want to avoid.
+  const guardPid = params.argv.dev
+    ? undefined
+    : spawnFailOpenGuard(params.host, params.port, process.pid);
   const readinessHost = params.host === "0.0.0.0" ? "127.0.0.1" : params.host;
   await waitForProxyReadiness({
     host: readinessHost,
@@ -1031,12 +1047,20 @@ async function startProxyRuntime(params: {
     params.spinner.succeed(chalk.green("Claude proxy started successfully"));
   }
 
+  const isDev = params.argv.dev ?? false;
   const normalizedHost = params.host === "0.0.0.0" ? "localhost" : params.host;
   const url = `http://${normalizedHost}:${params.port}`;
   printProxyBanner(url, params.strategy);
-  logger.always(
-    `  ${chalk.bold("Mode:")}       ${chalk.cyan(params.passthrough ? "passthrough" : "full")}`,
-  );
+
+  if (isDev) {
+    logger.always(
+      `  ${chalk.bold("Mode:")}       ${chalk.magenta("dev (isolated — state in .neurolink-dev/)")}`,
+    );
+  } else {
+    logger.always(
+      `  ${chalk.bold("Mode:")}       ${chalk.cyan(params.passthrough ? "passthrough" : "full")}`,
+    );
+  }
   if (params.passthrough) {
     logger.always(
       chalk.yellow(
@@ -1055,16 +1079,22 @@ async function startProxyRuntime(params: {
     );
   }
 
-  try {
-    await setClaudeProxySettings(url);
-    logger.always(chalk.green("  ✓ Auto-configured Claude Code settings"));
+  if (!isDev) {
+    try {
+      await setClaudeProxySettings(url);
+      logger.always(chalk.green("  ✓ Auto-configured Claude Code settings"));
+      logger.always(
+        chalk.dim("    Restart Claude Code to connect through proxy"),
+      );
+    } catch (error) {
+      logger.debug(
+        "[proxy] Failed to auto-configure Claude Code: " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+  } else {
     logger.always(
-      chalk.dim("    Restart Claude Code to connect through proxy"),
-    );
-  } catch (error) {
-    logger.debug(
-      "[proxy] Failed to auto-configure Claude Code: " +
-        (error instanceof Error ? error.message : String(error)),
+      chalk.dim("  ⊘ Dev mode: skipping client auto-configuration"),
     );
   }
 
@@ -1073,17 +1103,44 @@ async function startProxyRuntime(params: {
     server,
     host: params.host,
     port: params.port,
+    isDev,
     ...maintenance,
   });
 }
 
 async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
   const spinner = argv.quiet ? null : ora("Starting Claude proxy...").start();
+  const isDev = argv.dev ?? false;
 
   try {
-    await ensureProxyStartAllowed(spinner);
+    // In dev mode: redirect writable state to .neurolink-dev/ and skip singleton check
+    let devPaths:
+      | import("../../lib/proxy/proxyPaths.js").ProxyPaths
+      | undefined;
+    if (isDev) {
+      const { resolveProxyPaths } =
+        await import("../../lib/proxy/proxyPaths.js");
+      devPaths = resolveProxyPaths(true);
+      setProxyStateDir(devPaths.stateDir);
+
+      const { initAccountQuota } =
+        await import("../../lib/proxy/accountQuota.js");
+      initAccountQuota(devPaths.quotaFile);
+
+      // Ensure the dev state directory exists
+      const { mkdirSync, existsSync } = await import("fs");
+      if (!existsSync(devPaths.stateDir)) {
+        mkdirSync(devPaths.stateDir, { recursive: true, mode: 0o700 });
+      }
+    }
+
+    if (!isDev) {
+      await ensureProxyStartAllowed(spinner);
+    }
     const loadedEnvFile = await loadProxyStartEnv(argv, spinner);
-    const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime();
+    const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime(
+      devPaths?.logsDir,
+    );
     const { proxyConfig, strategy, modelRouter, passthrough } =
       await loadProxyStartConfiguration(argv, spinner);
 
@@ -1201,6 +1258,12 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
         default: false,
         description:
           "Run in transparent passthrough mode (no retry, no rotation, no polyfill)",
+      })
+      .option("dev", {
+        type: "boolean",
+        default: false,
+        description:
+          "Run in isolated dev mode — state files scoped to .neurolink-dev/ in cwd, no client auto-configuration, no singleton check",
       })
       .example(
         "neurolink proxy start",

--- a/src/cli/utils/serverUtils.ts
+++ b/src/cli/utils/serverUtils.ts
@@ -103,9 +103,10 @@ export class StateFileManager<T> {
   /**
    * Create a new state file manager
    * @param filename - Name of the state file (e.g., "serve-state.json")
+   * @param baseDir - Optional base directory (defaults to ~/.neurolink)
    */
-  constructor(filename: string) {
-    this.filePath = path.join(getNeuroLinkDir(), filename);
+  constructor(filename: string, baseDir?: string) {
+    this.filePath = path.join(baseDir ?? getNeuroLinkDir(), filename);
   }
 
   /**
@@ -120,7 +121,10 @@ export class StateFileManager<T> {
    * @param state - State object to save
    */
   save(state: T): void {
-    ensureStateDir();
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
     fs.writeFileSync(this.filePath, JSON.stringify(state, null, 2));
   }
 

--- a/src/lib/proxy/accountQuota.ts
+++ b/src/lib/proxy/accountQuota.ts
@@ -10,7 +10,7 @@
  * path is never blocked by file I/O.
  */
 
-import { join } from "path";
+import { dirname, join } from "path";
 import { homedir } from "os";
 import { promises as fs } from "fs";
 import type { AccountQuota } from "../types/index.js";
@@ -93,12 +93,35 @@ let cacheLoaded = false;
 let dirty = false;
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
+/** Custom quota file path set via initAccountQuota(). */
+let customQuotaFilePath: string | null = null;
+
+/**
+ * Initialise the quota module with a custom file path.
+ * When set, all reads/writes go to this path instead of the default
+ * ~/.neurolink/account-quotas.json. Call before the first load/save.
+ */
+export function initAccountQuota(quotaFilePath: string): void {
+  customQuotaFilePath = quotaFilePath;
+  // Cancel any pending flush from a previous configuration so it does not
+  // write stale data to the new path.
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  // Reset cache so the new path is picked up on next load
+  memoryCache = {};
+  cacheLoaded = false;
+  dirty = false;
+}
+
 function getQuotaFilePath(): string {
-  return join(homedir(), ".neurolink", QUOTA_FILE);
+  return customQuotaFilePath ?? join(homedir(), ".neurolink", QUOTA_FILE);
 }
 
 async function ensureDir(): Promise<void> {
-  const dir = join(homedir(), ".neurolink");
+  const filePath = getQuotaFilePath();
+  const dir = dirname(filePath);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => {
     // Non-fatal: directory may already exist
   });

--- a/src/lib/proxy/proxyPaths.ts
+++ b/src/lib/proxy/proxyPaths.ts
@@ -1,0 +1,47 @@
+/**
+ * Proxy file path resolver.
+ *
+ * In normal mode, all paths resolve under ~/.neurolink/.
+ * In dev mode (--dev), writable paths resolve under <cwd>/.neurolink-dev/
+ * so a local dev proxy never touches the global proxy's state.
+ *
+ * Read-only paths (like .env) always point to the global location
+ * since credentials must be shared.
+ *
+ * NOTE: Claude Code header snapshots (~/.neurolink/header-snapshots/) are
+ * not redirected in dev mode. They are only written when a real Claude Code
+ * client connects, which typically does not happen during dev testing.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type ProxyPaths = {
+  /** Base directory for proxy state files */
+  stateDir: string;
+  /** logs/ — request/response logs */
+  logsDir: string;
+  /** account-quotas.json — per-account rate limit state */
+  quotaFile: string;
+  /** Whether this is a dev-mode isolated instance */
+  isDev: boolean;
+};
+
+export function resolveProxyPaths(dev: boolean): ProxyPaths {
+  if (dev) {
+    const base = join(process.cwd(), ".neurolink-dev");
+    return {
+      stateDir: base,
+      logsDir: join(base, "logs"),
+      quotaFile: join(base, "account-quotas.json"),
+      isDev: true,
+    };
+  }
+  const base = join(homedir(), ".neurolink");
+  return {
+    stateDir: base,
+    logsDir: join(base, "logs"),
+    quotaFile: join(base, "account-quotas.json"),
+    isDev: false,
+  };
+}

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -67,14 +67,17 @@ const SENSITIVE_HEADER_PATTERN = /token|secret|key|password|credential/i;
 const SENSITIVE_BODY_KEYS =
   /("(?:password|access_token|refresh_token|api_key|apiKey|secret|authorization|token|credential|x-api-key)"\s*:\s*)"(?:[^"\\]|\\.)*"/gi;
 
-export function initRequestLogger(enabled: boolean = true): void {
+export function initRequestLogger(
+  enabled: boolean = true,
+  customLogsDir?: string,
+): void {
   logEnabled = enabled;
   if (!enabled) {
     return;
   }
 
   try {
-    logDir = join(homedir(), ".neurolink", "logs");
+    logDir = customLogsDir ?? join(homedir(), ".neurolink", "logs");
     if (!existsSync(logDir)) {
       mkdirSync(logDir, { recursive: true, mode: 0o700 });
     }

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -877,6 +877,7 @@ export type ProxyStartArgs = {
   config?: string;
   envFile?: string;
   passthrough?: boolean;
+  dev?: boolean;
 };
 
 /** Arguments accepted by `neurolink proxy status` */


### PR DESCRIPTION
## Summary

Adds a `--dev` flag to `neurolink proxy start` that redirects all writable state files to a local `.neurolink-dev/` directory in the current working directory. This allows running a local dev proxy alongside the global production proxy without any interference.

### Problem

Running `neurolink proxy start --port 5555` alongside a global proxy on 55669 clobbers shared state files under `~/.neurolink/`, breaking the global proxy's status tracking, log files, and potentially credential files.

### Solution

`neurolink proxy start --dev --port 5555` now:
- Writes state to `.neurolink-dev/proxy-state.json` (not `~/.neurolink/`)
- Writes logs to `.neurolink-dev/logs/` (not `~/.neurolink/logs/`)
- Writes quota to `.neurolink-dev/account-quotas.json` (not `~/.neurolink/`)
- Skips singleton check (coexists with global proxy)
- Skips Claude Code settings auto-configuration
- Still reads `.env` and OAuth credentials from `~/.neurolink/` (shared, read-only)

Zero impact on existing users — `--dev` defaults to `false`.

### Files Changed

| File | Change |
|------|--------|
| `src/lib/proxy/proxyPaths.ts` | **NEW** — path resolver (dev vs global) |
| `src/lib/types/cli.ts` | `dev?: boolean` on `ProxyStartArgs` |
| `src/cli/commands/proxy.ts` | `--dev` flag + lifecycle guards |
| `src/cli/utils/serverUtils.ts` | `StateFileManager` accepts custom base dir |
| `src/lib/proxy/requestLogger.ts` | Custom logs dir param |
| `src/lib/proxy/accountQuota.ts` | Custom quota file path |
| `.gitignore` | `.neurolink-dev/` |

## Test plan

- [ ] `neurolink proxy start` (no --dev) — verify behavior unchanged, state in `~/.neurolink/`
- [ ] `neurolink proxy start --dev --port 5555` — verify state in `.neurolink-dev/`, global proxy unaffected
- [ ] Kill dev proxy — verify `~/.neurolink/proxy-state.json` untouched
- [ ] `neurolink proxy status` — verify still reports global proxy correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --dev flag to start the proxy in isolated development mode: uses separate state, logs, and quota locations and skips automatic client auto-configuration and system-level singleton checks.
  * Dev mode supports redirecting request logs to a custom logs directory.

* **Chores**
  * Added development state directory to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->