### PR TITLE
fix(providers): prevent unhandled auth rejection from unused AnthropicVertex client

### DIFF
--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -2734,7 +2734,23 @@ export class GoogleVertexProvider extends BaseProvider {
       this.location,
       timeoutMs,
     );
-    return new mod.AnthropicVertex(settings);
+    const client = new mod.AnthropicVertex(settings);
+    // The vertex SDK eagerly starts Google ADC resolution in its constructor
+    // (`this._authClientPromise = this._auth.getClient()`) and only awaits it
+    // per-request in `prepareOptions()`. A client that is constructed but never
+    // used — or built with misconfigured credentials — would otherwise leak
+    // that rejection as a process-level `unhandledRejection`. Attaching a
+    // handler here marks the promise as handled (so Node no longer reports it);
+    // it does not consume the rejection — the per-request `await` in
+    // `prepareOptions()` is a separate continuation and still surfaces auth
+    // errors to callers. `void` flags the returned promise as deliberately
+    // ignored (codebase convention for fire-and-forget).
+    void (
+      client as unknown as { _authClientPromise?: Promise<unknown> }
+    )._authClientPromise?.catch(() => {
+      // Intentionally ignored — see above.
+    });
+    return client;
   }
 
   /**

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -185,6 +185,64 @@ const tests: TestFunction[] = [
         },
       ),
   },
+  {
+    name: "GoogleVertexProvider: Anthropic Vertex client construction does not leak unhandledRejection",
+    category: "vertex-anthropic",
+    fn: async () => {
+      // Regression: the vertex SDK constructor eagerly runs
+      // `this._authClientPromise = this._auth.getClient()` and only awaits it
+      // per-request. With unresolvable creds and no request, that rejected
+      // promise used to surface as a process-level unhandledRejection (which
+      // then polluted unrelated tests). createAnthropicVertexClient now attaches
+      // a catch. Detect only auth/creds-shaped leaks so this never false-fails
+      // on an unrelated rejection originating in another test.
+      let leaked = false;
+      const onUnhandled = (reason: unknown) => {
+        const text =
+          reason instanceof Error
+            ? (reason.stack ?? reason.message)
+            : String(reason);
+        if (
+          /creds|credential|ENOENT|GoogleAuth|getClient|application[_ ]?default/i.test(
+            text,
+          )
+        ) {
+          leaked = true;
+        }
+      };
+      process.on("unhandledRejection", onUnhandled);
+      try {
+        return await withTemporaryEnv(
+          {
+            GOOGLE_APPLICATION_CREDENTIALS:
+              "/tmp/neurolink-nonexistent-creds.json",
+            GOOGLE_CLOUD_PROJECT_ID: "test-project",
+            GOOGLE_CLOUD_LOCATION: "us-east5",
+          },
+          async () => {
+            const provider = new GoogleVertexProvider(
+              "claude-sonnet-4@20250514",
+              undefined,
+              undefined,
+              "us-east5",
+            );
+            await (
+              provider as unknown as {
+                createAnthropicVertexClient(
+                  timeoutMs?: number,
+                ): Promise<unknown>;
+              }
+            ).createAnthropicVertexClient(60_000);
+            // Let GoogleAuth's async ADC read settle + (previously) reject.
+            await new Promise((r) => setTimeout(r, 150));
+            return !leaked;
+          },
+        );
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+    },
+  },
 
   // ---------- Proxy routing: simplified ----------
   {


### PR DESCRIPTION
## Problem

The `@anthropic-ai/vertex-sdk` constructor eagerly resolves Google ADC and only awaits it per-request:

```js
this._auth = opts.googleAuth ?? new GoogleAuth({ ... });
this._authClientPromise = this._auth.getClient();   // eager, uncaught
// …only awaited later, per request, in prepareOptions()
```

A Vertex **Claude** client that is **constructed but never used** — or built with **misconfigured/missing credentials** — leaks that rejection as a process-level `unhandledRejection`. This can crash strict Node processes, and in the test suite it pollutes an unrelated assertion: `continuous-test-suite-bugfixes`'s *"executeStream HTTP failure does not produce unhandledRejection"* failed because the first vertex test's ENOENT auth rejection landed inside its listener window (confirmed via a global `unhandledRejection` tracer).

## Fix

`createAnthropicVertexClient` attaches a no-op `.catch` to the eager `_authClientPromise`. Real auth failures are unaffected — `prepareOptions()` still awaits the same promise on first use and surfaces the error to callers (each awaiter settles independently).

## Tests

- New regression test: construction with unresolvable creds produces no auth-shaped `unhandledRejection`.
- `test:bugfixes` **80/80** (was 78/79 — the polluted test now passes deterministically).
- `check` / `lint` / `test:stream-span` (106/106) green.