### PR TITLE
refactor(telemetry): dynamic-import @langfuse/otel, move to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,6 @@
     "@google/genai": "^1.43.0",
     "@huggingface/inference": "^4.13.14",
     "@juspay/hippocampus": "^0.1.4",
-    "@langfuse/otel": "^5.0.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "@opentelemetry/api-logs": "^0.214.0",
@@ -275,6 +274,7 @@
     }
   },
   "optionalDependencies": {
+    "@langfuse/otel": "^5.0.1",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@hono/node-server": "^1.19.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@juspay/hippocampus':
         specifier: ^0.1.4
         version: 0.1.4(@juspay/neurolink@9.37.0(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@types/node@25.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@langfuse/otel':
-        specifier: ^5.0.1
-        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.28.0(zod@4.3.6)
@@ -433,6 +430,9 @@ importers:
       '@koa/router':
         specifier: ^15.3.1
         version: 15.4.0(koa@3.2.0)
+      '@langfuse/otel':
+        specifier: ^5.0.1
+        version: 5.0.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -9733,6 +9733,7 @@ snapshots:
   '@langfuse/core@5.0.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+    optional: true
 
   '@langfuse/core@5.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9745,6 +9746,7 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+    optional: true
 
   '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
     dependencies:

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1013,7 +1013,7 @@ async function initializeProxyOpenTelemetry(): Promise<void> {
     const observabilityConfig = buildObservabilityConfigFromEnv();
     const langfuseConfig = observabilityConfig?.langfuse;
     const langfuseEnabled = langfuseConfig?.enabled === true;
-    initializeOpenTelemetry({
+    await initializeOpenTelemetry({
       enabled: langfuseEnabled,
       publicKey: langfuseConfig?.publicKey || "",
       secretKey: langfuseConfig?.secretKey || "",

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -2051,7 +2051,11 @@ Current user's request: ${currentInput}`;
         });
 
         // Initialize OpenTelemetry (sets defaults from config)
-        initializeOpenTelemetry(langfuseConfig);
+        void initializeOpenTelemetry(langfuseConfig).catch((err) => {
+          logger.error("[NeuroLink] OpenTelemetry initialization failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
 
         const healthStatus = getLangfuseHealthStatus();
         const langfuseInitDurationNs =
@@ -3006,7 +3010,11 @@ Current user's request: ${currentInput}`;
       const langfuseConfig = this.observabilityConfig?.langfuse;
 
       if (langfuseConfig?.enabled) {
-        initializeOpenTelemetry(langfuseConfig);
+        void initializeOpenTelemetry(langfuseConfig).catch((err) => {
+          logger.error("[NeuroLink] OpenTelemetry initialization failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
 
         logger.debug(
           "[NeuroLink] Langfuse observability initialized via public method",

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -7,7 +7,7 @@
  * Flow: Vercel AI SDK → OpenTelemetry Spans → LangfuseSpanProcessor → Langfuse Platform
  */
 
-import { LangfuseSpanProcessor } from "@langfuse/otel";
+import type { LangfuseSpanProcessor as LangfuseSpanProcessorType } from "@langfuse/otel";
 import type { Context } from "@opentelemetry/api";
 import { metrics, SpanStatusCode, trace } from "@opentelemetry/api";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
@@ -134,7 +134,7 @@ const contextStorage = new AsyncLocalStorage<LangfuseContext>();
 let tracerProvider: NodeTracerProvider | null = null;
 let meterProvider: MeterProvider | null = null;
 let loggerProvider: LoggerProvider | null = null;
-let langfuseProcessor: LangfuseSpanProcessor | null = null;
+let langfuseProcessor: LangfuseSpanProcessorType | null = null;
 let isInitialized = false;
 let isCredentialsValid = false;
 let currentConfig: LangfuseConfig | null = null;
@@ -657,10 +657,23 @@ class ContextEnricher implements SpanProcessor {
   }
 }
 
-function createLangfuseProcessor(
+async function createLangfuseProcessor(
   config: LangfuseConfig,
-): LangfuseSpanProcessor {
-  return new LangfuseSpanProcessor({
+): Promise<LangfuseSpanProcessorType> {
+  let mod: typeof import("@langfuse/otel");
+  try {
+    mod = await import(/* @vite-ignore */ "@langfuse/otel");
+  } catch (err) {
+    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
+    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("langfuse")) {
+      throw new Error(
+        'Langfuse observability requires "@langfuse/otel". Install it with:\n  pnpm add @langfuse/otel',
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+  return new mod.LangfuseSpanProcessor({
     publicKey: config.publicKey,
     secretKey: config.secretKey,
     baseUrl: config.baseUrl || "https://cloud.langfuse.com",
@@ -670,14 +683,14 @@ function createLangfuseProcessor(
   });
 }
 
-function initializeExternalOpenTelemetryMode(
+async function initializeExternalOpenTelemetryMode(
   config: LangfuseConfig,
   resource: ReturnType<typeof resourceFromAttributes>,
   otlpEndpoint: string | undefined,
   serviceName: string,
   langfuseRequested: boolean,
   hasLangfuseCreds: boolean,
-): void {
+): Promise<void> {
   if (langfuseRequested && !hasLangfuseCreds) {
     if (!otlpEndpoint) {
       logger.warn(
@@ -707,7 +720,7 @@ function initializeExternalOpenTelemetryMode(
     isCredentialsValid = hasLangfuseCreds;
     langfuseProcessor =
       langfuseRequested && hasLangfuseCreds
-        ? createLangfuseProcessor(config)
+        ? await createLangfuseProcessor(config)
         : null;
 
     usingExternalProvider = true;
@@ -726,11 +739,9 @@ function initializeExternalOpenTelemetryMode(
         // Auto-detect: skip if consumer already registered a LangfuseSpanProcessor.
         //
         // Detection strategy (ordered by robustness):
-        // 1. `instanceof LangfuseSpanProcessor` — reliable when both sides use
-        //    the same @langfuse/otel package instance (same module identity).
-        // 2. Duck-type check for Langfuse-specific public member
+        // 1. Duck-type check for Langfuse-specific public member
         //    (`langfuseClient` property) — survives minification.
-        // 3. `constructor.name === "LangfuseSpanProcessor"` — last resort,
+        // 2. `constructor.name === "LangfuseSpanProcessor"` — last resort,
         //    brittle under minification or bundler renaming.
         //
         // NOTE: `_registeredSpanProcessors` is an internal OpenTelemetry field.
@@ -744,10 +755,6 @@ function initializeExternalOpenTelemetryMode(
         const hasExistingLangfuse = existingProcessors.some((p) => {
           if (p === null || p === undefined || typeof p !== "object") {
             return false;
-          }
-          // Prefer instanceof — works when same @langfuse/otel package is shared
-          if (p instanceof LangfuseSpanProcessor) {
-            return true;
           }
           // Duck-type: Langfuse processor exposes a langfuseClient property
           if ("langfuseClient" in p) {
@@ -826,14 +833,14 @@ function initializeExternalOpenTelemetryMode(
   }
 }
 
-function initializeStandaloneOpenTelemetryMode(
+async function initializeStandaloneOpenTelemetryMode(
   config: LangfuseConfig,
   resource: ReturnType<typeof resourceFromAttributes>,
   otlpEndpoint: string | undefined,
   serviceName: string,
   langfuseRequested: boolean,
   hasLangfuseCreds: boolean,
-): void {
+): Promise<void> {
   if ((!langfuseRequested || !hasLangfuseCreds) && !otlpEndpoint) {
     if (langfuseRequested && !hasLangfuseCreds) {
       logger.warn(
@@ -868,7 +875,7 @@ function initializeStandaloneOpenTelemetryMode(
     isCredentialsValid = hasLangfuseCreds;
     langfuseProcessor =
       langfuseRequested && hasLangfuseCreds
-        ? createLangfuseProcessor(config)
+        ? await createLangfuseProcessor(config)
         : null;
 
     logger.debug(`${LOG_PREFIX} Standalone observability mode`, {
@@ -975,7 +982,9 @@ function initializeStandaloneOpenTelemetryMode(
  *
  * @param config - Langfuse configuration passed from parent application
  */
-export function initializeOpenTelemetry(config: LangfuseConfig): void {
+export async function initializeOpenTelemetry(
+  config: LangfuseConfig,
+): Promise<void> {
   // Guard against multiple initializations — but always update config
   // so that later NeuroLink instances can change traceNameFormat,
   // autoDetectOperationName, and other configuration preferences
@@ -1008,7 +1017,7 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
   const resource = createOtelResource(config, serviceName);
 
   if (shouldUseExternal) {
-    initializeExternalOpenTelemetryMode(
+    await initializeExternalOpenTelemetryMode(
       config,
       resource,
       otlpEndpoint,
@@ -1019,7 +1028,7 @@ export function initializeOpenTelemetry(config: LangfuseConfig): void {
     return;
   }
 
-  initializeStandaloneOpenTelemetryMode(
+  await initializeStandaloneOpenTelemetryMode(
     config,
     resource,
     otlpEndpoint,
@@ -1163,7 +1172,7 @@ export async function shutdownOpenTelemetry(): Promise<void> {
 /**
  * Get the Langfuse span processor
  */
-export function getLangfuseSpanProcessor(): LangfuseSpanProcessor | null {
+export function getLangfuseSpanProcessor(): SpanProcessor | null {
   return langfuseProcessor;
 }
 


### PR DESCRIPTION
## Summary
- Dynamic-import `@langfuse/otel` inside `createLangfuseProcessor()` instead of static top-level import
- Move from `dependencies` to `optionalDependencies`
- Replace `instanceof LangfuseSpanProcessor` with duck-type + constructor.name checks (class no longer in scope)
- Make `initializeOpenTelemetry`, `initializeExternalOpenTelemetryMode`, `initializeStandaloneOpenTelemetryMode` async

## Impact
- Users without Langfuse configured: zero change (import never triggers)
- Langfuse users: works identically when package is installed
- `--no-optional` installs: clear error with install hint

## Test plan
- [ ] `pnpm run build` succeeds
- [ ] `pnpm run check` passes
- [ ] Observability works with Langfuse configured
- [ ] No errors when Langfuse is not configured