### PR TITLE
🐛 fix(test): 6.14 verifies native-base providers' onError capture on the shared base

### DIFF
--- a/test/continuous-test-suite-context.ts
+++ b/test/continuous-test-suite-context.ts
@@ -3542,6 +3542,14 @@ async function test_6_14_providers_capture_and_pass_error(): Promise<void> {
     "providers/openRouter",
     "providers/anthropicBaseProvider",
   ];
+  // Native-base providers (those that `extends OpenAIChatCompletionsProvider`)
+  // capture the provider error centrally in the shared base rather than in
+  // their own file — the AI-SDK-era per-provider streamText capture moved there
+  // during the native migration. Assert the capture on the base for those, and
+  // on their own file for self-streaming providers (openRouter, anthropic).
+  const baseSrc = await fs
+    .readFile("dist/lib/providers/openaiChatCompletionsBase.js", "utf-8")
+    .catch(() => "");
   for (const t of targets) {
     const testName = `6.14 — ${t} captures onError and passes underlyingError to NoOutput helpers`;
     const path = `dist/lib/${t}.js`;
@@ -3556,11 +3564,13 @@ async function test_6_14_providers_capture_and_pass_error(): Promise<void> {
       );
       continue;
     }
+    const delegatesToBase = /extends\s+OpenAIChatCompletionsProvider/.test(src);
+    const captureSrc = delegatesToBase ? baseSrc : src;
     const capturesOnError =
-      /capturedProviderError\s*=\s*(?:event\.error|error)/.test(src);
+      /capturedProviderError\s*=\s*(?:event\.error|error)/.test(captureSrc);
     const passesToHelper =
       /capturedProviderError(?:\s*\)|\s*,)|getCapturedProviderError\s*\?\s*\.\s*\(/.test(
-        src,
+        captureSrc,
       );
     if (capturesOnError && passesToHelper) {
       recordIssue06(
@@ -3572,7 +3582,7 @@ async function test_6_14_providers_capture_and_pass_error(): Promise<void> {
       recordIssue06(
         testName,
         "FAIL",
-        `bug-confirmed: capture=${capturesOnError}, passes=${passesToHelper}`,
+        `bug-confirmed: delegatesToBase=${delegatesToBase}, capture=${capturesOnError}, passes=${passesToHelper}`,
       );
     }
   }


### PR DESCRIPTION
## Problem

Issue-06 regression test **6.14** statically asserts that each provider captures the upstream provider error (`capturedProviderError = error`) **in its own compiled file**.

After the native (no-AI-SDK) migration, `openAI`, `openaiCompatible`, `litellm`, and `huggingFace` `extends OpenAIChatCompletionsProvider` and capture the error **centrally in that shared base** — not in their own file. Because `openaiCompatible` + `litellm` already merged to `release`, **6.14 is already failing on `release`** (`capture=false, passes=false` for those two). The remaining migrations (huggingFace #1049, openAI #1059) extend the failure.

## Fix

When a provider delegates to the native base (detected via `extends OpenAIChatCompletionsProvider` in the compiled output), assert the onError capture **on the base**; for self-streaming providers (`openRouter`, `anthropicBaseProvider`) keep asserting on their own file.

The check is now **state-independent** — it passes whether or not a given provider has been migrated:
- pre-migration: provider `extends BaseProvider` → checked in its own file (AI-SDK-era self-capture) ✅
- post-migration: provider `extends OpenAIChatCompletionsProvider` → checked on the shared base ✅

## Verification

Replicated 6.14's logic against the built `dist` — all 6 targets PASS:

```
PASS providers/openAI               delegatesToBase=true  capture=true passes=true
PASS providers/openaiCompatible     delegatesToBase=true  capture=true passes=true
PASS providers/litellm              delegatesToBase=true  capture=true passes=true
PASS providers/huggingFace          delegatesToBase=true  capture=true passes=true
PASS providers/openRouter           delegatesToBase=false capture=true passes=true
PASS providers/anthropicBaseProvider delegatesToBase=false capture=true passes=true
```

Test-only change; `pnpm run check` + eslint clean.