### PR TITLE
fix(providers): make native Vertex+Claude path accept Anthropic-style model IDs and tool schemas

### DIFF
--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -53,6 +53,7 @@ import { logger } from "../utils/logger.js";
 import {
   hasRestrictedOutputLimit,
   RESTRICTED_OUTPUT_TOKEN_LIMIT,
+  toVertexAnthropicModelId,
 } from "../utils/modelDetection.js";
 import { resolveClaudeMaxTokens } from "../utils/tokenLimits.js";
 import {
@@ -2761,8 +2762,9 @@ export class GoogleVertexProvider extends BaseProvider {
   private async executeNativeAnthropicStream(
     options: StreamOptions,
   ): Promise<StreamResult> {
-    const modelName =
-      options.model || this.modelName || "claude-sonnet-4-5@20250929";
+    const modelName = toVertexAnthropicModelId(
+      options.model || this.modelName || "claude-sonnet-4-5@20250929",
+    );
     const startTime = Date.now();
     const streamTimeoutMs = parseTimeout(options.timeout) ?? 300_000;
     const client = await this.createAnthropicVertexClient(streamTimeoutMs);
@@ -2979,9 +2981,12 @@ export class GoogleVertexProvider extends BaseProvider {
         const legacyTool = tool as ToolWithLegacyParams;
         const toolParams = legacyTool.parameters || tool.inputSchema;
         if (toolParams) {
+          // Anthropic validates input_schema as JSON Schema draft 2020-12 and
+          // rejects OpenAPI-3 dialect output (e.g. `nullable: true`) with a
+          // 400 — use the default JSON Schema target, matching the direct
+          // anthropic provider. The Gemini paths keep "openApi3".
           const jsonSchema = convertZodToJsonSchema(
             toolParams as ZodUnknownSchema,
-            "openApi3",
           ) as Record<string, unknown>;
           const inlined = inlineJsonSchema(jsonSchema);
           anthropicTool.input_schema = {
@@ -3018,7 +3023,6 @@ export class GoogleVertexProvider extends BaseProvider {
       // Convert schema to JSON schema format
       const schemaAsJson = convertZodToJsonSchema(
         streamOptions.schema as ZodUnknownSchema,
-        "openApi3",
       ) as Record<string, unknown>;
       const inlinedSchema = inlineJsonSchema(schemaAsJson);
       if (inlinedSchema.$schema) {
@@ -3438,8 +3442,9 @@ export class GoogleVertexProvider extends BaseProvider {
   private async executeNativeAnthropicGenerate(
     options: TextGenerationOptions,
   ): Promise<EnhancedGenerateResult> {
-    const modelName =
-      options.model || this.modelName || "claude-sonnet-4-5@20250929";
+    const modelName = toVertexAnthropicModelId(
+      options.model || this.modelName || "claude-sonnet-4-5@20250929",
+    );
     const startTime = Date.now();
     const generateTimeoutMs = parseTimeout(options.timeout) ?? 300_000;
     const client = await this.createAnthropicVertexClient(generateTimeoutMs);
@@ -3669,9 +3674,12 @@ export class GoogleVertexProvider extends BaseProvider {
         const legacyTool = tool as ToolWithLegacyParams;
         const toolParams = legacyTool.parameters || tool.inputSchema;
         if (toolParams) {
+          // Anthropic validates input_schema as JSON Schema draft 2020-12 and
+          // rejects OpenAPI-3 dialect output (e.g. `nullable: true`) with a
+          // 400 — use the default JSON Schema target, matching the direct
+          // anthropic provider. The Gemini paths keep "openApi3".
           const jsonSchema = convertZodToJsonSchema(
             toolParams as ZodUnknownSchema,
-            "openApi3",
           ) as Record<string, unknown>;
           const inlined = inlineJsonSchema(jsonSchema);
           anthropicTool.input_schema = {
@@ -3700,7 +3708,6 @@ export class GoogleVertexProvider extends BaseProvider {
       // Convert schema to JSON schema format
       const schemaAsJson = convertZodToJsonSchema(
         options.schema as ZodUnknownSchema,
-        "openApi3",
       ) as Record<string, unknown>;
       const inlinedSchema = inlineJsonSchema(schemaAsJson);
       if (inlinedSchema.$schema) {

--- a/src/lib/utils/modelDetection.ts
+++ b/src/lib/utils/modelDetection.ts
@@ -121,3 +121,27 @@ export function hasRestrictedOutputLimit(modelName: string): boolean {
  * Get the max output tokens for a model (32768 for restricted models)
  */
 export const RESTRICTED_OUTPUT_TOKEN_LIMIT = 32768;
+
+/**
+ * Normalize an Anthropic-API-style Claude model ID to the Vertex publisher
+ * format.
+ *
+ * The Anthropic API dates models with a trailing dash segment
+ * ("claude-haiku-4-5-20251001") while Vertex publisher IDs separate the date
+ * with "@" ("claude-haiku-4-5@20251001"). Vertex rejects the dash form with a
+ * 404 (verified live against us-east5), so the native Vertex+Claude paths
+ * normalize before calling @anthropic-ai/vertex-sdk.
+ *
+ * Pass-through cases: IDs already in "@" form, bare aliases with no date
+ * ("claude-sonnet-4-6" — Vertex resolves these itself), and non-Claude models.
+ * Legacy v2-suffixed Vertex IDs ("claude-3-5-sonnet-v2@20241022") have no
+ * dash-date equivalent, so those legacy dash IDs stay out of scope: they 404
+ * today and still 404 after the transform — no regression either way.
+ */
+export function toVertexAnthropicModelId(modelName: string): string {
+  if (!modelName.startsWith("claude-") || modelName.includes("@")) {
+    return modelName;
+  }
+  const dashDate = modelName.match(/^(claude-[a-z0-9-]+)-(\d{8})$/);
+  return dashDate ? `${dashDate[1]}@${dashDate[2]}` : modelName;
+}

--- a/test/continuous-test-suite-vertex-model-id.ts
+++ b/test/continuous-test-suite-vertex-model-id.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Vertex Claude model-ID normalization (pure, no API).
+ *
+ * The Anthropic API dates Claude models with a trailing dash segment
+ * ("claude-haiku-4-5-20251001") while Vertex publisher IDs use "@"
+ * ("claude-haiku-4-5@20251001"). Deployments that share one model-name config
+ * across providers (e.g. TARA's Superposition flag) feed the dash form to the
+ * native Vertex path, which 404s. toVertexAnthropicModelId() bridges the two.
+ *
+ * Live verification (us-east5, project with Anthropic integration):
+ *   claude-haiku-4-5-20251001  → 404 NOT_FOUND
+ *   claude-haiku-4-5@20251001  → 200
+ *   claude-sonnet-4-6          → 200 (bare alias, Vertex resolves)
+ *
+ * Run: npx tsx test/continuous-test-suite-vertex-model-id.ts
+ */
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import { toVertexAnthropicModelId } from "../src/lib/utils/modelDetection.js";
+
+const { test, runSuite } = defineSuite("Vertex Claude model-ID normalization");
+
+// ── Dash-date → @-date conversion ───────────────────────────────────────────
+await test("converts haiku 4.5 dash-date to @ form", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-haiku-4-5-20251001"),
+    "claude-haiku-4-5@20251001",
+    "haiku dash-date",
+  );
+});
+
+await test("converts sonnet 4.5 dash-date to @ form", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-sonnet-4-5-20250929"),
+    "claude-sonnet-4-5@20250929",
+    "sonnet dash-date",
+  );
+});
+
+await test("converts opus 4.1 dash-date to @ form", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-opus-4-1-20250805"),
+    "claude-opus-4-1@20250805",
+    "opus dash-date",
+  );
+});
+
+await test("converts legacy 3.5 dash-date to @ form", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-3-5-haiku-20241022"),
+    "claude-3-5-haiku@20241022",
+    "legacy 3.5 dash-date",
+  );
+});
+
+// ── Pass-through cases ──────────────────────────────────────────────────────
+await test("leaves @-form IDs untouched", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-sonnet-4-5@20250929"),
+    "claude-sonnet-4-5@20250929",
+    "@ form unchanged",
+  );
+});
+
+await test("leaves bare aliases untouched", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-sonnet-4-6"),
+    "claude-sonnet-4-6",
+    "bare alias unchanged",
+  );
+});
+
+await test("leaves non-Claude models untouched", () => {
+  assertEqual(
+    toVertexAnthropicModelId("gemini-2.5-pro"),
+    "gemini-2.5-pro",
+    "gemini unchanged",
+  );
+});
+
+await test("does not treat short trailing digits as a date", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-sonnet-4-5"),
+    "claude-sonnet-4-5",
+    "version digits are not a date",
+  );
+});
+
+await test("does not convert digits longer than a date", () => {
+  assertEqual(
+    toVertexAnthropicModelId("claude-sonnet-4-5-202509290"),
+    "claude-sonnet-4-5-202509290",
+    "9-digit suffix unchanged",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## Problem

Deployments that share one model/tool config across providers (e.g. TARA/curator, where the model ID comes from a Superposition flag) break on the native `@anthropic-ai/vertex-sdk` path introduced in 9.61:

1. **Model-ID dialect.** The Anthropic API dates models with a trailing dash segment (`claude-haiku-4-5-20251001`) but Vertex publisher IDs use `@` (`claude-haiku-4-5@20251001`). The native path passed the dash form through verbatim → Vertex 404 `Publisher Model ... was not found` on every call.

   Verified live against `us-east5` (project with Anthropic integration):
   | model id | result |
   |---|---|
   | `claude-haiku-4-5-20251001` | **404 NOT_FOUND** |
   | `claude-haiku-4-5@20251001` | 200 |
   | `claude-sonnet-4-6` (bare alias) | 200 |

2. **Tool-schema dialect.** Once requests reach Vertex, the native Anthropic paths converted tool `input_schema` / the `final_result` schema with the `"openApi3"` target (correct for Gemini, wrong for Claude). Anthropic validates `input_schema` as JSON Schema draft 2020-12 and rejects OpenAPI-3 output (`nullable: true`) with `tools.N.custom.input_schema: JSON schema is invalid` 400s.

## Fix

- `toVertexAnthropicModelId()` in `modelDetection.ts` — normalizes trailing `-YYYYMMDD` to `@YYYYMMDD` for `claude-*` IDs at both native call sites (`executeNativeAnthropicStream` / `executeNativeAnthropicGenerate`). `@`-form IDs, bare aliases, and non-Claude models pass through untouched. Legacy v2-suffixed Vertex IDs have no dash-date equivalent and stay out of scope (they 404 before and after — no regression).
- The two native Anthropic tool-conversion sites and both `final_result` schema conversions now use the default JSON Schema target, matching the direct `anthropic` provider. All Gemini paths keep `"openApi3"`.

## Verification

- Deterministic unit suite: `npx tsx test/continuous-test-suite-vertex-model-id.ts` (9 cases — conversions + pass-throughs).
- E2E through curator (provider=`vertex`, `claude-haiku-4-5-20251001` from remote config, 88 MCP tools registered): chat + structured-attachment turns succeed with zero 404/400; before the fix the identical config failed every turn.
- `pre-commit` check/format/lint green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude model ID normalization for Anthropic Vertex compatibility, converting model IDs to expected date format.

* **Improvements**
  * Enhanced JSON Schema validation compatibility with Anthropic Vertex.
  * Updated tool schema conversion to use native JSON Schema format for better compatibility.

* **Tests**
  * Added comprehensive test suite validating model ID normalization across Claude variants and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->