### PR TITLE
refactor(providers): migrate openRouter to native OpenAIChatCompletionsProvider base

### DIFF
--- a/src/lib/providers/openRouter.ts
+++ b/src/lib/providers/openRouter.ts
@@ -1,20 +1,4 @@
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import type { ZodType } from "zod";
 import { AIProviderName } from "../constants/enums.js";
-import { BaseProvider } from "../core/baseProvider.js";
-import { DEFAULT_MAX_STEPS } from "../core/constants.js";
-import { streamAnalyticsCollector } from "../core/streamAnalytics.js";
-import type { NeuroLink } from "../neurolink.js";
-import { createProxyFetch } from "../proxy/proxyFetch.js";
-import type {
-  UnknownRecord,
-  OpenRouterConfig,
-  OpenRouterModelInfo,
-  OpenRouterModelsResponse,
-  StreamOptions,
-  StreamResult,
-  StreamTextResult,
-} from "../types/index.js";
 import {
   AuthenticationError,
   InvalidModelError,
@@ -22,56 +6,42 @@ import {
   ProviderError,
   RateLimitError,
 } from "../types/index.js";
+import type {
+  NeurolinkCredentials,
+  OpenRouterModelInfo,
+  OpenRouterModelsResponse,
+  UnknownRecord,
+} from "../types/index.js";
+import { createProxyFetch } from "../proxy/proxyFetch.js";
 import { isAbortError } from "../utils/errorHandling.js";
-import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
 import { logger } from "../utils/logger.js";
-import {
-  buildNoOutputSentinel,
-  detectPostStreamNoOutput,
-  stampNoOutputSpan,
-} from "../utils/noOutputSentinel.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
 import { getProviderModel } from "../utils/providerConfig.js";
-import {
-  composeAbortSignals,
-  createTimeoutController,
-  TimeoutError,
-} from "../utils/timeout.js";
-import { resolveToolChoice } from "../utils/toolChoice.js";
-import type { LanguageModel, Schema, Tool } from "../types/index.js";
-import { NoOutputGeneratedError } from "../utils/generationErrors.js";
-import { Output, stepCountIs } from "../utils/tool.js";
-import { streamText } from "../utils/generation.js";
+import { TimeoutError } from "../utils/timeout.js";
+import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
+import { stripTrailingSlash } from "./openaiChatCompletionsClient.js";
 
-// Constants
+// OpenRouter's OpenAI-compatible gateway. `${baseURL}/chat/completions` and
+// `${baseURL}/models` both resolve correctly off this root.
+const OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
 const MODELS_DISCOVERY_TIMEOUT_MS = 5000; // 5 seconds for model discovery
 
-// Configuration helpers
-const getOpenRouterConfig = (): OpenRouterConfig => {
+const getOpenRouterApiKey = (): string => {
   const apiKey = process.env.OPENROUTER_API_KEY;
-
   if (!apiKey) {
     throw new Error(
       "OPENROUTER_API_KEY environment variable is required. " +
         "Get your API key at https://openrouter.ai/keys",
     );
   }
-
-  return {
-    apiKey,
-    referer: process.env.OPENROUTER_REFERER,
-    appName: process.env.OPENROUTER_APP_NAME,
-  };
+  return apiKey;
 };
 
 /**
  * Returns the default model name for OpenRouter.
  *
- * OpenRouter uses a 'provider/model' format for model names.
- * For example:
- *   - 'anthropic/claude-sonnet-4.5'
- *   - 'openai/gpt-4o'
- *   - 'google/gemini-2.5-flash'
- *   - 'meta-llama/llama-3-70b-instruct'
+ * OpenRouter uses a 'provider/model' format for model names (e.g.
+ * 'anthropic/claude-sonnet-4.5', 'openai/gpt-4o', 'google/gemini-2.5-flash').
  *
  * The previous default `anthropic/claude-3-5-sonnet` was retired by OpenRouter
  * in late 2025 and now returns "No endpoints found for model" for every
@@ -80,21 +50,35 @@ const getOpenRouterConfig = (): OpenRouterConfig => {
  * model. Must stay aligned with the registry default in
  * `src/lib/factories/providerRegistry.ts` and `PROVIDER_DEFAULTS` in
  * `src/lib/utils/modelChoices.ts`.
- *
- * You can override the default by setting the OPENROUTER_MODEL environment variable.
  */
 const getDefaultOpenRouterModel = (): string => {
   return getProviderModel("OPENROUTER_MODEL", "anthropic/claude-sonnet-4.5");
 };
 
 /**
- * OpenRouter Provider - BaseProvider Implementation
- * Provides access to 300+ models from 60+ providers via OpenRouter unified gateway
+ * OpenRouter Provider — direct HTTP, no AI SDK.
+ *
+ * OpenAI-compatible unified gateway to 300+ models from 60+ providers. All
+ * request/stream/tool-loop orchestration lives in
+ * `OpenAIChatCompletionsProvider`; this class declares configuration plus the
+ * OpenRouter-specific behaviour:
+ *
+ *   1. Attribution headers — optional `HTTP-Referer` / `X-Title` (from
+ *      `OPENROUTER_REFERER` / `OPENROUTER_APP_NAME`) are merged into every
+ *      request via `getAuthHeaders` so usage shows up on the openrouter.ai
+ *      activity dashboard.
+ *   2. Per-model tool gating — OpenRouter proxies many models with varying
+ *      tool support, so `supportsTools()` consults a cached capability set
+ *      (populated by `cacheModelCapabilities()`) and falls back to a
+ *      conservative known-capable pattern list.
+ *   3. Dynamic model discovery — `getAvailableModels()` fetches the live
+ *      `/models` list (10-minute cache) with a hardcoded fallback.
+ *
+ * @see https://openrouter.ai/docs
  */
-export class OpenRouterProvider extends BaseProvider {
-  private model: LanguageModel;
-  private openRouterClient: ReturnType<typeof createOpenRouter>;
-  private config: OpenRouterConfig;
+export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
+  private readonly referer?: string;
+  private readonly appName?: string;
 
   // Cache for available models to avoid repeated API calls
   private static modelsCache: string[] = [];
@@ -109,49 +93,42 @@ export class OpenRouterProvider extends BaseProvider {
     modelName?: string,
     sdk?: unknown,
     _region?: string,
-    credentials?: { apiKey?: string; baseURL?: string },
+    credentials?: NeurolinkCredentials["openrouter"],
   ) {
-    super(modelName, AIProviderName.OPENROUTER, sdk as NeuroLink | undefined);
+    // Trim the override before applying precedence. A blank/whitespace
+    // `credentials.apiKey` must NOT bypass `getOpenRouterApiKey()` — that
+    // would build a client with an unusable bearer token and fail at request
+    // time with a confusing 401 instead of at construction time.
+    const overrideApiKey = credentials?.apiKey?.trim();
+    const apiKey =
+      overrideApiKey && overrideApiKey.length > 0
+        ? overrideApiKey
+        : getOpenRouterApiKey();
+    // Treat blank/whitespace overrides as unset so an empty
+    // `credentials.baseURL` or `OPENROUTER_BASE_URL=` cannot silently override
+    // the default with "" (mirrors the apiKey precedence above).
+    const baseURL =
+      credentials?.baseURL?.trim() ||
+      process.env.OPENROUTER_BASE_URL?.trim() ||
+      OPENROUTER_DEFAULT_BASE_URL;
 
-    // Build config: prefer credentials over env vars to avoid throwing when env vars are absent
-    if (credentials?.apiKey) {
-      this.config = {
-        apiKey: credentials.apiKey,
-        referer: process.env.OPENROUTER_REFERER,
-        appName: process.env.OPENROUTER_APP_NAME,
-      };
-    } else {
-      this.config = getOpenRouterConfig(); // throws if OPENROUTER_API_KEY missing
-    }
-    const config = this.config;
+    super(AIProviderName.OPENROUTER, modelName, sdk, { baseURL, apiKey });
 
-    // Build headers for attribution on openrouter.ai/activity dashboard
-    const headers: Record<string, string> = {};
-    if (config.referer) {
-      headers["HTTP-Referer"] = config.referer;
-    }
-    if (config.appName) {
-      headers["X-Title"] = config.appName;
-    }
-
-    // Create OpenRouter client with optional attribution headers
-    this.openRouterClient = createOpenRouter({
-      apiKey: config.apiKey,
-      ...(credentials?.baseURL ? { baseURL: credentials.baseURL } : {}),
-      ...(Object.keys(headers).length > 0 && { headers }),
-    });
-
-    // Initialize model with OpenRouter client
-    // OpenRouterChatLanguageModel implements LanguageModelV3 which is part of the LanguageModel union
-    this.model = this.openRouterClient(
-      this.modelName || getDefaultOpenRouterModel(),
-    );
+    // Trim attribution values so whitespace-only env vars are not sent as
+    // empty HTTP-Referer / X-Title headers.
+    this.referer = process.env.OPENROUTER_REFERER?.trim() || undefined;
+    this.appName = process.env.OPENROUTER_APP_NAME?.trim() || undefined;
 
     logger.debug("OpenRouter Provider initialized", {
       modelName: this.modelName,
-      provider: this.providerName,
+      providerName: this.providerName,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
+
+  // ===========================================================================
+  // Abstract hooks (required)
+  // ===========================================================================
 
   protected getProviderName(): AIProviderName {
     return AIProviderName.OPENROUTER;
@@ -161,14 +138,7 @@ export class OpenRouterProvider extends BaseProvider {
     return getDefaultOpenRouterModel();
   }
 
-  /**
-   * Returns the Vercel AI SDK model instance for OpenRouter
-   */
-  protected getAISDKModel(): LanguageModel {
-    return this.model;
-  }
-
-  public formatProviderError(error: unknown): Error {
+  protected formatProviderError(error: unknown): Error {
     if (error instanceof TimeoutError) {
       return new NetworkError(
         `Request timed out: ${error.message}`,
@@ -237,9 +207,9 @@ export class OpenRouterProvider extends BaseProvider {
         );
       }
 
-      // "No endpoints found" — model temporarily unavailable or unsupported parameters
-      // This is distinct from tool errors: it can happen on any request when the
-      // model has no available providers on OpenRouter (e.g., free-tier model down).
+      // "No endpoints found" — model temporarily unavailable or unsupported
+      // parameters. Distinct from tool errors: it can happen on any request
+      // when the model has no available providers on OpenRouter.
       if (errorRecord.message.includes("No endpoints found")) {
         return new InvalidModelError(
           `No endpoints found for model '${this.modelName}' on OpenRouter. ` +
@@ -276,9 +246,34 @@ export class OpenRouterProvider extends BaseProvider {
     );
   }
 
+  // ===========================================================================
+  // Optional hooks — provider-specific quirks
+  // ===========================================================================
+
+  protected getFallbackModelName(): string {
+    return getDefaultOpenRouterModel();
+  }
+
   /**
-   * OpenRouter supports tools for compatible models
-   * Checks cached model capabilities or uses known patterns as fallback
+   * Attribution headers are merged into every request alongside the bearer
+   * token so OpenRouter can attribute usage on its activity dashboard.
+   */
+  protected getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { ...super.getAuthHeaders() };
+    if (this.referer) {
+      headers["HTTP-Referer"] = this.referer;
+    }
+    if (this.appName) {
+      headers["X-Title"] = this.appName;
+    }
+    return headers;
+  }
+
+  /**
+   * OpenRouter proxies models with varying tool support. Use cached
+   * capabilities when available (populated by `cacheModelCapabilities()`),
+   * otherwise fall back to a conservative known-capable pattern list and
+   * disable tools for unknown models.
    */
   supportsTools(): boolean {
     const modelName = this.modelName || getDefaultOpenRouterModel();
@@ -332,296 +327,21 @@ export class OpenRouterProvider extends BaseProvider {
     return false;
   }
 
+  // ===========================================================================
+  // Model discovery (OpenRouter /models endpoint)
+  // ===========================================================================
+
   /**
-   * Provider-specific streaming implementation
-   * Note: This is only used when tools are disabled
+   * Models/capabilities endpoint, derived from the configured `baseURL` so a
+   * custom OpenRouter-compatible gateway is honoured for discovery too.
    */
-  protected async executeStream(
-    options: StreamOptions,
-    analysisSchema?: ZodType | Schema<unknown>,
-  ): Promise<StreamResult> {
-    this.validateStreamOptions(options);
-
-    const startTime = Date.now();
-    let chunkCount = 0; // Track chunk count for debugging
-    // Reviewer follow-up: capture upstream provider errors via onError so
-    // the post-stream NoOutput detect can propagate the *real* cause
-    // (e.g. content_filter, provider crash) into the sentinel's
-    // providerError / modelResponseRaw instead of the AI SDK's generic
-    // "No output generated" message.
-    let capturedProviderError: unknown;
-    const timeout = this.getTimeout(options);
-    const timeoutController = createTimeoutController(
-      timeout,
-      this.providerName,
-      "stream",
-    );
-
-    try {
-      // Build message array from options with multimodal support
-      // Using protected helper from BaseProvider to eliminate code duplication
-      const messages = await this.buildMessagesForStream(options);
-
-      const model = await this.getAISDKModelWithMiddleware(options);
-
-      // Get all available tools (direct + MCP + external) for streaming
-      // BaseProvider.stream() pre-merges base tools + external tools into options.tools
-      const shouldUseTools = !options.disableTools && this.supportsTools();
-      const tools: Record<string, Tool> = shouldUseTools
-        ? (options.tools as Record<string, Tool>) || (await this.getAllTools())
-        : {};
-
-      logger.debug(`OpenRouter: Tools for streaming`, {
-        shouldUseTools,
-        toolCount: Object.keys(tools).length,
-        toolNames: Object.keys(tools),
-      });
-
-      // Build complete stream options with proper typing
-      // Note: maxRetries set to 0 for OpenRouter free tier to prevent SDK's quick retries
-      // from consuming rate limits. Our test suite handles retries with appropriate delays.
-      let streamOptions: Parameters<typeof streamText>[0] = {
-        model: model,
-        messages: messages,
-        temperature: options.temperature,
-        maxRetries: 0, // Disable SDK retries - let caller handle rate limit retries with delays
-        // AI SDK v6 renamed `maxTokens` to `maxOutputTokens` — using the old
-        // name here is a silent no-op, so OpenRouter sees no cap and applies
-        // the model's full output max (typically 64K+ tokens) to its pre-bill
-        // affordability check. That trips "This request requires more credits"
-        // even on cheap models when the account balance is low.
-        ...(options.maxTokens && { maxOutputTokens: options.maxTokens }),
-        ...(shouldUseTools &&
-          Object.keys(tools).length > 0 && {
-            tools,
-            toolChoice: resolveToolChoice(options, tools, shouldUseTools),
-            stopWhen: stepCountIs(options.maxSteps || DEFAULT_MAX_STEPS),
-          }),
-        abortSignal: composeAbortSignals(
-          options.abortSignal,
-          timeoutController?.controller.signal,
-        ),
-        experimental_telemetry:
-          this.telemetryHandler.getTelemetryConfig(options),
-        experimental_repairToolCall: this.getToolCallRepairFn(options),
-
-        onError: (event: { error: unknown }) => {
-          const error = event.error;
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          // Reviewer follow-up: propagate the captured error to the
-          // post-stream NoOutput sentinel so telemetry sees the real
-          // provider cause instead of "No output generated".
-          capturedProviderError = error;
-          logger.error(`OpenRouter: Stream error`, {
-            provider: this.providerName,
-            modelName: this.modelName,
-            error: errorMessage,
-            chunkCount,
-          });
-        },
-
-        onFinish: (event: {
-          finishReason: string;
-          usage: Record<string, unknown>;
-          text?: string;
-        }) => {
-          logger.debug(`OpenRouter: Stream finished`, {
-            finishReason: event.finishReason,
-            totalChunks: chunkCount,
-          });
-        },
-
-        onChunk: () => {
-          chunkCount++;
-        },
-
-        onStepFinish: ({ toolCalls, toolResults }) => {
-          emitToolEndFromStepFinish(
-            this.neurolink?.getEventEmitter(),
-            toolResults as Array<{
-              toolName: string;
-              output?: unknown;
-              result?: unknown;
-              error?: string;
-            }>,
-          );
-          logger.info("Tool execution completed", {
-            toolCallCount: toolCalls?.length || 0,
-            toolResultCount: toolResults?.length || 0,
-            toolNames: toolCalls?.map(
-              (tc: { toolName: string }) => tc.toolName,
-            ),
-          });
-
-          this.handleToolExecutionStorage(
-            toolCalls,
-            toolResults,
-            options,
-            new Date(),
-          ).catch((error: unknown) => {
-            logger.warn("OpenRouterProvider: Failed to store tool executions", {
-              provider: this.providerName,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-        },
-      };
-
-      // Add analysisSchema support if provided
-      if (analysisSchema) {
-        try {
-          streamOptions = {
-            ...streamOptions,
-            experimental_output: Output.object({
-              schema: analysisSchema,
-            }),
-          };
-        } catch (error) {
-          logger.warn("Schema application failed, continuing without schema", {
-            error: String(error),
-          });
-        }
-      }
-
-      const result = await streamText(streamOptions);
-
-      // Guard against NoOutputGeneratedError becoming an unhandled rejection.
-      Promise.resolve(result.text)
-        .catch((err: unknown) => {
-          logger.debug(
-            "Stream text promise rejected (expected for empty streams)",
-            {
-              error: err instanceof Error ? err.message : String(err),
-            },
-          );
-        })
-        .finally(() => timeoutController?.cleanup());
-
-      // Transform stream to content object stream using fullStream (handles both text and tool calls)
-      const transformedStream = (async function* () {
-        // Reviewer follow-up: gate the post-stream NoOutput detect on
-        // *content yielded*, not raw chunk count. AI SDK fullStream emits
-        // control events ({ type: "start" }, "step-start", etc.) before
-        // any text-delta — those incremented `chunkCount` and made the
-        // post-stream check dead even when zero text was produced.
-        let contentYielded = 0;
-        try {
-          // Try fullStream first (handles both text and tool calls), fallback to textStream
-          const streamToUse = result.fullStream || result.textStream;
-
-          for await (const chunk of streamToUse) {
-            // Handle different chunk types from fullStream
-            if (chunk && typeof chunk === "object") {
-              // Check for error chunks first (critical error handling)
-              if ("type" in chunk && chunk.type === "error") {
-                const errorChunk = chunk as {
-                  type: "error";
-                  error: Record<string, unknown>;
-                };
-                logger.error(`OpenRouter: Error chunk received:`, {
-                  errorType: errorChunk.type,
-                  errorDetails: errorChunk.error,
-                });
-                throw new Error(
-                  `OpenRouter streaming error: ${
-                    (errorChunk.error as Record<string, unknown>)?.message ||
-                    "Unknown error"
-                  }`,
-                );
-              }
-
-              if ("textDelta" in chunk) {
-                // Text delta from fullStream
-                const textDelta = (chunk as { textDelta: string }).textDelta;
-                if (textDelta) {
-                  contentYielded++;
-                  yield { content: textDelta };
-                }
-              } else if (
-                "type" in chunk &&
-                chunk.type === "tool-call" &&
-                "toolCallId" in chunk
-              ) {
-                // Tool call event - log for debugging
-                const toolCallId = String(chunk.toolCallId);
-                const toolName =
-                  "toolName" in chunk ? String(chunk.toolName) : "unknown";
-                logger.debug("OpenRouter: Tool call", {
-                  toolCallId,
-                  toolName,
-                });
-              }
-            } else if (typeof chunk === "string") {
-              // Direct string chunk from textStream fallback
-              contentYielded++;
-              yield { content: chunk };
-            }
-          }
-        } catch (streamError) {
-          if (NoOutputGeneratedError.isInstance(streamError)) {
-            logger.warn(
-              "OpenRouter: Stream produced no output (NoOutputGeneratedError) — caught from textStream",
-            );
-            const sentinel = await buildNoOutputSentinel(
-              streamError,
-              result,
-              capturedProviderError,
-            );
-            stampNoOutputSpan(sentinel);
-            yield sentinel as { content: string };
-            return;
-          }
-          throw streamError;
-        }
-        // Curator P3-6 (round-2 fix): production trigger comes through
-        // result.finishReason rejection, not textStream throws.
-        if (contentYielded === 0) {
-          const detected = await detectPostStreamNoOutput(
-            result,
-            capturedProviderError,
-          );
-          if (detected) {
-            logger.warn(
-              "OpenRouter: Stream produced no output (NoOutputGeneratedError) — caught from finishReason rejection",
-            );
-            stampNoOutputSpan(detected.sentinel);
-            yield detected.sentinel as { content: string };
-          }
-        }
-      })();
-
-      // Create analytics promise that resolves after stream completion
-      const analyticsPromise = streamAnalyticsCollector.createAnalytics(
-        this.providerName,
-        this.modelName,
-        result as StreamTextResult,
-        Date.now() - startTime,
-        {
-          requestId: `openrouter-stream-${Date.now()}`,
-          streamingMode: true,
-        },
-      );
-
-      return {
-        stream: transformedStream,
-        provider: this.providerName,
-        model: this.modelName,
-        analytics: analyticsPromise,
-        metadata: {
-          startTime,
-          streamId: `openrouter-${Date.now()}`,
-        },
-      };
-    } catch (error) {
-      timeoutController?.cleanup();
-      throw this.handleProviderError(error);
-    }
+  private getModelsUrl(): string {
+    return `${stripTrailingSlash(this.config.baseURL)}/models`;
   }
 
   /**
-   * Get available models from OpenRouter API
-   * Dynamically fetches from /api/v1/models endpoint with caching and fallback
+   * Get available models from the OpenRouter `/models` endpoint, with a
+   * 10-minute cache and a hardcoded fallback when the fetch fails.
    */
   async getAvailableModels(): Promise<string[]> {
     const functionTag = "OpenRouterProvider.getAvailableModels";
@@ -644,7 +364,6 @@ export class OpenRouterProvider extends BaseProvider {
     try {
       const dynamicModels = await this.fetchModelsFromAPI();
       if (dynamicModels.length > 0) {
-        // Cache successful result
         OpenRouterProvider.modelsCache = dynamicModels;
         OpenRouterProvider.modelsCacheTime = now;
 
@@ -693,13 +412,11 @@ export class OpenRouterProvider extends BaseProvider {
   }
 
   /**
-   * Fetch available models from OpenRouter API /api/v1/models endpoint
+   * Fetch available models from the OpenRouter `/models` endpoint.
    * @private
    */
   private async fetchModelsFromAPI(): Promise<string[]> {
     const functionTag = "OpenRouterProvider.fetchModelsFromAPI";
-    const config = this.config;
-    const modelsUrl = "https://openrouter.ai/api/v1/models";
 
     const controller = new AbortController();
     const timeoutId = setTimeout(
@@ -708,13 +425,14 @@ export class OpenRouterProvider extends BaseProvider {
     );
 
     try {
+      const modelsUrl = this.getModelsUrl();
       logger.debug(`[${functionTag}] Fetching models from ${modelsUrl}`);
 
       const proxyFetch = createProxyFetch();
       const response = await proxyFetch(modelsUrl, {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${config.apiKey}`,
+          ...this.getAuthHeaders(),
           "Content-Type": "application/json",
         },
         signal: controller.signal,
@@ -759,7 +477,7 @@ export class OpenRouterProvider extends BaseProvider {
   }
 
   /**
-   * Type guard to validate the models API response structure
+   * Type guard to validate the models API response structure.
    * @private
    */
   private isValidModelsResponse(
@@ -774,8 +492,8 @@ export class OpenRouterProvider extends BaseProvider {
   }
 
   /**
-   * Fetch and cache model capabilities from OpenRouter API
-   * Call this to enable accurate tool support detection
+   * Fetch and cache model capabilities from the OpenRouter `/models` endpoint.
+   * Call this to enable accurate per-model tool support detection.
    */
   async cacheModelCapabilities(): Promise<void> {
     const functionTag = "OpenRouterProvider.cacheModelCapabilities";
@@ -785,9 +503,6 @@ export class OpenRouterProvider extends BaseProvider {
     }
 
     try {
-      const config = this.config;
-      const modelsUrl = "https://openrouter.ai/api/v1/models";
-
       const controller = new AbortController();
       const timeoutId = setTimeout(
         () => controller.abort(),
@@ -795,10 +510,10 @@ export class OpenRouterProvider extends BaseProvider {
       );
 
       const proxyFetch = createProxyFetch();
-      const response = await proxyFetch(modelsUrl, {
+      const response = await proxyFetch(this.getModelsUrl(), {
         method: "GET",
         headers: {
-          Authorization: `Bearer ${config.apiKey}`,
+          ...this.getAuthHeaders(),
           "Content-Type": "application/json",
         },
         signal: controller.signal,


### PR DESCRIPTION
## What & why

Final OpenAI-compatible provider in the migration series — moves **OpenRouter** off the Vercel AI SDK runtime (`createOpenRouter` + `streamText`) onto the native `OpenAIChatCompletionsProvider` base. OpenRouter's gateway is OpenAI-compatible, so all request / stream / tool-loop orchestration now lives in the shared base client, and the bespoke `executeStream` / `getAISDKModel` (~290 lines, including the manual `fullStream` + NoOutput-sentinel handling the base now does generically) is removed.

## Faithful migration — all OpenRouter behaviour preserved

- **Configuration**: `apiKey` (`credentials.apiKey` → `OPENROUTER_API_KEY`) and `baseURL` (`credentials.baseURL` → `OPENROUTER_BASE_URL` → `https://openrouter.ai/api/v1`), with the cohort's blank/whitespace-guard precedence.
- **Attribution headers**: optional `HTTP-Referer` / `X-Title` (from `OPENROUTER_REFERER` / `OPENROUTER_APP_NAME`) merged into every request via a `getAuthHeaders` override — usage still shows on the openrouter.ai activity dashboard.
- **Per-model tool gating**: `supportsTools()` keeps consulting the cached capability set (`cacheModelCapabilities`) with the known-capable pattern fallback. The base honours `supportsTools()` before attaching tools, so the behaviour is intact.
- **Dynamic model discovery**: `getAvailableModels()` retains the 10-minute cache, live `/models` fetch, and hardcoded fallback; `cacheModelCapabilities()` / `fetchModelsFromAPI()` retained.
- **Error mapping**: full `formatProviderError` preserved (auth / rate-limit / model-not-found / no-endpoints / insufficient-credits / tool-unsupported / timeout), returning typed errors — never throwing.
- `baseURL` redacted in the constructor debug log via `redactUrlCredentials` (the shared helper from #1068).

## Notes

- Only `src/lib/providers/openRouter.ts` changes — the registry already passes the `NeuroLink` sdk (no `@ai-sdk` cast to drop) and the `openrouter` credentials type already carries `baseURL`.
- The AI SDK's `maxRetries: 0` free-tier guard is dropped along with `streamText`; the native base does not do the AI SDK's quick automatic retries, so free-tier rate-limit consumption is not reintroduced.
- `src/browser/entry.ts` still re-exports `createOpenRouter` from `@openrouter/ai-sdk-provider` (separate browser-API surface); the dep is retained for it, matching the other migrations.

## Validation

- `pnpm run check` (svelte-check + `tsc --strict`) — pass, 0 errors
- lint + format — pass (0 errors)
- `pnpm run build` + publint — pass ("All good!")
- stream-span native-base audit — 106/106 pass (openRouter now audited as a native-base provider; `formatProviderError` returns only typed errors)

Single commit, per the repo's single-commit policy.
