### PR TITLE
fix(observability): emit generation:end exactly once on stream finalize

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -97,6 +97,7 @@ import type {
   MCPTool,
   RoutingDecision,
   MetricsTraceContext,
+  StreamGenerationEndContext,
 } from "./types/index.js";
 import { emergencyContentTruncation } from "./context/emergencyTruncation.js";
 import {
@@ -475,6 +476,41 @@ function isNonRetryableProviderError(error: unknown): boolean {
  * same NeuroLink instance would clobber each other's trace context.
  */
 const metricsTraceContextStorage = new AsyncLocalStorage<MetricsTraceContext>();
+
+/**
+ * Curator P2-4 dedup (concurrency-safe): native providers emit
+ * `generation:end` on the shared SDK emitter. We attach a fresh
+ * mutable `dedupContext` object directly to the per-call
+ * `StreamOptions` (under `_streamDedupContext`) so each stream gets
+ * its own instance — concurrent streams have different option objects
+ * and therefore different contexts, so they cannot interfere.
+ *
+ * Native provider emit sites read `options._streamDedupContext` and
+ * flip `.providerEmitted = true` before emitting; the orchestration's
+ * finally block reads the same closed-over reference and skips its
+ * own emit when the flag is set.
+ *
+ * This avoids the AsyncLocalStorage approach which doesn't reliably
+ * propagate through async-generator yield boundaries when iteration
+ * happens from outside the original `run()` scope (e.g. when the
+ * consumer drives `for await of result.stream` after `sdk.stream(...)`
+ * returns).
+ */
+export const STREAM_DEDUP_CONTEXT_KEY = "_streamDedupContext" as const;
+
+/**
+ * Native providers call this from their `generation:end` emit sites,
+ * passing the same `options` object they received. Safe no-op when
+ * the field isn't set.
+ */
+export function markStreamProviderEmittedGenerationEnd(
+  options: { _streamDedupContext?: StreamGenerationEndContext } | undefined,
+): void {
+  const ctx = options?._streamDedupContext;
+  if (ctx) {
+    ctx.providerEmitted = true;
+  }
+}
 
 export class NeuroLink {
   private mcpInitialized = false;
@@ -6888,8 +6924,27 @@ Current user's request: ${currentInput}`;
       const streamStartTime = Date.now();
       const sessionId = (enhancedOptions.context as Record<string, unknown>)
         ?.sessionId as string | undefined;
+      // Curator P2-4 dedup (concurrency-safe): native provider stream paths
+      // (Gemini 3 on Vertex / Google AI Studio) emit `generation:end`
+      // themselves. We attach a per-stream mutable flag directly to
+      // `enhancedOptions._streamDedupContext` — native providers receive
+      // these options and flip the flag before their emit; this finally
+      // block reads the same closed-over reference. Concurrent streams
+      // have different option objects so the contexts don't interfere.
+      const dedupContext: StreamGenerationEndContext = {
+        providerEmitted: false,
+      };
+      (
+        enhancedOptions as StreamOptions & {
+          _streamDedupContext?: StreamGenerationEndContext;
+        }
+      )._streamDedupContext = dedupContext;
       const processedStream = (async function* () {
         let streamError: unknown;
+        // Curator P2-4: hoist `resolvedUsage` so the finally block can emit a
+        // single `generation:end` event with cost data. Cost listeners
+        // subscribe here; previously the stream path never fired it.
+        let resolvedUsage: unknown;
         try {
           for await (const chunk of mcpStream) {
             chunkCount++;
@@ -6932,7 +6987,7 @@ Current user's request: ${currentInput}`;
             );
           }
 
-          let resolvedUsage = streamUsage;
+          resolvedUsage = streamUsage;
           if (!resolvedUsage && streamAnalytics) {
             try {
               const resolved = await Promise.resolve(streamAnalytics);
@@ -7010,6 +7065,69 @@ Current user's request: ${currentInput}`;
               error: metadata.error,
             },
           );
+
+          // Curator P2-4: emit `generation:end` exactly once per stream so
+          // cost listeners receive the same contract as for `generate()`.
+          // The previous implementation only fired `stream:complete`, leaving
+          // any subscriber to `generation:end` with zero events.
+          //
+          // Dedup: native provider stream paths (Gemini 3 on Vertex / Google
+          // AI Studio) already emit `generation:end` themselves so Pipeline B
+          // (Langfuse) records a GENERATION observation. Skip our emit when
+          // they already fired — preserves their Pipeline B observation
+          // source and keeps the "exactly once" contract. Per-stream flag
+          // is concurrency-safe because it's scoped via AsyncLocalStorage.
+          if (!dedupContext.providerEmitted) {
+            try {
+              const finalProvider =
+                metadata.fallbackProvider ?? providerName ?? "unknown";
+              const finalModel =
+                metadata.fallbackModel ??
+                streamModel ??
+                enhancedOptions.model ??
+                "unknown";
+              const finalFinishReason = streamError
+                ? "error"
+                : (streamState.finishReason ?? "stop");
+              self.emitter.emit("generation:end", {
+                provider: finalProvider,
+                model: finalModel,
+                responseTime: Date.now() - streamStartTime,
+                toolsUsed: streamState.toolCalls?.map((t) => t.toolName),
+                timestamp: Date.now(),
+                result: {
+                  content: accumulatedContent,
+                  usage: resolvedUsage,
+                  model: finalModel,
+                  provider: finalProvider,
+                  finishReason: finalFinishReason,
+                },
+                prompt:
+                  enhancedOptions.input?.text ||
+                  (enhancedOptions as Record<string, unknown>).prompt,
+                temperature: enhancedOptions.temperature,
+                maxTokens: enhancedOptions.maxTokens,
+                success: !streamError,
+                error: streamError
+                  ? streamError instanceof Error
+                    ? streamError.message
+                    : String(streamError)
+                  : undefined,
+                pipelineAHandled: true,
+              });
+            } catch (emitError) {
+              logger.debug(
+                "[NeuroLink.stream] generation:end listener threw — ignored",
+                {
+                  error:
+                    emitError instanceof Error
+                      ? emitError.message
+                      : String(emitError),
+                },
+              );
+            }
+          }
+
           self._disableToolCacheForCurrentRequest = false;
           cleanupListeners();
 

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -17,7 +17,10 @@ import {
 import { BaseProvider } from "../core/baseProvider.js";
 import { DEFAULT_MAX_STEPS } from "../core/constants.js";
 import { streamAnalyticsCollector } from "../core/streamAnalytics.js";
-import type { NeuroLink } from "../neurolink.js";
+import {
+  markStreamProviderEmittedGenerationEnd,
+  type NeuroLink,
+} from "../neurolink.js";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { ATTR, tracers, withClientSpan } from "../telemetry/index.js";
 import type {
@@ -1039,6 +1042,13 @@ export class GoogleAIStudioProvider extends BaseProvider {
               // AI SDK so experimental_telemetry is never injected; we emit manually.
               const nativeStreamEmitter = this.neurolink?.getEventEmitter();
               if (nativeStreamEmitter) {
+                // Curator P2-4 dedup: flag the per-stream context attached
+                // to options so the orchestration skips its own emit.
+                markStreamProviderEmittedGenerationEnd(
+                  options as unknown as Parameters<
+                    typeof markStreamProviderEmittedGenerationEnd
+                  >[0],
+                );
                 nativeStreamEmitter.emit("generation:end", {
                   provider: this.providerName,
                   responseTime,
@@ -1073,6 +1083,13 @@ export class GoogleAIStudioProvider extends BaseProvider {
               // Emit failure generation:end so Pipeline B records the failed stream
               const errorEmitter = this.neurolink?.getEventEmitter();
               if (errorEmitter) {
+                // Curator P2-4 dedup: flag the per-stream context attached
+                // to options so the orchestration skips its own emit.
+                markStreamProviderEmittedGenerationEnd(
+                  options as unknown as Parameters<
+                    typeof markStreamProviderEmittedGenerationEnd
+                  >[0],
+                );
                 errorEmitter.emit("generation:end", {
                   provider: this.providerName,
                   responseTime: Date.now() - startTime,

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -33,7 +33,10 @@ import {
   GLOBAL_LOCATION_MODELS,
 } from "../core/constants.js";
 import { ModelConfigurationManager } from "../core/modelConfiguration.js";
-import type { NeuroLink } from "../neurolink.js";
+import {
+  markStreamProviderEmittedGenerationEnd,
+  type NeuroLink,
+} from "../neurolink.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import { ATTR, tracers, withClientSpan } from "../telemetry/index.js";
 import type {
@@ -2334,8 +2337,16 @@ export class GoogleVertexProvider extends BaseProvider {
       // Emit generation:end so Pipeline B (Langfuse) creates a GENERATION
       // observation. The native @google/genai stream path on Vertex bypasses the
       // Vercel AI SDK so experimental_telemetry is never injected; we emit manually.
+      // Curator P2-4 dedup: flag the per-stream context attached to options
+      // so the orchestration in `runStandardStreamRequest` knows we already
+      // emitted and skips its own emit (preserving exactly-once).
       const vertexStreamEmitter = this.neurolink?.getEventEmitter();
       if (vertexStreamEmitter) {
+        markStreamProviderEmittedGenerationEnd(
+          params.options as unknown as Parameters<
+            typeof markStreamProviderEmittedGenerationEnd
+          >[0],
+        );
         vertexStreamEmitter.emit("generation:end", {
           provider: this.providerName,
           responseTime,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -63,3 +63,6 @@ export * from "./elicitation.js";
 
 // Dynamic Arguments types
 export * from "./dynamic.js";
+
+// Curator P2-4 dedup: per-stream AsyncLocalStorage context
+export * from "./streamDedup.js";

--- a/src/lib/types/streamDedup.ts
+++ b/src/lib/types/streamDedup.ts
@@ -1,0 +1,12 @@
+/**
+ * Curator P2-4 dedup (concurrency-safe): per-stream context that lets
+ * the orchestration's `runStandardStreamRequest` finally block know
+ * whether a *native provider* path within THIS stream's async chain
+ * already emitted `generation:end`. Native providers (Vertex / Google
+ * AI Studio for Gemini 3, etc.) emit on the shared SDK emitter; without
+ * scoping, a concurrent unrelated stream's emit on the same NeuroLink
+ * instance would suppress the wrong stream's orchestration emit.
+ *
+ * AsyncLocalStorage scopes each stream's flag to its own async chain.
+ */
+export type StreamGenerationEndContext = { providerEmitted: boolean };

--- a/test/continuous-test-suite-issue-04-generation-end-dedup.ts
+++ b/test/continuous-test-suite-issue-04-generation-end-dedup.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Issue #4 — generation:end emission count
+ *
+ * Curator P2-4: cost listeners that subscribe to `generation:end` may
+ * double-count when both the provider-level emit and the SDK orchestration
+ * emit fire for the same call.
+ *
+ * Strategy: REAL providers; subscribe sdk.on("generation:end", ...);
+ *           run a generate and a stream against each configured provider;
+ *           record emission count. No mocks.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-issue-04-generation-end-dedup.ts
+ */
+import "dotenv/config";
+
+import { NeuroLink } from "../dist/index.js";
+import {
+  isExpectedProviderError,
+  skipIfEnvMissing,
+} from "./helpers/envGuard.js";
+
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  bright: "\x1b[1m",
+};
+
+type Outcome = "PASS" | "FAIL" | "SKIP";
+const results: { name: string; outcome: Outcome; detail: string }[] = [];
+
+function record(name: string, outcome: Outcome, detail: string): void {
+  results.push({ name, outcome, detail });
+  const color =
+    outcome === "PASS"
+      ? colors.green
+      : outcome === "FAIL"
+        ? colors.red
+        : colors.yellow;
+  console.log(`${color}[${outcome}]${colors.reset} ${name} — ${detail}`);
+}
+
+function section(title: string): void {
+  console.log(
+    `\n${colors.cyan}${"=".repeat(72)}\n  ${title}\n${"=".repeat(72)}${colors.reset}`,
+  );
+}
+
+type ProviderTarget = {
+  provider: string;
+  envVars: string[];
+  modelEnv?: string;
+};
+
+const TARGETS: ProviderTarget[] = [
+  { provider: "openai", envVars: ["OPENAI_API_KEY"], modelEnv: "OPENAI_MODEL" },
+  {
+    provider: "vertex",
+    envVars: ["GOOGLE_VERTEX_PROJECT", "GOOGLE_AUTH_CLIENT_EMAIL"],
+    modelEnv: "VERTEX_MODEL",
+  },
+  {
+    provider: "google-ai-studio",
+    envVars: ["GOOGLE_AI_API_KEY"],
+    modelEnv: "GOOGLE_AI_MODEL",
+  },
+  {
+    provider: "litellm",
+    envVars: ["LITELLM_BASE_URL", "LITELLM_API_KEY", "LITELLM_MODEL"],
+    modelEnv: "LITELLM_MODEL",
+  },
+];
+
+async function countEmissionsForGenerate(
+  target: ProviderTarget,
+): Promise<void> {
+  const testName = `generate / ${target.provider} — generation:end emissions`;
+  const skip = skipIfEnvMissing(...target.envVars);
+  if (skip) {
+    record(testName, "SKIP", skip);
+    return;
+  }
+  const sdk = new NeuroLink();
+  const events: unknown[] = [];
+  sdk.getEventEmitter().on("generation:end", (e: unknown) => events.push(e));
+  try {
+    const model = target.modelEnv ? process.env[target.modelEnv] : undefined;
+    const result = await sdk.generate({
+      provider: target.provider as never,
+      ...(model && { model }),
+      input: { text: "Reply with the single word: hello" },
+      maxTokens: 32,
+      disableTools: true,
+    } as never);
+    const detail = `count=${events.length}; provider=${result.provider}; model=${result.model}`;
+    if (events.length === 1) {
+      record(testName, "PASS", `expected 1, ${detail}`);
+    } else {
+      record(testName, "FAIL", `expected 1, got ${events.length}: ${detail}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isExpectedProviderError(msg)) {
+      record(testName, "SKIP", msg.slice(0, 120));
+    } else {
+      record(testName, "FAIL", `unexpected error: ${msg.slice(0, 200)}`);
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function countEmissionsForStream(target: ProviderTarget): Promise<void> {
+  const testName = `stream  / ${target.provider} — generation:end emissions`;
+  const skip = skipIfEnvMissing(...target.envVars);
+  if (skip) {
+    record(testName, "SKIP", skip);
+    return;
+  }
+  const sdk = new NeuroLink();
+  const events: unknown[] = [];
+  sdk.getEventEmitter().on("generation:end", (e: unknown) => events.push(e));
+  try {
+    const model = target.modelEnv ? process.env[target.modelEnv] : undefined;
+    const r = await sdk.stream({
+      provider: target.provider as never,
+      ...(model && { model }),
+      input: { text: "Reply with the single word: hello" },
+      maxTokens: 32,
+      disableTools: true,
+    } as never);
+    let chunks = 0;
+    for await (const _ of r.stream) {
+      chunks++;
+    }
+    // small grace period for any post-stream async emit
+    await new Promise((r) => setTimeout(r, 250));
+    const detail = `count=${events.length}; chunks=${chunks}; provider=${r.provider}; model=${r.model}`;
+    if (events.length === 1) {
+      record(testName, "PASS", `expected 1, ${detail}`);
+    } else {
+      record(testName, "FAIL", `expected 1, got ${events.length}: ${detail}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isExpectedProviderError(msg)) {
+      record(testName, "SKIP", msg.slice(0, 120));
+    } else {
+      record(testName, "FAIL", `unexpected error: ${msg.slice(0, 200)}`);
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function main(): Promise<void> {
+  section("Issue #4 — generation:end emission count per call (expect 1)");
+  for (const t of TARGETS) {
+    await countEmissionsForGenerate(t);
+    await new Promise((r) => setTimeout(r, 1000));
+    await countEmissionsForStream(t);
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  const passed = results.filter((r) => r.outcome === "PASS").length;
+  const failed = results.filter((r) => r.outcome === "FAIL").length;
+  const skipped = results.filter((r) => r.outcome === "SKIP").length;
+  console.log(
+    `\n${colors.bright}Results:${colors.reset} ${passed} passed, ${failed} failed, ${skipped} skipped`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Curator P2-4: cost listeners that subscribe to `generation:end` previously received **zero** events from `sdk.stream()` calls. The doc described "fires twice"; the bug on shipped 9.56.x is the opposite direction — `stream()` emitted `stream:complete` but never `generation:end`, leaving any listener (cost-tracker, audit log, alerting) with nothing.

## Reproduction (real providers, before fix)

```
generate / vertex            count=1   PASS
stream  / vertex             count=0   FAIL  ← bug
generate / google-ai-studio  count=1   PASS
stream  / google-ai-studio   count=0   FAIL  ← bug
generate / litellm           count=1   PASS
stream  / litellm            count=0   FAIL  ← bug
```

After fix: all stream rows return `count=1`.

## Fix

In `runStandardStreamRequest`'s `processedStream` generator, emit `generation:end` exactly once in the `finally` block with the final stream state (provider, model, content, usage, finishReason, toolsUsed, prompt, temperature, maxTokens, success, error, `pipelineAHandled: true`). Hoist `resolvedUsage` to the generator scope so it's available in `finally`. The event payload mirrors `generate()`'s shape so listeners receive a consistent contract across both APIs.

## Backward compatibility

Additive only. Listeners that previously received zero events on streams now receive one event with the same shape `generate()` produces. Any listener that already expected the event will start working; any listener that didn't will still ignore the new event.

## Verification

```bash
pnpm run build
npx tsx test/continuous-test-suite-issue-04-generation-end-dedup.ts
```

Expected: 6 passed (3 generate + 3 stream); the OpenAI rows may SKIP/FAIL on env-specific quota / tool-injection issues unrelated to this fix.

## Test plan

- [x] Suite passes against fixed `release` for vertex, google-ai-studio, litellm
- [x] No regression on `generate()` paths (still count=1)
- [x] `pipelineAHandled: true` flag preserved for Langfuse exporter dedup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed event handling to ensure stream completion events are emitted exactly once per operation in concurrent scenarios.

* **Tests**
  * Added test suite validating event emission behavior across multiple AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->