### PR TITLE
fix(providers): detect image MIME from magic bytes on native Vertex path (PNG no longer mislabeled as JPEG)

### DIFF
--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -55,6 +55,7 @@ import {
   RESTRICTED_OUTPUT_TOKEN_LIMIT,
   toVertexAnthropicModelId,
 } from "../utils/modelDetection.js";
+import { detectImageMimeType } from "../utils/imageDetection.js";
 import { resolveClaudeMaxTokens } from "../utils/tokenLimits.js";
 import {
   validateApiKey,
@@ -1279,9 +1280,16 @@ export class GoogleVertexProvider extends BaseProvider {
           } else {
             // Assume base64 string
             imageBuffer = Buffer.from(image, "base64");
+            // Sniff the real format from magic bytes — bare base64 carries no
+            // mime hint, and leaving the image/jpeg default makes Anthropic
+            // reject PNG/GIF/WebP with a media-type mismatch 400.
+            mimeType = this.detectImageType(imageBuffer);
           }
         } else {
           imageBuffer = image;
+          // Buffer input (e.g. Slack/REST uploads) carries no mime hint; sniff
+          // it instead of defaulting to image/jpeg (mislabels PNG -> 400).
+          mimeType = this.detectImageType(imageBuffer);
         }
 
         const base64Data = imageBuffer.toString("base64");
@@ -2098,9 +2106,16 @@ export class GoogleVertexProvider extends BaseProvider {
           } else {
             // Assume base64 string
             imageBuffer = Buffer.from(image, "base64");
+            // Sniff the real format from magic bytes — bare base64 carries no
+            // mime hint, and leaving the image/jpeg default makes Anthropic
+            // reject PNG/GIF/WebP with a media-type mismatch 400.
+            mimeType = this.detectImageType(imageBuffer);
           }
         } else {
           imageBuffer = image;
+          // Buffer input (e.g. Slack/REST uploads) carries no mime hint; sniff
+          // it instead of defaulting to image/jpeg (mislabels PNG -> 400).
+          mimeType = this.detectImageType(imageBuffer);
         }
 
         const base64Data = imageBuffer.toString("base64");
@@ -2925,9 +2940,16 @@ export class GoogleVertexProvider extends BaseProvider {
           } else {
             // Assume base64 string
             imageBuffer = Buffer.from(image, "base64");
+            // Sniff the real format from magic bytes — bare base64 carries no
+            // mime hint, and leaving the image/jpeg default makes Anthropic
+            // reject PNG/GIF/WebP with a media-type mismatch 400.
+            mimeType = this.detectImageType(imageBuffer);
           }
         } else {
           imageBuffer = image;
+          // Buffer input (e.g. Slack/REST uploads) carries no mime hint; sniff
+          // it instead of defaulting to image/jpeg (mislabels PNG -> 400).
+          mimeType = this.detectImageType(imageBuffer);
         }
 
         const base64Data = imageBuffer.toString("base64");
@@ -3610,9 +3632,16 @@ export class GoogleVertexProvider extends BaseProvider {
           } else {
             // Assume base64 string
             imageBuffer = Buffer.from(image, "base64");
+            // Sniff the real format from magic bytes — bare base64 carries no
+            // mime hint, and leaving the image/jpeg default makes Anthropic
+            // reject PNG/GIF/WebP with a media-type mismatch 400.
+            mimeType = this.detectImageType(imageBuffer);
           }
         } else {
           imageBuffer = image;
+          // Buffer input (e.g. Slack/REST uploads) carries no mime hint; sniff
+          // it instead of defaulting to image/jpeg (mislabels PNG -> 400).
+          mimeType = this.detectImageType(imageBuffer);
         }
 
         const base64Data = imageBuffer.toString("base64");
@@ -5589,54 +5618,7 @@ export class GoogleVertexProvider extends BaseProvider {
    * Detect image MIME type from buffer
    */
   private detectImageType(buffer: Buffer): string {
-    // Check PNG signature
-    if (
-      buffer.length >= 8 &&
-      buffer[0] === 0x89 &&
-      buffer[1] === 0x50 &&
-      buffer[2] === 0x4e &&
-      buffer[3] === 0x47
-    ) {
-      return "image/png";
-    }
-
-    // Check JPEG signature
-    if (
-      buffer.length >= 3 &&
-      buffer[0] === 0xff &&
-      buffer[1] === 0xd8 &&
-      buffer[2] === 0xff
-    ) {
-      return "image/jpeg";
-    }
-
-    // Check WebP signature
-    if (
-      buffer.length >= 12 &&
-      buffer[0] === 0x52 &&
-      buffer[1] === 0x49 &&
-      buffer[2] === 0x46 &&
-      buffer[3] === 0x46 &&
-      buffer[8] === 0x57 &&
-      buffer[9] === 0x45 &&
-      buffer[10] === 0x42 &&
-      buffer[11] === 0x50
-    ) {
-      return "image/webp";
-    }
-
-    // Check GIF signature
-    if (
-      buffer.length >= 6 &&
-      buffer[0] === 0x47 &&
-      buffer[1] === 0x49 &&
-      buffer[2] === 0x46
-    ) {
-      return "image/gif";
-    }
-
-    // Default to PNG if unknown
-    return "image/png";
+    return detectImageMimeType(buffer);
   }
 
   /**

--- a/src/lib/utils/imageDetection.ts
+++ b/src/lib/utils/imageDetection.ts
@@ -1,0 +1,65 @@
+/**
+ * Image format detection from magic bytes.
+ *
+ * The native Vertex+Anthropic image block needs the correct `mimeType` for
+ * each inline image. Buffer and bare-base64 inputs (e.g. Slack / REST uploads)
+ * carry no mime hint, so the format must be sniffed from the leading bytes —
+ * otherwise a wrong default (historically `image/jpeg`) makes Anthropic reject
+ * PNG/GIF/WebP with a media-type mismatch 400.
+ */
+
+/**
+ * Detect an image's MIME type from its magic bytes. Returns `image/png` for
+ * buffers that match no known signature (the safest neutral default for the
+ * Vertex image path).
+ */
+export function detectImageMimeType(buffer: Buffer): string {
+  // PNG: 89 50 4E 47
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  // JPEG: FF D8 FF
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  // WebP: "RIFF"...."WEBP"
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  // GIF: "GIF"
+  if (
+    buffer.length >= 6 &&
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46
+  ) {
+    return "image/gif";
+  }
+
+  // Unknown — neutral default.
+  return "image/png";
+}

--- a/test/continuous-test-suite-vertex-image-mime.ts
+++ b/test/continuous-test-suite-vertex-image-mime.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: image MIME detection from magic bytes (pure, no API).
+ *
+ * The native Vertex+Anthropic image block must label each inline image with the
+ * correct mimeType. Buffer / bare-base64 inputs (Slack & REST uploads) carry no
+ * mime hint, so the format is sniffed from the leading bytes. A wrong default
+ * (historically image/jpeg) made Anthropic reject a PNG with:
+ *   "image specified using image/jpeg ... but the image appears to be image/png"
+ * detectImageMimeType() is the source of truth used by GoogleVertexProvider.
+ *
+ * Run: npx tsx test/continuous-test-suite-vertex-image-mime.ts
+ */
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import { detectImageMimeType } from "../src/lib/utils/imageDetection.js";
+
+const { test, runSuite } = defineSuite("Vertex image MIME detection");
+
+const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const webp = Buffer.concat([
+  Buffer.from("RIFF"),
+  Buffer.from([0x00, 0x00, 0x00, 0x00]),
+  Buffer.from("WEBP"),
+]);
+const gif = Buffer.from("GIF89a");
+
+await test("detects PNG from 89 50 4E 47", () => {
+  assertEqual(detectImageMimeType(png), "image/png", "png magic");
+});
+
+await test("detects JPEG from FF D8 FF", () => {
+  assertEqual(detectImageMimeType(jpeg), "image/jpeg", "jpeg magic");
+});
+
+await test("detects WebP from RIFF....WEBP", () => {
+  assertEqual(detectImageMimeType(webp), "image/webp", "webp magic");
+});
+
+await test("detects GIF from GIF8", () => {
+  assertEqual(detectImageMimeType(gif), "image/gif", "gif magic");
+});
+
+await test("does NOT mislabel a PNG as JPEG (the bug we fixed)", () => {
+  assertEqual(detectImageMimeType(png), "image/png", "png must not be jpeg");
+});
+
+await test("falls back to image/png for unknown bytes", () => {
+  assertEqual(
+    detectImageMimeType(Buffer.from([0x00, 0x01, 0x02, 0x03])),
+    "image/png",
+    "unknown default",
+  );
+});
+
+await test("falls back to image/png for too-short buffers", () => {
+  assertEqual(
+    detectImageMimeType(Buffer.from([0x89])),
+    "image/png",
+    "short buffer",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## Problem

On the native Vertex + Anthropic path (`GoogleVertexProvider`), the image block builder defaulted **every Buffer / bare-base64 image to `image/jpeg`** and never sniffed the real format. Callers that pass image **Buffers** — e.g. Slack and REST uploads in downstream apps — therefore sent PNG/GIF/WebP **mislabeled as JPEG**. Anthropic rejects the mismatch:

```
400 invalid_request_error: messages.0.content.0.image.source.base64:
The image was specified using the image/jpeg media type, but the image appears to be a image/png image
```

The image then silently never reaches the model (the caller's fallback drops it), so the user sees "please upload an image" even though they did. PNG is the common case (screenshots), so this affects most real image uploads on vertex+claude.

`detectImageType()` already existed and correctly sniffs magic bytes, but it was only used on the URL/data-URL branches — not the Buffer or bare-base64 branches.

## Fix

Sniff the format from magic bytes in the **bare-base64** and **Buffer** branches of all four native image builders (`executeNativeAnthropicStream`/`Generate`, `executeNativeGemini3Stream`/`Generate`). The detection logic is extracted to a standalone, unit-testable `detectImageMimeType()` helper that the private `detectImageType()` now delegates to.

## Verification

- New deterministic suite `test/continuous-test-suite-vertex-image-mime.ts` (7/7 pass): PNG/JPEG/WebP/GIF detection, the PNG-not-JPEG regression, and unknown/short-buffer fallback.
- Verified end-to-end against a downstream app on `vertex` + `claude-*`: a PNG Buffer that previously 400'd is now read correctly by the model; JPEG unaffected.

## Scope

Source-only (dist is gitignored). No behavior change for JPEG or for path/data-URL/HTTP image inputs; only Buffer and bare-base64 inputs are now correctly typed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved multimodal image handling by automatically detecting the correct image format instead of defaulting to a single format, preventing media-type mismatches that could cause image rejection.

* **Tests**
  * Added comprehensive test coverage for image format detection across multiple formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->