### PR TITLE
fix(providers): retry model auto-discovery after a failed probe

### DIFF
--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -253,7 +253,19 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       } catch (err) {
         logger.warn("Model auto-discovery failed, using fallback:", err);
       }
+      // Auto-discovery was attempted but yielded no model (local server/model
+      // not up yet, transient probe failure, …). Use the fallback for THIS
+      // call but persist NOTHING — not `resolvedModel`, and not `this.modelName`
+      // either. `refreshHandlersForModel()` sets `this.modelName = model`, which
+      // the explicit branch above would then memoize on the next call, pinning
+      // the instance to the fallback and defeating the retry. Returning the
+      // bare fallback (it is still used as the wire `modelId`) lets a later
+      // call re-probe once the server/model becomes available — matching the
+      // pre-migration local providers.
+      return this.getFallbackModelName();
     }
+    // No auto-discovery for this provider — the fallback is stable, so memoize
+    // it (and refresh handlers so telemetry/pricing reflect the resolved name).
     const fallback = this.getFallbackModelName();
     this.resolvedModel = fallback;
     this.refreshHandlersForModel(fallback);
@@ -604,10 +616,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     const result: StreamResult = {
       stream: transformedStream(),
       provider: this.providerName,
-      model: this.modelName,
+      model: modelId,
       analytics: streamAnalyticsCollector.createAnalytics(
         this.providerName,
-        this.modelName,
+        modelId,
         {
           textStream: (async function* () {})(),
           usage: usagePromise,


### PR DESCRIPTION
## Problem

`OpenAIChatCompletionsProvider.resolveModelName()` memoized the fallback model **even when auto-discovery failed**, pinning a provider instance to the fallback for its lifetime after a single early miss.

Local providers (llama.cpp, LM Studio) that start *after* the SDK is constructed never re-probe `/models` — they stay stuck on the fallback model name (`loaded-model` / `local-model`) until the process restarts. This is a regression vs the pre-migration local providers, which re-probed on the next call.

Raised by reviewers on #1047 (llamaCpp) and #1048 (lmStudio).

## Fix

Only memoize the fallback on the **no-discovery** path (where it is stable). When auto-discovery *is* attempted but yields nothing (server/model not up yet, transient probe failure), use the fallback for the current call **without caching it**, so a later call retries discovery once the server/model becomes available.

No behavior change for providers with an explicit/default model (they short-circuit before discovery) or providers that don't auto-discover.

## Validation
- `pnpm run check` — 0 errors
- `pnpm run lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model fallback behavior: when automatic model discovery fails, the system now uses a temporary fallback without permanently locking future attempts, allowing later rediscovery and restoring dynamic model selection.
  * Streaming analytics accuracy: streaming requests now record the specific per-call model identifier in analytics metadata, improving observability and reporting for individual requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->