### PR TITLE
fix(sdk): tool call repair, CLI abort handling, fallback provider (BZ-665, BZ-667, BZ-1341)

### DIFF
--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -45,6 +45,7 @@ import { initializeCliParser } from "../parser.js";
 import { formatFileSize, saveAudioToFile } from "../utils/audioFileUtils.js";
 import { resolveFilePaths } from "../utils/pathResolver.js";
 import { animatedWrite } from "../utils/typewriter.js";
+import { createStreamAbortHandler } from "../utils/abortHandler.js";
 import {
   formatVideoFileSize,
   getVideoMetadataSummary,
@@ -2992,6 +2993,15 @@ export class CLICommandFactory {
     let lastImageBase64: string | undefined;
     let contentReceived = false;
     const abortController = new AbortController();
+    // BZ-667: Wire SIGINT to abort stream gracefully
+    const abortHandler = createStreamAbortHandler();
+    abortHandler.signal.addEventListener(
+      "abort",
+      () => {
+        abortController.abort();
+      },
+      { once: true },
+    );
 
     // Create timeout promise for stream consumption (default: 30 seconds, respects user-provided timeout)
     const streamTimeout =
@@ -3019,23 +3029,43 @@ export class CLICommandFactory {
       });
     });
 
+    const streamIterator = stream.stream[Symbol.asyncIterator]();
     try {
       // Process the stream with timeout handling
-      const streamIterator = stream.stream[Symbol.asyncIterator]();
       let timeoutActive = true;
+
+      // BZ-667: Create an abort promise that rejects when the user presses Ctrl+C,
+      // so we can race it against streamIterator.next() and unblock pending reads.
+      const abortPromise = new Promise<never>((_, reject) => {
+        if (abortHandler.signal.aborted) {
+          reject(new DOMException("Stream aborted", "AbortError"));
+          return;
+        }
+        abortHandler.signal.addEventListener(
+          "abort",
+          () => {
+            reject(new DOMException("Stream aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      });
 
       while (true) {
         let nextResult;
 
         if (timeoutActive && !contentReceived) {
-          // Race between next chunk and timeout for first chunk only
+          // Race between next chunk, timeout, and abort signal
           nextResult = await Promise.race([
             streamIterator.next(),
             timeoutPromise,
+            abortPromise,
           ]);
         } else {
-          // No timeout for subsequent chunks
-          nextResult = await streamIterator.next();
+          // Race between next chunk and abort signal
+          nextResult = await Promise.race([
+            streamIterator.next(),
+            abortPromise,
+          ]);
         }
 
         if (nextResult.done) {
@@ -3099,8 +3129,28 @@ export class CLICommandFactory {
       }
     } catch (error) {
       abortController.abort(); // Clean up timeout
+      // BZ-667: Close the stream iterator so the provider connection is released.
+      // Wrap in try/catch to prevent cleanup failures from masking the original error.
+      try {
+        await streamIterator.return?.();
+      } catch {
+        // Iterator cleanup failed — swallow so the original error propagates
+      }
+      abortHandler.cleanup();
+      // BZ-667: Handle graceful abort — return partial content instead of throwing
+      if (
+        abortHandler.signal.aborted ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        if (!options.quiet) {
+          process.stdout.write("\n");
+        }
+        return { content: fullContent, imageBase64: lastImageBase64 };
+      }
       throw error;
     }
+
+    abortHandler.cleanup();
 
     if (!contentReceived) {
       throw new Error(

--- a/src/cli/utils/abortHandler.ts
+++ b/src/cli/utils/abortHandler.ts
@@ -1,0 +1,63 @@
+/**
+ * CLI Abort Handler (BZ-667)
+ *
+ * Bridges SIGINT (Ctrl+C) to an AbortController for graceful stream cancellation.
+ * First Ctrl+C aborts the stream and shows "Stream cancelled."
+ * Second Ctrl+C within 1 second force-exits the process.
+ *
+ * Uses `prependListener` so the stream handler fires BEFORE the top-level
+ * SIGINT handler in cli/index.ts (which calls process.exit). The listener
+ * remains registered until `cleanup()` removes it. On the first Ctrl+C the
+ * stream is cancelled gracefully; only a rapid second press exits.
+ *
+ * @module cli/utils/abortHandler
+ */
+
+import chalk from "chalk";
+
+/**
+ * Create an abort handler that wires SIGINT to an AbortController.
+ * Call cleanup() when the stream finishes (success or error) to remove listeners.
+ */
+export function createStreamAbortHandler(): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  let aborted = false;
+  let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const sigintHandler = () => {
+    if (aborted) {
+      // Second Ctrl+C — force exit
+      if (forceExitTimer) {
+        clearTimeout(forceExitTimer);
+      }
+      // Let the top-level SIGINT handler in cli/index.ts handle the exit
+      return;
+    }
+
+    aborted = true;
+    controller.abort();
+    process.stderr.write(chalk.yellow("\nStream cancelled.\n"));
+
+    // Allow force exit on second Ctrl+C within 1 second
+    forceExitTimer = setTimeout(() => {
+      forceExitTimer = null;
+    }, 1000);
+  };
+
+  // Use prependListener so our handler fires before the top-level
+  // SIGINT handler in cli/index.ts. cleanup() removes it after the stream ends.
+  process.prependListener("SIGINT", sigintHandler);
+
+  const cleanup = () => {
+    process.removeListener("SIGINT", sigintHandler);
+    if (forceExitTimer) {
+      clearTimeout(forceExitTimer);
+      forceExitTimer = null;
+    }
+  };
+
+  return { signal: controller.signal, cleanup };
+}

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1,5 +1,11 @@
 import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
-import type { LanguageModel, ModelMessage, Tool } from "ai";
+import type {
+  LanguageModel,
+  ModelMessage,
+  Tool,
+  ToolCallRepairFunction,
+  ToolSet,
+} from "ai";
 import { generateText } from "ai";
 import { directAgentTools } from "../agent/directTools.js";
 import type { AIProviderName } from "../constants/enums.js";
@@ -1257,6 +1263,31 @@ export abstract class BaseProvider implements AIProvider {
   }
 
   // ===================
+  // ===================
+  // BZ-665: Schema-driven tool call repair
+  // ===================
+
+  /**
+   * Create an `experimental_repairToolCall` handler for streamText/generateText.
+   * Dynamically reads the tool's JSON schema to repair wrong names and params.
+   * Returns undefined when repair is disabled via options.
+   */
+  protected getToolCallRepairFn(
+    options?: StreamOptions | TextGenerationOptions,
+  ): ToolCallRepairFunction<ToolSet> | undefined {
+    if (
+      (options as Record<string, unknown> | undefined)?.disableToolCallRepair
+    ) {
+      return undefined;
+    }
+    // Lazy import to avoid circular dependency at module load time
+    return (async (...args: Parameters<ToolCallRepairFunction<ToolSet>>) => {
+      const { createToolCallRepair } =
+        await import("../utils/toolCallRepair.js");
+      return createToolCallRepair()(...args);
+    }) as ToolCallRepairFunction<ToolSet>;
+  }
+
   // ABSTRACT METHODS - MUST BE IMPLEMENTED BY SUBCLASSES
   // ===================
 

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -6889,7 +6889,15 @@ Current user's request: ${currentInput}`;
       /* non-blocking */
     }
 
-    const fallbackRoute = ModelRouter.getFallbackRoute(
+    // BZ-1341: Support fallback provider override via options or env vars
+    const optFallbackProvider =
+      enhancedOptions.fallbackProvider?.trim() || undefined;
+    const optFallbackModel = enhancedOptions.fallbackModel?.trim() || undefined;
+    const envFallbackProvider =
+      process.env.FALLBACK_PROVIDER?.trim() || undefined;
+    const envFallbackModel = process.env.FALLBACK_MODEL?.trim() || undefined;
+
+    const modelConfigRoute = ModelRouter.getFallbackRoute(
       originalPrompt || enhancedOptions.input.text || "",
       {
         provider: providerName,
@@ -6900,9 +6908,23 @@ Current user's request: ${currentInput}`;
       { fallbackStrategy: "auto" },
     );
 
+    const fallbackRoute = {
+      ...modelConfigRoute,
+      provider:
+        optFallbackProvider ?? envFallbackProvider ?? modelConfigRoute.provider,
+      model: optFallbackModel ?? envFallbackModel ?? modelConfigRoute.model,
+    };
+
     logger.warn("Retrying with fallback provider", {
       originalProvider: providerName,
       fallbackProvider: fallbackRoute.provider,
+      fallbackModel: fallbackRoute.model,
+      fallbackSource:
+        optFallbackProvider || optFallbackModel
+          ? "options"
+          : envFallbackProvider || envFallbackModel
+            ? "env"
+            : "model_config",
       reason: errorMsg,
     });
 

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1060,6 +1060,7 @@ export class AnthropicProvider extends BaseProvider {
             options.abortSignal,
             timeoutController?.controller.signal,
           ),
+          experimental_repairToolCall: this.getToolCallRepairFn(options),
           experimental_telemetry:
             this.telemetryHandler.getTelemetryConfig(options),
           onStepFinish: ({ toolCalls, toolResults }) => {

--- a/src/lib/providers/anthropicBaseProvider.ts
+++ b/src/lib/providers/anthropicBaseProvider.ts
@@ -165,6 +165,7 @@ export class AnthropicProviderV2 extends BaseProvider {
           ),
           experimental_telemetry:
             this.telemetryHandler.getTelemetryConfig(options),
+          experimental_repairToolCall: this.getToolCallRepairFn(options),
           onStepFinish: ({ toolCalls, toolResults }) => {
             this.handleToolExecutionStorage(
               toolCalls,

--- a/src/lib/providers/azureOpenai.ts
+++ b/src/lib/providers/azureOpenai.ts
@@ -172,6 +172,7 @@ export class AzureOpenAIProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
         onStepFinish: (event: StepFinishEvent) => {
           this.handleToolExecutionStorage(
             [...event.toolCalls],

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -659,6 +659,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
         // Gemini 3: use thinkingLevel via providerOptions
         // Gemini 2.5: use thinkingBudget via providerOptions
         ...(options.thinkingConfig?.enabled && {

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -1403,6 +1403,7 @@ export class GoogleVertexProvider extends BaseProvider {
         timeoutController?.controller.signal,
       ),
       experimental_telemetry: this.telemetryHandler.getTelemetryConfig(options),
+      experimental_repairToolCall: this.getToolCallRepairFn(options),
       ...(options.thinkingConfig?.enabled && {
         providerOptions: {
           vertex: {

--- a/src/lib/providers/huggingFace.ts
+++ b/src/lib/providers/huggingFace.ts
@@ -213,6 +213,7 @@ export class HuggingFaceProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
         onStepFinish: ({ toolCalls, toolResults }) => {
           this.handleToolExecutionStorage(
             toolCalls,

--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -277,6 +277,7 @@ export class LiteLLMProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
 
         onError: (event: { error: unknown }) => {
           const error = event.error;

--- a/src/lib/providers/mistral.ts
+++ b/src/lib/providers/mistral.ts
@@ -115,6 +115,7 @@ export class MistralProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
         onStepFinish: ({ toolCalls, toolResults }) => {
           this.handleToolExecutionStorage(
             toolCalls,

--- a/src/lib/providers/openAI.ts
+++ b/src/lib/providers/openAI.ts
@@ -474,6 +474,7 @@ export class OpenAIProvider extends BaseProvider {
             options.abortSignal,
             timeoutController?.controller.signal,
           ),
+          experimental_repairToolCall: this.getToolCallRepairFn(options),
           experimental_telemetry:
             this.telemetryHandler.getTelemetryConfig(options),
           onStepFinish: ({ toolCalls, toolResults }) => {

--- a/src/lib/providers/openRouter.ts
+++ b/src/lib/providers/openRouter.ts
@@ -366,6 +366,7 @@ export class OpenRouterProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
 
         onError: (event: { error: unknown }) => {
           const error = event.error;

--- a/src/lib/providers/openaiCompatible.ts
+++ b/src/lib/providers/openaiCompatible.ts
@@ -287,6 +287,7 @@ export class OpenAICompatibleProvider extends BaseProvider {
         ),
         experimental_telemetry:
           this.telemetryHandler.getTelemetryConfig(options),
+        experimental_repairToolCall: this.getToolCallRepairFn(options),
         onStepFinish: (event: StepFinishEvent) => {
           this.handleToolExecutionStorage(
             [...event.toolCalls],

--- a/src/lib/types/streamTypes.ts
+++ b/src/lib/types/streamTypes.ts
@@ -376,6 +376,8 @@ export type StreamOptions = {
   /** AbortSignal for external cancellation of the AI call */
   abortSignal?: AbortSignal;
   disableTools?: boolean;
+  /** Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled). */
+  disableToolCallRepair?: boolean;
   maxSteps?: number; // Maximum tool execution steps. Defaults to 5 in the implementation if not specified.
 
   /**
@@ -513,6 +515,10 @@ export type StreamOptions = {
    * @internal Set by NeuroLink SDK — not typically used directly by consumers.
    */
   fileRegistry?: unknown;
+  /** BZ-1341: Override fallback provider name (takes precedence over env/model config). */
+  fallbackProvider?: string;
+  /** BZ-1341: Override fallback model name (takes precedence over env/model config). */
+  fallbackModel?: string;
 
   /** Callback invoked when streaming completes successfully. */
   onFinish?: OnFinishCallback;

--- a/src/lib/utils/toolCallRepair.ts
+++ b/src/lib/utils/toolCallRepair.ts
@@ -1,0 +1,369 @@
+/**
+ * Schema-Driven Tool Call Repair (BZ-665)
+ *
+ * Implements `experimental_repairToolCall` for the Vercel AI SDK.
+ * When an LLM sends a wrong tool name or wrong parameter names,
+ * this module attempts deterministic, schema-driven repair:
+ *
+ *  1. Tool name: case-insensitive → substring → Levenshtein
+ *  2. Param names: compare against JSON schema properties dynamically
+ *  3. Type coercion: string→number, JSON string→object/array per schema
+ *
+ * Zero static alias maps. The tool's JSON schema is the only source of truth.
+ *
+ * @module utils/toolCallRepair
+ */
+
+import type { ToolCallRepairFunction, ToolSet } from "ai";
+import type { JSONSchema7, LanguageModelV3ToolCall } from "@ai-sdk/provider";
+import { logger } from "./logger.js";
+
+/**
+ * Create an `experimental_repairToolCall` handler for streamText/generateText.
+ * Fully dynamic — reads the tool schema at repair time, no configuration needed.
+ */
+export function createToolCallRepair(): ToolCallRepairFunction<ToolSet> {
+  return async ({ toolCall, tools, inputSchema, error }) => {
+    // Import error classes lazily to avoid circular deps at module level
+    const { NoSuchToolError: NoSuchTool, InvalidToolInputError: InvalidInput } =
+      await import("ai");
+
+    if (NoSuchTool.isInstance(error)) {
+      return repairToolName(toolCall, Object.keys(tools));
+    }
+
+    if (InvalidInput.isInstance(error)) {
+      try {
+        const schema = await inputSchema({ toolName: toolCall.toolName });
+        return repairToolInput(toolCall, schema);
+      } catch {
+        // inputSchema() failed — can't repair without schema
+        return null;
+      }
+    }
+
+    return null;
+  };
+}
+
+// ─── Tool Name Repair ──────────────────────────────────────────────
+
+/**
+ * Attempt to match a wrong tool name against available tool names.
+ * Strategies (in order): case-insensitive exact → substring → Levenshtein.
+ */
+function repairToolName(
+  toolCall: LanguageModelV3ToolCall,
+  availableTools: string[],
+): LanguageModelV3ToolCall | null {
+  const called = toolCall.toolName;
+
+  // Guard: empty or whitespace-only tool name cannot be meaningfully repaired
+  if (!called || called.trim().length === 0) {
+    return null;
+  }
+
+  // 1. Case-insensitive exact match
+  const ciMatch = availableTools.find(
+    (t) => t.toLowerCase() === called.toLowerCase(),
+  );
+  if (ciMatch) {
+    logger.debug(
+      `[ToolCallRepair] Name repair (case): "${called}" → "${ciMatch}"`,
+    );
+    return { ...toolCall, toolName: ciMatch };
+  }
+
+  // 2. Substring match: "search_file" is substring of "search_files" or vice versa.
+  // Only accept when exactly one tool matches to avoid ambiguous repairs.
+  const calledLower = called.toLowerCase();
+  const subCandidates = availableTools.filter((t) => {
+    const tLower = t.toLowerCase();
+    return tLower.includes(calledLower) || calledLower.includes(tLower);
+  });
+  if (subCandidates.length === 1) {
+    logger.debug(
+      `[ToolCallRepair] Name repair (substring): "${called}" → "${subCandidates[0]}"`,
+    );
+    return { ...toolCall, toolName: subCandidates[0] };
+  }
+
+  // 3. Levenshtein distance — accept if normalized distance < 0.3
+  // Compare by normalized score (not raw edits) so length differences don't skew selection.
+  let bestMatch: string | null = null;
+  let bestNormalized = Infinity;
+  for (const t of availableTools) {
+    const dist = levenshtein(calledLower, t.toLowerCase());
+    const maxLen = Math.max(called.length, t.length);
+    const normalized = maxLen === 0 ? 0 : dist / maxLen;
+    if (normalized < 0.3 && normalized < bestNormalized) {
+      bestNormalized = normalized;
+      bestMatch = t;
+    }
+  }
+  if (bestMatch) {
+    logger.debug(
+      `[ToolCallRepair] Name repair (levenshtein ${bestNormalized.toFixed(2)}): "${called}" → "${bestMatch}"`,
+    );
+    return { ...toolCall, toolName: bestMatch };
+  }
+
+  logger.debug(
+    `[ToolCallRepair] Could not repair tool name "${called}". Available: [${availableTools.join(", ")}]`,
+  );
+  return null;
+}
+
+// ─── Tool Input Repair ─────────────────────────────────────────────
+
+/**
+ * Attempt to repair wrong parameter names and types using the JSON schema.
+ * Compares LLM-provided keys against schema properties dynamically.
+ *
+ * `toolCall.input` is a JSON string per LanguageModelV3ToolCall.
+ */
+function repairToolInput(
+  toolCall: LanguageModelV3ToolCall,
+  schema: JSONSchema7,
+): LanguageModelV3ToolCall | null {
+  let args: unknown;
+  try {
+    args = JSON.parse(toolCall.input);
+  } catch {
+    return null; // input is not valid JSON — can't repair
+  }
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return null;
+  }
+
+  const schemaProps = (schema as Record<string, unknown>).properties as
+    | Record<string, unknown>
+    | undefined;
+  if (!schemaProps) {
+    return null;
+  }
+
+  const expectedKeys = Object.keys(schemaProps);
+  const inputObj = args as Record<string, unknown>;
+  const inputKeys = Object.keys(inputObj);
+  const repaired = Object.create(null) as Record<string, unknown>;
+  let didRepair = false;
+  const dropUnknown =
+    (schema as Record<string, unknown>).additionalProperties === false;
+
+  for (const inputKey of inputKeys) {
+    // Already matches a schema property — keep as-is
+    if (expectedKeys.includes(inputKey)) {
+      repaired[inputKey] = inputObj[inputKey];
+      continue;
+    }
+
+    // Try to find a matching schema property
+    const mapped = findMatchingKey(inputKey, expectedKeys);
+    if (mapped) {
+      // Don't overwrite an already-populated canonical key — but still mark as repaired
+      // so the function returns the corrected object instead of null.
+      if (Object.prototype.hasOwnProperty.call(repaired, mapped)) {
+        didRepair = true;
+        continue;
+      }
+      logger.debug(
+        `[ToolCallRepair] Param repair: "${inputKey}" → "${mapped}" (tool: ${toolCall.toolName})`,
+      );
+      repaired[mapped] = inputObj[inputKey];
+      didRepair = true;
+    } else if (dropUnknown) {
+      // Schema forbids extra properties — drop unmapped keys
+      logger.debug(
+        `[ToolCallRepair] Dropping unmapped key "${inputKey}" (additionalProperties: false, tool: ${toolCall.toolName})`,
+      );
+      didRepair = true;
+    } else {
+      // Unknown key — pass through (schema allows additionalProperties)
+      repaired[inputKey] = inputObj[inputKey];
+    }
+  }
+
+  // Type coercion based on schema types
+  for (const key of Object.keys(repaired)) {
+    const propSchema = schemaProps[key] as Record<string, unknown> | undefined;
+    if (!propSchema) {
+      continue;
+    }
+    const coerced = coerceType(repaired[key], propSchema);
+    if (coerced !== repaired[key]) {
+      logger.debug(
+        `[ToolCallRepair] Type coercion on "${key}": ${typeof repaired[key]} → ${typeof coerced} (tool: ${toolCall.toolName})`,
+      );
+      repaired[key] = coerced;
+      didRepair = true;
+    }
+  }
+
+  if (didRepair) {
+    return { ...toolCall, input: JSON.stringify(repaired) };
+  }
+
+  return null;
+}
+
+/**
+ * Find a matching schema key for a mismatched input key.
+ * Strategies: case-insensitive → Levenshtein (threshold ≤2 edits).
+ */
+function findMatchingKey(
+  inputKey: string,
+  schemaKeys: string[],
+): string | null {
+  const inputLower = inputKey.toLowerCase();
+
+  // Case-insensitive match
+  const ciMatch = schemaKeys.find((k) => k.toLowerCase() === inputLower);
+  if (ciMatch) {
+    return ciMatch;
+  }
+
+  // Levenshtein — threshold ≤2 edits
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const k of schemaKeys) {
+    const dist = levenshtein(inputLower, k.toLowerCase());
+    if (dist <= 2 && dist < bestDist) {
+      bestDist = dist;
+      best = k;
+    }
+  }
+  return best;
+}
+
+// ─── Type Coercion ─────────────────────────────────────────────────
+
+/**
+ * Coerce a value to match the expected schema type.
+ * Handles: string→number, JSON string→object, JSON string→array, value→[value].
+ */
+function coerceType(
+  value: unknown,
+  propSchema: Record<string, unknown>,
+): unknown {
+  const expectedType = propSchema.type as string | undefined;
+  if (!expectedType || value === null || value === undefined) {
+    return value;
+  }
+
+  // String → Number (trim first, reject empty/whitespace, require finite result)
+  if (expectedType === "number" && typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed !== "") {
+      const num = Number(trimmed);
+      if (isFinite(num)) {
+        return num;
+      }
+    }
+  }
+
+  // String → Integer (strict: reject "12abc", "3.7", etc.)
+  if (expectedType === "integer" && typeof value === "string") {
+    const trimmed = value.trim();
+    if (/^[+-]?\d+$/.test(trimmed)) {
+      const num = Number(trimmed);
+      if (Number.isSafeInteger(num)) {
+        return num;
+      }
+    }
+  }
+
+  // String → Boolean
+  if (expectedType === "boolean" && typeof value === "string") {
+    if (value.toLowerCase() === "true") {
+      return true;
+    }
+    if (value.toLowerCase() === "false") {
+      return false;
+    }
+  }
+
+  // JSON string → Object
+  if (expectedType === "object" && typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Not valid JSON — return as-is
+    }
+  }
+
+  // JSON string → Array
+  if (expectedType === "array" && typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Not valid JSON — return as-is
+    }
+  }
+
+  // Single non-string value → Array (wrap).
+  // Strings are excluded because they are more likely a JSON-encoded array
+  // that failed to parse above, and wrapping "foo" into ["foo"] is rarely correct.
+  if (
+    expectedType === "array" &&
+    !Array.isArray(value) &&
+    typeof value !== "string"
+  ) {
+    return [value];
+  }
+
+  return value;
+}
+
+// ─── Levenshtein Distance ──────────────────────────────────────────
+
+/**
+ * Compute Levenshtein edit distance between two strings.
+ * Uses the iterative matrix approach — O(m*n) time, O(min(m,n)) space.
+ */
+function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+
+  // Use shorter string as column to minimize space
+  if (a.length > b.length) {
+    [a, b] = [b, a];
+  }
+
+  const aLen = a.length;
+  const bLen = b.length;
+  let prev = new Array<number>(aLen + 1);
+  let curr = new Array<number>(aLen + 1);
+
+  for (let i = 0; i <= aLen; i++) {
+    prev[i] = i;
+  }
+
+  for (let j = 1; j <= bLen; j++) {
+    curr[0] = j;
+    for (let i = 1; i <= aLen; i++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[i] = Math.min(
+        prev[i] + 1, // deletion
+        curr[i - 1] + 1, // insertion
+        prev[i - 1] + cost, // substitution
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[aLen];
+}


### PR DESCRIPTION
## Summary

- **BZ-665**: Schema-driven tool call repair via `experimental_repairToolCall` — dynamically fixes wrong tool names and parameter names from LLMs using the tool's JSON schema (no static alias maps). Wired into all 11 providers.
- **BZ-667**: Graceful CLI abort signal handling — Ctrl+C during streaming shows "Stream cancelled." and exits cleanly instead of killing the process abruptly.
- **BZ-1341**: Fallback provider override via `fallbackProvider`/`fallbackModel` stream options or `FALLBACK_PROVIDER`/`FALLBACK_MODEL` env vars (cherry-picked from PR #880 with fixes).

## Changes

### BZ-665: Tool Call Repair
- New `src/lib/utils/toolCallRepair.ts`: Levenshtein distance, type coercion (string→number, JSON string→object/array), schema-driven param remapping
- `baseProvider.ts`: `getToolCallRepairFn()` protected method with lazy import
- All 11 providers: +1 line each wiring `experimental_repairToolCall`
- `streamTypes.ts`: `disableToolCallRepair` opt-out option

### BZ-667: CLI Abort Handling
- New `src/cli/utils/abortHandler.ts`: SIGINT→AbortController bridge (first Ctrl+C cancels, second force-exits)
- `commandFactory.ts`: Wire abort handler into `processStreamWithTimeout()`

### BZ-1341: Fallback Provider
- `neurolink.ts`: Override fallback provider/model via options or env vars with empty-string guard (`.trim() || undefined`)
- `streamTypes.ts`: `fallbackProvider` and `fallbackModel` fields

## Test plan
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run lint` — 0 errors (1 pre-existing warning)
- [x] `pnpm run build` — success
- [x] BZ-665 E2E: `generate()` and `stream()` with Vertex/Gemini 2.5 Flash — tools execute correctly, repair wired in 13 source files
- [x] BZ-667 runtime: `neurolink stream` + SIGINT → "Stream cancelled." message confirmed
- [x] Before/after evidence saved in `/tmp/bz665-repro/` and `/tmp/bz667-repro/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful stream cancellation via Ctrl+C that returns partial results when aborted
  * Automatic tool-call repair: name matching, parameter reconciliation, and type coercion
  * Per-request fallback overrides for provider and model
  * Option to disable automatic tool-call repair

* **Improvements**
  * Better cleanup of abort handlers and streaming resources on success, error, or abort
  * Enhanced fallback logging to show chosen fallback model and its source
<!-- end of auto-generated comment: release notes by coderabbit.ai -->