### PR TITLE
fix(providers): add default validateConfiguration/getConfiguration to native base

### DIFF
--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -218,6 +218,33 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   }
 
   /**
+   * Health-check hook — part of the documented public provider contract
+   * (`docs/provider-integration/00-architecture.md`). Default returns true
+   * when an apiKey is configured; local providers (LM Studio, llama.cpp)
+   * override this to probe the server's `/models` endpoint.
+   */
+  async validateConfiguration(): Promise<boolean> {
+    return (
+      typeof this.config.apiKey === "string" &&
+      this.config.apiKey.trim().length > 0
+    );
+  }
+
+  /**
+   * Snapshot of the provider's resolved configuration — part of the documented
+   * public provider contract (`docs/provider-integration/00-architecture.md`).
+   * Subclasses inherit this; override only to expose extra fields.
+   */
+  getConfiguration() {
+    return {
+      provider: this.providerName,
+      model: this.modelName,
+      defaultModel: this.getDefaultModel(),
+      baseURL: this.config.baseURL,
+    };
+  }
+
+  /**
    * Returns a minimal V3-shaped model used by BaseProvider's `generate()`
    * non-streaming path. Driven by the parent's `generateText`. The
    * streaming path bypasses this entirely.


### PR DESCRIPTION
## What
Adds default `validateConfiguration()` / `getConfiguration()` to `OpenAIChatCompletionsProvider` so every native-base subclass inherits the documented public-contract methods.

## Why
These two methods are part of the documented provider contract (`docs/provider-integration/00-architecture.md`), but neither the native base nor `BaseProvider` provided them — so the AI-SDK to native migration silently dropped them on most providers (groq, togetherAi, perplexity, deepseek, openAI, cloudflare, ...). That is a backward-compatibility break per **CLAUDE.md Rule 5**.

Adding defaults to the base restores them everywhere via inheritance — no per-provider churn, and future subclasses get them for free. Providers needing a richer health probe (LM Studio, llama.cpp) keep their overrides; the cohere/nvidiaNim explicit versions remain valid (identical behavior).

## Defaults
- `validateConfiguration()` → true when an apiKey is configured.
- `getConfiguration()` → `{ provider, model, defaultModel, baseURL }`.

## Validation
`pnpm run check` (0 errors / 3837 files) confirms all existing subclass overrides remain compatible. Lint + prettier + build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved provider configuration handling: added configuration validation and the ability to retrieve a configuration snapshot to enhance reliability and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->