### PR TITLE
fix(providers): dedupe identical Gemini tool calls within a turn (BZ-3327)

### DIFF
--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -66,6 +66,7 @@ import {
   handleMaxStepsTermination,
   prependConversationMessages,
   pushModelResponseToHistory,
+  DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type { LanguageModel, Schema, Tool } from "../types/index.js";
@@ -735,7 +736,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Convert tools
           let toolsConfig: NativeToolsConfig | undefined;
-          let executeMap = new Map<string, Tool["execute"]>();
+          let executeMap = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
 
           if (
@@ -1134,7 +1135,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Convert tools (a0269210: trust options.tools — already merged + filtered upstream)
           let toolsConfig: NativeToolsConfig | undefined;
-          let executeMap = new Map<string, Tool["execute"]>();
+          let executeMap = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
 
           const shouldUseTools = !options.disableTools;

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -66,6 +66,7 @@ import {
   handleMaxStepsTermination,
   prependConversationMessages,
   pushModelResponseToHistory,
+  DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type { LanguageModel, Schema, Tool } from "../types/index.js";
@@ -735,7 +736,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Convert tools
           let toolsConfig: NativeToolsConfig | undefined;
-          let executeMap = new Map<string, Tool["execute"]>();
+          let executeMap: Map<string, Tool["execute"]> = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
 
           if (
@@ -1134,7 +1135,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Convert tools (a0269210: trust options.tools — already merged + filtered upstream)
           let toolsConfig: NativeToolsConfig | undefined;
-          let executeMap = new Map<string, Tool["execute"]>();
+          let executeMap: Map<string, Tool["execute"]> = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
 
           const shouldUseTools = !options.disableTools;

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -52,6 +52,59 @@ import {
 
 // ── Functions ──
 
+/** Stable, key-order-independent serialization of tool args for the dedup key. */
+function stableStringifyForDedup(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.keys(val as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, key) => {
+            acc[key] = (val as Record<string, unknown>)[key];
+            return acc;
+          }, {})
+      : val,
+  );
+}
+
+/**
+ * A per-turn tool execute map that deduplicates identical tool calls.
+ *
+ * Gemini occasionally re-emits a tool call with identical arguments across
+ * agentic steps even though the prior result is already in the conversation
+ * history (BZ-3327). Re-executing produces duplicate side effects and
+ * duplicate reports for the user, plus wasted tokens. This map caches the
+ * result of each {tool name + args} executed within the turn and returns it
+ * for any identical re-request instead of running the tool again.
+ *
+ * Providers build a fresh executeMap per request, so the cache scope is
+ * exactly one turn. Only `.get()` is overridden (the sole access path used by
+ * the native agentic loops), so iteration still yields the raw executors.
+ */
+export class DedupExecuteMap extends Map<string, Tool["execute"]> {
+  private readonly resultCache = new Map<string, unknown>();
+
+  override get(name: string): Tool["execute"] | undefined {
+    const execute = super.get(name);
+    if (!execute) {
+      return execute;
+    }
+    const resultCache = this.resultCache;
+    const wrapped: ToolExecuteFunction = async (args, options) => {
+      const key = `${name}::${stableStringifyForDedup(args)}`;
+      if (resultCache.has(key)) {
+        logger.warn(
+          `[DedupExecuteMap] Tool "${name}" re-requested with identical arguments in the same turn — reusing the previous result instead of re-executing.`,
+        );
+        return resultCache.get(key);
+      }
+      const result = await execute(args, options);
+      resultCache.set(key, result);
+      return result;
+    };
+    return wrapped as Tool["execute"];
+  }
+}
+
 /**
  * Google's `function_declarations[].name` validator regex.
  *
@@ -438,7 +491,7 @@ export function buildNativeToolDeclarations(
   tools: Record<string, Tool>,
 ): NativeToolDeclarationsResult {
   const functionDeclarations: NativeFunctionDeclaration[] = [];
-  const executeMap = new Map<string, Tool["execute"]>();
+  const executeMap = new DedupExecuteMap();
 
   const skippedTools: string[] = [];
   const renamedTools: Array<{ from: string; to: string }> = [];

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -55,6 +55,62 @@ import {
 
 // ── Functions ──
 
+/** Stable, key-order-independent serialization of tool args for the dedup key. */
+function stableStringifyForDedup(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.keys(val as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, key) => {
+            acc[key] = (val as Record<string, unknown>)[key];
+            return acc;
+          }, {})
+      : val,
+  );
+}
+
+/**
+ * A per-turn tool execute map that deduplicates identical tool calls.
+ *
+ * Gemini occasionally re-emits a tool call with identical arguments across
+ * agentic steps even though the prior result is already in the conversation
+ * history (BZ-3327). Re-executing produces duplicate side effects and
+ * duplicate reports for the user, plus wasted tokens. This map caches the
+ * result of each {tool name + args} executed within the turn and returns it
+ * for any identical re-request instead of running the tool again.
+ *
+ * Providers build a fresh executeMap per request, so the cache scope is
+ * exactly one turn. Only `.get()` is overridden (the sole access path used by
+ * the native agentic loops), so iteration still yields the raw executors.
+ */
+export class DedupExecuteMap extends Map<string, Tool["execute"]> {
+  private readonly resultCache = new Map<string, unknown>();
+
+  override get(name: string): Tool["execute"] | undefined {
+    const execute = super.get(name);
+    if (!execute) {
+      return execute;
+    }
+    const resultCache = this.resultCache;
+    const wrapped: ToolExecuteFunction<unknown, unknown> = async (
+      args,
+      options,
+    ) => {
+      const key = `${name}::${stableStringifyForDedup(args)}`;
+      if (resultCache.has(key)) {
+        logger.warn(
+          `[DedupExecuteMap] Tool "${name}" re-requested with identical arguments in the same turn — reusing the previous result instead of re-executing.`,
+        );
+        return resultCache.get(key);
+      }
+      const result = await execute(args, options);
+      resultCache.set(key, result);
+      return result;
+    };
+    return wrapped as Tool["execute"];
+  }
+}
+
 /**
  * Google's `function_declarations[].name` validator regex.
  *
@@ -441,7 +497,7 @@ export function buildNativeToolDeclarations(
   tools: Record<string, Tool>,
 ): NativeToolDeclarationsResult {
   const functionDeclarations: NativeFunctionDeclaration[] = [];
-  const executeMap = new Map<string, Tool["execute"]>();
+  const executeMap = new DedupExecuteMap();
 
   const skippedTools: string[] = [];
   const renamedTools: Array<{ from: string; to: string }> = [];

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -71,6 +71,7 @@ import {
   createTextChannel,
   extractThoughtSignature,
   prependConversationMessages,
+  DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import {
   ATTR,
@@ -1310,7 +1311,7 @@ export class GoogleVertexProvider extends BaseProvider {
     let tools:
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (
       options.tools &&
@@ -2135,7 +2136,7 @@ export class GoogleVertexProvider extends BaseProvider {
     let tools:
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (Object.keys(combinedTools).length > 0) {
       const functionDeclarations: VertexGenaiFunctionDeclaration[] = [];
@@ -2940,7 +2941,7 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (
       options.tools &&
@@ -3618,7 +3619,7 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
     const toolExecutions: Array<{
       name: string;
       input: Record<string, unknown>;

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -100,6 +100,7 @@ import {
   mapGeminiFinishReason,
   prependConversationMessages,
   resolveTurnStopReason,
+  DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import { getContextWindowSize } from "../constants/contextWindows.js";
 import {
@@ -124,7 +125,7 @@ import {
   extractMcpToolErrorMessage,
   extractToolFailureText,
 } from "../utils/mcpErrorText.js";
-import type { Schema, LanguageModel, Tool } from "../types/index.js";
+import type { Schema, LanguageModel } from "../types/index.js";
 
 // Import proper types for multimodal message handling
 
@@ -1556,7 +1557,7 @@ export class GoogleVertexProvider extends BaseProvider {
     let tools:
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (
       options.tools &&
@@ -2735,7 +2736,7 @@ export class GoogleVertexProvider extends BaseProvider {
     let tools:
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (Object.keys(combinedTools).length > 0) {
       const functionDeclarations: VertexGenaiFunctionDeclaration[] = [];
@@ -4044,7 +4045,7 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
 
     if (
       options.tools &&
@@ -5698,7 +5699,7 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;
-    const executeMap = new Map<string, Tool["execute"]>();
+    const executeMap = new DedupExecuteMap();
     const toolExecutions: Array<{
       name: string;
       input: Record<string, unknown>;

--- a/test/providers/dedupExecuteMap.test.ts
+++ b/test/providers/dedupExecuteMap.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { DedupExecuteMap } from "../../src/lib/providers/googleNativeGemini3.js";
+
+/**
+ * BZ-3327: Gemini occasionally re-emits an identical tool call across agentic
+ * steps even though the prior result is already in history, which produced
+ * duplicate tool executions and duplicate reports. DedupExecuteMap caches the
+ * result of each {tool name + args} per turn so identical re-requests reuse the
+ * previous result instead of re-executing.
+ */
+describe("DedupExecuteMap — per-turn tool-call dedup (BZ-3327)", () => {
+  it("executes the tool on first call and returns its result", async () => {
+    const exec = vi.fn(async (args: Record<string, unknown>) => ({ ok: true, args }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+
+    const result = await (map.get("report") as never as typeof exec)(
+      { range: "7d" },
+      {} as never,
+    );
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, args: { range: "7d" } });
+  });
+
+  it("reuses the cached result for an identical re-call without re-executing", async () => {
+    const exec = vi.fn(async () => ({ value: 42 }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    const first = await run({}, {} as never);
+    const second = await run({ x: 1 }, {} as never);
+    const third = await run({ x: 1 }, {} as never);
+
+    // first call ({}) and the ({x:1}) call execute; the second ({x:1}) is cached
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(third).toBe(second);
+    expect(first).not.toBe(second);
+  });
+
+  it("re-executes when args differ", async () => {
+    const exec = vi.fn(async (args: Record<string, unknown>) => ({ args }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    await run({ range: "7d" }, {} as never);
+    await run({ range: "30d" }, {} as never);
+
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats identical args with different key order as the same call", async () => {
+    const exec = vi.fn(async () => ({ ok: true }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    await run({ a: 1, b: { d: 4, c: 3 } }, {} as never);
+    await run({ b: { c: 3, d: 4 }, a: 1 }, {} as never);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes per tool name — different tools are independent", async () => {
+    const execA = vi.fn(async () => "A");
+    const execB = vi.fn(async () => "B");
+    const map = new DedupExecuteMap();
+    map.set("a", execA as never);
+    map.set("b", execB as never);
+
+    await (map.get("a") as never as typeof execA)({}, {} as never);
+    await (map.get("b") as never as typeof execB)({}, {} as never);
+
+    expect(execA).toHaveBeenCalledTimes(1);
+    expect(execB).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined for an unknown tool (no wrapping)", () => {
+    const map = new DedupExecuteMap();
+    expect(map.get("missing")).toBeUndefined();
+  });
+});

--- a/test/providers/dedupExecuteMap.test.ts
+++ b/test/providers/dedupExecuteMap.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { DedupExecuteMap } from "../../src/lib/providers/googleNativeGemini3.js";
+
+/**
+ * BZ-3327: Gemini occasionally re-emits an identical tool call across agentic
+ * steps even though the prior result is already in history, which produced
+ * duplicate tool executions and duplicate reports. DedupExecuteMap caches the
+ * result of each {tool name + args} per turn so identical re-requests reuse the
+ * previous result instead of re-executing.
+ */
+describe("DedupExecuteMap — per-turn tool-call dedup (BZ-3327)", () => {
+  it("executes the tool on first call and returns its result", async () => {
+    const exec = vi.fn(async (args: Record<string, unknown>) => ({
+      ok: true,
+      args,
+    }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+
+    const result = await (map.get("report") as never as typeof exec)(
+      { range: "7d" },
+      {} as never,
+    );
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, args: { range: "7d" } });
+  });
+
+  it("reuses the cached result for an identical re-call without re-executing", async () => {
+    const exec = vi.fn(async () => ({ value: 42 }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    const first = await run({}, {} as never);
+    const second = await run({ x: 1 }, {} as never);
+    const third = await run({ x: 1 }, {} as never);
+
+    // first call ({}) and the ({x:1}) call execute; the second ({x:1}) is cached
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(third).toBe(second);
+    expect(first).not.toBe(second);
+  });
+
+  it("re-executes when args differ", async () => {
+    const exec = vi.fn(async (args: Record<string, unknown>) => ({ args }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    await run({ range: "7d" }, {} as never);
+    await run({ range: "30d" }, {} as never);
+
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats identical args with different key order as the same call", async () => {
+    const exec = vi.fn(async () => ({ ok: true }));
+    const map = new DedupExecuteMap();
+    map.set("report", exec as never);
+    const run = map.get("report") as never as typeof exec;
+
+    await run({ a: 1, b: { d: 4, c: 3 } }, {} as never);
+    await run({ b: { c: 3, d: 4 }, a: 1 }, {} as never);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes per tool name — different tools are independent", async () => {
+    const execA = vi.fn(async () => "A");
+    const execB = vi.fn(async () => "B");
+    const map = new DedupExecuteMap();
+    map.set("a", execA as never);
+    map.set("b", execB as never);
+
+    await (map.get("a") as never as typeof execA)({}, {} as never);
+    await (map.get("b") as never as typeof execB)({}, {} as never);
+
+    expect(execA).toHaveBeenCalledTimes(1);
+    expect(execB).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined for an unknown tool (no wrapping)", () => {
+    const map = new DedupExecuteMap();
+    expect(map.get("missing")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## BZ-3327 — Duplicate tool calls in chat (Gemini)

### Problem
In chat mode the same report tool (GA4 / meta-ads `get_campaigns`, `get_insights`, …) executes **twice with identical inputs in a single turn**, producing duplicate reports for users plus extra latency and wasted tokens.

Confirmed from prod traces: in one request, `meta-ads get_insights` and `get_campaigns` each ran **twice, ~4s apart** — a *second agentic step* re-running the same calls.

### Root cause
The native Gemini agentic loop (`googleVertex` / `googleAiStudio`, `while (step < maxSteps)`) is **structurally correct** — it appends the model's `functionCall` then the `functionResponse` to history and re-sends the full history each step. The model nonetheless **re-emits identical tool calls** across steps (already acknowledged in `handleMaxStepsTermination`: *"the model continued requesting tool calls beyond the limit"*). The loop faithfully executes every re-request → duplicate execution.

### Fix
Add **`DedupExecuteMap`** — a per-turn `executeMap` (built fresh per request, so cache scope = one turn) whose `.get()` returns an execute wrapped with a `{tool name + args}` result cache. On an identical in-turn re-request it reuses the previous result instead of re-executing (also skipping the wrapped `execute` that emits the duplicate tool event). Args are serialized key-order-independently.

Swapped in at every Gemini `executeMap` construction — `googleVertex` (×4), `googleAiStudio` (×2), `googleNativeGemini3` (×1) — covering both vertex's inline execution and the shared `executeNativeToolCalls` path. Only `.get()` is overridden, so iteration still yields raw executors.

### Tests
`test/providers/dedupExecuteMap.test.ts` — first-call executes; identical re-call reuses cache; differing args re-execute; key-order-independent dedup; per-tool isolation; unknown tool → undefined.

### Notes
- Per-turn only — a fresh user message gets fresh data.
- Anthropic/OpenAI have their own loops; this targets the Gemini path where the duplicate was confirmed in prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Improved native tool execution by deduplicating repeated tool calls within the same response when the same tool is requested with identical arguments, reducing unnecessary re-executions and speeding up results.

* **Bug Fixes**
  * Prevented redundant re-running of tools caused by repeated identical tool requests during a single turn.

* **Tests**
  * Added automated coverage to verify per-turn deduplication behavior, including stable argument handling and isolation across different tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->