### PR TITLE
fix(vertex): sanitize Gemini responseSchema (strip errorMessage) to stop structured-output 400s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
 
       - name: Install ffmpeg
         uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
+          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
+          # job at download ("xz: File format not recognized"). Revert once
+          # upstream republishes a valid 8.1 build.
+          version: "7.1"
 
       - name: Verify ffmpeg installation
         run: |
@@ -155,6 +161,12 @@ jobs:
 
       - name: Install ffmpeg
         uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
+          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
+          # job at download ("xz: File format not recognized"). Revert once
+          # upstream republishes a valid 8.1 build.
+          version: "7.1"
 
       - name: Verify ffmpeg installation
         run: |
@@ -202,6 +214,12 @@ jobs:
 
       - name: Install ffmpeg
         uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
+          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
+          # job at download ("xz: File format not recognized"). Revert once
+          # upstream republishes a valid 8.1 build.
+          version: "7.1"
 
       - name: Verify ffmpeg installation
         run: |

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -109,11 +109,12 @@ const hasAnthropicSupport = (): boolean => {
 };
 
 /**
- * Recursively strip JSON-schema fields that Vertex Gemini's function-call
- * validator rejects with 400 INVALID_ARGUMENT. Vertex implements OpenAPI 3.0
- * Schema strictly and rejects extension fields that the broader JSON Schema
- * spec allows. The fields stripped here have no semantic meaning for the
- * model, so removing them is safe for every caller.
+ * Recursively strip JSON-schema fields that Vertex Gemini's function-call AND
+ * `responseSchema` (structured output) validators reject with 400
+ * INVALID_ARGUMENT. Vertex implements OpenAPI 3.0 Schema strictly and rejects
+ * extension fields that the broader JSON Schema spec allows. The fields
+ * stripped here have no semantic meaning for the model, so removing them is
+ * safe for every caller.
  *
  * Fields removed:
  * - `additionalProperties` — extension; Vertex rejects on any nested object.
@@ -124,8 +125,15 @@ const hasAnthropicSupport = (): boolean => {
  *   fields that Vertex doesn't recognise.
  * - `examples` — accepted by some Gemini variants but not 2.5-flash; strip
  *   to avoid the model rejecting tool schemas under that path.
+ * - `errorMessage` — emitted by `convertZodToJsonSchema` (which enables
+ *   zod-to-json-schema's `errorMessages: true`) for any field carrying a
+ *   custom message, e.g. `z.string().regex(re, { message })`. Vertex's
+ *   `response_schema` validator rejects it with `Unknown name "errorMessage"
+ *   … Cannot find field`, failing the whole structured-output request.
+ *
+ * Exported for deterministic unit testing of the sanitization contract.
  */
-function stripAdditionalPropertiesDeep(
+export function stripAdditionalPropertiesDeep(
   schema: Record<string, unknown> | undefined,
 ): void {
   if (!schema || typeof schema !== "object") {
@@ -140,6 +148,7 @@ function stripAdditionalPropertiesDeep(
     "definitions",
     "$defs",
     "examples",
+    "errorMessage",
   ] as const;
   for (const field of FIELDS_TO_STRIP) {
     if (field in schema) {
@@ -1504,6 +1513,13 @@ export class GoogleVertexProvider extends BaseProvider {
           // ensureNestedSchemaTypes recursively adds missing type fields
           // Note: convertZodToJsonSchema now uses openApi3 target which produces nullable: true
           const typedSchema = ensureNestedSchemaTypes(inlinedSchema);
+          // Sanitize the same way tool schemas are (see tool path above):
+          // Vertex's responseSchema validator rejects extension keywords such
+          // as `errorMessage` (from convertZodToJsonSchema's errorMessages
+          // option) and `additionalProperties`. Without this a user schema with
+          // a `.regex(.., { message })` field 400s the whole structured-output
+          // request and the recovery loop retries the same poisoned payload.
+          stripAdditionalPropertiesDeep(typedSchema);
           config.responseSchema = typedSchema;
 
           logger.debug(
@@ -2331,6 +2347,13 @@ export class GoogleVertexProvider extends BaseProvider {
           // ensureNestedSchemaTypes recursively adds missing type fields
           // Note: convertZodToJsonSchema now uses openApi3 target which produces nullable: true
           const typedSchema = ensureNestedSchemaTypes(inlinedSchema);
+          // Sanitize the same way tool schemas are (see tool path above):
+          // Vertex's responseSchema validator rejects extension keywords such
+          // as `errorMessage` (from convertZodToJsonSchema's errorMessages
+          // option) and `additionalProperties`. Without this a user schema with
+          // a `.regex(.., { message })` field 400s the whole structured-output
+          // request and the recovery loop retries the same poisoned payload.
+          stripAdditionalPropertiesDeep(typedSchema);
           config.responseSchema = typedSchema;
 
           logger.debug(

--- a/test/continuous-test-suite-vertex-response-schema-sanitize.ts
+++ b/test/continuous-test-suite-vertex-response-schema-sanitize.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: Vertex Gemini responseSchema sanitization (pure, no API).
+ *
+ * Vertex's `response_schema` (structured output) and function-call validators
+ * implement OpenAPI 3.0 strictly and reject JSON-Schema extension keywords.
+ * `convertZodToJsonSchema` enables zod-to-json-schema's `errorMessages: true`,
+ * so any field carrying a custom message — e.g. curator's
+ * `z.string().regex(re, { message })` on filename/extension/mimetype — emits an
+ * `errorMessage` keyword. Vertex then rejects the whole structured-output
+ * request with `Unknown name "errorMessage" … Cannot find field`, and a recovery
+ * loop retries the same poisoned payload.
+ *
+ * The tool path already sanitized via stripAdditionalPropertiesDeep; the
+ * responseSchema path did not, and `errorMessage` was not in the strip list.
+ * This suite locks in that stripAdditionalPropertiesDeep removes `errorMessage`
+ * (and the other Vertex-rejected keywords) recursively — including from a
+ * faithful reproduction of the exact production payload Vertex rejected — while
+ * preserving the real schema content (types, patterns, enums, required).
+ *
+ * Run: npx tsx test/continuous-test-suite-vertex-response-schema-sanitize.ts
+ */
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import { stripAdditionalPropertiesDeep } from "../src/lib/providers/googleVertex.js";
+
+const { test, runSuite } = defineSuite("Vertex responseSchema sanitization");
+
+/** True if `key` appears anywhere in the (possibly nested) object/array tree. */
+const hasKeyDeep = (node: unknown, key: string): boolean => {
+  if (Array.isArray(node)) {
+    return node.some((v) => hasKeyDeep(v, key));
+  }
+  if (node && typeof node === "object") {
+    return Object.entries(node as Record<string, unknown>).some(
+      ([k, v]) => k === key || hasKeyDeep(v, key),
+    );
+  }
+  return false;
+};
+
+// Faithful reproduction of the JSON schema `convertZodToJsonSchema` produces for
+// curator's StructuredAgentResponseSchema. Curator's schema is authored with
+// zod v3; `convertZodToJsonSchema` enables zod-to-json-schema's
+// `errorMessages: true`, so each `z.string().regex(re, { message })` field
+// (filename/extension/mimetype) emits an `errorMessage` object alongside its
+// `pattern`. Vertex's `response_schema` validator then 400s with
+// `Unknown name "errorMessage" … Cannot find field`. (Asserted as a literal,
+// not via the live converter, because this repo's own zod is v4 — which does not
+// emit errorMessage — so a converter-based assertion would not be portable.)
+const productionResponseSchema = (): Record<string, unknown> => ({
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    summary: { type: "string" },
+    attachment: {
+      type: "object",
+      nullable: true,
+      additionalProperties: false,
+      properties: {
+        filename: {
+          type: "string",
+          pattern: "^[A-Za-z0-9._\\- ]+$",
+          errorMessage: { pattern: "bad filename" },
+        },
+        extension: {
+          type: "string",
+          pattern: "^[A-Za-z0-9]+$",
+          errorMessage: { pattern: "bad extension" },
+        },
+        mimetype: {
+          type: "string",
+          pattern: "^[\\w.+-]+/[\\w.+-]+$",
+          errorMessage: { pattern: "bad mimetype" },
+        },
+        content: { type: "string" },
+      },
+      required: ["filename", "extension", "mimetype", "content"],
+    },
+  },
+  required: ["summary", "attachment"],
+});
+
+await test("strips errorMessage from the production-shaped responseSchema (the Vertex-400 payload)", () => {
+  const js = productionResponseSchema();
+  assertEqual(
+    hasKeyDeep(js, "errorMessage"),
+    true,
+    "errorMessage present before sanitize",
+  );
+  stripAdditionalPropertiesDeep(js);
+  assertEqual(
+    hasKeyDeep(js, "errorMessage"),
+    false,
+    "errorMessage must be gone everywhere after sanitize",
+  );
+});
+
+await test("also clears additionalProperties from the production-shaped responseSchema", () => {
+  const js = productionResponseSchema();
+  stripAdditionalPropertiesDeep(js);
+  assertEqual(
+    hasKeyDeep(js, "additionalProperties"),
+    false,
+    "additionalProperties gone",
+  );
+  // The real attachment fields and constraints survive.
+  const att = (js.properties as Record<string, Record<string, unknown>>)
+    .attachment;
+  const fn = (att.properties as Record<string, Record<string, unknown>>)
+    .filename;
+  assertEqual(fn.type, "string", "filename type preserved");
+  assertEqual(fn.pattern, "^[A-Za-z0-9._\\- ]+$", "filename pattern preserved");
+  assertEqual(
+    JSON.stringify(att.required),
+    JSON.stringify(["filename", "extension", "mimetype", "content"]),
+    "required preserved",
+  );
+});
+
+await test("also strips additionalProperties and $schema in nested objects/arrays", () => {
+  const js = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      a: { type: "string", errorMessage: "x" },
+      b: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: true,
+          errorMessage: "y",
+        },
+      },
+    },
+  } as Record<string, unknown>;
+  stripAdditionalPropertiesDeep(js);
+  assertEqual(
+    hasKeyDeep(js, "additionalProperties"),
+    false,
+    "additionalProperties gone",
+  );
+  assertEqual(hasKeyDeep(js, "$schema"), false, "$schema gone");
+  assertEqual(
+    hasKeyDeep(js, "errorMessage"),
+    false,
+    "nested errorMessage gone",
+  );
+});
+
+await test("strips rejected keywords inside anyOf branches", () => {
+  const js = {
+    type: "object",
+    properties: {
+      u: {
+        anyOf: [
+          { type: "string", errorMessage: "m" },
+          { type: "number", additionalProperties: false },
+        ],
+      },
+    },
+  } as Record<string, unknown>;
+  stripAdditionalPropertiesDeep(js);
+  assertEqual(
+    hasKeyDeep(js, "errorMessage"),
+    false,
+    "errorMessage in anyOf gone",
+  );
+  assertEqual(
+    hasKeyDeep(js, "additionalProperties"),
+    false,
+    "additionalProperties in anyOf gone",
+  );
+});
+
+await test("preserves legitimate schema content (type/description/enum/required)", () => {
+  const js = {
+    type: "object",
+    properties: {
+      name: { type: "string", description: "the name", enum: ["a", "b"] },
+    },
+    required: ["name"],
+  } as Record<string, unknown>;
+  stripAdditionalPropertiesDeep(js);
+  const props = js.properties as Record<string, Record<string, unknown>>;
+  assertEqual(props.name.type, "string", "type preserved");
+  assertEqual(props.name.description, "the name", "description preserved");
+  assertEqual(
+    JSON.stringify(props.name.enum),
+    JSON.stringify(["a", "b"]),
+    "enum preserved",
+  );
+  assertEqual(
+    JSON.stringify(js.required),
+    JSON.stringify(["name"]),
+    "required preserved",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## Problem

Vertex Gemini's `response_schema` (structured output) validator implements OpenAPI 3.0 strictly and rejects extension keywords. `convertZodToJsonSchema` enables zod-to-json-schema's `errorMessages: true`, so **any** schema field with a custom message — e.g. `z.string().regex(re, { message })` — emits an `errorMessage` keyword.

The **tool** path already sanitized schemas via `stripAdditionalPropertiesDeep`, but the **responseSchema** build assigned the converted schema directly, and `errorMessage` wasn't in the strip list. So a caller whose schema carries a custom-message field (e.g. curator's `{summary, attachment}` envelope — `attachment.filename/extension/mimetype` use `.regex(.., { message })`) gets, on **every** structured-output request:

```
400 INVALID_ARGUMENT: Unknown name "errorMessage" at
'generation_config.response_schema.properties[1].value.properties[0..2].value': Cannot find field
```

…and the recovery loop then retries the **same poisoned payload** across providers ("All providers failed").

This was found while validating curator against a Gemini model: the primary tool call (Anthropic format) succeeded, but the structured-output **recovery** generate 400'd with exactly this error. The Anthropic/Claude path is unaffected (no native `responseSchema`; Anthropic tolerates the schema), which is why it only surfaces on Gemini.

## Fix

- Add `errorMessage` to `FIELDS_TO_STRIP` in `stripAdditionalPropertiesDeep`.
- Call `stripAdditionalPropertiesDeep` on the `responseSchema` at **both** build sites (stream + generate), matching the tool path.
- Export the helper and add a deterministic suite (`test/continuous-test-suite-vertex-response-schema-sanitize.ts`) that reproduces the exact Vertex-rejected payload shape and asserts the keyword is stripped recursively while real content (types/patterns/enums/required) is preserved.

## Test

```
npx tsx test/continuous-test-suite-vertex-response-schema-sanitize.ts
# Passed: 5  Total: 5  RESULT: PASS
```
`tsc --noEmit` clean; eslint clean.

> Note: this repo's own zod is v4 (which doesn't emit `errorMessage` for these constructs); curator authors its schema with zod v3, which does. The test therefore asserts against a faithful literal of the production payload rather than the live converter, so it stays portable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured-output validation failures for Google Vertex Gemini responses by improving schema handling.

* **Chores**
  * Updated CI/CD pipeline to use a pinned FFmpeg version for consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->