### PR TITLE
feat(providers): surface reasoning_content natively in the SSE client + base

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "test:image-gen": "npx tsx test/continuous-test-suite-image-gen-extras.ts",
     "test:ssrf": "npx tsx test/continuous-test-suite-ssrf.ts",
     "test:log-sanitize": "npx tsx test/continuous-test-suite-log-sanitize.ts",
+    "test:sse-client": "npx tsx test/continuous-test-suite-sse-client.ts",
     "test:stream-span": "npx tsx test/continuous-test-suite-stream-span.ts",
     "test:credentials": "npx tsx test/continuous-test-suite-credentials.ts",
     "test:dynamic": "npx tsx test/continuous-test-suite-dynamic.ts",

--- a/src/lib/providers/deepseek.ts
+++ b/src/lib/providers/deepseek.ts
@@ -47,12 +47,12 @@ const getDefaultDeepSeekModel = (): string => {
  *      `@ai-sdk/openai-compatible` path this migration replaced. The base
  *      client injects the literal "json" word the API requires for that mode.
  *
- *   2. Reasoning support — the opt-in `thinking` request param (non-reasoner
- *      chat models) and `reasoning_content` surfacing (deepseek-reasoner / R1)
- *      both require plumbing the thinking signal and the reasoning delta
- *      through the native base client. That plumbing isn't in place yet, so
- *      neither is wired here; it is tracked as a base-client follow-up. All
- *      other behavior is preserved.
+ *   2. Reasoning support — `reasoning_content` (deepseek-reasoner / R1) is
+ *      surfaced automatically by the native base client: streamed deltas
+ *      arrive as `{ content: "", reasoning }` chunks and the non-streaming
+ *      result carries `result.reasoning`. The opt-in `thinking` request
+ *      param (non-reasoner chat models) still needs thinking-signal plumbing
+ *      and is tracked as a follow-up. All other behavior is preserved.
  *
  * @see https://api-docs.deepseek.com
  */

--- a/src/lib/providers/nvidiaNim.ts
+++ b/src/lib/providers/nvidiaNim.ts
@@ -187,7 +187,9 @@ const getDefaultNimModel = (): string => {
  * Wraps NVIDIA's hosted (or self-hosted) inference endpoints.
  * Passes NIM-specific extras (top_k, min_p, repetition_penalty,
  * chat_template_kwargs.reasoning_budget) via adjustBuildBodyOptions.
- * reasoning_content surfacing is a pending base-client follow-up (not emitted natively yet); all other behavior is preserved.
+ * reasoning_content is surfaced automatically by the native base client
+ * (streamed as `{ content: "", reasoning }` chunks; `result.reasoning` on
+ * the non-streaming path); all other behavior is preserved.
  *
  * @see https://docs.api.nvidia.com/nim/reference/
  */

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -407,6 +407,14 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             ? choice.message.content
             : "") ?? "";
         const content: Array<{ type: string } & Record<string, unknown>> = [];
+        // Reasoner-model output (DeepSeek `reasoning_content`, gateway
+        // `reasoning`) becomes a V3 reasoning part ahead of the text part —
+        // GenerationHandler joins reasoning parts into `result.reasoning`.
+        const reasoningText =
+          choice?.message?.reasoning_content ?? choice?.message?.reasoning;
+        if (typeof reasoningText === "string" && reasoningText.length > 0) {
+          content.push({ type: "reasoning", text: reasoningText });
+        }
         if (text.length > 0) {
           content.push({ type: "text", text });
         }
@@ -439,8 +447,15 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             },
             outputTokens: {
               total: json.usage?.completion_tokens,
-              text: json.usage?.completion_tokens,
-              reasoning: undefined,
+              text:
+                json.usage?.completion_tokens !== undefined &&
+                json.usage?.completion_tokens_details?.reasoning_tokens !==
+                  undefined
+                  ? json.usage.completion_tokens -
+                    json.usage.completion_tokens_details.reasoning_tokens
+                  : json.usage?.completion_tokens,
+              reasoning:
+                json.usage?.completion_tokens_details?.reasoning_tokens,
             },
           },
           warnings: [],
@@ -815,9 +830,17 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     if (!res.body) {
       throw new Error(`${this.providerName}: stream response had no body`);
     }
-    return parseSSEStream(res.body, (delta) => {
-      args.pushChunk({ content: delta });
-    });
+    return parseSSEStream(
+      res.body,
+      (delta) => {
+        args.pushChunk({ content: delta });
+      },
+      (reasoningDelta) => {
+        // Reasoning rides alongside an empty `content` so plain-text
+        // consumers (which only read chunk.content) are unaffected.
+        args.pushChunk({ content: "", reasoning: reasoningDelta });
+      },
+    );
   }
 
   private async executeToolBatch(args: {

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -496,9 +496,11 @@ export const buildBody = (
 export const parseSSEStream = async (
   body: ReadableStream<Uint8Array>,
   onTextDelta: (delta: string) => void,
+  onReasoningDelta?: (delta: string) => void,
 ): Promise<OpenAICompatSSEResult> => {
   const result: OpenAICompatSSEResult = {
     text: "",
+    reasoning: "",
     toolCalls: new Map(),
     finishReason: null,
     usage: undefined,
@@ -529,6 +531,14 @@ export const parseSSEStream = async (
     if (delta?.content) {
       result.text += delta.content;
       onTextDelta(delta.content);
+    }
+    // Reasoner-model deltas: DeepSeek/NIM emit `reasoning_content`, some
+    // gateways emit `reasoning`. The AI SDK's openai-compatible wrapper
+    // surfaced these automatically; the native client must do the same.
+    const reasoningDelta = delta?.reasoning_content ?? delta?.reasoning;
+    if (reasoningDelta) {
+      result.reasoning += reasoningDelta;
+      onReasoningDelta?.(reasoningDelta);
     }
     if (delta?.tool_calls) {
       for (const tc of delta.tool_calls) {

--- a/src/lib/types/openaiCompatible.ts
+++ b/src/lib/types/openaiCompatible.ts
@@ -112,6 +112,12 @@ export type OpenAICompatChatChoiceMessage = {
   content?: string | null;
   tool_calls?: OpenAICompatToolCallWire[];
   refusal?: string | null;
+  // Reasoner-model output. DeepSeek (deepseek-reasoner/R1) and NVIDIA NIM
+  // emit `reasoning_content`; some gateways (xAI, OpenRouter-normalized)
+  // emit `reasoning` instead. Both are optional extensions to the OpenAI
+  // shape — absent on non-reasoning models.
+  reasoning_content?: string | null;
+  reasoning?: string | null;
 };
 
 export type OpenAICompatChatChoice = {
@@ -149,6 +155,9 @@ export type OpenAICompatStreamDelta = {
     };
   }>;
   refusal?: string | null;
+  // Streaming reasoner-model deltas (see OpenAICompatChatChoiceMessage).
+  reasoning_content?: string | null;
+  reasoning?: string | null;
 };
 
 export type OpenAICompatStreamChunkChoice = {
@@ -241,6 +250,8 @@ export type OpenAICompatMessage = {
 
 export type OpenAICompatSSEResult = {
   text: string;
+  /** Accumulated reasoner-model output (`reasoning_content` / `reasoning` deltas). */
+  reasoning: string;
   toolCalls: Map<number, { id: string; name: string; argsBuffered: string }>;
   finishReason:
     | "stop"
@@ -252,7 +263,12 @@ export type OpenAICompatSSEResult = {
   usage?: OpenAICompatUsage;
 };
 
-export type OpenAICompatStreamChunk = { content: string } | { done: true };
+// Reasoning deltas ride alongside an always-present (empty) `content` string
+// so every existing `chunk.content` consumer stays type- and crash-safe;
+// reasoning-aware consumers read `chunk.reasoning`.
+export type OpenAICompatStreamChunk =
+  | { content: string; reasoning?: string }
+  | { done: true };
 
 // Per-execution tool record kept internally during the streaming multi-step
 // loop. Public shape lives in `ToolExecutionSummary` (src/lib/types/tools.ts).

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -595,13 +595,16 @@ export type StreamOptions = {
  */
 export type StreamResult = {
   stream: AsyncIterable<
-    | { content: string }
+    | { content: string; reasoning?: string }
     | StreamNoOutputSentinel
     | { type: "audio"; audio: AudioChunk }
     | { type: "tts_audio"; audio: TTSChunk }
     | { type: "image"; imageOutput: { base64: string } }
     | { content: string; type?: "preliminary" | "final" }
   >; // text chunks (with optional workflow stage), no-output sentinel, or audio/image events.
+  // Reasoner models (deepseek-reasoner/R1, NVIDIA NIM reasoning, o-series via
+  // gateways) interleave `{ content: "", reasoning: <delta> }` chunks; the
+  // `content` field is always present so plain-text consumers are unaffected.
   // NOTE: `type: "audio"` is realtime/Gemini PCM (`AudioChunk` shape).
   // `type: "tts_audio"` is synthesized TTS output (`TTSChunk` shape, with format/index/voice).
 

--- a/test/continuous-test-suite-sse-client.ts
+++ b/test/continuous-test-suite-sse-client.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Native SSE Client Verification Suite
+ *
+ * Locks in the reasoning_content surfacing added to the native
+ * OpenAI-compatible client (base-client follow-up from the provider
+ * migration series — deepseek #1057 / nvidiaNim #1058 / openAI #1059).
+ *
+ * Coverage:
+ *   - parseSSEStream accumulates `delta.reasoning_content` into
+ *     `result.reasoning` and fires `onReasoningDelta` per delta, without
+ *     polluting `result.text` / `onTextDelta`.
+ *   - The gateway-style `delta.reasoning` fallback field is honored.
+ *   - Interleaved reasoning→content (the deepseek-reasoner/R1 pattern)
+ *     keeps both accumulators correct and ordered.
+ *   - Non-reasoner streams leave `result.reasoning` empty and never fire
+ *     the callback; the callback parameter is optional.
+ *   - usage capture (incl. completion_tokens_details.reasoning_tokens)
+ *     and tool-call assembly are unaffected alongside reasoning deltas.
+ *
+ * No API keys required — pure unit tests over an in-memory SSE stream.
+ *
+ * Run with: pnpm run test:sse-client
+ */
+
+import { parseSSEStream } from "../src/lib/providers/openaiChatCompletionsClient.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { recordTest, runSuite } = defineSuite("Native SSE Client");
+
+// ───────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────
+
+const sseStream = (
+  events: Array<Record<string, unknown> | "[DONE]">,
+): ReadableStream<Uint8Array> => {
+  const enc = new TextEncoder();
+  const payload = events
+    .map((e) => `data: ${e === "[DONE]" ? e : JSON.stringify(e)}\n\n`)
+    .join("");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(enc.encode(payload));
+      controller.close();
+    },
+  });
+};
+
+const deltaEvent = (
+  delta: Record<string, unknown>,
+  finish: string | null = null,
+): Record<string, unknown> => ({
+  choices: [{ index: 0, delta, finish_reason: finish }],
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Section A — reasoning_content accumulation
+// ───────────────────────────────────────────────────────────────────────
+
+{
+  const reasoningDeltas: string[] = [];
+  const textDeltas: string[] = [];
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning_content: "Let me think" }),
+      deltaEvent({ reasoning_content: " step by step." }),
+      deltaEvent({ content: "Answer: 42" }, "stop"),
+      "[DONE]",
+    ]),
+    (d) => textDeltas.push(d),
+    (d) => reasoningDeltas.push(d),
+  );
+
+  recordTest(
+    "reasoning_content deltas accumulate into result.reasoning",
+    result.reasoning === "Let me think step by step.",
+    false,
+    `got "${result.reasoning}"`,
+  );
+  recordTest(
+    "reasoning deltas do not pollute result.text",
+    result.text === "Answer: 42",
+    false,
+    `got "${result.text}"`,
+  );
+  recordTest(
+    "onReasoningDelta fires once per reasoning delta, in order",
+    reasoningDeltas.length === 2 &&
+      reasoningDeltas[0] === "Let me think" &&
+      reasoningDeltas[1] === " step by step.",
+    false,
+    `got ${JSON.stringify(reasoningDeltas)}`,
+  );
+  recordTest(
+    "onTextDelta unaffected by reasoning deltas",
+    textDeltas.length === 1 && textDeltas[0] === "Answer: 42",
+    false,
+    `got ${JSON.stringify(textDeltas)}`,
+  );
+  recordTest(
+    "finishReason still captured alongside reasoning",
+    result.finishReason === "stop",
+    false,
+    `got ${String(result.finishReason)}`,
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section B — gateway-style `reasoning` fallback field
+// ───────────────────────────────────────────────────────────────────────
+
+{
+  const reasoningDeltas: string[] = [];
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning: "thinking…" }),
+      deltaEvent({ content: "done" }, "stop"),
+      "[DONE]",
+    ]),
+    () => {},
+    (d) => reasoningDeltas.push(d),
+  );
+  recordTest(
+    "`reasoning` fallback field accumulates when reasoning_content absent",
+    result.reasoning === "thinking…" && reasoningDeltas.length === 1,
+    false,
+    `reasoning="${result.reasoning}", deltas=${reasoningDeltas.length}`,
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section C — interleaved reasoning → content (deepseek-reasoner pattern)
+// ───────────────────────────────────────────────────────────────────────
+
+{
+  const order: string[] = [];
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning_content: "r1" }),
+      deltaEvent({ reasoning_content: "r2" }),
+      deltaEvent({ content: "c1" }),
+      deltaEvent({ reasoning_content: "r3" }),
+      deltaEvent({ content: "c2" }, "stop"),
+      "[DONE]",
+    ]),
+    (d) => order.push(`t:${d}`),
+    (d) => order.push(`r:${d}`),
+  );
+  recordTest(
+    "interleaved reasoning/content accumulate independently",
+    result.reasoning === "r1r2r3" && result.text === "c1c2",
+    false,
+    `reasoning="${result.reasoning}", text="${result.text}"`,
+  );
+  recordTest(
+    "interleaved callback order preserved",
+    order.join(",") === "r:r1,r:r2,t:c1,r:r3,t:c2",
+    false,
+    `got ${order.join(",")}`,
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section D — non-reasoner streams and optional callback
+// ───────────────────────────────────────────────────────────────────────
+
+{
+  let reasoningFired = false;
+  const result = await parseSSEStream(
+    sseStream([deltaEvent({ content: "plain" }, "stop"), "[DONE]"]),
+    () => {},
+    () => {
+      reasoningFired = true;
+    },
+  );
+  recordTest(
+    "non-reasoner stream leaves result.reasoning empty",
+    result.reasoning === "" && !reasoningFired,
+    false,
+    `reasoning="${result.reasoning}", fired=${reasoningFired}`,
+  );
+}
+
+{
+  // Two-arg call (no onReasoningDelta) must still accumulate without crashing.
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning_content: "silent" }),
+      deltaEvent({ content: "ok" }, "stop"),
+      "[DONE]",
+    ]),
+    () => {},
+  );
+  recordTest(
+    "onReasoningDelta is optional (accumulation still happens)",
+    result.reasoning === "silent" && result.text === "ok",
+    false,
+    `reasoning="${result.reasoning}", text="${result.text}"`,
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section E — usage + tool calls unaffected alongside reasoning
+// ───────────────────────────────────────────────────────────────────────
+
+{
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning_content: "thinking" }),
+      deltaEvent({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: '{"q":' },
+          },
+        ],
+      }),
+      deltaEvent({
+        tool_calls: [{ index: 0, function: { arguments: '"x"}' } }],
+      }),
+      deltaEvent({}, "tool_calls"),
+      {
+        choices: [],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 25,
+          total_tokens: 35,
+          completion_tokens_details: { reasoning_tokens: 7 },
+        },
+      },
+      "[DONE]",
+    ]),
+    () => {},
+  );
+  const tc = result.toolCalls.get(0);
+  recordTest(
+    "tool-call assembly intact alongside reasoning deltas",
+    tc?.id === "call_1" &&
+      tc?.name === "lookup" &&
+      tc?.argsBuffered === '{"q":"x"}',
+    false,
+    `got ${JSON.stringify(tc)}`,
+  );
+  recordTest(
+    "usage capture intact (incl. reasoning_tokens detail)",
+    result.usage?.completion_tokens === 25 &&
+      result.usage?.completion_tokens_details?.reasoning_tokens === 7,
+    false,
+    `got ${JSON.stringify(result.usage)}`,
+  );
+  recordTest(
+    "reasoning accumulated in tool-call stream",
+    result.reasoning === "thinking",
+    false,
+    `got "${result.reasoning}"`,
+  );
+}
+
+await runSuite();


### PR DESCRIPTION
## What & why

Reasoner models (deepseek-reasoner / R1, NVIDIA NIM reasoning models, o-series via gateways) emit chain-of-thought as `reasoning_content` (DeepSeek/NIM) or `reasoning` (some gateways). The AI SDK's openai-compatible wrapper surfaced these automatically; the native client didn't yet — the tracked base-client follow-up from the deepseek (#1057), nvidiaNim (#1058), and openAI (#1059) migrations. This wires it end-to-end for **all 19 native-base providers at once**.

## Design

**Streaming** — `parseSSEStream` gains an optional `onReasoningDelta` callback and accumulates `delta.reasoning_content ?? delta.reasoning` into `result.reasoning`. The base pushes reasoning deltas as `{ content: "", reasoning }` chunks:
- `content` stays an **always-present string**, so every existing `chunk.content` consumer (SDK loops, CLI, server SSE relays) is type- and crash-safe and renders nothing for reasoning chunks.
- Reasoning-aware consumers read `chunk.reasoning`. The public `StreamResult` chunk union documents the contract.

**Non-streaming** — the base's V3 `doGenerate` emits a `{ type: "reasoning", text }` content part ahead of the text part. `GenerationHandler` already joins V3 reasoning parts into `result.reasoning` (the exact channel the AI-SDK path used), so `generate()` results carry reasoning with zero new plumbing. `usage.outputTokens.reasoning` is populated from `completion_tokens_details.reasoning_tokens` when reported (and subtracted from the text-token count), so `result.reasoningTokens` works for o-series-style endpoints.

**Types** — `OpenAICompatChatChoiceMessage` / `OpenAICompatStreamDelta` gain the two optional wire fields; `OpenAICompatSSEResult.reasoning`; `OpenAICompatStreamChunk` + the public `StreamResult` chunk union gain optional `reasoning`.

deepseek/nvidiaNim doc comments updated — `reasoning_content` is no longer a pending follow-up (deepseek's `thinking` request param remains one, tracked separately).

## Tests

New no-API unit suite `test/continuous-test-suite-sse-client.ts` (`pnpm run test:sse-client`) — **13/13**: accumulation, the `reasoning` fallback field, interleaved reasoning→content ordering (R1 pattern), optional callback, non-reasoner streams, and usage/tool-call coexistence.

## Validation

- `pnpm run check` — pass, 0 errors · lint — pass · stream-span audit — 106/106
- `test:sse-client` — 13/13

Single commit, per the repo's single-commit policy.
