### PR TITLE
fix(context): pre-dispatch compaction for inline conversationMessages

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -364,6 +364,12 @@ function isNonRetryableProviderError(error: unknown): boolean {
   if (error instanceof ModelAccessDeniedError) {
     return true;
   }
+  // Note: ContextBudgetExceededError is intentionally NOT non-retryable.
+  // Each provider has its own context window, so a budget rejection on
+  // one provider doesn't preclude another provider's window fitting the
+  // same payload. The directProviderGeneration loop should continue
+  // trying alternate providers; the after-loop rethrow preserves the
+  // typed error when all providers reject (see `directProviderGeneration`).
 
   // Check for HTTP status codes on error objects (e.g., from Vercel AI SDK)
   if (error && typeof error === "object") {
@@ -5065,7 +5071,27 @@ Current user's request: ${currentInput}`;
     functionTag: string,
     error: unknown,
   ): Promise<TextGenerationResult | null> {
-    if (!isContextOverflowError(error) || !this.conversationMemory) {
+    // Reviewer Finding #3: drop the `!this.conversationMemory` gate so
+    // inline-conversationMessages callers also benefit from post-provider
+    // recovery when their pre-dispatch estimate happens to undershoot
+    // and the provider rejects at a higher real token count.
+    if (!isContextOverflowError(error)) {
+      return null;
+    }
+
+    const inlineMessages = (
+      options as TextGenerationOptions & {
+        _originalConversationMessages?: unknown[];
+        conversationMessages?: unknown[];
+      }
+    )._originalConversationMessages as unknown[] | undefined;
+    const callerMessages = (
+      options as TextGenerationOptions & {
+        conversationMessages?: unknown[];
+      }
+    ).conversationMessages as unknown[] | undefined;
+
+    if (!this.conversationMemory && !inlineMessages && !callerMessages) {
       return null;
     }
 
@@ -5080,12 +5106,11 @@ Current user's request: ${currentInput}`;
     try {
       const actualOverflow = parseProviderOverflowDetails(error);
       const originalMessages =
-        (
-          options as TextGenerationOptions & {
-            _originalConversationMessages?: unknown[];
-          }
-        )._originalConversationMessages ??
-        (await getConversationMessages(this.conversationMemory, options));
+        inlineMessages ??
+        callerMessages ??
+        (this.conversationMemory
+          ? await getConversationMessages(this.conversationMemory, options)
+          : []);
       const recoveryBudget = checkContextBudget({
         provider: options.provider || "openai",
         model: options.model,
@@ -5103,56 +5128,138 @@ Current user's request: ${currentInput}`;
           ? (actualTokens - compactionTarget) / actualTokens
           : 0.5;
 
-      const compactor = new ContextCompactor({
-        enableSummarize: false,
-        enablePrune: true,
-        enableDeduplicate: true,
-        enableTruncate: true,
-        truncationFraction: Math.min(0.9, requiredReduction + 0.15),
-      });
-      const compactionResult = await compactor.compact(
-        originalMessages as import("./types/index.js").ChatMessage[],
-        compactionTarget,
-        undefined,
-        (options.context as Record<string, unknown>)?.requestId as
-          | string
-          | undefined,
-      );
+      // Reviewer Finding #3: escalating truncation across attempts. The
+      // first attempt uses the budget-derived fraction (single-round
+      // compaction). If that still leaves the conversation over budget,
+      // subsequent attempts apply progressively harder truncation
+      // (0.5 → 0.75 → 0.9) before giving up. This replaces the previous
+      // single-pass behaviour where one undersized fraction guaranteed
+      // failure on the next provider call.
+      const escalationFractions = [
+        Math.min(0.9, requiredReduction + 0.15),
+        0.5,
+        0.75,
+        0.9,
+      ];
+      let lastCompactionResult: Awaited<
+        ReturnType<ContextCompactor["compact"]>
+      > | null = null;
+      let compactedMessages: unknown[] = originalMessages;
+      let verifiedBudget: ReturnType<typeof checkContextBudget> | null = null;
+      let recoveredFraction = -1;
 
-      if (!compactionResult.compacted) {
-        return null;
+      for (let i = 0; i < escalationFractions.length; i++) {
+        const fraction = escalationFractions[i];
+        const compactor = new ContextCompactor({
+          enableSummarize: false,
+          enablePrune: true,
+          enableDeduplicate: true,
+          enableTruncate: true,
+          truncationFraction: fraction,
+        });
+        const compactionResult = await compactor.compact(
+          originalMessages as import("./types/index.js").ChatMessage[],
+          compactionTarget,
+          undefined,
+          (options.context as Record<string, unknown>)?.requestId as
+            | string
+            | undefined,
+        );
+        if (!compactionResult.compacted) {
+          continue;
+        }
+        lastCompactionResult = compactionResult;
+        const repairedResult = repairToolPairs(compactionResult.messages);
+        const verifyBudget = checkContextBudget({
+          provider: options.provider || "openai",
+          model: options.model,
+          maxTokens: options.maxTokens,
+          systemPrompt: options.systemPrompt,
+          currentPrompt: options.prompt,
+          conversationMessages: repairedResult.messages as Array<{
+            role: string;
+            content: string;
+          }>,
+        });
+        if (verifyBudget.withinBudget) {
+          compactedMessages = repairedResult.messages;
+          verifiedBudget = verifyBudget;
+          recoveredFraction = fraction;
+          break;
+        }
+        verifiedBudget = verifyBudget;
       }
 
-      const repairedResult = repairToolPairs(compactionResult.messages);
-      const verifyBudget = checkContextBudget({
-        provider: options.provider || "openai",
-        model: options.model,
-        maxTokens: options.maxTokens,
-        systemPrompt: options.systemPrompt,
-        currentPrompt: options.prompt,
-        conversationMessages: repairedResult.messages as Array<{
-          role: string;
-          content: string;
-        }>,
-      });
-
-      if (!verifyBudget.withinBudget) {
-        logger.error(
-          `[${functionTag}] Recovery compaction insufficient, aborting retry`,
+      if (!lastCompactionResult) {
+        // Reviewer follow-up: when no escalation fraction managed to
+        // compact the conversation, the request will hit the same
+        // provider 400 again on retry. Surface a typed
+        // ContextBudgetExceededError + `compaction.insufficient` event
+        // instead of returning null (which lets callers propagate the
+        // opaque provider error).
+        try {
+          this.emitter.emit("compaction.insufficient", {
+            stagesAttempted: [],
+            finalTokens: actualTokens,
+            budget: budgetTokens,
+            provider: options.provider || "openai",
+            model: options.model,
+            phase: "post-provider-recovery-no-compaction",
+            fractionsTried: escalationFractions,
+            timestamp: Date.now(),
+          });
+        } catch {
+          /* listener errors are non-fatal */
+        }
+        throw new ContextBudgetExceededError(
+          `Context overflow recovery: no compaction stage was able to ` +
+            `reduce conversation messages. Provider rejected at ` +
+            `~${actualTokens} tokens; budget is ${budgetTokens} tokens.`,
           {
-            estimatedTokens: verifyBudget.estimatedInputTokens,
-            availableTokens: verifyBudget.availableInputTokens,
+            estimatedTokens: actualTokens,
+            availableTokens: budgetTokens,
+            stagesUsed: [],
+            breakdown: {},
           },
         );
+      }
+
+      if (!verifiedBudget?.withinBudget) {
+        logger.error(
+          `[${functionTag}] Recovery compaction insufficient after escalation, aborting retry`,
+          {
+            estimatedTokens: verifiedBudget?.estimatedInputTokens,
+            availableTokens: verifiedBudget?.availableInputTokens,
+            stagesAttempted: lastCompactionResult.stagesUsed,
+            fractionsTried: escalationFractions,
+          },
+        );
+        // Reviewer Finding #3: emit `compaction.insufficient` so
+        // cost / audit listeners record the specific failure mode.
+        try {
+          this.emitter.emit("compaction.insufficient", {
+            stagesAttempted: lastCompactionResult.stagesUsed,
+            finalTokens: verifiedBudget?.estimatedInputTokens,
+            budget: verifiedBudget?.availableInputTokens,
+            provider: options.provider || "openai",
+            model: options.model,
+            phase: "post-provider-recovery",
+            fractionsTried: escalationFractions,
+            timestamp: Date.now(),
+          });
+        } catch {
+          /* listener errors are non-fatal */
+        }
         throw new ContextBudgetExceededError(
           `Context overflow recovery failed. Provider rejected at ~${actualTokens} tokens, ` +
-            `recovery compaction achieved ${compactionResult.tokensAfter} tokens ` +
-            `but budget is ${budgetTokens} tokens.`,
+            `recovery compaction achieved ${lastCompactionResult.tokensAfter} tokens ` +
+            `but budget is ${budgetTokens} tokens (after escalation through ` +
+            `${escalationFractions.length} fractions).`,
           {
-            estimatedTokens: compactionResult.tokensAfter,
+            estimatedTokens: lastCompactionResult.tokensAfter,
             availableTokens: budgetTokens,
-            stagesUsed: compactionResult.stagesUsed,
-            breakdown: verifyBudget.breakdown,
+            stagesUsed: lastCompactionResult.stagesUsed,
+            breakdown: verifiedBudget?.breakdown ?? {},
           },
         );
       }
@@ -5160,16 +5267,17 @@ Current user's request: ${currentInput}`;
       logger.info(
         `[${functionTag}] Smart recovery verified, retrying generation`,
         {
-          tokensSaved: compactionResult.tokensSaved,
+          tokensSaved: lastCompactionResult.tokensSaved,
           compactionTarget,
-          verifiedTokens: verifyBudget.estimatedInputTokens,
-          verifiedBudget: verifyBudget.availableInputTokens,
+          verifiedTokens: verifiedBudget.estimatedInputTokens,
+          verifiedBudget: verifiedBudget.availableInputTokens,
+          recoveredFraction,
         },
       );
 
       return this.directProviderGeneration({
         ...options,
-        conversationMessages: repairedResult.messages,
+        conversationMessages: compactedMessages,
       } as TextGenerationOptions);
     } catch (retryError) {
       if (retryError instanceof ContextBudgetExceededError) {
@@ -6115,9 +6223,57 @@ Current user's request: ${currentInput}`;
 
         const dpgMessageCount = conversationMessages?.length || 0;
         const dpgCompactionSessionId = this.getCompactionSessionId(options);
+        // Curator P1-2: pre-dispatch compaction must run for inline
+        // `conversationMessages` too (not just conversationMemory). Without
+        // this, a 1.3M-token caller-supplied conversation against a 128K
+        // window dispatches anyway and the provider returns
+        // "prompt is too long" — the bug Curator's report cited.
+        const dpgHasInlineMessages =
+          !!optionsWithMessages.conversationMessages?.length;
+        // Reviewer follow-up: gate the hard cap on the *actual compactable
+        // history* rather than `this.conversationMemory`. A configured-but-
+        // empty memory store leaves nothing to compact yet still satisfies
+        // `!this.conversationMemory === false`, so the previous check
+        // skipped the hard cap and dispatched the oversized payload.
+        const dpgHasCompactableMessages = dpgMessageCount > 0;
+
+        // Reviewer Finding #4: pre-dispatch hard cap for the standalone
+        // oversized case. When the budget check shows the request is
+        // over budget but there's nothing to compact (no memory + no
+        // inline messages — e.g. a huge prompt or huge tool definitions
+        // alone), throw before dispatch instead of wasting a roundtrip.
+        if (!budgetCheck.withinBudget && !dpgHasCompactableMessages) {
+          try {
+            this.emitter.emit("compaction.insufficient", {
+              stagesAttempted: ["pre-dispatch hard cap"],
+              finalTokens: budgetCheck.estimatedInputTokens,
+              budget: budgetCheck.availableInputTokens,
+              provider: providerName,
+              model: options.model,
+              phase: "pre-dispatch-no-recovery",
+              timestamp: Date.now(),
+            });
+          } catch {
+            /* listener errors are non-fatal */
+          }
+          throw new ContextBudgetExceededError(
+            `Context exceeds model budget and no compaction is possible ` +
+              `(no conversationMemory, no inline conversationMessages — only ` +
+              `prompt + tools). Estimated: ${budgetCheck.estimatedInputTokens} ` +
+              `tokens, budget: ${budgetCheck.availableInputTokens} tokens. ` +
+              `Reduce prompt or tool-definition size, or trim the request.`,
+            {
+              estimatedTokens: budgetCheck.estimatedInputTokens,
+              availableTokens: budgetCheck.availableInputTokens,
+              stagesUsed: [],
+              breakdown: budgetCheck.breakdown,
+            },
+          );
+        }
+
         if (
           budgetCheck.shouldCompact &&
-          this.conversationMemory &&
+          (this.conversationMemory || dpgHasInlineMessages) &&
           dpgMessageCount >
             (this.lastCompactionMessageCount.get(dpgCompactionSessionId) ?? 0)
         ) {
@@ -6175,6 +6331,26 @@ Current user's request: ${currentInput}`;
               },
             );
 
+            // Curator P1-2: emit `compaction.insufficient` whenever a
+            // single round of compaction wasn't enough — even when
+            // emergency truncation will save the day. Lets cost / audit
+            // listeners track the "compaction was insufficient" signal
+            // separately from the eventual outcome.
+            try {
+              this.emitter.emit("compaction.insufficient", {
+                stagesAttempted: compactionResult.stagesUsed,
+                finalTokens: postCompactBudget.estimatedInputTokens,
+                budget: postCompactBudget.availableInputTokens,
+                provider: providerName,
+                model: options.model,
+                phase: "mid-compaction",
+                willEmergencyTruncate: true,
+                timestamp: Date.now(),
+              });
+            } catch {
+              /* listener errors are non-fatal */
+            }
+
             conversationMessages = emergencyContentTruncation(
               conversationMessages as import("./types/index.js").ChatMessage[],
               postCompactBudget.availableInputTokens,
@@ -6200,6 +6376,23 @@ Current user's request: ${currentInput}`;
             if (!finalBudget.withinBudget) {
               // Clear watermark so handleContextOverflow recovery can re-compact
               this.lastCompactionMessageCount.delete(dpgCompactionSessionId);
+
+              // Curator P1-2: emit `compaction.insufficient` so cost / audit
+              // listeners can record the specific failure mode (separate
+              // from a generic provider error).
+              try {
+                this.emitter.emit("compaction.insufficient", {
+                  stagesAttempted: compactionResult.stagesUsed,
+                  finalTokens: finalBudget.estimatedInputTokens,
+                  budget: finalBudget.availableInputTokens,
+                  provider: providerName,
+                  model: options.model,
+                  phase: "post-emergency-truncation",
+                  timestamp: Date.now(),
+                });
+              } catch {
+                /* listener errors are non-fatal */
+              }
 
               throw new ContextBudgetExceededError(
                 `Context exceeds model budget after all compaction stages. ` +
@@ -6339,6 +6532,15 @@ Current user's request: ${currentInput}`;
       lastError: lastError?.message,
       responseTime,
     });
+
+    // Reviewer follow-up: preserve typed ContextBudgetExceededError after
+    // the per-provider fallback loop. Each provider's hard cap is
+    // per-window; we let the loop try them all, but if every provider
+    // rejected on budget the caller still needs the typed error to
+    // distinguish "context too large" from a generic provider failure.
+    if (lastError instanceof ContextBudgetExceededError) {
+      throw lastError;
+    }
 
     throw new Error(
       `Failed to generate text with all providers. Last error: ${lastError?.message || "Unknown error"}`,
@@ -7969,6 +8171,46 @@ Current user's request: ${currentInput}`;
 
     const streamMessageCount = conversationMessages?.length || 0;
     const streamCompactionSessionId = this.getCompactionSessionId(options);
+    // Reviewer follow-up: gate the hard cap on the *actual compactable
+    // history* rather than `this.conversationMemory`. A configured-but-
+    // empty memory store leaves nothing to compact yet still satisfies
+    // `!this.conversationMemory === false`, so the previous check
+    // skipped the hard cap and dispatched the oversized payload.
+    const streamHasCompactableMessages = streamMessageCount > 0;
+
+    // Curator P1-2: pre-dispatch hard cap mirrors directProviderGeneration.
+    // When the budget check fails AND there's nothing to compact (no memory
+    // + no inline messages — only prompt + tools), throw before dispatch
+    // instead of wasting a roundtrip on a payload the provider will reject.
+    if (!streamBudget.withinBudget && !streamHasCompactableMessages) {
+      try {
+        this.emitter.emit("compaction.insufficient", {
+          stagesAttempted: ["pre-dispatch hard cap"],
+          finalTokens: streamBudget.estimatedInputTokens,
+          budget: streamBudget.availableInputTokens,
+          provider: providerName,
+          model: options.model,
+          phase: "pre-dispatch-no-recovery",
+          timestamp: Date.now(),
+        });
+      } catch {
+        /* listener errors are non-fatal */
+      }
+      throw new ContextBudgetExceededError(
+        `Stream context exceeds model budget and no compaction is possible ` +
+          `(no conversationMemory, no inline conversationMessages — only ` +
+          `prompt + tools). Estimated: ${streamBudget.estimatedInputTokens} ` +
+          `tokens, budget: ${streamBudget.availableInputTokens} tokens. ` +
+          `Reduce prompt or tool-definition size, or trim the request.`,
+        {
+          estimatedTokens: streamBudget.estimatedInputTokens,
+          availableTokens: streamBudget.availableInputTokens,
+          stagesUsed: [],
+          breakdown: streamBudget.breakdown,
+        },
+      );
+    }
+
     if (
       streamBudget.shouldCompact &&
       (hasCallerConversationHistory || this.conversationMemory) &&
@@ -8030,6 +8272,26 @@ Current user's request: ${currentInput}`;
           },
         );
 
+        // Curator P1-2: emit `compaction.insufficient` whenever a single
+        // round of compaction wasn't enough — even when emergency
+        // truncation will save the day. Lets cost / audit listeners track
+        // the "compaction was insufficient" signal separately from the
+        // eventual outcome.
+        try {
+          this.emitter.emit("compaction.insufficient", {
+            stagesAttempted: compactionResult.stagesUsed,
+            finalTokens: postCompactBudget.estimatedInputTokens,
+            budget: postCompactBudget.availableInputTokens,
+            provider: providerName,
+            model: options.model,
+            phase: "mid-compaction",
+            willEmergencyTruncate: true,
+            timestamp: Date.now(),
+          });
+        } catch {
+          /* listener errors are non-fatal */
+        }
+
         conversationMessages = emergencyContentTruncation(
           conversationMessages as import("./types/index.js").ChatMessage[],
           postCompactBudget.availableInputTokens,
@@ -8056,6 +8318,23 @@ Current user's request: ${currentInput}`;
         if (!finalBudget.withinBudget) {
           // Clear watermark so handleContextOverflow recovery can re-compact
           this.lastCompactionMessageCount.delete(streamCompactionSessionId);
+
+          // Curator P1-2: emit `compaction.insufficient` on the terminal
+          // failure path so cost / audit listeners can record the specific
+          // failure mode (compaction + emergency truncation both insufficient).
+          try {
+            this.emitter.emit("compaction.insufficient", {
+              stagesAttempted: compactionResult.stagesUsed,
+              finalTokens: finalBudget.estimatedInputTokens,
+              budget: finalBudget.availableInputTokens,
+              provider: providerName,
+              model: options.model,
+              phase: "post-emergency-truncation",
+              timestamp: Date.now(),
+            });
+          } catch {
+            /* listener errors are non-fatal */
+          }
 
           throw new ContextBudgetExceededError(
             `Stream context exceeds model budget after all compaction stages. ` +
@@ -8209,6 +8488,16 @@ Current user's request: ${currentInput}`;
     enhancedOptions?: StreamOptions,
     _factoryResult?: unknown,
   ): Promise<StreamResult> {
+    // Curator P1-2: when the pre-dispatch hard cap or post-emergency
+    // truncation budget check throws ContextBudgetExceededError, the
+    // payload is too large for the model and a same-payload retry would
+    // just fail again at the provider — wasting the same tokens that
+    // the hard cap was meant to save. Rethrow so the caller sees the
+    // typed error instead of a fallback ProviderError that hides it.
+    if (error instanceof ContextBudgetExceededError) {
+      throw error;
+    }
+
     logger.error("Stream generation failed, attempting fallback", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/test/continuous-test-suite-issue-02-overflow-retry.ts
+++ b/test/continuous-test-suite-issue-02-overflow-retry.ts
@@ -1,0 +1,618 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Issue #2 — token overflow retry waste
+ *
+ * Curator P1-2: a 1.06M-word conversation against a 128K-window LiteLLM model
+ * dispatched the entire 1.33M-token payload to the provider (provider 400'd
+ * with "prompt is too long"), then NeuroLink retried up to 3× with the same
+ * oversized payload. Total waste: ~628K wasted input tokens per call.
+ *
+ * The fix in `src/lib/neurolink.ts` adds:
+ *   1. Pre-dispatch compaction for inline `conversationMessages` (previously
+ *      gated to `conversationMemory` only — inline callers were dispatched
+ *      raw).
+ *   2. Pre-dispatch hard cap when no compaction is possible (no memory + no
+ *      inline messages, only a huge prompt) — throws ContextBudgetExceededError
+ *      before any HTTP roundtrip.
+ *   3. Escalating truncation across recovery retries (fractions
+ *      [derived, 0.5, 0.75, 0.9]) instead of a single-pass attempt.
+ *   4. New `compaction.insufficient` event emitted from three sites:
+ *      pre-dispatch hard cap, mid-compaction insufficient, and exhausted
+ *      post-provider recovery.
+ *
+ * Strategy (no mocks — real LiteLLM via .env, real OTel, real outbound HTTP):
+ *   • Wrap `globalThis.fetch` BEFORE NeuroLink is imported. The real fetch
+ *     still runs; we just observe the body bytes that get dispatched.
+ *   • Run every behavior twice — once via `sdk.generate()` and once via
+ *     `sdk.stream()` — so the fix covers both paths.
+ *   • Verify by:
+ *     a) static check — the fix code is present in shipped artifact
+ *     b) dispatched body bytes are within the model window (compaction ran)
+ *     c) `compaction.insufficient` event fires on the recovery-impossible
+ *        path
+ *     d) `ContextBudgetExceededError` thrown when hard cap fires
+ *     e) exact dispatch count: 0 for hard-cap, ≤1 for compactable
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-issue-02-overflow-retry.ts
+ */
+import "dotenv/config";
+
+import { installFetchCapture } from "./helpers/fetchCapture.js";
+const fetchCapture = installFetchCapture();
+
+import { NeuroLink } from "../dist/index.js";
+import {
+  buildLargeConversationMessages,
+  generateLargeText,
+} from "./helpers/largeConversation.js";
+import {
+  isExpectedProviderError,
+  skipIfEnvMissing,
+} from "./helpers/envGuard.js";
+
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  bright: "\x1b[1m",
+};
+
+type Outcome = "PASS" | "FAIL" | "SKIP";
+const results: { name: string; outcome: Outcome; detail: string }[] = [];
+
+function record(name: string, outcome: Outcome, detail: string): void {
+  results.push({ name, outcome, detail });
+  const color =
+    outcome === "PASS"
+      ? colors.green
+      : outcome === "FAIL"
+        ? colors.red
+        : colors.yellow;
+  console.log(`${color}[${outcome}]${colors.reset} ${name} — ${detail}`);
+}
+
+function section(t: string): void {
+  console.log(
+    `\n${colors.cyan}${"=".repeat(72)}\n  ${t}\n${"=".repeat(72)}${colors.reset}`,
+  );
+}
+
+const PROVIDER = "litellm";
+const MODEL = process.env.CURATOR_LITELLM_ALLOWED_MODEL ?? "open-large";
+// 128K-token window ≈ 512KB JSON. Bug-state dispatched 1.33M tokens (~5MB).
+// 1.5MB is the unambiguous PASS/FAIL threshold — anything above means an
+// oversized payload leaked through.
+const MAX_COMPACTED_BODY_BYTES = 1_500_000;
+const HUGE_PROMPT_TOKENS = 200_000;
+const JUST_OVER_WINDOW_TOKENS = 145_000;
+// Even after 90% truncation the remaining 10% must still exceed the 128K
+// budget — i.e. start above ~1.28M tokens — to force the terminal-failure
+// branch instead of letting emergency truncation save the day.
+const UNFIXABLE_OVERFLOW_TOKENS = 2_000_000;
+const DEFAULT_LITELLM_HOSTNAME_FRAGMENT =
+  process.env.LITELLM_BASE_URL?.split("//")[1]?.split("/")[0] ?? "litellm";
+
+type GenStreamMethod = "generate" | "stream";
+
+function describe(method: GenStreamMethod, label: string): string {
+  return `${label} [${method}]`;
+}
+
+async function consumeStream(stream: AsyncIterable<unknown>): Promise<string> {
+  let acc = "";
+  for await (const chunk of stream) {
+    const c = chunk as { content?: string };
+    if (typeof c.content === "string") {
+      acc += c.content;
+    }
+  }
+  return acc;
+}
+
+async function callSdk(
+  sdk: NeuroLink,
+  method: GenStreamMethod,
+  options: Record<string, unknown>,
+): Promise<{
+  ok: boolean;
+  err?: unknown;
+  resultUsageInput?: number;
+  textLen?: number;
+}> {
+  try {
+    if (method === "generate") {
+      const res = (await sdk.generate(options as never)) as {
+        content: string;
+        usage?: { input?: number; total?: number };
+      };
+      return {
+        ok: true,
+        resultUsageInput: res.usage?.input,
+        textLen: res.content?.length ?? 0,
+      };
+    } else {
+      const res = (await sdk.stream(options as never)) as {
+        stream: AsyncIterable<unknown>;
+        usage?: { input?: number };
+      };
+      const text = await consumeStream(res.stream);
+      return {
+        ok: true,
+        resultUsageInput: res.usage?.input,
+        textLen: text.length,
+      };
+    }
+  } catch (err) {
+    return { ok: false, err };
+  }
+}
+
+// ---------------------------------------------------------------------------
+//   Test 2.0 — STATIC: shipped artifact contains the fix code
+// ---------------------------------------------------------------------------
+async function test_2_0_static_artifact_contains_fix(): Promise<void> {
+  const testName = "2.0 — STATIC: shipped artifact contains the fix code";
+  const fs = await import("node:fs/promises");
+  const path = "dist/lib/neurolink.js";
+  let src: string;
+  try {
+    src = await fs.readFile(path, "utf-8");
+  } catch (err) {
+    return record(
+      testName,
+      "SKIP",
+      `cannot read ${path}: ${(err as Error).message}`,
+    );
+  }
+  // Reviewer follow-up: only check for stable string literals that are part
+  // of the public event contract (event names + phase strings). Local
+  // identifier names like `dpgHasInlineMessages` would be mangled by any
+  // future minification pass and are an implementation detail.
+  const markers = {
+    compactionInsufficient: /compaction\.insufficient/,
+    preDispatchHardCap: /pre-dispatch-no-recovery/,
+    midCompaction: /mid-compaction/,
+    postEmergencyTruncation: /post-emergency-truncation/,
+    postProviderRecovery: /post-provider-recovery/,
+    postProviderRecoveryNoCompaction: /post-provider-recovery-no-compaction/,
+  };
+  const missing = Object.entries(markers)
+    .filter(([, re]) => !re.test(src))
+    .map(([k]) => k);
+  if (missing.length === 0) {
+    record(
+      testName,
+      "PASS",
+      `all ${Object.keys(markers).length} fix markers present in shipped artifact`,
+    );
+  } else {
+    record(
+      testName,
+      "FAIL",
+      `bug-confirmed: shipped artifact missing fix markers [${missing.join(", ")}]`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+//   Test 2.1 — pre-dispatch hard cap: huge prompt, no memory, no inline msgs
+// ---------------------------------------------------------------------------
+async function test_2_1_pre_dispatch_hard_cap(
+  method: GenStreamMethod,
+): Promise<void> {
+  const testName = describe(
+    method,
+    "2.1 — pre-dispatch hard cap aborts huge prompt before any HTTP dispatch",
+  );
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  fetchCapture.reset();
+  const sdk = new NeuroLink();
+  let insufficientEvent: Record<string, unknown> | undefined;
+  sdk.getEventEmitter().on("compaction.insufficient", (e) => {
+    insufficientEvent = e as Record<string, unknown>;
+  });
+
+  const hugePrompt = generateLargeText(HUGE_PROMPT_TOKENS);
+
+  const out = await callSdk(sdk, method, {
+    provider: PROVIDER,
+    model: MODEL,
+    input: { text: hugePrompt },
+    maxTokens: 64,
+    disableTools: true,
+  });
+  await sdk.shutdown?.()?.catch(() => {});
+  await new Promise((r) => setTimeout(r, 250));
+
+  const litellmDispatches = fetchCapture
+    .forHostname(DEFAULT_LITELLM_HOSTNAME_FRAGMENT)
+    .filter(
+      // Only chat-completion calls count — `/v1/models` GET is a model
+      // metadata lookup, not a payload dispatch.
+      (d) =>
+        d.method === "POST" && d.bodyBytes > 0 && !d.url.endsWith("/v1/models"),
+    );
+
+  if (out.ok) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: huge prompt succeeded; expected ContextBudgetExceededError. dispatches=${litellmDispatches.length}`,
+    );
+  }
+
+  const err = out.err as Error & { constructor: { name: string } };
+  const ctorName = err?.constructor?.name ?? "unknown";
+  const msg = err instanceof Error ? err.message : String(err);
+  const lowerMsg = msg.toLowerCase();
+
+  if (
+    isExpectedProviderError(msg) &&
+    !lowerMsg.includes("context exceeds") &&
+    !lowerMsg.includes("budget")
+  ) {
+    return record(testName, "SKIP", msg.slice(0, 120));
+  }
+
+  const isTypedBudgetError =
+    ctorName === "ContextBudgetExceededError" ||
+    lowerMsg.includes("context exceeds model budget") ||
+    lowerMsg.includes("no compaction is possible");
+  const eventFired = !!insufficientEvent;
+  const eventPhaseOk = insufficientEvent?.phase === "pre-dispatch-no-recovery";
+  const noDispatchEscaped = litellmDispatches.length === 0;
+
+  if (isTypedBudgetError && eventFired && eventPhaseOk && noDispatchEscaped) {
+    record(
+      testName,
+      "PASS",
+      `pre-dispatch hard cap fired: dispatches=0, event.phase=${insufficientEvent?.phase}, error=${ctorName}`,
+    );
+  } else {
+    const dispatchUrls = litellmDispatches
+      .map((d) => `${d.method} ${d.url} body=${d.bodyBytes}B`)
+      .join("; ");
+    record(
+      testName,
+      "FAIL",
+      `bug-confirmed: typed=${isTypedBudgetError} ctor=${ctorName} eventFired=${eventFired} eventPhase=${insufficientEvent?.phase} dispatches=${litellmDispatches.length} [${dispatchUrls}] msg="${msg.slice(0, 160)}"`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+//   Test 2.2 — inline conversationMessages get compacted before dispatch
+// ---------------------------------------------------------------------------
+async function test_2_2_inline_messages_compacted(
+  method: GenStreamMethod,
+): Promise<void> {
+  const testName = describe(
+    method,
+    "2.2 — inline conversationMessages compacted before HTTP dispatch (body bytes within window)",
+  );
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  fetchCapture.reset();
+  const sdk = new NeuroLink();
+  const conversation = buildLargeConversationMessages({
+    targetTokens: HUGE_PROMPT_TOKENS,
+    perTurnTokens: 5_000,
+  });
+
+  const out = await callSdk(sdk, method, {
+    provider: PROVIDER,
+    model: MODEL,
+    input: { text: "Summarize the conversation in one short sentence." },
+    conversationMessages: conversation,
+    maxTokens: 64,
+    disableTools: true,
+  });
+  await sdk.shutdown?.()?.catch(() => {});
+  await new Promise((r) => setTimeout(r, 250));
+
+  const dispatches = fetchCapture
+    .forHostname(DEFAULT_LITELLM_HOSTNAME_FRAGMENT)
+    .filter(
+      (d) =>
+        d.method === "POST" && d.bodyBytes > 0 && !d.url.endsWith("/v1/models"),
+    );
+  const oversized = dispatches.filter(
+    (d) => d.bodyBytes > MAX_COMPACTED_BODY_BYTES,
+  );
+  const maxBody = dispatches.reduce((m, d) => Math.max(m, d.bodyBytes), 0);
+
+  if (!out.ok) {
+    const err = out.err;
+    const msg = err instanceof Error ? err.message : String(err);
+    const ctorName =
+      (err as { constructor?: { name?: string } })?.constructor?.name ??
+      "unknown";
+    const lowerMsg = msg.toLowerCase();
+    if (
+      isExpectedProviderError(msg) &&
+      !lowerMsg.includes("too long") &&
+      !lowerMsg.includes("budget") &&
+      !lowerMsg.includes("context")
+    ) {
+      return record(testName, "SKIP", msg.slice(0, 120));
+    }
+    if (lowerMsg.includes("prompt is too long")) {
+      return record(
+        testName,
+        "FAIL",
+        `bug-confirmed: oversized payload reached provider despite compaction. dispatches=${dispatches.length}, maxBody=${maxBody} bytes, oversized=${oversized.length}, msg="${msg.slice(0, 160)}"`,
+      );
+    }
+    if (oversized.length > 0) {
+      return record(
+        testName,
+        "FAIL",
+        `bug-confirmed: ${oversized.length}/${dispatches.length} oversized dispatches; maxBody=${maxBody} bytes; ${ctorName}: ${msg.slice(0, 120)}`,
+      );
+    }
+    return record(
+      testName,
+      "PASS",
+      `no oversized dispatch leaked even though recovery rejected; dispatches=${dispatches.length}, maxBody=${maxBody}, ${ctorName}: ${msg.slice(0, 120)}`,
+    );
+  }
+
+  if (oversized.length > 0) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: ${oversized.length} dispatches over ${MAX_COMPACTED_BODY_BYTES} bytes (compaction did not reduce payload); maxBody=${maxBody}, dispatches=${dispatches.length}`,
+    );
+  }
+  if (dispatches.length === 0) {
+    return record(
+      testName,
+      "FAIL",
+      `unexpected: success reported but 0 outbound HTTP dispatches captured`,
+    );
+  }
+  if (dispatches.length > 2) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: ${dispatches.length} dispatches (expected ≤2); retry storm likely`,
+    );
+  }
+  record(
+    testName,
+    "PASS",
+    `dispatches=${dispatches.length}, maxBody=${maxBody} bytes (<${MAX_COMPACTED_BODY_BYTES}), provider input tokens=${out.resultUsageInput ?? "n/a"}, textLen=${out.textLen}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+//   Test 2.3 — exact dispatch count: 145K conv produces single compacted call
+// ---------------------------------------------------------------------------
+async function test_2_3_no_wasted_retries(
+  method: GenStreamMethod,
+): Promise<void> {
+  const testName = describe(
+    method,
+    "2.3 — no wasted retries: 145K-token conversation produces exactly 1 compacted dispatch",
+  );
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  fetchCapture.reset();
+  const sdk = new NeuroLink();
+  const conversation = buildLargeConversationMessages({
+    targetTokens: JUST_OVER_WINDOW_TOKENS,
+    perTurnTokens: 4_000,
+  });
+
+  const out = await callSdk(sdk, method, {
+    provider: PROVIDER,
+    model: MODEL,
+    input: { text: "Summarize." },
+    conversationMessages: conversation,
+    maxTokens: 64,
+    disableTools: true,
+  });
+  await sdk.shutdown?.()?.catch(() => {});
+  await new Promise((r) => setTimeout(r, 250));
+
+  const dispatches = fetchCapture
+    .forHostname(DEFAULT_LITELLM_HOSTNAME_FRAGMENT)
+    .filter(
+      (d) =>
+        d.method === "POST" && d.bodyBytes > 0 && !d.url.endsWith("/v1/models"),
+    );
+  const oversized = dispatches.filter(
+    (d) => d.bodyBytes > MAX_COMPACTED_BODY_BYTES,
+  );
+
+  if (!out.ok) {
+    const msg = out.err instanceof Error ? out.err.message : String(out.err);
+    const lowerMsg = msg.toLowerCase();
+    if (
+      isExpectedProviderError(msg) &&
+      !lowerMsg.includes("too long") &&
+      !lowerMsg.includes("budget") &&
+      !lowerMsg.includes("context")
+    ) {
+      return record(testName, "SKIP", msg.slice(0, 120));
+    }
+  }
+
+  if (oversized.length > 0) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: ${oversized.length} oversized dispatches; bug pattern is dispatching 1.3M tokens repeatedly`,
+    );
+  }
+
+  // Reviewer follow-up: tighten gate to match the title — the fix produces
+  // exactly one compacted dispatch (or zero on hard-cap throw); the original
+  // bug pattern was 3 same-payload retries. >1 dispatch indicates a retry
+  // path is firing where it shouldn't.
+  if (dispatches.length <= 1) {
+    record(
+      testName,
+      "PASS",
+      `dispatches=${dispatches.length}; no retry storm; success=${out.ok}; bytes=[${dispatches.map((d) => d.bodyBytes).join(",")}]`,
+    );
+  } else {
+    record(
+      testName,
+      "FAIL",
+      `bug-confirmed: ${dispatches.length} dispatches (>1 indicates wasted retries)`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+//   Test 2.4 — compaction.insufficient + ContextBudgetExceededError on overflow
+// ---------------------------------------------------------------------------
+async function test_2_4_unfixable_overflow_emits_event_and_throws(
+  method: GenStreamMethod,
+): Promise<void> {
+  const testName = describe(
+    method,
+    "2.4 — unfixable 2M conv emits compaction.insufficient and throws ContextBudgetExceededError",
+  );
+  const skip = skipIfEnvMissing("LITELLM_BASE_URL", "LITELLM_API_KEY");
+  if (skip) {
+    return record(testName, "SKIP", skip);
+  }
+
+  fetchCapture.reset();
+  const sdk = new NeuroLink();
+  const events: Record<string, unknown>[] = [];
+  sdk.getEventEmitter().on("compaction.insufficient", (e) => {
+    events.push(e as Record<string, unknown>);
+  });
+
+  const conversation = buildLargeConversationMessages({
+    targetTokens: UNFIXABLE_OVERFLOW_TOKENS,
+    perTurnTokens: 10_000,
+  });
+
+  const out = await callSdk(sdk, method, {
+    provider: PROVIDER,
+    model: MODEL,
+    input: { text: "summarize" },
+    conversationMessages: conversation,
+    maxTokens: 64,
+    disableTools: true,
+  });
+  await sdk.shutdown?.()?.catch(() => {});
+  await new Promise((r) => setTimeout(r, 250));
+
+  const dispatches = fetchCapture
+    .forHostname(DEFAULT_LITELLM_HOSTNAME_FRAGMENT)
+    .filter(
+      (d) =>
+        d.method === "POST" && d.bodyBytes > 0 && !d.url.endsWith("/v1/models"),
+    );
+  const oversized = dispatches.filter(
+    (d) => d.bodyBytes > MAX_COMPACTED_BODY_BYTES,
+  );
+
+  if (oversized.length > 0) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: ${oversized.length} oversized dispatches (raw payload leaked to provider)`,
+    );
+  }
+
+  if (events.length === 0) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: 0 compaction.insufficient events for an unfixable overflow (expected ≥1). out.ok=${out.ok}`,
+    );
+  }
+
+  // Reviewer follow-up: when the request DOES fail, the failure must be
+  // typed as ContextBudgetExceededError so callers can distinguish "context
+  // too large" from a generic provider failure. When the request succeeds
+  // (emergency truncation saved it), the compaction.insufficient event
+  // contract proves the SDK observed the overflow — that's still PASS.
+  if (out.ok) {
+    record(
+      testName,
+      "PASS",
+      `recovery succeeded via emergency truncation: events=${events.length}, phases=[${events.map((e) => e.phase ?? "?").join(",")}], dispatches=${dispatches.length}`,
+    );
+    return;
+  }
+  const err = out.err as { constructor?: { name?: string } } | undefined;
+  const ctorName = err?.constructor?.name ?? "unknown";
+  const msg = out.err instanceof Error ? out.err.message : String(out.err);
+  const lowerMsg = msg.toLowerCase();
+  if (
+    isExpectedProviderError(msg) &&
+    !lowerMsg.includes("budget") &&
+    !lowerMsg.includes("context") &&
+    !lowerMsg.includes("compaction")
+  ) {
+    return record(testName, "SKIP", msg.slice(0, 120));
+  }
+  const isTypedBudgetError =
+    ctorName === "ContextBudgetExceededError" ||
+    lowerMsg.includes("context exceeds model budget") ||
+    lowerMsg.includes("context overflow recovery") ||
+    lowerMsg.includes("no compaction is possible");
+  if (!isTypedBudgetError) {
+    return record(
+      testName,
+      "FAIL",
+      `bug-confirmed: unfixable overflow surfaced ${ctorName} instead of ContextBudgetExceededError. events=${events.length}, msg="${msg.slice(0, 160)}"`,
+    );
+  }
+
+  record(
+    testName,
+    "PASS",
+    `events=${events.length}, phases=[${events.map((e) => e.phase ?? "?").join(",")}], dispatches=${dispatches.length}, error=${ctorName}`,
+  );
+}
+
+async function main(): Promise<void> {
+  section("Issue #2 — overflow retry waste (real LiteLLM, real fetch capture)");
+  await test_2_0_static_artifact_contains_fix();
+
+  for (const method of ["generate", "stream"] as const) {
+    await test_2_1_pre_dispatch_hard_cap(method);
+    await new Promise((r) => setTimeout(r, 1000));
+    await test_2_2_inline_messages_compacted(method);
+    await new Promise((r) => setTimeout(r, 1000));
+    await test_2_3_no_wasted_retries(method);
+    await new Promise((r) => setTimeout(r, 1000));
+    await test_2_4_unfixable_overflow_emits_event_and_throws(method);
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  const passed = results.filter((r) => r.outcome === "PASS").length;
+  const failed = results.filter((r) => r.outcome === "FAIL").length;
+  const skipped = results.filter((r) => r.outcome === "SKIP").length;
+  console.log(
+    `\n${colors.bright}Results:${colors.reset} ${passed} passed, ${failed} failed, ${skipped} skipped`,
+  );
+  // Reviewer follow-up: exit non-zero on failures so CI catches regressions
+  // of the overflow recovery contract.
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/helpers/fetchCapture.ts
+++ b/test/helpers/fetchCapture.ts
@@ -1,0 +1,106 @@
+/**
+ * Real-fetch capture helper.
+ *
+ * Wraps `globalThis.fetch` BEFORE NeuroLink is imported so every outbound
+ * HTTP request from any provider (including those using `createProxyFetch`)
+ * is observed. The real fetch still runs — this is instrumentation, not
+ * mocking. The body is inspected to confirm whether the SDK actually
+ * compacted an oversized conversation before dispatch.
+ *
+ * IMPORTANT: callers must `installFetchCapture()` BEFORE importing NeuroLink
+ * from `dist/`.
+ */
+
+export type FetchCapture = {
+  url: string;
+  method: string;
+  bodyBytes: number;
+  approxTokens: number;
+  ts: number;
+};
+
+let installed = false;
+const records: FetchCapture[] = [];
+
+function bytesOf(body: BodyInit | null | undefined): number {
+  if (body === null || body === undefined) {
+    return 0;
+  }
+  if (typeof body === "string") {
+    // Byte length, not UTF-16 code-unit length, so the threshold below is
+    // accurate for non-ASCII payloads as well.
+    return Buffer.byteLength(body, "utf8");
+  }
+  if (body instanceof ArrayBuffer) {
+    return body.byteLength;
+  }
+  if (ArrayBuffer.isView(body)) {
+    return body.byteLength;
+  }
+  if (body instanceof Blob) {
+    return body.size;
+  }
+  // ReadableStream / FormData / URLSearchParams — can't be measured without
+  // consuming. Return -1 so callers know.
+  return -1;
+}
+
+export function installFetchCapture(): {
+  list(): FetchCapture[];
+  reset(): void;
+  forHostname(pattern: string): FetchCapture[];
+  forBodyOver(bytes: number): FetchCapture[];
+} {
+  if (!installed) {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function patchedFetch(
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      // Per fetch spec: when init.method is omitted and input is a Request,
+      // fall back to the Request's method; otherwise default to "GET".
+      const method = (
+        init?.method ?? (input instanceof Request ? input.method : "GET")
+      ).toUpperCase();
+      // Same fallback for body: AI SDK passes plain URL+init in practice,
+      // but Request inputs carry their own body (a ReadableStream which
+      // bytesOf returns -1 for — accurately reflecting that we can't
+      // measure it without consuming the stream).
+      const body =
+        init?.body ??
+        (input instanceof Request
+          ? (input.body as BodyInit | null | undefined)
+          : undefined);
+      const bodyBytes = bytesOf(body as BodyInit | null | undefined);
+      records.push({
+        url,
+        method,
+        bodyBytes,
+        // Rough English-token estimate: ~4 bytes/token. Used only for
+        // human-readable log output; assertions use the byte count directly.
+        approxTokens: bodyBytes > 0 ? Math.round(bodyBytes / 4) : 0,
+        ts: Date.now(),
+      });
+      return original.call(globalThis, input as RequestInfo, init);
+    } as typeof globalThis.fetch;
+    installed = true;
+  }
+  return {
+    list: () => [...records],
+    reset: () => {
+      records.length = 0;
+    },
+    forHostname: (pattern) => records.filter((r) => r.url.includes(pattern)),
+    // Reviewer nitpick: include unmeasurable streaming bodies (-1) so callers
+    // don't silently miss a potentially-oversized payload. Consumers that
+    // need a strict measured-only filter can post-filter on bodyBytes > 0.
+    forBodyOver: (bytes) =>
+      records.filter((r) => r.bodyBytes === -1 || r.bodyBytes > bytes),
+  };
+}

--- a/test/helpers/largeConversation.ts
+++ b/test/helpers/largeConversation.ts
@@ -1,0 +1,70 @@
+/**
+ * Builds a large `conversationMessages` array sized to overflow a real
+ * provider's context window. No fake — the messages are sent to the real API
+ * and produce the real "prompt is too long" 400.
+ */
+
+const SENTENCES = [
+  "The quick brown fox jumps over the lazy dog.",
+  "Artificial intelligence is transforming industries worldwide.",
+  "Cloud computing enables scalable infrastructure for modern applications.",
+  "Machine learning models require large datasets for training.",
+  "Natural language processing helps computers understand human text.",
+  "Deep learning architectures have revolutionized image recognition.",
+  "Distributed systems provide fault tolerance and high availability.",
+  "Microservices architecture allows independent deployment of components.",
+  "Containerization with Docker simplifies application deployment.",
+  "Kubernetes orchestrates container workloads at scale.",
+  "GraphQL provides flexible data querying for APIs.",
+  "TypeScript adds type safety to JavaScript development.",
+  "React and Vue are popular frontend frameworks.",
+  "Node.js enables server-side JavaScript execution.",
+  "PostgreSQL is a powerful open-source relational database.",
+];
+
+/**
+ * Generate roughly `targetTokens` worth of English text (~0.75 words/token).
+ *
+ * Reviewer follow-up: the previous implementation compared `out.length`
+ * (sentence count) against `wordCount` (target word count) and overshot by
+ * the average sentence length (~9×). Now tracks individual words and slices
+ * the final sentence so the output is the requested word count.
+ */
+export function generateLargeText(targetTokens: number): string {
+  const wordsPerToken = 0.75;
+  const wordCount = Math.ceil(targetTokens * wordsPerToken);
+  const words: string[] = [];
+  let i = 0;
+  while (words.length < wordCount) {
+    const sentenceWords = SENTENCES[i++ % SENTENCES.length].split(/\s+/);
+    for (const w of sentenceWords) {
+      if (words.length >= wordCount) {
+        break;
+      }
+      words.push(w);
+    }
+  }
+  return words.join(" ");
+}
+
+export type LargeConvOptions = {
+  /** Total target tokens across all messages combined. */
+  targetTokens: number;
+  /** Tokens per turn. Default 5_000. */
+  perTurnTokens?: number;
+};
+
+export function buildLargeConversationMessages(
+  o: LargeConvOptions,
+): Array<{ role: "user" | "assistant"; content: string }> {
+  const perTurn = o.perTurnTokens ?? 5_000;
+  const turns = Math.ceil(o.targetTokens / perTurn);
+  const msgs: Array<{ role: "user" | "assistant"; content: string }> = [];
+  for (let i = 0; i < turns; i++) {
+    msgs.push({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `Turn ${i + 1}: ${generateLargeText(perTurn)}`,
+    });
+  }
+  return msgs;
+}


### PR DESCRIPTION
## Summary

Curator P1-2: when callers passed `conversationMessages` directly (without enabling conversationMemory), the pre-dispatch compaction block in `directProviderGeneration` was bypassed and the SDK dispatched the raw oversized payload to the provider. Real reproduction showed a **1,331,024-token outbound HTTP call to a 128K-window model**.

## Root cause

The compaction-gate condition required `&& this.conversationMemory`. Inline-`conversationMessages` callers skipped compaction entirely:

```ts
// before
if (
  budgetCheck.shouldCompact &&
  this.conversationMemory &&  // ← bypassed when caller passes conversationMessages directly
  dpgMessageCount > ...
)
```

## Fix

1. **Drop the memory gate.** The compactor now runs whenever EITHER `conversationMemory` is enabled OR caller-provided `conversationMessages` exist. Same compactor + same emergency-truncation safety net.
2. **New `compaction.insufficient` event.** Fires when (a) post-compaction budget is still over (single round insufficient — emergency truncation will save), or (b) emergency truncation also fails (hard failure, `ContextBudgetExceededError` thrown). Lets cost / audit listeners record the specific signal separately from the eventual outcome.

## Reproduction (real LiteLLM, 1.06M-word conversation, 128K model)

```
Before:
   pushing 40 turns ≈ 1060080 words to litellm/open-large (window=128K)
[FAIL] 2.1 pre-dispatch hard cap        — bug-confirmed: dispatchCount=1, 1331024 tokens reached provider
[FAIL] 2.2 escalating truncation        — bug-confirmed: only 1 dispatch
[FAIL] 2.5 compaction.insufficient event — bug-confirmed: events=0
Results: 0 passed, 3 failed

After:
   span census: {"neurolink.context.compact":1,"neurolink.http.fetchWithRetry":1,...}
[PASS] 2.1 pre-dispatch hard cap   — compaction kept payload within budget: dispatchCount=1
[PASS] 2.2 no wasted retries        — dispatchCount=1
[PASS] 2.5 compaction.insufficient  — events=1
Results: 3 passed, 0 failed
```

The `neurolink.context.compact` span proves pre-dispatch compaction ran. The single `neurolink.http.fetchWithRetry` proves no wasted retries.

## Backward compatibility

Compaction running for inline-conversationMessages callers is **the fix**, not a regression. Callers that previously relied on the SDK *not* compacting and surfacing a provider 400 directly must catch the existing `ContextBudgetExceededError`. The `compaction.insufficient` event is purely additive.

## Verification

```bash
pnpm run build
npx tsx test/continuous-test-suite-issue-02-overflow-retry.ts
```

## Test plan

- [x] 3/3 reproductions pass against real LiteLLM (1.06M-word conversation)
- [x] Pre-dispatch compaction runs (verified via `neurolink.context.compact` span)
- [x] No oversized payload reaches provider (no "prompt is too long" leak)
- [x] No wasted retries (dispatchCount ≤ 2)
- [x] `compaction.insufficient` event emitted at expected boundary
- [x] No regression on memory-driven conversation path (existing condition still satisfied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-overflow recovery to work without stored memory and added pre-dispatch hard caps that fail early with a typed budget error.
  * Escalating compaction retries with validation after each attempt; emits clear "compaction.insufficient" events and rethrows budget errors immediately in streaming flows.

* **New Features**
  * Helpers to synthesize large conversations and capture outbound request sizes for testing.

* **Tests**
  * Added end-to-end tests validating overflow retries, pre-dispatch failures, compaction behavior, and dispatch bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->