### PR TITLE
refactor(providers): lazy-load @aws-sdk/client-bedrock control-plane

### DIFF
--- a/src/lib/providers/amazonBedrock.ts
+++ b/src/lib/providers/amazonBedrock.ts
@@ -1,7 +1,6 @@
-import {
-  BedrockClient,
-  ListFoundationModelsCommand,
-} from "@aws-sdk/client-bedrock";
+async function loadBedrockControl() {
+  return await import(/* @vite-ignore */ "@aws-sdk/client-bedrock");
+}
 import type {
   Tool as BedrockTool,
   ContentBlock,
@@ -133,6 +132,8 @@ export class AmazonBedrockProvider extends BaseProvider {
    * This prevents the health check failure we saw in production logs
    */
   private async performInitialHealthCheck(): Promise<void> {
+    const { BedrockClient, ListFoundationModelsCommand } =
+      await loadBedrockControl();
     const bedrockClient = new BedrockClient({
       region: this.region,
     });
@@ -2166,6 +2167,8 @@ export class AmazonBedrockProvider extends BaseProvider {
 
     // Create a separate BedrockClient for health checks (not BedrockRuntimeClient)
     // Use simple configuration like working example - no custom proxy handler
+    const { BedrockClient, ListFoundationModelsCommand } =
+      await loadBedrockControl();
     const healthCheckClient = new BedrockClient({
       region: process.env.AWS_REGION || "us-east-1",
     });


### PR DESCRIPTION
## Summary
- Lazy-load `@aws-sdk/client-bedrock` (control-plane) in `performInitialHealthCheck()` and `checkBedrockHealth()`
- These are cold-path operations that don't need eager loading at provider init
- Inference via `client-bedrock-runtime` is completely unaffected
- Package stays in `dependencies` (used at runtime, just loaded lazily)

## Impact
- Faster Bedrock provider initialization (skips control-plane client loading)
- No behavioral change — same API, same functionality

## Test plan
- [ ] pnpm run build succeeds
- [ ] pnpm run check passes
- [ ] Bedrock provider inference works
- [ ] Health check / listModels works when called