### PR TITLE
refactor(providers): migrate ollama to native OpenAIChatCompletionsProvider base

### DIFF
--- a/src/lib/factories/providerRegistry.ts
+++ b/src/lib/factories/providerRegistry.ts
@@ -295,13 +295,18 @@ export class ProviderRegistry {
         async (
           modelName?: string,
           _providerName?: string,
-          _sdk?: UnknownRecord,
+          sdk?: UnknownRecord,
           _region?: string,
           credentials?: UnknownRecord,
         ) => {
           const ollamaCreds = credentials as NeurolinkCredentials["ollama"];
           const { OllamaProvider } = await import("../providers/ollama.js");
-          return new OllamaProvider(modelName, ollamaCreds);
+          return new OllamaProvider(
+            modelName,
+            sdk as unknown as NeuroLink | undefined,
+            undefined,
+            ollamaCreds,
+          );
         },
         process.env.OLLAMA_MODEL || OllamaModels.LLAMA3_2_LATEST,
         ["ollama", "local"],

--- a/src/lib/providers/ollama.ts
+++ b/src/lib/providers/ollama.ts
@@ -1,680 +1,110 @@
 import type { AIProviderName } from "../constants/enums.js";
-import { createAnalytics } from "../core/analytics.js";
-import { BaseProvider } from "../core/baseProvider.js";
-import { DEFAULT_MAX_STEPS } from "../core/constants.js";
+import { OllamaModels } from "../constants/enums.js";
 import { modelConfig } from "../core/modelConfiguration.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type {
-  JsonValue,
-  MessageContent,
-  MultimodalChatMessage,
-  OllamaAsLanguageModel,
-  OllamaHttpError,
-  OllamaMessage,
-  OllamaToolCall,
-  OllamaToolResult,
+  ModelsResponse,
+  NeurolinkCredentials,
   StreamOptions,
-  StreamResult,
-  Tool,
-  ToolArgs,
-  ZodUnknownSchema,
+  TextGenerationOptions,
+  UnknownRecord,
 } from "../types/index.js";
-import { logger } from "../utils/logger.js";
-import { buildMultimodalMessagesArray } from "../utils/messageBuilder.js";
-import { buildMultimodalOptions } from "../utils/multimodalOptionsBuilder.js";
-import { estimateTokens } from "../utils/tokenEstimation.js";
 import {
   InvalidModelError,
   NetworkError,
   ProviderError,
 } from "../types/index.js";
-import { tracers, ATTR, withClientStreamSpan } from "../telemetry/index.js";
-import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
-import { TimeoutError } from "../utils/timeout.js";
-import type { LanguageModel, Schema } from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
+import {
+  createTimeoutController,
+  parseTimeout,
+  TimeoutError,
+} from "../utils/timeout.js";
+import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
+import { stripTrailingSlash } from "./openaiChatCompletionsClient.js";
 
-// Model version constants (configurable via environment)
-const DEFAULT_OLLAMA_MODEL = process.env.OLLAMA_MODEL || "llama3.1:8b";
-const FALLBACK_OLLAMA_MODEL = "llama3.2:latest"; // Used when primary model fails
+// Ollama serves its OpenAI-compatible surface under `/v1` (/v1/chat/completions,
+// /v1/models, /v1/embeddings). The base client appends `/chat/completions` to
+// config.baseURL, so the base URL must already carry the `/v1` suffix.
+const OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/v1";
+// Local Ollama ignores the Authorization header, but the base HTTP client
+// requires a non-empty apiKey. A real key (OLLAMA_API_KEY) is only needed for
+// Ollama Cloud / an auth-proxying reverse proxy.
+const OLLAMA_PLACEHOLDER_KEY = "ollama";
+// Default model must match the registry default (providerRegistry.ts advertises
+// `OllamaModels.LLAMA3_2_LATEST`) so getConfiguration()/resolveModelName() agree
+// with what the registry reports.
+const DEFAULT_OLLAMA_MODEL = OllamaModels.LLAMA3_2_LATEST;
+const FALLBACK_OLLAMA_MODEL = "llama3.1:8b";
+const DEFAULT_EMBEDDING_MODEL = "nomic-embed-text";
+const EMBEDDINGS_TIMEOUT_MS = 30_000;
 
-// Configuration helpers
-const getOllamaBaseUrl = (): string => {
-  return process.env.OLLAMA_BASE_URL || "http://localhost:11434";
-};
-
-const isOpenAICompatibleMode = (): boolean => {
-  // Enable OpenAI-compatible API mode (/v1/chat/completions) instead of native Ollama API (/api/generate)
-  // Useful for Ollama deployments that only support OpenAI-compatible routes (e.g., breezehq.dev)
-  return process.env.OLLAMA_OPENAI_COMPATIBLE === "true";
-};
-
-// Create AbortController with timeout for better compatibility
-const createAbortSignalWithTimeout = (timeoutMs: number): AbortSignal => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-  // Clear timeout if signal is aborted through other means
-  controller.signal.addEventListener("abort", () => {
-    clearTimeout(timeoutId);
-  });
-
-  return controller.signal;
-};
-
-const getDefaultOllamaModel = (): string => {
-  return process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
-};
-
-const getOllamaTimeout = (): number => {
-  // Increased default timeout to 240000ms (4 minutes) to support slower native API responses
-  // especially for larger models like aliafshar/gemma3-it-qat-tools:latest (12.2B parameters)
-  return parseInt(process.env.OLLAMA_TIMEOUT || "240000", 10);
-};
-
-function isOllamaHttpError(error: unknown): error is OllamaHttpError {
-  return (
-    error instanceof ProviderError &&
-    typeof (error as { statusCode?: unknown }).statusCode === "number" &&
-    typeof (error as { responseBody?: unknown }).responseBody === "string"
-  );
-}
-
-async function createOllamaHttpError(
-  response: Response,
-): Promise<OllamaHttpError> {
-  let responseBody = "";
-  try {
-    responseBody = (await response.text()).trim();
-  } catch {
-    // Ignore unreadable bodies
-  }
-
-  const suffix = responseBody ? ` - ${responseBody.slice(0, 500)}` : "";
-  const error = new ProviderError(
-    `Ollama API error: ${response.status} ${response.statusText}${suffix}`,
-    "ollama",
-  ) as OllamaHttpError;
-  error.statusCode = response.status;
-  error.statusText = response.statusText;
-  error.responseBody = responseBody;
-  return error;
-}
-
-// Create proxy-aware fetch instance
-const proxyFetch = createProxyFetch();
-
-// Custom LanguageModel implementation for Ollama
-class OllamaLanguageModel implements OllamaAsLanguageModel {
-  /**
-   * Specification version for the AI SDK LanguageModel interface.
-   * Uses "v2" for structural compatibility with AI SDK v6's `LanguageModelV2`.
-   * The AI SDK checks this field to determine which interface version to use.
-   */
-  readonly specificationVersion = "v2" as const;
-  readonly provider = "ollama";
-  readonly modelId: string;
-  readonly maxTokens?: number;
-  readonly supportsStreaming = true;
-  readonly defaultObjectGenerationMode = "json" as const;
-
-  /**
-   * Supported URL patterns by media type.
-   * Ollama runs locally and does not natively download URLs, so this is empty.
-   * Required by the LanguageModelV2 interface.
-   */
-  readonly supportedUrls: Record<string, RegExp[]> = {};
-
-  private baseUrl: string;
-  private timeout: number;
-
-  constructor(modelId: string, baseUrl: string, timeout: number) {
-    this.modelId = modelId;
-    this.baseUrl = baseUrl;
-    this.timeout = timeout;
-  }
-
-  private estimateTokenCount(text: string): number {
-    return estimateTokens(text, "ollama");
-  }
-
-  private convertMessagesToPrompt(
-    messages: Array<{ role: string; content: unknown }>,
-  ): string {
-    return messages
-      .map((msg: { role: string; content: unknown }) => {
-        if (typeof msg.content === "string") {
-          return `${msg.role}: ${msg.content}`;
-        }
-        return `${msg.role}: ${JSON.stringify(msg.content)}`;
-      })
-      .join("\n");
-  }
-
-  async doGenerate(
-    options: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    // Vercel AI SDK passes messages via options.messages (same as stream mode)
-    // Check options.messages first, then fall back to options.prompt for backward compatibility
-    const messages =
-      (options as { messages?: Array<{ role: string; content: unknown }> })
-        .messages ||
-      (options as { prompt?: Array<{ role: string; content: unknown }> })
-        .prompt ||
-      [];
-
-    // Check if we should use OpenAI-compatible API
-    const useOpenAIMode = isOpenAICompatibleMode();
-
-    if (useOpenAIMode) {
-      // OpenAI-compatible mode: Use /v1/chat/completions
-      const requestBody = {
-        model: this.modelId,
-        messages,
-        temperature: options.temperature,
-        max_tokens: options.maxTokens,
-        stream: false,
-      };
-
-      if (logger.shouldLog("debug")) {
-        logger.debug(
-          "[OllamaLanguageModel] Using OpenAI-compatible API with messages:",
-          JSON.stringify(messages, null, 2),
-        );
-      }
-
-      const response = await proxyFetch(`${this.baseUrl}/v1/chat/completions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-        signal: createAbortSignalWithTimeout(this.timeout),
-      });
-
-      if (!response.ok) {
-        throw await createOllamaHttpError(response);
-      }
-
-      const data = await response.json();
-
-      logger.debug(
-        "[OllamaLanguageModel] OpenAI API Response:",
-        JSON.stringify(data, null, 2),
-      );
-
-      const text = data.choices?.[0]?.message?.content || "";
-      const usage = data.usage || {};
-      const promptTokens =
-        usage.prompt_tokens ??
-        this.estimateTokenCount(JSON.stringify(messages));
-      const completionTokens =
-        usage.completion_tokens ?? this.estimateTokenCount(text);
-
-      return {
-        content: text ? [{ type: "text", text }] : [],
-        text,
-        usage: {
-          inputTokens: promptTokens,
-          outputTokens: completionTokens,
-          promptTokens,
-          completionTokens,
-          totalTokens: usage.total_tokens ?? promptTokens + completionTokens,
-        },
-        finishReason: data.choices?.[0]?.finish_reason ?? "stop",
-        warnings: [],
-        request: {
-          body: JSON.stringify(requestBody),
-        },
-        response: {
-          id: data.id,
-          modelId: data.model,
-          timestamp: new Date(),
-          headers: {},
-          body: data,
-        },
-        rawCall: {
-          rawPrompt: messages,
-          rawSettings: {
-            model: this.modelId,
-            temperature: options.temperature,
-            max_tokens: options.maxTokens,
-          },
-        },
-        rawResponse: {
-          headers: {},
-        },
-      };
-    } else {
-      // Native Ollama mode: Use /api/generate
-      const prompt = this.convertMessagesToPrompt(messages);
-
-      logger.debug(
-        "[OllamaLanguageModel] Using native API with prompt:",
-        JSON.stringify(prompt),
-      );
-
-      const response = await proxyFetch(`${this.baseUrl}/api/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: this.modelId,
-          prompt,
-          stream: false,
-          system: messages.find(
-            (m: { role: string; content: unknown }) => m.role === "system",
-          )?.content,
-          options: {
-            temperature: options.temperature,
-            num_predict: options.maxTokens,
-          },
-        }),
-        signal: createAbortSignalWithTimeout(this.timeout),
-      });
-
-      if (!response.ok) {
-        throw await createOllamaHttpError(response);
-      }
-
-      const data = await response.json();
-
-      logger.debug(
-        "[OllamaLanguageModel] Native API Response:",
-        JSON.stringify(data, null, 2),
-      );
-
-      const text = String(data.response ?? "");
-      const promptTokens =
-        data.prompt_eval_count ?? this.estimateTokenCount(prompt);
-      const completionTokens = data.eval_count ?? this.estimateTokenCount(text);
-      const requestBody = {
-        model: this.modelId,
-        prompt,
-        stream: false,
-        system: messages.find(
-          (m: { role: string; content: unknown }) => m.role === "system",
-        )?.content,
-        options: {
-          temperature: options.temperature,
-          num_predict: options.maxTokens,
-        },
-      };
-
-      return {
-        content: text ? [{ type: "text", text }] : [],
-        text,
-        usage: {
-          inputTokens: promptTokens,
-          outputTokens: completionTokens,
-          promptTokens,
-          completionTokens,
-          totalTokens: promptTokens + completionTokens,
-        },
-        finishReason: data.done_reason ?? "stop",
-        warnings: [],
-        request: {
-          body: JSON.stringify(requestBody),
-        },
-        response: {
-          id: data.created_at,
-          modelId: this.modelId,
-          timestamp: data.created_at ? new Date(data.created_at) : new Date(),
-          headers: {},
-          body: data,
-        },
-        rawCall: {
-          rawPrompt: prompt,
-          rawSettings: {
-            model: this.modelId,
-            temperature: options.temperature,
-            num_predict: options.maxTokens,
-          },
-        },
-        rawResponse: {
-          headers: {},
-        },
-      };
-    }
-  }
-
-  async doStream(options: Record<string, unknown>): Promise<{
-    stream: ReadableStream<Record<string, unknown>>;
-    rawCall: { rawPrompt: unknown; rawSettings: Record<string, unknown> };
-    rawResponse?: { headers?: Record<string, string> };
-    request?: { body?: string };
-    warnings?: Array<{ type: "other"; message: string }>;
-  }> {
-    const messages =
-      (options as { messages?: Array<{ role: string; content: unknown }> })
-        .messages || [];
-
-    // Check if we should use OpenAI-compatible API
-    const useOpenAIMode = isOpenAICompatibleMode();
-
-    if (useOpenAIMode) {
-      // OpenAI-compatible mode: Use /v1/chat/completions
-      const requestUrl = `${this.baseUrl}/v1/chat/completions`;
-      const requestBody = {
-        model: this.modelId,
-        messages,
-        temperature: options.temperature,
-        max_tokens: options.maxTokens,
-        stream: true,
-      };
-
-      logger.debug(
-        "[OllamaLanguageModel] doStream: Using OpenAI-compatible API",
-        {
-          url: requestUrl,
-          baseUrl: this.baseUrl,
-          modelId: this.modelId,
-          requestBody: JSON.stringify(requestBody),
-        },
-      );
-
-      const response = await proxyFetch(requestUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-        signal: createAbortSignalWithTimeout(this.timeout),
-      });
-
-      logger.debug("[OllamaLanguageModel] doStream: Response received", {
-        status: response.status,
-        statusText: response.statusText,
-        ok: response.ok,
-      });
-
-      if (!response.ok) {
-        throw await createOllamaHttpError(response);
-      }
-
-      const self = this;
-      return {
-        stream: new ReadableStream({
-          async start(controller) {
-            try {
-              for await (const chunk of self.parseOpenAIStreamResponse(
-                response,
-                messages,
-              )) {
-                controller.enqueue(chunk);
-              }
-              controller.close();
-            } catch (error) {
-              controller.error(error);
-            }
-          },
-        }),
-        rawCall: {
-          rawPrompt: messages,
-          rawSettings: {
-            model: this.modelId,
-            temperature: options.temperature,
-            max_tokens: options.maxTokens,
-          },
-        },
-        rawResponse: {
-          headers: {},
-        },
-      };
-    } else {
-      // Native Ollama mode: Use /api/generate
-      const prompt = this.convertMessagesToPrompt(messages);
-      const requestUrl = `${this.baseUrl}/api/generate`;
-      const requestBody = {
-        model: this.modelId,
-        prompt,
-        stream: true,
-        system: messages.find(
-          (m: { role: string; content: unknown }) => m.role === "system",
-        )?.content,
-        options: {
-          temperature: options.temperature,
-          num_predict: options.maxTokens,
-        },
-      };
-
-      logger.debug("[OllamaLanguageModel] doStream: Using native API", {
-        url: requestUrl,
-        baseUrl: this.baseUrl,
-        modelId: this.modelId,
-        requestBody: JSON.stringify(requestBody),
-      });
-
-      const response = await proxyFetch(requestUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-        signal: createAbortSignalWithTimeout(this.timeout),
-      });
-
-      logger.debug("[OllamaLanguageModel] doStream: Response received", {
-        status: response.status,
-        statusText: response.statusText,
-        ok: response.ok,
-      });
-
-      if (!response.ok) {
-        throw await createOllamaHttpError(response);
-      }
-
-      const self = this;
-      return {
-        stream: new ReadableStream({
-          async start(controller) {
-            try {
-              for await (const chunk of self.parseStreamResponse(response)) {
-                controller.enqueue(chunk);
-              }
-              controller.close();
-            } catch (error) {
-              controller.error(error);
-            }
-          },
-        }),
-        rawCall: {
-          rawPrompt: messages,
-          rawSettings: {
-            model: this.modelId,
-            temperature: options.temperature,
-            num_predict: options.maxTokens,
-          },
-        },
-        rawResponse: {
-          headers: {},
-        },
-      };
-    }
-  }
-
-  private async *parseStreamResponse(
-    response: Response,
-  ): AsyncGenerator<Record<string, unknown>> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (line.trim()) {
-            try {
-              const data = JSON.parse(line);
-              if (data.response) {
-                yield {
-                  type: "text-delta",
-                  textDelta: data.response,
-                };
-              }
-              if (data.done) {
-                yield {
-                  type: "finish",
-                  finishReason: "stop",
-                  usage: {
-                    promptTokens:
-                      data.prompt_eval_count ||
-                      this.estimateTokenCount(data.context || ""),
-                    completionTokens: data.eval_count || 0,
-                  },
-                };
-                return;
-              }
-            } catch (error) {
-              logger.error("Error parsing Ollama stream response", {
-                error,
-              });
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  private async *parseOpenAIStreamResponse(
-    response: Response,
-    messages: Array<{ role: string; content: unknown }>,
-  ): AsyncGenerator<Record<string, unknown>> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-    // Estimate prompt tokens from messages (matches non-streaming behavior)
-    const totalPromptTokens = this.estimateTokenCount(JSON.stringify(messages));
-    // Accumulate full completion text; estimate tokens once at the end to avoid
-    // per-chunk rounding inflation that occurs when estimateTokenCount is called
-    // on every delta and the results are summed.
-    let completionText = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (trimmed === "" || trimmed === "data: [DONE]") {
-            continue;
-          }
-
-          if (trimmed.startsWith("data: ")) {
-            try {
-              const jsonStr = trimmed.slice(6); // Remove "data: " prefix
-              const data = JSON.parse(jsonStr);
-
-              // Extract content delta
-              const content = data.choices?.[0]?.delta?.content;
-              if (content) {
-                yield {
-                  type: "text-delta",
-                  textDelta: content,
-                };
-                completionText += content;
-              }
-
-              // Check for finish
-              const finishReason = data.choices?.[0]?.finish_reason;
-              if (finishReason === "stop") {
-                // Prefer server-reported usage; fall back to a single estimate over
-                // the full accumulated text (avoids per-chunk rounding inflation).
-                const promptTokens =
-                  data.usage?.prompt_tokens || totalPromptTokens;
-                const completionTokens =
-                  data.usage?.completion_tokens ||
-                  this.estimateTokenCount(completionText);
-
-                yield {
-                  type: "finish",
-                  finishReason: "stop",
-                  usage: {
-                    promptTokens,
-                    completionTokens,
-                  },
-                };
-                return;
-              }
-            } catch (error) {
-              logger.error("Error parsing OpenAI stream response", {
-                error,
-                line: trimmed,
-              });
-            }
-          }
-        }
-      }
-
-      // If loop exits without explicit finish, yield final finish
-      yield {
-        type: "finish",
-        finishReason: "stop",
-        usage: {
-          promptTokens: totalPromptTokens,
-          completionTokens: this.estimateTokenCount(completionText),
-        },
-      };
-    } finally {
-      reader.releaseLock();
-    }
-  }
-}
+const getDefaultOllamaModel = (): string =>
+  process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
 
 /**
- * Ollama Provider v2 - BaseProvider Implementation
- *
- * PHASE 3.7: BaseProvider wrap around existing custom Ollama implementation
- *
- * Features:
- * - Extends BaseProvider for shared functionality
- * - Preserves custom OllamaLanguageModel implementation
- * - Local model management and health checking
- * - Enhanced error handling with Ollama-specific guidance
+ * Resolve and normalize the Ollama base URL to the OpenAI-compatible root.
+ * Precedence: credentials override → `OLLAMA_BASE_URL` → default. A bare host
+ * (the historical `OLLAMA_BASE_URL=http://localhost:11434` form) is accepted
+ * and gets `/v1` appended for backward compatibility; an already-`/v1` base is
+ * left untouched. Blank/whitespace overrides fall through (cohort guard).
  */
-export class OllamaProvider extends BaseProvider {
-  private ollamaModel: OllamaLanguageModel;
-  private baseUrl: string;
-  private timeout: number;
+const resolveOllamaBaseURL = (override?: string): string => {
+  const raw =
+    override?.trim() ||
+    process.env.OLLAMA_BASE_URL?.trim() ||
+    OLLAMA_DEFAULT_BASE_URL;
+  const trimmed = stripTrailingSlash(raw);
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+};
 
-  constructor(modelName?: string, credentials?: { baseURL?: string }) {
-    super(modelName, "ollama" as AIProviderName);
+/**
+ * Ollama Provider — direct HTTP, no AI SDK.
+ *
+ * Wraps a local (or remote/Cloud) Ollama server via its OpenAI-compatible
+ * `/v1` API. All request / stream / multi-step tool-loop orchestration lives
+ * in `OpenAIChatCompletionsProvider`; this class declares configuration plus
+ * the Ollama-specific behaviour:
+ *
+ *   1. `/v1` base-URL normalization (accepts a bare `OLLAMA_BASE_URL` host).
+ *   2. No-auth-by-default with an optional `OLLAMA_API_KEY` for Ollama Cloud.
+ *   3. Configurable per-model tool gating via `OLLAMA_TOOL_CAPABLE_MODELS` /
+ *      `modelConfig` (`supportsTools`).
+ *   4. Elevated request timeout for slow large local models (5-minute base
+ *      default, overridable via `OLLAMA_TIMEOUT`).
+ *   5. Native `/v1/embeddings` (`embed` / `embedMany`).
+ *   6. Rich, actionable error mapping (`ollama serve` / `ollama pull` hints).
+ *
+ * Model discovery uses the base's `/v1/models` probe (Ollama supports it).
+ *
+ * @see https://docs.ollama.com/api/openai-compatibility
+ */
+export class OllamaProvider extends OpenAIChatCompletionsProvider {
+  constructor(
+    modelName?: string,
+    sdk?: unknown,
+    _region?: string,
+    credentials?: NeurolinkCredentials["ollama"],
+  ) {
+    const baseURL = resolveOllamaBaseURL(credentials?.baseURL);
+    const apiKey =
+      credentials?.apiKey?.trim() ||
+      process.env.OLLAMA_API_KEY?.trim() ||
+      OLLAMA_PLACEHOLDER_KEY;
 
-    this.baseUrl = credentials?.baseURL ?? getOllamaBaseUrl();
-    this.timeout = getOllamaTimeout();
+    super("ollama" as AIProviderName, modelName, sdk, { baseURL, apiKey });
 
-    // Initialize Ollama model
-    this.ollamaModel = new OllamaLanguageModel(
-      this.modelName || getDefaultOllamaModel(),
-      this.baseUrl,
-      this.timeout,
-    );
-
-    logger.debug("Ollama BaseProvider v2 initialized", {
+    logger.debug("Ollama Provider initialized", {
       modelName: this.modelName,
-      baseUrl: this.baseUrl,
-      timeout: this.timeout,
-      provider: this.providerName,
+      providerName: this.providerName,
+      baseURL: redactUrlCredentials(this.config.baseURL),
     });
   }
+
+  // ===========================================================================
+  // Abstract hooks (required)
+  // ===========================================================================
 
   protected getProviderName(): AIProviderName {
     return "ollama" as AIProviderName;
@@ -684,1607 +114,274 @@ export class OllamaProvider extends BaseProvider {
     return getDefaultOllamaModel();
   }
 
-  /**
-   * Returns the Vercel AI SDK model instance for Ollama.
-   *
-   * OllamaLanguageModel implements OllamaAsLanguageModel which is structurally
-   * compatible with LanguageModelV2 (specificationVersion "v2", modelId, provider,
-   * supportedUrls, doGenerate, doStream).
-   */
-  protected getAISDKModel(): LanguageModel {
-    const model: OllamaAsLanguageModel = this.ollamaModel;
-    return model as LanguageModel;
-  }
-
-  /**
-   * Ollama Tool Calling Support (Enhanced 2025)
-   *
-   * Uses configurable model list from ModelConfiguration instead of hardcoded values.
-   * Tool-capable models can be configured via OLLAMA_TOOL_CAPABLE_MODELS environment variable.
-   *
-   * **Configuration Options:**
-   * - Environment variable: OLLAMA_TOOL_CAPABLE_MODELS (comma-separated list)
-   * - Configuration file: providers.ollama.modelBehavior.toolCapableModels
-   * - Fallback: Default list of known tool-capable models
-   *
-   * **Implementation Features:**
-   * - Direct Ollama API integration (/v1/chat/completions)
-   * - Automatic tool schema conversion to Ollama format
-   * - Streaming tool calls with incremental response parsing
-   * - Model compatibility validation and fallback handling
-   *
-   * @returns true for supported models, false for unsupported models
-   */
-  supportsTools(): boolean {
-    const modelName = (this.modelName ?? getDefaultOllamaModel()).toLowerCase();
-
-    // Get tool-capable models from configuration
-    const ollamaConfig = modelConfig.getProviderConfiguration("ollama");
-    const toolCapableModels =
-      (ollamaConfig?.modelBehavior?.toolCapableModels as string[]) || [];
-
-    // Only disable tools if we have positive evidence the model doesn't support them
-    // If toolCapableModels config is empty, assume tools are supported (don't make assumptions)
-    if (toolCapableModels.length === 0) {
-      logger.debug("Ollama tool calling enabled", {
-        model: this.modelName,
-        reason: "No tool-capable config defined, assuming tools supported",
-        baseUrl: this.baseUrl,
-      });
-      return true;
-    }
-
-    // Config exists - check if current model matches tool-capable model patterns
-    const isToolCapable = toolCapableModels.some((capableModel) =>
-      modelName.includes(capableModel.toLowerCase()),
-    );
-
-    if (isToolCapable) {
-      logger.debug("Ollama tool calling enabled", {
-        model: this.modelName,
-        reason: "Model in tool-capable list",
-        baseUrl: this.baseUrl,
-        configuredModels: toolCapableModels.length,
-      });
-      return true;
-    }
-
-    // Config exists and model is NOT in list - disable tools
-    logger.debug("Ollama tool calling disabled", {
-      model: this.modelName,
-      reason: "Model not in tool-capable list",
-      suggestion:
-        "Consider using llama3.1:8b-instruct, mistral:7b-instruct, or hermes3:8b for tool calling",
-      availableToolModels: toolCapableModels.slice(0, 3), // Show first 3 for brevity
-    });
-
-    return false;
-  }
-
-  /**
-   * Extract images from multimodal messages for Ollama API
-   * Returns array of base64-encoded images
-   */
-  private extractImagesFromMessages(
-    messages: MultimodalChatMessage[],
-  ): string[] {
-    const images: string[] = [];
-
-    for (const msg of messages) {
-      if (Array.isArray(msg.content)) {
-        for (const content of msg.content) {
-          const typedContent = content as MessageContent;
-          if (typedContent.type === "image" && typedContent.image) {
-            const imageData =
-              typeof typedContent.image === "string"
-                ? typedContent.image.replace(/^data:image\/\w+;base64,/, "")
-                : Buffer.from(typedContent.image).toString("base64");
-            images.push(imageData);
-          }
-        }
-      }
-    }
-
-    return images;
-  }
-
-  /**
-   * Convert multimodal messages to Ollama chat format
-   * Extracts text content and handles images separately
-   */
-  private convertToOllamaMessages(
-    messages: MultimodalChatMessage[],
-  ): OllamaMessage[] {
-    return messages.map((msg) => {
-      let textContent = "";
-      const images: string[] = [];
-
-      if (typeof msg.content === "string") {
-        textContent = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        for (const content of msg.content) {
-          const typedContent = content as MessageContent;
-          if (typedContent.type === "text" && typedContent.text) {
-            textContent += typedContent.text;
-          } else if (typedContent.type === "image" && typedContent.image) {
-            const imageData =
-              typeof typedContent.image === "string"
-                ? typedContent.image.replace(/^data:image\/\w+;base64,/, "")
-                : Buffer.from(typedContent.image).toString("base64");
-            images.push(imageData);
-          }
-        }
-      }
-
-      const ollamaMsg: OllamaMessage = {
-        role: (msg.role === "system" ? "system" : msg.role) as
-          | "system"
-          | "user"
-          | "assistant"
-          | "tool",
-        content: textContent,
-      };
-
-      if (images.length > 0) {
-        ollamaMsg.images = images;
-      }
-
-      return ollamaMsg;
-    });
-  }
-
-  // executeGenerate removed - BaseProvider handles all generation with tools
-
-  protected async executeStream(
-    options: StreamOptions,
-    analysisSchema?: ZodUnknownSchema | Schema<unknown>,
-  ): Promise<StreamResult> {
-    try {
-      this.validateStreamOptions(options);
-      await this.checkOllamaHealth();
-
-      // Check if tools are supported and provided
-      const modelSupportsTools = this.supportsTools();
-      const hasTools = options.tools && Object.keys(options.tools).length > 0;
-
-      if (modelSupportsTools && hasTools) {
-        // Use chat API with tools for tool-capable models
-        return this.executeStreamWithTools(options, analysisSchema);
-      } else {
-        // Use generate API for non-tool scenarios
-        return this.executeStreamWithoutTools(options, analysisSchema);
-      }
-    } catch (error) {
-      throw this.handleProviderError(error);
-    }
-  }
-
-  /**
-   * Execute streaming with Ollama's function calling support
-   * Uses conversation loop to handle multi-step tool execution
-   */
-  private async executeStreamWithTools(
-    options: StreamOptions,
-    _analysisSchema?: ZodUnknownSchema | Schema<unknown>,
-  ): Promise<StreamResult> {
-    return withClientStreamSpan(
-      {
-        name: "neurolink.provider.stream",
-        tracer: tracers.provider,
-        attributes: {
-          [ATTR.GEN_AI_SYSTEM]: "ollama",
-          [ATTR.GEN_AI_MODEL]: this.modelName || FALLBACK_OLLAMA_MODEL,
-          [ATTR.GEN_AI_OPERATION]: "stream",
-          [ATTR.NL_HAS_TOOLS]: true,
-          [ATTR.NL_STREAM_MODE]: true,
-        },
-      },
-      async (span) => {
-        const startTime = Date.now();
-        const maxIterations = options.maxSteps || DEFAULT_MAX_STEPS;
-        let iteration = 0;
-
-        // Get all available tools (direct + MCP + external)
-        // BaseProvider.stream() pre-merges base tools + external tools into options.tools
-        const allTools =
-          (options.tools as Record<string, Tool>) || (await this.getAllTools());
-        // Convert tools to Ollama format
-        const ollamaTools = this.convertToolsToOllamaFormat(allTools);
-
-        span.setAttribute(ATTR.NL_TOOL_COUNT, ollamaTools.length);
-
-        // Validate that PDFs are not provided
-        if (options.input?.pdfFiles && options.input.pdfFiles.length > 0) {
-          throw this.handleProviderError(
-            new Error(
-              "PDF inputs are not supported by OllamaProvider. " +
-                "Please remove PDFs or use a supported provider (OpenAI, Anthropic, Google Vertex AI, etc.).",
-            ),
-          );
-        }
-
-        // Initialize conversation history
-        const conversationHistory: OllamaMessage[] = [];
-
-        // Build initial messages
-        const hasMultimodalInput = !!(
-          options.input?.images?.length ||
-          options.input?.content?.length ||
-          options.input?.files?.length ||
-          options.input?.csvFiles?.length
-        );
-
-        if (hasMultimodalInput) {
-          logger.debug(
-            `Ollama: Detected multimodal input, using multimodal message builder`,
-            {
-              hasImages: !!options.input?.images?.length,
-              imageCount: options.input?.images?.length || 0,
-            },
-          );
-
-          const multimodalOptions = buildMultimodalOptions(
-            options,
-            this.providerName,
-            this.modelName,
-          );
-
-          const multimodalMessages = await buildMultimodalMessagesArray(
-            multimodalOptions,
-            this.providerName,
-            this.modelName,
-          );
-
-          conversationHistory.push(
-            ...this.convertToOllamaMessages(multimodalMessages),
-          );
-        } else {
-          if (options.systemPrompt) {
-            conversationHistory.push({
-              role: "system",
-              content: options.systemPrompt,
-            });
-          }
-          conversationHistory.push({
-            role: "user",
-            content: options.input.text ?? "",
-          });
-        }
-
-        // Capture instance references before the stream for use in the finally block.
-        const ollamaNeurolink = this.neurolink;
-        const ollamaProviderName = this.providerName;
-        const ollamaModelName = this.modelName || FALLBACK_OLLAMA_MODEL;
-
-        // Conversation loop for multi-step tool execution
-        let totalInputTokens = 0;
-        let totalOutputTokens = 0;
-        let lastFinishReason: string | undefined;
-        let ollamaStreamErrored = false;
-        const stream = new ReadableStream({
-          start: async (controller) => {
-            try {
-              while (iteration < maxIterations) {
-                logger.debug(
-                  `[OllamaProvider] Conversation iteration ${iteration + 1}/${maxIterations}`,
-                );
-
-                // Make API request — request usage in stream_options so
-                // Pipeline B gets real token counts for Langfuse cost dashboards.
-                const response = await proxyFetch(
-                  `${this.baseUrl}/v1/chat/completions`,
-                  {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      model: this.modelName || FALLBACK_OLLAMA_MODEL,
-                      messages: conversationHistory,
-                      tools: ollamaTools,
-                      tool_choice: "auto",
-                      stream: true,
-                      stream_options: { include_usage: true },
-                      temperature: options.temperature,
-                      max_tokens: options.maxTokens,
-                    }),
-                    signal: createAbortSignalWithTimeout(this.timeout),
-                  },
-                );
-
-                if (!response.ok) {
-                  throw this.handleProviderError(
-                    await createOllamaHttpError(response),
-                  );
-                }
-
-                // Process response stream
-                const { content, toolCalls, finishReason, usage } =
-                  await this.processOllamaResponse(response, controller);
-
-                // Accumulate usage across iterations for Pipeline B
-                if (usage) {
-                  totalInputTokens += usage.input;
-                  totalOutputTokens += usage.output;
-                }
-                if (finishReason) {
-                  lastFinishReason = finishReason;
-                }
-
-                // Add assistant message to history
-                const assistantMessage: OllamaMessage = {
-                  role: "assistant",
-                  content: content || "",
-                };
-
-                if (toolCalls && toolCalls.length > 0) {
-                  assistantMessage.tool_calls = toolCalls;
-                }
-
-                conversationHistory.push(assistantMessage);
-
-                // Check finish reason
-                if (finishReason === "stop" || !finishReason) {
-                  // Conversation complete
-                  span.setAttribute(
-                    ATTR.GEN_AI_FINISH_REASON,
-                    finishReason || "stop",
-                  );
-                  controller.close();
-                  break;
-                } else if (
-                  finishReason === "tool_calls" &&
-                  toolCalls &&
-                  toolCalls.length > 0
-                ) {
-                  // Execute tools
-                  logger.debug(
-                    `[OllamaProvider] Executing ${toolCalls.length} tools`,
-                  );
-                  for (const tc of toolCalls) {
-                    span.addEvent("tool_call", {
-                      [ATTR.GEN_AI_TOOL_NAME]: tc.function.name,
-                    });
-                  }
-                  const toolResults = await this.executeOllamaTools(
-                    toolCalls,
-                    options,
-                  );
-
-                  // Add tool results to conversation
-                  const toolMessage: OllamaMessage = {
-                    role: "tool",
-                    content: JSON.stringify(toolResults),
-                  };
-                  conversationHistory.push(toolMessage);
-
-                  iteration++;
-                } else if (finishReason === "length") {
-                  // Max tokens reached, continue conversation
-                  logger.debug(
-                    `[OllamaProvider] Max tokens reached, continuing`,
-                  );
-                  conversationHistory.push({
-                    role: "user",
-                    content: "Please continue.",
-                  });
-                  iteration++;
-                } else {
-                  // Unknown finish reason, end conversation
-                  logger.warn(
-                    `[OllamaProvider] Unknown finish reason: ${finishReason}`,
-                  );
-                  span.setAttribute(ATTR.GEN_AI_FINISH_REASON, finishReason);
-                  controller.close();
-                  break;
-                }
-              }
-
-              if (iteration >= maxIterations) {
-                ollamaStreamErrored = true;
-                controller.error(
-                  new Error(
-                    `Ollama conversation exceeded maximum iterations (${maxIterations})`,
-                  ),
-                );
-              }
-            } catch (error) {
-              ollamaStreamErrored = true;
-              controller.error(error);
-            } finally {
-              // Resolve analytics with accumulated token counts so Pipeline A
-              // and Pipeline B both get real usage data from Ollama.
-              const aggregatedUsage = {
-                input: totalInputTokens,
-                output: totalOutputTokens,
-                total: totalInputTokens + totalOutputTokens,
-              };
-              resolveAnalytics(
-                createAnalytics(
-                  this.providerName,
-                  this.modelName || FALLBACK_OLLAMA_MODEL,
-                  { usage: aggregatedUsage },
-                  Date.now() - startTime,
-                  {
-                    requestId: `ollama-stream-${Date.now()}`,
-                    streamingMode: true,
-                    iterations: iteration,
-                  },
-                ),
-              );
-              // Emit generation:end so Pipeline B (Langfuse) creates a GENERATION
-              // observation. Ollama bypasses the Vercel AI SDK so
-              // experimental_telemetry is never injected; we emit manually.
-              const ollamaEmitter = ollamaNeurolink?.getEventEmitter();
-              if (ollamaEmitter) {
-                // Collect accumulated text from conversation history
-                const accumulatedContent = conversationHistory
-                  .filter((m) => m.role === "assistant")
-                  .map((m) => m.content)
-                  .join("");
-                ollamaEmitter.emit("generation:end", {
-                  provider: ollamaProviderName,
-                  responseTime: Date.now() - startTime,
-                  timestamp: Date.now(),
-                  result: {
-                    content: accumulatedContent,
-                    usage: aggregatedUsage,
-                    model: ollamaModelName,
-                    provider: ollamaProviderName,
-                    finishReason: ollamaStreamErrored
-                      ? "error"
-                      : (lastFinishReason ?? "stop"),
-                  },
-                  success: !ollamaStreamErrored,
-                });
-              }
-            }
-          },
-        });
-
-        // Defer analytics resolution until the stream's start callback finishes.
-        // This ensures responseTime and iteration reflect the actual completed values
-        // rather than values captured before the tool-loop executes.
-        let resolveAnalytics!: (
-          value: ReturnType<typeof createAnalytics>,
-        ) => void;
-        const analyticsPromise = new Promise<
-          ReturnType<typeof createAnalytics>
-        >((resolve) => {
-          resolveAnalytics = resolve;
-        });
-
-        return {
-          stream: this.convertToAsyncIterable(stream),
-          provider: this.providerName,
-          model: this.modelName || FALLBACK_OLLAMA_MODEL,
-          analytics: analyticsPromise,
-          metadata: {
-            startTime,
-            streamId: `ollama-${Date.now()}`,
-          },
-        };
-      },
-      (r) => r.stream,
-      (r, wrapped) => ({ ...r, stream: wrapped }),
-    );
-  }
-
-  /**
-   * Execute streaming without tools using the generate API
-   * Fallback for non-tool scenarios or when chat API is unavailable
-   */
-  private async executeStreamWithoutTools(
-    options: StreamOptions,
-    _analysisSchema?: ZodUnknownSchema | Schema<unknown>,
-  ): Promise<StreamResult> {
-    return withClientStreamSpan(
-      {
-        name: "neurolink.provider.stream",
-        tracer: tracers.provider,
-        attributes: {
-          [ATTR.GEN_AI_SYSTEM]: "ollama",
-          [ATTR.GEN_AI_MODEL]: this.modelName || FALLBACK_OLLAMA_MODEL,
-          [ATTR.GEN_AI_OPERATION]: "stream",
-          [ATTR.NL_HAS_TOOLS]: false,
-          [ATTR.NL_STREAM_MODE]: true,
-        },
-      },
-      async () => {
-        // Validate that PDFs are not provided
-        if (options.input?.pdfFiles && options.input.pdfFiles.length > 0) {
-          throw this.handleProviderError(
-            new Error(
-              "PDF inputs are not supported by OllamaProvider. " +
-                "Please remove PDFs or use a supported provider (OpenAI, Anthropic, Google Vertex AI, etc.).",
-            ),
-          );
-        }
-
-        // Check for multimodal input
-        const hasMultimodalInput = !!(
-          options.input?.images?.length ||
-          options.input?.content?.length ||
-          options.input?.files?.length ||
-          options.input?.csvFiles?.length
-        );
-
-        const useOpenAIMode = isOpenAICompatibleMode();
-
-        if (useOpenAIMode) {
-          // OpenAI-compatible mode: Use /v1/chat/completions with messages
-          logger.debug(`Ollama (OpenAI mode): Building messages for streaming`);
-
-          const messages: Array<{ role: string; content: string }> = [];
-
-          if (options.systemPrompt) {
-            messages.push({ role: "system", content: options.systemPrompt });
-          }
-
-          if (hasMultimodalInput) {
-            const multimodalOptions = buildMultimodalOptions(
-              options,
-              this.providerName,
-              this.modelName,
-            );
-
-            const multimodalMessages = await buildMultimodalMessagesArray(
-              multimodalOptions,
-              this.providerName,
-              this.modelName,
-            );
-
-            // Convert multimodal messages to text (OpenAI-compatible mode doesn't support images in /v1/chat/completions for Ollama)
-            const content = multimodalMessages
-              .map((msg) =>
-                typeof msg.content === "string" ? msg.content : "",
-              )
-              .join("\n");
-
-            messages.push({ role: "user", content });
-          } else {
-            messages.push({ role: "user", content: options.input.text ?? "" });
-          }
-
-          const requestUrl = `${this.baseUrl}/v1/chat/completions`;
-          const requestBody = {
-            model: this.modelName || FALLBACK_OLLAMA_MODEL,
-            messages,
-            temperature: options.temperature,
-            max_tokens: options.maxTokens,
-            stream: true,
-          };
-
-          logger.debug(`[Ollama OpenAI Mode] About to fetch:`, {
-            url: requestUrl,
-            baseUrl: this.baseUrl,
-            modelName: this.modelName,
-            requestBody: JSON.stringify(requestBody),
-          });
-
-          const response = await proxyFetch(requestUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(requestBody),
-            signal: createAbortSignalWithTimeout(this.timeout),
-          });
-
-          logger.debug(`[Ollama OpenAI Mode] Response received:`, {
-            status: response.status,
-            statusText: response.statusText,
-            ok: response.ok,
-          });
-
-          if (!response.ok) {
-            throw this.handleProviderError(
-              await createOllamaHttpError(response),
-            );
-          }
-
-          // Transform to async generator for OpenAI-compatible format
-          const self = this;
-          const transformedStream = async function* () {
-            const generator = self.createOpenAIStream(response);
-            for await (const chunk of generator) {
-              yield chunk;
-            }
-          };
-
-          return {
-            stream: transformedStream(),
-            provider: self.providerName,
-            model: self.modelName,
-          };
-        } else {
-          // Native Ollama mode: Use /api/generate
-          let prompt = options.input.text;
-          let images: string[] | undefined;
-
-          if (hasMultimodalInput) {
-            logger.debug(`Ollama (native mode): Detected multimodal input`, {
-              hasImages: !!options.input?.images?.length,
-              imageCount: options.input?.images?.length || 0,
-            });
-
-            const multimodalOptions = buildMultimodalOptions(
-              options,
-              this.providerName,
-              this.modelName,
-            );
-
-            const multimodalMessages = await buildMultimodalMessagesArray(
-              multimodalOptions,
-              this.providerName,
-              this.modelName,
-            );
-
-            // Extract text from messages for prompt
-            prompt = multimodalMessages
-              .map((msg) =>
-                typeof msg.content === "string" ? msg.content : "",
-              )
-              .join("\n");
-
-            // Extract images
-            images = this.extractImagesFromMessages(multimodalMessages);
-          }
-
-          const requestBody: Record<string, unknown> = {
-            model: this.modelName || FALLBACK_OLLAMA_MODEL,
-            prompt,
-            system: options.systemPrompt,
-            stream: true,
-            options: {
-              temperature: options.temperature,
-              num_predict: options.maxTokens,
-            },
-          };
-
-          if (images && images.length > 0) {
-            requestBody.images = images;
-          }
-
-          const requestUrl = `${this.baseUrl}/api/generate`;
-
-          logger.debug(`[Ollama Native Mode] About to fetch:`, {
-            url: requestUrl,
-            baseUrl: this.baseUrl,
-            modelName: this.modelName,
-            requestBody: JSON.stringify(requestBody),
-          });
-
-          const response = await proxyFetch(requestUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(requestBody),
-            signal: createAbortSignalWithTimeout(this.timeout),
-          });
-
-          logger.debug(`[Ollama Native Mode] Response received:`, {
-            status: response.status,
-            statusText: response.statusText,
-            ok: response.ok,
-          });
-
-          if (!response.ok) {
-            throw this.handleProviderError(
-              await createOllamaHttpError(response),
-            );
-          }
-
-          // Transform to async generator to match other providers
-          const self = this;
-          const transformedStream = async function* () {
-            const generator = self.createOllamaStream(response);
-            for await (const chunk of generator) {
-              yield chunk;
-            }
-          };
-
-          return {
-            stream: transformedStream(),
-            provider: this.providerName,
-            model: this.modelName,
-          };
-        }
-      },
-      (r) => r.stream,
-      (r, wrapped) => ({ ...r, stream: wrapped }),
-    );
-  }
-
-  /**
-   * Convert AI SDK tools format to Ollama's function calling format
-   */
-  private convertToolsToOllamaFormat(tools: unknown): unknown[] {
-    if (!tools || typeof tools !== "object") {
-      return [];
-    }
-
-    const toolsArray = Array.isArray(tools) ? tools : Object.values(tools);
-
-    return toolsArray.map(
-      (tool: {
-        name?: string;
-        description?: string;
-        parameters?: unknown;
-        function?: {
-          name?: string;
-          description?: string;
-          parameters?: unknown;
-        };
-      }) => ({
-        type: "function",
-        function: {
-          name: tool.name || tool.function?.name,
-          description: tool.description || tool.function?.description,
-          parameters: tool.parameters ||
-            tool.function?.parameters || {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-        },
-      }),
-    );
-  }
-
-  /**
-   * Parse tool calls from Ollama API response
-   */
-  private parseToolCalls(rawToolCalls: unknown): OllamaToolCall[] {
-    if (!Array.isArray(rawToolCalls)) {
-      return [];
-    }
-
-    return rawToolCalls
-      .map((call: unknown) => {
-        const callObj = call as {
-          id?: string;
-          type?: string;
-          function?: {
-            name?: string;
-            arguments?: string;
-          };
-        };
-
-        if (!callObj.function?.name) {
-          return null;
-        }
-
-        return {
-          id:
-            callObj.id ||
-            `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
-          type: "function" as const,
-          function: {
-            name: callObj.function.name,
-            arguments: callObj.function.arguments || "{}",
-          },
-        };
-      })
-      .filter((call): call is OllamaToolCall => call !== null);
-  }
-
-  /**
-   * Process Ollama streaming response and stream content to controller
-   * Returns aggregated content, tool calls, and finish reason
-   */
-  private async processOllamaResponse(
-    response: Response,
-    controller: ReadableStreamDefaultController,
-  ): Promise<{
-    content?: string;
-    toolCalls?: OllamaToolCall[];
-    finishReason?: string;
-    usage?: { input: number; output: number; total: number };
-  }> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body from Ollama");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let aggregatedContent = "";
-    let aggregatedToolCalls: OllamaToolCall[] = [];
-    let finalFinishReason: string | undefined;
-    let finalUsage:
-      | { input: number; output: number; total: number }
-      | undefined;
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (line.trim() && line.startsWith("data: ")) {
-            const dataLine = line.slice(6); // Remove "data: " prefix
-            if (dataLine === "[DONE]") {
-              break;
-            }
-
-            try {
-              const parsed = JSON.parse(dataLine);
-              // OpenAI-compatible usage chunk (Ollama may include usage
-              // in the final chunk when stream_options.include_usage is set,
-              // or as a standalone chunk with empty choices).
-              const parsedUsage = (
-                parsed as {
-                  usage?: {
-                    prompt_tokens?: number;
-                    completion_tokens?: number;
-                    total_tokens?: number;
-                  };
-                }
-              ).usage;
-              if (parsedUsage) {
-                const input = parsedUsage.prompt_tokens ?? 0;
-                const output = parsedUsage.completion_tokens ?? 0;
-                finalUsage = {
-                  input,
-                  output,
-                  total: parsedUsage.total_tokens ?? input + output,
-                };
-              }
-              const processed = this.processOllamaStreamData(parsed);
-
-              if (!processed) {
-                continue;
-              }
-
-              // Stream content to controller
-              if (processed.content) {
-                aggregatedContent += processed.content;
-                controller.enqueue({
-                  content: processed.content,
-                });
-              }
-
-              // Collect tool calls
-              if (processed.toolCalls && processed.toolCalls.length > 0) {
-                aggregatedToolCalls = [
-                  ...aggregatedToolCalls,
-                  ...processed.toolCalls,
-                ];
-              }
-
-              // Update finish reason
-              if (processed.finishReason) {
-                finalFinishReason = processed.finishReason;
-              }
-            } catch (parseError) {
-              logger.warn(
-                `[OllamaProvider] Failed to parse stream chunk: ${dataLine}`,
-                { error: parseError },
-              );
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-
-    return {
-      content: aggregatedContent || undefined,
-      toolCalls:
-        aggregatedToolCalls.length > 0 ? aggregatedToolCalls : undefined,
-      finishReason: finalFinishReason,
-      usage: finalUsage,
-    };
-  }
-
-  /**
-   * Process individual stream data chunk from Ollama
-   */
-  private processOllamaStreamData(data: unknown): {
-    content?: string;
-    toolCalls?: OllamaToolCall[];
-    finishReason?: string;
-    shouldReturn?: boolean;
-  } | null {
-    const dataRecord = data as Record<string, unknown>;
-    const choices = dataRecord.choices as
-      | Array<{
-          delta?: Record<string, unknown>;
-          finish_reason?: string;
-          message?: { tool_calls?: unknown[] };
-        }>
-      | undefined;
-    const delta = choices?.[0]?.delta;
-    const finishReason = choices?.[0]?.finish_reason;
-    let content = "";
-
-    if (delta?.content && typeof delta.content === "string") {
-      content += delta.content;
-    }
-
-    // Return tool calls for execution instead of formatting as text
-    if (delta?.tool_calls) {
-      const toolCalls = this.parseToolCalls(delta.tool_calls);
-      return {
-        toolCalls,
-        finishReason,
-        shouldReturn: !!finishReason,
-      };
-    }
-
-    // Also check for tool calls in the message field (some responses include it there)
-    if (choices?.[0]?.message?.tool_calls) {
-      const toolCalls = this.parseToolCalls(choices[0].message.tool_calls);
-      return {
-        toolCalls,
-        finishReason,
-        shouldReturn: !!finishReason,
-      };
-    }
-
-    const shouldReturn = !!finishReason;
-
-    return content
-      ? { content, finishReason, shouldReturn }
-      : { finishReason, shouldReturn };
-  }
-
-  /**
-   * Create stream generator for Ollama chat API with tool call support
-   */
-  private async *createOllamaChatStream(
-    response: Response,
-    _tools?: unknown,
-  ): AsyncGenerator<{ content: string }> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (line.trim() && line.startsWith("data: ")) {
-            const dataLine = line.slice(6); // Remove "data: " prefix
-            if (dataLine === "[DONE]") {
-              return;
-            }
-
-            try {
-              const data = JSON.parse(dataLine);
-              const result = this.processOllamaStreamData(data);
-
-              if (result?.content) {
-                yield { content: result.content };
-              }
-
-              if (result?.shouldReturn) {
-                return;
-              }
-            } catch (error) {
-              logger.error("Error parsing Ollama stream response", {
-                error,
-              });
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  /**
-   * Format tool calls for display when tools aren't executed directly
-   */
-  private formatToolCallForDisplay(
-    toolCalls: Array<{
-      function?: {
-        name?: string;
-        arguments?: string;
-      };
-    }>,
-  ): string {
-    if (!toolCalls || toolCalls.length === 0) {
-      return "";
-    }
-
-    const descriptions = toolCalls.map(
-      (call: {
-        function?: {
-          name?: string;
-          arguments?: string;
-        };
-      }) => {
-        const functionName = call.function?.name || "unknown_function";
-        let args = {};
-        if (call.function?.arguments) {
-          try {
-            args = JSON.parse(call.function.arguments);
-          } catch (error) {
-            // If arguments are malformed, preserve for debugging while marking as invalid
-            logger.warn?.(
-              "Malformed tool call arguments: " + call.function.arguments,
-            );
-            args = {
-              _malformed: true,
-              _originalArguments: call.function.arguments,
-              _error: error instanceof Error ? error.message : String(error),
-            };
-          }
-        }
-        return `\n[Tool Call: ${functionName}(${JSON.stringify(args)})]`;
-      },
-    );
-
-    return descriptions.join("");
-  }
-
-  /**
-   * Convert AI SDK tools to ToolDefinition format
-   */
-  private convertAISDKToolsToToolDefinitions(
-    aiTools: Record<string, Tool>,
-  ): Record<
-    string,
-    import("../types/index.js").ToolDefinition<ToolArgs, JsonValue>
-  > {
-    const result: Record<
-      string,
-      import("../types/index.js").ToolDefinition<ToolArgs, JsonValue>
-    > = {};
-
-    for (const [name, tool] of Object.entries(aiTools)) {
-      if ("description" in tool && tool.description) {
-        // AI SDK v6 uses `inputSchema`; legacy tools may still use `parameters`
-        const toolSchema:
-          | import("../types/index.js").ToolParameterSchema
-          | undefined =
-          "inputSchema" in tool
-            ? (tool.inputSchema as import("../types/index.js").ToolParameterSchema)
-            : "parameters" in tool
-              ? ((tool as Record<string, unknown>)
-                  .parameters as import("../types/index.js").ToolParameterSchema)
-              : undefined;
-        result[name] = {
-          description: tool.description,
-          parameters: toolSchema,
-          execute: async (params: ToolArgs) => {
-            if ("execute" in tool && tool.execute) {
-              const result = await tool.execute(params as ToolArgs, {
-                toolCallId: `tool_${Date.now()}`,
-                messages: [],
-              });
-              return {
-                success: true,
-                data: result,
-              };
-            }
-            throw new Error(`Tool ${name} has no execute method`);
-          },
-        };
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Execute a single tool and return the result
-   */
-  private async executeSingleTool(
-    toolName: string,
-    args: Record<string, unknown>,
-    _toolCallId?: string,
-  ): Promise<string> {
-    logger.debug(`[OllamaProvider] Executing single tool: ${toolName}`, {
-      args,
-    });
-
-    try {
-      // Use BaseProvider's tool execution mechanism
-      const aiTools = await this.getAllTools();
-      const tools = this.convertAISDKToolsToToolDefinitions(aiTools);
-
-      if (!tools[toolName]) {
-        throw new Error(`Tool not found: ${toolName}`);
-      }
-
-      const tool = tools[toolName];
-      if (!tool || !tool.execute) {
-        throw new Error(`Tool ${toolName} does not have execute method`);
-      }
-
-      const toolInput = args || {};
-
-      // Convert Record<string, unknown> to ToolArgs by filtering out non-JsonValue types
-      const toolArgs: ToolArgs = {};
-      for (const [key, value] of Object.entries(toolInput)) {
-        // Only include values that are JsonValue compatible
-        if (
-          value === null ||
-          typeof value === "string" ||
-          typeof value === "number" ||
-          typeof value === "boolean" ||
-          (typeof value === "object" && value !== null)
-        ) {
-          toolArgs[key] = value as JsonValue;
-        }
-      }
-
-      const result = await tool.execute(toolArgs);
-      logger.debug(`[OllamaProvider] Tool execution result:`, {
-        toolName,
-        result,
-      });
-
-      // Handle ToolResult type
-      if (result && typeof result === "object" && "success" in result) {
-        if (result.success && result.data !== undefined) {
-          if (typeof result.data === "string") {
-            return result.data;
-          } else if (typeof result.data === "object") {
-            return JSON.stringify(result.data, null, 2);
-          } else {
-            return String(result.data);
-          }
-        } else if (result.error) {
-          const errorMessage =
-            typeof result.error === "string"
-              ? result.error
-              : result.error.message || "Tool execution failed";
-          throw new Error(errorMessage);
-        }
-      }
-
-      // Fallback for non-ToolResult return types
-      if (typeof result === "string") {
-        return result;
-      } else if (typeof result === "object") {
-        return JSON.stringify(result, null, 2);
-      } else {
-        return String(result);
-      }
-    } catch (error) {
-      logger.error(`[OllamaProvider] Tool execution error:`, {
-        toolName,
-        error,
-      });
-      throw error;
-    }
-  }
-
-  /**
-   * Execute tools and format results for Ollama API
-   * Similar to Bedrock's executeStreamTools but for Ollama format
-   */
-  private async executeOllamaTools(
-    toolCalls: OllamaToolCall[],
-    options: StreamOptions,
-  ): Promise<OllamaToolResult[]> {
-    const toolResults: OllamaToolResult[] = [];
-    const toolCallsForStorage: Array<{
-      type: string;
-      toolCallId: string;
-      toolName: string;
-      args: unknown;
-    }> = [];
-    const toolResultsForStorage: Array<{
-      type: string;
-      toolCallId: string;
-      toolName: string;
-      result: unknown;
-    }> = [];
-
-    logger.debug(`[OllamaProvider] Executing ${toolCalls.length} tool calls`);
-
-    for (const call of toolCalls) {
-      logger.debug(`[OllamaProvider] Executing tool: ${call.function.name}`);
-
-      // Parse arguments
-      let args: Record<string, unknown>;
-      try {
-        args = JSON.parse(call.function.arguments);
-      } catch (error) {
-        logger.error(
-          `[OllamaProvider] Failed to parse tool arguments: ${call.function.arguments}`,
-          { error },
-        );
-        args = {};
-      }
-
-      // Track tool call for storage
-      toolCallsForStorage.push({
-        type: "tool-call",
-        toolCallId: call.id,
-        toolName: call.function.name,
-        args,
-      });
-
-      try {
-        // Execute tool using existing tool framework
-        const result = await this.executeSingleTool(
-          call.function.name,
-          args,
-          call.id,
-        );
-
-        logger.debug(
-          `[OllamaProvider] Tool execution successful: ${call.function.name}`,
-        );
-
-        // Track result for storage
-        toolResultsForStorage.push({
-          type: "tool-result",
-          toolCallId: call.id,
-          toolName: call.function.name,
-          result,
-        });
-
-        // Format for Ollama API
-        toolResults.push({
-          tool_call_id: call.id,
-          content: JSON.stringify(result),
-        });
-      } catch (error) {
-        logger.error(
-          `[OllamaProvider] Tool execution failed: ${call.function.name}`,
-          { error },
-        );
-
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        // Track failed result
-        toolResultsForStorage.push({
-          type: "tool-result",
-          toolCallId: call.id,
-          toolName: call.function.name,
-          result: { error: errorMessage },
-        });
-
-        // Format error for Ollama API
-        toolResults.push({
-          tool_call_id: call.id,
-          content: JSON.stringify({ error: errorMessage }),
-        });
-      }
-    }
-
-    // Emit tool:end for each completed tool result so Pipeline B
-    // captures telemetry for Ollama-driven tool calls (gap S2).
-    emitToolEndFromStepFinish(
-      this.neurolink?.getEventEmitter(),
-      toolResultsForStorage.map((tr) => {
-        const hasError =
-          tr.result && typeof tr.result === "object" && "error" in tr.result;
-        return {
-          toolName: tr.toolName,
-          result: tr.result,
-          error: hasError
-            ? String((tr.result as Record<string, unknown>).error)
-            : undefined,
-        };
-      }),
-    );
-
-    // Store tool executions (similar to Bedrock)
-    this.handleToolExecutionStorage(
-      toolCallsForStorage,
-      toolResultsForStorage,
-      options,
-      new Date(),
-    ).catch((error: unknown) => {
-      logger.warn("[OllamaProvider] Failed to store tool executions", {
-        provider: this.providerName,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-
-    return toolResults;
-  }
-
-  /**
-   * Convert ReadableStream to AsyncIterable for compatibility with StreamResult interface
-   */
-  private convertToAsyncIterable(
-    stream: ReadableStream,
-  ): AsyncIterable<{ content: string }> {
-    return {
-      async *[Symbol.asyncIterator]() {
-        const reader = stream.getReader();
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              break;
-            }
-            yield value;
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      },
-    };
-  }
-
-  /**
-   * Create stream generator for Ollama generate API (non-tool mode)
-   */
-  private async *createOllamaStream(
-    response: Response,
-  ): AsyncGenerator<{ content: string }> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (line.trim()) {
-            try {
-              const data = JSON.parse(line);
-              if (data.response) {
-                yield { content: data.response };
-              }
-              if (data.done) {
-                return;
-              }
-            } catch (error) {
-              logger.error("Error parsing Ollama stream response", {
-                error,
-              });
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  private async *createOpenAIStream(
-    response: Response,
-  ): AsyncGenerator<{ content: string }> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error("No response body");
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          const trimmedLine = line.trim();
-          if (!trimmedLine || trimmedLine === "data: [DONE]") {
-            continue;
-          }
-
-          if (trimmedLine.startsWith("data: ")) {
-            try {
-              const jsonStr = trimmedLine.slice(6); // Remove "data: " prefix
-              const data = JSON.parse(jsonStr);
-              const content = data.choices?.[0]?.delta?.content;
-              if (content) {
-                yield { content };
-              }
-              if (data.choices?.[0]?.finish_reason) {
-                return;
-              }
-            } catch (error) {
-              logger.error("Error parsing OpenAI stream response", {
-                error,
-                line: trimmedLine,
-              });
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
+  protected getFallbackModelName(): string {
+    return FALLBACK_OLLAMA_MODEL;
   }
 
   protected formatProviderError(error: unknown): Error {
     if (error instanceof TimeoutError) {
-      return new TimeoutError(
-        `Ollama request timed out. The model might be loading or the request is too complex.`,
-        this.timeout,
+      return new NetworkError(
+        `Ollama request timed out. The model may be loading or the request is too large.`,
+        "ollama",
       );
     }
+    const errorRecord = error as UnknownRecord;
+    const message =
+      typeof errorRecord?.message === "string"
+        ? errorRecord.message
+        : "Unknown error";
+    const cause = (errorRecord?.cause as UnknownRecord) ?? {};
+    const code = (errorRecord?.code ?? cause?.code) as string | undefined;
 
     if (
-      (error as Error).message?.includes("ECONNREFUSED") ||
-      (error as Error).message?.includes("fetch failed")
+      code === "ECONNREFUSED" ||
+      message.includes("ECONNREFUSED") ||
+      message.includes("Failed to fetch") ||
+      message.includes("fetch failed")
     ) {
       return new NetworkError(
-        `❌ Ollama Service Not Running\n\nCannot connect to Ollama at ${this.baseUrl}\n\n🔧 Steps to Fix:\n1. Install Ollama: https://ollama.ai/\n2. Start Ollama service: 'ollama serve'\n3. Verify it's running: 'curl ${this.baseUrl}/api/version'\n4. Try again`,
-        this.providerName,
+        `Cannot connect to Ollama at ${redactUrlCredentials(this.config.baseURL)}. ` +
+          `Install Ollama (https://ollama.com), start it with 'ollama serve', then try again.`,
+        "ollama",
       );
     }
+    // The base client (buildAPIError) attaches statusCode + responseBody to
+    // HTTP failures. Distinguish a genuine missing-model error (give 'ollama
+    // pull' guidance) from a bare endpoint-mismatch 404 (wrong base URL / not
+    // the OpenAI-compatible /v1 surface) so the advice is actionable. Match on
+    // wording, not a bare "404" substring, to avoid misclassifying unrelated
+    // messages that merely contain those digits.
+    const statusCode =
+      typeof errorRecord?.statusCode === "number"
+        ? errorRecord.statusCode
+        : undefined;
+    const responseBody =
+      typeof errorRecord?.responseBody === "string"
+        ? errorRecord.responseBody
+        : "";
+    const haystack = `${message} ${responseBody}`.toLowerCase();
+    const looksLikeMissingModel =
+      haystack.includes("model_not_found") ||
+      (haystack.includes("model") && haystack.includes("not found"));
 
-    if (
-      (error as Error).message?.includes("model") &&
-      (error as Error).message?.includes("not found")
-    ) {
+    if (looksLikeMissingModel) {
       return new InvalidModelError(
-        `❌ Ollama Model Not Found\n\nModel '${this.modelName}' is not available locally.\n\n🔧 Install Model:\n1. Run: ollama pull ${this.modelName}\n2. Or try a different model:\n   - ollama pull ${FALLBACK_OLLAMA_MODEL}\n   - ollama pull mistral:latest\n   - ollama pull codellama:latest\n\n🔧 List Available Models:\nollama list`,
-        this.providerName,
+        `Ollama model '${this.modelName}' is not available locally. ` +
+          `Pull it first with 'ollama pull ${this.modelName}' (or try '${FALLBACK_OLLAMA_MODEL}'); ` +
+          `list installed models with 'ollama list'.`,
+        "ollama",
       );
     }
-
-    const errMsg = (error as Error).message ?? "";
-    const httpStatus = isOllamaHttpError(error) ? error.statusCode : undefined;
-    const responseBody = isOllamaHttpError(error) ? error.responseBody : "";
-    if (
-      httpStatus === 404 &&
-      (responseBody.toLowerCase().includes("model") ||
-        responseBody.toLowerCase().includes("not found") ||
-        errMsg.toLowerCase().includes("model") ||
-        errMsg.toLowerCase().includes("not found"))
-    ) {
-      return new InvalidModelError(
-        `❌ Ollama Returned HTTP 404\n\nThis usually means the configured model '${this.modelName}' is not installed locally, although a bad base URL or incompatible API mode can also cause it.\n\n🔧 Check:\n1. Verify the model exists: 'ollama list'\n2. Pull it if missing: 'ollama pull ${this.modelName}'\n3. Verify the service is healthy: 'curl ${this.baseUrl}/api/version'\n4. If you use OpenAI-compatible mode, confirm the base URL serves /v1/chat/completions`,
-        this.providerName,
-      );
-    }
-
-    if (httpStatus === 404) {
+    if (statusCode === 404 || haystack.includes("status 404")) {
       return new ProviderError(
-        `❌ Ollama Endpoint Returned HTTP 404\n\nThe configured base URL (${this.baseUrl}) did not serve the expected Ollama endpoint for model '${this.modelName}'. This is usually a configuration or API-mode mismatch rather than a missing model.\n\n🔧 Check:\n1. Verify the base URL: ${this.baseUrl}\n2. For native Ollama mode, confirm /api/generate exists\n3. For OpenAI-compatible mode, confirm /v1/chat/completions exists\n4. If the model is missing, the response body should explicitly say so`,
-        this.providerName,
+        `Ollama returned HTTP 404 from ${redactUrlCredentials(this.config.baseURL)}. ` +
+          `Verify the base URL serves the OpenAI-compatible /v1 API and that the ` +
+          `model is installed ('ollama list').`,
+        "ollama",
       );
     }
+    return new ProviderError(`Ollama error: ${message}`, "ollama");
+  }
 
-    return new ProviderError(
-      `❌ Ollama Provider Error\n\n${(error as Error).message || "Unknown error occurred"}\n\n🔧 Troubleshooting:\n1. Check if Ollama service is running\n2. Verify model is installed: 'ollama list'\n3. Check network connectivity to ${this.baseUrl}\n4. Review Ollama logs for details`,
-      this.providerName,
+  // ===========================================================================
+  // Optional hooks — Ollama-specific behaviour
+  // ===========================================================================
+
+  /**
+   * Ollama proxies many local models with varying tool support. When
+   * `OLLAMA_TOOL_CAPABLE_MODELS` (or `modelConfig`'s
+   * `modelBehavior.toolCapableModels`) is configured, gate tools on a
+   * substring match against the current model; with no list configured,
+   * assume tools are supported (don't disable on absent evidence).
+   */
+  supportsTools(): boolean {
+    const modelName = (this.modelName ?? getDefaultOllamaModel()).toLowerCase();
+    const ollamaConfig = modelConfig.getProviderConfiguration("ollama");
+    const toolCapableModels =
+      (ollamaConfig?.modelBehavior?.toolCapableModels as string[]) || [];
+
+    if (toolCapableModels.length === 0) {
+      return true;
+    }
+
+    const isToolCapable = toolCapableModels.some((capableModel) =>
+      modelName.includes(capableModel.toLowerCase()),
     );
-  }
-
-  /**
-   * Check if Ollama service is healthy and accessible
-   */
-  private async checkOllamaHealth(): Promise<void> {
-    try {
-      // Use traditional AbortController for better compatibility
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-      const response = await proxyFetch(`${this.baseUrl}/api/version`, {
-        method: "GET",
-        signal: controller.signal,
+    if (!isToolCapable) {
+      logger.debug("Ollama tool calling disabled", {
+        model: this.modelName,
+        reason: "Model not in OLLAMA_TOOL_CAPABLE_MODELS list",
       });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new Error(`Ollama health check failed: ${response.status}`);
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("ECONNREFUSED")) {
-        throw new Error(
-          `❌ Ollama Service Not Running\n\nCannot connect to Ollama service.\n\n🔧 Start Ollama:\n1. Run: ollama serve\n2. Or start Ollama app\n3. Verify: curl ${this.baseUrl}/api/version`,
-          { cause: error },
-        );
-      }
-      throw error;
     }
+    return isToolCapable;
   }
 
   /**
-   * Get available models from Ollama
+   * Local models are slow; the base already defaults Ollama to a 5-minute
+   * timeout and honors a per-call `options.timeout`. Preserve the legacy
+   * `OLLAMA_TIMEOUT` env override for callers who relied on it, applied only
+   * when no explicit per-call timeout is set. Parsed with the shared
+   * `parseTimeout` so both millisecond numbers ("240000") and duration strings
+   * ("4m", "30s") work; a malformed value is ignored in favour of the default.
    */
-  async getAvailableModels(): Promise<string[]> {
+  public getTimeout(options: TextGenerationOptions | StreamOptions): number {
+    if (options.timeout === undefined || options.timeout === null) {
+      const envTimeout = process.env.OLLAMA_TIMEOUT?.trim();
+      if (envTimeout) {
+        try {
+          const parsed = parseTimeout(envTimeout);
+          if (parsed !== undefined && parsed > 0) {
+            return parsed;
+          }
+        } catch {
+          logger.debug(
+            `Ignoring invalid OLLAMA_TIMEOUT='${envTimeout}'; using the default. ` +
+              `Use a millisecond number (240000) or a duration like '4m' / '30s'.`,
+          );
+        }
+      }
+    }
+    return super.getTimeout(options);
+  }
+
+  /**
+   * Health check: probe `/v1/models` and require at least one installed model.
+   * A reachable server with zero models would let `resolveModelName()` fall
+   * back to a model that the first real request can't serve, so report unusable.
+   */
+  async validateConfiguration(): Promise<boolean> {
     try {
-      const response = await proxyFetch(`${this.baseUrl}/api/tags`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch models: ${response.status}`);
+      const url = `${stripTrailingSlash(this.config.baseURL)}/models`;
+      const proxyFetch = createProxyFetch();
+      const r = await proxyFetch(url, {
+        headers: {
+          ...this.getAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!r.ok) {
+        return false;
       }
-
-      const data = await response.json();
-      return data.models?.map((model: { name: string }) => model.name) || [];
+      const data = (await r.json().catch(() => null)) as ModelsResponse | null;
+      return Boolean(
+        data?.data?.some(
+          (m) => typeof m?.id === "string" && m.id.trim().length > 0,
+        ),
+      );
     } catch (error) {
-      logger.warn("Failed to fetch Ollama models:", error);
-      return [];
+      logger.debug("Ollama validateConfiguration probe failed", {
+        baseURL: redactUrlCredentials(this.config.baseURL),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
     }
   }
 
-  /**
-   * Check if a specific model is available
-   */
-  async isModelAvailable(modelName: string): Promise<boolean> {
-    const models = await this.getAvailableModels();
-    return models.includes(modelName);
-  }
-
-  /**
-   * Get recommendations for tool-calling capable Ollama models
-   * Provides guidance for users who want to use function calling locally
-   */
-  static getToolCallingRecommendations(): {
-    recommended: string[];
-    performance: Record<
-      string,
-      { speed: number; quality: number; size: string }
-    >;
-    notes: Record<string, string>;
-    installation: Record<string, string>;
-  } {
+  getConfiguration() {
     return {
-      recommended: [
-        "llama3.1:8b-instruct",
-        "mistral:7b-instruct-v0.3",
-        "hermes3:8b-llama3.1",
-        "codellama:34b-instruct",
-        "firefunction-v2:70b",
-      ],
-      performance: {
-        "llama3.1:8b-instruct": { speed: 3, quality: 3, size: "4.6GB" },
-        "mistral:7b-instruct-v0.3": { speed: 3, quality: 2, size: "4.1GB" },
-        "hermes3:8b-llama3.1": { speed: 3, quality: 3, size: "4.6GB" },
-        "codellama:34b-instruct": { speed: 1, quality: 3, size: "19GB" },
-        "firefunction-v2:70b": { speed: 1, quality: 3, size: "40GB" },
-      },
-      notes: {
-        "llama3.1:8b-instruct":
-          "Best balance of speed, quality, and tool calling capability",
-        "mistral:7b-instruct-v0.3":
-          "Lightweight with reliable function calling",
-        "hermes3:8b-llama3.1": "Specialized for tool execution and reasoning",
-        "codellama:34b-instruct":
-          "Excellent for code-related tool calling, requires more resources",
-        "firefunction-v2:70b":
-          "Optimized specifically for function calling, requires high-end hardware",
-      },
-      installation: {
-        "llama3.1:8b-instruct": "ollama pull llama3.1:8b-instruct",
-        "mistral:7b-instruct-v0.3": "ollama pull mistral:7b-instruct-v0.3",
-        "hermes3:8b-llama3.1": "ollama pull hermes3:8b-llama3.1",
-        "codellama:34b-instruct": "ollama pull codellama:34b-instruct",
-        "firefunction-v2:70b": "ollama pull firefunction-v2:70b",
-      },
+      provider: this.providerName,
+      model: this.modelName || this.resolvedModel || getDefaultOllamaModel(),
+      defaultModel: getDefaultOllamaModel(),
+      baseURL: this.config.baseURL,
     };
   }
-}
 
-export default OllamaProvider;
+  // ===========================================================================
+  // Embeddings — native POST /v1/embeddings
+  // ===========================================================================
+
+  /**
+   * Generate an embedding for a single text input via native /v1/embeddings.
+   * Uses `OLLAMA_EMBEDDING_MODEL` (default `nomic-embed-text`); the embedding
+   * model must be pulled locally (`ollama pull nomic-embed-text`).
+   */
+  async embed(text: string, modelName?: string): Promise<number[]> {
+    const embeddingModel =
+      modelName ||
+      process.env.OLLAMA_EMBEDDING_MODEL ||
+      DEFAULT_EMBEDDING_MODEL;
+    const [embedding] = await this.callEmbeddings(
+      embeddingModel,
+      [text],
+      "embed",
+    );
+    return embedding;
+  }
+
+  /**
+   * Generate embeddings for multiple text inputs via native /v1/embeddings.
+   */
+  async embedMany(texts: string[], modelName?: string): Promise<number[][]> {
+    const embeddingModel =
+      modelName ||
+      process.env.OLLAMA_EMBEDDING_MODEL ||
+      DEFAULT_EMBEDDING_MODEL;
+    return this.callEmbeddings(embeddingModel, texts, "embedMany");
+  }
+
+  private async callEmbeddings(
+    modelName: string,
+    input: string[],
+    operation: "embed" | "embedMany",
+  ): Promise<number[][]> {
+    const url = `${stripTrailingSlash(this.config.baseURL)}/embeddings`;
+    const fetchImpl = createProxyFetch();
+    const timeoutController = createTimeoutController(
+      EMBEDDINGS_TIMEOUT_MS,
+      this.providerName,
+      "generate",
+    );
+    try {
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...this.getAuthHeaders(),
+        },
+        body: JSON.stringify({
+          model: modelName,
+          input: input.length === 1 ? input[0] : input,
+        }),
+        ...(timeoutController?.controller.signal
+          ? { signal: timeoutController.controller.signal }
+          : {}),
+      });
+      if (!res.ok) {
+        const bodyText = await res.text().catch(() => "");
+        // Guard JSON.parse: a reverse proxy / gateway in front of Ollama can
+        // return a non-JSON error body (HTML 5xx page, plain text). Degrade to
+        // the status-based fallback message instead of throwing a SyntaxError.
+        let parsed: { error?: { message?: string } } | undefined;
+        if (bodyText) {
+          try {
+            parsed = JSON.parse(bodyText) as { error?: { message?: string } };
+          } catch {
+            parsed = undefined;
+          }
+        }
+        throw this.formatProviderError(
+          new Error(
+            parsed?.error?.message ||
+              `Ollama ${operation} failed with status ${res.status}`,
+          ),
+        );
+      }
+      const json = (await res.json()) as {
+        data?: Array<{ embedding?: number[] }>;
+      };
+      const embeddings = (json.data ?? [])
+        .map((row) => row.embedding)
+        .filter((e): e is number[] => Array.isArray(e));
+      if (embeddings.length === 0) {
+        throw new ProviderError(
+          `Ollama ${operation} returned no embeddings`,
+          "ollama",
+        );
+      }
+      return embeddings;
+    } finally {
+      timeoutController?.cleanup();
+    }
+  }
+}

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -7,7 +7,6 @@ import type {
   JsonValue,
   StreamingCapability,
 } from "./common.js";
-import type { ProviderError } from "./errors.js";
 import {
   AIProviderName,
   AnthropicModels,
@@ -201,7 +200,7 @@ export type NeurolinkCredentials = {
   openrouter?: { apiKey?: string; baseURL?: string };
   litellm?: { apiKey?: string; baseURL?: string };
   openaiCompatible?: { apiKey?: string; baseURL?: string };
-  ollama?: { baseURL?: string };
+  ollama?: { baseURL?: string; apiKey?: string };
   deepseek?: { apiKey?: string; baseURL?: string };
   nvidiaNim?: { apiKey?: string; baseURL?: string };
   // apiKey is optional for LM Studio / llama.cpp; use only when running them
@@ -1101,42 +1100,6 @@ export type ModelsResponse = {
   }>;
 };
 
-// ============================================================================
-// Ollama Provider Types
-// ============================================================================
-
-/**
- * Ollama tool call structure
- */
-export type OllamaToolCall = {
-  id: string;
-  type: "function";
-  function: {
-    name: string;
-    arguments: string;
-  };
-};
-
-/**
- * Ollama tool result structure
- */
-export type OllamaToolResult = {
-  tool_call_id: string;
-  content: string;
-};
-
-/**
- * Ollama message structure for conversation and tool execution
- */
-export type OllamaMessage = {
-  role: "system" | "user" | "assistant" | "tool";
-  content:
-    | string
-    | Array<{ type: string; text?: string; [key: string]: unknown }>;
-  tool_calls?: OllamaToolCall[];
-  images?: string[];
-};
-
 /**
  * Default model aliases for easy reference
  */
@@ -1705,23 +1668,6 @@ export type ProviderHealthStatusOptions = {
 // ============================================================================
 
 /**
- * Structural adapter type capturing what AI SDK's `streamText` / `generateText`
- * actually invoke at runtime on a model object.
- *
- * `OllamaLanguageModel` satisfies this type. The provider can cast
- * `new OllamaLanguageModel(...)` to `LanguageModel` via this
- * intermediate type, avoiding `as unknown as LanguageModel`.
- */
-export type OllamaAsLanguageModel = {
-  readonly specificationVersion: string;
-  readonly provider: string;
-  readonly modelId: string;
-  readonly supportedUrls: Record<string, RegExp[]>;
-  doGenerate(options: Record<string, unknown>): Promise<unknown>;
-  doStream(options: Record<string, unknown>): Promise<unknown>;
-};
-
-/**
  * Structural type that captures what AI SDK's `streamText` / `generateText`
  * actually invoke at runtime on a model object.
  *
@@ -2001,17 +1947,6 @@ export type ProviderRegistration = {
 /** Minimal NeuroLink-like instance accepted by the image generation service. */
 export type NeuroLinkInstance = {
   generate: (options: Record<string, unknown>) => Promise<unknown>;
-};
-
-// =============================================================================
-// OLLAMA (from providers/ollama.ts)
-// =============================================================================
-
-/** ProviderError enriched with HTTP response fields from Ollama. */
-export type OllamaHttpError = ProviderError & {
-  statusCode: number;
-  statusText: string;
-  responseBody: string;
 };
 
 // =============================================================================


### PR DESCRIPTION
## What & why

Migrates **ollama** off its bespoke implementation onto the native `OpenAIChatCompletionsProvider` base — the same base the other 18 OpenAI-compatible providers already use. Ollama exposes an OpenAI-compatible `/v1` surface, and the provider's **tool-calling path already used `/v1/chat/completions`**, so chat/streaming/tools route through the shared base client with equivalent behavior. The file drops **2,290 → ~330 lines** (256 insertions / 2,270 deletions), and a hand-rolled `OllamaLanguageModel` AI-SDK adapter, two stream parsers, a per-call health check, and a manual tool loop are deleted.

This was scoped before implementation (research → adversarial verification of Ollama's `/v1` limits → go/no-go); the two "scary" risks flagged in scoping (`num_ctx`/`keep_alive` loss, missing base class) were verified **non-issues** — the old code never set those knobs, and the base has shipped since 9.68.x.

## Ollama-specific behaviour — preserved via hooks

- **`/v1` base-URL normalization** — a bare `OLLAMA_BASE_URL` host (the historical `http://localhost:11434` form) gets `/v1` appended; an already-`/v1` base is left untouched. So `/v1/chat/completions`, `/v1/models`, `/v1/embeddings` all resolve correctly.
- **No-auth by default + optional cloud auth** — local Ollama ignores auth (placeholder key `ollama`); a real `OLLAMA_API_KEY` (added to the `ollama` credentials type) enables **Ollama Cloud** / an auth-proxying reverse proxy.
- **Per-model tool gating** — `supportsTools()` keeps the `OLLAMA_TOOL_CAPABLE_MODELS` / `modelConfig` gate with identical "empty list ⇒ assume supported" semantics.
- **Elevated timeout** — the base already defaults ollama to **5 min** (`DEFAULT_TIMEOUTS.providers.ollama`) and honors per-call `options.timeout`; the legacy `OLLAMA_TIMEOUT` env override is preserved via a small `getTimeout` hook.
- **Rich error mapping** — `formatProviderError` keeps the actionable `ollama serve` / `ollama pull <model>` / `ollama list` guidance, returning only typed errors. A 404 is split (via the base error's `statusCode`/`responseBody`) into a genuine **missing-model** error (`ollama pull`) vs a **base-URL/endpoint-mismatch** 404 (`ProviderError`), matching the old two-branch behaviour; timeouts map to `NetworkError`, consistent with the rest of the migrated cohort (lmStudio/mistral/openRouter). The native `/v1/embeddings` error path guards `JSON.parse` so a non-JSON proxy error body degrades to a typed error instead of a raw `SyntaxError`.
- `baseURL` redacted in the constructor debug log via `redactUrlCredentials` (the shared helper from #1068).

## Net-new (free from the base)

- **`embed()` / `embedMany()`** via native `/v1/embeddings` (litellm pattern), using `OLLAMA_EMBEDDING_MODEL` (default `nomic-embed-text`).
- **Model discovery** via the base's `/v1/models` probe (Ollama supports it); `validateConfiguration()` probes `/v1/models` and requires ≥1 installed model.

## Accepted, documented removals (no external consumers)

- Native `/api/generate` path + the `OLLAMA_OPENAI_COMPATIBLE` flag → `/v1` is the only path (output equivalent for text).
- Per-call `GET /api/version` health check → replaced by `validateConfiguration()`.
- `OllamaLanguageModel` AI-SDK adapter, `getToolCallingRecommendations()` (static), `isModelAvailable()`, and the rule-violating `export default OllamaProvider`.
- Dead `Ollama*` types removed from `types/providers.ts` (`OllamaMessage`, `OllamaToolCall`, `OllamaToolResult`, `OllamaAsLanguageModel`, `OllamaHttpError`).

`num_ctx` / `keep_alive` were **never set** by the old code, so there is no regression there (both run at Ollama's default before and after). Multimodal still flows through the base's standard `content[].image_url` message format, which Ollama `/v1` accepts.

## Validation

- `pnpm run check` (svelte-check + `tsc --strict`) — pass, 0 errors
- lint + format — pass (0 errors)
- `pnpm run build` + publint — pass ("All good!")
- stream-span native-base audit — 106/106 (ollama audited as native-base: no per-provider span, no plain `Error` in `formatProviderError`)

Single commit, per the repo's single-commit policy.
