### PR TITLE
fix(providers): restore NVIDIA NIM extras passthrough + one-shot 400 retry

### DIFF
--- a/src/lib/providers/nvidiaNim.ts
+++ b/src/lib/providers/nvidiaNim.ts
@@ -4,6 +4,7 @@ import type {
   NeurolinkCredentials,
   NvidiaNimExtraBody,
   OpenAICompatBuildBodyArgs,
+  OpenAICompatChatRequest,
   UnknownRecord,
 } from "../types/index.js";
 import {
@@ -185,8 +186,11 @@ const getDefaultNimModel = (): string => {
  * NVIDIA NIM Provider — native HTTP+SSE, no AI SDK.
  *
  * Wraps NVIDIA's hosted (or self-hosted) inference endpoints.
- * Passes NIM-specific extras (top_k, min_p, repetition_penalty,
- * chat_template_kwargs.reasoning_budget) via adjustBuildBodyOptions.
+ * Passes NIM-specific extras (top_k, min_p, repetition_penalty, min_tokens,
+ * chat_template, chat_template_kwargs.reasoning_budget) to the wire via the
+ * `extraBody` channel of adjustBuildBodyOptions, and retries once without
+ * `chat_template`/`reasoning_budget` when a model server rejects them with a
+ * 400 (adjustBodyAfter400 — applies on both generate and stream paths).
  * reasoning_content is surfaced automatically by the native base client
  * (streamed as `{ content: "", reasoning }` chunks; `result.reasoning` on
  * the non-streaming path); all other behavior is preserved.
@@ -260,7 +264,52 @@ export class NvidiaNimProvider extends OpenAIChatCompletionsProvider {
 
     const extra = buildNvidiaNimExtraBody(thinkingEnabled, maxTokens);
 
-    return { ...opts, ...extra };
+    // Attach via the explicit extraBody channel — buildBody spreads it onto
+    // the wire body. (Loose unknown keys on the returned options object are
+    // dropped by buildBody, which is why the extras previously never reached
+    // the wire.)
+    return Object.keys(extra).length > 0
+      ? { ...opts, extraBody: extra as Record<string, unknown> }
+      : opts;
+  }
+
+  /**
+   * One-shot 400 retry (base hook): some NIM model servers reject
+   * `chat_template` or `chat_template_kwargs.reasoning_budget` with a 400
+   * naming the field. Strip the rejected field(s) and let the base retry
+   * once, restoring the pre-migration fetch-level behavior. Returns
+   * undefined for unrelated 400s so they propagate unchanged.
+   */
+  protected adjustBodyAfter400(
+    body: OpenAICompatChatRequest,
+    error: Error & { statusCode?: number; responseBody?: string },
+  ): OpenAICompatChatRequest | undefined {
+    const responseBody = error.responseBody ?? "";
+    let serialized = JSON.stringify(body);
+    const strippedFields: string[] = [];
+
+    for (const field of ["chat_template", "reasoning_budget"] as const) {
+      if (isNimFieldRejection(responseBody, field)) {
+        const next = stripFieldFromJsonBody(serialized, field);
+        if (next !== null) {
+          serialized = next;
+          strippedFields.push(field);
+        }
+      }
+    }
+
+    if (strippedFields.length === 0) {
+      return undefined;
+    }
+    logger.debug(
+      "NVIDIA NIM: 400 rejected request field(s) — retrying once without them",
+      {
+        strippedFields,
+        model: body.model,
+        rejection: responseBody.slice(0, 200),
+      },
+    );
+    return JSON.parse(serialized) as OpenAICompatChatRequest;
   }
 
   protected formatProviderError(error: unknown): Error {

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -170,6 +170,21 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   }
 
   /**
+   * Hook called when a request fails with HTTP 400. Return a modified body to
+   * retry ONCE with it; return undefined (default) to propagate the error
+   * unchanged. Applies on both the non-streaming doGenerate path and the
+   * streaming path. NVIDIA NIM uses this to strip `chat_template` /
+   * `chat_template_kwargs.reasoning_budget` when a model server rejects them,
+   * restoring the pre-migration fetch-level retry behavior.
+   */
+  protected adjustBodyAfter400(
+    _body: OpenAICompatChatRequest,
+    _error: Error & { statusCode?: number; responseBody?: string },
+  ): OpenAICompatChatRequest | undefined {
+    return undefined;
+  }
+
+  /**
    * Hook called once at the start of every `executeStream` invocation.
    * Return lifecycle listeners (onUsage / onFinish) to receive deferred
    * analytics events as the stream progresses. Default returns undefined
@@ -307,6 +322,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     const adjustBuildBodyOptions = this.adjustBuildBodyOptions.bind(this);
     const adjustResponseFormat = this.adjustResponseFormat.bind(this);
     const adjustRequestBody = this.adjustRequestBody.bind(this);
+    const adjustBodyAfter400 = this.adjustBodyAfter400.bind(this);
     const getTimeoutForOptions = (
       opts: Record<string, unknown> | undefined,
     ): number => this.getTimeout((opts ?? {}) as never);
@@ -394,11 +410,42 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             body: JSON.stringify(body),
             ...(composedSignal ? { signal: composedSignal } : {}),
           });
+          if (!res.ok) {
+            const apiErr = await buildAPIError(url, body, res);
+            // One-shot 400 retry: a subclass may strip a rejected field and
+            // return a modified body (e.g. NIM's chat_template /
+            // reasoning_budget). The retry runs under the SAME timeout
+            // controller as the first attempt, so the configured timeout caps
+            // the overall call — matching the streaming path, which reuses
+            // its composed signal for the retry.
+            const retryBody =
+              res.status === 400
+                ? adjustBodyAfter400(
+                    body,
+                    apiErr as Error & {
+                      statusCode?: number;
+                      responseBody?: string;
+                    },
+                  )
+                : undefined;
+            if (!retryBody) {
+              throw apiErr;
+            }
+            res = await fetchImpl(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                ...getAuthHeaders(),
+              },
+              body: JSON.stringify(retryBody),
+              ...(composedSignal ? { signal: composedSignal } : {}),
+            });
+            if (!res.ok) {
+              throw await buildAPIError(url, retryBody, res);
+            }
+          }
         } finally {
           timeoutController?.cleanup();
-        }
-        if (!res.ok) {
-          throw await buildAPIError(url, body, res);
         }
         const json = (await res.json()) as OpenAICompatChatResponse;
         const choice = json.choices?.[0];
@@ -410,8 +457,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         // Reasoner-model output (DeepSeek `reasoning_content`, gateway
         // `reasoning`) becomes a V3 reasoning part ahead of the text part —
         // GenerationHandler joins reasoning parts into `result.reasoning`.
+        // `||` so an empty-string reasoning_content falls through to a
+        // non-empty `reasoning` field instead of shadowing it.
         const reasoningText =
-          choice?.message?.reasoning_content ?? choice?.message?.reasoning;
+          choice?.message?.reasoning_content || choice?.message?.reasoning;
         if (typeof reasoningText === "string" && reasoningText.length > 0) {
           content.push({ type: "reasoning", text: reasoningText });
         }
@@ -447,12 +496,17 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             },
             outputTokens: {
               total: json.usage?.completion_tokens,
+              // Clamped at 0 — some gateways report inconsistent usage where
+              // reasoning_tokens exceeds completion_tokens.
               text:
                 json.usage?.completion_tokens !== undefined &&
                 json.usage?.completion_tokens_details?.reasoning_tokens !==
                   undefined
-                  ? json.usage.completion_tokens -
-                    json.usage.completion_tokens_details.reasoning_tokens
+                  ? Math.max(
+                      0,
+                      json.usage.completion_tokens -
+                        json.usage.completion_tokens_details.reasoning_tokens,
+                    )
                   : json.usage?.completion_tokens,
               reasoning:
                 json.usage?.completion_tokens_details?.reasoning_tokens,
@@ -815,7 +869,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         args.modelId,
       ),
     );
-    const res = await args.fetchImpl(args.url, {
+    let res = await args.fetchImpl(args.url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -825,7 +879,31 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       ...(args.abortSignal ? { signal: args.abortSignal } : {}),
     });
     if (!res.ok) {
-      throw await buildAPIError(args.url, body, res);
+      const apiErr = await buildAPIError(args.url, body, res);
+      // One-shot 400 retry — same hook as the doGenerate path (e.g. NIM
+      // strips chat_template/reasoning_budget when a model rejects them).
+      const retryBody =
+        res.status === 400
+          ? this.adjustBodyAfter400(
+              body,
+              apiErr as Error & { statusCode?: number; responseBody?: string },
+            )
+          : undefined;
+      if (!retryBody) {
+        throw apiErr;
+      }
+      res = await args.fetchImpl(args.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...this.getAuthHeaders(),
+        },
+        body: JSON.stringify(retryBody),
+        ...(args.abortSignal ? { signal: args.abortSignal } : {}),
+      });
+      if (!res.ok) {
+        throw await buildAPIError(args.url, retryBody, res);
+      }
     }
     if (!res.body) {
       throw new Error(`${this.providerName}: stream response had no body`);

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -490,6 +490,13 @@ export const buildBody = (
   if (responseFormat) {
     body.response_format = responseFormat;
   }
+  // Provider-specific extras attached via options.extraBody (the explicit
+  // channel from adjustBuildBodyOptions) land verbatim on the wire body.
+  // Spread last — a provider that puts a core field here is intentionally
+  // overriding it.
+  if (options.extraBody) {
+    Object.assign(body, options.extraBody);
+  }
   return body;
 };
 
@@ -535,7 +542,9 @@ export const parseSSEStream = async (
     // Reasoner-model deltas: DeepSeek/NIM emit `reasoning_content`, some
     // gateways emit `reasoning`. The AI SDK's openai-compatible wrapper
     // surfaced these automatically; the native client must do the same.
-    const reasoningDelta = delta?.reasoning_content ?? delta?.reasoning;
+    // `||` (not `??`) so an empty-string reasoning_content falls through to
+    // a non-empty `reasoning` field instead of shadowing it.
+    const reasoningDelta = delta?.reasoning_content || delta?.reasoning;
     if (reasoningDelta) {
       result.reasoning += reasoningDelta;
       onReasoningDelta?.(reasoningDelta);

--- a/src/lib/types/openaiCompatible.ts
+++ b/src/lib/types/openaiCompatible.ts
@@ -318,6 +318,14 @@ export type OpenAICompatBuildBodyArgs = {
     frequencyPenalty?: number | null;
     seed?: number | null;
     stopSequences?: string[];
+    /**
+     * Provider-specific extra wire fields, spread verbatim onto the final
+     * request body by `buildBody` (after the standard fields). This is the
+     * explicit channel for non-OpenAI knobs (e.g. NVIDIA NIM's `top_k` /
+     * `chat_template_kwargs`) — loose unknown keys returned from
+     * `adjustBuildBodyOptions` are intentionally NOT forwarded.
+     */
+    extraBody?: Record<string, unknown>;
   };
   tools?: OpenAICompatChatTool[];
   toolChoice?: OpenAICompatToolChoiceWire;

--- a/test/continuous-test-suite-new-providers.ts
+++ b/test/continuous-test-suite-new-providers.ts
@@ -1387,12 +1387,11 @@ async function section9Errors(): Promise<void> {
   // NIM-specific K5: retry-on-400 strips reasoning_budget
   // Disable tools so we don't trip NIM's tool-choice config error on certain
   // model servers (which is a server config issue, not what this test verifies).
-  // Note: the retry-on-400 strip mechanism currently lives in the NIM
-  // provider's `executeStream` only — `generate` doesn't retry. When the
-  // selected model genuinely doesn't accept `reasoning_budget`, NIM's
-  // generate path bubbles up the upstream "Bad Request" verbatim. We treat
-  // that as SKIP (provider-side feature gap that the dedicated stream-mode
-  // K5 covers) instead of FAIL.
+  // Note: the retry-on-400 strip now lives in the base's adjustBodyAfter400
+  // hook and applies on BOTH the generate and stream paths, so this generate
+  // probe should succeed via the one-shot retry. The SKIP below is kept as a
+  // tolerant fallback for upstream model servers whose 400 body doesn't name
+  // the rejected field (the strip only fires on a field-naming rejection).
   if (HAS_NIM) {
     await runProviderTest(
       "K5 error.nim.retry.budget",
@@ -1413,10 +1412,11 @@ async function section9Errors(): Promise<void> {
           return Boolean(res?.content); // should succeed via retry
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          // Bad-Request bubbled up = retry-strip didn't apply for generate.
+          // Bad-Request bubbled up = the 400 body didn't name the rejected
+          // field, so the strip-and-retry hook (correctly) didn't fire.
           if (/\bbad request\b|\b400\b/i.test(msg)) {
             throw new Skip(
-              "NIM rejected reasoning_budget; retry-strip is stream-only",
+              "NIM 400 without field-naming rejection; strip not applicable",
             );
           }
           // Timeout / abort surfaces because NIM ran cold or rate-limited.

--- a/test/continuous-test-suite-sse-client.ts
+++ b/test/continuous-test-suite-sse-client.ts
@@ -131,6 +131,25 @@ const deltaEvent = (
   );
 }
 
+{
+  // Empty-string reasoning_content must not shadow a non-empty `reasoning`
+  // (|| precedence — regression for the #1073 review nit).
+  const result = await parseSSEStream(
+    sseStream([
+      deltaEvent({ reasoning_content: "", reasoning: "fallback" }),
+      deltaEvent({ content: "ok" }, "stop"),
+      "[DONE]",
+    ]),
+    () => {},
+  );
+  recordTest(
+    "empty reasoning_content falls through to non-empty `reasoning`",
+    result.reasoning === "fallback",
+    false,
+    `got "${result.reasoning}"`,
+  );
+}
+
 // ───────────────────────────────────────────────────────────────────────
 // Section C — interleaved reasoning → content (deepseek-reasoner pattern)
 // ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Restores two NVIDIA NIM behaviors lost in the #1058 migration (flagged in its Copilot review, tracked as the base-support follow-up):

1. **Extras never reached the wire** — `adjustBuildBodyOptions` returns NIM extras (`top_k`, `min_p`, `repetition_penalty`, `min_tokens`, `chat_template`, `chat_template_kwargs.reasoning_budget`; all opt-in via `NVIDIA_NIM_*` env vars + the thinking signal), but `buildBody()` drops unknown option keys — so they were silently discarded.
2. **The 400 strip-and-retry was lost** — pre-migration, a 400 naming `chat_template`/`reasoning_budget` as rejected triggered one retry without the field. The helpers (`isNimFieldRejection`, `stripFieldFromJsonBody`) survived as exported-but-unused code, and the K5 probe expected the behavior.

## Base support (generalizes beyond NIM)

- **`options.extraBody` channel through `buildBody`** — provider-specific wire fields are spread verbatim onto the final body. Explicit opt-in only: loose unknown keys on the options object stay dropped, so nothing from the runtime `StreamOptions` leaks onto the wire.
- **`adjustBodyAfter400(body, error)` hook** — on an HTTP 400, a subclass may return a modified body to retry **once**; default propagates the error. Applied on **both** the `doGenerate` and streaming paths — an upgrade over the pre-migration stream-only retry (the K5 generate-path probe that previously had to SKIP should now pass).

## NIM wiring

- Extras attach via `extraBody` (the thinking-signal reading was already correct — only the passthrough was broken).
- `adjustBodyAfter400` reuses the previously-orphaned helpers verbatim: field-naming rejection detection (keyword within ±80 chars) + JSON-body strip; unrelated 400s propagate unchanged.
- K5 comments updated to the new mechanism (tolerant SKIP kept for 400 bodies that don't name the field).

## Validation

- `pnpm run check` — pass, 0 errors · lint — pass · stream-span audit — 106/106
- 5 files, +154/−14. Single commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic retry mechanism for failed requests—when specific fields cause validation errors, the provider now retries with those fields removed.

* **Bug Fixes**
  * Fixed reasoning content extraction to properly prioritize alternative fields when reasoning content is empty.
  * Fixed token count calculation to prevent negative values with reasoning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->