### PR TITLE
refactor(deps): remove unused @ai-sdk packages (azure, openai-compatible, openrouter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,10 +297,8 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.50",
-    "@ai-sdk/azure": "^3.0.38",
     "@ai-sdk/mistral": "^3.0.21",
     "@ai-sdk/openai": "^3.0.37",
-    "@ai-sdk/openai-compatible": "^2.0.41",
     "@ai-sdk/provider": "^3.0.8",
     "@anthropic-ai/vertex-sdk": "^0.16.0",
     "@aws-sdk/client-bedrock": "^3.1000.0",
@@ -313,7 +311,6 @@
     "@google/genai": "^1.43.0",
     "@huggingface/inference": "^4.13.14",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@openrouter/ai-sdk-provider": "^2.2.3",
     "@opentelemetry/api-logs": "^0.214.0",
     "@opentelemetry/context-async-hooks": "^2.6.1",
     "@opentelemetry/core": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,18 +44,12 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.50
         version: 3.0.64(zod@4.3.6)
-      '@ai-sdk/azure':
-        specifier: ^3.0.38
-        version: 3.0.49(zod@4.3.6)
       '@ai-sdk/mistral':
         specifier: ^3.0.21
         version: 3.0.27(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.37
         version: 3.0.48(zod@4.3.6)
-      '@ai-sdk/openai-compatible':
-        specifier: ^2.0.41
-        version: 2.0.41(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
@@ -92,9 +86,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.28.0(zod@4.3.6)
-      '@openrouter/ai-sdk-provider':
-        specifier: ^2.2.3
-        version: 2.3.3(ai@6.0.141(zod@4.3.6))(zod@4.3.6)
       '@opentelemetry/api-logs':
         specifier: ^0.214.0
         version: 0.214.0
@@ -498,12 +489,6 @@ packages:
 
   '@ai-sdk/anthropic@3.0.68':
     resolution: {integrity: sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/azure@3.0.49':
-    resolution: {integrity: sha512-wskgAL+OmrHG7by/iWIxEBQCEdc1mDudha/UZav46i0auzdFfsDB/k2rXZaC4/3nWSgMZkxr0W3ncyouEGX/eg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2124,13 +2109,6 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
-
-  '@openrouter/ai-sdk-provider@2.3.3':
-    resolution: {integrity: sha512-4fVteGkVedc7fGoA9+qJs4tpYwALezMq14m2Sjub3KmyRlksCbK+WJf67NPdGem8+NZrV2tAN42A1NU3+SiV3w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
 
   '@openrouter/ai-sdk-provider@2.5.1':
     resolution: {integrity: sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ==}
@@ -4520,10 +4498,6 @@ packages:
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
-
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -7430,13 +7404,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/azure@3.0.49(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/openai': 3.0.48(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
-      zod: 4.3.6
-
   '@ai-sdk/azure@3.0.53(zod@4.3.6)':
     dependencies:
       '@ai-sdk/openai': 3.0.52(zod@4.3.6)
@@ -9687,7 +9654,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
       hono: 4.12.12
@@ -9892,11 +9859,6 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
-
-  '@openrouter/ai-sdk-provider@2.3.3(ai@6.0.141(zod@4.3.6))(zod@4.3.6)':
-    dependencies:
-      ai: 6.0.141(zod@4.3.6)
-      zod: 4.3.6
 
   '@openrouter/ai-sdk-provider@2.5.1(ai@6.0.158(zod@4.3.6))(zod@4.3.6)':
     dependencies:
@@ -12836,8 +12798,6 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
-
-  eventsource-parser@3.0.6: {}
 
   eventsource-parser@3.0.8: {}
 


### PR DESCRIPTION
## What & why

With all 19 OpenAI-compatible providers on the native `OpenAIChatCompletionsProvider` base (series completed in #1071 / 9.68.20), three `@ai-sdk` packages have **zero importers** across `src/` and `test/` — verified including dynamic `import()` forms:

| Package | Why it's dead |
|---|---|
| `@ai-sdk/azure` | azureOpenai migrated to the native base |
| `@ai-sdk/openai-compatible` | every former consumer migrated; remaining textual refs are doc comments + OpenCode proxy config strings (the `npm:` field in generated OpenCode config is resolved by the **external** OpenCode CLI from its own runtime, not NeuroLink's `node_modules`) |
| `@openrouter/ai-sdk-provider` | openRouter migrated; `src/browser/entry.ts` never re-exported it |

The browser entry's re-exports (`createAnthropic`/`createOpenAI`/`createMistral`) are unaffected — `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/mistral` stay until the planned (breaking) browser-surface removal later in the AI-SDK removal series.

## Validation

- `pnpm install` — lockfile updated cleanly
- `pnpm run check` — pass, 0 errors
- lint — pass (0 errors)
- `pnpm run build` + publint — pass ("All good!")

Only `package.json` + `pnpm-lock.yaml` change. Shrinks the published install footprint; no runtime behavior change. Single commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined dependencies by removing unused AI provider packages while maintaining support for primary integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->