### PR TITLE
fix(csv): support CRLF and CR line endings

### DIFF
--- a/src/lib/utils/csvProcessor.ts
+++ b/src/lib/utils/csvProcessor.ts
@@ -581,6 +581,15 @@ function isMetadataLine(lines: string[]): boolean {
 }
 
 /**
+ * Split CSV text into logical lines for metadata detection and raw row limiting.
+ *
+ * Supports Unix (LF), Windows (CRLF), and classic Mac (CR) line endings.
+ */
+function splitCsvLines(csvString: string): string[] {
+  return csvString.split(/\r\n|\n|\r/);
+}
+
+/**
  * CSV processor for converting CSV data to LLM-optimized formats
  *
  * Supports three output formats:
@@ -632,10 +641,10 @@ export class CSVProcessor {
 
     const csvString = content.toString("utf-8");
 
-    // For raw format, return original CSV with row limit (no parsing needed)
-    // This preserves the exact original format which works best for LLMs
+    // For raw format, return CSV text with row limit (no parsing needed)
+    // This preserves the CSV shape while normalizing line endings for row handling.
     if (formatStyle === "raw") {
-      const lines = csvString.split("\n");
+      const lines = splitCsvLines(csvString);
       const hasMetadataLine = isMetadataLine(lines);
 
       if (hasMetadataLine) {
@@ -863,7 +872,10 @@ export class CSVProcessor {
       let buffer = "";
       lineReader.on("data", (chunk: string | Buffer) => {
         buffer += chunk.toString();
-        const lines = buffer.split("\n");
+        const splitBuffer = buffer.endsWith("\r")
+          ? buffer.slice(0, -1)
+          : buffer;
+        const lines = splitCsvLines(splitBuffer);
         if (lines.length >= 2) {
           firstLines.push(lines[0], lines[1]);
           lineReader.destroy();
@@ -949,9 +961,11 @@ export class CSVProcessor {
     });
 
     // Detect and skip metadata line
-    const lines = csvString.split("\n");
+    const lines = splitCsvLines(csvString);
     const hasMetadataLine = isMetadataLine(lines);
-    const csvData = hasMetadataLine ? lines.slice(1).join("\n") : csvString;
+    const csvData = hasMetadataLine
+      ? lines.slice(1).join("\n")
+      : lines.join("\n");
 
     if (hasMetadataLine) {
       logger.debug("[CSVProcessor] Detected metadata line in string, skipping");
@@ -1032,7 +1046,10 @@ export class CSVProcessor {
 
     // Escape backslashes, pipes, and sanitize newlines to keep rows intact
     const escapePipe = (str: string) =>
-      str.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+      str
+        .replace(/\\/g, "\\\\")
+        .replace(/\|/g, "\\|")
+        .replace(/\r\n|\n|\r/g, " ");
 
     let markdown = "";
 
@@ -1102,7 +1119,11 @@ export class CSVProcessor {
 
     // Escape CSV values (wrap in quotes if contains comma, quote, or newline)
     const escapeCSV = (value: string): string => {
-      if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+      if (
+        value.includes(",") ||
+        value.includes('"') ||
+        /\r\n|\n|\r/.test(value)
+      ) {
         return `"${value.replace(/"/g, '""')}"`;
       }
       return value;

--- a/src/lib/utils/csvProcessor.ts
+++ b/src/lib/utils/csvProcessor.ts
@@ -581,6 +581,46 @@ function isMetadataLine(lines: string[]): boolean {
 }
 
 /**
+ * Split CSV text into logical rows for metadata detection and raw row limiting.
+ *
+ * Supports Unix (LF), Windows (CRLF), and classic Mac (CR) line endings, and is
+ * quote-aware: a line ending that appears *inside* a quoted field (RFC 4180) is
+ * kept as part of that field rather than treated as a row boundary. A doubled
+ * `""` inside quotes is the RFC-4180 escaped quote and does not toggle the quote
+ * state. For unquoted input this yields exactly the same result as a plain
+ * `split(/\r\n|\n|\r/)`.
+ */
+function splitCsvLines(csvString: string): string[] {
+  const rows: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < csvString.length; i++) {
+    const ch = csvString[i];
+    if (ch === '"') {
+      if (inQuotes && csvString[i + 1] === '"') {
+        // Escaped quote ("") — stays inside the field, quote state unchanged.
+        current += '""';
+        i++;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      current += ch;
+    } else if (!inQuotes && (ch === "\n" || ch === "\r")) {
+      // Row boundary outside quotes; collapse CRLF into a single boundary.
+      if (ch === "\r" && csvString[i + 1] === "\n") {
+        i++;
+      }
+      rows.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  rows.push(current);
+  return rows;
+}
+
+/**
  * CSV processor for converting CSV data to LLM-optimized formats
  *
  * Supports three output formats:
@@ -632,10 +672,10 @@ export class CSVProcessor {
 
     const csvString = content.toString("utf-8");
 
-    // For raw format, return original CSV with row limit (no parsing needed)
-    // This preserves the exact original format which works best for LLMs
+    // For raw format, return CSV text with row limit (no parsing needed)
+    // This preserves the CSV shape while normalizing line endings for row handling.
     if (formatStyle === "raw") {
-      const lines = csvString.split("\n");
+      const lines = splitCsvLines(csvString);
       const hasMetadataLine = isMetadataLine(lines);
 
       if (hasMetadataLine) {
@@ -863,7 +903,10 @@ export class CSVProcessor {
       let buffer = "";
       lineReader.on("data", (chunk: string | Buffer) => {
         buffer += chunk.toString();
-        const lines = buffer.split("\n");
+        const splitBuffer = buffer.endsWith("\r")
+          ? buffer.slice(0, -1)
+          : buffer;
+        const lines = splitCsvLines(splitBuffer);
         if (lines.length >= 2) {
           firstLines.push(lines[0], lines[1]);
           lineReader.destroy();
@@ -949,9 +992,11 @@ export class CSVProcessor {
     });
 
     // Detect and skip metadata line
-    const lines = csvString.split("\n");
+    const lines = splitCsvLines(csvString);
     const hasMetadataLine = isMetadataLine(lines);
-    const csvData = hasMetadataLine ? lines.slice(1).join("\n") : csvString;
+    const csvData = hasMetadataLine
+      ? lines.slice(1).join("\n")
+      : lines.join("\n");
 
     if (hasMetadataLine) {
       logger.debug("[CSVProcessor] Detected metadata line in string, skipping");
@@ -1032,7 +1077,10 @@ export class CSVProcessor {
 
     // Escape backslashes, pipes, and sanitize newlines to keep rows intact
     const escapePipe = (str: string) =>
-      str.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+      str
+        .replace(/\\/g, "\\\\")
+        .replace(/\|/g, "\\|")
+        .replace(/\r\n|\n|\r/g, " ");
 
     let markdown = "";
 
@@ -1102,7 +1150,11 @@ export class CSVProcessor {
 
     // Escape CSV values (wrap in quotes if contains comma, quote, or newline)
     const escapeCSV = (value: string): string => {
-      if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+      if (
+        value.includes(",") ||
+        value.includes('"') ||
+        /\r\n|\n|\r/.test(value)
+      ) {
         return `"${value.replace(/"/g, '""')}"`;
       }
       return value;

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/lib/proxy/routingPolicy.js";
 
 import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
+import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
 
 import {
   GoogleVertexProvider,
@@ -116,6 +117,53 @@ async function withTemporaryEnv<T>(
 // ============================================================================
 
 const tests: TestFunction[] = [
+  // ---------- CSV processor line ending handling ----------
+  {
+    name: "CSVProcessor.parseCSVString handles Unix, Windows, and classic Mac line endings",
+    category: "csv-processor",
+    fn: async () => {
+      const cases = [
+        "name,age\nAlice,30\nBob,25",
+        "name,age\r\nAlice,30\r\nBob,25",
+        "name,age\rAlice,30\rBob,25",
+      ];
+
+      for (const csv of cases) {
+        const rows = (await CSVProcessor.parseCSVString(csv, 10)) as Array<
+          Record<string, string>
+        >;
+        if (
+          rows.length !== 2 ||
+          rows[0]?.name !== "Alice" ||
+          rows[0]?.age !== "30" ||
+          rows[1]?.name !== "Bob" ||
+          rows[1]?.age !== "25"
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+  },
+  {
+    name: "CSVProcessor raw format counts CRLF rows without retaining carriage returns",
+    category: "csv-processor",
+    fn: async () => {
+      const result = await CSVProcessor.process(
+        Buffer.from("name,age\r\nAlice,30\r\nBob,25"),
+        { formatStyle: "raw", maxRows: 10 },
+      );
+
+      return (
+        result.metadata?.rowCount === 2 &&
+        result.metadata?.totalLines === 3 &&
+        typeof result.content === "string" &&
+        !result.content.includes("\r") &&
+        result.content.includes("Alice,30\nBob,25")
+      );
+    },
+  },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------
   {
     name: "resolveVertexLocation: gemini-* forced to global regardless of configured location",

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/lib/proxy/routingPolicy.js";
 
 import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
+import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
 
 import {
   GoogleVertexProvider,
@@ -121,6 +122,79 @@ async function withTemporaryEnv<T>(
 // ============================================================================
 
 const tests: TestFunction[] = [
+  // ---------- CSV processor line ending handling ----------
+  {
+    name: "CSVProcessor.parseCSVString handles Unix, Windows, and classic Mac line endings",
+    category: "csv-processor",
+    fn: async () => {
+      const cases = [
+        "name,age\nAlice,30\nBob,25",
+        "name,age\r\nAlice,30\r\nBob,25",
+        "name,age\rAlice,30\rBob,25",
+      ];
+
+      for (const csv of cases) {
+        const rows = (await CSVProcessor.parseCSVString(csv, 10)) as Array<
+          Record<string, string>
+        >;
+        if (
+          rows.length !== 2 ||
+          rows[0]?.name !== "Alice" ||
+          rows[0]?.age !== "30" ||
+          rows[1]?.name !== "Bob" ||
+          rows[1]?.age !== "25"
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+  },
+  {
+    name: "CSVProcessor raw format counts CRLF rows without retaining carriage returns",
+    category: "csv-processor",
+    fn: async () => {
+      const result = await CSVProcessor.process(
+        Buffer.from("name,age\r\nAlice,30\r\nBob,25"),
+        { formatStyle: "raw", maxRows: 10 },
+      );
+
+      return (
+        result.metadata?.rowCount === 2 &&
+        result.metadata?.totalLines === 3 &&
+        typeof result.content === "string" &&
+        !result.content.includes("\r") &&
+        result.content.includes("Alice,30\nBob,25")
+      );
+    },
+  },
+  {
+    name: "CSVProcessor: bare CR inside a quoted field is field content, not a row boundary (RFC 4180)",
+    category: "csv-processor",
+    fn: async () => {
+      // "line1\rline2" is one quoted field containing a classic-Mac CR — legal
+      // RFC-4180 content, not two rows. A quote-unaware row splitter would
+      // inflate the row count and rewrite the value; the quote-aware splitter
+      // must keep the field whole.
+      const csv = 'name,notes\nAlice,"line1\rline2"\nBob,ok';
+      const parsed = (await CSVProcessor.parseCSVString(csv, 10)) as Array<
+        Record<string, string>
+      >;
+      const raw = await CSVProcessor.process(Buffer.from(csv), {
+        formatStyle: "raw",
+        maxRows: 10,
+      });
+      return (
+        parsed.length === 2 &&
+        parsed[0]?.notes === "line1\rline2" &&
+        parsed[1]?.name === "Bob" &&
+        raw.metadata?.rowCount === 2 &&
+        typeof raw.content === "string" &&
+        raw.content.includes('"line1\rline2"')
+      );
+    },
+  },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------
   {
     name: "resolveVertexLocation: gemini-* forced to global regardless of configured location",


### PR DESCRIPTION
## Summary
- normalize CSV line splitting across Unix (LF), Windows (CRLF), and classic Mac (CR) line endings
- apply the same line handling to raw CSV row limiting, metadata-line detection, string parsing, and file sniffing
- add regression coverage for Unix, Windows, and classic Mac CSV inputs

Closes #364

## Validation
- git diff --check
- targeted static assertions that csvProcessor no longer uses split(\n) and that the new regression tests are present

I attempted to install dependencies and run pnpm run test:bugfixes, but the local Windows environment ran out of disk space during corepack pnpm install --frozen-lockfile (ERR_PNPM_ENOSPC). I removed the partial node_modules afterward and did not claim the full test suite passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV parsing and raw CSV processing to correctly support Unix (`\n`), Windows (`\r\n`), and classic Mac (`\r`) line endings.
  * Added RFC 4180–compatible behavior so line-ending characters inside quoted fields are preserved.
  * Normalized escaping for markdown and CSV so newline variants are consistently handled without leaking carriage returns.
* **Tests**
  * Expanded continuous test coverage for parsing and raw processing across all newline variants, including quoted-field edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->