### PR TITLE
fix(routing): dual-mode image text fallback + video-frame hijack gate

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -844,6 +844,22 @@ export abstract class BaseProvider implements AIProvider {
     if (!hasVideoFrames(messages)) {
       return null;
     }
+    // Bug 2 fix: callers requesting structured output (schema or explicit
+    // output.format) must NOT be hijacked into the prose-returning video
+    // analysis path. Without this gate, schema/format are silently dropped
+    // whenever messages contain >=3 image parts.
+    if (options.schema !== undefined || options.output?.format !== undefined) {
+      logger.info(
+        "[VideoFrameGen] Skipping video-frame analysis route; caller requested structured output",
+        {
+          provider: this.providerName,
+          model: this.modelName,
+          hasSchema: options.schema !== undefined,
+          outputFormat: options.output?.format,
+        },
+      );
+      return null;
+    }
 
     const videoAnalysisResult = await executeVideoAnalysis(messages, {
       provider: options.provider,

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -4252,7 +4252,14 @@ export class GoogleVertexProvider extends BaseProvider {
   }
 
   /**
-   * Parse the Vertex AI image generation REST API response and extract image data.
+   * Parse the Vertex AI image generation REST API response.
+   *
+   * Dual-mode image models (gemini-3.1-flash-image-preview, gemini-2.5-flash-image,
+   * gemini-3-pro-image-preview) decide per-request whether to emit an image or text.
+   * When the response contains text parts but no image part, surface the text via
+   * `textFallback` so the caller can return a normal text result instead of throwing
+   * "model returned text instead of image data" and burning retries on a query that
+   * the model has already answered.
    */
   private parseImageGenerationResponse(
     data: {
@@ -4267,7 +4274,7 @@ export class GoogleVertexProvider extends BaseProvider {
       }>;
     },
     imageModelName: string,
-  ): { imageData: string; mimeType: string } {
+  ): { imageData: string; mimeType: string } | { textFallback: string } {
     const candidate = data.candidates?.[0];
     if (!candidate?.content?.parts) {
       throw new ProviderError(
@@ -4288,12 +4295,16 @@ export class GoogleVertexProvider extends BaseProvider {
     );
 
     if (!imagePart) {
-      const hasTextContent = candidate.content.parts.some((part) => part.text);
-
+      // Filter out empty/whitespace-only text parts so an effectively empty
+      // response throws "no image data" instead of returning content: "".
+      const textParts = candidate.content.parts
+        .map((part) => (typeof part.text === "string" ? part.text : ""))
+        .filter((text) => text.trim().length > 0);
+      if (textParts.length > 0) {
+        return { textFallback: textParts.join("") };
+      }
       throw new ProviderError(
-        hasTextContent
-          ? `Image generation completed but model returned text instead of image data. Model: ${imageModelName}`
-          : `Image generation completed but no image data was returned. Model: ${imageModelName}`,
+        `Image generation completed but no image data was returned. Model: ${imageModelName}`,
         this.providerName,
       );
     }
@@ -4445,10 +4456,36 @@ export class GoogleVertexProvider extends BaseProvider {
         }>;
       };
 
-      const { imageData, mimeType } = this.parseImageGenerationResponse(
-        data,
-        imageModelName,
-      );
+      const parsed = this.parseImageGenerationResponse(data, imageModelName);
+
+      // Dual-mode model decided to emit text instead of an image. Surface the
+      // text as a normal text result instead of throwing — the model already
+      // answered the user; failing here just burns retries.
+      if ("textFallback" in parsed) {
+        logger.info(
+          "Dual-mode image model returned text; returning as text result",
+          {
+            model: imageModelName,
+            textLength: parsed.textFallback.length,
+            responseTime: Date.now() - startTime,
+          },
+        );
+        const inputTokens = this.estimateTokenCount(prompt);
+        const outputTokens = this.estimateTokenCount(parsed.textFallback);
+        const textResult: EnhancedGenerateResult = {
+          content: parsed.textFallback,
+          provider: this.providerName,
+          model: imageModelName,
+          usage: {
+            input: inputTokens,
+            output: outputTokens,
+            total: inputTokens + outputTokens,
+          },
+        };
+        return await this.enhanceResult(textResult, options, startTime);
+      }
+
+      const { imageData, mimeType } = parsed;
 
       logger.info("Image generation successful", {
         model: imageModelName,

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -4020,6 +4020,426 @@ async function testGoogleAIStudioImageGeneration(): Promise<boolean | null> {
 // Types imported from @juspay/neurolink: ProcessResult, TestFunction, TestResult
 
 // ============================================================
+// IMAGE-GEN ROUTING BUG REPROS
+// ============================================================
+// Two production routing bugs in src/lib/core/baseProvider.ts:
+//
+// Bug 1 (image-gen routing, baseProvider.ts:740-758 + :210-228):
+//   `isImageModel && !requestsNonImageOutput` routes to executeImageGeneration
+//   when the model name is in IMAGE_GENERATION_MODELS AND output.format is unset.
+//   gemini-3.1-flash-image-preview is dual-mode (returns text OR images), so a
+//   bare text prompt gets force-routed to the image pipeline. The model returns
+//   text, googleVertex.ts:4295 throws
+//   "Image generation completed but model returned text instead of image data".
+//
+// Bug 2 (video-frame hijack, baseProvider.ts:838+ via videoAnalysisProcessor.ts:37):
+//   handleVideoFrameGeneration fires whenever messages contain >=3 image parts,
+//   ignoring caller's schema/output.format. It runs executeVideoAnalysis with
+//   hardcoded model "gemini-2.5-flash" and returns prose. Schema is silently
+//   dropped; structured-output callers get garbage.
+//
+// Each test SKIPs on credential errors and FAILs on the bug signature.
+
+async function testTextRequestOnDualModeImageModelCLI(): Promise<
+  boolean | null
+> {
+  logSection("Testing Text Request on Dual-Mode Image Model (CLI)");
+
+  try {
+    const result = await runCommand("node", [
+      "dist/cli/index.js",
+      "generate",
+      "--provider=vertex",
+      "--model=gemini-3.1-flash-image-preview",
+      "--timeout=120",
+      "What is the capital of France? Reply with one word only.",
+    ]);
+
+    const combined = result.stderr + result.stdout;
+
+    // Check bug signature FIRST — googleVertex.ts:4295 throws this exact string
+    // when image-gen routing fires for a text-only request on a dual-mode model.
+    // The error includes troubleshooting text containing "credentials" / "authentication",
+    // so the SKIP-on-cred-error gate must come AFTER this check or it will mask the bug.
+    if (/returned text instead of image data/i.test(combined)) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (CLI)",
+        "FAIL",
+        "BUG REPRODUCED: text prompt force-routed to image-gen pipeline",
+      );
+      return false;
+    }
+
+    // SKIP only on genuine cred failures (no bug signature present)
+    if (
+      !result.success &&
+      /\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\b/i.test(
+        combined,
+      )
+    ) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (CLI)",
+        "SKIP",
+        "Vertex credentials not configured",
+      );
+      return null;
+    }
+
+    if (result.success && /paris/i.test(result.stdout)) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (CLI)",
+        "PASS",
+        "text response returned for text prompt on dual-mode image model",
+      );
+      return true;
+    }
+
+    logTest(
+      "Text Request on Dual-Mode Image Model (CLI)",
+      "FAIL",
+      `unexpected: code=${result.code} stdout=${result.stdout.substring(0, 200)} stderr=${result.stderr.substring(0, 200)}`,
+    );
+    return false;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logTest(
+      "Text Request on Dual-Mode Image Model (CLI)",
+      "FAIL",
+      errorMessage,
+    );
+    return false;
+  }
+}
+
+async function testTextRequestOnDualModeImageModelSDK(): Promise<
+  boolean | null
+> {
+  logSection("Testing Text Request on Dual-Mode Image Model (SDK)");
+
+  const tempDir = fs.mkdtempSync(
+    os.tmpdir() + "/test-text-on-image-model-sdk-",
+  );
+  const tempScriptPath = tempDir + "/test.mjs";
+
+  try {
+    const testScript = `
+import { NeuroLink } from '${process.cwd()}/dist/index.js';
+
+async function run() {
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.generate({
+      input: { text: 'What is the capital of France? Reply with one word only.' },
+      provider: 'vertex',
+      model: 'gemini-3.1-flash-image-preview',
+    });
+
+    const content = (result?.content || '').toLowerCase();
+    if (/paris/.test(content) && !result?.imageOutput?.base64) {
+      console.log('SDK Text on Image Model: PASS - text returned, no imageOutput');
+      process.exit(0);
+    }
+    console.log('SDK Text on Image Model: FAIL - content=' + JSON.stringify(result?.content || '').slice(0, 200) + ' imageOutput=' + (result?.imageOutput ? 'present' : 'absent'));
+    process.exit(1);
+  } catch (error) {
+    const msg = error?.message || '';
+    // Bug signature check FIRST — the error message includes troubleshooting text
+    // containing "credentials" which would otherwise trigger a false-SKIP.
+    if (/returned text instead of image data/i.test(msg)) {
+      console.log('SDK Text on Image Model: FAIL - BUG REPRODUCED: ' + msg.slice(0, 200));
+      process.exit(1);
+    }
+    if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
+      console.log('SDK Text on Image Model: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    console.log('SDK Text on Image Model: FAIL - ' + (msg || String(error)).slice(0, 300));
+    process.exit(1);
+  }
+}
+run();
+`;
+
+    fs.writeFileSync(tempScriptPath, testScript);
+    const result = await runCommand("node", [tempScriptPath]);
+
+    if (result.stdout.includes("SKIP")) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (SDK)",
+        "SKIP",
+        "credentials not configured",
+      );
+      return null;
+    }
+    if (result.stdout.includes("PASS")) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (SDK)",
+        "PASS",
+        "text returned for text prompt on dual-mode image model",
+      );
+      return true;
+    }
+    const failLine =
+      result.stdout.split("\n").find((l) => l.includes("FAIL")) ||
+      result.stdout.slice(0, 300);
+    logTest("Text Request on Dual-Mode Image Model (SDK)", "FAIL", failLine);
+    return false;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logTest(
+      "Text Request on Dual-Mode Image Model (SDK)",
+      "FAIL",
+      errorMessage,
+    );
+    return false;
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function testSchemaWithMultipleImagesSDK(): Promise<boolean | null> {
+  logSection("Testing Schema Output with 3+ Images (SDK)");
+
+  const screenshotPath = "test/fixtures/sample-screenshot.png";
+  if (!fs.existsSync(screenshotPath)) {
+    logTest(
+      "Schema Output with 3+ Images (SDK)",
+      "SKIP",
+      "screenshot fixture not available",
+    );
+    return null;
+  }
+
+  const tempDir = fs.mkdtempSync(os.tmpdir() + "/test-schema-multi-img-sdk-");
+  const tempScriptPath = tempDir + "/test.mjs";
+
+  try {
+    const testScript = `
+import { NeuroLink } from '${process.cwd()}/dist/index.js';
+import { z } from 'zod';
+import { readFileSync } from 'fs';
+
+async function run() {
+  const sdk = new NeuroLink();
+  const img = readFileSync('${process.cwd()}/${screenshotPath}');
+
+  // input.images (not input.files) is the canonical multi-image input.
+  // 3+ image content parts trigger hasVideoFrames=true → handleVideoFrameGeneration
+  // fires and returns videoAnalysisResult while ignoring options.schema.
+  // Deterministic hijack signature: result.usage.total === 0 (hijack returns
+  // hardcoded {input:0,output:0,total:0} when no systemPrompt is set).
+  // Standard flow always reports real token counts from the AI SDK.
+  const schema = z.object({
+    images: z.array(z.object({
+      index: z.number(),
+      description: z.string(),
+    })),
+  });
+
+  try {
+    const result = await sdk.generate({
+      input: {
+        text: 'For each of the 3 images, return its 0-based index and a one-sentence description as JSON matching the schema.',
+        images: [img, img, img],
+      },
+      provider: 'vertex',
+      model: 'gemini-2.5-pro',
+      schema,
+      disableTools: true,
+    });
+
+    const totalUsage = result?.usage?.total ?? 0;
+    if (totalUsage === 0) {
+      console.log('Schema 3+ Images: FAIL - BUG REPRODUCED: usage.total=0 indicates handleVideoFrameGeneration hijack fired (schema bypassed). content=' + (result.content || '').slice(0, 200));
+      process.exit(1);
+    }
+
+    let parsed;
+    try {
+      parsed = typeof result.content === 'string' ? JSON.parse(result.content.replace(/^\\\`\\\`\\\`json\\s*|\\s*\\\`\\\`\\\`$/g, '').trim()) : result.content;
+    } catch (e) {
+      console.log('Schema 3+ Images: FAIL - non-JSON content. content=' + (result.content || '').slice(0, 200));
+      process.exit(1);
+    }
+    const valid = schema.safeParse(parsed);
+    if (valid.success) {
+      // Tighten the assertion: 3 input images must produce 3 entries with
+      // indices 0,1,2. Schema-shape-only would let semantically-wrong
+      // responses (e.g. 1 image described 3 times) silently pass.
+      const indices = valid.data.images.map((x) => x.index).sort((a, b) => a - b);
+      const exactThree = valid.data.images.length === 3 && indices.join(',') === '0,1,2';
+      if (exactThree) {
+        console.log('Schema 3+ Images: PASS - schema honored, usage.total=' + totalUsage + ', images.length=' + valid.data.images.length);
+        process.exit(0);
+      }
+      console.log('Schema 3+ Images: FAIL - schema valid but expected exactly 3 entries with indices 0,1,2. images.length=' + valid.data.images.length + ' indices=[' + indices.join(',') + '] usage.total=' + totalUsage);
+      process.exit(1);
+    }
+    console.log('Schema 3+ Images: FAIL - response did not match schema. parsed=' + JSON.stringify(parsed).slice(0, 200));
+    process.exit(1);
+  } catch (error) {
+    const msg = error?.message || '';
+    if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
+      console.log('Schema 3+ Images: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    console.log('Schema 3+ Images: FAIL - ' + (msg || String(error)).slice(0, 300));
+    process.exit(1);
+  }
+}
+run();
+`;
+
+    fs.writeFileSync(tempScriptPath, testScript);
+    const result = await runCommand("node", [tempScriptPath]);
+
+    if (result.stdout.includes("SKIP")) {
+      logTest(
+        "Schema Output with 3+ Images (SDK)",
+        "SKIP",
+        "credentials or fixture missing",
+      );
+      return null;
+    }
+    if (result.stdout.includes("PASS")) {
+      logTest(
+        "Schema Output with 3+ Images (SDK)",
+        "PASS",
+        "schema honored for multi-image input",
+      );
+      return true;
+    }
+    const failLine =
+      result.stdout.split("\n").find((l) => l.includes("FAIL")) ||
+      result.stdout.slice(0, 300);
+    logTest("Schema Output with 3+ Images (SDK)", "FAIL", failLine);
+    return false;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logTest("Schema Output with 3+ Images (SDK)", "FAIL", errorMessage);
+    return false;
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function testJsonFormatWithMultipleImagesSDK(): Promise<boolean | null> {
+  logSection("Testing output.format=json with 3+ Images (SDK)");
+
+  const screenshotPath = "test/fixtures/sample-screenshot.png";
+  if (!fs.existsSync(screenshotPath)) {
+    logTest(
+      "JSON Format with 3+ Images (SDK)",
+      "SKIP",
+      "screenshot fixture not available",
+    );
+    return null;
+  }
+
+  const tempDir = fs.mkdtempSync(os.tmpdir() + "/test-json-multi-img-sdk-");
+  const tempScriptPath = tempDir + "/test.mjs";
+
+  try {
+    const testScript = `
+import { NeuroLink } from '${process.cwd()}/dist/index.js';
+import { readFileSync } from 'fs';
+
+async function run() {
+  const sdk = new NeuroLink();
+  const img = readFileSync('${process.cwd()}/${screenshotPath}');
+
+  // Same deterministic hijack signature as the schema test:
+  // result.usage.total === 0 ⇒ handleVideoFrameGeneration fired, output.format ignored.
+  try {
+    const result = await sdk.generate({
+      input: {
+        text: 'Return ONLY a JSON object of the form {"count": <number of images attached>}. No prose. No markdown fences.',
+        images: [img, img, img],
+      },
+      provider: 'vertex',
+      model: 'gemini-2.5-pro',
+      output: { format: 'json' },
+      disableTools: true,
+    });
+
+    const totalUsage = result?.usage?.total ?? 0;
+    if (totalUsage === 0) {
+      console.log('JSON 3+ Images: FAIL - BUG REPRODUCED: usage.total=0 indicates handleVideoFrameGeneration hijack fired (output.format=json bypassed). content=' + (result.content || '').slice(0, 200));
+      process.exit(1);
+    }
+
+    let parsed;
+    try {
+      parsed = typeof result.content === 'string' ? JSON.parse(result.content) : result.content;
+    } catch (e) {
+      console.log('JSON 3+ Images: FAIL - non-JSON content. content=' + (result.content || '').slice(0, 200));
+      process.exit(1);
+    }
+    if (parsed && typeof parsed === 'object' && Number(parsed.count) === 3) {
+      console.log('JSON 3+ Images: PASS - json output honored, usage.total=' + totalUsage + ', count=' + parsed.count);
+      process.exit(0);
+    }
+    console.log('JSON 3+ Images: FAIL - response did not match expected {"count":3}. parsed=' + JSON.stringify(parsed).slice(0, 200));
+    process.exit(1);
+  } catch (error) {
+    const msg = error?.message || '';
+    if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
+      console.log('JSON 3+ Images: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    console.log('JSON 3+ Images: FAIL - ' + (msg || String(error)).slice(0, 300));
+    process.exit(1);
+  }
+}
+run();
+`;
+
+    fs.writeFileSync(tempScriptPath, testScript);
+    const result = await runCommand("node", [tempScriptPath]);
+
+    if (result.stdout.includes("SKIP")) {
+      logTest(
+        "JSON Format with 3+ Images (SDK)",
+        "SKIP",
+        "credentials or fixture missing",
+      );
+      return null;
+    }
+    if (result.stdout.includes("PASS")) {
+      logTest(
+        "JSON Format with 3+ Images (SDK)",
+        "PASS",
+        "output.format=json honored for multi-image input",
+      );
+      return true;
+    }
+    const failLine =
+      result.stdout.split("\n").find((l) => l.includes("FAIL")) ||
+      result.stdout.slice(0, 300);
+    logTest("JSON Format with 3+ Images (SDK)", "FAIL", failLine);
+    return false;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logTest("JSON Format with 3+ Images (SDK)", "FAIL", errorMessage);
+    return false;
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================
 // Model Alias Resolution Tests (NL-004)
 // ============================================================
 
@@ -4831,6 +5251,23 @@ async function runAllTests(): Promise<void> {
       fn: testImageGenerationUnsupportedProvider,
     },
     { name: "Google AI Studio Image", fn: testGoogleAIStudioImageGeneration },
+    // Routing bug repros (Bug 1: dual-mode image-model text request, Bug 2: video-frame hijack on schema/json)
+    {
+      name: "Text Request on Dual-Mode Image Model (CLI)",
+      fn: testTextRequestOnDualModeImageModelCLI,
+    },
+    {
+      name: "Text Request on Dual-Mode Image Model (SDK)",
+      fn: testTextRequestOnDualModeImageModelSDK,
+    },
+    {
+      name: "Schema Output with 3+ Images (SDK)",
+      fn: testSchemaWithMultipleImagesSDK,
+    },
+    {
+      name: "JSON Format with 3+ Images (SDK)",
+      fn: testJsonFormatWithMultipleImagesSDK,
+    },
     { name: "CLI Generate", fn: testCLIGenerate },
     { name: "CLI Stream", fn: testCLIStream },
     { name: "SDK Generate", fn: () => testSDKGenerate(sharedSdk) },


### PR DESCRIPTION
## Summary

- **Bug 1**: Dual-mode Gemini image models (`gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image`, `gemini-3-pro-image-preview`) decide per-request whether to emit an image or text. When the model emitted text, `parseImageGenerationResponse` threw `"model returned text instead of image data"` and burned 3 retries — even though the response already carried the answer. Now returns the text via a `{ textFallback }` discriminated-union branch and `executeImageGeneration` packages it as a normal text result.
- **Bug 2**: `handleVideoFrameGeneration` fired whenever a request had ≥3 image content parts, ignored `options.schema` / `options.output.format`, and called `executeVideoAnalysis` with hardcoded `gemini-2.5-flash` returning prose. Schema callers silently lost their structured-output contract. Now early-returns when `options.schema` or `options.output?.format` is set, so the request falls through to the standard generate flow which honors both.

Image happy path unchanged. Genuinely-empty Vertex responses still throw. No public-API surface change beyond the now-richer `parseImageGenerationResponse` return type (private method).

## Files

- `src/lib/core/baseProvider.ts` — Bug 2 fix: `handleVideoFrameGeneration` schema/format gate
- `src/lib/providers/googleVertex.ts` — Bug 1 fix: `parseImageGenerationResponse` discriminated union + `executeImageGeneration` text-fallback handling
- `test/continuous-test-suite.ts` — 4 new end-to-end tests + runner registration

## Repro evidence (pre-fix)

```
[NEUROLINK:ERROR] Image generation failed {"error":"[vertex] Image generation completed but model returned text instead of image data. Model: gemini-3.1-flash-image-preview","prompt":"What is the capital of France? Reply with one word only."}
[BUG-1-TRACE] parseImageGenerationResponse: no image part {"candidatePartCount":3,"partTypes":["text","text","text"],"hasTextContent":true,"textPreview":"...the answer: Paris","textTotalLength":520}

Schema 3+ Images: FAIL - BUG REPRODUCED: usage.total=0 indicates handleVideoFrameGeneration hijack fired (schema bypassed)
JSON 3+ Images:   FAIL - BUG REPRODUCED: usage.total=0 indicates handleVideoFrameGeneration hijack fired (output.format=json bypassed)
```

## Post-fix (all 4 PASS)

```
Bug 1 CLI: Returns "Paris" (model's actual response surfaced as text)
SDK Text on Image Model: PASS - text returned, no imageOutput
Schema 3+ Images:        PASS - schema honored, usage.total=1209, images.length=3
JSON 3+ Images:          PASS - json output honored, usage.total=1079, count=3
```

## Test plan

- [x] `pnpm run check` — 0 errors, 0 warnings (3628 files)
- [x] `pnpm run lint` — 0 errors (18 pre-existing warnings in unchanged files)
- [x] Bug 1 CLI repro against Vertex `gemini-3.1-flash-image-preview` returns text instead of throwing
- [x] Bug 1 SDK repro asserts `result.content` has the answer + `result.imageOutput` is absent
- [x] Bug 2 schema repro against Vertex `gemini-2.5-pro` with 3 images + Zod schema asserts `usage.total > 0` (deterministic hijack signal) and schema validates
- [x] Bug 2 json repro with `output: { format: "json" }` asserts `usage.total > 0` and JSON parses
- [ ] Reviewer to confirm: image happy-path unchanged (existing `testCLIGenerateImage`, `testSDKGenerateImage`, `testGoogleAIStudioImageGeneration` still pass)
- [ ] Reviewer to confirm: bare 3-image queries (no schema, no format) still route through video-analysis (existing video-frame behavior preserved)

## Bug-2 test rationale: why `usage.total === 0` is the assertion, not response shape

Asserting on response content alone produces false positives — the hijacked path uses `gemini-2.5-flash` which can coincidentally emit JSON when the prompt requests it. The hijack returns a hardcoded `{ input: 0, output: 0, total: 0 }` usage when no `systemPrompt` is set; the standard generate flow always reports real token counts from the AI SDK. Asserting `usage.total > 0` is therefore the deterministic signal that the request reached the real model API rather than `executeVideoAnalysis`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured output (schema/JSON format) requests with multimodal image models
  * Enhanced handling when image generation returns text responses instead of image data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->