### PR TITLE
TTS-025: Add cross-platform CLI audio playback (--tts-play)

### DIFF
--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -39,6 +39,7 @@ import { handleError } from "../errorHandler.js";
 import { LoopSession } from "../loop/session.js";
 import { initializeCliParser } from "../parser.js";
 import { formatFileSize, saveAudioToFile } from "../utils/audioFileUtils.js";
+import { playAudio } from "../utils/audioPlayer.js";
 import { resolveFilePaths } from "../utils/pathResolver.js";
 import { animatedWrite } from "../utils/typewriter.js";
 import { createStreamAbortHandler } from "../utils/abortHandler.js";
@@ -925,16 +926,19 @@ export class CLICommandFactory {
   }
 
   /**
-   * Helper method to handle TTS audio file output
+   * Helper method to handle TTS audio file output and playback
    * Saves audio to file when --tts-output flag is provided
+   * Plays audio through system speaker when --tts-play flag is provided
    */
   private static async handleTTSOutput(
     result: CliGenerateResult | unknown,
     options: BaseCommandArgs & Record<string, unknown>,
   ): Promise<void> {
-    // Check if --tts-output flag is provided
     const ttsOutputPath = options.ttsOutput as string | undefined;
-    if (!ttsOutputPath) {
+    const ttsPlay = options.ttsPlay as boolean | undefined;
+
+    // Nothing to do if neither flag is set
+    if (!ttsOutputPath && !ttsPlay) {
       return;
     }
 
@@ -956,26 +960,52 @@ export class CLICommandFactory {
       return;
     }
 
-    try {
-      // Save audio to file
-      const saveResult = await saveAudioToFile(audio, ttsOutputPath);
+    // Save audio to file if --tts-output is provided
+    if (ttsOutputPath) {
+      try {
+        const saveResult = await saveAudioToFile(audio, ttsOutputPath);
 
-      if (saveResult.success) {
+        if (saveResult.success) {
+          if (!options.quiet) {
+            logger.always(
+              chalk.green(
+                `🔊 Audio saved to: ${saveResult.path} (${formatFileSize(saveResult.size)})`,
+              ),
+            );
+          }
+        } else {
+          handleError(
+            new Error(saveResult.error || "Failed to save audio file"),
+            "TTS Output",
+          );
+        }
+      } catch (error) {
+        handleError(error as Error, "TTS Output");
+      }
+    }
+
+    // Play audio through system speaker if --tts-play is provided
+    if (ttsPlay) {
+      try {
+        if (!options.quiet) {
+          logger.always(chalk.cyan("🔊 Playing audio..."));
+        }
+        await playAudio(audio.buffer, audio.format);
+      } catch (err) {
+        // Non-fatal: warn but don't crash the command
         if (!options.quiet) {
           logger.always(
-            chalk.green(
-              `🔊 Audio saved to: ${saveResult.path} (${formatFileSize(saveResult.size)})`,
+            chalk.yellow(
+              `⚠️  Audio playback failed: ${(err as Error).message}`,
+            ),
+          );
+          logger.always(
+            chalk.yellow(
+              "Tip: Save the audio with --tts-output <file> and play manually.",
             ),
           );
         }
-      } else {
-        handleError(
-          new Error(saveResult.error || "Failed to save audio file"),
-          "TTS Output",
-        );
       }
-    } catch (error) {
-      handleError(error as Error, "TTS Output");
     }
   }
 
@@ -3224,11 +3254,12 @@ export class CLICommandFactory {
       }
     }
 
-    // Handle TTS audio output if --tts-output is provided
+    // Handle TTS audio output/playback if --tts-output or --tts-play is provided
     // Note: For streaming, TTS audio is collected during the stream
     // and saved at the end if available
     const ttsOutputPath = options.ttsOutput as string | undefined;
-    if (ttsOutputPath) {
+    const ttsPlay = options.ttsPlay as boolean | undefined;
+    if (ttsOutputPath || ttsPlay) {
       // For now, streaming TTS output is not yet available
       // This will be enabled when the TTS streaming infrastructure is complete
       if (!options.quiet) {

--- a/src/cli/utils/audioPlayer.ts
+++ b/src/cli/utils/audioPlayer.ts
@@ -1,0 +1,93 @@
+/**
+ * Cross-platform audio playback for CLI
+ *
+ * Plays TTS audio through the system speaker using platform-native tools.
+ * No npm dependencies — uses only Node.js built-ins.
+ *
+ * @module cli/utils/audioPlayer
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { AudioFormat } from "../../lib/types/index.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Plays an audio buffer through the system speaker.
+ * Writes buffer to a temp file, plays it, then cleans up.
+ *
+ * @param buffer - Audio data to play
+ * @param format - Audio format of the buffer
+ */
+export async function playAudio(
+  buffer: Buffer,
+  format: AudioFormat,
+): Promise<void> {
+  const ext = getExtension(format);
+  const tmpFile = join(tmpdir(), `nl-tts-${Date.now()}.${ext}`);
+  try {
+    await fs.promises.writeFile(tmpFile, buffer);
+    await executePlayer(tmpFile, format);
+  } finally {
+    try {
+      await fs.promises.unlink(tmpFile);
+    } catch {
+      /* ignore cleanup errors */
+    }
+  }
+}
+
+function getExtension(format: AudioFormat): string {
+  const map: Record<string, string> = {
+    mp3: "mp3",
+    wav: "wav",
+    ogg: "ogg",
+    opus: "opus",
+  };
+  return map[format] ?? "mp3";
+}
+
+async function executePlayer(
+  filePath: string,
+  format: AudioFormat,
+): Promise<void> {
+  const platform = process.platform;
+  if (platform === "darwin") {
+    // macOS: afplay is built-in, supports mp3/wav/aac/flac
+    await execFileAsync("afplay", [filePath]);
+  } else if (platform === "linux") {
+    // Linux: try paplay (PulseAudio) first, fallback to aplay (ALSA) for WAV
+    if (format === "wav") {
+      await execFileAsync("aplay", [filePath]).catch(() =>
+        execFileAsync("paplay", [filePath]),
+      );
+    } else {
+      await execFileAsync("paplay", [filePath]).catch(() => {
+        throw new Error(
+          "Linux audio playback failed. Install PulseAudio (paplay) or use WAV format with ALSA (aplay).",
+        );
+      });
+    }
+  } else if (platform === "win32") {
+    // Windows: PowerShell SoundPlayer for WAV, WMPlayer for other formats
+    if (format === "wav") {
+      await execFileAsync("powershell", [
+        "-Command",
+        `(New-Object Media.SoundPlayer '${filePath}').PlaySync()`,
+      ]);
+    } else {
+      await execFileAsync("powershell", [
+        "-Command",
+        `$player = New-Object -ComObject WMPlayer.OCX; $player.URL = '${filePath}'; $player.controls.play(); Start-Sleep -Seconds 30`,
+      ]);
+    }
+  } else {
+    throw new Error(
+      `Unsupported platform for audio playback: ${platform}. Supported: macOS, Linux, Windows.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **New file** `src/cli/utils/audioPlayer.ts` — cross-platform audio playback utility using platform-native CLI tools (no npm dependencies): macOS (`afplay`), Linux (`paplay`/`aplay`), Windows (PowerShell)
- **Modified** `src/cli/factories/commandFactory.ts` — wired `playAudio()` into `handleTTSOutput` so both `--tts-output` (save) and `--tts-play` (playback) work independently or together
- Updated streaming command's TTS section to also warn when `--tts-play` is used (streaming TTS not yet available)
- Playback errors are **non-fatal** — the CLI warns but does not crash

## Files Changed

| File | Change |
|------|--------|
| `src/cli/utils/audioPlayer.ts` | **Created** — cross-platform audio playback utility |
| `src/cli/factories/commandFactory.ts` | **Modified** — import `playAudio`, update `handleTTSOutput` to support `--tts-play` |

## Design Decisions

- Temp file pattern: write buffer to `os.tmpdir()`, play, clean up in `finally` block
- Zero new npm dependencies — only Node.js built-ins
- Follows same structure and conventions as `src/cli/utils/audioFileUtils.ts`

## Test Plan

- [ ] Run `neurolink generate "Hello" --tts --tts-play` on macOS — verify audio plays through speakers
- [ ] Run with `--tts-play --tts-output output.mp3` — verify both save and playback work
- [ ] Run with `--tts-play` but without `--tts` — verify graceful "no audio available" warning
- [ ] Run `neurolink stream "Hello" --tts --tts-play` — verify warning about streaming TTS not yet available
- [ ] Verify temp files are cleaned up after playback

## Discussion Thread

https://slack.com/archives/D070Z4F0XNZ/p1776706127566189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--tts-play` flag to trigger automatic TTS audio playback from the command line.
  * Enabled cross-platform audio playback support (macOS, Linux, Windows).
  * Enhanced audio playback error handling with non-fatal warnings and automatic temporary file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->