### PR TITLE
fix(mcp/auth): add 30s timeout to OAuth token operations

### DIFF
--- a/src/lib/mcp/auth/oauthClientProvider.ts
+++ b/src/lib/mcp/auth/oauthClientProvider.ts
@@ -20,6 +20,10 @@ import {
   calculateExpiresAt,
 } from "./tokenStorage.js";
 import { logger } from "../../utils/logger.js";
+import { withTimeout } from "../../utils/errorHandling.js";
+
+/** Default timeout for OAuth token operations (30 seconds) */
+const OAUTH_TOKEN_TIMEOUT_MS = 30000;
 
 /**
  * NeuroLink OAuth Provider for MCP HTTP Transport
@@ -194,15 +198,21 @@ export class NeuroLinkOAuthProvider {
       body.set("code_verifier", codeVerifier);
     }
 
-    // Request tokens
-    const response = await fetch(this.config.tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-      },
-      body: body.toString(),
-    });
+    // Request tokens with timeout protection
+    const response = await withTimeout(
+      fetch(this.config.tokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: body.toString(),
+      }),
+      OAUTH_TOKEN_TIMEOUT_MS,
+      new Error(
+        `OAuth token exchange timed out after ${OAUTH_TOKEN_TIMEOUT_MS}ms`,
+      ),
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -246,14 +256,21 @@ export class NeuroLinkOAuthProvider {
       body.set("client_secret", this.config.clientSecret);
     }
 
-    const response = await fetch(this.config.tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-      },
-      body: body.toString(),
-    });
+    // Refresh tokens with timeout protection
+    const response = await withTimeout(
+      fetch(this.config.tokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: body.toString(),
+      }),
+      OAUTH_TOKEN_TIMEOUT_MS,
+      new Error(
+        `OAuth token refresh timed out after ${OAUTH_TOKEN_TIMEOUT_MS}ms`,
+      ),
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -299,13 +316,20 @@ export class NeuroLinkOAuthProvider {
     }
 
     try {
-      await fetch(revocationUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: body.toString(),
-      });
+      // Revoke tokens with timeout protection
+      await withTimeout(
+        fetch(revocationUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+        }),
+        OAUTH_TOKEN_TIMEOUT_MS,
+        new Error(
+          `OAuth token revocation timed out after ${OAUTH_TOKEN_TIMEOUT_MS}ms`,
+        ),
+      );
     } catch (error) {
       logger.warn(
         `[NeuroLinkOAuthProvider] Token revocation failed: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary

- Wrap `fetch` calls in `NeuroLinkOAuthProvider` with `withTimeout()` so token exchange, refresh, and revocation can never hang indefinitely.
- A stalled OAuth endpoint would otherwise block MCP HTTP transport indefinitely.

| Operation | Timeout |
| --- | --- |
| Token exchange | 30s |
| Token refresh | 30s |
| Token revocation | 30s |

Each timeout surfaces a descriptive error so callers can distinguish network hangs from auth failures.

## Test plan

- [x] `pnpm run check` passes (0 errors)
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings in untouched files)
- [ ] Manually verify OAuth token timeout fires when endpoint is unresponsive
- [ ] Confirm normal OAuth flows remain unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth token exchange, refresh, and revocation operations now enforce a 30-second timeout to prevent indefinite hangs. Timeout errors are thrown with specific error messages, improving error handling and reliability during authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->