### PR TITLE
feat(tokens): cap Gemini 3 + image models at 32768 output tokens

### DIFF
--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -20,10 +20,21 @@ export const PDF_IMAGE_GENERATION_MODELS = [
 
 // Global Location Models
 // Models that require global location configuration (uses aiplatform.googleapis.com instead of region-specific endpoints)
+// Includes Gemini 3.x text and image models, which are only available via the global endpoint on Vertex AI.
+// IMAGE_GENERATION_MODELS is spread in to keep the two lists from drifting:
+// any new image-gen model added there is automatically routed to global here.
 export const GLOBAL_LOCATION_MODELS = [
-  "gemini-3-pro-image-preview",
-  "gemini-2.5-flash-image",
-  "gemini-3.1-flash-image-preview",
+  // Image generation (sourced from IMAGE_GENERATION_MODELS)
+  ...IMAGE_GENERATION_MODELS,
+  // Gemini 3.1 text models (global-only)
+  "gemini-3.1-pro-preview",
+  "gemini-3.1-flash-lite-preview",
+  "gemini-3.1-pro-preview-customtools",
+  // Gemini 3 text models (global-only)
+  "gemini-3-pro-preview",
+  "gemini-3-pro-preview-11-2025",
+  "gemini-3-pro-latest",
+  "gemini-3-flash-preview",
 ];
 
 // Core AI Generation Defaults

--- a/src/lib/utils/tokenLimits.ts
+++ b/src/lib/utils/tokenLimits.ts
@@ -3,8 +3,38 @@
  * Provides safe maxTokens values based on provider and model capabilities
  */
 
-import { PROVIDER_MAX_TOKENS } from "../core/constants.js";
+import {
+  PROVIDER_MAX_TOKENS,
+  IMAGE_GENERATION_MODELS,
+} from "../core/constants.js";
 import { logger } from "./logger.js";
+
+// Gemini 3 models and Gemini 2.5 image models have a hard limit of 32768 output tokens
+const GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS = 32768;
+
+/**
+ * Check if a model has the restricted 32768 output token limit
+ * This applies to:
+ * - All Gemini 3 models (gemini-3-flash, gemini-3-pro, etc.)
+ * - All Gemini 2.5 image generation models (gemini-2.5-flash-image)
+ */
+function hasRestrictedOutputLimit(model?: string): boolean {
+  if (!model) {
+    return false;
+  }
+
+  // Check for Gemini 3 models
+  if (model.includes("gemini-3")) {
+    return true;
+  }
+
+  // Check for image generation models (includes gemini-2.5-flash-image)
+  if (IMAGE_GENERATION_MODELS.some((m) => model.includes(m))) {
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * Get the safe maximum tokens for a provider and model
@@ -14,6 +44,31 @@ export function getSafeMaxTokens(
   model?: string,
   requestedMaxTokens?: number,
 ): number | undefined {
+  // CRITICAL: Gemini 3 models AND image generation models have a hard limit of 32768 output tokens
+  // This check must happen FIRST, before any other logic, because these models
+  // will reject requests with maxOutputTokens > 32768
+  const isRestrictedModel = hasRestrictedOutputLimit(model);
+  if (isRestrictedModel) {
+    // Explicit undefined/null check so a caller-supplied 0 is preserved
+    // (truthy checks would treat 0 as "unset" and silently fall back to the cap).
+    if (
+      requestedMaxTokens !== undefined &&
+      requestedMaxTokens !== null &&
+      requestedMaxTokens > GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS
+    ) {
+      logger.warn(
+        `Requested maxTokens ${requestedMaxTokens} exceeds ${model} limit of ${GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS}. Using ${GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS} instead.`,
+      );
+      return GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS;
+    }
+    // If no maxTokens specified, use the restricted limit as default
+    if (requestedMaxTokens === undefined || requestedMaxTokens === null) {
+      return GEMINI_RESTRICTED_MAX_OUTPUT_TOKENS;
+    }
+    // Otherwise, use the requested value (it's within limits, including 0)
+    return requestedMaxTokens;
+  }
+
   // Get provider-specific limits
   const providerLimits =
     PROVIDER_MAX_TOKENS[provider as keyof typeof PROVIDER_MAX_TOKENS];


### PR DESCRIPTION
## Summary

- Gemini 3.x models and Gemini 2.5 image models reject any `maxOutputTokens > 32768` with a 400 from the upstream API.
- Without a client-side cap, callers passing explicit (or higher provider-default) `maxTokens` silently fail when they hit one of these models.
- `getSafeMaxTokens()` now detects `gemini-3*` names and any model in `IMAGE_GENERATION_MODELS`, caps requested values, and falls back to 32768 when no `maxTokens` is provided.
- Add Gemini 3 / 3.1 text-model identifiers to `GLOBAL_LOCATION_MODELS` so Vertex routes them to the global aiplatform endpoint (the only endpoint that serves these models today).

The cap runs ahead of the regular provider-limit logic, so the new behavior only triggers for the affected models; all other paths are unchanged.

## Test plan

- [x] `pnpm run check` passes (0 errors)
- [x] `pnpm run lint` passes (0 errors)
- [ ] Verify a request with `maxTokens: 65536` against `gemini-3-pro-preview` is silently capped to 32768 with the warning logged
- [ ] Verify a request with no `maxTokens` against `gemini-2.5-flash-image` defaults to 32768
- [ ] Confirm non-Gemini-3 / non-image providers are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini 3.1 and Gemini 3 text models via global endpoint.

* **Chores**
  * Implemented 32,768 output-token cap for specific Gemini models to ensure consistent behavior across all requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->