### PR TITLE
feat(errors): typed ModelAccessDeniedError + sdk.checkCredentials() API

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -153,6 +153,7 @@ import {
   AuthenticationError,
   AuthorizationError,
   InvalidModelError,
+  ModelAccessDeniedError,
 } from "./types/index.js";
 import { SpanSerializer } from "./observability/utils/spanSerializer.js";
 import {
@@ -353,6 +354,13 @@ function isNonRetryableProviderError(error: unknown): boolean {
     return true;
   }
   if (error instanceof AuthorizationError) {
+    return true;
+  }
+  // Curator P1-1: model-access-denied is permanent for the (provider, model)
+  // pair until the team whitelist changes. Retrying with the same config
+  // would just waste a second roundtrip. Caller / fallback-orchestrator
+  // should pick a different model.
+  if (error instanceof ModelAccessDeniedError) {
     return true;
   }
 
@@ -8433,6 +8441,97 @@ Current user's request: ${currentInput}`;
    */
   getEventEmitter() {
     return this.emitter;
+  }
+
+  /**
+   * Curator P1-1: synchronous credential health check for a single provider.
+   *
+   * Drives a tiny real call against the provider (1-token completion or
+   * `/models` listing depending on provider) to confirm the configured
+   * credentials are valid. Useful at startup so a service can refuse to
+   * boot if its primary provider's credentials are broken instead of
+   * discovering the problem on first user request.
+   *
+   * @example
+   * ```ts
+   * const health = await neurolink.checkCredentials({ provider: "litellm" });
+   * if (health.status !== "ok") {
+   *   throw new Error(`provider not ready: ${health.detail}`);
+   * }
+   * ```
+   *
+   * @param input - the provider to check
+   * @returns `{ provider, status, detail }`. Possible status values:
+   *   - `"ok"` — credentials valid and provider reachable
+   *   - `"missing"` — required env / credentials not configured
+   *   - `"expired"` — credentials present but rejected (401/403)
+   *   - `"denied"` — credentials valid but team not whitelisted for any model
+   *   - `"network"` — provider unreachable (timeout, ECONNREFUSED, DNS)
+   *   - `"unknown"` — other error; consult `detail`
+   */
+  async checkCredentials(input: { provider: string; model?: string }): Promise<{
+    provider: string;
+    status: "ok" | "missing" | "expired" | "denied" | "network" | "unknown";
+    detail: string;
+  }> {
+    const { provider, model } = input;
+    const probeText = "ping";
+    try {
+      // 1-token probe is cheap, exercises auth + routing without much cost.
+      await this.generate({
+        provider: provider as never,
+        ...(model && { model }),
+        input: { text: probeText },
+        maxTokens: 16,
+        disableTools: true,
+      } as never);
+      return { provider, status: "ok", detail: "credentials valid" };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const lower = msg.toLowerCase();
+      if (err instanceof ModelAccessDeniedError) {
+        return {
+          provider,
+          status: "denied",
+          detail: msg,
+        };
+      }
+      if (
+        lower.includes("authentication") ||
+        lower.includes("401") ||
+        lower.includes("invalid api key") ||
+        lower.includes("incorrect api key") ||
+        lower.includes("api_key_invalid") ||
+        lower.includes("token has expired") ||
+        lower.includes("expired credentials")
+      ) {
+        return { provider, status: "expired", detail: msg };
+      }
+      if (
+        lower.includes("not configured") ||
+        lower.includes("missing api") ||
+        lower.includes("api key is required") ||
+        lower.includes("no api key") ||
+        lower.includes("application default credentials") ||
+        lower.includes("google_application_credentials") ||
+        lower.includes("project_id") ||
+        lower.includes("default credentials") ||
+        lower.includes("service account")
+      ) {
+        return { provider, status: "missing", detail: msg };
+      }
+      if (
+        lower.includes("econnrefused") ||
+        lower.includes("enotfound") ||
+        lower.includes("could not resolve") ||
+        lower.includes("timeout") ||
+        lower.includes("network") ||
+        lower.includes("cannot connect")
+      ) {
+        return { provider, status: "network", detail: msg };
+      }
+      return { provider, status: "unknown", detail: msg };
+    }
   }
 
   // ========================================

--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -27,9 +27,12 @@ import type {
 import {
   AuthenticationError,
   InvalidModelError,
+  ModelAccessDeniedError,
   NetworkError,
   ProviderError,
   RateLimitError,
+  isModelAccessDeniedMessage,
+  parseAllowedModels,
 } from "../types/index.js";
 import { isAbortError } from "../utils/errorHandling.js";
 import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
@@ -162,6 +165,18 @@ export class LiteLLMProvider extends BaseProvider {
             `${process.env.LITELLM_BASE_URL || "http://localhost:4000"}`,
           this.providerName,
         );
+      }
+
+      // Curator P1-1: detect "team not allowed to access model" responses
+      // and surface as ModelAccessDeniedError with the allowed_models array
+      // parsed from the body. Must run before the generic "API key" check
+      // because LiteLLM phrases this as a 403 distinct from auth.
+      if (isModelAccessDeniedMessage(errorRecord.message)) {
+        return new ModelAccessDeniedError(errorRecord.message, {
+          provider: this.providerName,
+          requestedModel: this.modelName,
+          allowedModels: parseAllowedModels(errorRecord.message),
+        });
       }
 
       if (

--- a/src/lib/providers/openAI.ts
+++ b/src/lib/providers/openAI.ts
@@ -324,14 +324,32 @@ export class OpenAIProvider extends BaseProvider {
       errorObj?.type && typeof errorObj.type === "string"
         ? errorObj.type
         : undefined;
+    const statusCode =
+      typeof errorObj?.status === "number"
+        ? errorObj.status
+        : typeof errorObj?.statusCode === "number"
+          ? errorObj.statusCode
+          : undefined;
 
+    // Curator P1-1 / Reviewer Finding #4: only the explicit auth markers
+    // map to AuthenticationError. Earlier we treated every
+    // `invalid_request_error` as an auth failure — that's OpenAI's catch-all
+    // for any bad request (unsupported parameter, malformed JSON, etc.) and
+    // mislabelled them as "invalid API key". Use credential-specific
+    // signals only.
     if (
       message.includes("API_KEY_INVALID") ||
       message.includes("Invalid API key") ||
-      errorType === "invalid_api_key"
+      message.includes("Incorrect API key") ||
+      message.includes("invalid_api_key") ||
+      errorType === "invalid_api_key" ||
+      statusCode === 401
     ) {
       return new AuthenticationError(
-        "Invalid OpenAI API key. Please check your OPENAI_API_KEY environment variable.",
+        message.includes("Incorrect API key") ||
+          message.includes("Invalid API key")
+          ? message
+          : "Invalid OpenAI API key. Please check your OPENAI_API_KEY environment variable.",
         this.providerName,
       );
     }

--- a/src/lib/types/errors.ts
+++ b/src/lib/types/errors.ts
@@ -197,3 +197,111 @@ export class ModelAccessError extends BaseError {
     this.requiredTier = requiredTier;
   }
 }
+
+/**
+ * Curator P1-1: thrown when a provider rejects a request because the
+ * caller's team / API key is not whitelisted for the requested model.
+ *
+ * LiteLLM's `team not allowed to access model. This team can only access
+ * models=['glm-latest', 'kimi-latest', ...]` is the canonical example —
+ * the list is parsed off the error body so callers / fallback orchestrators
+ * can choose a whitelisted alternative without scraping strings.
+ */
+export class ModelAccessDeniedError extends ProviderError {
+  public readonly requestedModel: string | undefined;
+  public readonly allowedModels: string[] | undefined;
+  public readonly code = "MODEL_ACCESS_DENIED" as const;
+
+  constructor(
+    message: string,
+    options: {
+      provider?: string;
+      requestedModel?: string;
+      allowedModels?: string[];
+    } = {},
+  ) {
+    super(message, options.provider);
+    this.name = "ModelAccessDeniedError";
+    this.requestedModel = options.requestedModel;
+    this.allowedModels = options.allowedModels;
+  }
+}
+
+/** Maximum body length we'll attempt to parse. Real provider error
+ *  bodies are well under 10 KB; longer inputs are either truncated
+ *  log output or a deliberate ReDoS attempt. */
+const MAX_ALLOWED_MODELS_INPUT = 10_000;
+
+/**
+ * Parse the `allowed_models` array out of a provider error message body.
+ * Currently targets the LiteLLM team-whitelist response shape:
+ *
+ *   "team not allowed to access model. This team can only access
+ *    models=['glm-latest', 'kimi-latest', 'open-large']"
+ *
+ * Implementation note: deliberately uses `indexOf`/`slice` instead of a
+ * single `/models\s*=\s*\[([^\]]*)\]/` regex. CodeQL flagged the latter
+ * as `js/polynomial-redos` because the `[^\]]*` greedy quantifier on
+ * library-supplied input can be exploited by a crafted long string. The
+ * indexOf/slice path is O(n) with no backtracking and we additionally
+ * cap the input length.
+ *
+ * Returns undefined when no list is found.
+ */
+export function parseAllowedModels(message: string): string[] | undefined {
+  if (typeof message !== "string" || message.length === 0) {
+    return undefined;
+  }
+  if (message.length > MAX_ALLOWED_MODELS_INPUT) {
+    return undefined;
+  }
+  // Locate `models` keyword case-insensitively, then walk forward to
+  // confirm `=` and `[` markers — no regex backtracking.
+  const lower = message.toLowerCase();
+  let idx = lower.indexOf("models", 0);
+  while (idx !== -1) {
+    let cursor = idx + "models".length;
+    // Skip whitespace
+    while (cursor < message.length && /\s/.test(message[cursor])) {
+      cursor++;
+    }
+    if (message[cursor] !== "=") {
+      idx = lower.indexOf("models", idx + 1);
+      continue;
+    }
+    cursor++;
+    while (cursor < message.length && /\s/.test(message[cursor])) {
+      cursor++;
+    }
+    if (message[cursor] !== "[") {
+      idx = lower.indexOf("models", idx + 1);
+      continue;
+    }
+    const open = cursor;
+    const close = message.indexOf("]", open + 1);
+    if (close === -1) {
+      return undefined;
+    }
+    const inside = message.slice(open + 1, close);
+    const items = inside
+      .split(",")
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
+      .filter((s) => s.length > 0);
+    return items.length > 0 ? items : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Returns true when `message` looks like a model-access-denied response
+ * (LiteLLM "team not allowed", generic "not allowed to access model",
+ * or "team can only access models=[...]").
+ */
+export function isModelAccessDeniedMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    (lower.includes("team") && lower.includes("not allowed")) ||
+    lower.includes("team can only access") ||
+    /not\s+allowed\s+to\s+access\s+(this\s+)?model/i.test(message)
+  );
+}

--- a/test/continuous-test-suite-issue-01-model-access.ts
+++ b/test/continuous-test-suite-issue-01-model-access.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Issue #1 — model access denied surface
+ *
+ * Curator P1-1: when LiteLLM (or any provider) returns a "team not allowed
+ * to access model" 403, the SDK surfaces a raw error without a typed class
+ * and without parsing the `allowed_models` list. There is no
+ * `sdk.checkCredentials()` API for synchronous health-check.
+ *
+ * Strategy: REAL LiteLLM with `CURATOR_LITELLM_DENIED_MODEL`. Drive
+ *           sdk.generate() and inspect the rejected error object.
+ *           Probe the public surface for `checkCredentials`.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-issue-01-model-access.ts
+ */
+import "dotenv/config";
+
+import { NeuroLink } from "../dist/index.js";
+import {
+  isExpectedProviderError,
+  skipIfEnvMissing,
+} from "./helpers/envGuard.js";
+
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  bright: "\x1b[1m",
+};
+
+type Outcome = "PASS" | "FAIL" | "SKIP";
+const results: { name: string; outcome: Outcome; detail: string }[] = [];
+
+function record(name: string, outcome: Outcome, detail: string): void {
+  results.push({ name, outcome, detail });
+  const color =
+    outcome === "PASS"
+      ? colors.green
+      : outcome === "FAIL"
+        ? colors.red
+        : colors.yellow;
+  console.log(`${color}[${outcome}]${colors.reset} ${name} — ${detail}`);
+}
+
+function section(t: string): void {
+  console.log(
+    `\n${colors.cyan}${"=".repeat(72)}\n  ${t}\n${"=".repeat(72)}${colors.reset}`,
+  );
+}
+
+const DENIED = process.env.CURATOR_LITELLM_DENIED_MODEL ?? "sonnet-4-5";
+
+async function test_1_1_raw_error_surface(): Promise<void> {
+  const testName =
+    "1.1 — raw error surface: real LiteLLM 403 reaches caller as untyped error";
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  const sdk = new NeuroLink();
+  try {
+    let captured: unknown = undefined;
+    try {
+      await sdk.generate({
+        provider: "litellm",
+        model: DENIED,
+        input: { text: "hi" },
+        maxTokens: 32,
+        disableTools: true,
+      } as never);
+      record(
+        testName,
+        "FAIL",
+        "expected rejection on denied model — got success",
+      );
+      return;
+    } catch (err) {
+      captured = err;
+    }
+
+    const ctorName =
+      (captured as { constructor?: { name?: string } })?.constructor?.name ??
+      "unknown";
+    const msg = captured instanceof Error ? captured.message : String(captured);
+    if (isExpectedProviderError(msg)) {
+      // creds missing or rate-limited, not the bug we're testing
+      return record(testName, "SKIP", msg.slice(0, 120));
+    }
+
+    const isTypedAccessError = ctorName === "ModelAccessDeniedError";
+    if (isTypedAccessError) {
+      record(testName, "PASS", `typed: ${ctorName}`);
+    } else {
+      record(
+        testName,
+        "FAIL",
+        `bug-confirmed: surfaced as ${ctorName}; msg="${msg.slice(0, 200)}"`,
+      );
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function test_1_2_allowed_models_not_parsed(): Promise<void> {
+  const testName =
+    "1.2 — allowed_models extracted from real LiteLLM body onto rejection";
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  const sdk = new NeuroLink();
+  try {
+    let captured: unknown = undefined;
+    try {
+      await sdk.generate({
+        provider: "litellm",
+        model: DENIED,
+        input: { text: "hi" },
+        maxTokens: 32,
+        disableTools: true,
+      } as never);
+    } catch (err) {
+      captured = err;
+    }
+
+    if (!captured) {
+      return record(testName, "FAIL", "no rejection captured");
+    }
+
+    const e = captured as Record<string, unknown>;
+    const allowedModels = e.allowedModels;
+    const requestedModel = e.requestedModel;
+    const msg = e instanceof Error ? e.message : String(captured);
+
+    // Reviewer Finding #5: when a network/DNS/credential error fires
+    // before the SDK can extract `allowedModels`, treat it as SKIP
+    // (provider unreachable) — same convention as test 1.1. Without
+    // this guard a transient DNS failure misreports as `bug-confirmed`.
+    // The `!includes("can only access")` clause keeps the LiteLLM
+    // team-denied body (which does parse-as-bug) from being SKIPped.
+    if (isExpectedProviderError(msg) && !msg.includes("can only access")) {
+      return record(testName, "SKIP", msg.slice(0, 120));
+    }
+
+    if (Array.isArray(allowedModels) && allowedModels.length > 0) {
+      record(
+        testName,
+        "PASS",
+        `allowedModels=${JSON.stringify(allowedModels)}; requestedModel=${requestedModel}`,
+      );
+    } else {
+      record(
+        testName,
+        "FAIL",
+        `bug-confirmed: rejection has no .allowedModels property. raw msg contains list inline: ${msg.includes("can only access") ? "yes" : "no"}`,
+      );
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function test_1_3_checkCredentials_api_absent(): Promise<void> {
+  const testName =
+    "1.3 — sdk.checkCredentials({ provider }) exists on public surface";
+  const sdk = new NeuroLink();
+  try {
+    const fn = (sdk as unknown as Record<string, unknown>)["checkCredentials"];
+    if (typeof fn === "function") {
+      record(testName, "PASS", "method present");
+    } else {
+      record(
+        testName,
+        "FAIL",
+        `bug-confirmed: typeof sdk.checkCredentials === ${typeof fn}`,
+      );
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function test_1_5_bad_openai_key_surfaces_raw(): Promise<void> {
+  const testName =
+    "1.5 — wrong OpenAI key produces typed AuthenticationError (not raw 401)";
+  // We pass a deliberately-bad credential per-call so the env's good key
+  // is unaffected.
+  const sdk = new NeuroLink();
+  try {
+    let captured: unknown = undefined;
+    try {
+      await sdk.generate({
+        provider: "openai",
+        input: { text: "hi" },
+        maxTokens: 32,
+        disableTools: true,
+        credentials: { openai: { apiKey: "sk-test-deliberately-invalid" } },
+      } as never);
+    } catch (err) {
+      captured = err;
+    }
+    if (!captured) {
+      return record(testName, "SKIP", "expected rejection — got success");
+    }
+    const ctorName =
+      (captured as { constructor?: { name?: string } })?.constructor?.name ??
+      "unknown";
+    const msg = captured instanceof Error ? captured.message : String(captured);
+    if (ctorName === "AuthenticationError") {
+      record(testName, "PASS", `typed: ${ctorName}; msg=${msg.slice(0, 80)}`);
+    } else {
+      record(
+        testName,
+        "FAIL",
+        `bug-related: surfaced as ${ctorName}; msg="${msg.slice(0, 200)}"`,
+      );
+    }
+  } finally {
+    await sdk.shutdown?.().catch(() => {});
+  }
+}
+
+async function main(): Promise<void> {
+  section("Issue #1 — model access denied: typed errors and checkCredentials");
+  console.log(`   DENIED=${DENIED}\n`);
+  await test_1_1_raw_error_surface();
+  await test_1_2_allowed_models_not_parsed();
+  await test_1_3_checkCredentials_api_absent();
+  await test_1_5_bad_openai_key_surfaces_raw();
+  const passed = results.filter((r) => r.outcome === "PASS").length;
+  const failed = results.filter((r) => r.outcome === "FAIL").length;
+  const skipped = results.filter((r) => r.outcome === "SKIP").length;
+  console.log(
+    `\n${colors.bright}Results:${colors.reset} ${passed} passed, ${failed} failed, ${skipped} skipped`,
+  );
+  process.exit(0); // bug repro: failed > 0 expected
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Curator P1-1: when LiteLLM returned 403 with `team not allowed to access model. This team can only access models=['glm-latest', 'kimi-latest', 'open-large']`, the SDK surfaced a raw error without a typed class and without parsing the `allowed_models` list. There was no `sdk.checkCredentials()` API.

## Three deliverables

1. **`ModelAccessDeniedError`** — new typed error class extending `ProviderError`, with `requestedModel`, `allowedModels`, `code: "MODEL_ACCESS_DENIED"`. Plus `parseAllowedModels()` and `isModelAccessDeniedMessage()` helpers.
2. **LiteLLM + OpenAI formatters** — LiteLLM detects team-denied pattern and surfaces `ModelAccessDeniedError` with `allowedModels` parsed from the body; OpenAI formatter extended to surface typed `AuthenticationError` on real 401 ("Incorrect API key"). `ModelAccessDeniedError` added to the non-retryable short-circuit list in `neurolink.ts`.
3. **`sdk.checkCredentials({ provider, model? })`** — 1-token probe call, returns `{ provider, status, detail }` where `status` is `"ok" | "missing" | "expired" | "denied" | "network" | "unknown"`. Services can refuse to boot when their primary provider's credentials are broken.

## Reproduction (real LiteLLM at LITELLM_BASE_URL)

```
Before:
[FAIL] 1.1 raw error surface       — surfaced as Error
[FAIL] 1.2 allowed_models parsed   — no .allowedModels
[FAIL] 1.3 checkCredentials API    — typeof === undefined
[FAIL] 1.5 bad OpenAI key typed    — surfaced as Error
Results: 0 passed, 4 failed

After:
[PASS] 1.1 raw error surface       — typed: ModelAccessDeniedError
[PASS] 1.2 allowed_models parsed   — allowedModels=[19 entries from real proxy]
[PASS] 1.3 checkCredentials API    — method present
[PASS] 1.5 bad OpenAI key typed    — typed: AuthenticationError
Results: 4 passed, 0 failed
```

## Backward compatibility

- `ModelAccessDeniedError extends ProviderError` — callers catching plain `Error`/`ProviderError` continue to work.
- LiteLLM formerly surfaced team-denied as a generic `ProviderError`; now as the typed subclass. Same parent, same message, narrower type.
- `parseAllowedModels` / `isModelAccessDeniedMessage` are new exports.
- `checkCredentials()` is additive on `NeuroLink`.

## Verification

```bash
pnpm run build
npx tsx test/continuous-test-suite-issue-01-model-access.ts
```

## Test plan

- [x] 4/4 reproductions pass against real LiteLLM
- [x] Real `allowedModels` array (19 entries) parsed from real proxy response
- [x] `ModelAccessDeniedError` short-circuits the retry chain (no wasted retries)
- [x] OpenAI 401 surfaces typed `AuthenticationError`
- [x] `checkCredentials({ provider: "litellm" })` returns `status: "ok"` against working setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `checkCredentials()` method to diagnose provider authentication and model access status with structured reporting.

* **Improvements**
  * Enhanced error classification for authentication failures and model access denials with detailed diagnostic information including available models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->