### PR TITLE
feat(proxy): configurable primary (home) account via routing.primaryAccount

### DIFF
--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -250,6 +250,67 @@ neurolink auth enable anthropic:1-VjRIq
 
 Run `neurolink auth list` to see all accounts and their current status.
 
+### `neurolink auth set-primary`
+
+Designate the proxy's primary (home) Anthropic account by email/label. Writes `routing.primary-account` to the proxy config YAML; the proxy reads it on startup and tries this account first under fill-first (or uses it as the home reference under round-robin). Does **not** touch the encrypted token store and does **not** require re-OAuthing any account.
+
+| Argument   | Type     | Required | Description                                                               |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `<email>`  | `string` | **Yes**  | Email/label of the Anthropic account to make primary.                     |
+| `--config` | `string` | No       | Path to the proxy config file. Default: `~/.neurolink/proxy-config.yaml`. |
+
+If the email is not currently authenticated in the token store, the command still writes the field and prints a warning — the setting activates automatically once the account is added via `auth login --add`. If a proxy is currently running, a restart hint is printed.
+
+**Examples:**
+
+```bash
+# Make alice@example.com primary in the default config
+neurolink auth set-primary alice@example.com
+
+# Use a non-default config path
+neurolink auth set-primary alice@example.com --config ./proxy.yaml
+```
+
+> Note: writing YAML uses `js-yaml.dump`, which does not preserve comments. The command prints a warning before writing if the existing file contains comments. JSON config paths preserve everything except whitespace.
+
+### `neurolink auth get-primary`
+
+Show the proxy's currently configured primary account (and whether it is authenticated).
+
+| Argument   | Type     | Required | Description                                                               |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `--config` | `string` | No       | Path to the proxy config file. Default: `~/.neurolink/proxy-config.yaml`. |
+
+**Examples:**
+
+```bash
+neurolink auth get-primary
+```
+
+Output (when configured and authenticated):
+
+```
+Configured primary: alice@example.com
+Status: authenticated (anthropic:alice@example.com present in token store)
+Source: /Users/.../.neurolink/proxy-config.yaml
+```
+
+### `neurolink auth clear-primary`
+
+Remove `routing.primary-account` (and `routing.primaryAccount`) from the proxy config. The proxy reverts to insertion-order fallback on next start.
+
+| Argument   | Type     | Required | Description                                                               |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `--config` | `string` | No       | Path to the proxy config file. Default: `~/.neurolink/proxy-config.yaml`. |
+
+**Examples:**
+
+```bash
+neurolink auth clear-primary
+```
+
+Idempotent — clearing when no primary is configured prints `No primary account was configured.` and exits 0.
+
 ---
 
 ## 2. Config File (`~/.neurolink/proxy-config.yaml`)
@@ -324,6 +385,19 @@ accounts:
 routing:
   # Account selection strategy: "round-robin" | "fill-first"
   strategy: "fill-first"
+
+  # Primary (home) account: under fill-first this account is tried first;
+  # under round-robin it is the home reference for cooling resets and the
+  # starting offset on member-count changes. Resolved per-request to a
+  # stable token-store key (anthropic:<email>); a numeric index is never
+  # persisted, so reordering accounts in the token store is irrelevant.
+  # When omitted the proxy falls back to insertion-order index 0.
+  # Accepts: primary-account (kebab) or primaryAccount (camel).
+  # Manage via:
+  #   neurolink auth set-primary <email>
+  #   neurolink auth get-primary
+  #   neurolink auth clear-primary
+  primary-account: "alice@example.com"
 
   # Model mappings: remap incoming model names to different provider/model pairs
   # Accepts: model-mappings (kebab) or modelMappings (camel)
@@ -417,12 +491,13 @@ cloaking:
 
 #### Routing Fields
 
-| Field                                      | Type                            | Default  | Required | Description                                                                                                       |
-| ------------------------------------------ | ------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `strategy`                                 | `"round-robin" \| "fill-first"` | _(none)_ | No       | Account selection strategy. `round-robin` rotates across accounts. `fill-first` uses one account until exhausted. |
-| `model-mappings` / `modelMappings`         | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                          |
-| `fallback-chain` / `fallbackChain`         | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                 |
-| `passthrough-models` / `passthroughModels` | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                       |
+| Field                                      | Type                            | Default  | Required | Description                                                                                                                                                                                                                                                                    |
+| ------------------------------------------ | ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy`                                 | `"round-robin" \| "fill-first"` | _(none)_ | No       | Account selection strategy. `round-robin` rotates across accounts. `fill-first` uses one account until exhausted.                                                                                                                                                              |
+| `primary-account` / `primaryAccount`       | `string`                        | _(none)_ | No       | Email/label of the Anthropic account to treat as primary (home). Resolved per-request to `anthropic:<email>`; falls back to insertion-order index 0 when absent or when the configured account isn't currently authenticated. Manage via `neurolink auth set-primary <email>`. |
+| `model-mappings` / `modelMappings`         | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                                                                                                                                                                                       |
+| `fallback-chain` / `fallbackChain`         | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                                                                                                                                                                              |
+| `passthrough-models` / `passthroughModels` | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                                                                                                                                                                                    |
 
 #### ModelMapping Fields
 

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -125,6 +125,18 @@ Account sources are checked in priority order:
 2. **Legacy credentials file** (`~/.neurolink/anthropic-credentials.json`) -- only if no TokenStore accounts exist
 3. **Environment variable** (`ANTHROPIC_API_KEY`) -- only if no other accounts exist
 
+#### Designating a primary (home) account
+
+By default the "first" account is the first key in token-store insertion order. To override this without re-OAuthing or editing the encrypted token store, set `routing.primary-account` in the proxy config. The proxy resolves the email to a stable token-store key per request, so the choice survives account additions/removals and only takes effect when that account is currently authenticated:
+
+```bash
+neurolink auth set-primary alice@example.com
+neurolink proxy stop && neurolink proxy start
+curl http://127.0.0.1:55669/status   # stats.primaryAccount.label = alice@example.com
+```
+
+After a 429 cools off, traffic returns to the configured primary (not literal index 0). When the configured account is missing or disabled, the proxy logs a warning at startup and falls back to insertion-order index 0. See the [config reference](./claude-proxy-config-reference.md#neurolink-auth-set-primary) for the full CLI surface (`set-primary` / `get-primary` / `clear-primary`).
+
 ### Fallback Chain
 
 When all Claude accounts are rate-limited, the proxy walks the fallback chain defined in the config file. Each fallback entry specifies a provider and model:

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -40,9 +40,11 @@ import type {
   AccountQuota,
   AuthCommandArgs,
   AuthStatusResult,
+  CliProxyConfigDoc,
   OAuthTokens as OAuthTokensType,
   StoredCredentials,
   SupportedProvider,
+  YamlModule,
 } from "../../lib/types/index.js";
 import { loadAccountQuotas } from "../../lib/proxy/accountQuota.js";
 
@@ -938,6 +940,350 @@ export async function handleEnable(argv: AuthCommandArgs): Promise<void> {
     logger.error(chalk.red("Failed to enable account:"));
     logger.error(
       chalk.red(error instanceof Error ? error.message : "Unknown error"),
+    );
+    process.exit(1);
+  }
+}
+
+// =============================================================================
+// PRIMARY ACCOUNT (proxy routing.primaryAccount in YAML)
+// =============================================================================
+
+const DEFAULT_PROXY_CONFIG_PATH = path.join(
+  NEUROLINK_CONFIG_DIR,
+  "proxy-config.yaml",
+);
+
+/** Lazy-load js-yaml. Returns undefined if unavailable; callers that need YAML
+ *  output (rather than JSON fallback) should error with install guidance. */
+async function tryLoadJsYaml(): Promise<YamlModule | undefined> {
+  try {
+    return (await import(/* @vite-ignore */ "js-yaml" as string)) as YamlModule;
+  } catch {
+    return undefined;
+  }
+}
+
+function isYamlPath(p: string): boolean {
+  const lower = p.toLowerCase();
+  return lower.endsWith(".yaml") || lower.endsWith(".yml");
+}
+
+/** Read and parse a proxy config file. Returns an empty object when the file
+ *  doesn't exist (caller can mutate and write). Detects YAML vs JSON by
+ *  extension; falls back to JSON parsing if js-yaml is unavailable for a YAML
+ *  file (errors loudly if neither parser can read it). */
+async function readProxyConfigFile(
+  filePath: string,
+): Promise<CliProxyConfigDoc> {
+  const yamlExpected = isYamlPath(filePath);
+  let raw: string | undefined;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        data: {},
+        format: yamlExpected ? "yaml" : "json",
+        hadComments: false,
+      };
+    }
+    throw err;
+  }
+
+  const hadComments = /^\s*#/m.test(raw);
+  if (yamlExpected) {
+    const yaml = await tryLoadJsYaml();
+    if (yaml) {
+      const parsed = yaml.default?.load?.(raw) ?? yaml.load(raw);
+      return {
+        data:
+          parsed && typeof parsed === "object"
+            ? (parsed as Record<string, unknown>)
+            : {},
+        format: "yaml",
+        hadComments,
+      };
+    }
+    // YAML expected but js-yaml absent — try JSON
+    try {
+      return { data: JSON.parse(raw), format: "json", hadComments };
+    } catch {
+      throw new Error(
+        `Cannot edit ${filePath}: js-yaml is not installed and the file is ` +
+          `not valid JSON. Install js-yaml (pnpm add -D js-yaml) or convert ` +
+          `the file to JSON.`,
+      );
+    }
+  }
+  return { data: JSON.parse(raw), format: "json", hadComments };
+}
+
+/** Serialize and write a proxy config file. */
+async function writeProxyConfigFile(
+  filePath: string,
+  doc: CliProxyConfigDoc,
+): Promise<void> {
+  let serialized: string;
+  if (doc.format === "yaml") {
+    const yaml = await tryLoadJsYaml();
+    if (!yaml) {
+      throw new Error(
+        `Cannot write ${filePath} as YAML: js-yaml is not installed. ` +
+          `Install it (pnpm add -D js-yaml) or use a .json config path.`,
+      );
+    }
+    const dump = yaml.default?.dump ?? yaml.dump;
+    if (!dump) {
+      throw new Error(
+        `Cannot write ${filePath} as YAML: js-yaml module does not expose ` +
+          `a dump function (unexpected version).`,
+      );
+    }
+    serialized = dump(doc.data, {
+      lineWidth: 100,
+      noRefs: true,
+    });
+  } else {
+    serialized = `${JSON.stringify(doc.data, null, 2)}\n`;
+  }
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, serialized, "utf-8");
+}
+
+function getRoutingObject(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const routing = data.routing;
+  if (routing && typeof routing === "object" && !Array.isArray(routing)) {
+    return routing as Record<string, unknown>;
+  }
+  const fresh: Record<string, unknown> = {};
+  data.routing = fresh;
+  return fresh;
+}
+
+function readPrimaryFromRouting(
+  routing: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!routing) {
+    return undefined;
+  }
+  const kebab = routing["primary-account"];
+  if (typeof kebab === "string" && kebab.trim() !== "") {
+    return kebab.trim();
+  }
+  const camel = routing.primaryAccount;
+  if (typeof camel === "string" && camel.trim() !== "") {
+    return camel.trim();
+  }
+  return undefined;
+}
+
+/** Best-effort detection of a running proxy. Mirrors `proxy status` semantics
+ *  without importing the proxy module. */
+function detectRunningProxyPid(): number | undefined {
+  try {
+    const stateFile = path.join(NEUROLINK_CONFIG_DIR, "proxy-state.json");
+    if (!fs.existsSync(stateFile)) {
+      return undefined;
+    }
+    const parsed = JSON.parse(fs.readFileSync(stateFile, "utf-8")) as {
+      pid?: number;
+    };
+    if (!parsed.pid || typeof parsed.pid !== "number") {
+      return undefined;
+    }
+    process.kill(parsed.pid, 0);
+    return parsed.pid;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Handle the set-primary subcommand
+ * `neurolink auth set-primary <email> [--config <path>]`
+ *
+ * Writes routing.primary-account to the proxy config YAML so the proxy
+ * tries this account first under fill-first/round-robin home semantics.
+ * Does not touch the token store.
+ */
+export async function handleSetPrimary(argv: AuthCommandArgs): Promise<void> {
+  const email =
+    argv.email ?? (argv._ && argv._[2] ? String(argv._[2]) : undefined);
+  if (!email || email.trim() === "") {
+    logger.error(chalk.red("Missing required argument: <email>"));
+    logger.always(
+      chalk.blue(
+        "\nUsage: neurolink auth set-primary <email> [--config <path>]\n" +
+          "Run 'neurolink auth list' to see authenticated accounts.\n",
+      ),
+    );
+    process.exit(1);
+  }
+  const trimmed = email.trim();
+  const filePath = argv.config ?? DEFAULT_PROXY_CONFIG_PATH;
+
+  try {
+    const doc = await readProxyConfigFile(filePath);
+    if (doc.hadComments) {
+      logger.always(
+        chalk.yellow(
+          `⚠ Note: existing YAML comments in ${filePath} will not be preserved.`,
+        ),
+      );
+    }
+    const routing = getRoutingObject(doc.data);
+    delete routing.primaryAccount;
+    routing["primary-account"] = trimmed;
+    await writeProxyConfigFile(filePath, doc);
+
+    logger.always(chalk.green(`✓ Set primary account → ${trimmed}`));
+    logger.always(chalk.green(`✓ Saved to ${filePath}`));
+
+    // Token-store presence check (non-fatal)
+    const compoundKey = `anthropic:${trimmed}`;
+    const known = await defaultTokenStore.listByPrefix("anthropic:");
+    if (!known.includes(compoundKey)) {
+      logger.always("");
+      logger.always(
+        chalk.yellow(
+          "⚠ This account is not currently authenticated. Run\n" +
+            "  `neurolink auth login --add` to add it. The proxy will fall\n" +
+            "  back to the first enabled account until then.",
+        ),
+      );
+    }
+
+    // Restart hint
+    const pid = detectRunningProxyPid();
+    if (pid) {
+      logger.always("");
+      logger.always(
+        chalk.yellow(
+          `⚠ A proxy is currently running (PID ${pid}). Restart it to pick\n` +
+            "  up the change: `neurolink proxy stop && neurolink proxy start`.",
+        ),
+      );
+    }
+  } catch (err) {
+    logger.error(chalk.red("Failed to set primary account:"));
+    logger.error(
+      chalk.red(err instanceof Error ? err.message : "Unknown error"),
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Handle the get-primary subcommand
+ * `neurolink auth get-primary [--config <path>]`
+ */
+export async function handleGetPrimary(argv: AuthCommandArgs): Promise<void> {
+  const filePath = argv.config ?? DEFAULT_PROXY_CONFIG_PATH;
+  try {
+    if (!fs.existsSync(filePath)) {
+      logger.always(chalk.blue(`No proxy config file found at ${filePath}.`));
+      logger.always(
+        "Falling back to insertion-order index 0 (no primary configured).",
+      );
+      return;
+    }
+    const doc = await readProxyConfigFile(filePath);
+    const routing =
+      typeof doc.data.routing === "object" && doc.data.routing
+        ? (doc.data.routing as Record<string, unknown>)
+        : undefined;
+    const primary = readPrimaryFromRouting(routing);
+    if (!primary) {
+      logger.always(
+        chalk.blue(
+          `No primary account configured. Falling back to insertion-order ` +
+            `index 0.`,
+        ),
+      );
+      logger.always(
+        `Source: ${filePath} (no \`routing.primaryAccount\` field)`,
+      );
+      return;
+    }
+    const compoundKey = `anthropic:${primary}`;
+    const known = await defaultTokenStore.listByPrefix("anthropic:");
+    const present = known.includes(compoundKey);
+    logger.always(chalk.bold(`Configured primary: ${primary}`));
+    logger.always(
+      `Status: ${
+        present
+          ? chalk.green(`authenticated (${compoundKey} present in token store)`)
+          : chalk.yellow(
+              `not authenticated (token store has no ${compoundKey})`,
+            )
+      }`,
+    );
+    logger.always(`Source: ${filePath}`);
+  } catch (err) {
+    logger.error(chalk.red("Failed to read primary account:"));
+    logger.error(
+      chalk.red(err instanceof Error ? err.message : "Unknown error"),
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Handle the clear-primary subcommand
+ * `neurolink auth clear-primary [--config <path>]`
+ */
+export async function handleClearPrimary(argv: AuthCommandArgs): Promise<void> {
+  const filePath = argv.config ?? DEFAULT_PROXY_CONFIG_PATH;
+  try {
+    if (!fs.existsSync(filePath)) {
+      logger.always(chalk.blue(`No proxy config file found at ${filePath}.`));
+      logger.always("Nothing to clear.");
+      return;
+    }
+    const doc = await readProxyConfigFile(filePath);
+    const routing =
+      typeof doc.data.routing === "object" && doc.data.routing
+        ? (doc.data.routing as Record<string, unknown>)
+        : undefined;
+    const before = readPrimaryFromRouting(routing);
+    if (!before || !routing) {
+      logger.always(chalk.blue("No primary account was configured."));
+      return;
+    }
+    if (doc.hadComments) {
+      logger.always(
+        chalk.yellow(
+          `⚠ Note: existing YAML comments in ${filePath} will not be preserved.`,
+        ),
+      );
+    }
+    delete routing.primaryAccount;
+    delete routing["primary-account"];
+    await writeProxyConfigFile(filePath, doc);
+    logger.always(chalk.green(`✓ Cleared primary account (was: ${before})`));
+    logger.always(chalk.green(`✓ Saved to ${filePath}`));
+
+    const pid = detectRunningProxyPid();
+    if (pid) {
+      logger.always("");
+      logger.always(
+        chalk.yellow(
+          `⚠ A proxy is currently running (PID ${pid}). Restart it to pick\n` +
+            "  up the change: `neurolink proxy stop && neurolink proxy start`.",
+        ),
+      );
+    }
+  } catch (err) {
+    logger.error(chalk.red("Failed to clear primary account:"));
+    logger.error(
+      chalk.red(err instanceof Error ? err.message : "Unknown error"),
     );
     process.exit(1);
   }

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -39,6 +39,7 @@ import type {
   ProxyStartStrategy,
   ProxyState,
   ProxyStatusArgs,
+  ProxyStatusPrimaryAccount,
   ProxyTelemetryAction,
   ProxyTelemetryArgs,
   StatusStats,
@@ -116,6 +117,58 @@ function getProcessStatus(pid: number): "running" | "not_running" | "unknown" {
     }
     return "not_running";
   }
+}
+
+/** Resolve the primary-account info shown in /status. Reads the operator's
+ *  configured email from proxy config and cross-checks it against the token
+ *  store; falls back to the first enabled anthropic account when not set or
+ *  when the configured account isn't currently usable. */
+async function resolveStatusPrimaryAccount(
+  proxyConfig: LoadedProxyConfig | null,
+): Promise<ProxyStatusPrimaryAccount> {
+  const configured = proxyConfig?.routing?.primaryAccount?.trim() || null;
+  let enabledAnthropicKeys: string[] = [];
+  try {
+    const { tokenStore } = await import("../../lib/auth/tokenStore.js");
+    const all = await tokenStore.listByPrefix("anthropic:");
+    const filtered: string[] = [];
+    for (const key of all) {
+      const disabled = await tokenStore.isDisabled(key);
+      if (!disabled) {
+        filtered.push(key);
+      }
+    }
+    enabledAnthropicKeys = filtered;
+  } catch (err) {
+    logger.debug(
+      `[proxy] /status: failed to enumerate anthropic accounts: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (configured) {
+    const configuredKey = `anthropic:${configured}`;
+    if (enabledAnthropicKeys.includes(configuredKey)) {
+      return {
+        configured,
+        key: configuredKey,
+        label: configured,
+        source: "configured",
+      };
+    }
+  }
+
+  const fallbackKey = enabledAnthropicKeys[0] ?? null;
+  const fallbackLabel = fallbackKey
+    ? (fallbackKey.split(":")[1] ?? null)
+    : null;
+  return {
+    configured,
+    key: fallbackKey,
+    label: fallbackLabel,
+    source: "fallback",
+  };
 }
 
 /**
@@ -750,6 +803,7 @@ async function loadProxyStartConfiguration(
   strategy: ProxyStartStrategy;
   modelRouter: ModelRouter | undefined;
   passthrough: boolean;
+  primaryAccountKey: string | undefined;
 }> {
   const configPath =
     argv.config ?? join(homedir(), ".neurolink", "proxy-config.yaml");
@@ -794,13 +848,52 @@ async function loadProxyStartConfiguration(
     });
   }
 
+  const primaryAccountKey = await resolveBootPrimaryAccountKey(
+    proxyConfig?.routing?.primaryAccount,
+  );
+
   return {
     configPath,
     proxyConfig,
     strategy,
     modelRouter,
     passthrough: argv.passthrough ?? false,
+    primaryAccountKey,
   };
+}
+
+/** Resolve the operator's configured primary email to a stable token-store
+ *  key (anthropic:<email>). Cross-checks the token store and emits a one-time
+ *  startup warning if the configured account isn't authenticated — but still
+ *  returns the key so it activates automatically once the user runs
+ *  `auth login --add`. */
+async function resolveBootPrimaryAccountKey(
+  primaryEmail: string | undefined,
+): Promise<string | undefined> {
+  const trimmed = primaryEmail?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const key = `anthropic:${trimmed}`;
+  try {
+    const { tokenStore } = await import("../../lib/auth/tokenStore.js");
+    const known = await tokenStore.listByPrefix("anthropic:");
+    if (!known.includes(key)) {
+      logger.warn(
+        `[proxy] WARN: configured routing.primaryAccount=${trimmed} not ` +
+          `found in token store; falling back to first enabled account. ` +
+          `Run \`neurolink auth login --add\` to authenticate it, or ` +
+          `\`neurolink auth clear-primary\` to remove the setting.`,
+      );
+    }
+  } catch (err) {
+    logger.debug(
+      `[proxy] could not validate primary account against token store: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return key;
 }
 
 async function createProxyStartApp(params: {
@@ -811,6 +904,7 @@ async function createProxyStartApp(params: {
   port: number;
   host: string;
   proxyConfig: LoadedProxyConfig | null;
+  primaryAccountKey: string | undefined;
 }) {
   const { createClaudeProxyRoutes } =
     await import("../../lib/server/routes/claudeProxyRoutes.js");
@@ -841,6 +935,7 @@ async function createProxyStartApp(params: {
     "",
     params.strategy,
     params.passthrough,
+    params.primaryAccountKey,
   );
 
   for (const route of routeGroup.routes) {
@@ -998,6 +1093,9 @@ async function createProxyStartApp(params: {
       passthrough: params.passthrough,
       version: PROXY_VERSION,
     });
+    const primaryAccount = await resolveStatusPrimaryAccount(
+      params.proxyConfig,
+    );
     return c.json({
       status: "running",
       ready: health.ready,
@@ -1026,6 +1124,7 @@ async function createProxyStartApp(params: {
           rateLimits: account.rateLimitCount,
           cooling: false, // No persistent cooldown — always active
         })),
+        primaryAccount,
       },
       config: params.proxyConfig
         ? { hasRouting: !!params.proxyConfig.routing }
@@ -1384,8 +1483,13 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
     const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime(
       devPaths?.logsDir,
     );
-    const { proxyConfig, strategy, modelRouter, passthrough } =
-      await loadProxyStartConfiguration(argv, spinner);
+    const {
+      proxyConfig,
+      strategy,
+      modelRouter,
+      passthrough,
+      primaryAccountKey,
+    } = await loadProxyStartConfiguration(argv, spinner);
 
     if (spinner) {
       spinner.text = "Configuring server...";
@@ -1401,6 +1505,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       port,
       host,
       proxyConfig,
+      primaryAccountKey,
     });
 
     await initializeProxyOpenTelemetry();

--- a/src/cli/factories/authCommandFactory.ts
+++ b/src/cli/factories/authCommandFactory.ts
@@ -114,6 +114,34 @@ export class AuthCommandFactory {
             },
           )
           .command(
+            "set-primary <email>",
+            "Set the proxy's primary (home) Anthropic account",
+            (yargs) => this.buildSetPrimaryOptions(yargs),
+            async (argv) => {
+              const { handleSetPrimary } = await import("../commands/auth.js");
+              await handleSetPrimary(argv as AuthCommandArgs);
+            },
+          )
+          .command(
+            "get-primary",
+            "Show the proxy's currently configured primary account",
+            (yargs) => this.buildPrimaryConfigOption(yargs),
+            async (argv) => {
+              const { handleGetPrimary } = await import("../commands/auth.js");
+              await handleGetPrimary(argv as AuthCommandArgs);
+            },
+          )
+          .command(
+            "clear-primary",
+            "Clear the proxy's configured primary account",
+            (yargs) => this.buildPrimaryConfigOption(yargs),
+            async (argv) => {
+              const { handleClearPrimary } =
+                await import("../commands/auth.js");
+              await handleClearPrimary(argv as AuthCommandArgs);
+            },
+          )
+          .command(
             "providers",
             "List available authentication providers",
             (yargs) =>
@@ -207,6 +235,18 @@ export class AuthCommandFactory {
           .example(
             "$0 auth enable anthropic:1-VjRIq",
             "Re-enable a disabled account",
+          )
+          .example(
+            "$0 auth set-primary alice@example.com",
+            "Make alice@example.com the proxy's primary (home) account",
+          )
+          .example(
+            "$0 auth get-primary",
+            "Show the proxy's currently configured primary account",
+          )
+          .example(
+            "$0 auth clear-primary",
+            "Remove the configured primary account (use insertion-order fallback)",
           )
           .help();
       },
@@ -398,6 +438,43 @@ export class AuthCommandFactory {
         "$0 auth enable anthropic:1-VjRIq",
         "Re-enable a disabled account",
       );
+  }
+
+  /**
+   * Build options for set-primary subcommand
+   */
+  private static buildSetPrimaryOptions(yargs: Argv): Argv {
+    return yargs
+      .positional("email", {
+        type: "string",
+        description:
+          "Email/label of the Anthropic account to make primary (home)",
+        demandOption: true,
+      })
+      .option("config", {
+        type: "string",
+        description:
+          "Path to the proxy config YAML (default: ~/.neurolink/proxy-config.yaml)",
+      })
+      .example(
+        "$0 auth set-primary alice@example.com",
+        "Write routing.primary-account to the default proxy config",
+      )
+      .example(
+        "$0 auth set-primary alice@example.com --config ./proxy.yaml",
+        "Use a non-default config path",
+      );
+  }
+
+  /**
+   * Build options for get-primary / clear-primary subcommands.
+   */
+  private static buildPrimaryConfigOption(yargs: Argv): Argv {
+    return yargs.option("config", {
+      type: "string",
+      description:
+        "Path to the proxy config YAML (default: ~/.neurolink/proxy-config.yaml)",
+    });
   }
 
   /**

--- a/src/lib/proxy/proxyConfig.ts
+++ b/src/lib/proxy/proxyConfig.ts
@@ -437,6 +437,22 @@ function parseRoutingConfig(
     result.passthroughModels = rawPassthrough.map(String);
   }
 
+  // Primary account (accept kebab-case or camelCase). Email or label of the
+  // Anthropic account that should be tried first ("home"). Resolved to a
+  // stable key (anthropic:<email>) at proxy boot; absence preserves the
+  // pre-existing insertion-order behavior.
+  const rawPrimary = (raw["primary-account"] ?? raw.primaryAccount) as unknown;
+  if (rawPrimary !== undefined) {
+    if (typeof rawPrimary === "string" && rawPrimary.trim() !== "") {
+      result.primaryAccount = rawPrimary.trim();
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.primaryAccount: expected non-empty ` +
+          `string, got ${typeof rawPrimary}`,
+      );
+    }
+  }
+
   return result;
 }
 

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -111,6 +111,11 @@ const BLOCKED_UPSTREAM_HEADERS = new Set([
 let primaryAccountIndex = 0;
 /** Track account count so we can reset primaryAccountIndex when it changes. */
 let lastKnownAccountCount = 0;
+/** Stable account key (e.g. "anthropic:user@example.com") of the configured
+ *  home/primary account. Set once at proxy boot from routing.primaryAccount.
+ *  When undefined, home semantics fall back to enabledAccounts[0] (insertion
+ *  order) — preserves pre-existing behavior. */
+let configuredPrimaryAccountKey: string | undefined;
 
 const MAX_AUTH_RETRIES = 5;
 const MAX_CONSECUTIVE_REFRESH_FAILURES = 15;
@@ -157,27 +162,48 @@ function advancePrimaryIfCurrent(
   primaryAccountIndex = (primaryAccountIndex + 1) % enabledCount;
 }
 
-/** If the configured home primary (index 0) is no longer cooling, reset
- *  primaryAccountIndex back to 0 so traffic returns to the preferred account
- *  once its rate limit window expires. Called at the start of each request. */
+/** Resolve the configured primary's stable key to its current index in the
+ *  request's enabledAccounts list. Returns 0 (insertion-order fallback) when
+ *  no key is configured or the key cannot be matched (account disabled/
+ *  removed). The resolution is per-request because enabledAccounts membership
+ *  can shift between requests. */
+function resolveHomeIndex(enabledAccounts: ProxyPassthroughAccount[]): number {
+  if (!configuredPrimaryAccountKey) {
+    return 0;
+  }
+  const idx = enabledAccounts.findIndex(
+    (a) => a.key === configuredPrimaryAccountKey,
+  );
+  return idx >= 0 ? idx : 0;
+}
+
+/** If the configured home primary is no longer cooling, reset
+ *  primaryAccountIndex back to its index so traffic returns to the preferred
+ *  account once its rate limit window expires. Called at the start of each
+ *  request. Home is resolved fresh per call via resolveHomeIndex. */
 function maybeResetPrimaryToHome(
   enabledAccounts: ProxyPassthroughAccount[],
 ): void {
-  if (enabledAccounts.length <= 1 || primaryAccountIndex === 0) {
+  if (enabledAccounts.length <= 1) {
     return;
   }
-  const homeState = accountRuntimeState.get(enabledAccounts[0].key);
+  const homeIndex = resolveHomeIndex(enabledAccounts);
+  if (primaryAccountIndex === homeIndex) {
+    return;
+  }
+  const homeAccount = enabledAccounts[homeIndex];
+  const homeState = accountRuntimeState.get(homeAccount.key);
   if (
     !homeState ||
     !homeState.coolingUntil ||
     Date.now() >= homeState.coolingUntil
   ) {
     // Home account is no longer cooling — reset to it
-    primaryAccountIndex = 0;
+    primaryAccountIndex = homeIndex;
     if (homeState?.coolingUntil) {
       homeState.coolingUntil = undefined;
       logger.always(
-        `[proxy] home primary account=${enabledAccounts[0].label} cooling expired, resetting primaryAccountIndex to 0`,
+        `[proxy] home primary account=${homeAccount.label} cooling expired, resetting primaryAccountIndex to ${homeIndex}`,
       );
     }
   }
@@ -1704,7 +1730,7 @@ async function loadClaudeProxyAccounts(args: {
     accountStrategy === "round-robin" &&
     orderedAccounts.length !== lastKnownAccountCount
   ) {
-    primaryAccountIndex = 0;
+    primaryAccountIndex = resolveHomeIndex(orderedAccounts);
     lastKnownAccountCount = orderedAccounts.length;
   }
   if (orderedAccounts.length > 1) {
@@ -4717,7 +4743,9 @@ export function createClaudeProxyRoutes(
   basePath: string = "",
   accountStrategy: "round-robin" | "fill-first" = "fill-first",
   passthroughMode: boolean = false,
+  primaryAccountKey?: string,
 ): RouteGroup {
+  configuredPrimaryAccountKey = primaryAccountKey;
   return {
     prefix: `${basePath}/v1`,
     routes: [
@@ -5330,3 +5358,38 @@ export function isTransientHttpFailure(
     normalized.includes("internal server error")
   );
 }
+
+// ---------------------------------------------------------------------------
+// Test hooks (not part of the public SDK API). Only consumed by the proxy
+// continuous-test-suite to drive the in-process resolver/reset logic without
+// spinning up a full proxy. Keep this surface small.
+// ---------------------------------------------------------------------------
+
+export const __testHooks = {
+  resolveHomeIndex,
+  maybeResetPrimaryToHome,
+  setConfiguredPrimaryAccountKey: (key: string | undefined): void => {
+    configuredPrimaryAccountKey = key;
+  },
+  getConfiguredPrimaryAccountKey: (): string | undefined =>
+    configuredPrimaryAccountKey,
+  setPrimaryAccountIndex: (index: number): void => {
+    primaryAccountIndex = index;
+  },
+  getPrimaryAccountIndex: (): number => primaryAccountIndex,
+  setAccountRuntimeState: (
+    key: string,
+    state: Partial<RuntimeAccountState>,
+  ): void => {
+    const existing =
+      accountRuntimeState.get(key) ?? getOrCreateRuntimeState(key);
+    Object.assign(existing, state);
+    accountRuntimeState.set(key, existing);
+  },
+  resetAllRuntimeState: (): void => {
+    accountRuntimeState.clear();
+    primaryAccountIndex = 0;
+    lastKnownAccountCount = 0;
+    configuredPrimaryAccountKey = undefined;
+  },
+};

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -993,6 +993,10 @@ export type AuthCommandArgs = BaseCommandArgs & {
   label?: string;
   account?: string;
   force?: boolean;
+  /** Path to the proxy config YAML, used by set-/get-/clear-primary */
+  config?: string;
+  /** Email passed to `auth set-primary <email>` */
+  email?: string;
   /** Yargs positional arguments */
   _?: (string | number)[];
 };

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1195,10 +1195,36 @@ export type UpdateState = {
 // YAML LOADER (from proxy/proxyConfig.ts)
 // =============================================================================
 
-/** Shape of the dynamically-imported js-yaml module. */
+/** Shape of the dynamically-imported js-yaml module. `dump` is optional —
+ *  read-only consumers (proxy config loader) only need `load`; writers
+ *  (CLI primary-account commands) check `dump` before calling. */
 export type YamlModule = {
   load(content: string): unknown;
-  default?: { load(content: string): unknown };
+  dump?: (obj: unknown, opts?: Record<string, unknown>) => string;
+  default?: {
+    load(content: string): unknown;
+    dump?: (obj: unknown, opts?: Record<string, unknown>) => string;
+  };
+};
+
+/** Snapshot of a parsed proxy config file used by CLI primary-account
+ *  read/edit/write helpers. Tracks the original format and whether comments
+ *  were present (so the CLI can warn that comments will not round-trip). */
+export type CliProxyConfigDoc = {
+  data: Record<string, unknown>;
+  format: "yaml" | "json";
+  hadComments: boolean;
+};
+
+/** Primary-account info exposed by the proxy `/status` endpoint.
+ *  `source` is "configured" when the operator's `routing.primaryAccount` is
+ *  authenticated and enabled, otherwise "fallback" — either no primary set
+ *  or the configured one is missing/disabled. */
+export type ProxyStatusPrimaryAccount = {
+  configured: string | null;
+  key: string | null;
+  label: string | null;
+  source: "configured" | "fallback";
 };
 
 // =============================================================================

--- a/src/lib/types/subscription.ts
+++ b/src/lib/types/subscription.ts
@@ -1117,6 +1117,11 @@ export type ProxyRoutingConfig = {
   modelMappings: ModelMapping[];
   fallbackChain: FallbackEntry[];
   passthroughModels?: string[];
+  /** Email/label of the Anthropic account that should be tried first
+   *  ("home"). When absent, falls back to insertion-order index 0.
+   *  Resolved per-request to a stable key (anthropic:<email>); does not
+   *  encode an index. */
+  primaryAccount?: string;
 };
 
 /** Cloaking plugin config */

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -19,6 +19,10 @@ import { spawn, ChildProcess } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // ============================================================================
 // Types
@@ -1387,6 +1391,439 @@ async function testProxyShutdown(): Promise<boolean | null> {
 }
 
 // ============================================================================
+// Tests: Primary account selection (in-process unit-style)
+// ============================================================================
+
+async function testPrimaryResolveHomeIndex(): Promise<boolean | null> {
+  const { __testHooks } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  __testHooks.resetAllRuntimeState();
+
+  type Acct = { key: string; label: string; token: string; type: "oauth" };
+  const accts: Acct[] = [
+    { key: "anthropic:a@test", label: "a@test", token: "t", type: "oauth" },
+    { key: "anthropic:b@test", label: "b@test", token: "t", type: "oauth" },
+    { key: "anthropic:c@test", label: "c@test", token: "t", type: "oauth" },
+  ];
+
+  // Case: no key configured → 0
+  __testHooks.setConfiguredPrimaryAccountKey(undefined);
+  if (__testHooks.resolveHomeIndex(accts) !== 0) {
+    log("resolveHomeIndex: undefined key did not return 0", "red");
+    return false;
+  }
+
+  // Case: key resolves to its index
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:b@test");
+  if (__testHooks.resolveHomeIndex(accts) !== 1) {
+    log(
+      "resolveHomeIndex: did not return correct index for present key",
+      "red",
+    );
+    return false;
+  }
+
+  // Case: key not in list → 0
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:missing@test");
+  if (__testHooks.resolveHomeIndex(accts) !== 0) {
+    log("resolveHomeIndex: missing key did not fall back to 0", "red");
+    return false;
+  }
+
+  // Case: empty enabledAccounts → 0
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:b@test");
+  if (__testHooks.resolveHomeIndex([]) !== 0) {
+    log("resolveHomeIndex: empty list did not return 0", "red");
+    return false;
+  }
+
+  __testHooks.resetAllRuntimeState();
+  log("resolveHomeIndex: all 4 cases passed", "green");
+  return true;
+}
+
+async function testPrimaryMaybeResetToHome(): Promise<boolean | null> {
+  const { __testHooks } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  __testHooks.resetAllRuntimeState();
+
+  type Acct = { key: string; label: string; token: string; type: "oauth" };
+  const accts: Acct[] = [
+    { key: "anthropic:a@test", label: "a@test", token: "t", type: "oauth" },
+    { key: "anthropic:b@test", label: "b@test", token: "t", type: "oauth" },
+    { key: "anthropic:c@test", label: "c@test", token: "t", type: "oauth" },
+  ];
+
+  // Configure home as index 1 (b), simulate rotation to 2, expect reset to 1.
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:b@test");
+  __testHooks.setPrimaryAccountIndex(2);
+  __testHooks.maybeResetPrimaryToHome(accts);
+  if (__testHooks.getPrimaryAccountIndex() !== 1) {
+    log(
+      `maybeResetPrimaryToHome: expected index 1 after reset to home, got ${__testHooks.getPrimaryAccountIndex()}`,
+      "red",
+    );
+    return false;
+  }
+
+  // Already at home → no-op
+  __testHooks.maybeResetPrimaryToHome(accts);
+  if (__testHooks.getPrimaryAccountIndex() !== 1) {
+    log("maybeResetPrimaryToHome: should have stayed at home", "red");
+    return false;
+  }
+
+  // Home is cooling → does NOT reset
+  __testHooks.setPrimaryAccountIndex(2);
+  __testHooks.setAccountRuntimeState("anthropic:b@test", {
+    coolingUntil: Date.now() + 60_000,
+  });
+  __testHooks.maybeResetPrimaryToHome(accts);
+  if (__testHooks.getPrimaryAccountIndex() !== 2) {
+    log(
+      "maybeResetPrimaryToHome: should NOT have reset while home cooling",
+      "red",
+    );
+    return false;
+  }
+
+  // Cooling expires → resets
+  __testHooks.setAccountRuntimeState("anthropic:b@test", {
+    coolingUntil: Date.now() - 1_000,
+  });
+  __testHooks.maybeResetPrimaryToHome(accts);
+  if (__testHooks.getPrimaryAccountIndex() !== 1) {
+    log(
+      "maybeResetPrimaryToHome: should have reset after cooling expired",
+      "red",
+    );
+    return false;
+  }
+
+  // Configured key absent in enabledAccounts → home falls back to 0
+  __testHooks.resetAllRuntimeState();
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:missing@test");
+  __testHooks.setPrimaryAccountIndex(2);
+  __testHooks.maybeResetPrimaryToHome(accts);
+  if (__testHooks.getPrimaryAccountIndex() !== 0) {
+    log(
+      `maybeResetPrimaryToHome: missing key should fall back to 0, got ${__testHooks.getPrimaryAccountIndex()}`,
+      "red",
+    );
+    return false;
+  }
+
+  __testHooks.resetAllRuntimeState();
+  log("maybeResetPrimaryToHome: 5 cases passed", "green");
+  return true;
+}
+
+// ============================================================================
+// Tests: parseRoutingConfig.primaryAccount field
+// ============================================================================
+
+async function testParseRoutingPrimaryAccount(): Promise<boolean | null> {
+  const { parseRoutingConfig: _parseRoutingConfig } =
+    (await import("../src/lib/proxy/proxyConfig.js")) as {
+      parseRoutingConfig?: unknown;
+    };
+
+  // parseRoutingConfig is internal; skip if not exported
+  if (typeof _parseRoutingConfig !== "function") {
+    log(
+      "parseRoutingConfig is not exported; verifying via loadProxyConfig instead",
+      "yellow",
+    );
+    return await testParseRoutingPrimaryViaLoad();
+  }
+  const parseRoutingConfig = _parseRoutingConfig as (
+    raw: Record<string, unknown> | undefined,
+  ) => { primaryAccount?: string } | undefined;
+
+  const cases: Array<{
+    name: string;
+    input: Record<string, unknown>;
+    expected: string | undefined;
+  }> = [
+    {
+      name: "camelCase",
+      input: { primaryAccount: "user@example.com" },
+      expected: "user@example.com",
+    },
+    {
+      name: "kebab-case",
+      input: { "primary-account": "user@example.com" },
+      expected: "user@example.com",
+    },
+    {
+      name: "trim",
+      input: { primaryAccount: "  user@example.com  " },
+      expected: "user@example.com",
+    },
+    {
+      name: "empty string rejected",
+      input: { primaryAccount: "" },
+      expected: undefined,
+    },
+    {
+      name: "non-string rejected",
+      input: { primaryAccount: 42 },
+      expected: undefined,
+    },
+    {
+      name: "absent",
+      input: {},
+      expected: undefined,
+    },
+  ];
+
+  for (const c of cases) {
+    const result = parseRoutingConfig(c.input);
+    if (result?.primaryAccount !== c.expected) {
+      log(
+        `parseRoutingConfig: ${c.name} failed: expected ${String(c.expected)}, got ${String(result?.primaryAccount)}`,
+        "red",
+      );
+      return false;
+    }
+  }
+  log(`parseRoutingConfig: ${cases.length} cases passed`, "green");
+  return true;
+}
+
+/** Fallback when parseRoutingConfig isn't exported: write a config and run
+ *  loadProxyConfig (always exported), checking the parsed result. Uses JSON
+ *  config files so the test does not depend on js-yaml being installed. */
+async function testParseRoutingPrimaryViaLoad(): Promise<boolean | null> {
+  const { loadProxyConfig } = await import("../src/lib/proxy/proxyConfig.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "proxy-prim-"));
+  try {
+    const kebabPath = path.join(tmpDir, "kebab.json");
+    fs.writeFileSync(
+      kebabPath,
+      JSON.stringify({
+        accounts: { anthropic: [] },
+        routing: { "primary-account": "user@example.com" },
+      }),
+      "utf-8",
+    );
+    const cfg = (await loadProxyConfig(kebabPath)) as {
+      routing?: { primaryAccount?: string };
+    };
+    if (cfg.routing?.primaryAccount !== "user@example.com") {
+      log(
+        `loadProxyConfig kebab: got ${String(cfg.routing?.primaryAccount)}`,
+        "red",
+      );
+      return false;
+    }
+
+    const camelPath = path.join(tmpDir, "camel.json");
+    fs.writeFileSync(
+      camelPath,
+      JSON.stringify({
+        accounts: { anthropic: [] },
+        routing: { primaryAccount: "  user@example.com  " },
+      }),
+      "utf-8",
+    );
+    const cfg2 = (await loadProxyConfig(camelPath)) as {
+      routing?: { primaryAccount?: string };
+    };
+    if (cfg2.routing?.primaryAccount !== "user@example.com") {
+      log(
+        `loadProxyConfig camel+trim: got ${String(cfg2.routing?.primaryAccount)}`,
+        "red",
+      );
+      return false;
+    }
+
+    log("parseRoutingConfig via load: kebab/camel/trim passed", "green");
+    return true;
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================================
+// Tests: /status stats.primaryAccount additive guarantee
+// ============================================================================
+
+async function testStatusPrimaryAccountFallback(): Promise<boolean | null> {
+  // The test proxy is started in testProxyStartup without a routing.primaryAccount
+  // configured (no --config arg). Verify /status reports source="fallback" and a
+  // sensible label, proving the additive guarantee: existing operators see no
+  // behavior change from the new field's absence.
+  try {
+    const resp = await fetchProxy("/status");
+    if (!resp.ok) {
+      log(`/status returned ${resp.status}`, "red");
+      return false;
+    }
+    const body = (await resp.json()) as {
+      stats?: {
+        primaryAccount?: {
+          configured: string | null;
+          key: string | null;
+          label: string | null;
+          source: string;
+        };
+      };
+    };
+    const pa = body.stats?.primaryAccount;
+    if (!pa) {
+      log("Status response missing stats.primaryAccount", "red");
+      return false;
+    }
+    if (pa.source !== "fallback") {
+      log(
+        `Expected source="fallback" with no primary configured, got "${pa.source}"`,
+        "red",
+      );
+      return false;
+    }
+    if (pa.configured !== null) {
+      log(
+        `Expected configured=null with no primary configured, got "${pa.configured}"`,
+        "red",
+      );
+      return false;
+    }
+    log(
+      `stats.primaryAccount fallback OK: label=${String(pa.label)} key=${String(pa.key)}`,
+      "green",
+    );
+    return true;
+  } catch (err) {
+    log(
+      `Status primary fallback error: ${err instanceof Error ? err.message : String(err)}`,
+      "red",
+    );
+    return false;
+  }
+}
+
+// ============================================================================
+// Tests: CLI auth set-primary / get-primary / clear-primary roundtrip
+// ============================================================================
+
+async function testCliPrimaryRoundtrip(): Promise<boolean | null> {
+  const cliPath = path.join(__dirname, "..", "dist", "cli", "index.js");
+  if (!fs.existsSync(cliPath)) {
+    log(`CLI not built at ${cliPath}; run pnpm run build:cli first`, "yellow");
+    return null;
+  }
+
+  // Use a .json path so the test does not depend on js-yaml being installed.
+  // The CLI auth handlers detect format from the extension; behavior is
+  // identical for production YAML configs (verified manually).
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "proxy-prim-cli-"));
+  const cfgPath = path.join(tmpDir, "proxy-config.json");
+  const email = "primary-test@example.com";
+
+  const runCli = (
+    args: string[],
+  ): Promise<{ code: number; stdout: string; stderr: string }> =>
+    new Promise((resolve) => {
+      const child = spawn(process.execPath, [cliPath, ...args], {
+        env: { ...process.env, NEUROLINK_NO_COLOR: "1" },
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("close", (code) =>
+        resolve({ code: code ?? -1, stdout, stderr }),
+      );
+    });
+
+  try {
+    // 1. set-primary writes the field
+    const setRes = await runCli([
+      "auth",
+      "set-primary",
+      email,
+      "--config",
+      cfgPath,
+    ]);
+    if (setRes.code !== 0) {
+      log(`set-primary exited ${setRes.code}: ${setRes.stderr}`, "red");
+      return false;
+    }
+    if (!fs.existsSync(cfgPath)) {
+      log("set-primary did not create the config file", "red");
+      return false;
+    }
+    const yamlContent = fs.readFileSync(cfgPath, "utf-8");
+    if (!yamlContent.includes(email)) {
+      log(`Config does not contain ${email}: ${yamlContent}`, "red");
+      return false;
+    }
+    if (!/primary-account/.test(yamlContent)) {
+      log(
+        `Config does not contain kebab key 'primary-account': ${yamlContent}`,
+        "red",
+      );
+      return false;
+    }
+
+    // 2. get-primary reads it back
+    const getRes = await runCli(["auth", "get-primary", "--config", cfgPath]);
+    if (getRes.code !== 0) {
+      log(`get-primary exited ${getRes.code}: ${getRes.stderr}`, "red");
+      return false;
+    }
+    if (!getRes.stdout.includes(email)) {
+      log(`get-primary output missing ${email}: ${getRes.stdout}`, "red");
+      return false;
+    }
+
+    // 3. clear-primary removes the field
+    const clrRes = await runCli(["auth", "clear-primary", "--config", cfgPath]);
+    if (clrRes.code !== 0) {
+      log(`clear-primary exited ${clrRes.code}: ${clrRes.stderr}`, "red");
+      return false;
+    }
+    const yamlAfter = fs.readFileSync(cfgPath, "utf-8");
+    if (
+      yamlAfter.includes(email) ||
+      /primary-account|primaryAccount/.test(yamlAfter)
+    ) {
+      log(`clear-primary did not remove the field: ${yamlAfter}`, "red");
+      return false;
+    }
+
+    // 4. clear-primary is idempotent
+    const clrRes2 = await runCli([
+      "auth",
+      "clear-primary",
+      "--config",
+      cfgPath,
+    ]);
+    if (clrRes2.code !== 0) {
+      log(
+        `clear-primary (idempotent) exited ${clrRes2.code}: ${clrRes2.stderr}`,
+        "red",
+      );
+      return false;
+    }
+
+    log("CLI primary roundtrip: set/get/clear/clear all passed", "green");
+    return true;
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ============================================================================
 // Test Registration
 // ============================================================================
 
@@ -1409,6 +1846,35 @@ const tests: TestFunction[] = [
     category: "proxy-infra",
   },
   { name: "Count Tokens", fn: testProxyCountTokens, category: "proxy-infra" },
+
+  // Primary account selection (run BEFORE API tests so /status fetches
+  // happen while the proxy is still healthy — the upstream API tests
+  // can hang on auth and break subsequent fetches).
+  {
+    name: "Primary: resolveHomeIndex",
+    fn: testPrimaryResolveHomeIndex,
+    category: "proxy-primary",
+  },
+  {
+    name: "Primary: maybeResetPrimaryToHome",
+    fn: testPrimaryMaybeResetToHome,
+    category: "proxy-primary",
+  },
+  {
+    name: "Primary: parseRoutingConfig.primaryAccount",
+    fn: testParseRoutingPrimaryAccount,
+    category: "proxy-primary",
+  },
+  {
+    name: "Primary: /status fallback (no primary configured)",
+    fn: testStatusPrimaryAccountFallback,
+    category: "proxy-primary",
+  },
+  {
+    name: "Primary: CLI set-primary/get-primary/clear-primary roundtrip",
+    fn: testCliPrimaryRoundtrip,
+    category: "proxy-primary",
+  },
 
   // Error Handling
   {


### PR DESCRIPTION
## Summary

- Adds `routing.primary-account` / `routing.primaryAccount` to `proxy-config.yaml` so operators can designate which authenticated Anthropic account is the proxy's home without re-OAuthing or editing the encrypted token store
- Primary is tracked by stable key (`anthropic:<email>`) and resolved per-request via `resolveHomeIndex(enabledAccounts)` — replaces the hardcoded-zero assumption in `maybeResetPrimaryToHome` and round-robin's count-change reset
- CLI surface: `neurolink auth set-primary <email>`, `get-primary`, `clear-primary` (thin YAML/JSON editor with comment-loss warning)
- `/status` response gains `stats.primaryAccount: { configured, key, label, source }` — fully additive, no breaking change
- Boot wiring warns if configured email is not yet authenticated (non-fatal; activates automatically on `auth login --add`)

## Design doc

`docs/superpowers/specs/2026-05-02-proxy-primary-account-design.md`

## Files changed

| File | What |
|------|------|
| `src/lib/types/subscription.ts` | `primaryAccount?: string` on `ProxyRoutingConfig` |
| `src/lib/types/proxy.ts` | `CliProxyConfigDoc`, `ProxyStatusPrimaryAccount`, extended `YamlModule` |
| `src/lib/types/cli.ts` | `config?`, `email?` on `AuthCommandArgs` |
| `src/lib/proxy/proxyConfig.ts` | Parse `routing.primary-account` / `routing.primaryAccount` |
| `src/lib/server/routes/claudeProxyRoutes.ts` | `configuredPrimaryAccountKey`, `resolveHomeIndex`, updated `maybeResetPrimaryToHome`, `__testHooks` export |
| `src/cli/commands/proxy.ts` | `resolveStatusPrimaryAccount`, pass `primaryAccountKey` to route factory |
| `src/cli/commands/auth.ts` | `handleSetPrimary`, `handleGetPrimary`, `handleClearPrimary` + helpers |
| `src/cli/factories/authCommandFactory.ts` | Register 3 new auth subcommands |
| `test/continuous-test-suite-proxy.ts` | 5 new test cases (resolveHomeIndex, reset-to-home, config parse, /status, CLI roundtrip) |
| `docs/features/claude-proxy.md` | "Designating a primary account" subsection |
| `docs/features/claude-proxy-config-reference.md` | `primary-account` schema + 3 auth subcommand sections |

## Test plan

- [ ] `resolveHomeIndex` — 4 cases: no config, exact match, missing key fallback, multiple accounts
- [ ] `maybeResetPrimaryToHome` — 5 cases: configured+active, configured+cooling, missing key, no config, index already home
- [ ] Config parse — kebab-case, camelCase, leading/trailing trim, missing → undefined
- [ ] `/status` additive — `primaryAccount.source === "fallback"` when no config
- [ ] CLI roundtrip — `set-primary` → `get-primary` → `clear-primary` on a `.json` config file
- [ ] Manual (production only): trigger 429 on primary account, verify rotation, wait cooling window, verify proxy returns to `sachin.sharma@juspay.in` (not insertion-order index 0)

## Backward compatibility

Configs without `routing.primaryAccount` behave identically to before. The new 5th argument to `createClaudeProxyRoutes` is optional. `stats.accounts` in `/status` is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI commands to manage the proxy's primary Anthropic account: `auth set-primary`, `auth get-primary`, and `auth clear-primary`.
  * Introduced `routing.primary-account` configuration field to specify account prioritization in proxy routing.
  * Updated `/status` endpoint to report configured and resolved primary account.

* **Documentation**
  * Added primary account designation guidance including routing behavior and CLI usage examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/neurolink/pull/1017)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->