### PR TITLE
fix(proxy): replace blocking quiet-gate with best-effort wait for auto-updates

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1900,13 +1900,15 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           `[guard] update available: ${runningVersion} → ${result.latestVersion}`,
         );
 
-        // 2. Wait for quiet traffic
-        const maxQuietWaitMs = 60 * 60 * 1000; // 1 hour max wait
+        // 2. Best-effort quiet wait — try for a brief window, but proceed
+        //    regardless. The install (pnpm add -g) is non-disruptive; only the
+        //    restart causes a ~1-3s blip. Blocking updates for hours/days because
+        //    traffic never goes silent is worse than a brief interruption.
+        const maxQuietWaitMs = 5 * 60 * 1000; // 5 minutes max, then proceed
         const quietPollMs = 10_000; // check every 10s
         const quietStart = Date.now();
 
         while (Date.now() - quietStart < maxQuietWaitMs) {
-          // Bail out if parent proxy died during the wait
           if (getProcessStatus(parentPid) === "not_running") {
             logger.always(
               `[guard] parent process died during quiet-wait, aborting update`,
@@ -1915,6 +1917,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           }
           const quietStatus = checkTrafficQuiet(QUIET_THRESHOLD_MS);
           if (quietStatus.isQuiet) {
+            logger.always(`[guard] traffic quiet, proceeding with update`);
             break;
           }
           logger.debug(
@@ -1923,12 +1926,14 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           await new Promise((r) => setTimeout(r, quietPollMs));
         }
 
+        // Proceed with install regardless — don't block updates indefinitely.
+        // The install itself (pnpm add -g) doesn't affect the running process.
+        // Only the restart afterwards causes a brief interruption.
         const finalQuiet = checkTrafficQuiet(QUIET_THRESHOLD_MS);
         if (!finalQuiet.isQuiet) {
           logger.always(
-            `[guard] traffic didn't quiet down within 1 hour, skipping update cycle`,
+            `[guard] traffic still active after ${Math.round(maxQuietWaitMs / 1000)}s wait, proceeding with update anyway (restart will briefly interrupt in-flight requests)`,
           );
-          return;
         }
 
         // 3. Install update (validate version string before passing to shell)


### PR DESCRIPTION
## Summary

- The auto-update guard waited up to **1 hour** for 2 minutes of traffic silence before installing updates. If traffic never went quiet, the update was **skipped entirely**.
- On busy proxies with continuous Claude Code sessions (main + sub-agents/teams), updates **never installed** — every version got suppressed because the quiet window never appeared.
- Replace with a **5-minute best-effort wait**. If traffic is still active after 5 minutes, proceed with the update anyway.
- The `pnpm add -g` install is non-disruptive (writes to disk only). Only the `launchctl` restart causes a brief ~1-3s interruption — far better than running stale code for days.

## Evidence

From production proxy logs (April 18-25):
- 7 consecutive versions (9.55.6 → 9.56.2) suppressed as `install_failed`
- `lastUpdateAt: null` — **no update had ever succeeded**
- 6-hour overnight quiet window missed because the only available version was already suppressed
- Newer versions published during active traffic → quiet-gate blocked → suppressed → cycle repeats

## Test plan

- [ ] Verify single-session proxy: updates install during natural gaps (< 5 min wait)
- [ ] Verify multi-session proxy: updates proceed after 5 min even with active traffic
- [ ] Verify the log message "proceeding with update anyway" appears when traffic is active
- [ ] Verify in-flight requests experience only a brief (~1-3s) interruption on restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-updates now proceed faster with a 5-minute quiet traffic window, compared to potentially waiting up to 1 hour.
  * Updates are guaranteed to proceed even if network remains active, eliminating instances where updates could be skipped.
  * Improved logging provides better visibility into the update installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->