### PR TITLE
test(observability): regression guard for mcp.tool.name on Pipeline B spans

### DIFF
--- a/test/continuous-test-suite-issue-05-mcp-tool-name-spans.ts
+++ b/test/continuous-test-suite-issue-05-mcp-tool-name-spans.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Issue #5 — mcp.tool.name on Pipeline B spans
+ *
+ * Curator P1-5: NeuroLink-emitted spans (`neurolink.tool.execute`,
+ * `neurolink.tool.registry.execute`, `neurolink.tools.execute_custom`) must
+ * carry `mcp.tool.name` / `tool.name` / `gen_ai.tool.name` so per-tool
+ * error analysis works in Langfuse.
+ *
+ * Strategy: REAL OTel via InMemorySpanExporter. Register a real custom tool
+ *           on the public SDK; invoke it via sdk.executeTool() (deterministic,
+ *           no LLM needed). Inspect every span emitted; assert the tool-name
+ *           attribute is present.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-issue-05-mcp-tool-name-spans.ts
+ */
+import "dotenv/config";
+
+// Install OTel BEFORE importing NeuroLink so production tracers pick up the exporter.
+import { installSpanCapture, dumpAttrs } from "./helpers/spanCapture.js";
+const spans = installSpanCapture();
+
+import { NeuroLink } from "../dist/index.js";
+
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  bright: "\x1b[1m",
+};
+
+type Outcome = "PASS" | "FAIL" | "SKIP";
+const results: { name: string; outcome: Outcome; detail: string }[] = [];
+
+function record(name: string, outcome: Outcome, detail: string): void {
+  results.push({ name, outcome, detail });
+  const color =
+    outcome === "PASS"
+      ? colors.green
+      : outcome === "FAIL"
+        ? colors.red
+        : colors.yellow;
+  console.log(`${color}[${outcome}]${colors.reset} ${name} — ${detail}`);
+}
+
+function section(t: string): void {
+  console.log(
+    `\n${colors.cyan}${"=".repeat(72)}\n  ${t}\n${"=".repeat(72)}${colors.reset}`,
+  );
+}
+
+const NAME_KEYS = ["mcp.tool.name", "tool.name", "gen_ai.tool.name"];
+
+function getToolNameAttr(
+  attrs: Record<string, unknown>,
+): { key: string; value: unknown } | null {
+  for (const k of NAME_KEYS) {
+    if (attrs[k] !== undefined) {
+      return { key: k, value: attrs[k] };
+    }
+  }
+  return null;
+}
+
+async function checkSuccessPath(): Promise<void> {
+  const testName =
+    "5.1 — custom tool success: tool-name on every Pipeline B span";
+  spans.reset();
+
+  const sdk = new NeuroLink();
+  sdk.registerTool("calc_add", {
+    name: "calc_add",
+    description: "Add two numbers",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number" },
+        b: { type: "number" },
+      },
+      required: ["a", "b"],
+    },
+    execute: async (params: { a?: number; b?: number }) => ({
+      sum: (params.a ?? 0) + (params.b ?? 0),
+    }),
+  });
+
+  try {
+    const result = await sdk.executeTool("calc_add", { a: 2, b: 3 });
+    void result;
+
+    // Allow span exporter to flush
+    await new Promise((r) => setTimeout(r, 100));
+
+    const targetSpanNames = [
+      "neurolink.tool.execute",
+      "neurolink.tool.registry.execute",
+    ];
+    const findings: string[] = [];
+    for (const name of targetSpanNames) {
+      const span = spans.byName(name);
+      if (!span) {
+        findings.push(`${name}: NOT EMITTED`);
+        continue;
+      }
+      const attrs = dumpAttrs(span);
+      const tn = getToolNameAttr(attrs);
+      if (tn) {
+        findings.push(`${name}: ${tn.key}=${String(tn.value)}`);
+      } else {
+        findings.push(`${name}: NO TOOL NAME ATTRIBUTE`);
+      }
+    }
+    const allHaveName = findings.every((f) => !f.includes("NO TOOL NAME"));
+    if (allHaveName) {
+      record(testName, "PASS", findings.join(" | "));
+    } else {
+      record(testName, "FAIL", findings.join(" | "));
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function checkErrorPath(): Promise<void> {
+  const testName = "5.2 — tool throws: tool-name still set on span";
+  spans.reset();
+
+  const sdk = new NeuroLink();
+  sdk.registerTool("boom", {
+    name: "boom",
+    description: "Always throws",
+    inputSchema: { type: "object", properties: {} },
+    execute: async () => {
+      throw new Error("intentional");
+    },
+  });
+
+  try {
+    try {
+      await sdk.executeTool("boom", {});
+    } catch (err) {
+      void err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+
+    const span = spans.byName("neurolink.tool.execute");
+    if (!span) {
+      record(testName, "FAIL", "neurolink.tool.execute span missing");
+      return;
+    }
+    const attrs = dumpAttrs(span);
+    const tn = getToolNameAttr(attrs);
+    if (tn) {
+      record(
+        testName,
+        "PASS",
+        `${tn.key}=${String(tn.value)}; status=${span.status?.code ?? "?"}`,
+      );
+    } else {
+      record(
+        testName,
+        "FAIL",
+        `no tool-name on error span; attrs=${JSON.stringify(attrs).slice(0, 200)}`,
+      );
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function checkBogusName(): Promise<void> {
+  const testName = "5.6 — bogus tool name: span still carries requested name";
+  spans.reset();
+
+  const sdk = new NeuroLink();
+  try {
+    try {
+      await sdk.executeTool("does_not_exist_xyz", {});
+    } catch (err) {
+      void err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+
+    const span = spans.byName("neurolink.tool.execute");
+    if (!span) {
+      record(testName, "FAIL", "neurolink.tool.execute span missing");
+      return;
+    }
+    const attrs = dumpAttrs(span);
+    const tn = getToolNameAttr(attrs);
+    if (tn && tn.value === "does_not_exist_xyz") {
+      record(
+        testName,
+        "PASS",
+        `${tn.key}=${String(tn.value)}; status=${span.status?.code ?? "?"}`,
+      );
+    } else {
+      const detail = tn
+        ? `attr ${tn.key}=${String(tn.value)} (expected does_not_exist_xyz)`
+        : `attr not found (expected does_not_exist_xyz)`;
+      record(testName, "FAIL", detail);
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function dumpAllSpans(): Promise<void> {
+  const testName = "5.X — DEBUG: enumerate every captured span";
+  spans.reset();
+  const sdk = new NeuroLink();
+  sdk.registerTool("calc_dbg", {
+    name: "calc_dbg",
+    description: "debug",
+    inputSchema: { type: "object", properties: {} },
+    execute: async () => ({ ok: true }),
+  });
+  try {
+    await sdk.executeTool("calc_dbg", {});
+    await new Promise((r) => setTimeout(r, 200));
+    const finished = spans.finished();
+    if (finished.length === 0) {
+      record(testName, "FAIL", "(no spans captured)");
+      return;
+    }
+    const summary = finished
+      .map((s) => {
+        const a = dumpAttrs(s);
+        const tn = getToolNameAttr(a);
+        return `${s.name}[${tn ? tn.key + "=" + String(tn.value) : "no-name"}]`;
+      })
+      .join(", ");
+    const exec = spans.byName("neurolink.tool.execute");
+    if (!exec) {
+      record(
+        testName,
+        "FAIL",
+        `expected neurolink.tool.execute span; got: ${summary}`,
+      );
+      return;
+    }
+    const execTn = getToolNameAttr(dumpAttrs(exec));
+    if (!execTn) {
+      record(
+        testName,
+        "FAIL",
+        `neurolink.tool.execute span has no tool-name attribute; spans=${summary}`,
+      );
+      return;
+    }
+    record(testName, "PASS", summary);
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function main(): Promise<void> {
+  section("Issue #5 — Pipeline B spans must carry mcp.tool.name");
+  await dumpAllSpans();
+  await checkSuccessPath();
+  await checkErrorPath();
+  await checkBogusName();
+  const passed = results.filter((r) => r.outcome === "PASS").length;
+  const failed = results.filter((r) => r.outcome === "FAIL").length;
+  const skipped = results.filter((r) => r.outcome === "SKIP").length;
+  console.log(
+    `\n${colors.bright}Results:${colors.reset} ${passed} passed, ${failed} failed, ${skipped} skipped`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/helpers/spanCapture.ts
+++ b/test/helpers/spanCapture.ts
@@ -1,0 +1,61 @@
+/**
+ * Real OpenTelemetry capture helper.
+ *
+ * Registers a NodeTracerProvider with InMemorySpanExporter BEFORE NeuroLink
+ * is imported, so production tracers pick it up. InMemorySpanExporter is a
+ * standard `@opentelemetry/sdk-trace-base` exporter — captures every span
+ * the production code actually emits. Not a mock.
+ *
+ * IMPORTANT: callers must `installSpanCapture()` BEFORE importing NeuroLink
+ * from `dist/`.
+ */
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+export type SpanCapture = {
+  finished(): ReadableSpan[];
+  byName(name: string): ReadableSpan | undefined;
+  allByName(name: string): ReadableSpan[];
+  reset(): void;
+};
+
+let installed = false;
+let exporter: InMemorySpanExporter | null = null;
+
+/**
+ * One-shot install: the first call registers a NodeTracerProvider with the
+ * shared in-memory exporter; subsequent calls return additional handles to
+ * the *same* exporter. That means calling `.reset()` on any handle clears
+ * spans for every other handle in the process — keep one handle per suite
+ * and reset between tests.
+ */
+export function installSpanCapture(): SpanCapture {
+  if (!installed) {
+    exporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+    installed = true;
+  }
+  if (!exporter) {
+    throw new Error("span capture not installed");
+  }
+  // Snapshot the module-level exporter into a local const so the closure
+  // doesn't need non-null assertions on every method call.
+  const captured = exporter;
+  return {
+    finished: () => captured.getFinishedSpans(),
+    byName: (n) => captured.getFinishedSpans().find((s) => s.name === n),
+    allByName: (n) => captured.getFinishedSpans().filter((s) => s.name === n),
+    reset: () => captured.reset(),
+  };
+}
+
+export function dumpAttrs(span: ReadableSpan): Record<string, unknown> {
+  return { ...span.attributes };
+}


### PR DESCRIPTION
## Summary

Curator P2-5 reported that NeuroLink-emitted tool spans did not carry a tool-name attribute, breaking per-tool error analysis in Langfuse. The P1-3 fix in 9.55.11 already plumbed the attribute on every internal span:

| Span | Attribute key | Source |
|---|---|---|
| `neurolink.tool.execute` | `tool.name` | `src/lib/neurolink.ts:8765` |
| `neurolink.tool.registry.execute` | `gen_ai.tool.name` | `src/lib/mcp/toolRegistry.ts:332` |
| `neurolink.tools.execute_custom` | `tool.name` | `src/lib/core/modules/ToolsManager.ts:542` |

This PR adds a regression-guard suite so it can't silently regress. **No production-code change.**

The suite uses real OpenTelemetry (`InMemorySpanExporter` from `@opentelemetry/sdk-trace-base`) and the public `sdk.executeTool()` API.

## Verification

```bash
pnpm run build
npx tsx test/continuous-test-suite-issue-05-mcp-tool-name-spans.ts
```

Expected: `Results: 4 passed, 0 failed, 0 skipped`.

## Test plan

- [x] Suite runs and passes against current `release`
- [x] No source-code changes — bug is already fixed
- [x] Regression-guard documents the contract
- [x] One small follow-up (out of scope): attribute key differs between spans (`tool.name` vs `gen_ai.tool.name`); a downstream normaliser may help if Langfuse queries filter on a single key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Introduced new OpenTelemetry span capture helper utility for test infrastructure, enabling precise validation of real-time telemetry data and span attributes throughout the system
* Added comprehensive test suite to validate that tool-name attributes are properly captured in execution spans across multiple scenarios, including successful execution, error handling, and non-existent tool requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->