### PR TITLE
fix(providers): redact embedded credentials from baseURL in debug logs

### DIFF
--- a/src/lib/providers/cloudflare.ts
+++ b/src/lib/providers/cloudflare.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createCloudflareConfig,
   getProviderModel,
@@ -76,7 +77,7 @@ export class CloudflareProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Cloudflare Workers AI Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/cohere.ts
+++ b/src/lib/providers/cohere.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import {
   createCohereConfig,
@@ -62,7 +63,7 @@ export class CohereProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Cohere Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/deepseek.ts
+++ b/src/lib/providers/deepseek.ts
@@ -13,6 +13,7 @@ import type {
   UnknownRecord,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createDeepSeekConfig,
   getProviderModel,
@@ -84,7 +85,7 @@ export class DeepSeekProvider extends OpenAIChatCompletionsProvider {
     logger.debug("DeepSeek Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/fireworks.ts
+++ b/src/lib/providers/fireworks.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createFireworksConfig,
   getProviderModel,
@@ -61,7 +62,7 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Fireworks Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/groq.ts
+++ b/src/lib/providers/groq.ts
@@ -8,6 +8,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createGroqConfig,
   getProviderModel,
@@ -58,7 +59,7 @@ export class GroqProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Groq Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/huggingFace.ts
+++ b/src/lib/providers/huggingFace.ts
@@ -8,6 +8,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createHuggingFaceConfig,
   getProviderModel,
@@ -58,7 +59,7 @@ export class HuggingFaceProvider extends OpenAIChatCompletionsProvider {
     logger.debug("HuggingFaceProvider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -18,6 +18,7 @@ import {
 } from "../types/index.js";
 import { isAbortError } from "../utils/errorHandling.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { isGemini25Model as isCanonicalGemini25Model } from "../utils/modelDetection.js";
 import { calculateCost } from "../utils/pricing.js";
 import { getProviderModel } from "../utils/providerConfig.js";
@@ -82,7 +83,7 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
     logger.debug("LiteLLM Provider initialized", {
       modelName: this.modelName,
       provider: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/llamaCpp.ts
+++ b/src/lib/providers/llamaCpp.ts
@@ -2,6 +2,7 @@ import type { AIProviderName } from "../constants/enums.js";
 import { NetworkError, ProviderError } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { TimeoutError } from "../utils/timeout.js";
 import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
@@ -11,14 +12,6 @@ const LLAMACPP_PLACEHOLDER_KEY = "llamacpp";
 const getLlamaCppBaseURL = (): string => {
   return process.env.LLAMACPP_BASE_URL || LLAMACPP_DEFAULT_BASE_URL;
 };
-
-/**
- * Strip embedded `user:pass@` credentials from a URL before logging it or
- * surfacing it in a user-facing error. Preserves host/port/path so the URL
- * stays useful for diagnostics.
- */
-const redactUrlCredentials = (url: string): string =>
-  url.replace(/\/\/[^/@]+@/, "//***@");
 
 /**
  * llama.cpp Provider — direct HTTP, no AI SDK.

--- a/src/lib/providers/lmStudio.ts
+++ b/src/lib/providers/lmStudio.ts
@@ -11,6 +11,7 @@ import {
   ProviderError,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { TimeoutError } from "../utils/timeout.js";
 import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
@@ -55,7 +56,7 @@ export class LMStudioProvider extends OpenAIChatCompletionsProvider {
     logger.debug("LM Studio Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 
@@ -93,7 +94,7 @@ export class LMStudioProvider extends OpenAIChatCompletionsProvider {
       message.includes("fetch failed")
     ) {
       return new NetworkError(
-        `LM Studio server not reachable at ${this.config.baseURL}. ` +
+        `LM Studio server not reachable at ${redactUrlCredentials(this.config.baseURL)}. ` +
           `Open the LM Studio app, load a model, and click "Start Server".`,
         "lm-studio",
       );

--- a/src/lib/providers/nvidiaNim.ts
+++ b/src/lib/providers/nvidiaNim.ts
@@ -14,6 +14,7 @@ import {
   RateLimitError,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createNvidiaNimConfig,
   getProviderModel,
@@ -216,7 +217,7 @@ export class NvidiaNimProvider extends OpenAIChatCompletionsProvider {
     logger.debug("NVIDIA NIM Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/openAI.ts
+++ b/src/lib/providers/openAI.ts
@@ -17,6 +17,7 @@ import {
   RateLimitError,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { calculateCost } from "../utils/pricing.js";
 import {
   createOpenAIConfig,
@@ -106,7 +107,7 @@ export class OpenAIProvider extends OpenAIChatCompletionsProvider {
     logger.debug("OpenAIProvider initialized", {
       model: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/openaiCompatible.ts
+++ b/src/lib/providers/openaiCompatible.ts
@@ -8,6 +8,7 @@ import {
 } from "../types/index.js";
 import type { UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { TimeoutError } from "../utils/timeout.js";
 import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
@@ -68,7 +69,7 @@ export class OpenAICompatibleProvider extends OpenAIChatCompletionsProvider {
     logger.debug("OpenAI Compatible Provider initialized", {
       modelName: this.modelName,
       provider: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 
@@ -122,7 +123,7 @@ export class OpenAICompatibleProvider extends OpenAIChatCompletionsProvider {
         errorRecord.message.includes("Failed to fetch")
       ) {
         return new NetworkError(
-          `OpenAI Compatible endpoint not available. Please check your OPENAI_COMPATIBLE_BASE_URL: ${this.config.baseURL}`,
+          `OpenAI Compatible endpoint not available. Please check your OPENAI_COMPATIBLE_BASE_URL: ${redactUrlCredentials(this.config.baseURL)}`,
           "openai-compatible",
         );
       }

--- a/src/lib/providers/perplexity.ts
+++ b/src/lib/providers/perplexity.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createPerplexityConfig,
   getProviderModel,
@@ -60,7 +61,7 @@ export class PerplexityProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Perplexity Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/togetherAi.ts
+++ b/src/lib/providers/togetherAi.ts
@@ -9,6 +9,7 @@ import {
   RateLimitError,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createTogetherAIConfig,
   getProviderModel,
@@ -62,7 +63,7 @@ export class TogetherAIProvider extends OpenAIChatCompletionsProvider {
     logger.debug("Together AI Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/providers/xai.ts
+++ b/src/lib/providers/xai.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/index.js";
 import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createXaiConfig,
   getProviderModel,
@@ -60,7 +61,7 @@ export class XaiProvider extends OpenAIChatCompletionsProvider {
     logger.debug("xAI Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
-      baseURL: this.config.baseURL,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 

--- a/src/lib/utils/logSanitize.ts
+++ b/src/lib/utils/logSanitize.ts
@@ -101,6 +101,23 @@ export function sanitizeForLog(text: string, maxLen = 500): string {
 }
 
 /**
+ * Strip embedded `user:pass@` credentials from a URL's authority component
+ * before logging it or surfacing it in a user-facing error.
+ *
+ * Turns `https://user:secret@host/path` into `https://***@host/path` while
+ * leaving credential-free URLs untouched, so the host/port/path stay useful
+ * for diagnostics. Use this for any `baseURL`/endpoint a caller may have
+ * supplied with inline credentials. The match is global, so every `//…@`
+ * authority in the string is redacted (e.g. a proxy chain or a URL embedded
+ * in a query parameter), not just the first.
+ *
+ * @param url - The URL (or URL-shaped string) to redact.
+ */
+export function redactUrlCredentials(url: string): string {
+  return url.replace(/\/\/[^/@]+@/g, "//***@");
+}
+
+/**
  * Recursively sanitize a record/array, returning a structurally identical
  * value with sensitive keys redacted and string values run through
  * {@link sanitizeForLog}.

--- a/test/continuous-test-suite-log-sanitize.ts
+++ b/test/continuous-test-suite-log-sanitize.ts
@@ -22,6 +22,7 @@ import "dotenv/config";
  */
 
 import {
+  redactUrlCredentials,
   sanitizeForLog,
   sanitizeHeaders,
   sanitizeRecord,
@@ -348,6 +349,71 @@ try {
     false,
     false,
     err instanceof Error ? err.message : String(err),
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section I — redactUrlCredentials (baseURL credential stripping)
+// ───────────────────────────────────────────────────────────────────────
+
+console.log("\n=== Section I: redactUrlCredentials ===\n");
+
+// Positive: embedded user:pass@ must be stripped, host/path preserved.
+const redactCases: Array<[string, string, string]> = [
+  // [raw, expected, label]
+  [
+    "https://user:secret@api.example.com/v1",
+    "https://***@api.example.com/v1",
+    "user:pass@ in https baseURL",
+  ],
+  [
+    "http://admin:p%40ss@localhost:8080/v1",
+    "http://***@localhost:8080/v1",
+    "credentials with encoded chars + port",
+  ],
+  [
+    "redis://default:token123@redis.internal:6379",
+    "redis://***@redis.internal:6379",
+    "non-http scheme (redis)",
+  ],
+];
+
+for (const [raw, expected, label] of redactCases) {
+  const out = redactUrlCredentials(raw);
+  recordTest(
+    `redactUrlCredentials strips ${label}`,
+    out === expected,
+    false,
+    out === expected ? undefined : `expected "${expected}", got "${out}"`,
+  );
+}
+
+// Global flag: EVERY //…@ authority is redacted, not just the first.
+const multi = redactUrlCredentials(
+  "https://u1:p1@host-a/path?next=https://u2:p2@host-b/cb",
+);
+recordTest(
+  "redactUrlCredentials redacts all embedded credentials (global)",
+  !multi.includes("u1:p1") && !multi.includes("u2:p2"),
+  false,
+  `got "${multi}"`,
+);
+
+// Negative: credential-free URLs are returned unchanged.
+const noCredCases: Array<[string, string]> = [
+  ["https://api.mistral.ai/v1", "plain https baseURL"],
+  ["http://localhost:8080/v1", "localhost baseURL"],
+  ["https://api.openai.com/v1/chat/completions", "path with no userinfo"],
+  ["", "empty string"],
+];
+
+for (const [input, label] of noCredCases) {
+  const out = redactUrlCredentials(input);
+  recordTest(
+    `redactUrlCredentials leaves ${label} unchanged`,
+    out === input,
+    false,
+    out === input ? undefined : `unexpected change: "${input}" → "${out}"`,
   );
 }
 


### PR DESCRIPTION
## What & why

Follow-up to the provider-migration series (releases 9.68.11–9.68.16). This addresses the CodeRabbit "Major" findings raised on #1050 (groq) and #1053 (cohere): a user-configurable `baseURL` (supplied via credentials or env) can carry inline `user:pass@host` credentials, and the provider **constructor debug logs** plus the **"not reachable" / "endpoint not available" error messages** previously emitted that `baseURL` verbatim — so credentials could land in debug output.

Rather than patch one provider at a time, this applies the fix consistently across the whole OpenAI-compatible cohort and promotes the existing `llamaCpp` helper to a shared util.

## Changes

- **Extract** `redactUrlCredentials(url)` out of `llamaCpp` into the shared `src/lib/utils/logSanitize.ts` util (turns `https://user:pass@host` into `https://***@host`; no-op for credential-free URLs). `llamaCpp` now imports it instead of defining its own copy.
- **Wrap `baseURL` in the constructor debug log** of: `groq`, `cohere`, `deepseek`, `perplexity`, `togetherAi`, `openAI`, `nvidiaNim`, `cloudflare`, `openaiCompatible`, `litellm`, `huggingFace`, `xai`, `lmStudio`, `fireworks`.
- **Wrap the user-facing endpoint error message** in `lmStudio` ("server not reachable at …") and `openaiCompatible` ("endpoint not available … OPENAI_COMPATIBLE_BASE_URL: …").

## Deliberately untouched

- The public `getConfiguration()` contract returns the **raw** `baseURL` (callers depend on the real value) — verified for `cohere`, `nvidiaNim`, `lmStudio`, and the base class.
- All request-URL construction (`${stripTrailingSlash(this.config.baseURL)}/...`, etc.) keeps the **raw** `baseURL` — redacting it would break requests.
- Image/media providers (`ideogram`, `recraft`, `replicate`, `voyage`, `stability`, `jina`) use a **fixed provider `baseURL`** with no user-supplied credentials, so there is nothing to redact — out of scope by design.

## Validation

- `tsc --noEmit --strict` — pass
- lint + format — pass (0 errors)
- `pnpm run build` + publint — pass ("All good!")
- stream-span native-base audit — 106/106 pass
- `validate:all` (Gitleaks) — no secrets detected

Single commit, per the repo's single-commit policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic credential redaction across all AI provider integrations, ensuring sensitive URL information no longer appears in debug logs or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->