### PR TITLE
chore(deps): move pdf-parse and pdf-to-img to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,8 +248,6 @@
     "open": "^11.0.0",
     "ora": "^9.3.0",
     "p-limit": "^7.3.0",
-    "pdf-parse": "^2.4.5",
-    "pdf-to-img": "^5.0.0",
     "pptxgenjs": "^4.0.1",
     "redis": "^5.11.0",
     "tar-stream": "^3.1.8",
@@ -275,6 +273,8 @@
   },
   "optionalDependencies": {
     "@langfuse/otel": "^5.0.1",
+    "pdf-parse": "^2.4.5",
+    "pdf-to-img": "^5.0.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@hono/node-server": "^1.19.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,12 +197,6 @@ importers:
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
-      pdf-parse:
-        specifier: ^2.4.5
-        version: 2.4.5
-      pdf-to-img:
-        specifier: ^5.0.0
-        version: 5.0.0
       pptxgenjs:
         specifier: ^4.0.1
         version: 4.0.1
@@ -432,7 +426,7 @@ importers:
         version: 15.4.0(koa@3.2.0)
       '@langfuse/otel':
         specifier: ^5.0.1
-        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -454,6 +448,12 @@ importers:
       koa-bodyparser:
         specifier: ^4.4.1
         version: 4.4.1
+      pdf-parse:
+        specifier: ^2.4.5
+        version: 2.4.5
+      pdf-to-img:
+        specifier: ^5.0.0
+        version: 5.0.0
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -1858,24 +1858,10 @@ packages:
     peerDependencies:
       koa: ^2.0.0 || ^3.0.0
 
-  '@langfuse/core@5.0.1':
-    resolution: {integrity: sha512-DirjtE+RjToRuJeVzy7EC05ebtz+ryEDBjjeRNbcQ5OQ38VaIMqWgt124ZQXfW5Rel9oobGcYDu6V5nkr2TuMg==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
   '@langfuse/core@5.1.0':
     resolution: {integrity: sha512-yFvC67HBtrY4B3tyzF8+RJaIqK79LBVXtAgtmEc2vhpKauecvSW0zevRnRynFX+ajUHqi9TN7tnD91FJszFLgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
-
-  '@langfuse/otel@5.0.1':
-    resolution: {integrity: sha512-yCR8pfhPTzScgXmtcoFMo9+/705yTXJXVxMeVNATMhkoO7wtzZSuYqc/QX8XHY7/rE6K0HqI/riB7DVySRk4Eg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/core': ^2.0.1
-      '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
-      '@opentelemetry/sdk-trace-base': ^2.6.0
 
   '@langfuse/otel@5.1.0':
     resolution: {integrity: sha512-pvaXgZHMHqjsRjn+Gs5amrrq61w0Rxz1OChmLr2FfQzlymNl7+MxSXsWBj5dZQlufGbhyG+LT3wdx3MV8aLXHQ==}
@@ -9730,23 +9716,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@langfuse/core@5.0.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-    optional: true
-
   '@langfuse/core@5.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-
-  '@langfuse/otel@5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@langfuse/core': 5.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-    optional: true
 
   '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -9755,6 +9727,15 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@langfuse/core': 5.1.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+    optional: true
 
   '@lukeed/ms@2.0.2':
     optional: true


### PR DESCRIPTION
## Summary
- Move `pdf-parse` (21 MB) and `pdf-to-img` from `dependencies` to `optionalDependencies`
- Both already use dynamic `await import()` with try/catch — zero code changes needed
- `loaders.ts` already provides a graceful fallback with install hint for RAG users

## Impact
- Default `pnpm install`: no change (optional deps install by default)
- `--no-optional` installs: PDF processing unavailable, clear error messages
- Install savings: ~21 MB for opt-out consumers

## Test plan
- [ ] `pnpm run build` succeeds
- [ ] `pnpm run check` passes
- [ ] PDF RAG pipeline works when pdf-parse is installed
- [ ] Graceful error when pdf-parse is missing