### PR TITLE
chore(deps): bump webpack-dev-server to 5.2.4 and raise devalue floor

### DIFF
--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -740,6 +740,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -6035,8 +6039,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.3:
-    resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
+  webpack-dev-server@5.2.4:
+    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -7013,6 +7017,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
@@ -7481,7 +7487,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.104.1
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.104.1)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.104.1)
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -9088,7 +9094,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -13594,7 +13600,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.104.1):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/landing/package.json
+++ b/landing/package.json
@@ -38,7 +38,7 @@
   "pnpm": {
     "overrides": {
       "tar": ">=7.5.11",
-      "devalue": ">=5.6.4",
+      "devalue": ">=5.8.1",
       "rollup": ">=4.59.0",
       "minimatch": ">=10.2.3"
     }

--- a/landing/pnpm-lock.yaml
+++ b/landing/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   tar: '>=7.5.11'
-  devalue: '>=5.6.4'
+  devalue: '>=5.8.1'
   rollup: '>=4.59.0'
   minimatch: '>=10.2.3'
 


### PR DESCRIPTION
## What

Closes two dependency security gaps that dependabot left unaddressed.

| Package | Change | Advisory |
|---|---|---|
| `webpack-dev-server` (docs-site) | 5.2.3 → 5.2.4 | **GHSA-79cf-xcqc-c78w** — source code theft via malicious site (dev-server only) |
| `devalue` (landing) | pnpm override floor `>=5.6.4` → `>=5.8.1` | **GHSA-77vg-94rm-hx3p** (High) — DoS via crafted input; hardens the floor against regression |

## Why this is manual

Dependabot opened, then auto-closed its `webpack-dev-server` PR claiming the dependency was "no longer updatable." That claim was **false** — `docs-site/pnpm-lock.yaml` still locked the vulnerable `5.2.3`. Verified against `origin/release` at 9.70.2: the gap was live. This applies the in-range lockfile-only bump that dependabot should have made.

## Scope

Surgical — 3 files, lockfile-only where possible:
- `docs-site/pnpm-lock.yaml` — `pnpm update webpack-dev-server` (in-range; includes a benign `@babel/runtime` rider)
- `landing/package.json` — override floor raised
- `landing/pnpm-lock.yaml` — override record updated

No production runtime code touched. webpack-dev-server is dev-server tooling; devalue ships in the landing SvelteKit app but the floor already resolved to 5.8.1 — this pins the floor so it can't regress.

`chore(deps):` → no semantic-release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package constraint to ensure improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->