### PR TITLE
feat(proxy): OpenAI-compatible endpoint + OpenCode auto-config

### DIFF
--- a/docs/features/opencode-proxy-support.md
+++ b/docs/features/opencode-proxy-support.md
@@ -1,0 +1,721 @@
+# OpenCode Support for NeuroLink Proxy
+
+## Status: Implemented & Verified
+
+This document was originally written as a design proposal. Every item it called out as missing or to-be-built has since been implemented and verified end-to-end (see §11). The "what was built" wording in §4 and §8 reflects the delivered state; future-tense language has been kept only where it explains historical context.
+
+---
+
+## 1. Overview
+
+NeuroLink's proxy currently supports **Claude Code** as a client — when `neurolink proxy start` runs, it automatically configures Claude Code by writing `ANTHROPIC_BASE_URL` to `~/.claude/settings.json`. Claude Code then sends Anthropic Messages API requests to the proxy, which routes them to any provider.
+
+This document describes adding **OpenCode** as a second supported client with the **same zero-config experience**: `neurolink proxy start` should auto-configure OpenCode so it connects to the proxy with no manual setup.
+
+### What is OpenCode?
+
+[OpenCode](https://opencode.ai) (github.com/sst/opencode) is an open-source AI coding agent built by the SST team. It is a **TypeScript monorepo** that shares the same technology stack as NeuroLink:
+
+- **Vercel AI SDK** (`ai` package) with `streamText()`, `Tool` types, `ModelMessage`
+- **Provider SDKs**: `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`, `@ai-sdk/google`, `@ai-sdk/amazon-bedrock`, `@ai-sdk/azure`, `@ai-sdk/xai`, `@ai-sdk/mistral`, `@ai-sdk/groq`, `@openrouter/ai-sdk-provider`, and more
+- **MCP**: `@modelcontextprotocol/sdk` for tool integration
+- **Zod**: for tool parameter schemas
+
+OpenCode is provider-agnostic. It supports Claude, OpenAI, Google, Bedrock, Groq, Azure, xAI, Mistral, Cohere, and any OpenAI-compatible endpoint via `@ai-sdk/openai-compatible`.
+
+---
+
+## 2. How Claude Code Auto-Configuration Works Today
+
+When `neurolink proxy start` runs:
+
+1. **Server starts** on configured port (default 4141)
+2. **Accounts are loaded** from proxy config + OAuth credentials
+3. **Claude Code settings are auto-configured**:
+   - Writes to `~/.claude/settings.json`
+   - Sets `env.ANTHROPIC_BASE_URL = "http://localhost:<port>"`
+   - Sets `env.ENABLE_TOOL_SEARCH = "true"`
+   - Preserves original values in `__proxy_original_env` for restoration
+4. **On proxy stop**: restores original Claude Code settings
+
+Key code (`src/cli/commands/proxy.ts`):
+
+```typescript
+const CLAUDE_SETTINGS_PATH = join(homedir(), ".claude", "settings.json");
+const PROXY_MANAGED_KEYS = ["ANTHROPIC_BASE_URL", "ENABLE_TOOL_SEARCH"];
+
+async function setClaudeProxySettings(baseUrl: string): Promise<void> {
+  // Reads ~/.claude/settings.json
+  // Snapshots original env values
+  // Sets ANTHROPIC_BASE_URL to proxy URL
+  // Writes back
+}
+```
+
+Claude Code then sends all requests to the proxy's `/v1/messages` endpoint (Anthropic Messages API format).
+
+---
+
+## 3. How OpenCode Configuration Works
+
+### Config File Locations
+
+OpenCode uses XDG base directories (via `xdg-basedir` npm package):
+
+| Platform    | Global Config Path                                     |
+| ----------- | ------------------------------------------------------ |
+| **macOS**   | `~/Library/Application Support/opencode/opencode.json` |
+| **Linux**   | `~/.config/opencode/opencode.json`                     |
+| **Windows** | `%LOCALAPPDATA%/opencode/opencode.json`                |
+
+Project-level config: `.opencode/opencode.json` in any parent directory.
+
+### Provider Config Schema
+
+From `packages/opencode/src/config/config.ts` (line 787-846):
+
+```typescript
+Config.Provider = ModelsDev.Provider.partial().extend({
+  models: z.record(z.string(), ModelsDev.Model.partial()).optional(),
+  options: z
+    .object({
+      apiKey: z.string().optional(),
+      baseURL: z.string().optional(),
+      // ... timeout, chunkTimeout, etc.
+    })
+    .catchall(z.any())
+    .optional(),
+});
+
+Config.Info = z.object({
+  // ...
+  provider: z.record(z.string(), Config.Provider).optional(),
+  model: z.string().optional(), // format: "provider/model"
+  // ...
+});
+```
+
+### How OpenCode Loads Providers
+
+From `packages/opencode/src/provider/provider.ts`:
+
+1. **Bundled providers** are imported directly (line 127-150):
+
+   ```typescript
+   const BUNDLED_PROVIDERS = {
+     "@ai-sdk/openai": createOpenAI,
+     "@ai-sdk/anthropic": createAnthropic,
+     "@ai-sdk/openai-compatible": createOpenAICompatible,
+     // ... 20+ providers
+   };
+   ```
+
+2. **Custom providers** from config's `provider` field get initialized with their `options` (including `baseURL`, `apiKey`)
+
+3. **Model definitions** come from `models.dev` API (fetched and cached) + config overrides
+
+4. **Auto-discovery**: if env vars for a provider are set (e.g., `ANTHROPIC_API_KEY`), that provider loads automatically
+
+### The Key: `@ai-sdk/openai-compatible`
+
+When OpenCode uses a custom provider with `npm: "@ai-sdk/openai-compatible"`, it:
+
+- Creates an SDK instance via `createOpenAICompatible({ baseURL, apiKey })`
+- Sends requests to `{baseURL}/chat/completions` (the AI SDK appends the path)
+- Uses standard OpenAI Chat Completions wire format
+- Handles streaming via SSE (`data: {"choices":[...]}` format)
+
+---
+
+## 4. The Gap (Closed): What Was Built
+
+### Endpoints — Added
+
+The proxy now exposes both shapes:
+
+| Endpoint                                  | Format                      | For client   | Status                                |
+| ----------------------------------------- | --------------------------- | ------------ | ------------------------------------- |
+| `POST /v1/messages`                       | Anthropic Messages API      | Claude Code  | Pre-existing                          |
+| `POST /v1/messages/count_tokens`          | Anthropic                   | Claude Code  | Pre-existing                          |
+| `GET /v1/models` (Anthropic format)       | Anthropic                   | Claude Code  | Pre-existing                          |
+| **`POST /v1/chat/completions`**           | **OpenAI Chat Completions** | **OpenCode** | **Added (`openaiProxyRoutes.ts`)**    |
+| **`GET /v1/models` (OpenAI list format)** | **OpenAI**                  | **OpenCode** | **Added (`buildModelsListResponse`)** |
+
+### Auto-Configuration — Added
+
+`src/cli/commands/proxy.ts` gained the symmetric helpers used during `proxy start` / `proxy stop`:
+
+- `setOpenCodeProxySettings(baseUrl)` — line 293, writes the `provider.neurolink` block to OpenCode's `opencode.json` (XDG-resolved path)
+- `clearOpenCodeProxySettings(baseUrl)` — line 341, removes only entries whose `baseURL` matches the proxy's
+- Wired into the start path (line 1431) and stop/uninstall paths (lines 1292, 2357)
+- Skipped automatically under `--dev` so isolated dev instances never touch the user's OpenCode config
+
+---
+
+## 5. Architecture
+
+### Data Flow
+
+```
+OpenCode                        NeuroLink Proxy                   Any Provider
+───────                         ──────────────                    ────────────
+@ai-sdk/openai-compatible
+  createOpenAICompatible({
+    baseURL: "http://localhost:4141/v1",
+    apiKey: "proxy-key"
+  })
+      │
+      ▼
+POST /v1/chat/completions ────▶ openaiProxyRoutes.ts
+  {                               │
+    model: "claude-sonnet-4",     ├─ parseOpenAIRequest()
+    messages: [...],              │    → Extract system prompt
+    tools: [...],                 │    → Flatten messages
+    stream: true                  │    → Convert tools (function → AI SDK)
+  }                               │    → Map tool_choice
+                                  │
+                                  ├─ ModelRouter.resolve(model)
+                                  │    → claude-* → anthropic
+                                  │    → gemini-* → vertex
+                                  │    → custom mappings
+                                  │
+                                  ├─ buildProxyTranslationPlan()
+                                  │    → Classify request
+                                  │    → Build fallback chain
+                                  │
+                                  ├─ ctx.neurolink.stream(options) ──────▶ Any Provider
+                                  │                                        (Anthropic, Google,
+                                  │                                         OpenAI, Bedrock, etc.)
+                                  ▼
+                              serializeOpenAIResponse()
+                              OpenAIStreamSerializer
+                                  │
+SSE Response ◀────────────────────┘
+  data: {"choices":[{"delta":{"content":"..."}}]}
+  data: {"choices":[{"delta":{"tool_calls":[...]}}]}
+  data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+  data: [DONE]
+```
+
+### Symmetric Design
+
+| Aspect                 | Claude Code Path                    | OpenCode Path                        |
+| ---------------------- | ----------------------------------- | ------------------------------------ |
+| **Wire format**        | Anthropic Messages API              | OpenAI Chat Completions              |
+| **Endpoint**           | `POST /v1/messages`                 | `POST /v1/chat/completions`          |
+| **Format translator**  | `claudeFormat.ts`                   | `openaiFormat.ts` (NEW)              |
+| **Route handler**      | `claudeProxyRoutes.ts`              | `openaiProxyRoutes.ts` (NEW)         |
+| **Stream serializer**  | `ClaudeStreamSerializer`            | `OpenAIStreamSerializer` (NEW)       |
+| **Auto-config target** | `~/.claude/settings.json`           | XDG `opencode.json`                  |
+| **Auto-config key**    | `env.ANTHROPIC_BASE_URL`            | `provider.neurolink.options.baseURL` |
+| **Internal pipeline**  | Same `ctx.neurolink.stream()`       | Same `ctx.neurolink.stream()`        |
+| **Model routing**      | Same `ModelRouter`                  | Same `ModelRouter`                   |
+| **Account management** | Same accounts, cooldowns, fallbacks | Same accounts, cooldowns, fallbacks  |
+
+---
+
+## 6. Wire Format Translation
+
+### Request: OpenAI → Internal
+
+| OpenAI Field                                     | NeuroLink Internal                             | Notes                                |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------ |
+| `messages[role="system"].content`                | `systemPrompt`                                 | Concatenate multiple system messages |
+| `messages[role="user/assistant/tool"]`           | `conversationMessages[]`                       | Flatten to `{role, content}`         |
+| Last user message `.content`                     | `prompt`                                       | Extracted as string                  |
+| `messages[role="assistant"].tool_calls`          | Inline as `[tool_use:id:name] {args}`          | Same pattern as `claudeFormat.ts`    |
+| `messages[role="tool"]`                          | Inline as `[tool_result:tool_call_id] content` | Same pattern as `claudeFormat.ts`    |
+| `content[type="image_url"].image_url.url`        | `images[]`                                     | From latest user message only        |
+| `tools[].function.{name,description,parameters}` | `tools{}` via `jsonSchema()`                   | AI SDK format                        |
+| `tool_choice: "auto"/"required"/"none"`          | `toolChoice`                                   | Direct mapping                       |
+| `tool_choice: {type:"function",function:{name}}` | `toolChoice: "required"` + `toolChoiceName`    | Named tool                           |
+| `max_tokens` / `max_completion_tokens`           | `maxTokens`                                    | Default 4096 if unset                |
+| `temperature`, `top_p`                           | `temperature`, `topP`                          | Direct                               |
+| `stop`                                           | `stopSequences`                                | Direct                               |
+| `stream`                                         | `stream`                                       | Direct                               |
+
+### Response: Internal → OpenAI
+
+| NeuroLink `InternalResult`              | OpenAI Response                                                     |
+| --------------------------------------- | ------------------------------------------------------------------- |
+| `content`                               | `choices[0].message.content`                                        |
+| `toolCalls[].toolName`                  | `choices[0].message.tool_calls[].function.name`                     |
+| `toolCalls[].args`                      | `choices[0].message.tool_calls[].function.arguments` (stringified!) |
+| `toolCalls[].toolCallId`                | `choices[0].message.tool_calls[].id`                                |
+| `finishReason: "end_turn"/"stop"`       | `finish_reason: "stop"`                                             |
+| `finishReason: "tool-calls"/"tool_use"` | `finish_reason: "tool_calls"`                                       |
+| `finishReason: "length"/"max_tokens"`   | `finish_reason: "length"`                                           |
+| `usage.input`                           | `usage.prompt_tokens`                                               |
+| `usage.output`                          | `usage.completion_tokens`                                           |
+| `usage.total`                           | `usage.total_tokens`                                                |
+| `model`                                 | `model`                                                             |
+| `reasoning`                             | Not standard — drop or use custom field                             |
+
+### Streaming: Internal → OpenAI SSE
+
+| Event           | SSE Frame                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Stream start    | `data: {"choices":[{"delta":{"role":"assistant"}}]}`                                                                                    |
+| Text chunk      | `data: {"choices":[{"delta":{"content":"text"}}]}`                                                                                      |
+| Tool call start | `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_xx","type":"function","function":{"name":"Read","arguments":""}}]}}]}` |
+| Tool call args  | `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"chunk"}}]}}]}`                                           |
+| Finish          | `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{...}}`                                                                 |
+| Done            | `data: [DONE]`                                                                                                                          |
+
+---
+
+## 7. Auto-Configuration Design
+
+### Current (Claude Code)
+
+```
+neurolink proxy start
+  → setClaudeProxySettings("http://localhost:4141")
+    → writes ~/.claude/settings.json
+      → env.ANTHROPIC_BASE_URL = "http://localhost:4141"
+
+neurolink proxy stop
+  → clearClaudeProxySettings()
+    → restores original ~/.claude/settings.json values
+```
+
+### New (OpenCode) — Same Pattern
+
+```
+neurolink proxy start
+  → setClaudeProxySettings(...)   // existing
+  → setOpenCodeProxySettings("http://localhost:4141/v1", "proxy-key")  // NEW
+    → detects OpenCode config path (XDG)
+    → reads existing opencode.json (or creates)
+    → adds provider.neurolink = {
+        npm: "@ai-sdk/openai-compatible",
+        name: "NeuroLink Proxy",
+        env: [],
+        models: { /* available models from proxy config */ },
+        options: {
+          baseURL: "http://localhost:4141/v1",
+          apiKey: "proxy-key"
+        }
+      }
+    → preserves original values for restoration
+    → writes back
+
+neurolink proxy stop
+  → clearClaudeProxySettings()      // existing
+  → clearOpenCodeProxySettings()     // NEW
+    → removes provider.neurolink from opencode.json
+    → restores original values
+```
+
+### OpenCode Config Path Resolution
+
+```typescript
+// Same logic as OpenCode's global/index.ts
+import { xdgConfig } from "xdg-basedir";
+const OPENCODE_CONFIG_DIR = join(
+  xdgConfig ?? join(homedir(), ".config"),
+  "opencode",
+);
+const OPENCODE_CONFIG_PATH = join(OPENCODE_CONFIG_DIR, "opencode.json");
+```
+
+On macOS: `~/Library/Application Support/opencode/opencode.json`
+On Linux: `~/.config/opencode/opencode.json`
+
+### Detection
+
+The proxy should detect whether OpenCode is installed before writing config:
+
+```typescript
+async function isOpenCodeInstalled(): Promise<boolean> {
+  // Check if opencode config directory exists (XDG path)
+  // Or check if opencode binary exists in PATH (which opencode)
+  // Or check if ~/.opencode/ exists in any parent directory
+}
+```
+
+If OpenCode is not installed, skip auto-configuration silently (same behavior as Claude Code — if `~/.claude/` doesn't exist, the proxy doesn't fail).
+
+### Alternative: Env-Var Based Auto-Config
+
+OpenCode's provider system has an `autoload` mechanism. Each provider's custom loader checks for env vars (via `input.env.some((item) => env[item])`). If the provider's required env vars are present, it autoloads.
+
+For providers using `@ai-sdk/openai-compatible`, the env vars are typically:
+
+- `OPENAI_COMPATIBLE_BASE_URL` — the endpoint URL
+- `OPENAI_COMPATIBLE_API_KEY` — the API key
+
+**This means an even simpler auto-config path**: instead of writing to `opencode.json`, the proxy could write env vars to a shared `.env` file or inject them into the process environment. However, the config-file approach is more reliable and matches the Claude Code pattern.
+
+### Both Approaches Combined
+
+The proxy should use **both** approaches for maximum compatibility:
+
+1. **Config file** (primary): Write `provider.neurolink` to `opencode.json` — this gives users a visible, editable config entry with model definitions
+2. **Env vars** (fallback): If the config file approach fails (permissions, etc.), fall back to writing env vars that `@ai-sdk/openai-compatible` auto-detects
+
+---
+
+## 8. Implementation (Delivered)
+
+### New Files (in this branch)
+
+| File                                         | Purpose                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| `src/lib/proxy/openaiFormat.ts`              | OpenAI ↔ Internal translator (parser, serializer, SSE transform)   |
+| `src/lib/server/routes/openaiProxyRoutes.ts` | `/v1/chat/completions` + `/v1/models` + Anthropic loopback bridge  |
+| `src/lib/proxy/proxyTranslationEngine.ts`    | Unified translation engine shared with the Claude route (refactor) |
+| `test/fixtures/opencode-local-proxy.json`    | OpenCode fixture pointing at the dev proxy                         |
+| `docs/features/opencode-proxy-support.md`    | This document (design + manual testing playbook)                   |
+
+OpenAI wire types and `ProxyFormat` / `StreamSerializerAdapter` live in `src/lib/types/proxy.ts` (the canonical types barrel; the original design-time path `proxyTypes.ts` was renamed during the release-line refactor).
+
+### Modified Files
+
+| File                                         | Change (delivered)                                                                          |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `src/lib/server/routes/index.ts`             | Adds `openaiProxy` flag + unified `proxy` flag; registers `createOpenAIProxyRoutes`         |
+| `src/cli/commands/proxy.ts`                  | Adds `setOpenCodeProxySettings()` and `clearOpenCodeProxySettings()`; wired into start/stop |
+| `src/lib/proxy/modelRouter.ts`               | Surfaces `getModelMappings()` / `getPassthroughModels()` for `buildModelsListResponse`      |
+| `src/lib/types/proxy.ts`                     | OpenAI wire-format types + `ProxyFormat` + `StreamSerializerAdapter`                        |
+| `src/lib/types/server.ts`                    | `CreateRoutesOptions` gains `proxy` and `openaiProxy` flags                                 |
+| `src/lib/server/routes/claudeProxyRoutes.ts` | Refactored to share the new translation engine; `/v1/models` returns the unified list       |
+
+### Reused As-Is (no changes needed)
+
+| Component                         | Why it works                                    |
+| --------------------------------- | ----------------------------------------------- |
+| `ModelRouter`                     | `resolve()` is format-agnostic                  |
+| `routingPolicy.ts`                | Request classification works on internal format |
+| `proxyConfig.ts`                  | Account pools, model mappings — format-agnostic |
+| `proxyTracer.ts`                  | OTel tracing — format-agnostic                  |
+| `requestLogger.ts`                | Structured logging — format-agnostic            |
+| `usageStats.ts`                   | Per-account stats — format-agnostic             |
+| NeuroLink `generate()`/`stream()` | The entire backend — unchanged                  |
+
+### Historical Build Sequence (delivered in this order, all complete)
+
+1. ✅ OpenAI wire types added to the proxy types barrel
+2. ✅ `openaiFormat.ts` — parser, response serializer, streaming SSE serializer, error builder
+3. ✅ `openaiProxyRoutes.ts` — `/v1/chat/completions` + `/v1/models` + Anthropic loopback bridge
+4. ✅ `routes/index.ts` updated with `openaiProxy` and unified `proxy` flags
+5. ✅ `setOpenCodeProxySettings()` / `clearOpenCodeProxySettings()` added to `proxy.ts`
+6. ✅ `neurolink proxy start` auto-configures OpenCode (skipped under `--dev`)
+7. ✅ Manual test plan in §11; verified end-to-end against OpenCode 1.3.13
+
+---
+
+## 9. User Experience
+
+### Before (Manual)
+
+User must manually edit OpenCode config to add a custom provider. No auto-detection.
+
+### After (Zero-Config)
+
+```bash
+neurolink proxy start
+# Output:
+# NeuroLink Proxy v9.47.0 listening on http://localhost:4141
+# Claude Code: configured (ANTHROPIC_BASE_URL → http://localhost:4141)
+# OpenCode:    configured (provider.neurolink → http://localhost:4141/v1)
+# 3 accounts loaded (2 anthropic, 1 vertex)
+```
+
+Both Claude Code and OpenCode immediately connect to the proxy. No manual configuration needed.
+
+### Model Selection in OpenCode
+
+After auto-config, users select models in OpenCode's TUI model picker. Available models come from the proxy's model mappings + available accounts. The proxy serves them via `GET /v1/models`.
+
+---
+
+## 10. Edge Cases
+
+| Case                                    | Handling                                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| OpenCode not installed                  | Skip auto-config silently                                                                         |
+| Existing `provider.neurolink` in config | Update `baseURL`/`apiKey`, preserve other fields                                                  |
+| Proxy stops unexpectedly                | OpenCode falls back to its other configured providers                                             |
+| `n > 1` in request                      | Ignore — return single choice (NeuroLink generates n=1)                                           |
+| `response_format: json_object`          | Map to `structuredOutput` where provider supports it                                              |
+| Reasoning/thinking content              | Not in standard OpenAI format — drop (OpenCode handles this per-provider via `ProviderTransform`) |
+| Image content in messages               | `image_url` blocks → extract to `images[]`                                                        |
+| Legacy `functions` field                | Not supported — `tools` only (matches OpenCode's behavior)                                        |
+| `stream_options: {include_usage: true}` | Include usage in final streaming chunk                                                            |
+| Auth (`Authorization: Bearer`)          | Accept any token (validate against proxy config if auth is enabled)                               |
+
+---
+
+## 11. Manual Testing & Verification
+
+This section is a self-contained playbook for verifying the OpenCode proxy support end to end. It assumes you are on the `feat/opencode-support-for-proxy` branch and the global proxy on `:55669` should remain untouched throughout.
+
+### 11.1 Prerequisites
+
+- Node 20+ and `pnpm` available
+- `opencode` CLI installed (`opencode --version` should print 1.3.x or newer)
+- `jq` and `curl` available
+- A working `~/.neurolink/proxy-config.yaml` and `~/.neurolink/.env` (used by the global proxy)
+- The `dist/` directory built from this branch (`pnpm run build:cli` if not built)
+
+### 11.2 Mental Model
+
+You are starting a **second** proxy instance, isolated from the global one:
+
+|                        | Global proxy    | Dev proxy under test     |
+| ---------------------- | --------------- | ------------------------ |
+| Port                   | 55669           | 5555                     |
+| State dir              | `~/.neurolink/` | `<repo>/.neurolink-dev/` |
+| Managed by             | launchd         | foreground process       |
+| Touched by these tests | Never           | Yes                      |
+
+Two safety invariants checked throughout:
+
+- `curl http://localhost:55669/health` → 200 (global never goes down)
+- The dev PID from `.neurolink-dev/proxy-state.json` ≠ the global PID from `~/.neurolink/proxy-state.json`
+
+### 11.3 Why a non-Claude alias is required
+
+OpenCode 1.3.13 hardcodes the Anthropic SDK whenever the model name contains `claude` — it bypasses `/v1/chat/completions` and posts directly to `/v1/messages`. To exercise this branch's new OpenAI endpoint end-to-end, the OpenCode fixture must use a non-claude alias (we use `gpt-4o`) and the proxy must be told to map that alias to a real Anthropic model. We map to **Haiku** because Sonnet aggressively rate-limits 150-KB requests with OpenCode's full tool set and produces noisy 429s during testing.
+
+### 11.4 One-time setup
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+
+# (a) Build CLI if needed
+pnpm run build:cli
+
+# (b) Start fresh — wipe any prior dev state. Global state untouched.
+rm -rf .neurolink-dev
+mkdir -p .neurolink-dev
+
+# (c) Routing config: extend your global mappings with the gpt-4o alias.
+#     Output goes only to .neurolink-dev/proxy-config.yaml — global config is unchanged.
+jq '.routing["model-mappings"] += [{"from":"gpt-4o","to":"claude-haiku-4-5","provider":"anthropic"}]' \
+  ~/.neurolink/proxy-config.yaml > .neurolink-dev/proxy-config.yaml
+
+# (d) OpenCode fixture in an isolated workspace.
+#     The repo ships two fixtures:
+#       - test/fixtures/opencode-local-proxy.json              (claude-sonnet-4-6, hits /v1/messages — exercises Claude passthrough)
+#       - test/fixtures/opencode-local-proxy-openai-route.json (gpt-4o alias,    hits /v1/chat/completions — exercises this branch's new code)
+#     For end-to-end verification of this branch you want the second one.
+mkdir -p /tmp/opencode-proxy-test
+cp test/fixtures/opencode-local-proxy-openai-route.json /tmp/opencode-proxy-test/opencode.json
+```
+
+### 11.5 Start the dev proxy (separate terminal)
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+node dist/cli/index.js proxy start --dev --port 5555 --config .neurolink-dev/proxy-config.yaml
+```
+
+`--dev` scopes all state to `.neurolink-dev/`, skips launchd, and skips client auto-configuration. Wait for `Server is ready`.
+
+In a third terminal, tail the proxy lifecycle log:
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+tail -f .neurolink-dev/logs/proxy-$(date -u +%F).jsonl | jq
+```
+
+### 11.6 Smoke checks
+
+| #   | Check                 | Command                                                                                  | Pass criteria                 |
+| --- | --------------------- | ---------------------------------------------------------------------------------------- | ----------------------------- |
+| S1  | Dev proxy up          | `curl -s http://localhost:5555/health \| jq`                                             | `status: "ok"`, `ready: true` |
+| S2  | Global untouched      | `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:55669/health`                 | `200`                         |
+| S3  | Routing alias visible | `curl -s http://localhost:5555/v1/models \| jq '.data \| map(.id)'`                      | List contains `gpt-4o`        |
+| S4  | PIDs distinct         | `jq -r .pid .neurolink-dev/proxy-state.json && jq -r .pid ~/.neurolink/proxy-state.json` | Two different numbers         |
+
+### 11.7 Wire-level tests (curl directly — no OpenCode needed)
+
+These prove the proxy code is correct in isolation. Each test should print `HTTP 200` and a sane response.
+
+```bash
+PROXY=http://localhost:5555
+
+# W1 Non-streaming
+curl -s $PROXY/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Reply with one word: hello."}],"max_tokens":20}' \
+  | jq '.choices[0].message.content'
+
+# W2 Streaming
+curl -N -s $PROXY/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Count to 3."}],"max_tokens":30,"stream":true}'
+
+# W3 Tool call (request)
+curl -s $PROXY/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":200,
+       "messages":[{"role":"user","content":"What is the weather in Tokyo? Use the tool."}],
+       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get current weather",
+         "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}' \
+  | jq '{finish: .choices[0].finish_reason, tool_calls: .choices[0].message.tool_calls}'
+
+# W4 Tool result round-trip — multi-turn with assistant.tool_calls + role:tool message
+curl -s $PROXY/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":100,
+       "messages":[
+         {"role":"user","content":"What is the weather in Tokyo?"},
+         {"role":"assistant","content":null,"tool_calls":[{"id":"toolu_X","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Tokyo\"}"}}]},
+         {"role":"tool","tool_call_id":"toolu_X","content":"{\"temp_celsius\":18,\"condition\":\"cloudy\"}"}
+       ],
+       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get current weather",
+         "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}' \
+  | jq '.choices[0].message.content'
+
+# W5 Streaming tool call
+curl -N -s $PROXY/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":100,"stream":true,
+       "messages":[{"role":"user","content":"Get weather in Paris."}],
+       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather",
+         "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}'
+```
+
+Expected:
+
+- W1: a one-word reply
+- W2: SSE chunks ending with `data: [DONE]`, each chunk is `chatcmpl-...` shape
+- W3: `finish: "tool_calls"`, `tool_calls[0].function.name == "get_weather"`, args `{"city":"Tokyo"}`
+- W4: a sentence describing 18°C cloudy weather in Tokyo
+- W5: deltas containing `delta.tool_calls[0]` with progressively concatenating `function.arguments`, ending with `finish_reason: "tool_calls"`
+
+### 11.8 OpenCode end-to-end tests
+
+Run from the OpenCode workspace so it picks up the fixture:
+
+```bash
+cd /tmp/opencode-proxy-test
+```
+
+| #   | Command                                                                                                                                                                                                          | Pass criteria                                                                   |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| E1  | `opencode run "Reply with exactly one word: hello"`                                                                                                                                                              | Output contains `hello`                                                         |
+| E2  | `opencode run "What is 17 multiplied by 23? Reply with just the number."`                                                                                                                                        | Output contains `391`                                                           |
+| E3  | `echo "test content $(date)" > marker.txt && opencode run "Read the file marker.txt and tell me what's in it. Just the content."`                                                                                | Output contains `test content`                                                  |
+| E4  | `opencode run "Run the bash command 'echo PROXY_E2E_OK' and report its output. Just the output."`                                                                                                                | Output contains `PROXY_E2E_OK`                                                  |
+| E5  | `rm -f output.txt && opencode run "Create a file output.txt with the text 'success token 7426'. Then read it back."`                                                                                             | `cat output.txt` shows `success token 7426`                                     |
+| E6  | `mkdir -p src && echo "function alpha() { return 1; }" > src/a.js && echo "function alpha2() { return 3; }" > src/b.js && opencode run "Use grep to find all functions whose name starts with 'alpha' in src/."` | Output mentions both `alpha` and `alpha2`                                       |
+| E7  | `opencode run --format json "Reply with one word: jsontest"`                                                                                                                                                     | Output is JSON-line stream including `step_start`, `text`, `step_finish` events |
+| E8  | `opencode run "Write a TypeScript function called add that takes two numbers and returns their sum. Reply with just the code."`                                                                                  | Output contains `function add` (or `const add =`)                               |
+| E9  | Multi-turn: capture session id from a first JSON run, then continue (snippet below)                                                                                                                              | Second turn recalls the number from the first                                   |
+| E10 | `LONG=$(seq 1 200 \| sed 's/^/item_/' \| tr '\n' ' '); opencode run "Items: $LONG. Reply with only the integer count."`                                                                                          | Output contains `200`                                                           |
+
+Snippet for E9:
+
+```bash
+SID=$(opencode run --format json "Remember the number 8472. Reply 'noted'." 2>&1 \
+  | jq -r 'select(.sessionID)|.sessionID' | head -1)
+opencode run --session "$SID" "What number did I tell you to remember? Just the number."
+# expected: 8472
+```
+
+### 11.9 Empirical proof the request flowed through _this branch's_ code
+
+Run this immediately after any OpenCode test above:
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+DATE=$(date -u +%F)
+
+# (a) Body captures appeared on disk for that request.
+ls -td .neurolink-dev/logs/bodies/$DATE/*/ | head -2
+
+# (b) The captured body contains the exact prompt you typed and was tagged with the alias.
+DIR=$(ls -td .neurolink-dev/logs/bodies/$DATE/*/ | head -1)
+REQ=$(ls "$DIR" | grep client_request | head -1)
+gunzip -c "$DIR$REQ" | jq '{
+  user_agent: .headers["user-agent"],
+  content_length: .headers["content-length"],
+  body_model: (.body | (if type=="string" then fromjson else . end) | .model),
+  user_msg: (.body | (if type=="string" then fromjson else . end) | .messages[-1].content)
+}'
+```
+
+Pass criteria for (b):
+
+- `user_agent: "node"` — OpenCode runs on Node
+- `content_length` ≥ 100000 — only OpenCode sends bodies that large (114 tool defs)
+- `body_model: "claude-haiku-4-5"` — the proxy's router rewrote `gpt-4o` → `claude-haiku-4-5` _before_ this capture, proving the request passed through `openaiProxyRoutes.ts` and `routingPolicy.ts`
+- `user_msg` is the exact string you sent OpenCode
+
+Independent confirmation from OpenCode's own logs:
+
+```bash
+cd /tmp/opencode-proxy-test
+opencode run --print-logs --log-level INFO "ping" 2>&1 \
+  | grep -E "providerID=neurolink|pkg=@ai-sdk/openai-compatible"
+```
+
+Pass: two lines including `pkg=@ai-sdk/openai-compatible using bundled provider` — proves the OpenAI-compatible SDK was used, not the bundled Anthropic SDK.
+
+### 11.10 Negative test (proves OpenCode is exclusively talking to the dev proxy)
+
+Stop the dev proxy and verify OpenCode hangs/errors. This rules out any "OpenCode silently bypassed the proxy and went straight to Anthropic" hypothesis.
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+DEV_PID=$(jq -r '.pid' .neurolink-dev/proxy-state.json)
+GLOBAL_PID=$(jq -r '.pid' ~/.neurolink/proxy-state.json)
+[ "$DEV_PID" = "$GLOBAL_PID" ] && echo "ABORT: PIDs match — refusing to kill global" && exit 1
+kill -TERM "$DEV_PID" && sleep 2
+curl -s -o /dev/null -w "dev :5555 after stop: %{http_code}\n" http://localhost:5555/health    # expect 000
+curl -s -o /dev/null -w "global :55669 still: %{http_code}\n"  http://localhost:55669/health    # expect 200
+
+cd /tmp/opencode-proxy-test
+timeout 30 opencode run "ping" ; echo "exit=$?"
+# Pass: exit 124 (timeout) and no LLM reply printed → OpenCode could not reach any model.
+```
+
+Then restart the proxy and rerun any E1–E10 to confirm recovery.
+
+### 11.11 Isolation audit
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+
+# Global proxy unaffected
+curl -s -o /dev/null -w "global :55669 health: %{http_code}\n" http://localhost:55669/health        # 200
+
+# Dev state lives only in repo-local dir, never in HOME
+ls .neurolink-dev/                                                   # has proxy-state.json, logs/, account-quotas.json
+[ -f ~/.neurolink/proxy-state-dev.json ] && echo "BAD: dev leaked into HOME" || echo "no leakage"
+
+# Dev proxy is bound only to 5555
+lsof -nP -iTCP:5555 -sTCP:LISTEN | head -3
+```
+
+### 11.12 Cleanup
+
+```bash
+cd /path/to/neurolink/feat/opencode-support-for-proxy
+DEV_PID=$(jq -r '.pid' .neurolink-dev/proxy-state.json)
+GLOBAL_PID=$(jq -r '.pid' ~/.neurolink/proxy-state.json)
+[ "$DEV_PID" != "$GLOBAL_PID" ] && kill -TERM "$DEV_PID"
+# Optional: remove dev state
+# rm -rf .neurolink-dev
+# Optional: remove test workspace
+# rm -rf /tmp/opencode-proxy-test
+```
+
+### 11.13 Pass/fail summary checklist
+
+A clean run looks like this:
+
+- [ ] S1–S4 all pass (proxy up, global untouched, alias visible, PIDs distinct)
+- [ ] W1–W5 all return HTTP 200 with the expected fields
+- [ ] E1–E10 all produce the expected output strings
+- [ ] §11.9 (a) shows ≥1 capture per OpenCode run; (b) shows your prompt verbatim and `body_model: claude-haiku-4-5`
+- [ ] §11.9 OpenCode debug log shows `pkg=@ai-sdk/openai-compatible`
+- [ ] §11.10 OpenCode times out / errors out when proxy is killed; resumes when restarted
+- [ ] §11.11 global :55669 health is 200 throughout
+
+If any step deviates, the directory `.neurolink-dev/logs/bodies/$(date -u +%F)/<requestId>/` for the failing request contains the exact request body, every retry attempt, and the upstream response — open the matching `*-upstream_response-attempt-N.json.gz` for the upstream error message.
+
+### 11.14 Known caveats
+
+- OpenCode 1.3.13 always sends `claude-*` model names with Anthropic format (bypassing `/v1/chat/completions`). Tests must use the alias indirection described above.
+- Anthropic Sonnet aggressively 429s 150-KB requests when its per-account burst budget is in cooldown. The alias points to **Haiku** to avoid this. If you need to test Sonnet specifically, expect intermittent 429s.
+- Both the parent `/v1/chat/completions` request and (for Anthropic-routed traffic) the inner loopback `/v1/messages` request now emit lifecycle entries in `proxy-*.jsonl`. The parent line carries `accountType: "openai-bridge"`; the child carries the OAuth account details from the Claude passthrough path. Filter on `requestId` to correlate them, or filter on `path: /v1/chat/completions` to see only the parent entries.

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -323,6 +323,144 @@ async function clearClaudeProxySettings(
   return hadBaseUrl || hadToolSearch;
 }
 
+// =============================================================================
+// OPENCODE AUTO-CONFIGURATION
+// =============================================================================
+
+function getOpenCodeConfigDir(): string {
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support", "opencode");
+  }
+  // Linux/other: XDG_CONFIG_HOME or ~/.config
+  return join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+    "opencode",
+  );
+}
+
+const OPENCODE_CONFIG_PATH = join(getOpenCodeConfigDir(), "opencode.json");
+
+/**
+ * Key under which we persist the snapshot of the user's pre-existing
+ * `provider.neurolink` config inside `opencode.json` itself. Persisting (rather
+ * than relying on in-process state) means restoration still works even if the
+ * proxy crashes or shutdown handlers run in a different process.
+ *
+ * Mirrors the Claude pattern (`__proxy_original_env` inside Claude's settings).
+ */
+const OPENCODE_ORIGINAL_KEY = "__proxy_original_neurolink";
+
+async function setOpenCodeProxySettings(
+  baseUrl: string,
+  proxyKey?: string,
+): Promise<void> {
+  const fs = await import("fs");
+
+  const configDir = getOpenCodeConfigDir();
+  try {
+    fs.accessSync(configDir);
+  } catch {
+    // OpenCode not installed — config directory does not exist, skip silently
+    return;
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(OPENCODE_CONFIG_PATH, "utf8"));
+  } catch {
+    // file missing/invalid — create fresh config object
+    config = { provider: {} };
+  }
+
+  const provider = (config.provider ?? {}) as Record<string, unknown>;
+
+  // Persist a snapshot of the user's pre-existing provider.neurolink — but
+  // only the first time we touch the file. Subsequent set() calls must NOT
+  // overwrite the snapshot (otherwise after the proxy writes its own block,
+  // the next set() would store the proxy's block as the "original" and
+  // permanently lose the user's real config on the next clear()).
+  if (!(OPENCODE_ORIGINAL_KEY in config)) {
+    (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY] =
+      "neurolink" in provider
+        ? JSON.parse(JSON.stringify(provider.neurolink))
+        : null;
+  }
+
+  provider.neurolink = {
+    id: "neurolink",
+    name: "NeuroLink Proxy",
+    npm: "@ai-sdk/openai-compatible",
+    env: [],
+    models: {},
+    options: {
+      baseURL: baseUrl,
+      apiKey: proxyKey || "neurolink-proxy",
+    },
+  };
+
+  config.provider = provider;
+  fs.writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+async function clearOpenCodeProxySettings(
+  expectedBaseUrl?: string,
+): Promise<boolean> {
+  const fs = await import("fs");
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(OPENCODE_CONFIG_PATH, "utf8"));
+  } catch {
+    return false;
+  }
+
+  const provider = config.provider as Record<string, unknown> | undefined;
+  if (!provider || !("neurolink" in provider)) {
+    return false;
+  }
+
+  // Check if our proxy URL matches before removing
+  const existing = provider.neurolink as Record<string, unknown> | undefined;
+  if (expectedBaseUrl && existing) {
+    const options = existing.options as Record<string, unknown> | undefined;
+    if (options && typeof options.baseURL === "string") {
+      if (options.baseURL !== expectedBaseUrl) {
+        // User configured a different URL; do not clobber
+        return false;
+      }
+    }
+  }
+
+  const hadNeurolink = "neurolink" in provider;
+
+  // Restore from the snapshot persisted at first set(), regardless of process
+  // identity. Only delete provider.neurolink when the snapshot says the user
+  // explicitly had no entry before — never on an "undefined" snapshot, since
+  // that would mean the snapshot was lost and we cannot prove the entry is ours.
+  if (OPENCODE_ORIGINAL_KEY in config) {
+    const snapshot = (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY];
+    if (snapshot === null) {
+      // User had no provider.neurolink before the proxy started — safe to remove.
+      delete provider.neurolink;
+    } else {
+      provider.neurolink = snapshot;
+    }
+    delete (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY];
+  } else {
+    // No snapshot present — refuse to delete to avoid destroying a config
+    // the proxy may not own (e.g. a user wrote their own `neurolink` block
+    // before the snapshot key was introduced, or this is being cleared from
+    // a process that never ran set()).
+    logger.debug(
+      "[proxy] OpenCode clear: no original-provider snapshot found, leaving provider.neurolink intact",
+    );
+    return false;
+  }
+
+  config.provider = provider;
+  fs.writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2));
+  return hadNeurolink;
+}
+
 async function isProxyHealthy(
   host: string,
   port: number,
@@ -684,9 +822,16 @@ function printProxyBanner(url: string, strategy: string): void {
   logger.always(`  ${chalk.bold("PID:")}        ${chalk.cyan(process.pid)}`);
   logger.always("");
   logger.always(chalk.bold("Endpoints:"));
-  logger.always(`  ${chalk.blue("POST")} /v1/messages  — Proxy to Anthropic`);
-  logger.always(`  ${chalk.green("GET")}  /health       — Health check`);
-  logger.always(`  ${chalk.green("GET")}  /status       — Detailed status`);
+  logger.always(
+    `  ${chalk.blue("POST")} /v1/messages         — Claude proxy (Anthropic format)`,
+  );
+  logger.always(
+    `  ${chalk.blue("POST")} /v1/chat/completions — OpenAI-compatible proxy`,
+  );
+  logger.always(`  ${chalk.green("GET")}  /health              — Health check`);
+  logger.always(
+    `  ${chalk.green("GET")}  /status              — Detailed status`,
+  );
   logger.always("");
   logger.always(chalk.bold("Set in Claude Code:"));
   logger.always(`  ${chalk.cyan(`ANTHROPIC_BASE_URL=${url}`)}`);
@@ -930,6 +1075,8 @@ async function createProxyStartApp(params: {
 }) {
   const { createClaudeProxyRoutes } =
     await import("../../lib/server/routes/claudeProxyRoutes.js");
+  const { createOpenAIProxyRoutes } =
+    await import("../../lib/server/routes/openaiProxyRoutes.js");
   const { Hono } = await import("hono");
 
   const app = new Hono();
@@ -960,7 +1107,14 @@ async function createProxyStartApp(params: {
     params.primaryAccountKey,
   );
 
-  for (const route of routeGroup.routes) {
+  const openaiRouteGroup = createOpenAIProxyRoutes(
+    params.modelRouter,
+    "",
+    params.port,
+  );
+  const allProxyRoutes = [...routeGroup.routes, ...openaiRouteGroup.routes];
+
+  for (const route of allProxyRoutes) {
     const method = route.method.toLowerCase() as "get" | "post";
     app[method](route.path, async (c) => {
       const emptyBody = {};
@@ -1332,6 +1486,15 @@ function registerProxyShutdownHandlers(params: {
       } catch {
         // non-fatal
       }
+      try {
+        const shutdownHost =
+          params.host === "0.0.0.0" ? "localhost" : params.host;
+        await clearOpenCodeProxySettings(
+          `http://${shutdownHost}:${params.port}/v1`,
+        );
+      } catch {
+        // non-fatal
+      }
     }
 
     try {
@@ -1455,6 +1618,17 @@ async function startProxyRuntime(params: {
     } catch (error) {
       logger.debug(
         "[proxy] Failed to auto-configure Claude Code: " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+
+    try {
+      await setOpenCodeProxySettings(`${url}/v1`);
+      logger.always(chalk.green("  ✓ Auto-configured OpenCode settings"));
+      logger.always(chalk.dim("    Restart OpenCode to connect through proxy"));
+    } catch (error) {
+      logger.debug(
+        "[proxy] Failed to auto-configure OpenCode: " +
           (error instanceof Error ? error.message : String(error)),
       );
     }
@@ -2390,6 +2564,11 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
 
     // Restart failed or launchd not installed — clean up Claude settings
     const cleared = await clearClaudeProxySettings(expectedBaseUrl);
+    try {
+      await clearOpenCodeProxySettings(`${expectedBaseUrl}/v1`);
+    } catch {
+      // non-fatal
+    }
 
     const state = loadProxyState();
     if (
@@ -2531,10 +2710,20 @@ export const proxySetupCommand: CommandModule = {
       } catch (e) {
         console.info(
           chalk.yellow(
-            `  ⚠ Could not auto-configure: ${e instanceof Error ? e.message : String(e)}`,
+            `  ⚠ Could not auto-configure Claude Code: ${e instanceof Error ? e.message : String(e)}`,
           ),
         );
         console.info(chalk.yellow(`  Set manually: ANTHROPIC_BASE_URL=${url}`));
+      }
+      try {
+        await setOpenCodeProxySettings(`${url}/v1`);
+        console.info(chalk.green("  ✓ OpenCode configured"));
+      } catch (e) {
+        console.info(
+          chalk.yellow(
+            `  ⚠ Could not auto-configure OpenCode: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
       }
 
       // Done!

--- a/src/lib/proxy/modelRouter.ts
+++ b/src/lib/proxy/modelRouter.ts
@@ -40,4 +40,14 @@ export class ModelRouter {
   getFallbackChain(): FallbackEntry[] {
     return this.fallback;
   }
+
+  /** Return the raw model mapping entries (used by /v1/models). */
+  getModelMappings(): ModelMapping[] {
+    return Array.from(this.mappings.values());
+  }
+
+  /** Return models configured for passthrough (used by /v1/models). */
+  getPassthroughModels(): string[] {
+    return Array.from(this.passthrough);
+  }
 }

--- a/src/lib/proxy/openaiFormat.ts
+++ b/src/lib/proxy/openaiFormat.ts
@@ -1,0 +1,973 @@
+/**
+ * OpenAI Chat Completions API format conversion layer.
+ *
+ * Provides a request parser (OpenAI -> NeuroLink), a response serializer
+ * (NeuroLink -> OpenAI), a streaming SSE state machine, and an error
+ * envelope helper.  Together they allow NeuroLink to act as a
+ * drop-in OpenAI API proxy.
+ *
+ * Reference: https://platform.openai.com/docs/api-reference/chat/create
+ */
+
+import { jsonSchema, tool } from "../utils/tool.js";
+import { randomBytes } from "crypto";
+import type {
+  ClaudeContentBlock,
+  ClaudeMessage,
+  ClaudeRequest,
+  ClaudeResponse,
+  InternalResult,
+  OpenAICompletionRequest,
+  OpenAICompletionResponse,
+  OpenAIErrorResponse,
+  OpenAIStreamChunk,
+  OpenAIToolCall,
+  ParsedOpenAIRequest,
+  StreamLifecycleState,
+} from "../types/index.js";
+import { normalizeJsonSchemaObject } from "../utils/schemaConversion.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a unique chat completion ID in the OpenAI format. */
+export function generateChatCompletionId(): string {
+  return `chatcmpl-${randomBytes(12).toString("base64url").slice(0, 24)}`;
+}
+
+/** Generate an OpenAI-format tool call ID (`call_` + random chars). */
+export function generateOpenAIToolCallId(): string {
+  return `call_${randomBytes(12).toString("base64url").slice(0, 24)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Request parser: OpenAI -> NeuroLink internal format
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an incoming OpenAI Chat Completions request into an intermediate
+ * representation consumable by NeuroLink's generate/stream pipeline.
+ *
+ * Handles:
+ * - System prompt extraction from system messages
+ * - Message flattening (text + image parts)
+ * - Tool definition conversion
+ * - tool_choice mapping
+ * - top_p, temperature, max_tokens pass-through
+ */
+export function parseOpenAIRequest(
+  body: OpenAICompletionRequest,
+): ParsedOpenAIRequest {
+  // --- system prompt ---
+  const systemParts: string[] = [];
+  for (const msg of body.messages) {
+    if (msg.role === "system") {
+      systemParts.push(msg.content);
+    }
+  }
+  const systemPrompt =
+    systemParts.length > 0 ? systemParts.join("\n\n") : undefined;
+
+  // --- messages ---
+  // Find the index of the last user message so we can distinguish the
+  // current turn from history.  Images from historical messages are kept
+  // inline as text references; only images from the latest user message
+  // are extracted into the top-level `images` array.
+  const conversationMessages: Array<{ role: string; content: string }> = [];
+  const images: string[] = [];
+  let lastUserPrompt = "";
+
+  let lastUserMsgIdx = -1;
+  for (let i = body.messages.length - 1; i >= 0; i--) {
+    if (body.messages[i].role === "user") {
+      lastUserMsgIdx = i;
+      break;
+    }
+  }
+
+  // NOTE: This loop intentionally does NOT use MessageBuilder because the proxy
+  // layer translates between OpenAI's wire format and NeuroLink's internal
+  // representation. MessageBuilder is for SDK-side message construction from
+  // user inputs (files, images, etc.).
+  for (let msgIdx = 0; msgIdx < body.messages.length; msgIdx++) {
+    const msg = body.messages[msgIdx];
+    const isLatestUserMsg = msgIdx === lastUserMsgIdx;
+
+    if (msg.role === "system") {
+      // System messages are already extracted above; skip them in the
+      // conversation history to avoid duplication.
+      continue;
+    }
+
+    if (msg.role === "user") {
+      if (typeof msg.content === "string") {
+        conversationMessages.push({ role: msg.role, content: msg.content });
+        lastUserPrompt = msg.content;
+      } else if (Array.isArray(msg.content)) {
+        const textParts: string[] = [];
+        for (const part of msg.content) {
+          if (part.type === "text") {
+            textParts.push(part.text);
+          } else if (part.type === "image_url") {
+            if (isLatestUserMsg) {
+              images.push(part.image_url.url);
+            } else {
+              textParts.push("[image]");
+            }
+          }
+        }
+        const combined = textParts.join("\n");
+        conversationMessages.push({ role: msg.role, content: combined });
+        lastUserPrompt = combined;
+      }
+    } else if (msg.role === "assistant") {
+      const textParts: string[] = [];
+      if (msg.content) {
+        textParts.push(msg.content);
+      }
+      if (msg.tool_calls) {
+        for (const tc of msg.tool_calls) {
+          textParts.push(
+            `[tool_use:${tc.id}:${tc.function.name}] ${tc.function.arguments}`,
+          );
+        }
+      }
+      const combined = textParts.join("\n");
+      conversationMessages.push({ role: msg.role, content: combined });
+    } else if (msg.role === "tool") {
+      conversationMessages.push({
+        role: "user",
+        content: `[tool_result:${msg.tool_call_id}] ${msg.content}`,
+      });
+    }
+  }
+
+  // --- tools ---
+  const tools: ParsedOpenAIRequest["tools"] = {};
+  if (body.tools) {
+    for (const t of body.tools) {
+      tools[t.function.name] = tool({
+        description: t.function.description ?? "",
+        inputSchema: jsonSchema(
+          normalizeJsonSchemaObject(
+            t.function.parameters ?? { type: "object" as const },
+          ),
+        ),
+      });
+    }
+  }
+
+  // --- tool_choice ---
+  let toolChoice: ParsedOpenAIRequest["toolChoice"];
+  let toolChoiceName: string | undefined;
+  if (body.tool_choice) {
+    if (typeof body.tool_choice === "string") {
+      switch (body.tool_choice) {
+        case "auto":
+          toolChoice = "auto";
+          break;
+        case "required":
+          toolChoice = "required";
+          break;
+        case "none":
+          toolChoice = "none";
+          break;
+      }
+    } else if (
+      typeof body.tool_choice === "object" &&
+      body.tool_choice.type === "function"
+    ) {
+      toolChoice = "required";
+      toolChoiceName = body.tool_choice.function.name;
+    }
+  }
+
+  // --- stop sequences ---
+  let stopSequences: string[] | undefined;
+  if (body.stop) {
+    stopSequences = Array.isArray(body.stop) ? body.stop : [body.stop];
+  }
+
+  // --- response format ---
+  let responseFormat: ParsedOpenAIRequest["responseFormat"];
+  if (body.response_format) {
+    responseFormat = {
+      type: body.response_format.type,
+      jsonSchema: body.response_format.json_schema,
+    };
+  }
+
+  return {
+    model: body.model,
+    maxTokens: body.max_tokens ?? body.max_completion_tokens ?? 4096,
+    temperature: body.temperature,
+    topP: body.top_p,
+    systemPrompt,
+    stream: body.stream === true,
+    prompt: lastUserPrompt,
+    images,
+    conversationMessages,
+    tools,
+    toolChoice,
+    toolChoiceName,
+    stopSequences,
+    responseFormat,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response serializer: NeuroLink result -> OpenAI response
+// ---------------------------------------------------------------------------
+
+/**
+ * Map NeuroLink finish-reason strings to OpenAI finish_reason values.
+ */
+function mapFinishReason(
+  finishReason: string | undefined,
+): "stop" | "tool_calls" | "length" | "content_filter" | null {
+  switch (finishReason) {
+    case "stop":
+    case "end_turn":
+      return "stop";
+    case "length":
+    case "max_tokens":
+      return "length";
+    case "tool-calls":
+    case "tool_use":
+      return "tool_calls";
+    case "content_filter":
+    case "safety":
+      return "content_filter";
+    default:
+      return finishReason ? "stop" : null;
+  }
+}
+
+/**
+ * Serialize a NeuroLink GenerateResult into an OpenAI Chat Completions response.
+ */
+export function serializeOpenAIResponse(
+  result: InternalResult,
+  requestModel: string,
+): OpenAICompletionResponse {
+  const inferredFinishReason =
+    result.toolCalls &&
+    result.toolCalls.length > 0 &&
+    (!result.finishReason || result.finishReason === "stop")
+      ? "tool_calls"
+      : result.finishReason;
+
+  // Build tool_calls array if present
+  let toolCalls: OpenAIToolCall[] | undefined;
+  if (result.toolCalls && result.toolCalls.length > 0) {
+    toolCalls = result.toolCalls.map((tc) => ({
+      id: tc.toolCallId || generateOpenAIToolCallId(),
+      type: "function" as const,
+      function: {
+        name: tc.toolName,
+        arguments: JSON.stringify(tc.args ?? {}),
+      },
+    }));
+  }
+
+  // Content is null when only tool calls are present (no text content)
+  const content = toolCalls && !result.content ? null : result.content || "";
+
+  return {
+    id: generateChatCompletionId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: result.model ?? requestModel,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content,
+          ...(toolCalls ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: mapFinishReason(inferredFinishReason),
+      },
+    ],
+    usage: {
+      prompt_tokens: result.usage?.input ?? 0,
+      completion_tokens: result.usage?.output ?? 0,
+      total_tokens: result.usage?.total ?? 0,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error envelope
+// ---------------------------------------------------------------------------
+
+/** Map HTTP status codes to OpenAI error types. */
+function errorTypeFromStatus(status: number): string {
+  switch (status) {
+    case 400:
+      return "invalid_request_error";
+    case 401:
+      return "authentication_error";
+    case 403:
+      return "permission_error";
+    case 404:
+      return "not_found_error";
+    case 429:
+      return "rate_limit_error";
+    default:
+      return status >= 500 ? "server_error" : "invalid_request_error";
+  }
+}
+
+/**
+ * Build an OpenAI-compatible error envelope.
+ */
+export function buildOpenAIError(
+  status: number,
+  message: string,
+): OpenAIErrorResponse {
+  return {
+    error: {
+      message,
+      type: errorTypeFromStatus(status),
+      code: null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SSE helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a single OpenAI SSE frame.
+ * OpenAI uses only `data:` lines (no `event:` prefix unlike Claude).
+ */
+export function formatOpenAISSE(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming SSE state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateful SSE serializer that emits a well-formed OpenAI streaming response.
+ *
+ * Tracks lifecycle state (`idle` -> `streaming` -> `done`) and the current
+ * tool call index for multi-tool streaming.
+ *
+ * Usage:
+ * ```ts
+ * const sse = new OpenAIStreamSerializer(requestModel);
+ *
+ * // Start the stream
+ * yield* sse.start();
+ *
+ * // Text deltas
+ * for await (const chunk of textStream) {
+ *   yield* sse.pushDelta(chunk);
+ * }
+ *
+ * // Tool use
+ * yield* sse.pushToolUse(toolId, toolName, toolInput);
+ *
+ * // Finalize
+ * yield* sse.finish("stop", usage);
+ * ```
+ */
+export class OpenAIStreamSerializer {
+  private state: StreamLifecycleState = "idle";
+  private readonly id: string;
+  private readonly model: string;
+  private started = false;
+  private toolCallIndex = -1;
+
+  constructor(model: string) {
+    this.id = generateChatCompletionId();
+    this.model = model;
+  }
+
+  /** Current lifecycle state (exposed for testing). */
+  getState(): StreamLifecycleState {
+    return this.state;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  private makeChunk(
+    delta: OpenAIStreamChunk["choices"][0]["delta"],
+    finishReason: string | null = null,
+    usage?: OpenAIStreamChunk["usage"],
+  ): OpenAIStreamChunk {
+    return {
+      id: this.id,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: this.model,
+      choices: [
+        {
+          index: 0,
+          delta,
+          finish_reason: finishReason,
+        },
+      ],
+      ...(usage ? { usage } : {}),
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Emit the opening frame with `role: "assistant"`.
+   */
+  *start(): Generator<string> {
+    if (this.state !== "idle") {
+      return;
+    }
+
+    this.started = true;
+    this.state = "streaming";
+
+    yield formatOpenAISSE(this.makeChunk({ role: "assistant" }));
+  }
+
+  /**
+   * Push a text content delta.
+   */
+  *pushDelta(text: string): Generator<string> {
+    if (this.state === "done" || this.state === "error") {
+      return;
+    }
+
+    if (!this.started) {
+      yield* this.start();
+    }
+
+    yield formatOpenAISSE(this.makeChunk({ content: text }));
+  }
+
+  /**
+   * Push the start of a tool call (id, name, empty arguments).
+   */
+  *pushToolCallStart(id: string, name: string): Generator<string> {
+    if (this.state === "done" || this.state === "error") {
+      return;
+    }
+
+    if (!this.started) {
+      yield* this.start();
+    }
+
+    this.toolCallIndex += 1;
+
+    yield formatOpenAISSE(
+      this.makeChunk({
+        tool_calls: [
+          {
+            index: this.toolCallIndex,
+            id,
+            type: "function",
+            function: { name, arguments: "" },
+          },
+        ],
+      }),
+    );
+  }
+
+  /**
+   * Push an arguments delta for the current tool call.
+   */
+  *pushToolCallArgDelta(index: number, argsChunk: string): Generator<string> {
+    if (this.state === "done" || this.state === "error") {
+      return;
+    }
+
+    yield formatOpenAISSE(
+      this.makeChunk({
+        tool_calls: [
+          {
+            index,
+            function: { arguments: argsChunk },
+          },
+        ],
+      }),
+    );
+  }
+
+  /**
+   * Push a complete tool use: emits tool call start followed by chunked
+   * argument deltas (~100 chars per chunk).
+   */
+  *pushToolUse(id: string, name: string, input: unknown): Generator<string> {
+    if (this.state === "done" || this.state === "error") {
+      return;
+    }
+
+    yield* this.pushToolCallStart(id, name);
+
+    const jsonStr = JSON.stringify(input ?? {});
+    const CHUNK_SIZE = 100;
+    const currentIndex = this.toolCallIndex;
+
+    for (let i = 0; i < jsonStr.length; i += CHUNK_SIZE) {
+      const chunk = jsonStr.slice(i, i + CHUNK_SIZE);
+      yield* this.pushToolCallArgDelta(currentIndex, chunk);
+    }
+
+    // If the input was empty, still emit at least one delta
+    if (jsonStr.length === 0) {
+      yield* this.pushToolCallArgDelta(currentIndex, "{}");
+    }
+  }
+
+  /**
+   * Finalize the stream: emit finish_reason chunk, then `data: [DONE]`.
+   */
+  *finish(
+    finishReason?: string,
+    usage?: { input: number; output: number; total: number },
+  ): Generator<string> {
+    if (this.state === "idle") {
+      yield* this.start();
+    }
+
+    if (this.state === "done" || this.state === "error") {
+      return;
+    }
+
+    const mappedReason = mapFinishReason(finishReason) ?? "stop";
+    const usagePayload = usage
+      ? {
+          prompt_tokens: usage.input,
+          completion_tokens: usage.output,
+          total_tokens: usage.total,
+        }
+      : undefined;
+
+    yield formatOpenAISSE(this.makeChunk({}, mappedReason, usagePayload));
+    yield "data: [DONE]\n\n";
+
+    this.state = "done";
+  }
+
+  /**
+   * Emit an error event.  Transitions to terminal ERROR state.
+   */
+  *emitError(message: string): Generator<string> {
+    this.state = "error";
+    yield formatOpenAISSE({
+      error: { message, type: "server_error" },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI <-> Claude (Anthropic) format bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an OpenAI Chat Completions request to a Claude Messages API request.
+ *
+ * Used by the OpenAI proxy endpoint to internally loopback requests targeting
+ * Claude models through the proxy's native /v1/messages passthrough path,
+ * so they benefit from OAuth account rotation, retry, SSE interception, etc.
+ */
+export function convertOpenAIToClaudeRequest(
+  openai: OpenAICompletionRequest,
+): ClaudeRequest {
+  // --- system messages ---
+  const systemMessages = openai.messages.filter(
+    (m) => m.role === "system",
+  ) as Array<{
+    role: "system";
+    content: string;
+  }>;
+  const system =
+    systemMessages.length > 0
+      ? systemMessages.map((m) => ({ type: "text" as const, text: m.content }))
+      : undefined;
+
+  // --- conversation messages ---
+  const messages: ClaudeMessage[] = [];
+  for (const msg of openai.messages) {
+    if (msg.role === "system") {
+      continue;
+    }
+
+    if (msg.role === "user") {
+      if (typeof msg.content === "string") {
+        messages.push({ role: "user", content: msg.content });
+      } else if (Array.isArray(msg.content)) {
+        const blocks: ClaudeContentBlock[] = msg.content.map((part) => {
+          if (part.type === "text") {
+            return { type: "text", text: part.text };
+          }
+          if (part.type === "image_url") {
+            return {
+              type: "image",
+              source: { type: "url" as const, url: part.image_url.url },
+            };
+          }
+          return { type: "text", text: "" };
+        });
+        messages.push({ role: "user", content: blocks });
+      }
+    } else if (msg.role === "assistant") {
+      const blocks: ClaudeContentBlock[] = [];
+      if (msg.content) {
+        blocks.push({ type: "text", text: msg.content });
+      }
+      if (msg.tool_calls) {
+        for (const tc of msg.tool_calls) {
+          let input: Record<string, unknown>;
+          try {
+            input = tc.function.arguments
+              ? (JSON.parse(tc.function.arguments) as Record<string, unknown>)
+              : {};
+          } catch {
+            input = {};
+          }
+          blocks.push({
+            type: "tool_use",
+            id: tc.id,
+            name: tc.function.name,
+            input,
+          });
+        }
+      }
+      messages.push({
+        role: "assistant",
+        content:
+          blocks.length === 1 && blocks[0].type === "text"
+            ? blocks[0].text
+            : blocks,
+      });
+    } else if (msg.role === "tool") {
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: msg.tool_call_id,
+            content: msg.content,
+          },
+        ],
+      });
+    }
+  }
+
+  // --- tools ---
+  const tools = openai.tools?.map((t) => ({
+    name: t.function.name,
+    description: t.function.description || "",
+    input_schema: t.function.parameters,
+  }));
+
+  // --- tool_choice ---
+  let tool_choice: ClaudeRequest["tool_choice"];
+  if (openai.tool_choice === "auto") {
+    tool_choice = { type: "auto" };
+  } else if (openai.tool_choice === "required") {
+    tool_choice = { type: "any" };
+  } else if (openai.tool_choice === "none") {
+    tool_choice = { type: "none" };
+  } else if (
+    typeof openai.tool_choice === "object" &&
+    openai.tool_choice.type === "function"
+  ) {
+    tool_choice = { type: "tool", name: openai.tool_choice.function.name };
+  }
+
+  const result: ClaudeRequest = {
+    model: openai.model,
+    messages,
+    max_tokens: openai.max_tokens ?? openai.max_completion_tokens ?? 4096,
+    stream: openai.stream ?? false,
+  };
+
+  if (system) {
+    result.system = system;
+  }
+  if (openai.temperature !== undefined) {
+    result.temperature = openai.temperature;
+  }
+  if (openai.top_p !== undefined) {
+    result.top_p = openai.top_p;
+  }
+  if (tools && tools.length > 0) {
+    result.tools = tools;
+  }
+  if (tool_choice) {
+    result.tool_choice = tool_choice;
+  }
+  if (openai.stop) {
+    result.stop_sequences = Array.isArray(openai.stop)
+      ? openai.stop
+      : [openai.stop];
+  }
+
+  return result;
+}
+
+/**
+ * Convert a non-streaming Claude Messages response to an OpenAI Chat
+ * Completions response by bridging through {@link InternalResult}.
+ */
+export function convertClaudeToOpenAIResponse(
+  claude: ClaudeResponse,
+  requestModel: string,
+): OpenAICompletionResponse {
+  const content = claude.content
+    .filter((b) => b.type === "text")
+    .map((b) => (b as { type: "text"; text: string }).text)
+    .join("");
+
+  const toolCalls = claude.content
+    .filter((b) => b.type === "tool_use")
+    .map((b) => {
+      const tu = b as {
+        type: "tool_use";
+        id: string;
+        name: string;
+        input: Record<string, unknown>;
+      };
+      return {
+        toolCallId: tu.id,
+        toolName: tu.name,
+        args: tu.input ?? {},
+      };
+    });
+
+  const internal: InternalResult = {
+    content,
+    model: claude.model,
+    finishReason: claude.stop_reason ?? "end_turn",
+    usage: {
+      input: claude.usage.input_tokens,
+      output: claude.usage.output_tokens,
+      total: claude.usage.input_tokens + claude.usage.output_tokens,
+    },
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+  };
+
+  return serializeOpenAIResponse(internal, requestModel);
+}
+
+/**
+ * Create a TransformStream that parses Claude Messages API SSE events from
+ * the upstream response and re-emits them as OpenAI Chat Completions SSE
+ * frames.
+ *
+ * Handles the canonical Claude SSE event types:
+ *  - message_start       -> emits the opening `role: "assistant"` chunk
+ *  - content_block_start -> text block: no-op; tool_use block: emit tool call start
+ *  - content_block_delta -> text_delta: emit content delta;
+ *                           input_json_delta: emit tool call argument delta
+ *  - content_block_stop  -> no-op
+ *  - message_delta       -> captures stop_reason and output token usage
+ *  - message_stop        -> emits the final `finish_reason` chunk + `[DONE]`
+ */
+export function createClaudeToOpenAIStreamTransform(
+  requestModel: string,
+): TransformStream<Uint8Array, Uint8Array> {
+  const serializer = new OpenAIStreamSerializer(requestModel);
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  // Track per-content-block state so we can map Claude's indexed block
+  // stream to OpenAI's flat delta stream.
+  const blockState = new Map<
+    number,
+    {
+      kind: "text" | "tool_use" | "thinking" | "other";
+      toolCallIndex?: number;
+    }
+  >();
+
+  let stopReason: string | undefined;
+  let usage: { input: number; output: number; total: number } | undefined;
+  let inputTokens = 0;
+  let nextToolCallIndex = 0;
+  let finished = false;
+
+  const emit = (
+    controller: TransformStreamDefaultController<Uint8Array>,
+    gen: Generator<string>,
+  ): void => {
+    for (const frame of gen) {
+      controller.enqueue(encoder.encode(frame));
+    }
+  };
+
+  const handleEvent = (
+    eventName: string,
+    dataStr: string,
+    controller: TransformStreamDefaultController<Uint8Array>,
+  ): void => {
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(dataStr) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    switch (eventName) {
+      case "message_start": {
+        const message = (data.message ?? {}) as {
+          usage?: { input_tokens?: number; output_tokens?: number };
+        };
+        if (message.usage?.input_tokens !== undefined) {
+          inputTokens = message.usage.input_tokens;
+        }
+        emit(controller, serializer.start());
+        return;
+      }
+
+      case "content_block_start": {
+        const index =
+          typeof data.index === "number" ? (data.index as number) : 0;
+        const block = (data.content_block ?? {}) as {
+          type?: string;
+          id?: string;
+          name?: string;
+        };
+        if (block.type === "tool_use") {
+          const toolCallIndex = nextToolCallIndex++;
+          blockState.set(index, { kind: "tool_use", toolCallIndex });
+          emit(
+            controller,
+            serializer.pushToolCallStart(block.id ?? "", block.name ?? ""),
+          );
+        } else if (block.type === "text") {
+          blockState.set(index, { kind: "text" });
+        } else if (block.type === "thinking") {
+          blockState.set(index, { kind: "thinking" });
+        } else {
+          blockState.set(index, { kind: "other" });
+        }
+        return;
+      }
+
+      case "content_block_delta": {
+        const index =
+          typeof data.index === "number" ? (data.index as number) : 0;
+        const delta = (data.delta ?? {}) as {
+          type?: string;
+          text?: string;
+          partial_json?: string;
+        };
+        const state = blockState.get(index);
+        if (!state) {
+          return;
+        }
+
+        if (delta.type === "text_delta" && state.kind === "text") {
+          emit(controller, serializer.pushDelta(delta.text ?? ""));
+        } else if (
+          delta.type === "input_json_delta" &&
+          state.kind === "tool_use" &&
+          state.toolCallIndex !== undefined
+        ) {
+          emit(
+            controller,
+            serializer.pushToolCallArgDelta(
+              state.toolCallIndex,
+              delta.partial_json ?? "",
+            ),
+          );
+        }
+        // thinking_delta is intentionally dropped — OpenAI has no equivalent.
+        return;
+      }
+
+      case "content_block_stop": {
+        // No-op: OpenAI stream has no per-block close event.
+        return;
+      }
+
+      case "message_delta": {
+        const delta = (data.delta ?? {}) as { stop_reason?: string };
+        if (delta.stop_reason) {
+          stopReason = delta.stop_reason;
+        }
+        const u = (data.usage ?? {}) as { output_tokens?: number };
+        if (u.output_tokens !== undefined) {
+          usage = {
+            input: inputTokens,
+            output: u.output_tokens,
+            total: inputTokens + u.output_tokens,
+          };
+        }
+        return;
+      }
+
+      case "message_stop": {
+        if (!finished) {
+          finished = true;
+          emit(controller, serializer.finish(stopReason, usage));
+        }
+        return;
+      }
+
+      default:
+        // ping, error, and unknown events are ignored.
+        return;
+    }
+  };
+
+  // Parse any complete SSE events present in `buffer`, mutating it as events
+  // are consumed. Shared between the streaming `transform` and the terminal
+  // `flush` (after the decoder is drained) so trailing events aren't lost.
+  const drainBufferedEvents = (
+    controller: TransformStreamDefaultController<Uint8Array>,
+  ): void => {
+    // Claude SSE events are separated by blank lines (`\n\n`).
+    let sepIdx = buffer.indexOf("\n\n");
+    while (sepIdx !== -1) {
+      const rawEvent = buffer.slice(0, sepIdx);
+      buffer = buffer.slice(sepIdx + 2);
+
+      let eventName = "";
+      const dataLines: string[] = [];
+      for (const line of rawEvent.split("\n")) {
+        if (line.startsWith("event:")) {
+          eventName = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).trim());
+        }
+      }
+      if (eventName && dataLines.length > 0) {
+        handleEvent(eventName, dataLines.join("\n"), controller);
+      }
+      sepIdx = buffer.indexOf("\n\n");
+    }
+  };
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      drainBufferedEvents(controller);
+    },
+
+    flush(controller) {
+      // Drain any bytes still held inside the TextDecoder, then re-run the
+      // event parser so a complete trailing event that arrived without a
+      // closing `\n\n` is not silently lost.
+      buffer += decoder.decode();
+      drainBufferedEvents(controller);
+
+      // If the upstream closed without a message_stop, still finalize.
+      if (!finished) {
+        finished = true;
+        emit(controller, serializer.finish(stopReason, usage));
+      }
+    },
+  });
+}

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -1,0 +1,908 @@
+/**
+ * Proxy Translation Engine
+ *
+ * Shared translation logic used by both Claude and OpenAI proxy routes.
+ * Both formats follow the same pipeline:
+ *   1. Parse request (format-specific, done by the caller)
+ *   2. Loop through fallback attempts calling ctx.neurolink.stream()
+ *   3. Serialize response (format-specific, via serializer/response builder)
+ *
+ * This module exports the helpers that were previously duplicated between
+ * claudeProxyRoutes.ts and openaiProxyRoutes.ts, plus unified stream and
+ * JSON handlers that accept a format discriminator.
+ */
+
+import {
+  ClaudeStreamSerializer,
+  generateToolUseId,
+  serializeClaudeResponse,
+} from "./claudeFormat.js";
+import {
+  generateOpenAIToolCallId,
+  OpenAIStreamSerializer,
+  serializeOpenAIResponse,
+} from "./openaiFormat.js";
+import type { ProxyTracer } from "./proxyTracer.js";
+import { logRequest } from "./requestLogger.js";
+import {
+  recordAttempt,
+  recordAttemptError,
+  recordFinalError,
+  recordFinalSuccess,
+} from "./usageStats.js";
+import type {
+  InternalResult,
+  ParsedClaudeRequest,
+  ParsedOpenAIRequest,
+  ProxyFormat,
+  ProxyTranslationAttempt,
+  ServerContext,
+  StreamSerializerAdapter,
+} from "../types/index.js";
+import { ErrorCategory, ErrorSeverity } from "../constants/enums.js";
+import { withTimeout } from "../utils/async/withTimeout.js";
+import { ERROR_CODES, NeuroLinkError } from "../utils/errorHandling.js";
+import { logger } from "../utils/logger.js";
+
+// Upper bound on a single translation attempt. Long enough for slow upstreams
+// (Vertex/LiteLLM can take 60–90s on big requests) but short enough that a
+// hung provider can't stall the request handler indefinitely.
+const TRANSLATION_ATTEMPT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract text content from a stream chunk (handles various chunk formats).
+ */
+export function extractText(chunk: unknown): string | null {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+
+  if (chunk && typeof chunk === "object") {
+    const c = chunk as Record<string, unknown>;
+
+    // NeuroLink StreamResult chunk format: { content: string }
+    if (typeof c.content === "string") {
+      return c.content;
+    }
+
+    // Vercel AI SDK text delta format
+    if (c.type === "text-delta" && typeof c.textDelta === "string") {
+      return c.textDelta;
+    }
+
+    // Direct text field
+    if (typeof c.text === "string") {
+      return c.text;
+    }
+  }
+
+  return null;
+}
+
+/** Extract tool call arguments from various shapes. */
+export function extractToolArgs(toolCall: unknown): unknown {
+  return (
+    (toolCall as { args?: unknown }).args ??
+    (toolCall as { parameters?: unknown }).parameters ??
+    (toolCall as { input?: unknown }).input ??
+    {}
+  );
+}
+
+/** Check if there's meaningful output from translation. */
+export function hasTranslatedOutput(
+  collectedText: string,
+  toolCalls: unknown[] | undefined,
+): boolean {
+  return collectedText.trim().length > 0 || (toolCalls?.length ?? 0) > 0;
+}
+
+/**
+ * Normalize usage from various AI SDK / NeuroLink shapes.
+ *
+ * Handles:
+ * - AI SDK v6: inputTokens / outputTokens
+ * - AI SDK v4: promptTokens / completionTokens
+ * - NeuroLink internal: input / output
+ */
+export function extractUsageFromStreamResult(usage: unknown): {
+  input: number;
+  output: number;
+  total: number;
+} {
+  if (!usage || typeof usage !== "object") {
+    return { input: 0, output: 0, total: 0 };
+  }
+  const u = usage as Record<string, unknown>;
+  const input =
+    (typeof u.inputTokens === "number" ? u.inputTokens : 0) ||
+    (typeof u.promptTokens === "number" ? u.promptTokens : 0) ||
+    (typeof u.input === "number" ? u.input : 0);
+  const output =
+    (typeof u.outputTokens === "number" ? u.outputTokens : 0) ||
+    (typeof u.completionTokens === "number" ? u.completionTokens : 0) ||
+    (typeof u.output === "number" ? u.output : 0);
+  return { input, output, total: input + output };
+}
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect which proxy format a request is using based on path and headers.
+ */
+export function detectProxyFormat(
+  path: string,
+  headers: Record<string, string>,
+): ProxyFormat {
+  // Path-based detection (primary, most reliable)
+  if (path.includes("/chat/completions")) {
+    return "openai";
+  }
+  if (path.includes("/messages")) {
+    return "claude";
+  }
+
+  // Header-based fallback
+  if (headers["anthropic-version"]) {
+    return "claude";
+  }
+  if (headers["x-claude-code-session-id"]) {
+    return "claude";
+  }
+
+  // Default to openai (more universal)
+  return "openai";
+}
+
+// ---------------------------------------------------------------------------
+// Provider/model-specific overrides for translated requests
+// ---------------------------------------------------------------------------
+
+function shouldOmitImagesForTarget(provider?: string, model?: string): boolean {
+  // `open-large` in our LiteLLM setup handles text and tools, but returns an
+  // empty completion when binary images are forwarded. Claude Code already
+  // includes textual image markers in the prompt, so dropping only the binary
+  // image payload keeps the request usable instead of breaking fallback.
+  return provider === "litellm" && model === "open-large";
+}
+
+function shouldOmitThinkingConfigForTarget(
+  provider?: string,
+  model?: string,
+): boolean {
+  // LiteLLM speaks an OpenAI-shaped API and does not understand the Anthropic
+  // `thinkingConfig` block — always strip it for litellm targets.
+  if (provider === "litellm") {
+    return true;
+  }
+  // For Vertex, only Gemini 2.5+ and 3.x support thinking on the wire.
+  // Other Vertex models (text-bison, older Gemini, Claude-on-Vertex) reject
+  // it, so omit for anything outside that allow-list.
+  if (provider === "vertex") {
+    const m = model?.toLowerCase() ?? "";
+    return !/gemini-(2\.5|3)/.test(m);
+  }
+  // Other providers (anthropic, openai, etc.) either support it natively or
+  // ignore unknown fields — pass it through.
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Unified options builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build options for ctx.neurolink.stream() from a parsed request
+ * and an optional provider/model override.
+ *
+ * Works for both ParsedClaudeRequest and ParsedOpenAIRequest — the
+ * only differences are Claude-specific fields (topK, thinkingConfig)
+ * which are safely absent on OpenAI parsed requests.
+ */
+export function buildTranslationOptions(
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest,
+  overrides: { provider?: string; model?: string } = {},
+): Record<string, unknown> {
+  const historyMessages = parsed.conversationMessages.slice(0, -1);
+  const toolNames = Object.keys(parsed.tools);
+
+  // Claude-specific fields: topK and thinkingConfig
+  const claudeParsed = parsed as Partial<ParsedClaudeRequest>;
+  const images = shouldOmitImagesForTarget(overrides.provider, overrides.model)
+    ? []
+    : parsed.images;
+  const thinkingConfig =
+    claudeParsed.thinkingConfig &&
+    !shouldOmitThinkingConfigForTarget(overrides.provider, overrides.model)
+      ? claudeParsed.thinkingConfig
+      : undefined;
+
+  const toolChoice = parsed.toolChoiceName
+    ? { type: "tool" as const, toolName: parsed.toolChoiceName }
+    : parsed.toolChoice;
+
+  return {
+    input: {
+      text: parsed.prompt,
+      ...(images.length > 0 ? { images } : {}),
+    },
+    ...(overrides.provider ? { provider: overrides.provider } : {}),
+    ...(overrides.model ? { model: overrides.model } : {}),
+    systemPrompt: parsed.systemPrompt,
+    ...(parsed.maxTokens !== undefined ? { maxTokens: parsed.maxTokens } : {}),
+    ...(parsed.temperature !== undefined
+      ? { temperature: parsed.temperature }
+      : {}),
+    ...(parsed.topP !== undefined ? { topP: parsed.topP } : {}),
+    ...(claudeParsed.topK !== undefined ? { topK: claudeParsed.topK } : {}),
+    ...(parsed.stopSequences?.length
+      ? { stopSequences: parsed.stopSequences }
+      : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
+    ...(toolNames.length === 0 ? { disableTools: true } : {}),
+    ...(toolNames.length > 0
+      ? {
+          tools: parsed.tools,
+          toolFilter: toolNames,
+        }
+      : {}),
+    ...(toolChoice ? { toolChoice } : {}),
+    ...(historyMessages.length > 0
+      ? { conversationMessages: historyMessages }
+      : {}),
+    disableInternalFallback: true,
+    skipToolPromptInjection: true,
+    maxSteps: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Serializer adapter — normalizes differences between Claude and OpenAI
+// stream serializers behind a common interface.
+// ---------------------------------------------------------------------------
+
+function createClaudeSerializerAdapter(model: string): StreamSerializerAdapter {
+  const inner = new ClaudeStreamSerializer(model, 0);
+  return {
+    start: () => inner.start(),
+    pushDelta: (text) => inner.pushDelta(text),
+    pushToolUse: (id, name, input) => inner.pushToolUse(id, name, input),
+    finish: (finishReason, usage) => inner.finish(usage.output, finishReason),
+    emitError: (message) => inner.emitError(500, message),
+  };
+}
+
+function createOpenAISerializerAdapter(model: string): StreamSerializerAdapter {
+  const inner = new OpenAIStreamSerializer(model);
+  return {
+    start: () => inner.start(),
+    pushDelta: (text) => inner.pushDelta(text),
+    pushToolUse: (id, name, input) => inner.pushToolUse(id, name, input),
+    finish: (finishReason, usage) => inner.finish(finishReason, usage),
+    emitError: (message) => inner.emitError(message),
+  };
+}
+
+function generateToolId(format: ProxyFormat): string {
+  return format === "claude" ? generateToolUseId() : generateOpenAIToolCallId();
+}
+
+function defaultFinishReason(format: ProxyFormat): string {
+  return format === "claude" ? "end_turn" : "stop";
+}
+
+function logTag(format: ProxyFormat): string {
+  return format === "claude" ? "[proxy]" : "[proxy:openai]";
+}
+
+// ---------------------------------------------------------------------------
+// Unified streaming handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a translated stream request for either Claude or OpenAI format.
+ *
+ * The streaming loop logic (iterate attempts, call neurolink.stream, collect
+ * text, handle tool calls, keepalive timer) is identical across formats.
+ * Only the serializer differs.
+ */
+export async function handleTranslatedStreamRequest(args: {
+  ctx: ServerContext;
+  format: ProxyFormat;
+  requestModel: string;
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest;
+  attempts: ProxyTranslationAttempt[];
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+}): Promise<Response> {
+  const {
+    ctx,
+    format,
+    requestModel,
+    parsed,
+    attempts,
+    tracer,
+    requestStartTime,
+  } = args;
+  const tag = logTag(format);
+  const serializer =
+    format === "claude"
+      ? createClaudeSerializerAdapter(requestModel)
+      : createOpenAISerializerAdapter(requestModel);
+
+  const KEEPALIVE_INTERVAL_MS = 15_000;
+  const encoder = new TextEncoder();
+  let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
+  let cancelled = false;
+  let succeeded = false;
+  let translatedModel: string | undefined;
+  let finalStreamError = "No translation providers succeeded";
+  let upstreamIterator: AsyncIterator<unknown> | undefined;
+  let lastAttemptLabel = "translation";
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      // Emit opening frame
+      for (const frame of serializer.start()) {
+        controller.enqueue(encoder.encode(frame));
+      }
+
+      keepAliveTimer = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": keep-alive\n\n"));
+        } catch {
+          // Controller already closed.
+        }
+      }, KEEPALIVE_INTERVAL_MS);
+
+      try {
+        for (
+          let attemptIndex = 0;
+          attemptIndex < attempts.length;
+          attemptIndex++
+        ) {
+          const attempt = attempts[attemptIndex];
+          lastAttemptLabel = attempt.label ?? "translation";
+          logger.always(
+            `[proxy:${format}] attempt ${attemptIndex + 1}/${attempts.length}: ${attempt.label}`,
+          );
+          recordAttempt(lastAttemptLabel, "translation");
+
+          let collectedText = "";
+          try {
+            const options = buildTranslationOptions(
+              parsed,
+              attempt.provider
+                ? { provider: attempt.provider, model: attempt.model }
+                : {},
+            );
+            const streamResult = await withTimeout(
+              ctx.neurolink.stream(
+                options as Parameters<typeof ctx.neurolink.stream>[0],
+              ),
+              TRANSLATION_ATTEMPT_TIMEOUT_MS,
+              `Translation attempt ${attempt.label} timed out after ${TRANSLATION_ATTEMPT_TIMEOUT_MS}ms`,
+            );
+            const iterable = streamResult.stream as AsyncIterable<unknown>;
+            upstreamIterator = iterable[Symbol.asyncIterator]();
+
+            while (true) {
+              if (cancelled) {
+                break;
+              }
+              const { value: chunk, done } = await upstreamIterator.next();
+              if (done || cancelled) {
+                break;
+              }
+              const text = extractText(chunk);
+              if (text) {
+                collectedText += text;
+                for (const frame of serializer.pushDelta(text)) {
+                  controller.enqueue(encoder.encode(frame));
+                }
+              }
+            }
+
+            const toolCalls = streamResult.toolCalls ?? [];
+            if (!hasTranslatedOutput(collectedText, toolCalls)) {
+              finalStreamError = `Translated provider ${attempt.label} returned no content or tool calls`;
+              logger.debug(
+                `${tag} translation attempt ${attempt.label} returned no content or tool calls`,
+              );
+              continue;
+            }
+
+            if (!cancelled && toolCalls.length) {
+              for (const toolCall of toolCalls) {
+                const toolName =
+                  (toolCall as { toolName?: string }).toolName ??
+                  (toolCall as { name?: string }).name ??
+                  "unknown";
+                const toolId =
+                  (toolCall as { toolCallId?: string }).toolCallId ||
+                  generateToolId(format);
+                for (const frame of serializer.pushToolUse(
+                  toolId,
+                  toolName,
+                  extractToolArgs(toolCall),
+                )) {
+                  controller.enqueue(encoder.encode(frame));
+                }
+              }
+            }
+
+            if (!cancelled) {
+              const reason =
+                streamResult.finishReason ?? defaultFinishReason(format);
+              const resolvedUsage = extractUsageFromStreamResult(
+                streamResult.usage,
+              );
+              for (const frame of serializer.finish(reason, resolvedUsage)) {
+                controller.enqueue(encoder.encode(frame));
+              }
+            }
+
+            // Track usage and metrics
+            const resolvedUsageForTracer = extractUsageFromStreamResult(
+              streamResult.usage,
+            );
+            tracer?.setUsage({
+              inputTokens: resolvedUsageForTracer.input,
+              outputTokens: resolvedUsageForTracer.output,
+              cacheCreationTokens: 0,
+              cacheReadTokens: 0,
+            });
+            tracer?.recordMetrics();
+
+            translatedModel = streamResult.model;
+            succeeded = true;
+            recordFinalSuccess(lastAttemptLabel, "translation");
+            return;
+          } catch (streamErr) {
+            if (cancelled) {
+              return;
+            }
+            finalStreamError =
+              streamErr instanceof Error
+                ? streamErr.message
+                : String(streamErr);
+            if (collectedText.trim().length > 0) {
+              logger.always(`${tag} mid-stream error: ${finalStreamError}`);
+              for (const frame of serializer.emitError(
+                `Upstream stream interrupted: ${finalStreamError}`,
+              )) {
+                controller.enqueue(encoder.encode(frame));
+              }
+              return;
+            }
+            logger.debug(
+              `${tag} translation attempt ${attempt.label} failed: ${finalStreamError}`,
+            );
+            recordAttemptError(lastAttemptLabel, "translation", 500);
+          }
+        }
+
+        // All attempts exhausted
+        recordFinalError(500, lastAttemptLabel, "translation");
+        if (!cancelled) {
+          logger.always(
+            `${tag} all translation attempts failed: ${finalStreamError}`,
+          );
+          for (const frame of serializer.emitError(finalStreamError)) {
+            controller.enqueue(encoder.encode(frame));
+          }
+        }
+      } finally {
+        if (keepAliveTimer) {
+          clearInterval(keepAliveTimer);
+        }
+        if (!cancelled) {
+          controller.close();
+        }
+        if (tracer && translatedModel && translatedModel !== requestModel) {
+          tracer.setModelSubstitution(requestModel, translatedModel);
+        }
+        if (!succeeded) {
+          tracer?.setError("generation_error", finalStreamError.slice(0, 500));
+        }
+        // Use the real outcome status so trace data matches the logged
+        // responseStatus below (success path is 200, exhausted-attempts path is 500).
+        tracer?.end(succeeded ? 200 : 500, Date.now() - requestStartTime);
+
+        const traceCtx = tracer?.getTraceContext();
+        logRequest({
+          timestamp: new Date().toISOString(),
+          requestId: ctx.requestId,
+          method: ctx.method,
+          path: ctx.path,
+          model: requestModel,
+          stream: true,
+          toolCount: Object.keys(parsed.tools).length,
+          account: "translation",
+          accountType: "translation",
+          responseStatus: succeeded ? 200 : 500,
+          responseTimeMs: Date.now() - requestStartTime,
+          ...(traceCtx?.traceId ? { traceId: traceCtx.traceId } : {}),
+          ...(traceCtx?.spanId ? { spanId: traceCtx.spanId } : {}),
+        });
+      }
+    },
+    cancel() {
+      cancelled = true;
+      if (keepAliveTimer) {
+        clearInterval(keepAliveTimer);
+        keepAliveTimer = undefined;
+      }
+      if (upstreamIterator?.return) {
+        upstreamIterator.return(undefined).catch((cancelErr) => {
+          logger.debug(
+            `${tag} upstream cancel error: ${cancelErr instanceof Error ? cancelErr.message : String(cancelErr)}`,
+          );
+        });
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Unified JSON (non-streaming) handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a translated non-streaming request for either Claude or OpenAI format.
+ */
+export async function handleTranslatedJsonRequest(args: {
+  ctx: ServerContext;
+  format: ProxyFormat;
+  requestModel: string;
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest;
+  attempts: ProxyTranslationAttempt[];
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+}): Promise<unknown> {
+  const {
+    ctx,
+    format,
+    requestModel,
+    parsed,
+    attempts,
+    tracer,
+    requestStartTime,
+  } = args;
+  const tag = logTag(format);
+  let lastAttemptError = "No translation providers succeeded";
+  let lastAttemptLabel = "translation";
+
+  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+    const attempt = attempts[attemptIndex];
+    lastAttemptLabel = attempt.label ?? "translation";
+    logger.always(
+      `[proxy:${format}] attempt ${attemptIndex + 1}/${attempts.length}: ${attempt.label}`,
+    );
+    recordAttempt(lastAttemptLabel, "translation");
+
+    try {
+      const options = buildTranslationOptions(
+        parsed,
+        attempt.provider
+          ? { provider: attempt.provider, model: attempt.model }
+          : {},
+      );
+      const streamResult = await withTimeout(
+        ctx.neurolink.stream(
+          options as Parameters<typeof ctx.neurolink.stream>[0],
+        ),
+        TRANSLATION_ATTEMPT_TIMEOUT_MS,
+        `Translation attempt ${attempt.label} timed out after ${TRANSLATION_ATTEMPT_TIMEOUT_MS}ms`,
+      );
+      let collectedText = "";
+      for await (const chunk of streamResult.stream) {
+        const text = extractText(chunk);
+        if (text) {
+          collectedText += text;
+        }
+      }
+
+      if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
+        lastAttemptError = `Translated provider ${attempt.label} returned no content or tool calls`;
+        logger.debug(
+          `${tag} translation attempt ${attempt.label} returned no content or tool calls`,
+        );
+        continue;
+      }
+
+      const internal: InternalResult = {
+        content: collectedText,
+        model: streamResult.model,
+        finishReason: streamResult.finishReason ?? defaultFinishReason(format),
+        reasoning: undefined,
+        usage: streamResult.usage
+          ? extractUsageFromStreamResult(streamResult.usage)
+          : undefined,
+        toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
+      };
+
+      // Track usage and metrics
+      const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
+      tracer?.setUsage({
+        inputTokens: resolvedUsage.input,
+        outputTokens: resolvedUsage.output,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+      });
+      tracer?.recordMetrics();
+
+      if (tracer && streamResult.model && streamResult.model !== requestModel) {
+        tracer.setModelSubstitution(requestModel, streamResult.model);
+      }
+      tracer?.end(200, Date.now() - requestStartTime);
+
+      recordFinalSuccess(lastAttemptLabel, "translation");
+
+      const traceCtx = tracer?.getTraceContext();
+      logRequest({
+        timestamp: new Date().toISOString(),
+        requestId: ctx.requestId,
+        method: ctx.method,
+        path: ctx.path,
+        model: requestModel,
+        stream: false,
+        toolCount: Object.keys(parsed.tools).length,
+        account: "translation",
+        accountType: "translation",
+        responseStatus: 200,
+        responseTimeMs: Date.now() - requestStartTime,
+        inputTokens: resolvedUsage.input,
+        outputTokens: resolvedUsage.output,
+        ...(traceCtx?.traceId ? { traceId: traceCtx.traceId } : {}),
+        ...(traceCtx?.spanId ? { spanId: traceCtx.spanId } : {}),
+      });
+
+      return format === "claude"
+        ? serializeClaudeResponse(internal, requestModel)
+        : serializeOpenAIResponse(internal, requestModel);
+    } catch (attemptError) {
+      lastAttemptError =
+        attemptError instanceof Error
+          ? attemptError.message
+          : String(attemptError);
+      logger.debug(
+        `${tag} translation attempt ${attempt.label} failed: ${lastAttemptError}`,
+      );
+      recordAttemptError(lastAttemptLabel, "translation", 500);
+    }
+  }
+
+  recordFinalError(500, lastAttemptLabel, "translation");
+
+  tracer?.setError("generation_error", lastAttemptError.slice(0, 500));
+  tracer?.end(500, Date.now() - requestStartTime);
+
+  const traceCtx = tracer?.getTraceContext();
+  logRequest({
+    timestamp: new Date().toISOString(),
+    requestId: ctx.requestId,
+    method: ctx.method,
+    path: ctx.path,
+    model: requestModel,
+    stream: false,
+    toolCount: Object.keys(parsed.tools).length,
+    account: "translation",
+    accountType: "translation",
+    responseStatus: 500,
+    responseTimeMs: Date.now() - requestStartTime,
+    errorType: "generation_error",
+    errorMessage: lastAttemptError.slice(0, 500),
+    ...(traceCtx?.traceId ? { traceId: traceCtx.traceId } : {}),
+    ...(traceCtx?.spanId ? { spanId: traceCtx.spanId } : {}),
+  });
+
+  throw new NeuroLinkError({
+    code: ERROR_CODES.PROVIDER_NOT_AVAILABLE,
+    message: lastAttemptError,
+    category: ErrorCategory.EXECUTION,
+    severity: ErrorSeverity.HIGH,
+    retriable: false,
+    context: { attemptLabel: lastAttemptLabel, format },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Models list handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the /v1/models response in OpenAI list format.
+ * Used by both Claude and OpenAI proxy routes.
+ */
+export function buildModelsListResponse(modelRouter?: {
+  getModelMappings?: () => Array<{ from: string }>;
+  getPassthroughModels?: () => string[];
+}): {
+  object: string;
+  data: Array<{
+    id: string;
+    object: string;
+    created: number;
+    owned_by: string;
+  }>;
+} {
+  const models: Array<{
+    id: string;
+    object: string;
+    created: number;
+    owned_by: string;
+  }> = [];
+
+  if (modelRouter) {
+    const mappings = modelRouter.getModelMappings?.() ?? [];
+    for (const m of mappings) {
+      models.push({
+        id: m.from,
+        object: "model",
+        created: 0,
+        owned_by: "neurolink",
+      });
+    }
+
+    const passthroughModels = modelRouter.getPassthroughModels?.() ?? [];
+    for (const id of passthroughModels) {
+      models.push({
+        id,
+        object: "model",
+        created: 0,
+        owned_by: "neurolink",
+      });
+    }
+  }
+
+  // Always include a default entry if nothing else is configured
+  if (models.length === 0) {
+    for (const id of DEFAULT_MODEL_IDS) {
+      models.push({
+        id,
+        object: "model",
+        created: 0,
+        owned_by: "neurolink",
+      });
+    }
+  }
+
+  return {
+    object: "list",
+    data: models,
+  };
+}
+
+/**
+ * Canonical default model IDs surfaced when no router is configured. Format
+ * matches the IDs used throughout `src/lib/models/` and `src/lib/constants/`
+ * (e.g. `claude-3-5-haiku-20241022`, not `claude-haiku-3.5-20241022`).
+ */
+const DEFAULT_MODEL_IDS = [
+  // Claude 4-series (current generation, hyphen-suffix family)
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+  // Claude 4 dated variant
+  "claude-sonnet-4-20250514",
+  // Claude 3.5-series (canonical Anthropic form: claude-3-5-{variant}-{date})
+  "claude-3-5-sonnet-20241022",
+  "claude-3-5-haiku-20241022",
+  // OpenAI / Google for translated-fallback users
+  "gpt-4o",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+];
+
+/**
+ * Build an Anthropic-shaped `/v1/models` list response.
+ *
+ * Used by the Claude-compatible route so Anthropic SDK consumers receive
+ * the schema they expect:
+ *   { data: [{type, id, display_name, created_at}], first_id, last_id, has_more }
+ *
+ * The OpenAI route continues to use {@link buildModelsListResponse} for the
+ * OpenAI list shape.
+ */
+export function buildAnthropicModelsListResponse(modelRouter?: {
+  getModelMappings?: () => Array<{ from?: string }>;
+  getPassthroughModels?: () => string[];
+}): {
+  data: Array<{
+    type: "model";
+    id: string;
+    display_name: string;
+    created_at: string;
+  }>;
+  first_id: string | null;
+  last_id: string | null;
+  has_more: boolean;
+} {
+  const ids: string[] = [];
+
+  if (modelRouter) {
+    const mappings = modelRouter.getModelMappings?.() ?? [];
+    for (const m of mappings) {
+      if (m.from) {
+        ids.push(m.from);
+      }
+    }
+    const passthrough = modelRouter.getPassthroughModels?.() ?? [];
+    for (const id of passthrough) {
+      ids.push(id);
+    }
+  }
+
+  if (ids.length === 0) {
+    ids.push(...DEFAULT_MODEL_IDS);
+  }
+
+  // Deduplicate while preserving order — multiple router sources can publish
+  // the same id (e.g. both an explicit mapping and a passthrough entry).
+  const seen = new Set<string>();
+  const unique = ids.filter((id) => {
+    if (seen.has(id)) {
+      return false;
+    }
+    seen.add(id);
+    return true;
+  });
+
+  const data = unique.map((id) => ({
+    type: "model" as const,
+    id,
+    display_name: humanizeModelId(id),
+    // Anthropic uses ISO-8601 timestamps. We don't have a real creation date
+    // for proxy-published models, so anchor to the epoch — clients that care
+    // about ordering have `first_id`/`last_id` instead.
+    created_at: new Date(0).toISOString(),
+  }));
+
+  return {
+    data,
+    first_id: data[0]?.id ?? null,
+    last_id: data[data.length - 1]?.id ?? null,
+    has_more: false,
+  };
+}
+
+/** Best-effort pretty name for a model id (e.g. `claude-3-5-haiku-20241022` -> `Claude 3.5 Haiku`). */
+function humanizeModelId(id: string): string {
+  // Drop the trailing date suffix if present (e.g. -20241022).
+  const base = id.replace(/-\d{8}$/, "");
+  // claude-3-5-haiku → ["claude", "3", "5", "haiku"] → "Claude 3.5 Haiku"
+  const parts = base.split("-");
+  const numericVersion: string[] = [];
+  const words: string[] = [];
+  for (const p of parts) {
+    if (
+      /^\d+$/.test(p) &&
+      words.length > 0 &&
+      words[0].toLowerCase() === "claude"
+    ) {
+      numericVersion.push(p);
+    } else {
+      words.push(p.charAt(0).toUpperCase() + p.slice(1));
+    }
+  }
+  const versionPart =
+    numericVersion.length > 0 ? ` ${numericVersion.join(".")}` : "";
+  return words.length > 0
+    ? `${words[0]}${versionPart}${words.slice(1).length ? " " + words.slice(1).join(" ") : ""}`
+    : id;
+}

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -31,6 +31,16 @@ import {
   parseClaudeRequest,
   serializeClaudeResponse,
 } from "../../proxy/claudeFormat.js";
+import {
+  buildAnthropicModelsListResponse,
+  buildTranslationOptions,
+  extractText,
+  extractToolArgs,
+  extractUsageFromStreamResult,
+  handleTranslatedJsonRequest,
+  handleTranslatedStreamRequest,
+  hasTranslatedOutput,
+} from "../../proxy/proxyTranslationEngine.js";
 import type { ModelRouter } from "../../proxy/modelRouter.js";
 import { tracers } from "../../telemetry/tracers.js";
 import { withSpan } from "../../telemetry/withSpan.js";
@@ -81,7 +91,6 @@ import type {
   PreparedAnthropicAccountAttempt,
   ProxyBodyCaptureLogger,
   ProxyPassthroughAccount,
-  ProxyTranslationAttempt,
   RouteGroup,
   RuntimeAccountState,
   ServerContext,
@@ -698,24 +707,25 @@ async function handleTranslatedClaudeRequest(args: {
   const attempts = plan.attempts;
 
   if (body.stream) {
-    return handleTranslatedClaudeStreamRequest({
+    return handleTranslatedStreamRequest({
       ctx,
-      body,
-      attempts,
+      format: "claude",
+      requestModel: body.model,
       parsed,
+      attempts,
       tracer,
       requestStartTime,
     });
   }
 
-  return handleTranslatedClaudeJsonRequest({
+  return handleTranslatedJsonRequest({
     ctx,
-    body,
-    attempts,
+    format: "claude",
+    requestModel: body.model,
     parsed,
+    attempts,
     tracer,
     requestStartTime,
-    logProxyBody,
   });
 }
 
@@ -732,289 +742,6 @@ function logProxyRoutingPlan(
       attempts: plan.attempts,
     },
   });
-}
-
-async function handleTranslatedClaudeStreamRequest(args: {
-  ctx: ServerContext;
-  body: ClaudeRequest;
-  attempts: ProxyTranslationAttempt[];
-  parsed: ParsedClaudeRequest;
-  tracer?: ProxyTracer;
-  requestStartTime: number;
-}): Promise<Response> {
-  const { ctx, body, attempts, parsed, tracer, requestStartTime } = args;
-  const serializer = new ClaudeStreamSerializer(body.model, 0);
-  const KEEPALIVE_INTERVAL_MS = 15_000;
-  const encoder = new TextEncoder();
-  let translationKeepAliveTimer: ReturnType<typeof setInterval> | undefined;
-  let translationCancelled = false;
-  let translationSucceeded = false;
-  let translatedModel: string | undefined;
-  let finalStreamError = "No translation providers succeeded";
-  let upstreamIterator: AsyncIterator<unknown> | undefined;
-
-  const translationStream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      for (const frame of serializer.start()) {
-        controller.enqueue(encoder.encode(frame));
-      }
-
-      translationKeepAliveTimer = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(": keep-alive\n\n"));
-        } catch {
-          // Controller already closed.
-        }
-      }, KEEPALIVE_INTERVAL_MS);
-
-      try {
-        for (
-          let attemptIndex = 0;
-          attemptIndex < attempts.length;
-          attemptIndex++
-        ) {
-          const attempt = attempts[attemptIndex];
-          if (attemptIndex > 0) {
-            logger.always(`[proxy] fallback → ${attempt.label}`);
-          }
-
-          let collectedText = "";
-          try {
-            const options = buildProxyFallbackOptions(
-              parsed,
-              attempt.provider
-                ? {
-                    provider: attempt.provider,
-                    model: attempt.model,
-                  }
-                : {},
-            );
-            const streamResult = await ctx.neurolink.stream(
-              options as Parameters<typeof ctx.neurolink.stream>[0],
-            );
-            const iterable = streamResult.stream as AsyncIterable<unknown>;
-            upstreamIterator = iterable[Symbol.asyncIterator]();
-
-            while (true) {
-              if (translationCancelled) {
-                break;
-              }
-              const { value: chunk, done } = await upstreamIterator.next();
-              if (done || translationCancelled) {
-                break;
-              }
-              const text = extractText(chunk);
-              if (text) {
-                collectedText += text;
-                for (const frame of serializer.pushDelta(text)) {
-                  controller.enqueue(encoder.encode(frame));
-                }
-              }
-            }
-
-            const toolCalls = streamResult.toolCalls ?? [];
-            if (!hasTranslatedOutput(collectedText, toolCalls)) {
-              finalStreamError = `Translated provider ${attempt.label} returned no content or tool calls`;
-              logger.debug(
-                `[proxy] translation attempt ${attempt.label} returned no content or tool calls`,
-              );
-              continue;
-            }
-
-            if (!translationCancelled && toolCalls.length) {
-              for (const toolCall of toolCalls) {
-                const toolName =
-                  (toolCall as { toolName?: string }).toolName ??
-                  (toolCall as { name?: string }).name ??
-                  "unknown";
-                for (const frame of serializer.pushToolUse(
-                  generateToolUseId(),
-                  toolName,
-                  extractToolArgs(toolCall),
-                )) {
-                  controller.enqueue(encoder.encode(frame));
-                }
-              }
-            }
-
-            if (!translationCancelled) {
-              const reason = streamResult.finishReason ?? "end_turn";
-              const resolvedUsage = extractUsageFromStreamResult(
-                streamResult.usage,
-              );
-              for (const frame of serializer.finish(
-                resolvedUsage.output,
-                reason,
-              )) {
-                controller.enqueue(encoder.encode(frame));
-              }
-            }
-
-            translatedModel = streamResult.model;
-            translationSucceeded = true;
-            return;
-          } catch (streamErr) {
-            if (translationCancelled) {
-              return;
-            }
-            finalStreamError =
-              streamErr instanceof Error
-                ? streamErr.message
-                : String(streamErr);
-            if (collectedText.trim().length > 0) {
-              logger.always(
-                `[proxy] mid-stream error (translation mode): ${finalStreamError}`,
-              );
-              const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
-              controller.enqueue(encoder.encode(errorEvent));
-              return;
-            }
-            logger.debug(
-              `[proxy] translation attempt ${attempt.label} failed: ${finalStreamError}`,
-            );
-          }
-        }
-
-        if (!translationCancelled) {
-          logger.always(
-            `[proxy] mid-stream error (translation mode): ${finalStreamError}`,
-          );
-          const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${finalStreamError}` } })}\n\n`;
-          controller.enqueue(encoder.encode(errorEvent));
-        }
-      } finally {
-        if (translationKeepAliveTimer) {
-          clearInterval(translationKeepAliveTimer);
-        }
-        if (!translationCancelled) {
-          controller.close();
-        }
-        if (tracer && translatedModel && translatedModel !== body.model) {
-          tracer.setModelSubstitution(body.model, translatedModel);
-        }
-        if (!translationSucceeded) {
-          tracer?.setError("generation_error", finalStreamError.slice(0, 500));
-        }
-        tracer?.end(200, Date.now() - requestStartTime);
-      }
-    },
-    cancel() {
-      translationCancelled = true;
-      if (translationKeepAliveTimer) {
-        clearInterval(translationKeepAliveTimer);
-        translationKeepAliveTimer = undefined;
-      }
-      if (upstreamIterator?.return) {
-        upstreamIterator.return(undefined).catch((cancelErr) => {
-          logger.debug(
-            `[proxy] upstream cancel error: ${cancelErr instanceof Error ? cancelErr.message : String(cancelErr)}`,
-          );
-        });
-      }
-    },
-  });
-
-  return new Response(translationStream, {
-    headers: {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache",
-      connection: "keep-alive",
-    },
-  });
-}
-
-async function handleTranslatedClaudeJsonRequest(args: {
-  ctx: ServerContext;
-  body: ClaudeRequest;
-  attempts: ProxyTranslationAttempt[];
-  parsed: ParsedClaudeRequest;
-  tracer?: ProxyTracer;
-  requestStartTime: number;
-  logProxyBody: ProxyBodyCaptureLogger;
-}): Promise<unknown> {
-  const {
-    ctx,
-    body,
-    attempts,
-    parsed,
-    tracer,
-    requestStartTime,
-    logProxyBody,
-  } = args;
-  let lastAttemptError = "No translation providers succeeded";
-
-  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
-    const attempt = attempts[attemptIndex];
-    if (attemptIndex > 0) {
-      logger.always(`[proxy] fallback → ${attempt.label}`);
-    }
-
-    try {
-      const options = buildProxyFallbackOptions(
-        parsed,
-        attempt.provider
-          ? {
-              provider: attempt.provider,
-              model: attempt.model,
-            }
-          : {},
-      );
-      const streamResult = await ctx.neurolink.stream(
-        options as Parameters<typeof ctx.neurolink.stream>[0],
-      );
-      let collectedText = "";
-      for await (const chunk of streamResult.stream) {
-        const text = extractText(chunk);
-        if (text) {
-          collectedText += text;
-        }
-      }
-      if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
-        lastAttemptError = `Translated provider ${attempt.label} returned no content or tool calls`;
-        logger.debug(
-          `[proxy] translation attempt ${attempt.label} returned no content or tool calls`,
-        );
-        continue;
-      }
-
-      const internal: InternalResult = {
-        content: collectedText,
-        model: streamResult.model,
-        finishReason: streamResult.finishReason ?? "end_turn",
-        reasoning: undefined,
-        usage: streamResult.usage
-          ? extractUsageFromStreamResult(streamResult.usage)
-          : undefined,
-        toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
-      };
-      if (tracer && streamResult.model && streamResult.model !== body.model) {
-        tracer.setModelSubstitution(body.model, streamResult.model);
-      }
-      tracer?.end(200, Date.now() - requestStartTime);
-      const clientResponse = serializeClaudeResponse(internal, body.model);
-      const clientResponseText = JSON.stringify(clientResponse);
-      logProxyBody({
-        phase: "client_response",
-        headers: { "content-type": "application/json" },
-        body: clientResponseText,
-        bodySize: Buffer.byteLength(clientResponseText, "utf8"),
-        contentType: "application/json",
-        responseStatus: 200,
-        durationMs: Date.now() - requestStartTime,
-      });
-      return clientResponse;
-    } catch (attemptError) {
-      lastAttemptError =
-        attemptError instanceof Error
-          ? attemptError.message
-          : String(attemptError);
-      logger.debug(
-        `[proxy] translation attempt ${attempt.label} failed: ${lastAttemptError}`,
-      );
-    }
-  }
-
-  throw new Error(lastAttemptError);
 }
 
 async function handleClaudePassthroughRequest(args: {
@@ -4874,7 +4601,13 @@ export function createClaudeProxyRoutes(
       },
 
       // =====================================================================
-      // GET /v1/models -- List available models
+      // GET /v1/models -- List available models (Anthropic schema)
+      //
+      // Returns the Anthropic-shaped list response (`type`, `display_name`,
+      // `created_at`, `first_id`, `last_id`, `has_more`) so Anthropic SDK
+      // consumers calling this Claude-compatible surface get the schema they
+      // expect. The OpenAI route serves the same data in OpenAI list format
+      // via its own builder.
       // =====================================================================
       {
         method: "GET",
@@ -4886,26 +4619,9 @@ export function createClaudeProxyRoutes(
               tracer: tracers.http,
               attributes: { "http.route": `${basePath}/v1/models` },
             },
-            async () => {
-              const models = [
-                "claude-sonnet-4-20250514",
-                "claude-sonnet-4-5-20250929",
-                "claude-haiku-4-5-20241022",
-                "claude-opus-4-20250514",
-              ];
-
-              return {
-                object: "list",
-                data: models.map((id) => ({
-                  id,
-                  object: "model",
-                  created: 1700000000,
-                  owned_by: "anthropic",
-                })),
-              };
-            },
+            async () => buildAnthropicModelsListResponse(modelRouter),
           ),
-        description: "List available Claude models",
+        description: "List available models (Anthropic schema)",
         tags: ["claude-proxy", "models"],
       },
 
@@ -4964,63 +4680,6 @@ export function createClaudeProxyRoutes(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Extract token usage from a StreamResult.usage object, handling multiple
- * naming conventions across AI SDK versions and providers:
- * - AI SDK v6: inputTokens / outputTokens
- * - AI SDK v4: promptTokens / completionTokens
- * - NeuroLink internal: input / output
- */
-function extractUsageFromStreamResult(usage: unknown): {
-  input: number;
-  output: number;
-  total: number;
-} {
-  if (!usage || typeof usage !== "object") {
-    return { input: 0, output: 0, total: 0 };
-  }
-  const u = usage as Record<string, unknown>;
-  const input =
-    (typeof u.inputTokens === "number" ? u.inputTokens : 0) ||
-    (typeof u.promptTokens === "number" ? u.promptTokens : 0) ||
-    (typeof u.input === "number" ? u.input : 0);
-  const output =
-    (typeof u.outputTokens === "number" ? u.outputTokens : 0) ||
-    (typeof u.completionTokens === "number" ? u.completionTokens : 0) ||
-    (typeof u.output === "number" ? u.output : 0);
-  return { input, output, total: input + output };
-}
-
-/**
- * Extract text content from a stream chunk (handles various chunk formats).
- */
-function extractText(chunk: unknown): string | null {
-  if (typeof chunk === "string") {
-    return chunk;
-  }
-
-  if (chunk && typeof chunk === "object") {
-    const c = chunk as Record<string, unknown>;
-
-    // NeuroLink StreamResult chunk format: { content: string }
-    if (typeof c.content === "string") {
-      return c.content;
-    }
-
-    // Vercel AI SDK text delta format
-    if (c.type === "text-delta" && typeof c.textDelta === "string") {
-      return c.textDelta;
-    }
-
-    // Direct text field
-    if (typeof c.text === "string") {
-      return c.text;
-    }
-  }
-
-  return null;
-}
 
 function getOrCreateRuntimeState(accountKey: string): RuntimeAccountState {
   const existing = accountRuntimeState.get(accountKey);
@@ -5223,104 +4882,10 @@ function normalizeClaudeRequestForAnthropic(
   };
 }
 
-export function buildProxyFallbackOptions(
-  parsed: ParsedClaudeRequest,
-  overrides: {
-    provider?: string;
-    model?: string;
-  } = {},
-): Record<string, unknown> {
-  const historyMessages = parsed.conversationMessages.slice(0, -1);
-  const toolNames = Object.keys(parsed.tools);
-  const images = shouldOmitImagesForTarget(overrides.provider, overrides.model)
-    ? []
-    : parsed.images;
-  const thinkingConfig = shouldOmitThinkingConfigForTarget(
-    overrides.provider,
-    overrides.model,
-  )
-    ? undefined
-    : parsed.thinkingConfig;
-  const toolChoice = parsed.toolChoiceName
-    ? { type: "tool" as const, toolName: parsed.toolChoiceName }
-    : parsed.toolChoice;
-
-  return {
-    input: {
-      text: parsed.prompt,
-      ...(images.length > 0 ? { images } : {}),
-    },
-    ...(overrides.provider ? { provider: overrides.provider } : {}),
-    ...(overrides.model ? { model: overrides.model } : {}),
-    systemPrompt: parsed.systemPrompt,
-    maxTokens: parsed.maxTokens,
-    ...(parsed.temperature !== undefined
-      ? { temperature: parsed.temperature }
-      : {}),
-    ...(parsed.topP !== undefined ? { topP: parsed.topP } : {}),
-    ...(parsed.topK !== undefined ? { topK: parsed.topK } : {}),
-    ...(parsed.stopSequences?.length
-      ? { stopSequences: parsed.stopSequences }
-      : {}),
-    ...(thinkingConfig ? { thinkingConfig } : {}),
-    ...(toolNames.length === 0 ? { disableTools: true } : {}),
-    // Claude-compatible requests already declare the exact tool contract.
-    // Filter out NeuroLink's built-in agent tools so translated fallbacks only
-    // expose the tools the client actually knows how to handle.
-    ...(toolNames.length > 0
-      ? {
-          tools: parsed.tools,
-          toolFilter: toolNames,
-        }
-      : {}),
-    ...(toolChoice ? { toolChoice } : {}),
-    ...(historyMessages.length > 0
-      ? { conversationMessages: historyMessages }
-      : {}),
-    disableInternalFallback: true,
-    skipToolPromptInjection: true,
-    maxSteps: 1,
-  };
-}
-
-function hasTranslatedOutput(
-  collectedText: string,
-  toolCalls: unknown[] | undefined,
-): boolean {
-  return collectedText.trim().length > 0 || (toolCalls?.length ?? 0) > 0;
-}
-
-function shouldOmitImagesForTarget(provider?: string, model?: string): boolean {
-  // `open-large` in our LiteLLM setup handles text and tools, but returns an
-  // empty completion when binary images are forwarded. Claude Code already
-  // includes textual image markers in the prompt, so dropping only the binary
-  // image payload keeps the request usable instead of breaking fallback.
-  return provider === "litellm" && model === "open-large";
-}
-
-function shouldOmitThinkingConfigForTarget(
-  provider?: string,
-  model?: string,
-): boolean {
-  if (provider === "litellm") {
-    return true;
-  }
-  if (provider !== "vertex") {
-    return false;
-  }
-  // Only Gemini 2.5+ and 3.x support thinking_level on Vertex.
-  const m = model?.toLowerCase() ?? "";
-  return !/gemini-(2\.5|3)/.test(m);
-}
-
-function extractToolArgs(toolCall: unknown): unknown {
-  return (
-    (toolCall as { args?: unknown }).args ??
-    (toolCall as { parameters?: unknown }).parameters ??
-    (toolCall as { input?: unknown }).input ??
-    {}
-  );
-}
+/**
+ * Backward-compatible alias — delegates to the shared translation engine.
+ */
+export const buildProxyFallbackOptions = buildTranslationOptions;
 
 /**
  * Detect transient upstream failures that should trigger account/provider failover.

--- a/src/lib/server/routes/index.ts
+++ b/src/lib/server/routes/index.ts
@@ -12,6 +12,7 @@ import { createAgentRoutes } from "./agentRoutes.js";
 import { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 // ClaudeProxyDeps removed
 import { createHealthRoutes } from "./healthRoutes.js";
+import { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
 import { createMCPRoutes } from "./mcpRoutes.js";
 import { createMemoryRoutes } from "./memoryRoutes.js";
 import { createOpenApiRoutes } from "./openApiRoutes.js";
@@ -22,6 +23,7 @@ export { createAgentRoutes } from "./agentRoutes.js";
 export { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 // ClaudeProxyDeps removed
 export { createHealthRoutes } from "./healthRoutes.js";
+export { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
 export { createMCPRoutes } from "./mcpRoutes.js";
 export { createMemoryRoutes } from "./memoryRoutes.js";
 export { createOpenApiRoutes } from "./openApiRoutes.js";
@@ -48,9 +50,17 @@ export function createAllRoutes(
     routes.push(createOpenApiRoutes(basePath, options.getRoutes));
   }
 
-  // Conditionally add Claude-compatible proxy routes
-  if (options?.claudeProxy) {
+  // Unified proxy flag enables both Claude and OpenAI endpoints.
+  // Legacy per-format flags are still supported for backward compatibility.
+  const enableClaudeProxy = options?.proxy || options?.claudeProxy;
+  const enableOpenAIProxy = options?.proxy || options?.openaiProxy;
+
+  if (enableClaudeProxy) {
     routes.push(createClaudeProxyRoutes(undefined, basePath));
+  }
+
+  if (enableOpenAIProxy) {
+    routes.push(createOpenAIProxyRoutes(undefined, basePath));
   }
 
   return routes;

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -1,0 +1,453 @@
+/**
+ * OpenAI-Compatible Proxy Routes
+ *
+ * Exposes OpenAI Chat Completions-compatible /v1/chat/completions endpoint.
+ * ALL requests are routed through ctx.neurolink.stream() — no direct
+ * HTTP calls to any upstream provider.
+ *
+ * This is a thin wrapper that parses OpenAI format requests and delegates
+ * to the shared proxy translation engine.
+ *
+ * An optional ModelRouter can remap incoming model names to different
+ * provider/model pairs (e.g. "gpt-4o" -> vertex/gemini-2.5-pro).
+ */
+
+import {
+  buildOpenAIError,
+  convertClaudeToOpenAIResponse,
+  convertOpenAIToClaudeRequest,
+  createClaudeToOpenAIStreamTransform,
+  parseOpenAIRequest,
+} from "../../proxy/openaiFormat.js";
+import type { ModelRouter } from "../../proxy/modelRouter.js";
+import { ProxyTracer } from "../../proxy/proxyTracer.js";
+import {
+  buildModelsListResponse,
+  handleTranslatedJsonRequest,
+  handleTranslatedStreamRequest,
+} from "../../proxy/proxyTranslationEngine.js";
+import { logRequest } from "../../proxy/requestLogger.js";
+import { buildProxyTranslationPlan } from "../../proxy/routingPolicy.js";
+import type {
+  ClaudeResponse,
+  OpenAICompletionRequest,
+  ParsedOpenAIRequest,
+  RouteGroup,
+  ServerContext,
+} from "../../types/index.js";
+import { withTimeout } from "../../utils/async/withTimeout.js";
+import { sanitizeForLog } from "../../utils/logSanitize.js";
+import { logger } from "../../utils/logger.js";
+
+// Maximum time the internal loopback fetch is allowed to take before we
+// give up — keeps a stuck inner /v1/messages handler from hanging the outer
+// /v1/chat/completions request indefinitely.
+const LOOPBACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — long enough for slow Claude streams
+
+// Default loopback port — matches the CLI proxy default. Overridden via
+// `createOpenAIProxyRoutes`'s third argument when the actual listener port is
+// known (e.g. when started from the CLI handler).
+const DEFAULT_LOOPBACK_PORT = 55669;
+
+/**
+ * Build an OpenAI-shaped error as a typed Response with the intended status.
+ *
+ * Without the explicit Response wrapper, the CLI proxy runtime maps plain
+ * objects to HTTP 200, so error returns would silently arrive as 200s with
+ * an error payload. Wrapping in Response forces the runtime to honor the
+ * status code we computed.
+ */
+function buildOpenAIErrorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify(buildOpenAIError(status, message)), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapt ParsedOpenAIRequest to the shape buildProxyTranslationPlan expects
+// ---------------------------------------------------------------------------
+
+/**
+ * buildProxyTranslationPlan's classifier expects ParsedClaudeRequest.
+ * The shapes are nearly identical; we just fill in the extra fields it inspects
+ * (thinkingConfig, topK) with safe defaults.
+ */
+function adaptForTranslationPlan(parsed: ParsedOpenAIRequest): {
+  model: string;
+  maxTokens: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  systemPrompt?: string;
+  stream: boolean;
+  prompt: string;
+  images: string[];
+  conversationMessages: Array<{ role: string; content: string }>;
+  tools: Record<
+    string,
+    {
+      description?: string;
+      inputSchema: unknown;
+      execute?: (...args: unknown[]) => unknown;
+    }
+  >;
+  toolChoice?: "auto" | "required" | "none";
+  toolChoiceName?: string;
+  stopSequences?: string[];
+  thinkingConfig?: { enabled: boolean };
+} {
+  return {
+    model: parsed.model,
+    maxTokens: parsed.maxTokens ?? 4096,
+    temperature: parsed.temperature,
+    topP: parsed.topP,
+    systemPrompt:
+      typeof parsed.systemPrompt === "string" ? parsed.systemPrompt : undefined,
+    stream: parsed.stream,
+    prompt: parsed.prompt,
+    images: parsed.images,
+    conversationMessages: parsed.conversationMessages,
+    tools: parsed.tools,
+    toolChoice: parsed.toolChoice,
+    toolChoiceName: parsed.toolChoiceName,
+    stopSequences: parsed.stopSequences,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI -> Anthropic loopback bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Forward an OpenAI-format request targeting a Claude model through the
+ * proxy's own /v1/messages endpoint via a loopback fetch().
+ *
+ * This reuses the full Claude passthrough path (OAuth account rotation, retry,
+ * SSE interception, etc.) and only adds format conversion at the edges.
+ *
+ * The loopback target is ALWAYS `127.0.0.1:<loopbackPort>` (never derived
+ * from the client-controlled `Host` header — that would be an SSRF vector).
+ * `loopbackPort` is provided at route-build time from the listener's actual
+ * port via `createOpenAIProxyRoutes(modelRouter, basePath, loopbackPort)`.
+ */
+async function handleOpenAIToAnthropicBridge(args: {
+  ctx: ServerContext;
+  body: OpenAICompletionRequest;
+  targetModel: string;
+  requestStartTime: number;
+  loopbackPort: number;
+}): Promise<unknown> {
+  const { ctx, body, targetModel, requestStartTime, loopbackPort } = args;
+  const stream = body.stream === true;
+  const toolCount = body.tools?.length ?? 0;
+
+  const writeLifecycle = (
+    responseStatus: number,
+    extra: {
+      errorType?: string;
+      errorMessage?: string;
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    } = {},
+  ) =>
+    logRequest({
+      timestamp: new Date().toISOString(),
+      requestId: ctx.requestId,
+      method: ctx.method,
+      path: ctx.path,
+      model: body.model,
+      stream,
+      toolCount,
+      account: "",
+      accountType: "openai-bridge",
+      responseStatus,
+      responseTimeMs: Date.now() - requestStartTime,
+      ...extra,
+    });
+
+  // Convert to Claude format and remap the model to the router's choice.
+  const claudeBody = convertOpenAIToClaudeRequest(body);
+  claudeBody.model = targetModel;
+
+  // SECURITY: Never derive the loopback target from the client-controlled
+  // `Host` header. The bridge always fetches from 127.0.0.1 on the listener's
+  // configured port — anything else would be an SSRF vector.
+  const internalUrl = `http://127.0.0.1:${loopbackPort}/v1/messages`;
+
+  // Forward a minimal set of headers. The proxy's own /v1/messages handler
+  // will attach OAuth credentials from its account pool.
+  const forwardHeaders: Record<string, string> = {
+    "content-type": "application/json",
+    accept: stream ? "text/event-stream" : "application/json",
+  };
+  for (const [k, v] of Object.entries(ctx.headers)) {
+    if (typeof v !== "string") {
+      continue;
+    }
+    const lower = k.toLowerCase();
+    if (lower.startsWith("anthropic-") || lower === "x-api-key") {
+      forwardHeaders[lower] = v;
+    }
+  }
+
+  // Bound the self-call with a timeout so a stuck inner handler can't hang
+  // the outer /v1/chat/completions request indefinitely.
+  const upstream = await withTimeout(
+    fetch(internalUrl, {
+      method: "POST",
+      headers: forwardHeaders,
+      body: JSON.stringify({ ...claudeBody, stream }),
+    }),
+    LOOPBACK_TIMEOUT_MS,
+    `Anthropic loopback timed out after ${LOOPBACK_TIMEOUT_MS}ms`,
+  );
+
+  if (!upstream.ok) {
+    const errText = await upstream.text().catch(() => "");
+    const safeErrText = sanitizeForLog(errText);
+    logger.always(
+      `[proxy:openai] anthropic loopback error ${upstream.status}: ${safeErrText}`,
+    );
+    await writeLifecycle(upstream.status, {
+      errorType: "loopback_upstream_error",
+      errorMessage: safeErrText,
+    });
+    return buildOpenAIErrorResponse(
+      upstream.status,
+      safeErrText || `Anthropic loopback failed with status ${upstream.status}`,
+    );
+  }
+
+  if (stream) {
+    if (!upstream.body) {
+      await writeLifecycle(502, {
+        errorType: "loopback_empty_stream",
+        errorMessage: "Anthropic loopback returned empty stream body",
+      });
+      return buildOpenAIErrorResponse(
+        502,
+        "Anthropic loopback returned empty stream body",
+      );
+    }
+    // Streaming success: log now since the response body is consumed by the
+    // client. Token counts are not visible at this layer (the inner /v1/messages
+    // handler accounts them), so we omit them here.
+    await writeLifecycle(200);
+    const transformed = upstream.body.pipeThrough(
+      createClaudeToOpenAIStreamTransform(body.model),
+    );
+    return new Response(transformed, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
+  }
+
+  const claudeJson = (await upstream.json()) as ClaudeResponse;
+  await writeLifecycle(200, {
+    inputTokens: claudeJson.usage?.input_tokens,
+    outputTokens: claudeJson.usage?.output_tokens,
+    cacheCreationTokens: claudeJson.usage?.cache_creation_input_tokens,
+    cacheReadTokens: claudeJson.usage?.cache_read_input_tokens,
+  });
+  return convertClaudeToOpenAIResponse(claudeJson, body.model);
+}
+
+// ---------------------------------------------------------------------------
+// Route factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create OpenAI-compatible proxy routes.
+ *
+ * Every request flows through ctx.neurolink.stream() — no direct HTTP calls
+ * to any upstream provider.
+ *
+ * @param modelRouter   - Optional model router for remapping model names.
+ * @param basePath      - Base path prefix (default: "").
+ * @param loopbackPort  - Listener port used by the Anthropic loopback bridge.
+ *                        Defaults to the CLI proxy default (55669). MUST be the
+ *                        actual listener port — never derived from request
+ *                        headers — to avoid SSRF.
+ * @returns RouteGroup with OpenAI-compatible endpoints.
+ */
+export function createOpenAIProxyRoutes(
+  modelRouter?: ModelRouter,
+  basePath: string = "",
+  loopbackPort: number = DEFAULT_LOOPBACK_PORT,
+): RouteGroup {
+  return {
+    prefix: `${basePath}/v1`,
+    routes: [
+      // =================================================================
+      // POST /v1/chat/completions — Main chat completions endpoint
+      // =================================================================
+      {
+        method: "POST",
+        path: `${basePath}/v1/chat/completions`,
+        description: "OpenAI-compatible chat completions (translation mode)",
+        handler: async (ctx: ServerContext) => {
+          const requestStartTime = Date.now();
+          const body = ctx.body as OpenAICompletionRequest | undefined;
+
+          // --- Validation ---
+          if (!body || !body.model || !body.messages?.length) {
+            return buildOpenAIErrorResponse(
+              400,
+              "Request must include 'model' and 'messages' fields",
+            );
+          }
+
+          // --- Resolve target provider/model ---
+          const route = modelRouter
+            ? modelRouter.resolve(body.model)
+            : { provider: null, model: body.model };
+          const targetProvider = route.provider ?? undefined;
+          const targetModel = route.model ?? body.model;
+
+          logger.debug(
+            `[proxy:openai] ${body.model} → ${targetProvider ?? "auto"}/${targetModel}`,
+          );
+
+          // --- Anthropic loopback bridge ---
+          // When the resolved target is Anthropic, the proxy has no
+          // ANTHROPIC_API_KEY (it uses OAuth passthrough). Instead of trying
+          // to stream through the SDK, forward the request to our own
+          // /v1/messages endpoint via loopback so it goes through the full
+          // Claude passthrough path (OAuth, retry, rotation, SSE intercept).
+          if (route.provider === "anthropic") {
+            try {
+              return await handleOpenAIToAnthropicBridge({
+                ctx,
+                body,
+                targetModel,
+                requestStartTime,
+                loopbackPort,
+              });
+            } catch (err) {
+              // Internal exception text (.message + any stack-trace remnants)
+              // is kept ONLY in server-side logs + tracer. The client receives
+              // a fixed generic message so internal paths/frames don't leak
+              // back through the response body. (CodeQL: information exposure
+              // through a stack trace.)
+              const rawMessage =
+                err instanceof Error ? err.message : String(err);
+              const internalDetail = sanitizeForLog(rawMessage);
+              logger.always(
+                `[proxy:openai] anthropic loopback failed: ${internalDetail}`,
+              );
+              await logRequest({
+                timestamp: new Date().toISOString(),
+                requestId: ctx.requestId,
+                method: ctx.method,
+                path: ctx.path,
+                model: body.model,
+                stream: body.stream === true,
+                toolCount: body.tools?.length ?? 0,
+                account: "",
+                accountType: "openai-bridge",
+                responseStatus: 502,
+                responseTimeMs: Date.now() - requestStartTime,
+                errorType: "loopback_exception",
+                errorMessage: internalDetail,
+              });
+              return buildOpenAIErrorResponse(502, "Anthropic loopback failed");
+            }
+          }
+
+          // --- Parse request ---
+          const parsed = parseOpenAIRequest(body);
+
+          // --- Build translation plan ---
+          const adapted = adaptForTranslationPlan(parsed);
+          const plan = buildProxyTranslationPlan(
+            {
+              provider: targetProvider ?? "auto",
+              model: targetModel,
+            },
+            modelRouter?.getFallbackChain() ?? [],
+            body.model,
+            // The classifier only reads fields present on both types.
+            adapted as Parameters<typeof buildProxyTranslationPlan>[3],
+          );
+          const attempts = plan.attempts;
+
+          // --- Optional tracing ---
+          let tracer: ProxyTracer | undefined;
+          try {
+            tracer = ProxyTracer.startRequest(
+              {
+                requestId: ctx.requestId,
+                method: ctx.method,
+                path: ctx.path,
+                model: body.model,
+                stream: body.stream === true,
+                toolCount: Object.keys(parsed.tools).length,
+                clientApp: "openai-compat",
+                userAgent: ctx.headers["user-agent"] ?? "",
+              },
+              ctx.headers,
+            );
+            tracer.setMode("full");
+          } catch {
+            // Tracing is best-effort; continue without it.
+          }
+
+          // --- Dispatch via shared translation engine ---
+          try {
+            if (body.stream) {
+              return handleTranslatedStreamRequest({
+                ctx,
+                format: "openai",
+                requestModel: body.model,
+                parsed,
+                attempts,
+                tracer,
+                requestStartTime,
+              });
+            }
+
+            return await handleTranslatedJsonRequest({
+              ctx,
+              format: "openai",
+              requestModel: body.model,
+              parsed,
+              attempts,
+              tracer,
+              requestStartTime,
+            });
+          } catch (err) {
+            // Internal exception text is kept ONLY in server-side logs +
+            // tracer. The client receives a fixed generic message so internal
+            // paths/frames don't leak back through the response body.
+            // (CodeQL: information exposure through a stack trace.)
+            const rawMessage = err instanceof Error ? err.message : String(err);
+            const internalDetail = sanitizeForLog(rawMessage);
+            logger.always(`[proxy:openai] request failed: ${internalDetail}`);
+            tracer?.setError("generation_error", internalDetail);
+            tracer?.end(500, Date.now() - requestStartTime);
+            return buildOpenAIErrorResponse(500, "Internal proxy error");
+          }
+        },
+      },
+
+      // =================================================================
+      // GET /v1/models — List available models (OpenAI list format)
+      // =================================================================
+      {
+        method: "GET",
+        path: `${basePath}/v1/models`,
+        description: "List available models in OpenAI format",
+        handler: async () => {
+          return buildModelsListResponse(modelRouter);
+        },
+      },
+    ],
+  };
+}

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1320,3 +1320,181 @@ export type ProxyTelemetryAction =
   | "status"
   | "logs"
   | "import-dashboard";
+
+// =============================================================================
+// PROXY FORMAT (from proxy/proxyTranslationEngine.ts)
+// =============================================================================
+
+/** Wire format a proxy request is using. */
+export type ProxyFormat = "claude" | "openai";
+
+/**
+ * Common adapter interface that hides the differences between
+ * Claude and OpenAI stream serializers from the unified translation engine.
+ */
+export type StreamSerializerAdapter = {
+  start(): Iterable<string>;
+  pushDelta(text: string): Iterable<string>;
+  pushToolUse(id: string, name: string, input: unknown): Iterable<string>;
+  finish(
+    finishReason: string,
+    usage: { input: number; output: number; total: number },
+  ): Iterable<string>;
+  emitError(message: string): Iterable<string>;
+};
+
+// =============================================================================
+// OPENAI CHAT COMPLETIONS TYPES (for OpenCode proxy support)
+// =============================================================================
+
+/** OpenAI content part in a user message. */
+export type OpenAIContentPartText = { type: "text"; text: string };
+export type OpenAIContentPartImage = {
+  type: "image_url";
+  image_url: { url: string; detail?: "auto" | "low" | "high" };
+};
+export type OpenAIContentPart = OpenAIContentPartText | OpenAIContentPartImage;
+
+/** OpenAI message types. */
+export type OpenAISystemMessage = { role: "system"; content: string };
+export type OpenAIUserMessage = {
+  role: "user";
+  content: string | OpenAIContentPart[];
+};
+export type OpenAIAssistantMessage = {
+  role: "assistant";
+  content?: string | null;
+  tool_calls?: OpenAIToolCall[];
+};
+export type OpenAIToolMessage = {
+  role: "tool";
+  tool_call_id: string;
+  content: string;
+};
+export type OpenAIMessage =
+  | OpenAISystemMessage
+  | OpenAIUserMessage
+  | OpenAIAssistantMessage
+  | OpenAIToolMessage;
+
+/** OpenAI tool call (in assistant messages and responses). */
+export type OpenAIToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string }; // arguments is stringified JSON
+};
+
+/** OpenAI tool definition. */
+export type OpenAIToolDef = {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters: Record<string, unknown>;
+  };
+};
+
+/** OpenAI tool_choice options. */
+export type OpenAIToolChoice =
+  | "auto"
+  | "required"
+  | "none"
+  | { type: "function"; function: { name: string } };
+
+/** OpenAI Chat Completions request body. */
+export type OpenAICompletionRequest = {
+  model: string;
+  messages: OpenAIMessage[];
+  tools?: OpenAIToolDef[];
+  tool_choice?: OpenAIToolChoice;
+  stream?: boolean;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  stop?: string | string[];
+  n?: number;
+  response_format?: {
+    type: "text" | "json_object" | "json_schema";
+    json_schema?: unknown;
+  };
+  stream_options?: { include_usage?: boolean };
+};
+
+/** OpenAI usage counters. */
+export type OpenAIUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+/** OpenAI non-streaming response. */
+export type OpenAICompletionResponse = {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: "assistant";
+      content: string | null;
+      tool_calls?: OpenAIToolCall[];
+    };
+    finish_reason: "stop" | "tool_calls" | "length" | "content_filter" | null;
+  }>;
+  usage: OpenAIUsage;
+};
+
+/** OpenAI streaming chunk. */
+export type OpenAIStreamChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: "assistant";
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason: string | null;
+  }>;
+  usage?: OpenAIUsage;
+};
+
+/** OpenAI error response. */
+export type OpenAIErrorResponse = {
+  error: { message: string; type: string; code: string | null };
+};
+
+/** Parsed OpenAI request — intermediate form for NeuroLink pipeline. */
+export type ParsedOpenAIRequest = {
+  model: string;
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  systemPrompt?: string;
+  stream: boolean;
+  prompt: string;
+  images: string[];
+  conversationMessages: Array<{ role: string; content: string }>;
+  tools: Record<
+    string,
+    {
+      description?: string;
+      inputSchema: unknown;
+      execute?: (...args: unknown[]) => unknown;
+    }
+  >;
+  toolChoice?: "auto" | "required" | "none";
+  toolChoiceName?: string;
+  stopSequences?: string[];
+  responseFormat?: { type: string; jsonSchema?: unknown };
+};

--- a/src/lib/types/server.ts
+++ b/src/lib/types/server.ts
@@ -1401,7 +1401,10 @@ export type OpenAPISpec = {
 export type CreateRoutesOptions = {
   enableSwagger?: boolean;
   getRoutes?: () => RouteDefinition[];
+  /** Enable both Claude and OpenAI proxy endpoints. */
+  proxy?: boolean;
   claudeProxy?: boolean;
+  openaiProxy?: boolean;
 };
 
 // =============================================================================

--- a/test/continuous-test-suite-proxy-openai-format.ts
+++ b/test/continuous-test-suite-proxy-openai-format.ts
@@ -1,0 +1,508 @@
+#!/usr/bin/env tsx
+
+/**
+ * Continuous Test Suite — OpenAI-Compatible Proxy (format level)
+ *
+ * Pure unit-level tests of the format converters that power the
+ * `/v1/chat/completions` endpoint. These tests do NOT spin up a real
+ * proxy or hit any upstream — they exercise the conversion helpers in
+ * `src/lib/proxy/openaiFormat.ts` directly, which is where the SSE
+ * framing, tool-call translation, and error envelope live.
+ *
+ * Why these tests exist:
+ * - The `/v1/chat/completions` endpoint had zero regression coverage.
+ * - Reviewers (CodeRabbit + Copilot) flagged the lack of automated
+ *   tests for the new surface, the streaming flush behaviour, and the
+ *   error-envelope shape.
+ *
+ * Run:
+ *   npx tsx test/continuous-test-suite-proxy-openai-format.ts
+ *
+ * No environment variables, no network, no credentials required.
+ */
+
+import {
+  buildOpenAIError,
+  convertClaudeToOpenAIResponse,
+  convertOpenAIToClaudeRequest,
+  createClaudeToOpenAIStreamTransform,
+  generateChatCompletionId,
+  generateOpenAIToolCallId,
+  parseOpenAIRequest,
+} from "../src/lib/proxy/openaiFormat.js";
+import { defineSuite, log, logSection } from "./helpers/harness.js";
+import type {
+  ClaudeResponse,
+  OpenAICompletionRequest,
+  OpenAIErrorResponse,
+} from "../src/lib/types/index.js";
+
+const { recordTest, runSuite } = defineSuite("Proxy OpenAI Format");
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function assertEqual<T>(name: string, actual: T, expected: T): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${name}: expected ${e}, got ${a}`);
+  }
+}
+
+function assert(name: string, condition: boolean, detail = ""): void {
+  if (!condition) {
+    throw new Error(`${name}${detail ? `: ${detail}` : ""}`);
+  }
+}
+
+// ============================================================================
+// Helpers for streaming the SSE transform end-to-end
+// ============================================================================
+
+/**
+ * Drive a `TransformStream<Uint8Array, Uint8Array>` with a sequence of
+ * UTF-8 chunks and return the concatenated decoded output.
+ */
+async function runTransform(
+  transform: TransformStream<Uint8Array, Uint8Array>,
+  chunks: string[],
+): Promise<string> {
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const decoder = new TextDecoder();
+  let collected = "";
+
+  const readerPromise = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      collected += decoder.decode(value, { stream: true });
+    }
+    collected += decoder.decode();
+  })();
+
+  const encoder = new TextEncoder();
+  for (const chunk of chunks) {
+    await writer.write(encoder.encode(chunk));
+  }
+  await writer.close();
+  await readerPromise;
+
+  return collected;
+}
+
+/**
+ * Parse OpenAI-style SSE output (`data: <json>\n\n` frames) into an array
+ * of parsed events. Skips `[DONE]`.
+ */
+function parseOpenAISseFrames(text: string): unknown[] {
+  const frames: unknown[] = [];
+  for (const block of text.split("\n\n")) {
+    const line = block.trim();
+    if (!line || !line.startsWith("data:")) {
+      continue;
+    }
+    const payload = line.slice(5).trim();
+    if (payload === "[DONE]") {
+      continue;
+    }
+    try {
+      frames.push(JSON.parse(payload));
+    } catch {
+      // Ignore non-JSON frames; the transform should not emit any.
+    }
+  }
+  return frames;
+}
+
+// ============================================================================
+// Test cases
+// ============================================================================
+
+const tests = [
+  // ──────────────────────────────────────────────────────────────────────
+  // ID generators
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "generateChatCompletionId returns chatcmpl- prefix with random suffix",
+    fn: () => {
+      const id = generateChatCompletionId();
+      assert("prefix", id.startsWith("chatcmpl-"));
+      assert(
+        "non-empty random suffix",
+        id.length > "chatcmpl-".length,
+        `id=${id}`,
+      );
+      // Verify uniqueness — two calls should differ.
+      const id2 = generateChatCompletionId();
+      assert("ids differ between calls", id !== id2, `id=${id} id2=${id2}`);
+      return true;
+    },
+  },
+  {
+    name: "generateOpenAIToolCallId returns call_ prefix",
+    fn: () => {
+      const id = generateOpenAIToolCallId();
+      assert("prefix", id.startsWith("call_"));
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // buildOpenAIError envelope (regression test for Copilot C1)
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "buildOpenAIError emits OpenAI-shaped error envelope with mapped type",
+    fn: () => {
+      const e400 = buildOpenAIError(400, "bad input") as OpenAIErrorResponse;
+      assert("400 has .error", typeof e400.error === "object");
+      assertEqual("400 message", e400.error.message, "bad input");
+      assert(
+        "400 type is invalid_request_error",
+        e400.error.type === "invalid_request_error",
+        `got ${e400.error.type}`,
+      );
+
+      const e500 = buildOpenAIError(500, "boom") as OpenAIErrorResponse;
+      assert(
+        "500 maps to server-class error",
+        e500.error.type === "server_error" ||
+          e500.error.type === "api_error" ||
+          e500.error.type === "internal_error",
+        `got ${e500.error.type}`,
+      );
+
+      const e429 = buildOpenAIError(429, "slow down") as OpenAIErrorResponse;
+      assert(
+        "429 type is rate_limit_exceeded",
+        e429.error.type === "rate_limit_exceeded" ||
+          e429.error.type === "rate_limit_error",
+        `got ${e429.error.type}`,
+      );
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // parseOpenAIRequest
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "parseOpenAIRequest extracts system + last user prompt",
+    fn: () => {
+      const req: OpenAICompletionRequest = {
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "First turn" },
+          { role: "assistant", content: "Hi" },
+          { role: "user", content: "Second turn — what's 2+2?" },
+        ],
+        max_tokens: 256,
+        temperature: 0.5,
+      };
+      const parsed = parseOpenAIRequest(req);
+      assertEqual("systemPrompt", parsed.systemPrompt, "You are helpful.");
+      assert(
+        "prompt is last user message",
+        parsed.prompt.includes("Second turn"),
+        `got "${parsed.prompt}"`,
+      );
+      assertEqual("maxTokens", parsed.maxTokens, 256);
+      assertEqual("temperature", parsed.temperature, 0.5);
+      assertEqual("model", parsed.model, "gpt-4o");
+      return true;
+    },
+  },
+  {
+    name: "parseOpenAIRequest converts OpenAI tools to internal tool registry",
+    fn: () => {
+      const req: OpenAICompletionRequest = {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "ping" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "echo",
+              description: "Echo back a string",
+              parameters: {
+                type: "object",
+                properties: { msg: { type: "string" } },
+                required: ["msg"],
+              },
+            },
+          },
+        ],
+        tool_choice: "auto",
+      };
+      const parsed = parseOpenAIRequest(req);
+      assert("echo tool registered", "echo" in parsed.tools);
+      assertEqual("tool count", Object.keys(parsed.tools).length, 1);
+      assertEqual("toolChoice", parsed.toolChoice, "auto");
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // convertOpenAIToClaudeRequest
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "convertOpenAIToClaudeRequest preserves model + max_tokens + messages",
+    fn: () => {
+      const req: OpenAICompletionRequest = {
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "S" },
+          { role: "user", content: "U" },
+        ],
+        max_tokens: 128,
+      };
+      const claude = convertOpenAIToClaudeRequest(req);
+      assertEqual("claude.model", claude.model, "gpt-4o");
+      assertEqual("claude.max_tokens", claude.max_tokens, 128);
+      assert(
+        "claude.system carries S",
+        typeof claude.system === "string"
+          ? claude.system.includes("S")
+          : Array.isArray(claude.system) &&
+              claude.system.some((b) =>
+                (b as { text?: string }).text?.includes("S"),
+              ),
+        `got ${JSON.stringify(claude.system)}`,
+      );
+      assert(
+        "claude.messages has a user turn",
+        claude.messages.some((m) => m.role === "user"),
+      );
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // convertClaudeToOpenAIResponse
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "convertClaudeToOpenAIResponse maps content + usage",
+    fn: () => {
+      const claude: ClaudeResponse = {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-haiku-4-5",
+        content: [{ type: "text", text: "Hello world" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 12, output_tokens: 3 },
+      };
+      const openai = convertClaudeToOpenAIResponse(claude, "gpt-4o");
+      assert(
+        "openai object",
+        (openai as { object?: string }).object === "chat.completion",
+      );
+      assertEqual(
+        "openai model echoes request alias",
+        (openai as { model: string }).model,
+        "claude-haiku-4-5",
+      );
+      const choice = (
+        openai as {
+          choices: Array<{
+            index: number;
+            message: { role: string; content: string };
+            finish_reason: string;
+          }>;
+        }
+      ).choices[0];
+      assertEqual("choice.0.role", choice.message.role, "assistant");
+      assertEqual("choice.0.content", choice.message.content, "Hello world");
+      assertEqual("choice.0.finish_reason", choice.finish_reason, "stop");
+
+      const usage = (
+        openai as {
+          usage: {
+            prompt_tokens: number;
+            completion_tokens: number;
+            total_tokens: number;
+          };
+        }
+      ).usage;
+      assertEqual("usage.prompt_tokens", usage.prompt_tokens, 12);
+      assertEqual("usage.completion_tokens", usage.completion_tokens, 3);
+      assertEqual("usage.total_tokens", usage.total_tokens, 15);
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SSE transform — happy path (text deltas)
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "createClaudeToOpenAIStreamTransform emits chatcmpl chunks for text deltas",
+    fn: async () => {
+      const transform = createClaudeToOpenAIStreamTransform("gpt-4o");
+      const chunks = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", model: "claude-haiku-4-5", usage: { input_tokens: 5 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hel" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "lo" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+      ];
+      const out = await runTransform(transform, chunks);
+
+      assert("ends with [DONE] sentinel", out.includes("data: [DONE]"));
+      const frames = parseOpenAISseFrames(out);
+      assert("emitted at least 2 frames", frames.length >= 2);
+
+      const textDeltas = frames
+        .map(
+          (f) =>
+            (f as { choices?: Array<{ delta?: { content?: string } }> })
+              .choices?.[0]?.delta?.content ?? "",
+        )
+        .join("");
+      assert(
+        "concatenated text deltas == 'Hello'",
+        textDeltas === "Hello",
+        `got "${textDeltas}"`,
+      );
+
+      const finishFrame = frames.find(
+        (f) =>
+          (f as { choices?: Array<{ finish_reason?: string | null }> })
+            .choices?.[0]?.finish_reason !== null &&
+          (f as { choices?: Array<{ finish_reason?: string | null }> })
+            .choices?.[0]?.finish_reason !== undefined,
+      );
+      assert(
+        "has a finish_reason frame mapped to 'stop'",
+        (finishFrame as { choices: Array<{ finish_reason: string }> })
+          .choices[0].finish_reason === "stop",
+      );
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SSE transform — chunk boundary that splits an event mid-frame
+  // (regression guard for CR-D — flush() must drain any held bytes)
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "createClaudeToOpenAIStreamTransform handles event split across chunks (decoder flush)",
+    fn: async () => {
+      const transform = createClaudeToOpenAIStreamTransform("gpt-4o");
+
+      const start = `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", model: "claude-haiku-4-5", usage: { input_tokens: 1 } } })}\n\n`;
+      const block = `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`;
+      const delta = `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "World" } })}\n\n`;
+      const stop = `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`;
+
+      // Slice the delta event in half so the second half arrives only after
+      // the buffer is empty — verifying the parser correctly drains across
+      // chunk boundaries.
+      const half = Math.floor(delta.length / 2);
+      const part1 = delta.slice(0, half);
+      const part2 = delta.slice(half);
+
+      const out = await runTransform(transform, [
+        start,
+        block,
+        part1,
+        part2,
+        stop,
+      ]);
+      const frames = parseOpenAISseFrames(out);
+      const textDeltas = frames
+        .map(
+          (f) =>
+            (f as { choices?: Array<{ delta?: { content?: string } }> })
+              .choices?.[0]?.delta?.content ?? "",
+        )
+        .join("");
+      assert(
+        "delta survives split chunk boundary",
+        textDeltas === "World",
+        `got "${textDeltas}"`,
+      );
+      return true;
+    },
+  },
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SSE transform — tool_use translation
+  // ──────────────────────────────────────────────────────────────────────
+  {
+    name: "createClaudeToOpenAIStreamTransform emits tool_calls for tool_use blocks",
+    fn: async () => {
+      const transform = createClaudeToOpenAIStreamTransform("gpt-4o");
+      const chunks = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m2", model: "claude-haiku-4-5", usage: { input_tokens: 2 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "tu_1", name: "echo" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"msg":"hi"}' } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 4 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+      ];
+      const out = await runTransform(transform, chunks);
+      const frames = parseOpenAISseFrames(out);
+
+      const toolNameFrame = frames.find(
+        (f) =>
+          ((
+            f as {
+              choices?: Array<{
+                delta?: {
+                  tool_calls?: Array<{ function?: { name?: string } }>;
+                };
+              }>;
+            }
+          ).choices?.[0]?.delta?.tool_calls?.[0]?.function?.name ?? "") ===
+          "echo",
+      );
+      assert("found tool_use frame naming 'echo'", toolNameFrame !== undefined);
+
+      const finishFrame = frames.find(
+        (f) =>
+          (f as { choices?: Array<{ finish_reason?: string | null }> })
+            .choices?.[0]?.finish_reason === "tool_calls",
+      );
+      assert(
+        "stop_reason 'tool_use' maps to OpenAI finish_reason 'tool_calls'",
+        finishFrame !== undefined,
+      );
+      return true;
+    },
+  },
+];
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+async function runAll(): Promise<void> {
+  logSection("Proxy OpenAI Format Tests");
+  for (const test of tests) {
+    try {
+      const ok = await test.fn();
+      recordTest(
+        test.name,
+        ok === true,
+        false,
+        ok === true ? undefined : "assertion returned false",
+      );
+      log(
+        `  ${ok === true ? "PASS" : "FAIL"} — ${test.name}`,
+        ok === true ? "green" : "red",
+      );
+    } catch (e) {
+      recordTest(test.name, false, false, getErrorMessage(e));
+      log(`  FAIL — ${test.name}: ${getErrorMessage(e)}`, "red");
+    }
+  }
+}
+
+await runSuite(runAll);

--- a/test/fixtures/opencode-local-proxy-openai-route.json
+++ b/test/fixtures/opencode-local-proxy-openai-route.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "_comment": "OpenCode fixture that exercises the proxy's /v1/chat/completions endpoint. OpenCode 1.3.x routes any model name containing 'claude' through its bundled Anthropic SDK directly to /v1/messages, bypassing this branch's new code. Using a non-claude alias forces OpenCode through the @ai-sdk/openai-compatible adapter, which is what hits /v1/chat/completions. The proxy must have a routing entry mapping 'gpt-4o' (or whichever alias you pick) back to anthropic/claude-haiku-4-5 — see docs/features/opencode-proxy-support.md §11.",
+  "provider": {
+    "neurolink": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "NeuroLink Local Proxy (OpenAI route)",
+      "env": [],
+      "models": {
+        "gpt-4o": {
+          "name": "GPT-4o (alias → claude-haiku-4-5 via proxy router)",
+          "tool_call": true,
+          "temperature": true,
+          "attachment": true,
+          "reasoning": true,
+          "release_date": "2025-06-10",
+          "limit": { "context": 200000, "output": 16384 }
+        }
+      },
+      "options": {
+        "baseURL": "http://localhost:5555/v1",
+        "apiKey": "neurolink-local-test"
+      }
+    }
+  },
+  "model": "neurolink/gpt-4o"
+}

--- a/test/fixtures/opencode-local-proxy.json
+++ b/test/fixtures/opencode-local-proxy.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "neurolink": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "NeuroLink Local Proxy",
+      "env": [],
+      "models": {
+        "claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6",
+          "tool_call": true,
+          "temperature": true,
+          "attachment": true,
+          "reasoning": true,
+          "release_date": "2025-06-10",
+          "limit": { "context": 200000, "output": 16384 }
+        }
+      },
+      "options": {
+        "baseURL": "http://localhost:5555/v1",
+        "apiKey": "neurolink-local-test"
+      }
+    }
+  },
+  "model": "neurolink/claude-sonnet-4-6"
+}


### PR DESCRIPTION
## Summary

- Adds OpenAI-compatible `POST /v1/chat/completions` + `GET /v1/models` endpoints to the proxy with full request / response / SSE / tool-call / tool-result format translation (`src/lib/proxy/openaiFormat.ts`, `src/lib/server/routes/openaiProxyRoutes.ts`).
- When the resolved target is Anthropic, the request loops through the proxy's own `/v1/messages` via internal `fetch()` to reuse OAuth account rotation, retry, and SSE intercept — parent lifecycle is logged as `accountType: openai-bridge` and correlates 1:1 with the child `/v1/messages` log entry (matching `requestId` not, but matching timestamp + token counts).
- `proxy setup` now auto-configures the OpenCode CLI alongside Claude Code; new `--dev` flag isolates state to `.neurolink-dev/` so testing the proxy doesn't touch the user's launchd-managed instance. Two fixtures land for manual + automated testing: `test/fixtures/opencode-local-proxy.json` (Claude passthrough) and `test/fixtures/opencode-local-proxy-openai-route.json` (gpt-4o alias mapped back to claude-haiku via router config — this is the one that exercises the new `/v1/chat/completions` branch, since OpenCode 1.3.x routes any model name containing `claude` straight through its bundled Anthropic SDK to `/v1/messages`).

Implementation reference: `docs/features/opencode-proxy-support.md` (full design + §11 manual test plan).

## Test plan

- [ ] Smoke: `GET /health`, `GET /v1/models`, non-stream + stream `POST /v1/chat/completions`
- [ ] OpenCode E2E flow §11.8 (E1–E10) using `opencode-local-proxy-openai-route.json` fixture
- [ ] Negative test (§11.10): kill proxy → OpenCode request times out; restart → success — proves OpenCode is actually flowing through the proxy, not direct to Anthropic
- [ ] Verify proxy JSONL logs show paired parent (`accountType: openai-bridge`, path `/v1/chat/completions`) + child (`/v1/messages`) entries with matching input/output token counts
- [ ] CI: `pnpm run check`, `pnpm run lint`, `pnpm run build:cli`, `pnpm test`
- [ ] Manual confirmation that `--dev` mode does not clobber `~/.config/opencode/opencode.json` or the launchd proxy on :55669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode can now be automatically configured when the proxy starts and stops.
  * OpenAI-compatible endpoints are now available (`/v1/chat/completions` and `/v1/models`).
  * Proxy automatically routes OpenAI requests to the appropriate backend.

* **Documentation**
  * Added comprehensive guide for OpenCode proxy integration including setup, configuration, and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/neurolink/pull/1029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->