### PR TITLE
feat(observability): emit Langfuse spans for the native Vertex provider path

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "test:log-sanitize": "npx tsx test/continuous-test-suite-log-sanitize.ts",
     "test:sse-client": "npx tsx test/continuous-test-suite-sse-client.ts",
     "test:stream-span": "npx tsx test/continuous-test-suite-stream-span.ts",
+    "test:vertex-langfuse-spans": "npx tsx test/continuous-test-suite-vertex-langfuse-spans.ts",
     "test:credentials": "npx tsx test/continuous-test-suite-credentials.ts",
     "test:dynamic": "npx tsx test/continuous-test-suite-dynamic.ts",
     "test:proxy": "npx tsx test/continuous-test-suite-proxy.ts",

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -164,12 +164,14 @@ import {
 import { SpanSerializer } from "./observability/utils/spanSerializer.js";
 import {
   flushOpenTelemetry,
+  getLangfuseContext,
   getLangfuseHealthStatus,
   initializeOpenTelemetry,
   isOpenTelemetryInitialized,
   runWithCurrentLangfuseContext,
   setLangfuseContext,
   shutdownOpenTelemetry,
+  stampGuestRescueIdentity,
 } from "./services/server/ai/observability/instrumentation.js";
 import { TaskManager } from "./tasks/taskManager.js";
 import { createTaskTools } from "./tasks/tools/taskTools.js";
@@ -1941,11 +1943,9 @@ Current user's request: ${currentInput}`;
     responseContent: string,
     userId: string,
     additionalUsers?: AdditionalMemoryUser[],
+    langfuseIdentity?: { traceName?: string | null; sessionId?: string | null },
   ): void {
-    // Preserve AsyncLocalStorage context across setImmediate boundary so that
-    // memory writes appear under the originating Langfuse trace instead of
-    // becoming orphan spans.
-    const wrappedMemoryWrite = runWithCurrentLangfuseContext(async () => {
+    const memoryWrite = async () => {
       try {
         const client = this.ensureMemoryReady();
         if (!client) {
@@ -1981,7 +1981,27 @@ Current user's request: ${currentInput}`;
       } catch (error) {
         logger.warn("Memory storage failed:", error);
       }
-    });
+    };
+
+    // Carry the turn's identity across the setImmediate boundary so the
+    // condensation generate + redis spans don't orphan to "guest". Keep the
+    // ambient store when it survived (generate path — carries conversationId,
+    // metadata, …); re-establish from the caller only when it was lost (stream
+    // path, which fires after the caller consumed the stream).
+    const ambient = getLangfuseContext();
+    const wrappedMemoryWrite =
+      !(ambient?.traceName || ambient?.userId) &&
+      (langfuseIdentity?.traceName || langfuseIdentity?.sessionId)
+        ? () =>
+            setLangfuseContext(
+              {
+                userId,
+                sessionId: langfuseIdentity.sessionId ?? null,
+                traceName: langfuseIdentity.traceName ?? null,
+              },
+              memoryWrite,
+            )
+        : runWithCurrentLangfuseContext(memoryWrite);
     setImmediate(wrappedMemoryWrite);
   }
 
@@ -3693,13 +3713,24 @@ Current user's request: ${currentInput}`;
       return await this.runWithFallbackOrchestration(
         optionsOrPrompt,
         "generate",
-        (opts) =>
-          tracers.sdk.startActiveSpan(
+        (opts) => {
+          // Capture root-ness before startActiveSpan makes generateSpan active.
+          // The actual guest-rescue stamp is deferred to executeGenerateRequest,
+          // AFTER prepareGenerateRequest merges auth/requestContext-derived
+          // identity into options.context — otherwise an auth:{token} caller
+          // with no pre-set context.userId would stamp the root span as guest.
+          const generateIsRoot = !trace.getSpan(context.active());
+          return tracers.sdk.startActiveSpan(
             "neurolink.generate",
             { kind: SpanKind.INTERNAL },
             (generateSpan) =>
-              this.executeGenerateWithMetricsContext(opts, generateSpan),
-          ),
+              this.executeGenerateWithMetricsContext(
+                opts,
+                generateSpan,
+                generateIsRoot,
+              ),
+          );
+        },
       );
     } catch (error) {
       // Lifecycle middleware (wrapGenerate.catch in builtin/lifecycle.ts)
@@ -3933,16 +3964,19 @@ Current user's request: ${currentInput}`;
   private async executeGenerateWithMetricsContext(
     optionsOrPrompt: GenerateOptions | DynamicOptions | string,
     generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+    isRootSpan: boolean,
   ): Promise<GenerateResult> {
     return metricsTraceContextStorage.run(
       this.createMetricsTraceContext(),
-      () => this.executeGenerateRequest(optionsOrPrompt, generateSpan),
+      () =>
+        this.executeGenerateRequest(optionsOrPrompt, generateSpan, isRootSpan),
     );
   }
 
   private async executeGenerateRequest(
     optionsOrPrompt: GenerateOptions | DynamicOptions | string,
     generateSpan: ReturnType<typeof tracers.sdk.startSpan>,
+    isRootSpan: boolean,
   ): Promise<GenerateResult> {
     let resolvedOptions: GenerateOptions | undefined;
     try {
@@ -3951,6 +3985,9 @@ Current user's request: ${currentInput}`;
         generateSpan,
       );
       resolvedOptions = options;
+      // Stamp now that prepareGenerateRequest has merged any auth/requestContext
+      // identity into options.context (see capture of isRootSpan in generate()).
+      stampGuestRescueIdentity(generateSpan, options.context, isRootSpan);
       const earlyResult = await this.maybeHandleEarlyGenerateResult(
         options,
         generateSpan,
@@ -4742,6 +4779,7 @@ Current user's request: ${currentInput}`;
         generateResult.content.trim(),
         options.context.userId as string,
         options.memory?.additionalUsers,
+        options.context as { traceName?: string; sessionId?: string },
       );
     }
   }
@@ -7511,12 +7549,22 @@ Current user's request: ${currentInput}`;
         [ATTR.NL_PROVIDER]: (options.provider as string) || "default",
         [ATTR.GEN_AI_MODEL]: options.model || "default",
         [ATTR.NL_INPUT_LENGTH]: options.input?.text?.length || 0,
-        [ATTR.NL_HAS_TOOLS]: !!(
-          options.tools && Object.keys(options.tools).length > 0
-        ),
+        // Count registered custom tools too — chat hosts put their MCP tools
+        // in the registry, so options.tools alone under-reports.
+        [ATTR.NL_HAS_TOOLS]:
+          !options.disableTools &&
+          (!!(options.tools && Object.keys(options.tools).length > 0) ||
+            this.getCustomTools().size > 0),
         [ATTR.NL_STREAM_MODE]: true,
       },
     });
+
+    // streamSpan isn't active yet, so context.active() is its parent — empty =
+    // root. Capture root-ness here, but defer the actual guest-rescue stamp to
+    // after validateStreamRequestOptions merges auth/requestContext identity
+    // into options.context (below) — otherwise an auth:{token} caller with no
+    // pre-set context.userId would stamp the root span as guest.
+    const streamIsRoot = !trace.getSpan(context.active());
     const spanStartTime = Date.now();
     this._disableToolCacheForCurrentRequest = !!options.disableToolCache;
 
@@ -7569,6 +7617,9 @@ Current user's request: ${currentInput}`;
       options.fileRegistry = this.fileRegistry;
       await this.validateStreamRequestOptions(options, startTime);
 
+      // options.context now carries any auth/requestContext-derived identity.
+      stampGuestRescueIdentity(streamSpan, options.context, streamIsRoot);
+
       const workflowResult = await this.maybeHandleWorkflowStreamRequest({
         options,
         startTime,
@@ -7578,6 +7629,10 @@ Current user's request: ${currentInput}`;
       if (workflowResult) {
         return workflowResult;
       }
+
+      // Make neurolink.stream the active span so every provider span (generations,
+      // tool calls) parents under it — one Langfuse trace per turn, not a forest.
+      const streamSpanContext = trace.setSpan(context.active(), streamSpan);
 
       // TTS Mode 2 deferred: stream() emits text first, then synthesizes the
       // accumulated response into a single audio chunk at end-of-stream and
@@ -7598,9 +7653,8 @@ Current user's request: ${currentInput}`;
           })
         : undefined;
 
-      const streamResult = await this.setLangfuseContextFromOptions(
-        options,
-        () =>
+      const streamResult = await context.with(streamSpanContext, () =>
+        this.setLangfuseContextFromOptions(options, () =>
           this.runStandardStreamRequest({
             options,
             streamSpan,
@@ -7611,6 +7665,7 @@ Current user's request: ${currentInput}`;
             originalPrompt,
             ttsResolver: resolveStreamTtsAudio,
           }),
+        ),
       );
       if (streamSttTranscription) {
         streamResult.transcription = streamSttTranscription;
@@ -8884,6 +8939,7 @@ Current user's request: ${currentInput}`;
         accumulatedContent.trim(),
         enhancedOptions.context?.userId as string,
         enhancedOptions.memory?.additionalUsers,
+        enhancedOptions.context as { traceName?: string; sessionId?: string },
       );
     }
   }

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -77,13 +77,23 @@ import {
 } from "./googleNativeGemini3.js";
 import {
   ATTR,
+  LANGFUSE_ATTR,
+  spanJsonAttribute,
   tracers,
   withClientSpan,
   withClientStreamSpan,
   withSpan,
 } from "../telemetry/index.js";
+import {
+  SpanKind,
+  SpanStatusCode,
+  context as otelContext,
+  trace as otelTrace,
+} from "@opentelemetry/api";
 import { calculateCost } from "../utils/pricing.js";
 import { transformToolExecutions } from "../utils/transformationUtils.js";
+import { sanitizeAnthropicMessagesForTrace } from "../utils/anthropicTraceSanitizer.js";
+import { extractMcpToolErrorMessage } from "../utils/mcpErrorText.js";
 import type { Schema, LanguageModel, Tool } from "../types/index.js";
 
 // Import proper types for multimodal message handling
@@ -3177,6 +3187,52 @@ export class GoogleVertexProvider extends BaseProvider {
     const toolsUsedRef: string[] = [];
     const structuredOutputRef: { value?: Record<string, unknown> } = {};
 
+    // Langfuse/OTel: the native SDK bypasses the Vercel AI SDK's
+    // experimental_telemetry, so emit spans manually — one turn span, one
+    // generation span per API call, one tool span per execution — all carrying
+    // langfuse.* attributes the LangfuseSpanProcessor maps to observations.
+    // Usage lives ONLY on the generation spans (Langfuse sums usage across
+    // observations for trace totals, so repeating it on the turn double-counts).
+    const offeredToolNames = (tools ?? []).map(
+      (anthropicTool) => anthropicTool.name,
+    );
+    const turnInputAttribute = spanJsonAttribute({
+      system: systemPromptWithSchema,
+      messages: sanitizeAnthropicMessagesForTrace(messages),
+    });
+    const turnSpan = tracers.provider.startSpan("anthropic.vertex.stream", {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        // Mark as span, not generation — without it Langfuse infers "generation"
+        // from the gen_ai.* attributes; the model calls live in child spans.
+        [LANGFUSE_ATTR.OBSERVATION_TYPE]: "span",
+        [ATTR.GEN_AI_SYSTEM]: "anthropic",
+        [ATTR.GEN_AI_MODEL]: modelName,
+        [ATTR.GEN_AI_OPERATION]: "stream",
+        [ATTR.NL_PROVIDER]: this.providerName,
+        [ATTR.NL_TOOL_COUNT]: offeredToolNames.length,
+        [LANGFUSE_ATTR.OBSERVATION_INPUT]: turnInputAttribute,
+        // Also lift IO to the trace — Langfuse reads trace input/output from
+        // langfuse.trace.* and the trace list is unreadable without it.
+        [LANGFUSE_ATTR.TRACE_INPUT]: turnInputAttribute,
+        [LANGFUSE_ATTR.OBSERVATION_METADATA]: spanJsonAttribute({
+          toolsOffered: offeredToolNames,
+          toolCount: offeredToolNames.length,
+          maxSteps,
+          structuredOutput: useFinalResultTool,
+        }),
+      },
+    });
+    const turnContext = otelTrace.setSpan(otelContext.active(), turnSpan);
+    let aggregatedTurnText = "";
+    // Anthropic prompt-cache token accounting, aggregated across loop steps.
+    const turnCacheUsage = {
+      read: 0,
+      creation: 0,
+      creation5m: 0,
+      creation1h: 0,
+    };
+
     // Track the active Anthropic stream so options.abortSignal can cancel it
     // mid-flight (pre-rewrite code had no abort handling — fixed for free).
     let activeStream:
@@ -3213,34 +3269,156 @@ export class GoogleVertexProvider extends BaseProvider {
           }
           step++;
 
-          const stream = await client.messages.stream({
-            ...requestParams,
-            messages: currentMessages as Parameters<
-              typeof client.messages.stream
-            >[0]["messages"],
-          });
-          activeStream = stream;
+          // One generation observation per API call: request in, content + usage out.
+          const generationSpan = tracers.generation.startSpan(
+            "anthropic.messages.stream",
+            {
+              kind: SpanKind.CLIENT,
+              attributes: {
+                [LANGFUSE_ATTR.OBSERVATION_TYPE]: "generation",
+                [LANGFUSE_ATTR.OBSERVATION_MODEL_NAME]: modelName,
+                [LANGFUSE_ATTR.OBSERVATION_MODEL_PARAMETERS]: spanJsonAttribute(
+                  {
+                    max_tokens: requestParams.max_tokens,
+                    temperature: requestParams.temperature,
+                    top_p: requestParams.top_p,
+                  },
+                ),
+                [LANGFUSE_ATTR.OBSERVATION_INPUT]: spanJsonAttribute({
+                  system: systemPromptWithSchema,
+                  messages: sanitizeAnthropicMessagesForTrace(currentMessages),
+                }),
+                [LANGFUSE_ATTR.OBSERVATION_METADATA]: spanJsonAttribute({
+                  step,
+                  toolsOffered: offeredToolNames.length,
+                }),
+                [ATTR.GEN_AI_SYSTEM]: "anthropic",
+                [ATTR.GEN_AI_MODEL]: modelName,
+                [ATTR.GEN_AI_OPERATION]: "chat",
+              },
+            },
+            turnContext,
+          );
 
-          // Forward each text delta to the consumer as it arrives. The
-          // Anthropic SDK fires this listener synchronously for every
-          // content_block_delta SSE event, so the channel sees bytes at
-          // the same cadence the wire delivers them.
-          stream.on("text", (delta: string) => {
-            if (delta.length > 0) {
-              channel.push(delta);
+          let response: Awaited<
+            ReturnType<
+              Awaited<ReturnType<typeof client.messages.stream>>["finalMessage"]
+            >
+          >;
+          try {
+            const stream = await client.messages.stream({
+              ...requestParams,
+              messages: currentMessages as Parameters<
+                typeof client.messages.stream
+              >[0]["messages"],
+            });
+            activeStream = stream;
+
+            // Forward each text delta as it arrives — the Anthropic SDK fires
+            // this synchronously per content_block_delta, so the channel streams
+            // at wire cadence. The first delta stamps completion_start_time,
+            // giving Langfuse the generation's time-to-first-token.
+            let firstDeltaSeen = false;
+            stream.on("text", (delta: string) => {
+              if (delta.length > 0) {
+                if (!firstDeltaSeen) {
+                  firstDeltaSeen = true;
+                  generationSpan.setAttribute(
+                    LANGFUSE_ATTR.OBSERVATION_COMPLETION_START_TIME,
+                    new Date().toISOString(),
+                  );
+                }
+                channel.push(delta);
+              }
+            });
+
+            // finalMessage() resolves AFTER message_stop. By then the listener
+            // has already fired for every delta — awaiting here doesn't block
+            // visible streaming, it just gives us the structured response
+            // shape needed for tool_use block extraction.
+            response = await stream.finalMessage();
+          } catch (modelCallError) {
+            generationSpan.setStatus({
+              code: SpanStatusCode.ERROR,
+              message:
+                modelCallError instanceof Error
+                  ? modelCallError.message
+                  : String(modelCallError),
+            });
+            if (modelCallError instanceof Error) {
+              generationSpan.recordException(modelCallError);
             }
-          });
-
-          // finalMessage() resolves AFTER message_stop. By then the listener
-          // has already fired for every delta — awaiting here doesn't block
-          // visible streaming, it just gives us the structured response
-          // shape needed for tool_use block extraction.
-          const response = await stream.finalMessage();
+            generationSpan.end();
+            throw modelCallError;
+          }
           activeStream = undefined;
 
-          usage.input += response.usage?.input_tokens || 0;
-          usage.output += response.usage?.output_tokens || 0;
-          usage.total = usage.input + usage.output;
+          // End the generation span even if the bookkeeping below throws (else
+          // it leaks). The model-call error path already ended it — no double-end.
+          try {
+            const stepCacheRead = response.usage?.cache_read_input_tokens ?? 0;
+            const stepCacheCreation =
+              response.usage?.cache_creation_input_tokens ?? 0;
+            const stepCacheCreation5m =
+              response.usage?.cache_creation?.ephemeral_5m_input_tokens ?? 0;
+            const stepCacheCreation1h =
+              response.usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
+            turnCacheUsage.read += stepCacheRead;
+            turnCacheUsage.creation += stepCacheCreation;
+            turnCacheUsage.creation5m += stepCacheCreation5m;
+            turnCacheUsage.creation1h += stepCacheCreation1h;
+
+            usage.input += response.usage?.input_tokens || 0;
+            usage.output += response.usage?.output_tokens || 0;
+            usage.total = usage.input + usage.output;
+
+            for (const block of response.content) {
+              if (block.type === "text" && typeof block.text === "string") {
+                aggregatedTurnText += block.text;
+              }
+            }
+
+            generationSpan.setAttribute(
+              LANGFUSE_ATTR.OBSERVATION_OUTPUT,
+              spanJsonAttribute(response.content),
+            );
+            // 5m and 1h cache-creation are priced differently, so keep both;
+            // drop the aggregate input_cache_creation (= 5m + 1h) that would
+            // double-count. total sums the per-TTL keys shown here to match them.
+            generationSpan.setAttribute(
+              LANGFUSE_ATTR.OBSERVATION_USAGE_DETAILS,
+              spanJsonAttribute({
+                input: response.usage?.input_tokens ?? 0,
+                output: response.usage?.output_tokens ?? 0,
+                input_cached_tokens: stepCacheRead,
+                input_cache_creation_5m: stepCacheCreation5m,
+                input_cache_creation_1h: stepCacheCreation1h,
+                total:
+                  (response.usage?.input_tokens ?? 0) +
+                  (response.usage?.output_tokens ?? 0) +
+                  stepCacheRead +
+                  stepCacheCreation5m +
+                  stepCacheCreation1h,
+              }),
+            );
+            generationSpan.setAttribute(
+              ATTR.GEN_AI_INPUT_TOKENS,
+              response.usage?.input_tokens ?? 0,
+            );
+            generationSpan.setAttribute(
+              ATTR.GEN_AI_OUTPUT_TOKENS,
+              response.usage?.output_tokens ?? 0,
+            );
+            if (response.stop_reason) {
+              generationSpan.setAttribute(
+                ATTR.GEN_AI_FINISH_REASON,
+                response.stop_reason,
+              );
+            }
+            generationSpan.setStatus({ code: SpanStatusCode.OK });
+          } finally {
+            generationSpan.end();
+          }
 
           const toolUseBlocks = (
             response.content as VertexAnthropicContentBlock[]
@@ -3313,6 +3491,54 @@ export class GoogleVertexProvider extends BaseProvider {
               args: toolUse.input,
             });
 
+            // One tool observation per execution. ai.toolCall.* names follow the
+            // Vercel AI SDK convention so existing tooling keeps working.
+            const toolSpan = tracers.mcp.startSpan(
+              "ai.toolCall",
+              {
+                kind: SpanKind.INTERNAL,
+                attributes: {
+                  [LANGFUSE_ATTR.OBSERVATION_TYPE]: "tool",
+                  [ATTR.GEN_AI_TOOL_NAME]: toolUse.name,
+                  "ai.toolCall.name": toolUse.name,
+                  "ai.toolCall.id": toolUse.id,
+                  "ai.toolCall.args": spanJsonAttribute(toolUse.input, 20_000),
+                  [LANGFUSE_ATTR.OBSERVATION_INPUT]: spanJsonAttribute(
+                    toolUse.input,
+                    20_000,
+                  ),
+                  [LANGFUSE_ATTR.OBSERVATION_METADATA]: spanJsonAttribute({
+                    step,
+                  }),
+                },
+              },
+              turnContext,
+            );
+            const endToolSpan = (output: unknown, errorMessage?: string) => {
+              toolSpan.setAttribute(
+                "ai.toolCall.result",
+                spanJsonAttribute(output),
+              );
+              toolSpan.setAttribute(
+                LANGFUSE_ATTR.OBSERVATION_OUTPUT,
+                spanJsonAttribute(output),
+              );
+              if (errorMessage) {
+                toolSpan.setAttribute(LANGFUSE_ATTR.OBSERVATION_LEVEL, "ERROR");
+                toolSpan.setAttribute(
+                  LANGFUSE_ATTR.OBSERVATION_STATUS_MESSAGE,
+                  errorMessage,
+                );
+                toolSpan.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: errorMessage,
+                });
+              } else {
+                toolSpan.setStatus({ code: SpanStatusCode.OK });
+              }
+              toolSpan.end();
+            };
+
             const execute = executeMap.get(toolUse.name);
             if (execute) {
               try {
@@ -3321,7 +3547,16 @@ export class GoogleVertexProvider extends BaseProvider {
                   messages: [],
                   abortSignal: options.abortSignal,
                 };
-                const result = await execute(toolUse.input, toolOptions);
+                // Run with toolSpan active so spans inside execute
+                // (neurolink.tool.execute) nest under this observation instead
+                // of becoming disconnected siblings.
+                const result = await otelContext.with(
+                  otelTrace.setSpan(turnContext, toolSpan),
+                  () => execute(toolUse.input, toolOptions),
+                );
+                // MCP failures are returned, not thrown — surface them on
+                // the span so failed calls show as ERROR in Langfuse.
+                endToolSpan(result, extractMcpToolErrorMessage(result));
                 toolExecutions.push({
                   name: toolUse.name,
                   input: toolUse.input,
@@ -3347,6 +3582,7 @@ export class GoogleVertexProvider extends BaseProvider {
               } catch (err) {
                 const errMsg = `Error executing tool "${toolUse.name}": ${err instanceof Error ? err.message : String(err)}`;
                 const errorPayload = { error: errMsg };
+                endToolSpan(errorPayload, errMsg);
                 toolExecutions.push({
                   name: toolUse.name,
                   input: toolUse.input,
@@ -3366,6 +3602,7 @@ export class GoogleVertexProvider extends BaseProvider {
             } else {
               const errMsg = `TOOL_NOT_FOUND: The tool "${toolUse.name}" does not exist.`;
               const errorPayload = { error: errMsg };
+              endToolSpan(errorPayload, errMsg);
               toolExecutions.push({
                 name: toolUse.name,
                 input: toolUse.input,
@@ -3427,11 +3664,54 @@ export class GoogleVertexProvider extends BaseProvider {
         metadata.totalToolExecutions = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
         ).length;
+
+        const turnOutputAttribute = spanJsonAttribute({
+          text: aggregatedTurnText,
+          ...(structuredOutputRef.value
+            ? { structuredOutput: structuredOutputRef.value }
+            : {}),
+        });
+        turnSpan.setAttribute(
+          LANGFUSE_ATTR.OBSERVATION_OUTPUT,
+          turnOutputAttribute,
+        );
+        turnSpan.setAttribute(LANGFUSE_ATTR.TRACE_OUTPUT, turnOutputAttribute);
+        // Turn usage is metadata-only (not usage_details) — see the note at the
+        // top of this method on why it must not contribute to the cost rollup.
+        turnSpan.setAttribute(
+          LANGFUSE_ATTR.OBSERVATION_METADATA,
+          spanJsonAttribute({
+            toolsOffered: offeredToolNames,
+            toolCount: offeredToolNames.length,
+            maxSteps,
+            steps: step,
+            toolCallCount: metadata.totalToolExecutions,
+            toolsCalled: toolsUsedRef.filter((name) => name !== "final_result"),
+            structuredOutput: useFinalResultTool,
+            usage: {
+              input: usage.input,
+              output: usage.output,
+              input_cached_tokens: turnCacheUsage.read,
+              input_cache_creation: turnCacheUsage.creation,
+              input_cache_creation_5m: turnCacheUsage.creation5m,
+              input_cache_creation_1h: turnCacheUsage.creation1h,
+            },
+          }),
+        );
+        turnSpan.setStatus({ code: SpanStatusCode.OK });
         channel.close();
       } catch (err) {
+        turnSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        if (err instanceof Error) {
+          turnSpan.recordException(err);
+        }
         logger.error("[GoogleVertex] Native Anthropic SDK stream error", err);
         channel.error(this.handleProviderError(err));
       } finally {
+        turnSpan.end();
         options.abortSignal?.removeEventListener("abort", abortHandler);
         clearTimeout(streamTimeoutHandle);
       }
@@ -4425,6 +4705,19 @@ export class GoogleVertexProvider extends BaseProvider {
           (mergedOptions as { prompt?: string }).prompt ||
           "";
 
+        // Set generation input before the call so error paths still carry the
+        // request; output is set after the native call resolves.
+        const generationInputAttribute = spanJsonAttribute({
+          ...(mergedOptions.systemPrompt
+            ? { system: mergedOptions.systemPrompt }
+            : {}),
+          prompt: inputPrompt,
+        });
+        generateSpan.setAttribute(
+          LANGFUSE_ATTR.OBSERVATION_INPUT,
+          generationInputAttribute,
+        );
+
         try {
           let result: EnhancedGenerateResult;
           // Wrap the actual native generate call in `neurolink.executeGeneration`
@@ -4442,9 +4735,11 @@ export class GoogleVertexProvider extends BaseProvider {
                 "neurolink.path": isAnthropicModel(modelName)
                   ? "native.anthropic"
                   : "native.google-genai",
+                [LANGFUSE_ATTR.OBSERVATION_INPUT]: generationInputAttribute,
               },
             },
-            async () => {
+            async (executionSpan) => {
+              let nativeResult: EnhancedGenerateResult;
               if (isAnthropicModel(modelName)) {
                 logger.info(
                   "[GoogleVertex] Routing Claude generate to native @anthropic-ai/vertex-sdk",
@@ -4453,16 +4748,24 @@ export class GoogleVertexProvider extends BaseProvider {
                     totalToolCount: Object.keys(mergedOptions.tools).length,
                   },
                 );
-                return this.executeNativeAnthropicGenerate(mergedOptions);
+                nativeResult =
+                  await this.executeNativeAnthropicGenerate(mergedOptions);
+              } else {
+                logger.info(
+                  "[GoogleVertex] Routing Gemini generate to native @google/genai",
+                  {
+                    model: modelName,
+                    totalToolCount: Object.keys(mergedOptions.tools).length,
+                  },
+                );
+                nativeResult =
+                  await this.executeNativeGemini3Generate(mergedOptions);
               }
-              logger.info(
-                "[GoogleVertex] Routing Gemini generate to native @google/genai",
-                {
-                  model: modelName,
-                  totalToolCount: Object.keys(mergedOptions.tools).length,
-                },
+              executionSpan.setAttribute(
+                LANGFUSE_ATTR.OBSERVATION_OUTPUT,
+                spanJsonAttribute(nativeResult?.content ?? ""),
               );
-              return this.executeNativeGemini3Generate(mergedOptions);
+              return nativeResult;
             },
           );
           this.attachUsageAndCostAttributes(
@@ -4475,6 +4778,10 @@ export class GoogleVertexProvider extends BaseProvider {
           // enabled / useAiResponse is false, so the cost is zero on
           // non-TTS paths.
           result = await this.synthesizeAIResponseIfNeeded(result, options);
+          generateSpan.setAttribute(
+            LANGFUSE_ATTR.OBSERVATION_OUTPUT,
+            spanJsonAttribute(result?.content ?? ""),
+          );
           // Fire onFinish lifecycle callback for the native generate path.
           // Pipeline A providers get this for free via the AI SDK middleware
           // wrapper (LifecycleMiddleware); native @google/genai bypasses

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -9,7 +9,12 @@
 
 import type { LangfuseSpanProcessor as LangfuseSpanProcessorType } from "@langfuse/otel";
 import type { Context } from "@opentelemetry/api";
-import { metrics, SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  metrics,
+  SpanStatusCode,
+  trace,
+  type Span as ApiSpan,
+} from "@opentelemetry/api";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
@@ -41,6 +46,7 @@ import type {
 } from "../../../../types/index.js";
 import { extractMcpErrorText } from "../../../../utils/mcpErrorText.js";
 import { logger } from "../../../../utils/logger.js";
+import { LANGFUSE_ATTR } from "../../../../telemetry/attributes.js";
 
 const LOG_PREFIX = "[OpenTelemetry]";
 
@@ -1444,6 +1450,50 @@ export async function setLangfuseContext<T = void>(
  */
 export function getLangfuseContext(): LangfuseContext | undefined {
   return contextStorage.getStore();
+}
+
+/**
+ * Fill a span's Langfuse identity when the caller's context would otherwise
+ * fall back to "guest". Identity (user.id / session.id) is set additively —
+ * only fields ambient context didn't already provide, so a host's own context
+ * is never overridden. trace.name (the title) is rescued only when no ambient
+ * name source exists AND this span is the trace root, mirroring
+ * ContextEnricher.onStart so a host wrapper span isn't relabelled.
+ */
+export function stampGuestRescueIdentity(
+  span: ApiSpan,
+  callContext: unknown,
+  isRootSpan: boolean,
+): void {
+  const ambient = getLangfuseContext();
+  const ctx = callContext as Record<string, unknown> | undefined;
+  const userId =
+    typeof ctx?.userId === "string" && ctx.userId ? ctx.userId : undefined;
+  const sessionId =
+    typeof ctx?.sessionId === "string" && ctx.sessionId
+      ? ctx.sessionId
+      : undefined;
+
+  // Title: the trace name comes from traceName ?? userId, so only rescue it
+  // from "guest" when ambient has neither, and only on the trace root.
+  if (isRootSpan && !ambient?.traceName && !ambient?.userId) {
+    const traceName =
+      typeof ctx?.traceName === "string" && ctx.traceName
+        ? ctx.traceName
+        : userId;
+    if (traceName) {
+      span.setAttribute(LANGFUSE_ATTR.TRACE_NAME, traceName);
+      span.setAttribute("trace.name", traceName);
+    }
+  }
+
+  // Identity: additive — set each field only where ambient didn't.
+  if (userId && !ambient?.userId) {
+    span.setAttribute("user.id", userId);
+  }
+  if (sessionId && !ambient?.sessionId) {
+    span.setAttribute("session.id", sessionId);
+  }
 }
 
 /**

--- a/src/lib/telemetry/attributes.ts
+++ b/src/lib/telemetry/attributes.ts
@@ -114,3 +114,55 @@ export const ATTR = {
   AR_DESCRIPTION: "autoresearch.description",
   AR_ERROR_CODE: "autoresearch.error_code",
 } as const;
+
+/**
+ * Langfuse observation/trace attribute names recognised by `@langfuse/otel`'s
+ * LangfuseSpanProcessor (already registered on the global TracerProvider). They
+ * let native (non-AI-SDK) provider paths emit spans that render as proper
+ * generation / tool observations — the same data the Vercel AI SDK's
+ * `experimental_telemetry` produced before providers moved to native SDKs.
+ */
+export const LANGFUSE_ATTR = {
+  TRACE_NAME: "langfuse.trace.name",
+  TRACE_INPUT: "langfuse.trace.input",
+  TRACE_OUTPUT: "langfuse.trace.output",
+  OBSERVATION_TYPE: "langfuse.observation.type",
+  OBSERVATION_INPUT: "langfuse.observation.input",
+  OBSERVATION_OUTPUT: "langfuse.observation.output",
+  OBSERVATION_METADATA: "langfuse.observation.metadata",
+  OBSERVATION_MODEL_NAME: "langfuse.observation.model.name",
+  OBSERVATION_MODEL_PARAMETERS: "langfuse.observation.model.parameters",
+  OBSERVATION_USAGE_DETAILS: "langfuse.observation.usage_details",
+  OBSERVATION_LEVEL: "langfuse.observation.level",
+  OBSERVATION_STATUS_MESSAGE: "langfuse.observation.status_message",
+  OBSERVATION_COMPLETION_START_TIME:
+    "langfuse.observation.completion_start_time",
+} as const;
+
+/** Default ceiling for serialized span attribute values. */
+export const SPAN_ATTRIBUTE_MAX_CHARS = 40_000;
+
+/**
+ * Serialize an arbitrary value for a span attribute, hard-capped at
+ * `maxChars` so a pathological prompt or tool result can't put megabytes
+ * on a single span. Strings pass through unserialized; everything else is
+ * JSON-stringified with a String() fallback for circular structures.
+ */
+export function spanJsonAttribute(
+  value: unknown,
+  maxChars: number = SPAN_ATTRIBUTE_MAX_CHARS,
+): string {
+  let serialized: string;
+  try {
+    serialized =
+      typeof value === "string"
+        ? value
+        : (JSON.stringify(value) ?? String(value));
+  } catch {
+    serialized = String(value);
+  }
+  if (serialized.length > maxChars) {
+    return `${serialized.slice(0, maxChars)}...[truncated ${serialized.length - maxChars} chars]`;
+  }
+  return serialized;
+}

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -9,7 +9,12 @@ export {
   withStreamSpan,
   withClientStreamSpan,
 } from "./withSpan.js";
-export { ATTR } from "./attributes.js";
+export {
+  ATTR,
+  LANGFUSE_ATTR,
+  SPAN_ATTRIBUTE_MAX_CHARS,
+  spanJsonAttribute,
+} from "./attributes.js";
 import { logger } from "../utils/logger.js";
 
 /**

--- a/src/lib/utils/anthropicTraceSanitizer.ts
+++ b/src/lib/utils/anthropicTraceSanitizer.ts
@@ -1,0 +1,29 @@
+import type { VertexAnthropicMessage } from "../types/index.js";
+
+/**
+ * Strips base64 image/PDF payloads from Anthropic messages before they go on a
+ * trace attribute — one screenshot would otherwise be megabytes on a span.
+ * Other block types pass through; the serializer still applies its length cap.
+ */
+export function sanitizeAnthropicMessagesForTrace(
+  messages: VertexAnthropicMessage[],
+): Array<Record<string, unknown>> {
+  return messages.map((message) => {
+    if (typeof message.content === "string") {
+      return { role: message.role, content: message.content };
+    }
+    return {
+      role: message.role,
+      content: message.content.map((block) => {
+        if (block.type === "image" || block.type === "document") {
+          return {
+            type: block.type,
+            media_type: block.source.media_type,
+            base64_chars: block.source.data.length,
+          };
+        }
+        return block;
+      }),
+    };
+  });
+}

--- a/src/lib/utils/mcpErrorText.ts
+++ b/src/lib/utils/mcpErrorText.ts
@@ -35,3 +35,41 @@ export function extractMcpErrorText(raw: unknown): string {
     .map((c) => c.text);
   return texts.join(" ").substring(0, 500);
 }
+
+/**
+ * MCP tools signal failure by RETURNING `{ isError: true, ... }`, not throwing,
+ * so execute()'s try/catch never sees it. Returns a capped status message for
+ * failures (undefined for success) for the caller to set the span error level.
+ *
+ * Generic over input shape: accepts either a result object or a JSON-stringified
+ * envelope (different providers hand back different shapes), mirroring
+ * `extractMcpErrorText`. A non-JSON string has no `isError` field, so it is
+ * correctly treated as "not an error" (→ undefined).
+ *
+ * Layered on `extractMcpErrorText`: this adds the `isError === true` gate and
+ * the human-readable "MCP tool returned isError: …" prefix, while the shared
+ * helper owns the content parsing and the 500-char cap. When `isError` is set
+ * but no readable text is present, falls back to a generic message.
+ */
+export function extractMcpToolErrorMessage(
+  result: unknown,
+): string | undefined {
+  let resultObj: unknown = result;
+  if (typeof resultObj === "string") {
+    try {
+      resultObj = JSON.parse(resultObj);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!resultObj || typeof resultObj !== "object") {
+    return undefined;
+  }
+  if ((resultObj as { isError?: unknown }).isError !== true) {
+    return undefined;
+  }
+  const text = extractMcpErrorText(resultObj);
+  return text
+    ? `MCP tool returned isError: ${text}`
+    : "MCP tool returned isError: true";
+}

--- a/test/continuous-test-suite-vertex-langfuse-spans.ts
+++ b/test/continuous-test-suite-vertex-langfuse-spans.ts
@@ -1,0 +1,432 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Vertex / Langfuse Span Telemetry Suite
+ *
+ * Locks in the pure-logic pieces of commit 5747c021
+ * ("feat(observability): emit Langfuse spans for the native Vertex provider
+ * path"). The span *wiring* is exercised against the live provider in the
+ * observability suites; here we cover the deterministic, credential-free
+ * helpers that the new span code leans on:
+ *
+ *   1. spanJsonAttribute()  — the serializer + hard length cap that stops a
+ *      pathological prompt/tool result from putting megabytes on one span.
+ *   2. LANGFUSE_ATTR / SPAN_ATTRIBUTE_MAX_CHARS — the attribute-name contract
+ *      the LangfuseSpanProcessor maps to observations.
+ *   3. sanitizeAnthropicMessagesForTrace() — strips base64 image/PDF payloads
+ *      from messages before they land on a trace attribute.
+ *   4. extractMcpToolErrorMessage() — surfaces MCP tools that signal failure by
+ *      RETURNING { isError: true } (execute()'s try/catch never sees it).
+ *
+ * No network, no API keys — pure functions only.
+ *
+ * Run with: npx tsx test/continuous-test-suite-vertex-langfuse-spans.ts
+ *       or: pnpm run test:vertex-langfuse-spans
+ */
+
+import {
+  LANGFUSE_ATTR,
+  SPAN_ATTRIBUTE_MAX_CHARS,
+  spanJsonAttribute,
+} from "../src/lib/telemetry/index.js";
+import { extractMcpToolErrorMessage } from "../src/lib/utils/mcpErrorText.js";
+import { sanitizeAnthropicMessagesForTrace } from "../src/lib/utils/anthropicTraceSanitizer.js";
+import {
+  setLangfuseContext,
+  stampGuestRescueIdentity,
+} from "../src/lib/services/server/ai/observability/instrumentation.js";
+import type { VertexAnthropicMessage } from "../src/lib/types/index.js";
+import {
+  assert,
+  assertEqual,
+  assertIncludes,
+  defineSuite,
+} from "./helpers/harness.js";
+
+/** Minimal Span stand-in that records the attributes set on it. */
+function makeFakeSpan(): {
+  attrs: Record<string, unknown>;
+  span: Parameters<typeof stampGuestRescueIdentity>[0];
+} {
+  const attrs: Record<string, unknown> = {};
+  const span = {
+    setAttribute(key: string, value: unknown) {
+      attrs[key] = value;
+      return this;
+    },
+  } as unknown as Parameters<typeof stampGuestRescueIdentity>[0];
+  return { attrs, span };
+}
+
+const { test, section, runSuite } = defineSuite(
+  "Vertex / Langfuse Span Telemetry",
+);
+
+await runSuite(async () => {
+  // ─────────────────────────────────────────────────────────────────────
+  section("spanJsonAttribute — serialization");
+
+  await test("string value passes through unserialized (no added quotes)", () => {
+    assertEqual(spanJsonAttribute("hello world"), "hello world");
+  });
+
+  await test("object value is JSON-stringified", () => {
+    assertEqual(spanJsonAttribute({ a: 1, b: "x" }), '{"a":1,"b":"x"}');
+  });
+
+  await test("number / boolean values stringify", () => {
+    assertEqual(spanJsonAttribute(42), "42");
+    assertEqual(spanJsonAttribute(true), "true");
+  });
+
+  await test("array value is JSON-stringified", () => {
+    assertEqual(spanJsonAttribute([1, 2, 3]), "[1,2,3]");
+  });
+
+  await test("undefined falls back to String() (JSON.stringify→undefined)", () => {
+    // JSON.stringify(undefined) === undefined, so the `?? String(value)` kicks in.
+    assertEqual(spanJsonAttribute(undefined), "undefined");
+  });
+
+  await test("circular structure does not throw — String() fallback", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    let result: string | undefined;
+    let threw = false;
+    try {
+      result = spanJsonAttribute(circular);
+    } catch {
+      threw = true;
+    }
+    assert(!threw, "spanJsonAttribute threw on a circular structure");
+    assertEqual(result, "[object Object]");
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  section("spanJsonAttribute — length cap");
+
+  await test("value at/under the cap is not truncated", () => {
+    const exact = "x".repeat(100);
+    assertEqual(spanJsonAttribute(exact, 100), exact);
+  });
+
+  await test("value one char over the cap is truncated with exact suffix", () => {
+    const over = "y".repeat(101);
+    const out = spanJsonAttribute(over, 100);
+    assertEqual(out, `${"y".repeat(100)}...[truncated 1 chars]`);
+  });
+
+  await test("truncated output keeps the first maxChars chars intact", () => {
+    const out = spanJsonAttribute("z".repeat(5000), 1000);
+    assert(out.startsWith("z".repeat(1000)), "prefix was altered");
+    assertIncludes(out, "...[truncated 4000 chars]");
+  });
+
+  await test("default cap is SPAN_ATTRIBUTE_MAX_CHARS (40_000)", () => {
+    const out = spanJsonAttribute("a".repeat(SPAN_ATTRIBUTE_MAX_CHARS + 1));
+    assertIncludes(out, "...[truncated 1 chars]");
+    // Just under the default cap must NOT truncate.
+    const under = spanJsonAttribute("b".repeat(SPAN_ATTRIBUTE_MAX_CHARS));
+    assert(!under.includes("[truncated"), "value at default cap was truncated");
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  section("LANGFUSE_ATTR / SPAN_ATTRIBUTE_MAX_CHARS — attribute contract");
+
+  await test("SPAN_ATTRIBUTE_MAX_CHARS is 40_000", () => {
+    assertEqual(SPAN_ATTRIBUTE_MAX_CHARS, 40_000);
+  });
+
+  await test("known attribute names map to the langfuse.* keys Langfuse reads", () => {
+    assertEqual(LANGFUSE_ATTR.TRACE_NAME, "langfuse.trace.name");
+    assertEqual(LANGFUSE_ATTR.TRACE_INPUT, "langfuse.trace.input");
+    assertEqual(LANGFUSE_ATTR.TRACE_OUTPUT, "langfuse.trace.output");
+    assertEqual(LANGFUSE_ATTR.OBSERVATION_TYPE, "langfuse.observation.type");
+    assertEqual(
+      LANGFUSE_ATTR.OBSERVATION_USAGE_DETAILS,
+      "langfuse.observation.usage_details",
+    );
+    assertEqual(
+      LANGFUSE_ATTR.OBSERVATION_COMPLETION_START_TIME,
+      "langfuse.observation.completion_start_time",
+    );
+  });
+
+  await test("every LANGFUSE_ATTR value is a non-empty langfuse.* string", () => {
+    const values = Object.values(LANGFUSE_ATTR);
+    assert(values.length >= 13, `expected ≥13 attrs, got ${values.length}`);
+    for (const v of values) {
+      assert(
+        typeof v === "string" && v.startsWith("langfuse."),
+        `attribute "${v}" is not a langfuse.* key`,
+      );
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  section("sanitizeAnthropicMessagesForTrace — base64 stripping");
+
+  await test("string content passes through as { role, content }", () => {
+    const msgs: VertexAnthropicMessage[] = [
+      { role: "user", content: "just text" },
+    ];
+    const out = sanitizeAnthropicMessagesForTrace(msgs);
+    assertEqual(out.length, 1);
+    assertEqual(out[0].role, "user");
+    assertEqual(out[0].content, "just text");
+  });
+
+  await test("image block: base64 data replaced by char count, payload dropped", () => {
+    const data = "A".repeat(2048);
+    const msgs: VertexAnthropicMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data },
+          },
+        ],
+      },
+    ];
+    const out = sanitizeAnthropicMessagesForTrace(msgs);
+    const block = (out[0].content as Array<Record<string, unknown>>)[0];
+    assertEqual(block.type, "image");
+    assertEqual(block.media_type, "image/png");
+    assertEqual(block.base64_chars, 2048);
+    // The actual payload must be gone — this is the whole point of the helper.
+    assert(!("data" in block), "base64 data leaked onto the trace block");
+    assert(
+      !("source" in block),
+      "raw source object leaked onto the trace block",
+    );
+    assert(
+      !JSON.stringify(out).includes("AAAA"),
+      "serialized trace still contains base64 payload",
+    );
+  });
+
+  await test("document block is stripped the same way as image", () => {
+    const msgs: VertexAnthropicMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "PDFBYTES".repeat(10),
+            },
+          },
+        ],
+      },
+    ];
+    const out = sanitizeAnthropicMessagesForTrace(msgs);
+    const block = (out[0].content as Array<Record<string, unknown>>)[0];
+    assertEqual(block.type, "document");
+    assertEqual(block.media_type, "application/pdf");
+    assertEqual(block.base64_chars, 80);
+    assert(!("data" in block), "pdf data leaked onto the trace block");
+  });
+
+  await test("text / tool_use blocks pass through untouched", () => {
+    const msgs: VertexAnthropicMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "tool_use", id: "t1", name: "search", input: { q: "x" } },
+        ],
+      },
+    ];
+    const out = sanitizeAnthropicMessagesForTrace(msgs);
+    const blocks = out[0].content as Array<Record<string, unknown>>;
+    assertEqual(blocks[0].text, "hello");
+    assertEqual(blocks[1].name, "search");
+    assertEqual((blocks[1].input as { q: string }).q, "x");
+  });
+
+  await test("mixed multi-message conversation maps element-for-element", () => {
+    const msgs: VertexAnthropicMessage[] = [
+      { role: "user", content: "first" },
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: "Z".repeat(64),
+            },
+          },
+          { type: "text", text: "describe this" },
+        ],
+      },
+    ];
+    const out = sanitizeAnthropicMessagesForTrace(msgs);
+    assertEqual(out.length, 2);
+    assertEqual(out[0].content, "first");
+    const blocks = out[1].content as Array<Record<string, unknown>>;
+    assertEqual(blocks.length, 2);
+    assertEqual(blocks[0].base64_chars, 64);
+    assertEqual(blocks[1].text, "describe this");
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  section("extractMcpToolErrorMessage — surface returned isError");
+
+  await test("non-object / null / primitive inputs return undefined", () => {
+    assertEqual(extractMcpToolErrorMessage(null), undefined);
+    assertEqual(extractMcpToolErrorMessage(undefined), undefined);
+    assertEqual(extractMcpToolErrorMessage("error"), undefined);
+    assertEqual(extractMcpToolErrorMessage(123), undefined);
+  });
+
+  await test("object without is:Error (or isError !== true) returns undefined", () => {
+    assertEqual(extractMcpToolErrorMessage({}), undefined);
+    assertEqual(extractMcpToolErrorMessage({ isError: false }), undefined);
+    // Truthy-but-not-boolean-true must not count as an error.
+    assertEqual(extractMcpToolErrorMessage({ isError: "true" }), undefined);
+    assertEqual(extractMcpToolErrorMessage({ isError: 1 }), undefined);
+  });
+
+  await test("isError:true with no usable content → generic message", () => {
+    assertEqual(
+      extractMcpToolErrorMessage({ isError: true }),
+      "MCP tool returned isError: true",
+    );
+    assertEqual(
+      extractMcpToolErrorMessage({ isError: true, content: "not-an-array" }),
+      "MCP tool returned isError: true",
+    );
+    assertEqual(
+      extractMcpToolErrorMessage({ isError: true, content: [{}, null] }),
+      "MCP tool returned isError: true",
+    );
+  });
+
+  await test("isError:true surfaces the first content block's text", () => {
+    assertEqual(
+      extractMcpToolErrorMessage({
+        isError: true,
+        content: [{ type: "text", text: "boom" }],
+      }),
+      "MCP tool returned isError: boom",
+    );
+  });
+
+  await test("multiple text blocks are joined; non-text blocks ignored", () => {
+    assertEqual(
+      extractMcpToolErrorMessage({
+        isError: true,
+        content: [
+          { type: "text", text: "first" },
+          { type: "image" },
+          { type: "text", text: "second" },
+        ],
+      }),
+      "MCP tool returned isError: first second",
+    );
+  });
+
+  await test("a block with text but no type:text is not surfaced", () => {
+    // Shared extractMcpErrorText requires type === "text", so an untyped block
+    // is ignored and the generic fallback is used.
+    assertEqual(
+      extractMcpToolErrorMessage({
+        isError: true,
+        content: [{ text: "untyped" }],
+      }),
+      "MCP tool returned isError: true",
+    );
+  });
+
+  await test("long error text is capped at 500 chars", () => {
+    const longText = "E".repeat(1000);
+    const out = extractMcpToolErrorMessage({
+      isError: true,
+      content: [{ type: "text", text: longText }],
+    });
+    const prefix = "MCP tool returned isError: ";
+    assertEqual(out, `${prefix}${"E".repeat(500)}`);
+    assertEqual(out?.length, prefix.length + 500);
+  });
+
+  await test("stringified isError envelope is JSON-parsed and surfaced", () => {
+    assertEqual(
+      extractMcpToolErrorMessage(
+        JSON.stringify({
+          isError: true,
+          content: [{ type: "text", text: "boom" }],
+        }),
+      ),
+      "MCP tool returned isError: boom",
+    );
+  });
+
+  await test("stringified success envelope returns undefined", () => {
+    assertEqual(
+      extractMcpToolErrorMessage(
+        JSON.stringify({ content: [{ type: "text", text: "ok" }] }),
+      ),
+      undefined,
+    );
+  });
+
+  await test("non-JSON string returns undefined (not an error envelope)", () => {
+    assertEqual(extractMcpToolErrorMessage("just a plain string"), undefined);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  section("stampGuestRescueIdentity — guest rescue is additive");
+
+  await test("empty ambient + root span: stamps trace name, user, session", () => {
+    const { attrs, span } = makeFakeSpan();
+    stampGuestRescueIdentity(
+      span,
+      { userId: "u1", sessionId: "s1", traceName: "my-trace" },
+      true,
+    );
+    assertEqual(attrs[LANGFUSE_ATTR.TRACE_NAME], "my-trace");
+    assertEqual(attrs["trace.name"], "my-trace");
+    assertEqual(attrs["user.id"], "u1");
+    assertEqual(attrs["session.id"], "s1");
+  });
+
+  await test("empty ambient, no traceName: trace name falls back to userId", () => {
+    const { attrs, span } = makeFakeSpan();
+    stampGuestRescueIdentity(span, { userId: "u2" }, true);
+    assertEqual(attrs[LANGFUSE_ATTR.TRACE_NAME], "u2");
+    assertEqual(attrs["user.id"], "u2");
+    assert(!("session.id" in attrs), "session.id set without a sessionId");
+  });
+
+  await test("non-root span: identity stamped but trace name is not", () => {
+    const { attrs, span } = makeFakeSpan();
+    stampGuestRescueIdentity(span, { userId: "u3", sessionId: "s3" }, false);
+    assert(!(LANGFUSE_ATTR.TRACE_NAME in attrs), "trace name rescued off-root");
+    assert(!("trace.name" in attrs), "trace.name rescued off-root");
+    assertEqual(attrs["user.id"], "u3");
+    assertEqual(attrs["session.id"], "s3");
+  });
+
+  await test("host ambient context is never overridden (additive only)", () => {
+    const { attrs, span } = makeFakeSpan();
+    // A host already established its own Langfuse context.
+    setLangfuseContext({ userId: "host-user" }, () => {
+      stampGuestRescueIdentity(
+        span,
+        { userId: "caller-user", sessionId: "caller-session" },
+        true,
+      );
+    });
+    // Host had userId → neither trace name nor user.id is touched…
+    assert(!(LANGFUSE_ATTR.TRACE_NAME in attrs), "overrode host trace name");
+    assert(!("user.id" in attrs), "overrode host user.id");
+    // …but session.id, which the host lacked, is filled in additively.
+    assertEqual(attrs["session.id"], "caller-session");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The native Anthropic/Vertex SDK paths bypass the Vercel AI SDK, so its built-in telemetry never ran — model calls produced no Langfuse observations and deferred work (memory, Redis) orphaned into anonymous "guest" traces. This PR manually emits the missing OpenTelemetry spans and fixes trace identity propagation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When the Vercel AI SDK was removed from the native Anthropic streaming path, all automatic telemetry stopped firing. This caused:
- **No Langfuse observations** for model calls made through the native SDK
- **Orphaned "guest" traces** — deferred work (memory writes, Redis ops) lost its parent context and appeared under anonymous traces
- **Missing usage metrics** — prompt-cache hits, TTFT, and token usage were not recorded

## Changes Made

- **Manual span emission on native Anthropic stream**: Added turn-level, per-call generation (usage + prompt-cache + TTFT), and tool spans — all parented under `neurolink.stream` (one trace per turn)
- **Trace identity rescue**: Stamp `user.id` and `session.id` on `stream`/`generate` root spans when they are empty, without overriding a host's own context
- **Identity propagation across `setImmediate`**: Carry the turn's trace context so memory/Redis spans nest correctly under the parent trace
- **Usage details cleanup**: Retain the 5-minute/1-hour cache buckets in `usage_details` and drop the double-counting aggregate; ensure the generation span always ends

## Breaking Changes

- [x] No breaking changes

> [!IMPORTANT]
> **Observability-only change** — no modifications to model selection, tool execution, memory behavior, return values, or control flow.

## Testing

- [x] Manual testing completed
- [x] Verified Langfuse traces appear with correct parent–child nesting
- [x] Verified `user.id` / `session.id` stamps on root spans
- [x] Verified usage metrics (tokens, cache buckets, TTFT) are recorded

## Performance Impact

- [x] No performance impact — spans are lightweight metadata; no changes to hot paths

## Security Considerations

- [x] No security implications

Dev proof
<img width="1148" height="964" alt="Screenshot 2026-06-12 at 6 33 56 PM" src="https://github.com/user-attachments/assets/c21a1faa-78ee-4bd2-bdc0-a6ebe55a6c46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Langfuse/OpenTelemetry identity propagation so trace, user, and session attribution is correctly maintained across async background work and streaming flows, avoiding incorrect “guest” attribution.

* **Improvements**
  * Enhanced Vertex AI streaming observability with richer tracing for turns, generations, tool calls, usage breakdowns, and improved tool error reporting.
  * Added safe telemetry helpers for Langfuse attribute naming, capped/truncated JSON span serialization, and trace-safe Anthropic message sanitization.

* **Tests**
  * Added a continuous, credential-free Vertex/Langfuse span test suite and a script to run it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->