### PR TITLE
fix(proxy): full OAuth betas through proxy, explicit baseURL, and lower cooldown floor

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -14,6 +14,7 @@ import {
   ANTHROPIC_TOKEN_URL,
   CLAUDE_CLI_USER_AGENT,
   CLAUDE_CODE_CLIENT_ID,
+  CLAUDE_CODE_OAUTH_BETAS,
 } from "../auth/anthropicOAuth.js";
 import {
   type AIProviderName,
@@ -439,6 +440,9 @@ export class AnthropicProvider extends BaseProvider {
       anthropic = createAnthropic({
         apiKey: apiKeyToUse,
         headers,
+        ...(process.env.ANTHROPIC_BASE_URL && {
+          baseURL: process.env.ANTHROPIC_BASE_URL,
+        }),
         fetch: createProxyFetch(),
       });
 
@@ -489,9 +493,23 @@ export class AnthropicProvider extends BaseProvider {
   public getAuthHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
 
-    // Add beta headers if enabled
+    // When routing through proxy (ANTHROPIC_BASE_URL set), use the full
+    // OAuth beta set so the proxy forwards them upstream. Without these,
+    // Anthropic treats the request with tighter non-subscription rate limits.
+    const usingProxy = !!process.env.ANTHROPIC_BASE_URL;
+
     if (this.enableBetaFeatures) {
-      headers["anthropic-beta"] = ANTHROPIC_BETA_HEADERS["anthropic-beta"];
+      if (usingProxy) {
+        headers["anthropic-beta"] = [
+          ...CLAUDE_CODE_OAUTH_BETAS,
+          "fine-grained-tool-streaming-2025-05-14",
+          "context-1m-2025-08-07",
+          "interleaved-thinking-2025-05-14",
+          "redact-thinking-2026-02-12",
+        ].join(",");
+      } else {
+        headers["anthropic-beta"] = ANTHROPIC_BETA_HEADERS["anthropic-beta"];
+      }
     }
 
     // Add subscription-specific headers if applicable

--- a/src/lib/proxy/routingPolicy.ts
+++ b/src/lib/proxy/routingPolicy.ts
@@ -27,7 +27,7 @@ const STREAMING_CONVERSATIONAL_TOOL_THRESHOLD = 4;
 const STRONG_TOOL_FIDELITY_THRESHOLD = 8;
 const HIGH_TOOL_COUNT_THRESHOLD = 24;
 const DEFAULT_COOLDOWN_FLOOR_MS = 1_000;
-const HIGH_TOOL_COUNT_COOLDOWN_FLOOR_MS = 120_000;
+const HIGH_TOOL_COUNT_COOLDOWN_FLOOR_MS = 10_000;
 const HIGH_FIDELITY_COOLDOWN_FLOOR_MS = 300_000;
 
 export function inferClaudeProxyModelTier(
@@ -346,12 +346,16 @@ export function applyRateLimitCooldownScope(args: {
     mtBackoffLevels[modelTierKey] ?? 0,
   );
 
-  const floorMs =
-    args.profile.modelTier === "opus" || args.profile.requiresStrongToolFidelity
+  // High-tool-count-non-stream gets its own (lower) floor so that requests
+  // recover faster once proper OAuth betas are forwarded. Check it first
+  // because every >=24-tool request also satisfies requiresStrongToolFidelity
+  // (threshold 8), which would otherwise shadow this branch.
+  const floorMs = args.profile.isHighToolCountNonStream
+    ? HIGH_TOOL_COUNT_COOLDOWN_FLOOR_MS
+    : args.profile.modelTier === "opus" ||
+        args.profile.requiresStrongToolFidelity
       ? HIGH_FIDELITY_COOLDOWN_FLOOR_MS
-      : args.profile.isHighToolCountNonStream
-        ? HIGH_TOOL_COUNT_COOLDOWN_FLOOR_MS
-        : DEFAULT_COOLDOWN_FLOOR_MS;
+      : DEFAULT_COOLDOWN_FLOOR_MS;
   const baseCooldownMs = Math.max(args.retryAfterMs ?? 0, floorMs);
   const backoffMs = Math.min(
     baseCooldownMs * 2 ** scopedBackoffLevel,


### PR DESCRIPTION
## Summary

Three fixes that together restore proper rate-limit treatment and recovery for Claude requests routed through the NeuroLink proxy:

- **Full OAuth betas forwarded through proxy**: `getAuthHeaders()` now emits the complete `CLAUDE_CODE_OAUTH_BETAS` set (oauth, claude-code, context-management, prompt-caching, advanced-tool-use, effort) plus streaming/context/thinking extras (`fine-grained-tool-streaming`, `context-1m`, `interleaved-thinking`, `redact-thinking`) whenever `ANTHROPIC_BASE_URL` is set. Without this, upstream Anthropic treats requests as non-subscription and applies much tighter rate limits.
- **Explicit `baseURL` to `createAnthropic()`**: when `ANTHROPIC_BASE_URL` is set, the SDK now passes it through to `@ai-sdk/anthropic` so requests actually hit the proxy (previously only the fetch wrapper knew about it).
- **Lower `HIGH_TOOL_COUNT_COOLDOWN_FLOOR_MS` from 120s → 10s**: with the correct betas forwarded, upstream limits are generous enough that a 2-minute cooldown is unnecessarily punitive.
- **Fix cooldown priority**: reordered `applyRateLimitCooldownScope` so `isHighToolCountNonStream` is checked *before* `requiresStrongToolFidelity`. Every >=24-tool request also satisfies the >=8-tool strong-fidelity threshold, which previously shadowed the high-tool-count branch and made the new 10s floor unreachable.

## Verification

Added two verification scripts (36 total assertions, all passing):

| Suite | Checks |
| --- | --- |
| `test/verify-bug-fixes.ts` | 23 unit-level assertions for Fix 1/2/3 (headers, baseURL spread, cooldown math, source invariants) |
| `test/verify-cli-fixes.ts` | 13 CLI + SDK integration checks (CLI smoke, provider status, proxy header verification, cooldown via routing policy) |

Also verified:
- `tsc --noEmit --strict`: 0 errors across 3616 files
- `pnpm run build`: SDK + CLI + browser, 0 errors, publint clean
- `pnpm test` (full continuous suite): 36 passed, 0 failed, 2 skipped

## Test plan

- [x] Run `npx tsx test/verify-bug-fixes.ts` — all 23 assertions pass
- [x] Run `npx tsx test/verify-cli-fixes.ts` — all 13 assertions pass
- [x] Run `pnpm test` — continuous test suite 36/36
- [x] Run `pnpm run build` — clean build
- [ ] Manual smoke: start proxy, make high-tool-count request with `ANTHROPIC_BASE_URL` set, confirm full beta header is forwarded upstream
- [ ] Manual smoke: trigger a 429 with >=24 tools and confirm the cooldown is ~10s rather than ~120s