### PR TITLE
fix(auth): always display OAuth URL for remote device compatibility

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1267,6 +1267,9 @@ async function handleCreateApiKeyOAuth(
   logger.always("3. Copy the authorization code shown on the page");
   logger.always("4. Paste the code below");
   logger.always("");
+  logger.always(chalk.dim("  Authentication URL:"));
+  logger.always(chalk.cyan(`  ${authUrl.toString()}`));
+  logger.always("");
 
   // Prompt user to enter the authorization code
   const { authCode } = await inquirer.prompt([
@@ -1483,6 +1486,9 @@ async function handleOAuthAuth(provider: SupportedProvider): Promise<void> {
   logger.always("2. Authorize the application");
   logger.always("3. Copy the authorization code shown on the page");
   logger.always("4. Paste the code below");
+  logger.always("");
+  logger.always(chalk.dim("  Authentication URL:"));
+  logger.always(chalk.cyan(`  ${authUrl.toString()}`));
   logger.always("");
 
   // Prompt user to enter the authorization code


### PR DESCRIPTION
## Summary
- Always display the OAuth authentication URL in the instructions block during `neurolink proxy setup` and `neurolink auth login`
- Previously the URL was only shown in the `catch` block (when browser failed to open), leaving remote SSH users with no URL to copy
- Applies to both `handleOAuthAuth` and `handleCreateApiKeyOAuth` flows

## Test plan
- [ ] Run `neurolink proxy setup` on a local machine — URL is visible alongside browser open
- [ ] Run `neurolink proxy setup` on a remote SSH session — URL is visible to copy and open manually
- [ ] Verify `neurolink auth login anthropic --method oauth` also shows the URL
- [ ] Verify `neurolink auth login anthropic --method create-api-key` also shows the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The OAuth and API key creation authentication flows now display the authentication URL directly in the CLI. Users will see a formatted "Authentication URL:" field with the URL value shown immediately after authentication instructions, eliminating the need for additional steps to obtain the endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->