### PR TITLE
refactor(types): close lint gap for bare `export type` re-exports

### DIFF
--- a/eslint-rules/no-type-export-outside-types.cjs
+++ b/eslint-rules/no-type-export-outside-types.cjs
@@ -57,7 +57,7 @@ module.exports = {
       // Pattern C: `export { type X } from "..."` (inline type modifier).
       ExportNamedDeclaration(node) {
         // `export type { X } from "..."` has `exportKind === "type"` at the declaration level.
-        if (node.exportKind === "type" && node.source) {
+        if (node.exportKind === "type") {
           context.report({ node, messageId: "noTypeReExport" });
           return;
         }

--- a/src/lib/auth/tokenStore.ts
+++ b/src/lib/auth/tokenStore.ts
@@ -26,9 +26,6 @@ import type {
   TokenRefresher,
 } from "../types/index.js";
 
-// Re-export so existing consumers of `../auth/tokenStore.js` keep working.
-export type { StoredOAuthTokens, TokenRefresher };
-
 const { readFile, writeFile, mkdir, unlink, access, chmod, rename } = fs;
 
 // =============================================================================

--- a/src/lib/client/httpClient.ts
+++ b/src/lib/client/httpClient.ts
@@ -1125,36 +1125,3 @@ export class NeuroLinkClient {
 export function createClient(config: ClientConfig): NeuroLinkClient {
   return new NeuroLinkClient(config);
 }
-
-// =============================================================================
-// Type Exports
-// =============================================================================
-
-export type {
-  ClientConfig,
-  ClientRequestOptions,
-  ClientApiResponse,
-  ClientApiError,
-  ClientRetryConfig,
-  ClientMiddleware,
-  ClientMiddlewareRequest,
-  ClientMiddlewareResponse,
-  ClientMiddlewareContext,
-  ClientStreamCallbacks,
-  ClientStreamEvent,
-  ClientStreamResult,
-  ClientGenerateRequestOptions,
-  ClientGenerateResponse,
-  ClientStreamRequestOptions,
-  ClientAgentExecuteOptions,
-  ClientAgentExecuteResult,
-  ClientAgentInfo,
-  ClientWorkflowExecuteOptions,
-  ClientWorkflowExecuteResult,
-  ClientWorkflowInfo,
-  ClientToolInfo,
-  ClientProviderStatus,
-  ClientWebSocketOptions,
-  ClientWebSocketState,
-  ClientWebSocketMessageHandler,
-};

--- a/src/lib/client/sseClient.ts
+++ b/src/lib/client/sseClient.ts
@@ -700,14 +700,3 @@ export class NeuroLinkSSE {
 export function createSSEClient(config: SSEConfig): NeuroLinkSSE {
   return new NeuroLinkSSE(config);
 }
-
-// =============================================================================
-// Type Exports
-// =============================================================================
-
-export type {
-  ClientStreamCallbacks,
-  StreamEvent,
-  StreamResult,
-  ClientApiError,
-};

--- a/src/lib/client/wsClient.ts
+++ b/src/lib/client/wsClient.ts
@@ -12,7 +12,6 @@ import type {
   ClientStreamCallbacks,
   ClientStreamEvent as StreamEvent,
   ClientStreamResult as StreamResult,
-  ClientApiError,
   WebSocketEventHandlers,
   ClientClientWebSocketState,
   ClientWebSocketMessage,
@@ -463,14 +462,3 @@ export function createWebSocketClient(
 ): NeuroLinkWebSocket {
   return new NeuroLinkWebSocket(config);
 }
-
-// =============================================================================
-// Type Exports
-// =============================================================================
-
-export type {
-  ClientStreamCallbacks,
-  StreamEvent,
-  StreamResult,
-  ClientApiError,
-};

--- a/src/lib/core/toolEvents.ts
+++ b/src/lib/core/toolEvents.ts
@@ -1,7 +1,5 @@
 import type { ToolEventPayload } from "../types/index.js";
 
-export type { ToolEventPayload };
-
 export function createToolEventPayload(
   toolName: string,
   payload: Omit<ToolEventPayload, "tool" | "toolName"> = {},

--- a/src/lib/memory/hippocampusInitializer.ts
+++ b/src/lib/memory/hippocampusInitializer.ts
@@ -1,11 +1,5 @@
-import {
-  Hippocampus,
-  type HippocampusConfig,
-  type StorageConfig,
-} from "@juspay/hippocampus";
+import { Hippocampus, type HippocampusConfig } from "@juspay/hippocampus";
 import { logger } from "../utils/logger.js";
-
-export type { HippocampusConfig, StorageConfig };
 
 export function initializeHippocampus(
   config: HippocampusConfig,

--- a/src/lib/models/anthropicModels.ts
+++ b/src/lib/models/anthropicModels.ts
@@ -11,8 +11,7 @@ import type {
 } from "../types/index.js";
 import { ModelAccessError } from "../types/index.js";
 
-// Re-export for convenience
-export type { ClaudeSubscriptionTier, AnthropicModelMetadata };
+// Re-export runtime value for convenience
 export { ModelAccessError };
 
 // ============================================================================

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -130,10 +130,8 @@ import { ToolRouter } from "./mcp/routing/index.js";
 import { directToolsServer } from "./mcp/servers/agent/directToolsServer.js";
 import { inferAnnotations, isSafeToRetry } from "./mcp/toolAnnotations.js";
 import { MCPToolRegistry } from "./mcp/toolRegistry.js";
-import {
-  type HippocampusConfig,
-  initializeHippocampus,
-} from "./memory/hippocampusInitializer.js";
+import type { HippocampusConfig } from "@juspay/hippocampus";
+import { initializeHippocampus } from "./memory/hippocampusInitializer.js";
 import { createMemoryRetrievalTools } from "./memory/memoryRetrievalTools.js";
 import {
   getMetricsAggregator,

--- a/src/lib/observability/exporterRegistry.ts
+++ b/src/lib/observability/exporterRegistry.ts
@@ -5,11 +5,11 @@
 
 import { logger } from "../utils/logger.js";
 import type { BaseExporter } from "./exporters/baseExporter.js";
-import type { Sampler } from "./sampling/samplers.js";
 import { AlwaysSampler } from "./sampling/samplers.js";
 import type {
   ExporterHealthStatus,
   ExportResult,
+  Sampler,
   SpanData,
 } from "../types/index.js";
 

--- a/src/lib/observability/retryPolicy.ts
+++ b/src/lib/observability/retryPolicy.ts
@@ -9,7 +9,6 @@ import type {
   RetryContext,
   RetryDecision,
 } from "../types/index.js";
-export type { RetryPolicy };
 
 /**
  * Base retry policy with common configuration

--- a/src/lib/observability/sampling/samplers.ts
+++ b/src/lib/observability/sampling/samplers.ts
@@ -12,8 +12,6 @@ import type {
 
 import { SpanStatus } from "../../types/index.js";
 
-export type { Sampler };
-
 /**
  * Always sample all spans
  */

--- a/src/lib/observability/spanProcessor.ts
+++ b/src/lib/observability/spanProcessor.ts
@@ -10,8 +10,6 @@ import type {
   SpanProcessor,
 } from "../types/index.js";
 
-export type { SpanProcessor };
-
 /**
  * No-op processor that passes spans through unchanged
  */

--- a/src/lib/processors/errors/errorHelpers.ts
+++ b/src/lib/processors/errors/errorHelpers.ts
@@ -16,8 +16,6 @@ import type {
 
 import { ERROR_MESSAGES, FileErrorCode } from "./FileErrorCode.js";
 
-export type { FileProcessingError };
-
 /**
  * Summary of file processing operations.
  */

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -29,6 +29,7 @@ import type {
   GoogleGenAIClass,
   LiveServerMessage,
   AudioChunk,
+  NativeToolsConfig,
   StreamOptions,
   StreamResult,
   StreamToolCall,
@@ -61,7 +62,6 @@ import {
   executeNativeToolCalls,
   extractTextFromParts,
   handleMaxStepsTermination,
-  type NativeToolsConfig,
   pushModelResponseToHistory,
   sanitizeToolsForGemini,
 } from "./googleNativeGemini3.js";

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -41,15 +41,6 @@ import {
 } from "../utils/schemaConversion.js";
 
 import { createNativeThinkingConfig } from "../utils/thinkingConfig.js";
-export type {
-  CollectedChunkResult,
-  NativeFunctionCall,
-  NativeFunctionDeclaration,
-  NativeFunctionResponse,
-  NativeToolDeclarationsResult,
-  NativeToolsConfig,
-  TextChannel,
-};
 
 // ── Functions ──
 

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -44,6 +44,7 @@ import type {
   TextGenerationOptions,
   GenAIClient,
   GoogleGenAIClass,
+  NativeToolsConfig,
   NeurolinkCredentials,
   StreamOptions,
   StreamResult,
@@ -90,7 +91,6 @@ import {
   extractTextFromParts,
   handleMaxStepsTermination,
   normalizeToolsForJsonSchemaProvider,
-  type NativeToolsConfig,
   pushModelResponseToHistory,
   sanitizeToolsForGemini,
 } from "./googleNativeGemini3.js";

--- a/src/lib/proxy/proxyHealth.ts
+++ b/src/lib/proxy/proxyHealth.ts
@@ -3,8 +3,6 @@ import type {
   ProxyReadinessState,
 } from "../types/index.js";
 
-export type { ProxyHealthResponse, ProxyReadinessState };
-
 export function createProxyReadinessState(
   startTimeMs: number = Date.now(),
 ): ProxyReadinessState {

--- a/src/lib/proxy/routingPolicy.ts
+++ b/src/lib/proxy/routingPolicy.ts
@@ -6,12 +6,6 @@ import type {
   ProxyTranslationPlan,
 } from "../types/index.js";
 
-export type {
-  ClaudeProxyModelTier,
-  ProxyTranslationAttempt,
-  ProxyTranslationPlan,
-};
-
 export function inferClaudeProxyModelTier(
   modelName: string,
 ): ClaudeProxyModelTier {

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -49,8 +49,8 @@ import {
 import {
   buildProxyTranslationPlan,
   parseRetryAfterMs,
-  type ProxyTranslationPlan,
 } from "../../proxy/routingPolicy.js";
+import type { ProxyTranslationPlan } from "../../types/index.js";
 import { writeJsonSnapshotAtomically } from "../../proxy/snapshotPersistence.js";
 import {
   recordAttempt,

--- a/src/lib/utils/sanitizers/filename.ts
+++ b/src/lib/utils/sanitizers/filename.ts
@@ -99,7 +99,6 @@ import type {
   SanitizeFileNameOptions,
   SanitizeDisplayNameOptions,
 } from "../../types/index.js";
-export type { SanitizeFileNameOptions, SanitizeDisplayNameOptions };
 
 /**
  * Sanitize a filename for safe filesystem storage.


### PR DESCRIPTION
## Summary

- **Fixed ESLint rule gap**: `no-type-export-outside-types` only caught `export type { X } from "..."` (with `from`) but missed bare `export type { X }` (import-then-re-export without `from`). Removed the `&& node.source` guard on line 60.
- **Eliminated all 15 newly-surfaced violations** by deleting the re-export blocks across auth, client, core, memory, models, observability, processors, providers, proxy, and utils modules.
- **Repointed 5 consumer imports** that depended on the re-exports to import from the canonical types barrel (`../types/index.js`) or the external package directly.
- **Cleaned up 2 unused imports** (`StorageConfig`, `ClientApiError`) that were only imported for re-export.

## Files changed (21)

| Category | Files |
|----------|-------|
| ESLint rule | `eslint-rules/no-type-export-outside-types.cjs` |
| Re-exports removed (15) | `auth/tokenStore`, `client/httpClient`, `client/sseClient`, `client/wsClient`, `core/toolEvents`, `memory/hippocampusInitializer`, `models/anthropicModels`, `observability/retryPolicy`, `observability/sampling/samplers`, `observability/spanProcessor`, `processors/errors/errorHelpers`, `providers/googleNativeGemini3`, `proxy/proxyHealth`, `proxy/routingPolicy`, `utils/sanitizers/filename` |
| Consumer imports repointed (5) | `observability/exporterRegistry`, `server/routes/claudeProxyRoutes`, `providers/googleAiStudio`, `providers/googleVertex`, `neurolink` |

## Test plan

- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run lint` — 0 errors, 7 pre-existing warnings (unrelated)
- [x] `npx tsx test/continuous-test-suite-bugfixes.ts` — 48/48 pass
- [x] Full pre-commit hook (check + format + lint + validate + build) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type definitions and reorganized type imports for improved code maintainability.
  * Removed redundant type re-exports across multiple modules and centralized type imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->