### PR TITLE
refactor(providers): migrate lmStudio to native OpenAIChatCompletionsProvider base

### DIFF
--- a/src/lib/providers/lmStudio.ts
+++ b/src/lib/providers/lmStudio.ts
@@ -1,19 +1,9 @@
-import { createOpenAI } from "@ai-sdk/openai";
 import type { AIProviderName } from "../constants/enums.js";
-import { BaseProvider } from "../core/baseProvider.js";
-import { DEFAULT_MAX_STEPS } from "../core/constants.js";
-import { streamAnalyticsCollector } from "../core/streamAnalytics.js";
-import { isNeuroLink } from "../neurolink.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
-import { createLoggingFetch } from "../utils/loggingFetch.js";
-import { tracers, ATTR, withClientStreamSpan } from "../telemetry/index.js";
 import type {
-  UnknownRecord,
-  NeurolinkCredentials,
   ModelsResponse,
-  StreamOptions,
-  StreamResult,
-  ValidationSchema,
+  NeurolinkCredentials,
+  UnknownRecord,
 } from "../types/index.js";
 import {
   InvalidModelError,
@@ -21,17 +11,8 @@ import {
   ProviderError,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import {
-  composeAbortSignals,
-  createTimeoutController,
-  TimeoutError,
-} from "../utils/timeout.js";
-import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
-import { resolveToolChoice } from "../utils/toolChoice.js";
-import { toAnalyticsStreamResult } from "./providerTypeUtils.js";
-import type { LanguageModel, Tool } from "../types/index.js";
-import { stepCountIs } from "../utils/tool.js";
-import { streamText } from "../utils/generation.js";
+import { TimeoutError } from "../utils/timeout.js";
+import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
 const LM_STUDIO_DEFAULT_BASE_URL = "http://localhost:1234/v1";
 const LM_STUDIO_PLACEHOLDER_KEY = "lm-studio";
@@ -42,271 +23,52 @@ const getLmStudioBaseURL = (): string => {
 };
 
 /**
- * LM Studio Provider
+ * LM Studio Provider — direct HTTP, no AI SDK.
+ *
  * Wraps the LM Studio local server (https://lmstudio.ai/) which exposes an
  * OpenAI-compatible API at http://localhost:1234/v1 by default.
- * Auto-discovers the loaded model via /v1/models if no model specified.
+ * Auto-discovers the loaded model via /v1/models if no model is specified.
+ * All request/stream/tool-loop orchestration lives in
+ * `OpenAIChatCompletionsProvider`; this class only declares configuration
+ * and provider-specific error mapping.
+ *
+ * @see https://lmstudio.ai/
  */
-export class LMStudioProvider extends BaseProvider {
-  private model?: LanguageModel;
-  // The model name passed by the caller — never overwritten by auto-discovery,
-  // so a discovery-miss FALLBACK_MODEL never poisons the next call's branch
-  // through `if (explicit && explicit.trim() !== "")`.
-  private readonly requestedModelName?: string;
-  private baseURL: string;
-  private apiKey: string;
-  private discoveredModel?: string;
-  private lmstudioClient: ReturnType<typeof createOpenAI>;
-
+export class LMStudioProvider extends OpenAIChatCompletionsProvider {
   constructor(
     modelName?: string,
     sdk?: unknown,
     _region?: string,
     credentials?: NeurolinkCredentials["lmStudio"],
   ) {
-    const validatedNeurolink = isNeuroLink(sdk) ? sdk : undefined;
-
-    super(modelName, "lm-studio" as AIProviderName, validatedNeurolink);
-    this.requestedModelName = modelName;
-
-    this.baseURL = credentials?.baseURL ?? getLmStudioBaseURL();
-    // LM Studio's local server doesn't authenticate, but the AI SDK's
-    // createOpenAI() requires an apiKey. Allow override via credentials/env
-    // for users who run LM Studio behind an auth-proxying reverse-proxy.
-    this.apiKey =
+    // LM Studio's local server doesn't authenticate, but the base HTTP client
+    // requires an apiKey. Allow override via credentials/env for users who
+    // run LM Studio behind an auth-proxying reverse-proxy.
+    const apiKey =
       credentials?.apiKey ??
       process.env.LM_STUDIO_API_KEY ??
       LM_STUDIO_PLACEHOLDER_KEY;
+    const baseURL = credentials?.baseURL ?? getLmStudioBaseURL();
 
-    this.lmstudioClient = createOpenAI({
-      baseURL: this.baseURL,
-      apiKey: this.apiKey,
-      fetch: createLoggingFetch("lm-studio"),
-    });
+    super("lm-studio" as AIProviderName, modelName, sdk, { baseURL, apiKey });
 
     logger.debug("LM Studio Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.baseURL,
+      baseURL: this.config.baseURL,
     });
-  }
-
-  private async getAvailableModels(
-    callerSignal?: AbortSignal,
-  ): Promise<string[]> {
-    const url = `${this.baseURL.replace(/\/$/, "")}/models`;
-    // Use the proxy-aware fetch + bearer auth header so users running LM
-    // Studio behind an auth-proxying reverse-proxy can still discover models.
-    // Compose the caller's request signal (per-request timeout / abort) with
-    // a fixed 5s discovery cap so cancellation propagates AND a hung server
-    // can't stall provider initialization.
-    const proxyFetch = createProxyFetch();
-    const discoveryTimeout = AbortSignal.timeout(5000);
-    const composedSignal = callerSignal
-      ? AbortSignal.any([callerSignal, discoveryTimeout])
-      : discoveryTimeout;
-    const response = await proxyFetch(url, {
-      headers:
-        this.apiKey && this.apiKey !== LM_STUDIO_PLACEHOLDER_KEY
-          ? { Authorization: `Bearer ${this.apiKey}` }
-          : undefined,
-      signal: composedSignal,
-    });
-    if (!response.ok) {
-      throw new Error(
-        `LM Studio /v1/models returned ${response.status}: ${response.statusText}`,
-      );
-    }
-    const data = (await response.json()) as ModelsResponse;
-    return data.data.map((m) => m.id);
-  }
-
-  protected async getAISDKModel(signal?: AbortSignal): Promise<LanguageModel> {
-    if (this.model) {
-      return this.model;
-    }
-
-    let modelToUse: string;
-    let discoverySucceeded = false;
-    // Use requestedModelName, not this.modelName — refreshHandlersForModel()
-    // mutates this.modelName, so on a retry after a discovery miss the
-    // FALLBACK_MODEL would look like an explicit user choice and we'd never
-    // re-attempt /v1/models. The constructor-captured name preserves intent.
-    const explicit = this.requestedModelName;
-    if (explicit && explicit.trim() !== "") {
-      modelToUse = explicit;
-      discoverySucceeded = true; // explicit user choice — treat as success
-    } else {
-      try {
-        const models = await this.getAvailableModels(signal);
-        if (models.length > 0) {
-          this.discoveredModel = models[0];
-          modelToUse = this.discoveredModel;
-          discoverySucceeded = true;
-          logger.info(
-            `LM Studio auto-discovered model: ${modelToUse} (${models.length} loaded)`,
-          );
-        } else {
-          modelToUse = FALLBACK_MODEL;
-          logger.warn(
-            "LM Studio /v1/models returned no models. Load a model in the LM Studio app.",
-          );
-        }
-      } catch (error) {
-        logger.warn(
-          `LM Studio model auto-discovery failed: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-        modelToUse = FALLBACK_MODEL;
-      }
-    }
-
-    // Persist resolved model on the instance and rebuild the composed
-    // handlers (TelemetryHandler, MessageBuilder, etc.) so pricing /
-    // telemetry / span attributes report the discovered model name. Plain
-    // assignment to `this.modelName` is not enough — handlers cached the
-    // pre-discovery value at construction time.
-    this.refreshHandlersForModel(modelToUse);
-
-    // .chat() — LM Studio exposes /v1/chat/completions, not /v1/responses
-    const resolvedModel = this.lmstudioClient.chat(modelToUse);
-    // Only memoize on actual success. After a discovery miss (server down,
-    // empty /v1/models, /models 5xx), starting LM Studio or loading a model
-    // should let the next call re-attempt discovery instead of being stuck
-    // on FALLBACK_MODEL for the lifetime of this provider instance.
-    if (discoverySucceeded) {
-      this.model = resolvedModel;
-    }
-    return resolvedModel;
-  }
-
-  protected async executeStream(
-    options: StreamOptions,
-    _analysisSchema?: ValidationSchema,
-  ): Promise<StreamResult> {
-    // Resolve the LM Studio model BEFORE opening the span so OTEL
-    // attributes, MessageBuilder, and downstream image/tool adapters all see
-    // the discovered model id rather than the empty pre-discovery placeholder.
-    // Pass the caller's abort signal so user cancellation / per-request
-    // timeouts are honored during the discovery probe (not just after it).
-    await this.getAISDKModel(options.abortSignal);
-    return withClientStreamSpan(
-      {
-        name: "neurolink.provider.stream",
-        tracer: tracers.provider,
-        attributes: {
-          [ATTR.GEN_AI_SYSTEM]: "lm-studio",
-          [ATTR.GEN_AI_MODEL]:
-            this.modelName || this.discoveredModel || FALLBACK_MODEL,
-          [ATTR.GEN_AI_OPERATION]: "stream",
-          [ATTR.NL_STREAM_MODE]: true,
-        },
-      },
-      async () => this.executeStreamInner(options),
-      (r) => r.stream,
-      (r, wrapped) => ({ ...r, stream: wrapped }),
-    );
-  }
-
-  private async executeStreamInner(
-    options: StreamOptions,
-  ): Promise<StreamResult> {
-    this.validateStreamOptions(options);
-
-    const startTime = Date.now();
-    const timeout = this.getTimeout(options);
-    const timeoutController = createTimeoutController(
-      timeout,
-      this.providerName,
-      "stream",
-    );
-
-    try {
-      const shouldUseTools = !options.disableTools && this.supportsTools();
-      const tools = shouldUseTools
-        ? (options.tools as Record<string, Tool>) || (await this.getAllTools())
-        : {};
-
-      // Resolve the AI SDK model BEFORE building messages so message/image
-      // adapters see the same handlers/model that streamText will use. Without
-      // this, a fallback warm-up + late-server-start pattern could build
-      // messages under FALLBACK_MODEL handlers and stream under a different
-      // discovered model — and pay an extra `/v1/models` probe each time.
-      const model = await this.getAISDKModelWithMiddleware(options);
-      const messages = await this.buildMessagesForStream(options);
-
-      const result = await streamText({
-        model,
-        messages,
-        temperature: options.temperature,
-        maxOutputTokens: options.maxTokens,
-        tools,
-        stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
-        toolChoice: resolveToolChoice(options, tools, shouldUseTools),
-        abortSignal: composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        ),
-        experimental_telemetry:
-          this.telemetryHandler.getTelemetryConfig(options),
-        experimental_repairToolCall: this.getToolCallRepairFn(options),
-        onStepFinish: ({ toolCalls, toolResults }) => {
-          emitToolEndFromStepFinish(
-            this.neurolink?.getEventEmitter(),
-            toolResults as Array<{
-              toolName: string;
-              output?: unknown;
-              result?: unknown;
-              error?: string;
-            }>,
-          );
-          this.handleToolExecutionStorage(
-            toolCalls,
-            toolResults,
-            options,
-            new Date(),
-          ).catch((error: unknown) => {
-            logger.warn("[LMStudioProvider] Failed to store tool executions", {
-              provider: this.providerName,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-        },
-      });
-
-      timeoutController?.cleanup();
-      const transformedStream = this.createTextStream(result);
-      const analyticsPromise = streamAnalyticsCollector.createAnalytics(
-        this.providerName,
-        this.modelName || this.discoveredModel || FALLBACK_MODEL,
-        toAnalyticsStreamResult(result),
-        Date.now() - startTime,
-        {
-          requestId: `lmstudio-stream-${Date.now()}`,
-          streamingMode: true,
-        },
-      );
-
-      return {
-        stream: transformedStream,
-        provider: this.providerName,
-        model: this.modelName || this.discoveredModel || FALLBACK_MODEL,
-        analytics: analyticsPromise,
-        metadata: { startTime, streamId: `lmstudio-${Date.now()}` },
-      };
-    } catch (error) {
-      timeoutController?.cleanup();
-      throw this.handleProviderError(error);
-    }
   }
 
   protected getProviderName(): AIProviderName {
-    return this.providerName;
+    return "lm-studio" as AIProviderName;
   }
 
   protected getDefaultModel(): string {
     return process.env.LM_STUDIO_MODEL || "";
+  }
+
+  protected getFallbackModelName(): string {
+    return FALLBACK_MODEL;
   }
 
   protected formatProviderError(error: unknown): Error {
@@ -331,7 +93,7 @@ export class LMStudioProvider extends BaseProvider {
       message.includes("fetch failed")
     ) {
       return new NetworkError(
-        `LM Studio server not reachable at ${this.baseURL}. ` +
+        `LM Studio server not reachable at ${this.config.baseURL}. ` +
           `Open the LM Studio app, load a model, and click "Start Server".`,
         "lm-studio",
       );
@@ -347,12 +109,12 @@ export class LMStudioProvider extends BaseProvider {
 
   async validateConfiguration(): Promise<boolean> {
     try {
-      const url = `${this.baseURL.replace(/\/$/, "")}/models`;
+      const url = `${this.config.baseURL.replace(/\/$/, "")}/models`;
       const proxyFetch = createProxyFetch();
       const r = await proxyFetch(url, {
         headers:
-          this.apiKey && this.apiKey !== LM_STUDIO_PLACEHOLDER_KEY
-            ? { Authorization: `Bearer ${this.apiKey}` }
+          this.config.apiKey && this.config.apiKey !== LM_STUDIO_PLACEHOLDER_KEY
+            ? { Authorization: `Bearer ${this.config.apiKey}` }
             : undefined,
         signal: AbortSignal.timeout(5000),
       });
@@ -360,7 +122,7 @@ export class LMStudioProvider extends BaseProvider {
         return false;
       }
       // A 200 with an empty data array means LM Studio is up but no model is
-      // loaded — `getAISDKModel()` will fall back to FALLBACK_MODEL and the
+      // loaded — `resolveModelName()` will fall back to FALLBACK_MODEL and the
       // first real request will fail. Require at least one loaded model so
       // health checks honestly reflect whether the provider is usable.
       const data = (await r.json().catch(() => null)) as ModelsResponse | null;
@@ -377,11 +139,9 @@ export class LMStudioProvider extends BaseProvider {
   getConfiguration() {
     return {
       provider: this.providerName,
-      model: this.modelName || this.discoveredModel || FALLBACK_MODEL,
+      model: this.modelName || this.resolvedModel || FALLBACK_MODEL,
       defaultModel: this.getDefaultModel(),
-      baseURL: this.baseURL,
+      baseURL: this.config.baseURL,
     };
   }
 }
-
-export default LMStudioProvider;


### PR DESCRIPTION
## What
Migrates the **LM Studio** provider off `@ai-sdk/openai` to the native `OpenAIChatCompletionsProvider` base (merged in #1034) — continuing the AI-SDK removal after openai-compatible (#1030), litellm (#1033), and xai (#1045).

The base owns all request/stream/tool-loop orchestration; this file declares only configuration + provider-specific error mapping.

## Behavior-preserving
- Error mapping copied **verbatim** (same match substrings, classes, messages).
- Default model, baseURL, and env-var precedence unchanged.
- `withClientStreamSpan` dropped — BaseProvider.stream() already emits the provider OTel span.
- `createLoggingFetch` dropped — debug-only; errors surface via base buildAPIError.
- Registry unchanged — same class name + constructor signature.

## Test plan
- `tsc --strict` 0 errors · `eslint` 0 errors · `prettier --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * LM Studio provider's internal structure was refactored to align with standard provider architecture. Configuration validation and model discovery functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->