### PR TITLE
refactor(providers): migrate mistral to native OpenAIChatCompletionsProvider base

### DIFF
--- a/src/lib/factories/providerRegistry.ts
+++ b/src/lib/factories/providerRegistry.ts
@@ -9,7 +9,6 @@ import type {
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import type { NeuroLink } from "../neurolink.js";
-import type { MistralProvider as MistralProviderType } from "@ai-sdk/mistral";
 import {
   AIProviderName,
   GoogleAIModels,
@@ -281,7 +280,7 @@ export class ProviderRegistry {
           const { MistralProvider } = await import("../providers/mistral.js");
           return new MistralProvider(
             modelName,
-            sdk as unknown as MistralProviderType | undefined,
+            sdk as unknown as NeuroLink | undefined,
             undefined,
             mistralCreds,
           );

--- a/src/lib/providers/mistral.ts
+++ b/src/lib/providers/mistral.ts
@@ -1,223 +1,97 @@
-import { createMistral } from "@ai-sdk/mistral";
 import type { AIProviderName } from "../constants/enums.js";
-import { BaseProvider } from "../core/baseProvider.js";
-import { DEFAULT_MAX_STEPS } from "../core/constants.js";
-import { streamAnalyticsCollector } from "../core/streamAnalytics.js";
-import { isNeuroLink } from "../neurolink.js";
-import { createProxyFetch } from "../proxy/proxyFetch.js";
-import type {
-  UnknownRecord,
-  NeurolinkCredentials,
-  StreamOptions,
-  StreamResult,
-  ValidationSchema,
-} from "../types/index.js";
+import { MistralModels } from "../constants/enums.js";
 import {
   AuthenticationError,
+  InvalidModelError,
   NetworkError,
   ProviderError,
   RateLimitError,
 } from "../types/index.js";
-
-import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
+import type { NeurolinkCredentials, UnknownRecord } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import {
   createMistralConfig,
   getProviderModel,
   validateApiKey,
 } from "../utils/providerConfig.js";
-import {
-  composeAbortSignals,
-  createTimeoutController,
-  TimeoutError,
-} from "../utils/timeout.js";
-import { resolveToolChoice } from "../utils/toolChoice.js";
-import { toAnalyticsStreamResult } from "./providerTypeUtils.js";
-import type { LanguageModel, Tool } from "../types/index.js";
-import { stepCountIs } from "../utils/tool.js";
-import { streamText } from "../utils/generation.js";
+import { TimeoutError } from "../utils/timeout.js";
+import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
-// Configuration helpers - now using consolidated utility
+const MISTRAL_DEFAULT_BASE_URL = "https://api.mistral.ai/v1";
+
 const getMistralApiKey = (): string => {
   return validateApiKey(createMistralConfig());
 };
 
 const getDefaultMistralModel = (): string => {
-  // Default to vision-capable Mistral Small 2506 (June 2025) with multimodal support
-  return getProviderModel("MISTRAL_MODEL", "mistral-small-2506");
+  // Vision-capable Mistral Small (June 2025) with multimodal support.
+  return getProviderModel("MISTRAL_MODEL", MistralModels.MISTRAL_SMALL_2506);
 };
 
 /**
- * Mistral AI Provider v2 - BaseProvider Implementation
- * Supports official AI-SDK integration with all Mistral models
+ * Mistral AI Provider — direct HTTP, no AI SDK.
+ *
+ * OpenAI-compatible chat completions at api.mistral.ai/v1. All request/stream/
+ * tool-loop orchestration lives in `OpenAIChatCompletionsProvider`; this class
+ * only declares configuration and the provider-specific error mapping.
+ *
+ * Mistral's `/chat/completions` accepts `response_format: { type:
+ * "json_schema" }` on current models (mistral-small-2506 and newer), so no
+ * structured-output downgrade is needed — the base client's default
+ * pass-through is correct.
+ *
+ * @see https://docs.mistral.ai/api/
  */
-export class MistralProvider extends BaseProvider {
-  private model: LanguageModel;
-
+export class MistralProvider extends OpenAIChatCompletionsProvider {
   constructor(
     modelName?: string,
     sdk?: unknown,
     _region?: string,
     credentials?: NeurolinkCredentials["mistral"],
   ) {
-    // Type guard for NeuroLink parameter validation
-    const validatedNeurolink = isNeuroLink(sdk) ? sdk : undefined;
+    // Trim the override before applying precedence. A blank/whitespace
+    // `credentials.apiKey` must NOT bypass `getMistralApiKey()` — that would
+    // build a client with an unusable bearer token and fail at request time
+    // with a confusing 401 instead of at construction time.
+    const overrideApiKey = credentials?.apiKey?.trim();
+    const apiKey =
+      overrideApiKey && overrideApiKey.length > 0
+        ? overrideApiKey
+        : getMistralApiKey();
+    // Treat blank/whitespace overrides as unset so an empty
+    // `credentials.baseURL` or `MISTRAL_BASE_URL=` cannot silently override
+    // the default with "" (mirrors the apiKey precedence above).
+    const baseURL =
+      credentials?.baseURL?.trim() ||
+      process.env.MISTRAL_BASE_URL?.trim() ||
+      MISTRAL_DEFAULT_BASE_URL;
 
-    super(modelName, "mistral" as AIProviderName, validatedNeurolink);
+    super("mistral" as AIProviderName, modelName, sdk, { baseURL, apiKey });
 
-    // Initialize Mistral model with API key validation and proxy support
-    const apiKey = credentials?.apiKey ?? getMistralApiKey();
-    const mistral = createMistral({
-      apiKey: apiKey,
-      fetch: createProxyFetch(),
-    });
-    this.model = mistral(this.modelName);
-
-    logger.debug("Mistral Provider v2 initialized", {
+    logger.debug("Mistral Provider initialized", {
       modelName: this.modelName,
       providerName: this.providerName,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
 
-  // generate() method is inherited from BaseProvider; this provider uses the base implementation for generation with tools
+  // ===========================================================================
+  // Abstract hooks (required)
+  // ===========================================================================
 
-  protected async executeStream(
-    options: StreamOptions,
-    _analysisSchema?: ValidationSchema,
-  ): Promise<StreamResult> {
-    this.validateStreamOptions(options);
-
-    const startTime = Date.now();
-    const timeout = this.getTimeout(options);
-    const timeoutController = createTimeoutController(
-      timeout,
-      this.providerName,
-      "stream",
-    );
-
-    try {
-      // Get tools - options.tools is pre-merged by BaseProvider.stream()
-      const shouldUseTools = !options.disableTools && this.supportsTools();
-      const tools = shouldUseTools
-        ? (options.tools as Record<string, Tool>) || (await this.getAllTools())
-        : {};
-
-      // Build message array from options with multimodal support
-      // Using protected helper from BaseProvider to eliminate code duplication
-      const messages = await this.buildMessagesForStream(options);
-
-      const model = await this.getAISDKModelWithMiddleware(options); // This is where network connection happens!
-      // Reviewer follow-up: capture upstream provider errors via onError
-      // so the post-stream NoOutput sentinel carries the real cause.
-      let capturedProviderError: unknown;
-      const result = await streamText({
-        model,
-        messages: messages,
-        temperature: options.temperature,
-        maxOutputTokens: options.maxTokens, // No default limit - unlimited unless specified
-        tools,
-        stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
-        toolChoice: resolveToolChoice(options, tools, shouldUseTools),
-        abortSignal: composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        ),
-        experimental_telemetry:
-          this.telemetryHandler.getTelemetryConfig(options),
-        experimental_repairToolCall: this.getToolCallRepairFn(options),
-        onError: (event: { error: unknown }) => {
-          capturedProviderError = event.error;
-          logger.error("Mistral: Stream error", {
-            error:
-              event.error instanceof Error
-                ? event.error.message
-                : String(event.error),
-          });
-        },
-        onStepFinish: ({ toolCalls, toolResults }) => {
-          emitToolEndFromStepFinish(
-            this.neurolink?.getEventEmitter(),
-            toolResults as Array<{
-              toolName: string;
-              output?: unknown;
-              result?: unknown;
-              error?: string;
-            }>,
-          );
-          this.handleToolExecutionStorage(
-            toolCalls,
-            toolResults,
-            options,
-            new Date(),
-          ).catch((error: unknown) => {
-            logger.warn("[MistralProvider] Failed to store tool executions", {
-              provider: this.providerName,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-        },
-      });
-
-      timeoutController?.cleanup();
-
-      // Transform string stream to content object stream using BaseProvider method
-      const transformedStream = this.createTextStream(
-        result,
-        () => capturedProviderError,
-      );
-
-      // Create analytics promise that resolves after stream completion
-      const analyticsPromise = streamAnalyticsCollector.createAnalytics(
-        this.providerName,
-        this.modelName,
-        toAnalyticsStreamResult(result),
-        Date.now() - startTime,
-        {
-          requestId: `mistral-stream-${Date.now()}`,
-          streamingMode: true,
-        },
-      );
-
-      return {
-        stream: transformedStream,
-        provider: this.providerName,
-        model: this.modelName,
-        analytics: analyticsPromise,
-        metadata: {
-          startTime,
-          streamId: `mistral-${Date.now()}`,
-        },
-      };
-    } catch (error) {
-      timeoutController?.cleanup();
-      throw this.handleProviderError(error);
-    }
+  protected getProviderName(): AIProviderName {
+    return "mistral" as AIProviderName;
   }
 
-  // ===================
-  // ABSTRACT METHOD IMPLEMENTATIONS
-  // ===================
-
-  public getProviderName(): AIProviderName {
-    return this.providerName;
-  }
-
-  public getDefaultModel(): string {
+  protected getDefaultModel(): string {
     return getDefaultMistralModel();
   }
 
-  /**
-   * Returns the Vercel AI SDK model instance for Mistral
-   */
-  public getAISDKModel(): LanguageModel {
-    return this.model;
-  }
-
-  public formatProviderError(error: unknown): Error {
+  protected formatProviderError(error: unknown): Error {
     if (error instanceof TimeoutError) {
       return new NetworkError(`Request timed out: ${error.message}`, "mistral");
     }
-
     const errorRecord = error as UnknownRecord;
     const message =
       typeof errorRecord?.message === "string"
@@ -226,43 +100,43 @@ export class MistralProvider extends BaseProvider {
 
     if (
       message.includes("API_KEY_INVALID") ||
-      message.includes("Invalid API key")
+      message.includes("Invalid API key") ||
+      message.includes("Unauthorized") ||
+      message.includes("401")
     ) {
       return new AuthenticationError(
         "Invalid Mistral API key. Please check your MISTRAL_API_KEY environment variable.",
         "mistral",
       );
     }
-
-    if (message.includes("Rate limit exceeded")) {
+    if (
+      message.includes("rate limit") ||
+      message.includes("Rate limit") ||
+      message.includes("429")
+    ) {
       return new RateLimitError("Mistral rate limit exceeded", "mistral");
     }
-
+    if (message.includes("model_not_found") || message.includes("404")) {
+      return new InvalidModelError(
+        `Mistral model '${this.modelName}' not found.`,
+        "mistral",
+      );
+    }
     return new ProviderError(`Mistral error: ${message}`, "mistral");
   }
 
-  /**
-   * Validate provider configuration
-   */
-  async validateConfiguration(): Promise<boolean> {
-    try {
-      getMistralApiKey();
-      return true;
-    } catch {
-      return false;
-    }
+  // ===========================================================================
+  // Optional hooks
+  // ===========================================================================
+
+  protected getFallbackModelName(): string {
+    return MistralModels.MISTRAL_SMALL_2506;
   }
 
-  /**
-   * Get provider-specific configuration
-   */
-  getConfiguration() {
-    return {
-      provider: this.providerName,
-      model: this.modelName,
-      defaultModel: getDefaultMistralModel(),
-    };
+  protected getFallbackModels(): string[] {
+    return [
+      MistralModels.MISTRAL_SMALL_2506,
+      MistralModels.MISTRAL_LARGE_LATEST,
+    ];
   }
 }
-
-export default MistralProvider;

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -196,7 +196,7 @@ export type NeurolinkCredentials = {
     // best-effort deployment-name heuristic is used.
     useMaxCompletionTokens?: boolean;
   };
-  mistral?: { apiKey?: string };
+  mistral?: { apiKey?: string; baseURL?: string };
   huggingFace?: { apiKey?: string; baseURL?: string };
   openrouter?: { apiKey?: string; baseURL?: string };
   litellm?: { apiKey?: string; baseURL?: string };


### PR DESCRIPTION
## What & why

Continues the provider-migration series — moves **Mistral** off the Vercel AI SDK runtime (`createMistral` + `streamText`) onto the native `OpenAIChatCompletionsProvider` base, the same path already taken by groq, deepseek, openAI, cohere, perplexity, togetherAi, xai, litellm, nvidiaNim, cloudflare, huggingFace, lmStudio, openaiCompatible, and llamaCpp.

Mistral's `/v1/chat/completions` endpoint is OpenAI-compatible, so all request / stream / tool-loop orchestration now lives in the shared base client instead of a bespoke `executeStream`.

## Changes

- `MistralProvider extends OpenAIChatCompletionsProvider` — the provider's own `executeStream` / `getAISDKModel` / `streamText` plumbing (~205 lines) is removed in favour of the base.
- **Configuration** via constructor with the cohort's blank/whitespace-guarded precedence:
  - `apiKey`: `credentials.apiKey` → `MISTRAL_API_KEY`
  - `baseURL`: `credentials.baseURL` → `MISTRAL_BASE_URL` → `https://api.mistral.ai/v1`
- **Error mapping preserved** through `formatProviderError` (auth / rate-limit / model-not-found / timeout), returning typed errors — never throwing.
- **Default + fallback models** retained via base hooks (`mistral-small-2506`, `mistral-large-latest`).
- `response_format: { type: "json_schema" }` is **passed through** (current Mistral models support structured outputs), so no downgrade hook is needed.
- `baseURL` is redacted in the constructor debug log via `redactUrlCredentials` (the shared helper from #1068).
- Add `baseURL` to the `mistral` per-request credentials type; drop the now-unused `@ai-sdk/mistral` type import from `providerRegistry`.

## Out of scope

- `src/browser/entry.ts` still re-exports `createMistral`/`mistral` from `@ai-sdk/mistral` (a separate browser-API surface); the npm dep is retained for it, matching the other migrations.

## Validation

- `pnpm run check` (svelte-check + `tsc --strict`) — pass, 0 errors
- lint + format — pass (0 errors)
- `pnpm run build` + publint — pass ("All good!")
- stream-span native-base audit — 106/106 pass (mistral now audited as a delegating native-base provider)

Single commit, per the repo's single-commit policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom base URL configuration for the Mistral provider.

* **Improvements**
  * Enhanced error handling for Mistral API errors, including better recognition of authentication failures, rate limiting, and invalid models.
  * Implemented fallback model selection for improved provider reliability.

* **Refactor**
  * Restructured Mistral provider architecture for streamlined compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->