### PR TITLE
docs(readme): add GitHub Discussions link to Contributing & Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,6 +999,7 @@ Full command and API breakdown lives in [`docs/cli/commands.md`](docs/cli/comman
 ## Contributing & Support
 
 - Bug reports and feature requests → [GitHub Issues](https://github.com/juspay/neurolink/issues)
+- Questions and discussions → [GitHub Discussions](https://github.com/juspay/neurolink/discussions)
 - Development workflow, testing, and pull request guidelines → [`docs/development/contributing.md`](docs/development/contributing.md)
 - Documentation improvements → open a PR referencing the [documentation matrix](docs/tracking/FEATURE-DOC-MATRIX.md).
 


### PR DESCRIPTION
## Summary
- Added a "Questions and discussions → GitHub Discussions" bullet point to the Contributing & Support section in README.md
- Minimal, non-breaking documentation update to test GitHub repo integration

## Files Changed
- `README.md` — 1 line added

## Discussion Thread
https://slack.com/archives/D070Z4F0XNZ/p1776740491001689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the Contributing & Support section with a link to GitHub Discussions, enabling users to ask questions and engage in community discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->