### PR TITLE
feat(utils): add tryImport utility for optional dependencies

### DIFF
--- a/src/lib/utils/tryImport.ts
+++ b/src/lib/utils/tryImport.ts
@@ -1,0 +1,42 @@
+/**
+ * Dynamically import an optional dependency with a helpful error message.
+ *
+ * Use this for packages in `optionalDependencies` — when the import fails
+ * because the package isn't installed, the caller gets a clear install hint
+ * instead of a cryptic ERR_MODULE_NOT_FOUND.
+ *
+ * Only intercepts missing-module errors; real failures (syntax errors,
+ * ESM/CJS interop issues, transitive dep problems) are rethrown unchanged.
+ *
+ * @example
+ * ```ts
+ * const ExcelJS = await tryImport<typeof import("exceljs")>("exceljs", "Excel file processing");
+ * ```
+ */
+export async function tryImport<T = unknown>(
+  pkg: string,
+  feature: string,
+): Promise<T> {
+  try {
+    return (await import(/* @vite-ignore */ pkg)) as T;
+  } catch (err) {
+    if (isMissingModule(err, pkg)) {
+      throw new Error(
+        `${feature} requires the "${pkg}" package. Install it with:\n  pnpm add ${pkg}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+}
+
+function isMissingModule(err: unknown, pkg: string): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+  return err.message.includes(`'${pkg}'`) || err.message.includes(`"${pkg}"`);
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/utils/tryImport.ts` — a shared helper that wraps `await import(pkg)` with a user-friendly error when the package is missing
- Produces: `Excel file processing requires the "exceljs" package. Install it with: pnpm add exceljs`
- Foundation for making heavy deps optional without cryptic `ERR_MODULE_NOT_FOUND` crashes

## Impact
- New file only, no existing code changes
- Will be consumed by subsequent PRs that move deps to `optionalDependencies`

## Test plan
- [ ] `pnpm run check` passes
- [ ] `pnpm run build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of optional runtime dependencies: when a module is missing, users now receive a clearer, actionable error message with an install hint.
  * Original error context is preserved for troubleshooting while unrelated errors are still surfaced unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->