### PR TITLE
fix(proxy): validate pnpm global store compatibility before auto-update install

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -395,13 +395,43 @@ exit 127
 }
 
 /**
+ * Check whether a pnpm binary can install into the global store.
+ *
+ * Multiple pnpm major versions can coexist (e.g., standalone v8 + nvm v10).
+ * They use different store layouts (`store/v10` vs `store/v10/v3`), so a
+ * pnpm that passes `--version` may still fail `pnpm add -g` with
+ * ERR_PNPM_UNEXPECTED_STORE. We detect this by running `pnpm root -g` and
+ * checking whether the resolved global root directory actually exists on disk.
+ */
+function canInstallGlobally(pnpmPath: string): boolean {
+  try {
+    const { execFileSync } = _require(
+      "node:child_process",
+    ) as typeof import("node:child_process");
+    const { existsSync } = _require("fs") as typeof import("fs");
+    const globalRoot = execFileSync(pnpmPath, ["root", "-g"], {
+      encoding: "utf8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    // If the global root exists, this pnpm version is compatible with
+    // the current store layout and can install packages there.
+    return !!globalRoot && existsSync(globalRoot);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Resolve the `pnpm` binary defensively.
  *
- * Tries multiple candidates in order of preference and validates each by
- * running `--version`. Returns the first one that actually works, along
- * with a list of all candidates tried (for diagnostics). This defends
- * against environments where `which pnpm` returns a broken shim or an
- * incompatible version.
+ * Tries multiple candidates in order of preference. Each candidate must:
+ * 1. Respond to `pnpm --version` (binary works)
+ * 2. Have a compatible global store (`pnpm root -g` points to an existing dir)
+ *
+ * This defends against environments with multiple pnpm major versions
+ * (e.g., standalone v8 + nvm v10) where the wrong one would fail with
+ * ERR_PNPM_UNEXPECTED_STORE on `pnpm add -g`.
  *
  * Honors `NEUROLINK_PNPM_PATH` as an escape hatch.
  */
@@ -409,7 +439,12 @@ function resolveFullPnpmPath(): {
   bin: string;
   resolved: boolean;
   version?: string;
-  tried: Array<{ path: string; version?: string; working: boolean }>;
+  tried: Array<{
+    path: string;
+    version?: string;
+    working: boolean;
+    globalStoreOk?: boolean;
+  }>;
 } {
   const candidates: string[] = [];
 
@@ -454,18 +489,34 @@ function resolveFullPnpmPath(): {
     return true;
   });
 
-  // Probe each candidate
+  // Probe each candidate: must pass --version AND have a compatible global store
   const tried = unique.map((path) => {
     const version = probeBinVersion(path);
-    return { path, version, working: version !== undefined };
+    const working = version !== undefined;
+    const globalStoreOk = working ? canInstallGlobally(path) : false;
+    return { path, version, working, globalStoreOk };
   });
 
-  const working = tried.find((r) => r.working);
-  if (working) {
+  // Prefer a candidate that can actually install globally
+  const fullyWorking = tried.find((r) => r.working && r.globalStoreOk);
+  if (fullyWorking) {
     return {
-      bin: working.path,
+      bin: fullyWorking.path,
       resolved: true,
-      version: working.version,
+      version: fullyWorking.version,
+      tried,
+    };
+  }
+
+  // Fall back to any candidate that at least responds to --version
+  // (better than nothing — the install may still fail, but will be
+  // caught and suppressed by the caller)
+  const anyWorking = tried.find((r) => r.working);
+  if (anyWorking) {
+    return {
+      bin: anyWorking.path,
+      resolved: true,
+      version: anyWorking.version,
       tried,
     };
   }


### PR DESCRIPTION
## Summary

- The auto-update guard picks the first `pnpm` binary that responds to `--version`, but on systems with multiple pnpm major versions (e.g., standalone v8 + nvm v10), the wrong one gets selected.
- Different major versions use different global store layouts (`store/v10` vs `store/v10/v3`), causing `pnpm add -g` to fail with `ERR_PNPM_UNEXPECTED_STORE` even though the binary works fine.
- This resulted in **every** auto-update attempt failing and getting suppressed — `lastUpdateAt: null` (no update ever succeeded).

## Fix

Add `canInstallGlobally()` validation to `resolveFullPnpmPath()`. After a candidate passes `--version`, also run `pnpm root -g` and verify the resolved global root directory exists on disk. If the store is incompatible, skip to the next candidate.

Candidate selection is now:
1. Pass `pnpm --version` (binary exists and runs)
2. Pass `pnpm root -g` → path exists (store layout is compatible)

Falls back to any `--version`-passing candidate if none pass the store check, so single-pnpm systems are unaffected.

## Evidence

From production logs (April 18-28):
- 11+ versions suppressed as `install_failed` over 10 days
- Standalone pnpm v8.13.1 at `~/Library/pnpm/pnpm` was selected over nvm pnpm v10.15.1
- `pnpm add -g` failed with `ERR_PNPM_UNEXPECTED_STORE` every time
- Running the same command with the nvm pnpm succeeded with exit code 0

## Test plan

- [ ] Single pnpm system: auto-update works as before (no behavior change)
- [ ] Multi pnpm system (v8 + v10): guard skips incompatible v8 and uses v10
- [ ] Guard logs show `globalStoreOk` status for each candidate in `pnpm candidates:` line
- [ ] No pnpm on system: falls back to `resolved: false` (unchanged behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous test suite with dedicated scripts for evaluation scoring, MCP limits, telemetry gaps, proxy, tasks, tool reliability, authentication, bugfixes, dynamic tests, autoresearch variants, and issue-specific tests
  * Migrated all test suites to a unified harness framework for improved consistency
  * Added composite CI scripts (`test:unit`, `test:live`, `test:product`) for organized test execution

* **Bug Fixes**
  * Enhanced pnpm resolver with improved global store verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->