### PR TITLE
refactor(tasks): dynamic-import bullmq, move to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,6 @@
     "@picovoice/cobra-node": "^3.0.2",
     "adm-zip": "^0.5.16",
     "ai": "^6.0.134",
-    "bullmq": "^5.52.2",
     "chalk": "^5.6.2",
     "croner": "^9.1.0",
     "csv-parser": "^3.2.0",
@@ -273,6 +272,7 @@
   },
   "optionalDependencies": {
     "@langfuse/otel": "^5.0.1",
+    "bullmq": "^5.52.2",
     "pdf-parse": "^2.4.5",
     "pdf-to-img": "^5.0.0",
     "@fastify/cors": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       ai:
         specifier: ^6.0.134
         version: 6.0.141(zod@4.3.6)
-      bullmq:
-        specifier: ^5.52.2
-        version: 5.71.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -426,7 +423,10 @@ importers:
         version: 15.4.0(koa@3.2.0)
       '@langfuse/otel':
         specifier: ^5.0.1
-        version: 5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+      bullmq:
+        specifier: ^5.52.2
+        version: 5.71.1
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -1858,10 +1858,24 @@ packages:
     peerDependencies:
       koa: ^2.0.0 || ^3.0.0
 
+  '@langfuse/core@5.0.1':
+    resolution: {integrity: sha512-DirjtE+RjToRuJeVzy7EC05ebtz+ryEDBjjeRNbcQ5OQ38VaIMqWgt124ZQXfW5Rel9oobGcYDu6V5nkr2TuMg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@langfuse/core@5.1.0':
     resolution: {integrity: sha512-yFvC67HBtrY4B3tyzF8+RJaIqK79LBVXtAgtmEc2vhpKauecvSW0zevRnRynFX+ajUHqi9TN7tnD91FJszFLgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+
+  '@langfuse/otel@5.0.1':
+    resolution: {integrity: sha512-yCR8pfhPTzScgXmtcoFMo9+/705yTXJXVxMeVNATMhkoO7wtzZSuYqc/QX8XHY7/rE6K0HqI/riB7DVySRk4Eg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^2.0.1
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
+      '@opentelemetry/sdk-trace-base': ^2.6.0
 
   '@langfuse/otel@5.1.0':
     resolution: {integrity: sha512-pvaXgZHMHqjsRjn+Gs5amrrq61w0Rxz1OChmLr2FfQzlymNl7+MxSXsWBj5dZQlufGbhyG+LT3wdx3MV8aLXHQ==}
@@ -9573,7 +9587,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@ioredis/commands@1.5.1': {}
+  '@ioredis/commands@1.5.1':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9716,9 +9731,23 @@ snapshots:
       - supports-color
     optional: true
 
+  '@langfuse/core@5.0.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    optional: true
+
   '@langfuse/core@5.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@langfuse/otel@5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@langfuse/core': 5.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+    optional: true
 
   '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -9727,15 +9756,6 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-
-  '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@langfuse/core': 5.1.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-    optional: true
 
   '@lukeed/ms@2.0.2':
     optional: true
@@ -12360,6 +12380,7 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -12621,6 +12642,7 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+    optional: true
 
   croner@9.1.0: {}
 
@@ -12686,7 +12708,8 @@ snapshots:
   delegates@1.0.0:
     optional: true
 
-  denque@2.1.0: {}
+  denque@2.1.0:
+    optional: true
 
   depd@1.1.2:
     optional: true
@@ -13688,6 +13711,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ip-address@10.1.0: {}
 
@@ -14024,7 +14048,8 @@ snapshots:
 
   lodash.groupby@4.6.0: {}
 
-  lodash.isarguments@3.1.0: {}
+  lodash.isarguments@3.1.0:
+    optional: true
 
   lodash.isboolean@3.0.3: {}
 
@@ -14079,7 +14104,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
-  luxon@3.7.2: {}
+  luxon@3.7.2:
+    optional: true
 
   magic-string@0.30.21:
     dependencies:
@@ -14242,6 +14268,7 @@ snapshots:
   msgpackr@1.11.5:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+    optional: true
 
   music-metadata@11.12.3:
     dependencies:
@@ -14291,7 +14318,8 @@ snapshots:
       semver: 7.7.4
     optional: true
 
-  node-abort-controller@3.1.1: {}
+  node-abort-controller@3.1.1:
+    optional: true
 
   node-addon-api@7.1.1:
     optional: true
@@ -14919,11 +14947,13 @@ snapshots:
   real-require@0.2.0:
     optional: true
 
-  redis-errors@1.2.0: {}
+  redis-errors@1.2.0:
+    optional: true
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+    optional: true
 
   redis@4.7.1:
     dependencies:
@@ -15312,7 +15342,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standard-as-callback@2.1.0: {}
+  standard-as-callback@2.1.0:
+    optional: true
 
   statuses@1.5.0:
     optional: true
@@ -15731,7 +15762,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.0:
+    optional: true
 
   uuid@13.0.0: {}
 

--- a/src/lib/tasks/backends/bullmqBackend.ts
+++ b/src/lib/tasks/backends/bullmqBackend.ts
@@ -7,7 +7,7 @@
  * - Survives process restarts (Redis-persisted)
  */
 
-import { Queue, Worker, type Job } from "bullmq";
+import type { Queue, Worker, Job } from "bullmq";
 import { logger } from "../../utils/logger.js";
 import { TaskError } from "../errors.js";
 import {
@@ -17,6 +17,21 @@ import {
   type TaskManagerConfig,
   TASK_DEFAULTS,
 } from "../../types/index.js";
+
+async function loadBullMQ() {
+  try {
+    return await import(/* @vite-ignore */ "bullmq");
+  } catch (err) {
+    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
+    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("bullmq")) {
+      throw new Error(
+        'BullMQ task backend requires the "bullmq" package. Install it with:\n  pnpm add bullmq',
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+}
 
 const QUEUE_NAME = "neurolink-tasks";
 
@@ -32,11 +47,12 @@ export class BullMQBackend implements TaskBackend {
   }
 
   async initialize(): Promise<void> {
+    const { Queue: BullQueue, Worker: BullWorker } = await loadBullMQ();
     const connection = this.getConnectionConfig();
 
-    this.queue = new Queue(QUEUE_NAME, { connection });
+    this.queue = new BullQueue(QUEUE_NAME, { connection });
 
-    this.worker = new Worker(
+    this.worker = new BullWorker(
       QUEUE_NAME,
       async (job: Job) => {
         const taskId = job.data.taskId as string;


### PR DESCRIPTION
## Summary
- Convert static `import { Queue, Worker } from "bullmq"` to dynamic import inside `initialize()`
- Move `bullmq` from `dependencies` to `optionalDependencies`
- Add clear install hint on failure: `pnpm add bullmq`
- Default task backend (`nodeTimeoutBackend`) is completely unaffected

## Impact
- **SDK-only users** who never configure `backend: "bullmq"`: no change
- **BullMQ users**: still works if bullmq is installed (optional deps install by default)
- **`--no-optional` installs**: BullMQ backend will throw a clear error with install instructions

## Test plan
- [ ] `pnpm run build` succeeds
- [ ] `pnpm run check` passes
- [ ] Default task backend works without bullmq in node_modules
- [ ] BullMQ backend works when bullmq is installed