### PR TITLE
fix(fallback): abort on deterministic 400 errors embedded in provider messages

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -223,7 +223,10 @@ import { resolveModel } from "./utils/modelAliasResolver.js";
 // Import orchestration components
 import { ModelRouter } from "./utils/modelRouter.js";
 import { getBestProvider } from "./utils/providerUtils.js";
-import { NON_RETRYABLE_HTTP_STATUS_CODES } from "./utils/retryability.js";
+import {
+  NON_RETRYABLE_HTTP_STATUS_CODES,
+  isDeterministicClientErrorMessage,
+} from "./utils/retryability.js";
 import { isZodSchema } from "./utils/schemaConversion.js";
 import { BinaryTaskClassifier } from "./utils/taskClassifier.js";
 // Tool detection and execution imports
@@ -414,6 +417,15 @@ function isNonRetryableProviderError(error: unknown): boolean {
       msg.includes("PERMISSION_DENIED") ||
       msg.includes("UNAUTHENTICATED")
     ) {
+      return true;
+    }
+    // A deterministic 400 / malformed-request whose status is only present in
+    // the message string (e.g. Vertex wraps `{"code":400,"status":
+    // "INVALID_ARGUMENT"}` inside the message). The object-level status check
+    // above misses it, so without this the fallback orchestrator retries the
+    // identical bad payload on every other provider — they reject it the same
+    // way. The request itself is malformed, so abort fast.
+    if (isDeterministicClientErrorMessage(msg)) {
       return true;
     }
   }

--- a/src/lib/utils/retryability.ts
+++ b/src/lib/utils/retryability.ts
@@ -24,3 +24,28 @@ export function isRetryableStatusCode(code: number): boolean {
 export function isNonRetryableStatusCode(code: number): boolean {
   return (NON_RETRYABLE_HTTP_STATUS_CODES as readonly number[]).includes(code);
 }
+
+/**
+ * Detect a deterministic client-error (HTTP 400 / malformed request) signature
+ * embedded in a provider error MESSAGE, for cases where the numeric status is
+ * not exposed as a structured `status`/`statusCode` field. Vertex/Gemini wrap a
+ * 400 INVALID_ARGUMENT inside the message string (e.g. `Google Vertex AI Invalid
+ * Request: {"error":{"code":400,"status":"INVALID_ARGUMENT", …}}`), so the
+ * object-level status check misses it and the fallback orchestrator keeps
+ * retrying the identical, malformed payload on every other provider — they
+ * reject it the same way. A 400 means the request itself is bad, so retrying is
+ * pointless regardless of provider. Matches only unambiguous markers to avoid
+ * misclassifying transient (5xx/429) failures.
+ */
+export function isDeterministicClientErrorMessage(message: string): boolean {
+  if (!message) {
+    return false;
+  }
+  return (
+    message.includes("INVALID_ARGUMENT") ||
+    message.includes("Invalid JSON payload") ||
+    /\bInvalid Request\b/i.test(message) ||
+    /"code"\s*:\s*400\b/.test(message) ||
+    /\b400\s+Bad Request\b/i.test(message)
+  );
+}

--- a/test/continuous-test-suite-deterministic-400-abort.ts
+++ b/test/continuous-test-suite-deterministic-400-abort.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: deterministic-400 fallback abort (pure, no API).
+ *
+ * The provider fallback orchestrator (directProviderGeneration) stops retrying
+ * when isNonRetryableProviderError(error) is true. HTTP 400 is already in
+ * NON_RETRYABLE_HTTP_STATUS_CODES, but that only helps when the status is a
+ * structured `status`/`statusCode` field. Vertex/Gemini wrap a 400
+ * INVALID_ARGUMENT inside the error MESSAGE string, so the object-level check
+ * misses it and the orchestrator retries the identical malformed payload on
+ * every other provider — they reject it the same way ("All providers failed").
+ *
+ * isDeterministicClientErrorMessage detects those embedded markers so the turn
+ * aborts fast. This suite locks in that it matches the real Vertex 400 payloads
+ * while NOT matching transient (5xx / 429 / network) errors that SHOULD retry.
+ *
+ * Run: npx tsx test/continuous-test-suite-deterministic-400-abort.ts
+ */
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import { isDeterministicClientErrorMessage } from "../src/lib/utils/retryability.js";
+
+const { test, runSuite } = defineSuite("Deterministic-400 fallback abort");
+
+// The actual production message (responseSchema rejection) — abbreviated but
+// keeping the exact markers the detector keys on.
+const VERTEX_RESPONSE_SCHEMA_400 =
+  '[vertex] Google Vertex AI Invalid Request: {"error":{"message":"{\\n  ' +
+  '\\"error\\": {\\n    \\"code\\": 400,\\n    \\"message\\": \\"Invalid JSON ' +
+  'payload received. Unknown name \\\\\\"errorMessage\\\\\\" at ' +
+  "'generation_config.response_schema.properties[1]...': Cannot find field.\\\"," +
+  '\\n    \\"status\\": \\"INVALID_ARGUMENT\\"\\n  }\\n}\\n","code":400,' +
+  '"status":"Bad Request"}}';
+
+const VERTEX_TOOL_ENUM_400 =
+  "[vertex] Google Vertex AI error: 400 Invalid value at " +
+  "'tools[0].function_declarations[64].parameters' INVALID_ARGUMENT";
+
+await test("matches the production responseSchema 400 (INVALID_ARGUMENT in message)", () => {
+  assertEqual(
+    isDeterministicClientErrorMessage(VERTEX_RESPONSE_SCHEMA_400),
+    true,
+    "wrapped Vertex 400 must be non-retryable",
+  );
+});
+
+await test("matches a tool-schema INVALID_ARGUMENT 400", () => {
+  assertEqual(
+    isDeterministicClientErrorMessage(VERTEX_TOOL_ENUM_400),
+    true,
+    "tool-schema 400 must be non-retryable",
+  );
+});
+
+await test('matches a bare "400 Bad Request"', () => {
+  assertEqual(
+    isDeterministicClientErrorMessage("Request failed: 400 Bad Request"),
+    true,
+    "bare 400 Bad Request is deterministic",
+  );
+});
+
+await test('matches an embedded "code": 400', () => {
+  assertEqual(
+    isDeterministicClientErrorMessage('upstream said {"code": 400}'),
+    true,
+    '"code": 400 is deterministic',
+  );
+});
+
+await test("does NOT match transient 5xx / 429 / network errors (these should still retry)", () => {
+  const transient = [
+    "[vertex] 503 Service Unavailable",
+    "429 Too Many Requests: rate limit exceeded",
+    "500 Internal Server Error",
+    "ECONNRESET socket hang up",
+    "fetch failed: network timeout after 30000ms",
+    "UNAVAILABLE: backend overloaded",
+  ];
+  for (const msg of transient) {
+    assertEqual(
+      isDeterministicClientErrorMessage(msg),
+      false,
+      `transient error should remain retryable: ${msg}`,
+    );
+  }
+});
+
+await test("does NOT match a generic success-ish or empty message", () => {
+  assertEqual(isDeterministicClientErrorMessage(""), false, "empty → false");
+  assertEqual(
+    isDeterministicClientErrorMessage("completed in 1200ms"),
+    false,
+    "unrelated message → false",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## Problem

`isNonRetryableProviderError` already treats HTTP **400** as non-retryable (`NON_RETRYABLE_HTTP_STATUS_CODES`), but only when the status is a structured `status`/`statusCode` field. Vertex/Gemini wrap a 400 **INVALID_ARGUMENT** inside the error *message string*:

```
[vertex] Google Vertex AI Invalid Request: {"error":{ … "code":400, "status":"INVALID_ARGUMENT" … }}
```

So the object-level status check misses it, and `directProviderGeneration` retries the **identical malformed payload** on every other provider — they reject it the same way, producing `All providers failed` plus wasted latency and cost. (Observed live alongside the responseSchema `errorMessage` bug fixed in #1092: the recovery generate 400'd, then the fallback chain retried the same poisoned payload.)

## Fix

- Add `isDeterministicClientErrorMessage()` to `retryability.ts` — matches `INVALID_ARGUMENT`, `Invalid JSON payload`, `Invalid Request`, `"code": 400`, `400 Bad Request`.
- Consult it in `isNonRetryableProviderError`'s message check so a 400 whose status lives only in the message aborts the turn fast with the real error, instead of poisoning the fallback chain.
- **Transient** errors (5xx / 429 / network / UNAVAILABLE) are intentionally **not** matched and still retry across providers.

## Test

```
npx tsx test/continuous-test-suite-deterministic-400-abort.ts
# Passed: 6  Total: 6  RESULT: PASS
```
Covers the real Vertex responseSchema + tool-enum 400 payloads (match), bare `400 Bad Request` / `"code":400` (match), and 5xx/429/network/empty (no match → still retryable). `tsc --noEmit` clean; eslint 0 errors.

Complements #1092 (which removes the `errorMessage` that triggered the 400 in the first place); this PR is the defense-in-depth so any future deterministic 400 fails fast.