### PR TITLE
refactor(cli): dynamic-import @aws-sdk/client-sagemaker, move to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
     "@ai-sdk/provider": "^3.0.8",
     "@aws-sdk/client-bedrock": "^3.1000.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
-    "@aws-sdk/client-sagemaker": "^3.1000.0",
     "@aws-sdk/client-sagemaker-runtime": "^3.1000.0",
     "@google-cloud/text-to-speech": "^6.4.0",
     "@google-cloud/vertexai": "^1.10.0",
@@ -271,6 +270,7 @@
     }
   },
   "optionalDependencies": {
+    "@aws-sdk/client-sagemaker": "^3.1000.0",
     "@langfuse/otel": "^5.0.1",
     "bullmq": "^5.52.2",
     "pdf-parse": "^2.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1000.0
         version: 3.1019.0
-      '@aws-sdk/client-sagemaker':
-        specifier: ^3.1000.0
-        version: 3.1019.0
       '@aws-sdk/client-sagemaker-runtime':
         specifier: ^3.1000.0
         version: 3.1019.0
@@ -406,6 +403,9 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2
     optionalDependencies:
+      '@aws-sdk/client-sagemaker':
+        specifier: ^3.1000.0
+        version: 3.1019.0
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -8003,6 +8003,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/client-sagemaker@3.1029.0':
     dependencies:

--- a/src/cli/factories/sagemakerCommandFactory.ts
+++ b/src/cli/factories/sagemakerCommandFactory.ts
@@ -2,11 +2,25 @@ import type { Argv, CommandModule } from "yargs";
 import chalk from "chalk";
 import ora from "ora";
 import inquirer from "inquirer";
-import {
-  SageMakerClient,
-  ListEndpointsCommand,
-  type EndpointSummary,
-} from "@aws-sdk/client-sagemaker";
+import type { EndpointSummary } from "@aws-sdk/client-sagemaker";
+
+async function loadSageMakerControl() {
+  try {
+    return await import(/* @vite-ignore */ "@aws-sdk/client-sagemaker");
+  } catch (err) {
+    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
+    if (
+      e?.code === "ERR_MODULE_NOT_FOUND" &&
+      e.message.includes("client-sagemaker")
+    ) {
+      throw new Error(
+        'SageMaker setup requires "@aws-sdk/client-sagemaker". Install it with:\n  pnpm add @aws-sdk/client-sagemaker',
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+}
 import type {
   UnknownRecord,
   DoGenerateModel,
@@ -236,10 +250,11 @@ export class SageMakerCommandFactory {
   /**
    * Validate secure configuration without exposing credentials
    */
-  private static validateSecureConfiguration(
+  private static async validateSecureConfiguration(
     secureConfig: SecureConfiguration,
-  ): void {
+  ): Promise<void> {
     // Create temporary AWS SDK client with secure credentials
+    const { SageMakerClient } = await loadSageMakerControl();
     const tempClient = new SageMakerClient({
       region: secureConfig.region,
       credentials: {
@@ -425,6 +440,8 @@ export class SageMakerCommandFactory {
       // Use AWS SDK directly for better security and error handling
       try {
         const config = await getSageMakerConfig();
+        const { SageMakerClient, ListEndpointsCommand } =
+          await loadSageMakerControl();
         const sagemakerClient = new SageMakerClient({
           region: config.region,
           credentials: {
@@ -698,7 +715,7 @@ export class SageMakerCommandFactory {
       clearConfigurationCache();
 
       try {
-        this.validateSecureConfiguration(secureConfig); // Validate configuration is loadable
+        await this.validateSecureConfiguration(secureConfig); // Validate configuration is loadable
         spinner.succeed("✅ Configuration validated successfully");
 
         logger.always(chalk.green("\n🎉 SageMaker setup complete!"));


### PR DESCRIPTION
## Summary
- Dynamic-import `@aws-sdk/client-sagemaker` (12 MB control-plane) in CLI setup commands
- Move from `dependencies` to `optionalDependencies`
- SageMaker inference via `client-sagemaker-runtime` is unaffected (stays in dependencies)
- Clear install hint on failure

## Impact
- CLI `setup-sagemaker` command: requires explicit install if using `--no-optional`
- SageMaker provider inference: completely unaffected
- Install savings: ~12 MB for consumers who don't use SageMaker CLI setup

## Test plan
- [ ] `pnpm run build` succeeds
- [ ] `pnpm run check` passes
- [ ] `neurolink setup-sagemaker` works when package is installed