### PR TITLE
Add speech-to-speech (S2S) realtime voice agent to NeuroLink

### DIFF
--- a/package.json
+++ b/package.json
@@ -387,6 +387,7 @@
     "@livekit/agents-plugin-cartesia": "^1.4.5",
     "@livekit/agents-plugin-deepgram": "^1.4.5",
     "@livekit/agents-plugin-elevenlabs": "^1.4.5",
+    "@livekit/agents-plugin-google": "^1.4.5",
     "@livekit/agents-plugin-livekit": "^1.4.5",
     "@livekit/agents-plugin-silero": "^1.4.5",
     "@livekit/agents-plugin-soniox": "^1.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,9 @@ importers:
       '@livekit/agents-plugin-elevenlabs':
         specifier: ^1.4.5
         version: 1.4.5(@livekit/agents@1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)
+      '@livekit/agents-plugin-google':
+        specifier: ^1.4.5
+        version: 1.4.6(@livekit/agents@1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@livekit/agents-plugin-livekit':
         specifier: ^1.4.5
         version: 1.4.5(@livekit/agents@1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6))
@@ -2050,6 +2053,12 @@ packages:
     resolution: {integrity: sha512-cUHcyrTaDi25ena5AwVDlNo9V75rA0mcCVu5T9BT0a2USHKHmjiB1wEpxR7/tlEu8U9QbkwEVBaeV7xiA4t4+A==}
     peerDependencies:
       '@livekit/agents': 1.4.5
+      '@livekit/rtc-node': ^0.13.29
+
+  '@livekit/agents-plugin-google@1.4.6':
+    resolution: {integrity: sha512-XFp8GNMseH1Qkq8RZ3gY5Dsuj/YsttHJF62HaAha42IP9d37C3IEpw8jKrDppNyZNJfOneOFkgjgfYVRd0wVYg==}
+    peerDependencies:
+      '@livekit/agents': 1.4.6
       '@livekit/rtc-node': ^0.13.29
 
   '@livekit/agents-plugin-livekit@1.4.5':
@@ -10116,6 +10125,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.7.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.3
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.28.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.7.0
@@ -10756,6 +10779,25 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    optional: true
+
+  '@livekit/agents-plugin-google@1.4.6(@livekit/agents@1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6))(@livekit/rtc-node@0.13.29)(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))
+      '@livekit/agents': 1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6)
+      '@livekit/mutex': 1.1.1
+      '@livekit/rtc-node': 0.13.29
+      '@types/json-schema': 7.0.15
+      google-auth-library: 10.7.0
+      json-schema: 0.4.0
+      openai: 6.42.0(ws@8.21.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
     optional: true
 
   '@livekit/agents-plugin-livekit@1.4.5(@livekit/agents@1.4.5(@livekit/rtc-node@0.13.29)(typescript@5.9.3)(zod@4.3.6))':

--- a/src/lib/types/livekit.ts
+++ b/src/lib/types/livekit.ts
@@ -170,6 +170,7 @@ export type LiveKitVoiceAgentConfig = {
   conversationIdPrefix?: string;
   /** Optional user id recorded alongside memory. */
   userId?: string;
+  greeting?: string;
   /** Silero VAD tuning (stricter = ignores background noise). */
   vad?: LiveKitVadConfig;
   /** Turn-detection tuning (VAD vs STT endpointing, delays). */
@@ -402,4 +403,154 @@ export type LiveKitEventBridgeParams = {
 export type LiveKitEventBridgeHandle = {
   /** Remove all listeners and stop publishing. Idempotent. */
   dispose: () => void;
+};
+
+/**
+ * Credentials for LiveKit server-side REST calls (room create, agent dispatch).
+ * `url` accepts `ws(s)://` or `http(s)://`; helpers convert it to https.
+ */
+export type LiveKitServerCredentials = {
+  url: string;
+  apiKey: string;
+  apiSecret: string;
+};
+
+/**
+ * Realtime voice configuration resolved from the environment.
+ *
+ * In speech-to-speech mode one realtime model (Gemini Live on Vertex) does STT,
+ * reasoning, TTS, and turn detection — so there is no separate STT/TTS/VAD/EOU
+ * config. `resolveRealtimeVoiceConfig` fills every field from `process.env`
+ * (with defaults); `RealtimeVoiceAgentConfig` lets a caller override any of them.
+ */
+export type RealtimeVoiceConfig = {
+  /** Vertex project id (from VERTEX_PROJECT / GOOGLE_AUTH_* / GOOGLE_CLOUD_PROJECT_ID). */
+  project: string | undefined;
+  /** Vertex location; native-audio Live is served on `global`, not regionally. */
+  location: string;
+  /** Realtime model id (e.g. "gemini-live-2.5-flash"). */
+  model: string;
+  /** Optional Gemini voice name; omit for the plugin default. */
+  voice: string | undefined;
+  /** Response modality: "AUDIO" (native S2S) or "TEXT" (half-cascade). */
+  responseModality: string;
+  /** System prompt / instructions for the agent. */
+  systemPrompt: string;
+  /** Opening line the agent speaks on connect ("" disables). */
+  greeting: string;
+  /** Whether to bridge Lighthouse MCP tools as Gemini function tools. */
+  toolsEnabled: boolean;
+  /** Full URL of the MCP server the tools are bridged from. */
+  mcpUrl: string;
+  /** Grace period after the caller leaves before the job shuts down (ms). */
+  emptyRoomGraceMs: number;
+  /** Deadline for a participant to join before the job shuts down (ms). */
+  joinDeadlineMs: number;
+  /** How long a HITL confirmation waits before being treated as a decline (ms). */
+  hitlTimeoutMs: number;
+  /** Interval for the RSS/heap metrics log (ms). */
+  metricsIntervalMs: number;
+};
+
+/** A single log record handed to a `RealtimeVoiceAgentConfig.onLog` sink. */
+export type RealtimeVoiceLogEntry = {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  timestamp: number;
+  data?: unknown;
+};
+
+export type RealtimeVoiceLogContext = {
+  room: string;
+};
+
+/**
+ * Options for `defineRealtimeVoiceAgent`. Every field is optional: omitted
+ * values fall back to `resolveRealtimeVoiceConfig()` (i.e. the environment), so
+ * a caller can use `defineRealtimeVoiceAgent()` with no arguments and configure
+ * everything via env.
+ */
+export type RealtimeVoiceAgentConfig = {
+  project?: string;
+  location?: string;
+  model?: string;
+  voice?: string;
+  responseModality?: string;
+  systemPrompt?: string;
+  greeting?: string;
+  /** MCP tool bridging overrides. */
+  tools?: {
+    enabled?: boolean;
+    mcpUrl?: string;
+  };
+  /** Data-channel topic for outbound events (default "ai-events"). */
+  eventsTopic?: string;
+  /** Data-channel topic for inbound control messages (default "ai-control"). */
+  controlTopic?: string;
+  /**
+   * Optional sink for the agent's own logs. When set, the realtime agent wires
+   * NeuroLink's logger to this callback for the duration of the call, so a host
+   * can forward worker logs into its logging pipeline. Each record is tagged
+   * with per-call context (the room name). Subject to the logger's level gate:
+   * without debug mode only `error` records are emitted (set `NEUROLINK_DEBUG`).
+   */
+  onLog?: (entry: RealtimeVoiceLogEntry, ctx: RealtimeVoiceLogContext) => void;
+};
+
+/** Auth token + base64 MCP execution context decoded from a room's metadata. */
+export type LiveKitRoomCallContext = {
+  /** Lighthouse access JWT used as `x-auth-token` to the MCP server. */
+  authToken: string;
+  /** base64(JSON) MCP execution context used as `x-context` (or "" if absent). */
+  xContext: string;
+};
+
+/** Publishes a single voice event envelope onto the room data channel. */
+export type RealtimeEventPublisher = (
+  type: LiveKitVoiceEventType,
+  data: Record<string, unknown>,
+) => void;
+
+/** Requests a HITL confirmation and resolves to the user's decision. */
+export type RealtimeConfirmationRequester = (
+  toolName: string,
+  args: Record<string, unknown>,
+) => Promise<boolean>;
+
+/** Handle returned by `attachRealtimeEventBridge`. */
+export type RealtimeEventBridgeHandle = {
+  /** Publish an outbound event to the browser (data packet or text stream). */
+  publishEvent: RealtimeEventPublisher;
+  /** Open a HITL prompt and await the browser's decision (timeout = decline). */
+  requestConfirmation: RealtimeConfirmationRequester;
+  /** Remove the control-channel listener and clear pending confirmations. */
+  dispose: () => void;
+};
+
+/** Inputs to `attachRealtimeEventBridge`. */
+export type RealtimeEventBridgeParams = {
+  /** The LiveKit room for this call (from the job context). */
+  room: LiveKitBridgeRoom;
+  /** HITL confirmation timeout in ms before a request is auto-declined. */
+  hitlTimeoutMs?: number;
+  /** Outbound events topic (default "ai-events"). */
+  eventsTopic?: string;
+  /** Inbound control topic (default "ai-control"). */
+  controlTopic?: string;
+  /** Payloads larger than this are sent via the chunked text stream (default 12000). */
+  maxInlineBytes?: number;
+};
+
+/** Inputs to `buildRealtimeMcpTools`. */
+export type BuildRealtimeMcpToolsParams = {
+  /** Full URL of the MCP server (e.g. ".../ai/mcp/v2"). */
+  mcpUrl: string;
+  /** Lighthouse access JWT forwarded as `x-auth-token`. */
+  authToken: string;
+  /** base64(JSON) execution context forwarded as `x-context`. */
+  xContext: string;
+  /** Publishes tool start/result events to the browser. */
+  publishEvent: RealtimeEventPublisher;
+  /** Opens a HITL confirmation for destructive tools and awaits the decision. */
+  requestConfirmation: RealtimeConfirmationRequester;
 };

--- a/src/lib/voice/livekit/brain.ts
+++ b/src/lib/voice/livekit/brain.ts
@@ -86,7 +86,7 @@ export function createVoiceBrain(
 
     for await (const chunk of result.stream) {
       if (signal?.aborted) {
-        logger.debug("[LiveKitBrain] Turn aborted mid-stream; stopping");
+        logger.debug("voice.brain.turnAborted", { reason: "signal-aborted" });
         return;
       }
       const delta = extractTextDelta(chunk);

--- a/src/lib/voice/livekit/config.ts
+++ b/src/lib/voice/livekit/config.ts
@@ -11,6 +11,7 @@
 import type {
   LiveKitServerConfig,
   LiveKitBrainDefaults,
+  RealtimeVoiceConfig,
 } from "../../types/index.js";
 
 const DEFAULT_LLM_PROVIDER = "bedrock";
@@ -32,6 +33,24 @@ function readEnv(name: string, fallback: string): string {
   const value = process.env[name];
   if (typeof value === "string" && value.trim().length > 0) {
     return value.trim();
+  }
+  return fallback;
+}
+
+function readOptionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function readNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    const parsed = Number(raw.trim());
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
   }
   return fallback;
 }
@@ -61,6 +80,55 @@ export function resolveBrainDefaults(): LiveKitBrainDefaults {
   return {
     provider: readEnv("VOICE_LLM_PROVIDER", DEFAULT_LLM_PROVIDER),
     model: readEnv("VOICE_LLM_MODEL", DEFAULT_LLM_MODEL),
+  };
+}
+
+const DEFAULT_REALTIME_MODEL = "gemini-live-2.5-flash";
+const DEFAULT_REALTIME_LOCATION = "global";
+const DEFAULT_RESPONSE_MODALITY = "AUDIO";
+const DEFAULT_SYSTEM_PROMPT =
+  "You are a concise voice assistant for a merchant dashboard. Keep replies short and spoken.";
+const DEFAULT_GREETING =
+  "Briefly greet the merchant and ask how you can help with their store today.";
+const DEFAULT_LIGHTHOUSE_URL = "http://localhost:5173";
+const DEFAULT_MCP_PATH = "/ai/mcp/v2";
+
+/**
+ * Resolve the realtime (Gemini Live speech-to-speech) voice configuration from
+ * the environment.
+ *
+ * Every value has a safe default so a worker can run with no realtime-specific
+ * env at all. Vertex `project` is resolved from `VERTEX_PROJECT`, then the
+ * service-account project (`GOOGLE_AUTH_BREEZE_PROJECT_ID`), then
+ * `GOOGLE_CLOUD_PROJECT_ID`. The MCP URL is `VOICE_MCP_URL` if set, otherwise
+ * `${LIGHTHOUSE_URL}/ai/mcp/v2`.
+ */
+export function resolveRealtimeVoiceConfig(): RealtimeVoiceConfig {
+  const lighthouseUrl = readEnv("LIGHTHOUSE_URL", DEFAULT_LIGHTHOUSE_URL);
+  const mcpUrl = readEnv(
+    "VOICE_MCP_URL",
+    `${lighthouseUrl}${DEFAULT_MCP_PATH}`,
+  );
+  return {
+    project:
+      readOptionalEnv("VERTEX_PROJECT") ??
+      readOptionalEnv("GOOGLE_AUTH_BREEZE_PROJECT_ID") ??
+      readOptionalEnv("GOOGLE_CLOUD_PROJECT_ID"),
+    location: readEnv("VERTEX_LOCATION", DEFAULT_REALTIME_LOCATION),
+    model: readEnv("VOICE_LIVE_MODEL", DEFAULT_REALTIME_MODEL),
+    voice: readOptionalEnv("VOICE_S2S_VOICE"),
+    responseModality: readEnv(
+      "VOICE_RESPONSE_MODALITY",
+      DEFAULT_RESPONSE_MODALITY,
+    ).toUpperCase(),
+    systemPrompt: readEnv("VOICE_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT),
+    greeting: readEnv("VOICE_GREETING", DEFAULT_GREETING),
+    toolsEnabled: readEnv("VOICE_S2S_TOOLS", "").toLowerCase() === "true",
+    mcpUrl,
+    emptyRoomGraceMs: readNumberEnv("VOICE_EMPTY_ROOM_GRACE_MS", 30_000),
+    joinDeadlineMs: readNumberEnv("VOICE_JOIN_DEADLINE_MS", 60_000),
+    hitlTimeoutMs: readNumberEnv("VOICE_HITL_TIMEOUT_MS", 45_000),
+    metricsIntervalMs: readNumberEnv("VOICE_METRICS_INTERVAL_MS", 10_000),
   };
 }
 

--- a/src/lib/voice/livekit/eventBridge.ts
+++ b/src/lib/voice/livekit/eventBridge.ts
@@ -228,7 +228,7 @@ export async function attachEventBridge(
     const json = JSON.stringify(envelope);
     const bytes = encoder.encode(json);
     const onError = (transport: string) => (error: unknown) => {
-      logger.warn("[LiveKitEventBridge] Failed to publish event", {
+      logger.warn("voice.bridge.publishFailed", {
         transport,
         type: event.type,
         error: error instanceof Error ? error.message : String(error),
@@ -351,7 +351,7 @@ export async function attachEventBridge(
     try {
       parsed = JSON.parse(decoder.decode(payload));
     } catch (error) {
-      logger.warn("[LiveKitEventBridge] Dropping malformed control message", {
+      logger.warn("voice.bridge.controlMalformed", {
         error: error instanceof Error ? error.message : String(error),
       });
       return;
@@ -384,7 +384,7 @@ export async function attachEventBridge(
 
   publish({ type: "status", data: { state: "listening" } });
 
-  logger.info("[LiveKitEventBridge] Attached", {
+  logger.info("voice.bridge.attached", {
     eventsTopic,
     controlTopic,
     filtered: include !== undefined,
@@ -406,7 +406,7 @@ export async function attachEventBridge(
       emitter.off(STREAM_END_EVENT, onStreamComplete);
       emitter.off(STREAM_ERROR_EVENT, onStreamError);
       room.off(RoomEvent.DataReceived, onData);
-      logger.info("[LiveKitEventBridge] Disposed");
+      logger.info("voice.bridge.disposed", {});
     },
   };
 }

--- a/src/lib/voice/livekit/index.ts
+++ b/src/lib/voice/livekit/index.ts
@@ -9,8 +9,27 @@
  */
 
 export { createVoiceBrain } from "./brain.js";
-export { resolveLiveKitServerConfig, resolveBrainDefaults } from "./config.js";
+export {
+  resolveLiveKitServerConfig,
+  resolveBrainDefaults,
+  resolveRealtimeVoiceConfig,
+} from "./config.js";
 export { attachEventBridge } from "./eventBridge.js";
+export { attachRealtimeEventBridge } from "./realtimeEventBridge.js";
 export { mintJoinToken } from "./tokens.js";
+export { createVoiceRoom, dispatchVoiceAgent } from "./roomDispatch.js";
 export { defineVoiceAgent } from "./voiceAgent.js";
-export { startVoiceAgentWorker } from "./voiceAgentWorker.js";
+export { defineRealtimeVoiceAgent } from "./realtimeVoiceAgent.js";
+export {
+  startVoiceAgentWorker,
+  startRealtimeVoiceAgentWorker,
+  installVoiceWorkerProcessGuards,
+} from "./voiceAgentWorker.js";
+export { ensureVertexAdc, clearGeminiApiKeyEnv } from "./vertexAuth.js";
+export { readCallContextFromRoom } from "./roomContext.js";
+export {
+  sanitizeSchema,
+  sanitizeToolParameters,
+  findSchemaIssue,
+} from "./schemaSanitizer.js";
+export { buildRealtimeMcpTools, mcpResultToText } from "./realtimeMcpTools.js";

--- a/src/lib/voice/livekit/realtimeEventBridge.ts
+++ b/src/lib/voice/livekit/realtimeEventBridge.ts
@@ -1,0 +1,178 @@
+/**
+ * Realtime data-channel event bridge.
+ *
+ * The cascaded bridge (`eventBridge.ts`) is driven by NeuroLink's event emitter.
+ */
+
+import { z } from "zod";
+import { logger } from "../../utils/logger.js";
+import type {
+  RealtimeEventBridgeHandle,
+  RealtimeEventBridgeParams,
+} from "../../types/index.js";
+
+const DEFAULT_EVENTS_TOPIC = "ai-events";
+const DEFAULT_CONTROL_TOPIC = "ai-control";
+const DEFAULT_MAX_INLINE_BYTES = 12_000;
+const DEFAULT_HITL_TIMEOUT_MS = 45_000;
+
+const hitlControlMessageSchema = z.object({
+  action: z.enum(["hitl:accept", "hitl:reject"]),
+  confirmationId: z.string(),
+});
+
+/**
+ * Attach the realtime event bridge to a room.
+ *
+ * Returns `publishEvent` (worker → browser), `requestConfirmation` (HITL
+ * round-trip), and `dispose` (remove the control listener, decline anything
+ * still pending).
+ */
+export async function attachRealtimeEventBridge(
+  params: RealtimeEventBridgeParams,
+): Promise<RealtimeEventBridgeHandle> {
+  const { room } = params;
+  const eventsTopic = params.eventsTopic ?? DEFAULT_EVENTS_TOPIC;
+  const controlTopic = params.controlTopic ?? DEFAULT_CONTROL_TOPIC;
+  const maxInlineBytes = params.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
+  const hitlTimeoutMs = params.hitlTimeoutMs ?? DEFAULT_HITL_TIMEOUT_MS;
+
+  const { RoomEvent } = await import("@livekit/rtc-node");
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let seq = 0;
+  let disposed = false;
+  const startedAt = Date.now();
+
+  const publishEvent: RealtimeEventBridgeHandle["publishEvent"] = (
+    type,
+    data,
+  ) => {
+    if (disposed) {
+      return;
+    }
+    const participant = room.localParticipant;
+    if (!participant) {
+      return;
+    }
+    try {
+      seq += 1;
+      const json = JSON.stringify({ seq, ts: Date.now(), type, data });
+      const bytes = encoder.encode(json);
+      const via = bytes.byteLength <= maxInlineBytes ? "data" : "stream";
+
+      logger.debug("realtime.bridge.publish", {
+        ms: Date.now() - startedAt,
+        seq,
+        type,
+        via,
+        bytes: bytes.byteLength,
+      });
+      if (via === "data") {
+        void participant.publishData(bytes, {
+          reliable: true,
+          topic: eventsTopic,
+        });
+      } else {
+        void participant.sendText(json, { topic: eventsTopic });
+      }
+    } catch {
+      /* non-fatal — the UI bridge is best-effort */
+    }
+  };
+
+  // HITL: WRITE-labeled tools pause for user confirmation. We publish a
+  // `hitl-prompt`, the UI replies on the control topic, and we resolve the
+  // pending request by confirmationId. A timeout is treated as a decline so a
+  // turn can never hang waiting on the user.
+  const pendingHitl = new Map<string, (approved: boolean) => void>();
+  let hitlSeq = 0;
+
+  const onData = (...args: unknown[]): void => {
+    const payload = args[0];
+    const topic = args[3];
+    if (topic !== controlTopic || !(payload instanceof Uint8Array)) {
+      return;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(decoder.decode(payload));
+    } catch {
+      return;
+    }
+    const message = hitlControlMessageSchema.safeParse(raw);
+    if (!message.success) {
+      return;
+    }
+    const { action, confirmationId } = message.data;
+    const resolver = pendingHitl.get(confirmationId);
+    if (resolver) {
+      logger.debug("realtime.bridge.controlReceived", {
+        action,
+        confirmationId,
+      });
+      pendingHitl.delete(confirmationId);
+      resolver(action === "hitl:accept");
+    } else {
+      logger.warn("realtime.bridge.controlUnmatched", {
+        action,
+        confirmationId,
+      });
+    }
+  };
+
+  room.on(RoomEvent.DataReceived, onData);
+
+  const requestConfirmation: RealtimeEventBridgeHandle["requestConfirmation"] =
+    (toolName, args) => {
+      if (disposed) {
+        logger.warn("realtime.bridge.hitlDisposed", { toolName });
+        return Promise.resolve(false);
+      }
+      hitlSeq += 1;
+      const confirmationId = `hitl_${seq}_${hitlSeq}`;
+      publishEvent("hitl-prompt", {
+        confirmationId,
+        toolName,
+        actionType: `Run ${toolName}`,
+        arguments: args ?? {},
+      });
+      logger.info("realtime.bridge.hitlPrompt", { toolName, confirmationId });
+      return new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => {
+          pendingHitl.delete(confirmationId);
+          logger.warn("realtime.bridge.hitlTimeout", {
+            toolName,
+            confirmationId,
+            timeoutMs: hitlTimeoutMs,
+          });
+          resolve(false);
+        }, hitlTimeoutMs);
+        pendingHitl.set(confirmationId, (approved) => {
+          clearTimeout(timer);
+          logger.info("realtime.bridge.hitlResolved", {
+            toolName,
+            confirmationId,
+            approved,
+          });
+          resolve(approved);
+        });
+      });
+    };
+
+  return {
+    publishEvent,
+    requestConfirmation,
+    dispose(): void {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      room.off(RoomEvent.DataReceived, onData);
+      for (const [, resolver] of pendingHitl) {
+        resolver(false);
+      }
+      pendingHitl.clear();
+    },
+  };
+}

--- a/src/lib/voice/livekit/realtimeMcpTools.ts
+++ b/src/lib/voice/livekit/realtimeMcpTools.ts
@@ -1,0 +1,233 @@
+/**
+ * MCP tools → Gemini function tools bridge (realtime mode).
+ *
+ * In speech-to-speech mode Gemini owns the tool loop, so an external MCP
+ * server's tools are registered as LiveKit/Gemini function tools rather than
+ * NeuroLink tools. This connects to the MCP server as the calling user
+ * (`x-auth-token` + base64 `x-context`), sanitizes each tool's schema into the
+ * Gemini-safe subset, wires WRITE-labeled (destructive) tools through a HITL
+ * confirmation, and forwards tool start/result events to the browser bridge.
+ *
+ * `@livekit/agents` and `@modelcontextprotocol/sdk` are imported dynamically so
+ * the core package does not require them unless the realtime agent is used.
+ *
+ * See docs/features/livekit-voice-agent.md.
+ */
+
+import { z } from "zod";
+import type { llm as llmNs } from "@livekit/agents";
+import { logger } from "../../utils/logger.js";
+import { findSchemaIssue, sanitizeToolParameters } from "./schemaSanitizer.js";
+import type { BuildRealtimeMcpToolsParams } from "../../types/index.js";
+
+/**
+ * The fields of an MCP tool result we render: text content parts and the error
+ * flag. The result crosses a network boundary from an external MCP server, so it
+ * is decoded with a schema (other content kinds — image, resource — are dropped).
+ */
+const toolResultSchema = z.object({
+  isError: z.boolean().optional(),
+  content: z
+    .array(
+      z.object({ type: z.string().optional(), text: z.string().optional() }),
+    )
+    .optional(),
+});
+
+/** Flatten an MCP tool result's text content into a single string for the model. */
+export function mcpResultToText(result: unknown): string {
+  const decoded = toolResultSchema.safeParse(result);
+  if (!decoded.success) {
+    return "Tool returned no content.";
+  }
+  const text = (decoded.data.content ?? [])
+    .map((part) => (part.type === "text" && part.text ? part.text : ""))
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  if (decoded.data.isError) {
+    return `Tool error: ${text || "unknown error"}`;
+  }
+  return text || "Tool returned no content.";
+}
+
+/**
+ * The function-result text returned to Gemini when the user rejects a HITL tool.
+ * Scope the rejection to THIS attempt — a "never retry" wording made the model
+ * refuse the tool permanently even when the user later asked for it again.
+ */
+function buildHitlDeclineMessage(toolName: string): string {
+  return (
+    `The user reviewed the request to run "${toolName}" and chose to reject it, ` +
+    `so it was NOT executed this time. Do not run it right now. Briefly let the user know ` +
+    `you didn't proceed because they declined, and ask if there's anything else. ` +
+    `If the user later asks for "${toolName}" again or says to go ahead, you may run it then — ` +
+    `this rejection applies only to this request, not to all future requests.`
+  );
+}
+
+/**
+ * Register a tool handler under the name variants the model might call:
+ *   1. the Gemini-safe full name (hyphens → underscores; Gemini rewrites these
+ *      itself, so the rewritten form must be registered or the round-trip fails)
+ *   2. the bare short name (the model often drops the server prefix)
+ * First registration wins, so a unique full name is never shadowed by a generic
+ * short name. Returns the aliases actually registered.
+ */
+function registerToolAliases(
+  toolContext: llmNs.ToolContext,
+  mcpToolName: string,
+  handler: llmNs.ToolContext[string],
+): string[] {
+  const safeFullName = mcpToolName.replace(/[^a-zA-Z0-9_]/g, "_");
+  const shortName = safeFullName.includes("_")
+    ? safeFullName.slice(safeFullName.lastIndexOf("_") + 1)
+    : safeFullName;
+  const candidates = [safeFullName, shortName].filter(
+    (name, index, all) => name.length > 0 && all.indexOf(name) === index,
+  );
+  const registered: string[] = [];
+  for (const alias of candidates) {
+    if (alias in toolContext) {
+      continue; // taken by another tool — don't clobber
+    }
+    toolContext[alias] = handler;
+    registered.push(alias);
+  }
+  return registered;
+}
+
+/**
+ * Connect to the MCP server as the calling user and bridge every tool into a
+ * LiveKit `ToolContext`. Returns the tool map + the client (close on shutdown).
+ * The server already scopes the tool list by `x-context`, so no client-side
+ * filtering is needed.
+ */
+export async function buildRealtimeMcpTools(
+  params: BuildRealtimeMcpToolsParams,
+): Promise<{
+  tools: llmNs.ToolContext;
+  client: { close: () => Promise<void> };
+}> {
+  const { mcpUrl, authToken, xContext, publishEvent, requestConfirmation } =
+    params;
+
+  const { llm } = await import("@livekit/agents");
+  const { Client: McpClient } =
+    await import("@modelcontextprotocol/sdk/client/index.js");
+  const { StreamableHTTPClientTransport } =
+    await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), {
+    requestInit: {
+      headers: { "x-auth-token": authToken, "x-context": xContext },
+    },
+  });
+  const client = new McpClient(
+    { name: "neurolink-realtime-voice", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  logger.info("realtime.mcp.connecting", {
+    mcpUrl,
+    hasAuthToken: authToken !== "",
+    hasContext: xContext !== "",
+  });
+  await client.connect(transport);
+
+  try {
+    const { tools: mcpTools } = await client.listTools();
+    logger.info("realtime.mcp.toolsListed", { count: mcpTools.length });
+    const toolContext: llmNs.ToolContext = {};
+    const skipped: string[] = [];
+
+    for (const mcpTool of mcpTools) {
+      const parameters = sanitizeToolParameters(mcpTool.inputSchema);
+      const issue = findSchemaIssue(parameters);
+      if (issue) {
+        skipped.push(mcpTool.name);
+        logger.warn("realtime.mcp.toolSkipped", {
+          tool: mcpTool.name,
+          issue,
+          rawInputSchema: JSON.stringify(mcpTool.inputSchema),
+        });
+        continue;
+      }
+
+      const requiresConfirmation =
+        mcpTool.annotations?.destructiveHint === true;
+
+      const handler = llm.tool({
+        description: mcpTool.description ?? mcpTool.name,
+        parameters,
+        execute: async (args: Record<string, unknown>) => {
+          if (requiresConfirmation) {
+            const approved = await requestConfirmation(
+              mcpTool.name,
+              args ?? {},
+            );
+            if (!approved) {
+              logger.info("realtime.tool.hitlRejected", {
+                tool: mcpTool.name,
+              });
+              return buildHitlDeclineMessage(mcpTool.name);
+            }
+            logger.info("realtime.tool.hitlApproved", { tool: mcpTool.name });
+          }
+          logger.info("realtime.tool.invoke", {
+            tool: mcpTool.name,
+            args: args ?? {},
+          });
+          publishEvent("tool-start", { name: mcpTool.name });
+          const startedAt = Date.now();
+          try {
+            const result = await client.callTool({
+              name: mcpTool.name,
+              arguments: args ?? {},
+            });
+            const text = mcpResultToText(result);
+            logger.info("realtime.tool.result", {
+              tool: mcpTool.name,
+              isError: result.isError === true,
+              chars: text.length,
+              ms: Date.now() - startedAt,
+            });
+            // Forward the RAW result so the client can extract a
+            // chart/UIComponent and clear the in-progress indicator.
+            publishEvent("tool-result", { name: mcpTool.name, result });
+            return text;
+          } catch (error) {
+            logger.error("realtime.tool.error", {
+              tool: mcpTool.name,
+              ms: Date.now() - startedAt,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            publishEvent("tool-result", { name: mcpTool.name, result: null });
+            return `Tool ${mcpTool.name} failed: ${String(error)}`;
+          }
+        },
+      });
+
+      const aliases = registerToolAliases(toolContext, mcpTool.name, handler);
+      logger.info("realtime.mcp.toolRegistered", {
+        tool: mcpTool.name,
+        aliases,
+        hitl: requiresConfirmation,
+      });
+    }
+
+    logger.info("realtime.mcp.connected", {
+      registered: Object.keys(toolContext).length,
+      skipped: skipped.length,
+      skippedTools: skipped,
+    });
+    return { tools: toolContext, client };
+  } catch (error) {
+    await client.close().catch((closeError) => {
+      logger.warn("realtime.mcp.closeFailed", {
+        error:
+          closeError instanceof Error ? closeError.message : String(closeError),
+      });
+    });
+    throw error;
+  }
+}

--- a/src/lib/voice/livekit/realtimeVoiceAgent.ts
+++ b/src/lib/voice/livekit/realtimeVoiceAgent.ts
@@ -1,0 +1,409 @@
+/**
+ * LiveKit Agents agent definition — realtime (Gemini Live speech-to-speech).
+ *
+ * `defineRealtimeVoiceAgent` returns the agent object placed as the default
+ * export of a worker entry file. Unlike the cascaded `defineVoiceAgent`
+ * (Silero VAD → STT → NeuroLink → TTS), here a single realtime model (Gemini
+ * Live on Vertex) does STT + reasoning + TTS + turn detection over one
+ *
+ * `@livekit/agents`, `@livekit/agents-plugin-google`, `@livekit/rtc-node`, and
+ * `@google/genai` are imported dynamically so the core package does not require
+ * them unless the realtime agent is used. Type-only imports are erased at build.
+ *
+ * See docs/features/livekit-voice-agent.md.
+ */
+
+import { z } from "zod";
+import type { JobContext, llm as llmNs } from "@livekit/agents";
+import { logger } from "../../utils/logger.js";
+import { resolveRealtimeVoiceConfig } from "./config.js";
+import { ensureVertexAdc, clearGeminiApiKeyEnv } from "./vertexAuth.js";
+import { readCallContextFromRoom } from "./roomContext.js";
+import { attachRealtimeEventBridge } from "./realtimeEventBridge.js";
+import { buildRealtimeMcpTools } from "./realtimeMcpTools.js";
+import type {
+  RealtimeVoiceAgentConfig,
+  RealtimeVoiceConfig,
+} from "../../types/index.js";
+
+const realtimeLogEventSchema = z.object({
+  level: z.enum(["debug", "info", "warn", "error"]),
+  message: z.string(),
+  timestamp: z.number(),
+  data: z.unknown().optional(),
+});
+
+/**
+ * Install the per-call job lifecycle: shut down when the caller leaves, log
+ * connection transitions, run the empty-room / join-deadline watchdog, and reap
+ * the worker (parent) + this job (child) on shutdown.
+ *
+ * In `connect` mode the worker does NOT exit when a job shuts down, so the child
+ * must SIGTERM its parent and hard-exit itself.
+ */
+async function installRealtimeJobLifecycle(
+  ctx: JobContext,
+  cfg: RealtimeVoiceConfig,
+): Promise<void> {
+  const { RoomEvent } = await import("@livekit/rtc-node");
+  const joinedAt = Date.now();
+
+  ctx.room.on(RoomEvent.ParticipantDisconnected, () => {
+    if (ctx.room.remoteParticipants.size === 0) {
+      logger.info("realtime.room.participantLeft", {
+        remotes: 0,
+        action: "shutdown",
+      });
+      ctx.shutdown("participant left");
+    }
+  });
+  const logConn =
+    (label: string) =>
+    (...args: unknown[]): void => {
+      if (!logger.shouldLog("debug")) {
+        return;
+      }
+      logger.debug("realtime.room.connection", {
+        event: label,
+        remotes: ctx.room.remoteParticipants.size,
+        ...(args.length ? { detail: JSON.stringify(args).slice(0, 200) } : {}),
+      });
+    };
+  ctx.room.on(RoomEvent.Disconnected, (...args) => {
+    logConn("Disconnected")(...args);
+    ctx.shutdown("room disconnected");
+  });
+  ctx.room.on(RoomEvent.Reconnecting, logConn("Reconnecting"));
+  ctx.room.on(RoomEvent.Reconnected, logConn("Reconnected"));
+  ctx.room.on(
+    RoomEvent.ConnectionStateChanged,
+    logConn("ConnectionStateChanged"),
+  );
+  ctx.room.on(
+    RoomEvent.ConnectionQualityChanged,
+    logConn("ConnectionQualityChanged"),
+  );
+
+  let sawParticipant = ctx.room.remoteParticipants.size > 0;
+  let emptySince: number | null = null;
+  const emptyRoomWatchdog = setInterval(() => {
+    const remotes = ctx.room.remoteParticipants.size;
+    if (remotes > 0) {
+      sawParticipant = true;
+      emptySince = null;
+      return;
+    }
+    if (sawParticipant) {
+      emptySince ??= Date.now();
+      if (Date.now() - emptySince >= cfg.emptyRoomGraceMs) {
+        logger.info("realtime.watchdog.emptyRoom", {
+          graceMs: cfg.emptyRoomGraceMs,
+          action: "shutdown",
+        });
+        ctx.shutdown("empty-room watchdog");
+      }
+    } else if (Date.now() - joinedAt >= cfg.joinDeadlineMs) {
+      logger.info("realtime.watchdog.joinDeadline", {
+        joinDeadlineMs: cfg.joinDeadlineMs,
+        action: "shutdown",
+      });
+      ctx.shutdown("join-deadline watchdog");
+    }
+  }, 5000);
+  emptyRoomWatchdog.unref?.();
+  ctx.addShutdownCallback(async () => {
+    clearInterval(emptyRoomWatchdog);
+  });
+
+  if (process.env.LK_REALTIME_CONNECT_MODE === "true") {
+    ctx.addShutdownCallback(async () => {
+      const parentPid = process.ppid;
+      logger.info("realtime.reap.parent", {
+        mode: "connect",
+        jobPid: process.pid,
+        parentPid,
+      });
+      if (typeof parentPid === "number" && parentPid > 1) {
+        try {
+          process.kill(parentPid, "SIGTERM");
+        } catch {
+          logger.debug("realtime.reap.parentGone", { parentPid });
+        }
+      }
+      setTimeout(() => {
+        process.exit(0);
+      }, 1000);
+    });
+  }
+}
+
+/** Merge caller overrides over the env-resolved realtime config. */
+function resolveConfig(
+  overrides: RealtimeVoiceAgentConfig,
+): RealtimeVoiceConfig {
+  const base = resolveRealtimeVoiceConfig();
+  return {
+    ...base,
+    project: overrides.project ?? base.project,
+    location: overrides.location ?? base.location,
+    model: overrides.model ?? base.model,
+    voice: overrides.voice ?? base.voice,
+    responseModality: overrides.responseModality ?? base.responseModality,
+    systemPrompt: overrides.systemPrompt ?? base.systemPrompt,
+    greeting: overrides.greeting ?? base.greeting,
+    toolsEnabled: overrides.tools?.enabled ?? base.toolsEnabled,
+    mcpUrl: overrides.tools?.mcpUrl ?? base.mcpUrl,
+  };
+}
+
+/**
+ * Define a realtime (Gemini Live S2S) LiveKit voice agent.
+ *
+ * Place the result as the default export of the worker entry file and launch it
+ * with `startRealtimeVoiceAgentWorker`. With no `config` everything is resolved
+ * from the environment (see `resolveRealtimeVoiceConfig`).
+ */
+export function defineRealtimeVoiceAgent(
+  config: RealtimeVoiceAgentConfig = {},
+): { entry: (ctx: JobContext) => Promise<void> } {
+  const cfg = resolveConfig(config);
+  const eventsTopic = config.eventsTopic;
+  const controlTopic = config.controlTopic;
+  const onLog = config.onLog;
+
+  async function entry(ctx: JobContext): Promise<void> {
+    // The Gemini Live WS authenticates to Vertex via ADC; materialise it and
+    // force ADC (not an API key) auth before any realtime connection.
+    ensureVertexAdc();
+    clearGeminiApiKeyEnv();
+
+    logger.info("realtime.config", {
+      model: cfg.model,
+      location: cfg.location,
+      project: cfg.project ?? null,
+      voice: cfg.voice ?? null,
+      modality: cfg.responseModality,
+      toolsEnabled: cfg.toolsEnabled,
+      mcpUrl: cfg.mcpUrl,
+    });
+
+    await ctx.connect();
+    const connectedAt = Date.now();
+    const sinceConnect = (): number => Date.now() - connectedAt;
+
+    if (onLog) {
+      const room = ctx.room.name ?? "unknown";
+      logger.setEventEmitter({
+        emit: (event: string, ...args: unknown[]): boolean => {
+          if (event === "log-event") {
+            const decoded = realtimeLogEventSchema.safeParse(args[0]);
+            if (decoded.success) {
+              try {
+                onLog(decoded.data, { room });
+              } catch {
+                /* a log sink must never break the call */
+              }
+            }
+          }
+          return true;
+        },
+      });
+      ctx.addShutdownCallback(async () => {
+        logger.clearEventEmitter();
+      });
+    }
+
+    logger.info("realtime.room.joined", {
+      room: ctx.room.name ?? "unknown",
+      model: cfg.model,
+      location: cfg.location,
+      ms: sinceConnect(),
+    });
+
+    await installRealtimeJobLifecycle(ctx, cfg);
+
+    const { voice } = await import("@livekit/agents");
+    const google = await import("@livekit/agents-plugin-google");
+    const { Modality } = await import("@google/genai");
+
+    const bridge = await attachRealtimeEventBridge({
+      room: ctx.room,
+      hitlTimeoutMs: cfg.hitlTimeoutMs,
+      ...(eventsTopic !== undefined ? { eventsTopic } : {}),
+      ...(controlTopic !== undefined ? { controlTopic } : {}),
+    });
+    ctx.addShutdownCallback(async () => {
+      bridge.dispose();
+    });
+
+    let agentTools: llmNs.ToolContext | undefined;
+    if (cfg.toolsEnabled) {
+      const { authToken, xContext } = readCallContextFromRoom(
+        ctx.room.metadata,
+      );
+      if (xContext === "") {
+        logger.warn("realtime.mcp.noContext", {
+          reason: "room-metadata-missing-context",
+          action: "running-without-tools",
+        });
+      } else {
+        try {
+          const toolset = await buildRealtimeMcpTools({
+            mcpUrl: cfg.mcpUrl,
+            authToken,
+            xContext,
+            publishEvent: bridge.publishEvent,
+            requestConfirmation: bridge.requestConfirmation,
+          });
+          agentTools = toolset.tools;
+          logger.info("realtime.mcp.enabled", {
+            mcpUrl: cfg.mcpUrl,
+            toolCount: Object.keys(toolset.tools).length,
+            hasAuthToken: authToken !== "",
+          });
+          ctx.addShutdownCallback(async () => {
+            await toolset.client.close();
+          });
+        } catch (error) {
+          logger.error("realtime.mcp.setupFailed", {
+            mcpUrl: cfg.mcpUrl,
+            error: error instanceof Error ? error.message : String(error),
+            action: "running-without-tools",
+          });
+        }
+      }
+    }
+
+    const modality = Object.values(Modality).find(
+      (value) => value === cfg.responseModality,
+    );
+    const modelOptions: NonNullable<
+      ConstructorParameters<typeof google.realtime.RealtimeModel>[0]
+    > = {
+      vertexai: true,
+      model: cfg.model,
+      // Emit text transcripts of BOTH sides; LiveKit forwards them to the room.
+      inputAudioTranscription: {},
+      outputAudioTranscription: {},
+    };
+    if (modality !== undefined) {
+      modelOptions.modalities = [modality];
+    }
+    if (cfg.project) {
+      modelOptions.project = cfg.project;
+    }
+    if (cfg.location) {
+      modelOptions.location = cfg.location;
+    }
+    if (cfg.voice) {
+      modelOptions.voice = cfg.voice;
+    }
+
+    const session = new voice.AgentSession({
+      llm: new google.realtime.RealtimeModel(modelOptions),
+    });
+    const agent = new voice.Agent({
+      instructions: cfg.systemPrompt,
+      ...(agentTools ? { tools: agentTools } : {}),
+    });
+
+    agent.transcriptionNode = async (textStream, _modelSettings) => {
+      const [forUi, forDownstream] = textStream.tee();
+      void (async () => {
+        const reader = forUi.getReader();
+        let chunkCount = 0;
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            const chunk =
+              typeof value === "string" ? value : (value.text ?? "");
+            if (chunk) {
+              chunkCount += 1;
+              if (chunkCount === 1) {
+                logger.debug("realtime.session.assistantFirstChunk", {
+                  ms: sinceConnect(),
+                  preview: chunk.slice(0, 30),
+                });
+              }
+              bridge.publishEvent("text", { delta: chunk });
+            }
+          }
+        } catch {
+          /* best-effort live streaming */
+        }
+      })();
+      return forDownstream;
+    };
+
+    session.on(voice.AgentSessionEventTypes.MetricsCollected, (ev) => {
+      const metrics = ev.metrics;
+      if (metrics.type !== "realtime_model_metrics") {
+        return;
+      }
+      const inAudio = metrics.inputTokenDetails.audioTokens;
+      const outAudio = metrics.outputTokenDetails.audioTokens;
+      const inText = Math.max(0, metrics.inputTokens - inAudio);
+      const outText = Math.max(0, metrics.outputTokens - outAudio);
+      logger.info("realtime.usage", {
+        inputTokens: metrics.inputTokens,
+        inputAudioTokens: inAudio,
+        inputTextTokens: inText,
+        outputTokens: metrics.outputTokens,
+        outputAudioTokens: outAudio,
+        outputTextTokens: outText,
+      });
+    });
+
+    // --- Session events → browser ------------------------------------------
+    session.on(voice.AgentSessionEventTypes.UserInputTranscribed, (ev) => {
+      logger.debug("realtime.session.userTranscript", {
+        ms: sinceConnect(),
+        final: ev.isFinal,
+        transcript: ev.transcript,
+      });
+      bridge.publishEvent("user-text", {
+        text: ev.transcript,
+        final: ev.isFinal,
+      });
+    });
+    session.on(voice.AgentSessionEventTypes.AgentStateChanged, (ev) => {
+      logger.debug("realtime.session.stateChanged", {
+        ms: sinceConnect(),
+        from: ev.oldState,
+        to: ev.newState,
+      });
+      bridge.publishEvent("status", { state: ev.newState });
+    });
+    session.on(voice.AgentSessionEventTypes.ConversationItemAdded, (ev) => {
+      if (
+        ev.item.type === "message" &&
+        ev.item.role === "assistant" &&
+        ev.item.textContent
+      ) {
+        logger.debug("realtime.session.turnDone", { ms: sinceConnect() });
+        bridge.publishEvent("done", {});
+      }
+    });
+    session.on(voice.AgentSessionEventTypes.Error, (ev) => {
+      logger.error("realtime.session.error", {
+        ms: sinceConnect(),
+        error: ev.error,
+      });
+      bridge.publishEvent("status", { state: "error" });
+    });
+
+    await session.start({ agent, room: ctx.room });
+    logger.info("realtime.session.start", { ms: sinceConnect() });
+    bridge.publishEvent("status", { state: "listening" });
+
+    if (cfg.greeting.trim().length > 0) {
+      logger.info("realtime.session.greeting", { ms: sinceConnect() });
+      session.generateReply({ instructions: cfg.greeting });
+    }
+  }
+
+  return { entry };
+}

--- a/src/lib/voice/livekit/roomContext.ts
+++ b/src/lib/voice/livekit/roomContext.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-call context from LiveKit room metadata.
+ *
+ * The manager (e.g. a Lighthouse `/start` endpoint) pre-creates the room with
+ * `base64(JSON({ authToken, mcpContext }))` metadata, built from the caller's
+ * session. The worker reads it on join — nothing per-call comes from worker env.
+ * Returns the MCP `x-auth-token` and the base64(JSON) `x-context` the server
+ * expects.
+ *
+ * The metadata is untrusted input, so it is decoded with a zod schema rather
+ * than a trusted `JSON.parse` cast.
+ *
+ * See docs/features/livekit-voice-agent.md.
+ */
+
+import { Buffer } from "node:buffer";
+import { z } from "zod";
+import { logger } from "../../utils/logger.js";
+import type { LiveKitRoomCallContext } from "../../types/index.js";
+
+/** Shape the manager writes into room metadata. `mcpContext` is opaque here. */
+const roomMetadataSchema = z.object({
+  authToken: z.string().optional(),
+  mcpContext: z.unknown().optional(),
+});
+
+/** Decode the base64(JSON) metadata string into an `unknown`, or `undefined`. */
+function decodeBase64Json(encoded: string): unknown {
+  try {
+    return JSON.parse(Buffer.from(encoded, "base64").toString("utf-8"));
+  } catch (error) {
+    logger.error(
+      `[RealtimeVoiceAgent] room metadata is not valid base64 JSON: ${String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Decode `{ authToken, mcpContext }` from a room's base64(JSON) metadata.
+ *
+ * `authToken` may be empty (demo/guest, where the MCP server gates on the
+ * context's `demoMode`); `xContext` is the re-encoded base64(JSON) of
+ * `mcpContext`, or `""` when no context was supplied or the metadata is invalid.
+ */
+export function readCallContextFromRoom(
+  roomMetadata: string | undefined,
+): LiveKitRoomCallContext {
+  const empty: LiveKitRoomCallContext = { authToken: "", xContext: "" };
+  if (!roomMetadata) {
+    logger.warn(
+      "[RealtimeVoiceAgent] room has no metadata — MCP auth/context unavailable.",
+    );
+    return empty;
+  }
+  const decoded = roomMetadataSchema.safeParse(decodeBase64Json(roomMetadata));
+  if (!decoded.success) {
+    logger.error(
+      `[RealtimeVoiceAgent] room metadata has unexpected shape: ${decoded.error.message}`,
+    );
+    return empty;
+  }
+  const { authToken, mcpContext } = decoded.data;
+  const xContext =
+    mcpContext === undefined || mcpContext === null
+      ? ""
+      : Buffer.from(JSON.stringify(mcpContext), "utf-8").toString("base64");
+  return { authToken: authToken ?? "", xContext };
+}

--- a/src/lib/voice/livekit/roomDispatch.ts
+++ b/src/lib/voice/livekit/roomDispatch.ts
@@ -1,0 +1,56 @@
+/**
+ * LiveKit server-side room operations: create a room with metadata, and
+ * dispatch a named agent to a room.
+ *
+ * Wraps `livekit-server-sdk` (an optional dependency, imported dynamically) so
+ * consumers route all LiveKit *server* calls through `@juspay/neurolink/livekit`
+ * — they never depend on the SDK directly. Mirrors `mintJoinToken`.
+ */
+
+import type { LiveKitServerCredentials } from "../../types/index.js";
+
+const toHttpUrl = (url: string): string => url.replace(/^ws/, "http");
+
+export async function createVoiceRoom(
+  req: LiveKitServerCredentials & {
+    room: string;
+    metadata?: string;
+    emptyTimeoutSeconds?: number;
+    departureTimeoutSeconds?: number;
+  },
+): Promise<void> {
+  const { RoomServiceClient } = await import("livekit-server-sdk");
+  const client = new RoomServiceClient(
+    toHttpUrl(req.url),
+    req.apiKey,
+    req.apiSecret,
+  );
+  await client.createRoom({
+    name: req.room,
+    metadata: req.metadata ?? "",
+    emptyTimeout: req.emptyTimeoutSeconds ?? 300,
+    departureTimeout: req.departureTimeoutSeconds ?? 20,
+  });
+}
+
+/**
+ * Explicitly dispatch a named agent to a room. The long-lived worker registered
+ * under `agentName` receives the job and forks a child to run the call.
+ */
+export async function dispatchVoiceAgent(
+  req: LiveKitServerCredentials & {
+    room: string;
+    agentName: string;
+    metadata?: string;
+  },
+): Promise<void> {
+  const { AgentDispatchClient } = await import("livekit-server-sdk");
+  const client = new AgentDispatchClient(
+    toHttpUrl(req.url),
+    req.apiKey,
+    req.apiSecret,
+  );
+  await client.createDispatch(req.room, req.agentName, {
+    metadata: req.metadata ?? "",
+  });
+}

--- a/src/lib/voice/livekit/schemaSanitizer.ts
+++ b/src/lib/voice/livekit/schemaSanitizer.ts
@@ -1,0 +1,171 @@
+/**
+ * Gemini function-calling schema sanitizer.
+ *
+ * Normalises an MCP tool's JSON Schema into the subset Gemini's function-calling
+ * accepts. `@google/genai`'s processJsonSchema crashes on untyped nodes,
+ * `$ref`/`$defs`, and some `anyOf`/`oneOf` shapes, so we rebuild a clean tree:
+ * every node gets a concrete `type`, unions collapse to their first concrete
+ * branch, and unsupported keywords are dropped.
+ *
+ * Pure, dependency-free, and assertion-free — values arrive as `unknown` and are
+ * narrowed with the `isRecord` guard. Safe to reuse for any Gemini tool path.
+ */
+
+const GEMINI_TYPES = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "array",
+  "object",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The first concrete (non-`"null"`-typed) branch of an `anyOf`/`oneOf`/`allOf`
+ * union, or `undefined` when there is no union to collapse.
+ */
+function firstConcreteUnionBranch(
+  schema: Record<string, unknown>,
+): unknown | undefined {
+  const union = schema.anyOf ?? schema.oneOf ?? schema.allOf;
+  if (!Array.isArray(union)) {
+    return undefined;
+  }
+  return union.find((branch) => isRecord(branch) && branch.type !== "null");
+}
+
+function resolveSchemaType(schema: Record<string, unknown>): string {
+  if (typeof schema.type === "string") {
+    return GEMINI_TYPES.has(schema.type) ? schema.type : "string";
+  }
+  if (Array.isArray(schema.type)) {
+    const named = schema.type.find(
+      (entry): entry is string => typeof entry === "string" && entry !== "null",
+    );
+    if (named !== undefined && GEMINI_TYPES.has(named)) {
+      return named;
+    }
+  }
+  if (isRecord(schema.properties)) {
+    return "object";
+  }
+  if (schema.items !== undefined) {
+    return "array";
+  }
+  return "string";
+}
+
+function sanitizeObjectMembers(
+  schema: Record<string, unknown>,
+  out: Record<string, unknown>,
+): void {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const sanitizedProperties: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    sanitizedProperties[key] = sanitizeSchema(value);
+  }
+  out.properties = sanitizedProperties;
+  if (Array.isArray(schema.required)) {
+    out.required = schema.required.filter(
+      (name) => typeof name === "string" && name in sanitizedProperties,
+    );
+  }
+  if (Object.keys(sanitizedProperties).length === 0) {
+    out.additionalProperties = true;
+  }
+}
+
+/**
+ * Rebuild a JSON Schema node into the Gemini-safe subset. Returns a fresh object
+ * with a concrete `type` on every node.
+ */
+export function sanitizeSchema(node: unknown): Record<string, unknown> {
+  if (!isRecord(node)) {
+    return { type: "string" };
+  }
+  const out: Record<string, unknown> = {};
+  if (typeof node.description === "string") {
+    out.description = node.description;
+  }
+
+  if (typeof node.type !== "string") {
+    const branch = firstConcreteUnionBranch(node);
+    if (branch !== undefined) {
+      const merged = sanitizeSchema(branch);
+      return out.description
+        ? { ...merged, description: out.description }
+        : merged;
+    }
+  }
+
+  const type = resolveSchemaType(node);
+  out.type = type;
+
+  if (Array.isArray(node.enum)) {
+    out.enum = node.enum;
+  }
+  if (type === "object") {
+    sanitizeObjectMembers(node, out);
+  }
+  if (type === "array") {
+    out.items = sanitizeSchema(node.items);
+  }
+  return out;
+}
+
+/** Tool parameters must be an object schema; force it and sanitize the tree. */
+export function sanitizeToolParameters(
+  schema: unknown,
+): Record<string, unknown> {
+  const sanitized = sanitizeSchema(schema ?? {});
+  if (sanitized.type !== "object") {
+    return { type: "object", properties: {}, additionalProperties: true };
+  }
+  return sanitized;
+}
+
+/**
+ * Walk a (sanitized) schema and return the first node the google plugin would
+ * turn into `undefined` — which genai then crashes on. Returns a human-readable
+ * path/reason, or `null` if the schema is safe. After `sanitizeSchema` this
+ * should always be `null`; if not, it names the exact offending path.
+ */
+export function findSchemaIssue(
+  node: unknown,
+  pathPrefix = "$",
+): string | null {
+  if (!isRecord(node)) {
+    return `${pathPrefix}: not an object schema`;
+  }
+  if (typeof node.type !== "string") {
+    return `${pathPrefix}: missing string "type"`;
+  }
+  if (node.type === "object") {
+    const properties = isRecord(node.properties) ? node.properties : undefined;
+    const isEmpty =
+      properties === undefined || Object.keys(properties).length === 0;
+    if (
+      isEmpty &&
+      (node.additionalProperties === undefined ||
+        node.additionalProperties === null)
+    ) {
+      return `${pathPrefix}: empty object schema without additionalProperties (plugin → undefined)`;
+    }
+    if (properties !== undefined) {
+      for (const [key, value] of Object.entries(properties)) {
+        const childIssue = findSchemaIssue(value, `${pathPrefix}.${key}`);
+        if (childIssue) {
+          return childIssue;
+        }
+      }
+    }
+  }
+  if (node.type === "array") {
+    return findSchemaIssue(node.items, `${pathPrefix}[]`);
+  }
+  return null;
+}

--- a/src/lib/voice/livekit/vertexAuth.ts
+++ b/src/lib/voice/livekit/vertexAuth.ts
@@ -1,0 +1,83 @@
+/**
+ * Vertex authentication helpers for the realtime voice agent.
+ *
+ * The Gemini Live WebSocket authenticates to Vertex via Application Default
+ * Credentials (ADC). These helpers materialise ADC from the split
+ * `GOOGLE_AUTH_*` env fields when no credentials file is configured, and remove
+ * any Gemini Developer API key from the environment so `@google/genai` uses
+ * Vertex/ADC auth (not an API key) for the realtime WebSocket.
+ *
+ * See docs/features/livekit-voice-agent.md.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Materialise Vertex ADC from the split `GOOGLE_AUTH_*` env fields.
+ *
+ * The google realtime plugin authenticates Vertex via ADC (it does not accept
+ * inline credentials), so this writes a temp service-account JSON and points
+ * `GOOGLE_APPLICATION_CREDENTIALS` at it — unless ADC is already configured.
+ * No-op when `GOOGLE_APPLICATION_CREDENTIALS` is set or the `GOOGLE_AUTH_*`
+ * fields are absent (auth then relies on ambient ADC).
+ */
+export function ensureVertexAdc(): void {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return;
+  }
+  const clientEmail = process.env.GOOGLE_AUTH_CLIENT_EMAIL;
+  const rawPrivateKey = process.env.GOOGLE_AUTH_PRIVATE_KEY;
+  if (!clientEmail || !rawPrivateKey) {
+    logger.warn(
+      "[RealtimeVoiceAgent] No GOOGLE_APPLICATION_CREDENTIALS and no GOOGLE_AUTH_* fields — Vertex auth will rely on ambient ADC.",
+    );
+    return;
+  }
+  const credentials = {
+    type: process.env.GOOGLE_AUTH_TYPE ?? "service_account",
+    project_id:
+      process.env.GOOGLE_AUTH_BREEZE_PROJECT_ID ??
+      process.env.GOOGLE_CLOUD_PROJECT_ID,
+    private_key_id: process.env.GOOGLE_AUTH_PRIVATE_KEY_ID,
+    private_key: rawPrivateKey.replace(/\\n/g, "\n"),
+    client_email: clientEmail,
+    token_uri:
+      process.env.GOOGLE_AUTH_TOKEN_URI ??
+      "https://oauth2.googleapis.com/token",
+  };
+  const credentialsDir = mkdtempSync(path.join(os.tmpdir(), "vertex-adc-"));
+  const credentialsPath = path.join(credentialsDir, "adc.json");
+  writeFileSync(credentialsPath, JSON.stringify(credentials), {
+    mode: 0o600,
+    flag: "wx",
+  });
+  process.on("exit", () => {
+    rmSync(credentialsDir, { recursive: true, force: true });
+  });
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+  logger.info(
+    `[RealtimeVoiceAgent] Vertex ADC written to ${credentialsPath} (project ${credentials.project_id}).`,
+  );
+}
+
+/**
+ * Force pure Vertex/ADC auth for the Gemini Live WebSocket.
+ *
+ * `@google/genai` 1.52+ uses a Gemini Developer API key for the realtime
+ * WebSocket auth even when `vertexai: true` and project/location are set, which
+ * Vertex rejects at the handshake (WS close 1006). The realtime worker only
+ * ever talks to Vertex, so remove these keys (only affects this process).
+ */
+export function clearGeminiApiKeyEnv(): void {
+  for (const key of ["GOOGLE_API_KEY", "GOOGLE_AI_API_KEY", "GEMINI_API_KEY"]) {
+    if (process.env[key]) {
+      delete process.env[key];
+      logger.info(
+        `[RealtimeVoiceAgent] cleared ${key} so genai uses Vertex/ADC auth (not API key) for the Live WS.`,
+      );
+    }
+  }
+}

--- a/src/lib/voice/livekit/voiceAgent.ts
+++ b/src/lib/voice/livekit/voiceAgent.ts
@@ -241,11 +241,21 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
   async function entry(ctx: JobContext): Promise<void> {
     const entryStartedAt = Date.now();
     await ctx.connect();
-    logger.debug(
-      `[LiveKitVoiceAgent] Joined room "${ctx.room.name}" in ${Date.now() - entryStartedAt}ms`,
-    );
-    // When the user actually stopped speaking (VAD), used to measure how long
-    // the agent waited after speech before committing the turn to the LLM.
+    logger.debug("voice.agent.roomJoined", {
+      room: ctx.room.name,
+      ms: Date.now() - entryStartedAt,
+    });
+
+    const { RoomEvent } = await import("@livekit/rtc-node");
+    ctx.room.on(RoomEvent.ParticipantDisconnected, () => {
+      if (ctx.room.remoteParticipants.size === 0) {
+        logger.info("voice.agent.participantLeft", {
+          room: ctx.room.name,
+          action: "shutdown",
+        });
+        ctx.shutdown("participant left");
+      }
+    });
     let userStoppedSpeakingAt: number | undefined;
 
     const neurolink = await config.createNeuroLink();
@@ -307,12 +317,6 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
         final: false,
       });
     }
-
-    /**
-     * Lock the user bubble at turn-end and reset the buffer for the next turn.
-     * `replacesPrevious` tells the client this committed turn absorbed a prior
-     * interrupted turn, so it should remove the orphaned previous user bubble.
-     */
     function commitUserTranscript(
       finalText: string,
       replacesPrevious = false,
@@ -346,9 +350,9 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
 
         commitUserTranscript(promptText, hadPrefix);
         if (userStoppedSpeakingAt !== undefined) {
-          logger.debug(
-            `[LiveKitVoiceAgent] Endpointing waited ${Date.now() - userStoppedSpeakingAt}ms before sending turn to LLM`,
-          );
+          logger.debug("voice.agent.endpointingWaited", {
+            ms: Date.now() - userStoppedSpeakingAt,
+          });
         }
         return brainTurnStream(brain, promptText, conversationId, () => {
           // Interrupted before producing any reply → carry this turn's text
@@ -379,9 +383,7 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
     };
     if (eouTurnDetector !== undefined) {
       turnHandling.turnDetection = eouTurnDetector;
-      logger.info(
-        "[LiveKitVoiceAgent] Semantic end-of-utterance turn detection enabled (English)",
-      );
+      logger.info("voice.agent.eouEnabled", { language: "english" });
     } else if (config.turn?.mode) {
       turnHandling.turnDetection = config.turn.mode;
     }
@@ -401,21 +403,12 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
       tts,
       llm: new PlaceholderLLM(),
       turnHandling,
-      // Do NOT speculatively call the LLM on preflight transcripts before the
-      // turn ends — with NeuroLink as the brain each call is a real LLM request,
-      // and it makes the agent feel like it responds while you're still talking.
       preemptiveGeneration: false,
     });
     const agent = new NeuroLinkVoiceAgent({
       instructions: config.systemPrompt ?? "",
     });
 
-    // Inactivity watchdog: shut the per-call Job down after a stretch with no
-    // user or agent activity (mirrors Clairvoyance). On timeout `ctx.shutdown`
-    // runs the shutdown callbacks (disposing the bridge) and the Job process
-    // exits — freeing its RAM and the EOU model — while the browser observes a
-    // room disconnect. Reset on every interaction below. Configure via
-    // VOICE_INACTIVITY_TIMEOUT_MS (default 10 min); <= 0 disables the watchdog.
     const inactivityTimeoutMs = Number(
       process.env.VOICE_INACTIVITY_TIMEOUT_MS ?? 600_000,
     );
@@ -436,11 +429,11 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
       clearInactivityTimer();
       inactivityTimer = setTimeout(() => {
         inactivityFired = true;
-        logger.info(
-          `[LiveKitVoiceAgent] Inactivity timeout (${Math.round(
-            inactivityTimeoutMs / 1000,
-          )}s) reached — shutting down job for room "${ctx.room.name}"`,
-        );
+        logger.info("voice.agent.inactivityTimeout", {
+          room: ctx.room.name,
+          timeoutMs: inactivityTimeoutMs,
+          action: "shutdown",
+        });
         ctx.shutdown("inactivity timeout");
       }, inactivityTimeoutMs);
       // The watchdog must not, by itself, keep the event loop alive.
@@ -450,8 +443,23 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
       clearInactivityTimer();
     });
 
-    // Track when the user actually stops speaking (VAD) so endpointing latency
-    // can be measured, and reset the inactivity watchdog on user activity.
+    if (process.env.LK_REALTIME_CONNECT_MODE === "true") {
+      ctx.addShutdownCallback(async () => {
+        const parentPid = process.ppid;
+
+        setTimeout(() => {
+          try {
+            if (typeof parentPid === "number" && parentPid > 1) {
+              process.kill(parentPid, "SIGTERM");
+            }
+          } catch {
+            // Parent already gone — fall through to the hard exit below.
+          }
+          process.exit(0);
+        }, 500).unref?.();
+      });
+    }
+
     session.on(voice.AgentSessionEventTypes.UserStateChanged, (ev) => {
       noteActivity();
       if (ev.oldState === "speaking" && ev.newState !== "speaking") {
@@ -459,9 +467,6 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
       }
     });
 
-    // Reset the inactivity watchdog on any agent speech/processing and on every
-    // committed conversation item (user turn or agent reply), so the timeout
-    // only fires during a genuine lull in the conversation.
     session.on(voice.AgentSessionEventTypes.AgentStateChanged, () => {
       noteActivity();
     });
@@ -469,19 +474,13 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
       noteActivity();
     });
 
-    // Forward user STT transcripts to the data-channel bridge as a single
-    // live-updating bubble. `UserInputTranscribed` fires `isFinal: true` per
-    // finalized SEGMENT (several per turn), so we never forward those as the
-    // turn-final; `emitUserTranscriptSegment` accumulates them into the per-turn
-    // buffer and emits `final: false`. The lone `final: true` is sent from
-    // `llmNode` at the real turn boundary.
     if (transcriptEventsEnabled) {
       session.on(voice.AgentSessionEventTypes.UserInputTranscribed, (ev) => {
         emitUserTranscriptSegment(ev.transcript, ev.isFinal);
       });
     }
 
-    logger.info("[LiveKitVoiceAgent] Session starting", {
+    logger.info("voice.agent.sessionStarting", {
       room: ctx.room.name,
       provider,
       model,
@@ -489,13 +488,20 @@ export function defineVoiceAgent(config: LiveKitVoiceAgentConfig): JobAgent {
 
     await session.start({ agent, room: ctx.room });
 
-    // Start the inactivity countdown now that the session is live; every
-    // interaction handler above re-arms it.
+    if (config.greeting !== undefined && config.greeting.trim().length > 0) {
+      const greetingStream = brainTurnStream(
+        brain,
+        config.greeting,
+        conversationId,
+      );
+      session.say(greetingStream, {
+        addToChatCtx: true,
+        allowInterruptions: true,
+      });
+    }
+
     noteActivity();
 
-    // Data-channel event bridge: forward NeuroLink events (text, tool calls,
-    // results, HITL prompts, status) to the browser, and accept HITL responses
-    // back. Only when enabled and the instance exposes its event emitter.
     if (config.events?.enabled === true && neurolink.getEventEmitter) {
       const bridge = await attachEventBridge({
         room: ctx.room,

--- a/src/lib/voice/livekit/voiceAgentWorker.ts
+++ b/src/lib/voice/livekit/voiceAgentWorker.ts
@@ -15,10 +15,68 @@ import {
   resolveEouTurnDetection,
   resolveLiveKitServerConfig,
 } from "./config.js";
+import { logger } from "../../utils/logger.js";
 import type { LiveKitWorkerLaunchOptions } from "../../types/index.js";
 
 const DEFAULT_AGENT_NAME = "neurolink-voice";
 const EOU_METHOD_MULTILINGUAL = "lk_end_of_utterance_multilingual";
+
+const IS_JOB_CHILD = process.argv.some((arg) => arg.includes("job_proc"));
+const PROC_ROLE = IS_JOB_CHILD ? "job(child)" : "worker(parent)";
+
+let processGuardsInstalled = false;
+
+export function installVoiceWorkerProcessGuards(
+  metricsIntervalMs = Number(process.env.VOICE_METRICS_INTERVAL_MS ?? 10000),
+): void {
+  if (processGuardsInstalled) {
+    return;
+  }
+  processGuardsInstalled = true;
+  const procInfo = {
+    role: PROC_ROLE,
+    pid: process.pid,
+    ppid: process.ppid,
+  };
+
+  process.on("uncaughtException", (error) => {
+    logger.error("voiceWorker.uncaughtException", {
+      ...procInfo,
+      error: error?.stack ?? String(error),
+    });
+    if (IS_JOB_CHILD) {
+      setTimeout(() => process.exit(1), 1000).unref?.();
+    }
+  });
+  process.on("unhandledRejection", (reason) => {
+    logger.error("voiceWorker.unhandledRejection", {
+      ...procInfo,
+      error: reason instanceof Error ? reason.stack : String(reason),
+    });
+  });
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    process.on(signal, () => {
+      logger.warn("voiceWorker.signal", { ...procInfo, signal });
+      setTimeout(() => process.exit(0), 1500);
+    });
+  }
+
+  if (Number.isFinite(metricsIntervalMs) && metricsIntervalMs > 0) {
+    const mb = (bytes: number): number =>
+      Math.round((bytes / 1024 / 1024) * 10) / 10;
+    const timer = setInterval(() => {
+      const usage = process.memoryUsage();
+      logger.debug("voiceWorker.mem", {
+        ...procInfo,
+        rssMb: mb(usage.rss),
+        heapUsedMb: mb(usage.heapUsed),
+        heapTotalMb: mb(usage.heapTotal),
+        externalMb: mb(usage.external),
+      });
+    }, metricsIntervalMs);
+    timer.unref?.();
+  }
+}
 
 /**
  * Register the English EOU inference runner in the worker process.
@@ -68,4 +126,21 @@ export async function startVoiceAgentWorker(
       apiSecret: server.apiSecret,
     }),
   );
+}
+
+export async function startRealtimeVoiceAgentWorker(
+  options: LiveKitWorkerLaunchOptions,
+): Promise<void> {
+  installVoiceWorkerProcessGuards();
+  if (process.env.LIVEKIT_EOU_TURN_DETECTION) {
+    delete process.env.LIVEKIT_EOU_TURN_DETECTION;
+    logger.info("realtime.worker.eouDisabled", {
+      reason: "s2s-in-model-turn-detection",
+    });
+  }
+  if (process.argv.includes("connect")) {
+    process.env.LK_REALTIME_CONNECT_MODE = "true";
+    logger.info("realtime.worker.connectMode", { enabled: true });
+  }
+  await startVoiceAgentWorker(options);
 }


### PR DESCRIPTION
# Pull Request

## Description

Adds a **speech-to-speech (S2S) realtime voice agent** to NeuroLink, built on LiveKit Agents + Gemini Live (Vertex). Unlike the existing cascaded pipeline (VAD → STT → LLM → TTS), a single Gemini Live model owns the audio loop and the tool loop. The PR wires the realtime agent end-to-end: Vertex/ADC auth, env-driven config, a data-channel bridge to the browser (streamed transcripts + HITL confirmations), and an MCP→Gemini function-tool integration with Gemini-safe schema sanitization and destructive-action approval. It also includes lifecycle/auth/robustness hardening from review.

## Related Issues

Relates to BZ-3856

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Security vulnerability fixed (temp-credential handling — see Security)

## Motivation and Context

The cascaded voice path adds STT/LLM/TTS latency and loses paralinguistic nuance. Gemini Live S2S gives lower-latency, more natural turn-taking by letting one realtime model handle audio in/out and tool calls directly. This PR makes that available in NeuroLink behind the same LiveKit worker model (one job process per call), with the merchant-dashboard MCP tools bridged in and write-labeled tools gated by human-in-the-loop confirmation.

## Changes Made

- **Realtime voice agent** (`realtimeVoiceAgent.ts`) — Gemini Live agent over Vertex; empty-room / join-deadline watchdogs; optional greeting; streamed transcripts; connect-mode parent reaping.
- **Realtime event bridge** (`realtimeEventBridge.ts`) — worker→browser event publishing and a control channel for HITL accept/reject with timeout-as-decline; declines immediately when the bridge is disposed.
- **MCP → Gemini tools** (`realtimeMcpTools.ts`) — connects to the MCP server as the calling user (`x-auth-token` + `x-context`), bridges each tool, routes `destructiveHint` tools through HITL; closes the client if post-connect setup fails.
- **Schema sanitizer** (`schemaSanitizer.ts`) — reduces MCP tool schemas to the Gemini-safe subset.
- **Vertex auth** (`vertexAuth.ts`) — materializes ADC from split `GOOGLE_AUTH_*` env into a private temp dir; forces Vertex/ADC auth for the Live WS.
- **Config** (`config.ts`) — env resolution for realtime settings; positive-only validation for `VOICE_*_MS` durations.
- **Server helpers** (`roomContext.ts`, `roomDispatch.ts`) — room/agent dispatch utilities.
- **Worker lifecycle** (`voiceAgentWorker.ts`) — process guards; connect-mode flag; exit on `uncaughtException` in job-child only.
- **Types** (`types/livekit.ts`) — realtime config / bridge / params types.

## Breaking Changes

- [x] No breaking changes

Public SDK API is unchanged; all additions are new modules and the LiveKit plugin is an optional dependency.

## Testing

- [x] Manual testing completed
- [x] Tested with multiple providers: Vertex (Gemini Live `gemini-live-2.5-flash`) for S2S; Bedrock/Claude for the cascaded brain default
- [x] Tested on multiple platforms: macOS (darwin)

### Test Coverage

- [x] Existing tests pass
- [ ] All new code is covered by tests — realtime LiveKit paths require a live LiveKit server + Vertex creds; covered by manual call testing rather than the automated suite

### Manual Testing Steps

1. Set `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET`, Vertex `GOOGLE_AUTH_*` (or `GOOGLE_APPLICATION_CREDENTIALS`), and `VOICE_MCP_URL` (or `LIGHTHOUSE_URL`).
2. Start the realtime worker (`startRealtimeVoiceAgentWorker`) and join the room from the browser client.
3. Verify two-way audio, streamed transcripts in the UI, and that a write-labeled tool triggers a HITL prompt — accept runs it, reject declines for that turn only, timeout declines.
4. Confirm `GOOGLE_APPLICATION_CREDENTIALS` points at a `0700` temp dir that is removed on process exit.

## Code Quality

- [x] Code follows the project's style guidelines (ESLint passes)
- [x] Code is properly formatted (Prettier applied)
- [x] Self-review of code completed
- [x] No console.log statements (using logger instead)
- [x] No hardcoded API keys or secrets
- [x] TypeScript strict mode compliance
- [x] Proper error handling implemented

## Documentation

- [x] JSDoc comments added/updated for public APIs (module headers reference `docs/features/livekit-voice-agent.md`)
- [ ] Others — n/a

## Commit Message Format

- [x] Commit message follows format: `type(scope): description`
- [x] Valid type used (`feat`)
- [x] Scope specified (`voice`)

`feat(voice): add support for s2s agent in neurolink through livekit`

## Dependencies

- [x] Dependencies added (list below)

```
@livekit/agents-plugin-google - Gemini Live realtime model for the S2S agent (optional, dynamically imported)
```

## Performance Impact

- [x] Performance improved — S2S removes the STT→LLM→TTS hop, lowering turn latency vs the cascaded path. EOU turn detection is opt-in (adds ~200MB RAM / ~10ms per turn-end when enabled) and is disabled for S2S since the model handles turn-taking.

## Security Considerations

- [x] Security vulnerability fixed

- **Temp credential hardening:** Vertex ADC is now written to a random-named `mkdtemp` dir (`0700`) with an exclusive (`wx`) write and removed on exit, replacing a predictable pid-named temp file in the shared tmpdir (prevents co-tenant symlink/precreate attacks; no longer leaves the service-account key on disk).
- **Auth scoping:** MCP server is contacted per-user via `x-auth-token` + `x-context`; Gemini Developer API keys are stripped so the Live WS uses Vertex/ADC only.
- **HITL:** destructive (`destructiveHint`) tools require explicit user approval before execution; timeout and bridge-dispose both default to decline.
- **Worker isolation:** parent process is only reaped in connect mode, so a single job's shutdown can't terminate concurrent calls on a shared dispatch worker.

## Deployment Notes

- [x] Requires environment variable changes (list below)

```
LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET   - LiveKit server connection
GOOGLE_AUTH_* (or GOOGLE_APPLICATION_CREDENTIALS)  - Vertex ADC for Gemini Live
VERTEX_PROJECT / VERTEX_LOCATION                   - Vertex project + region (location defaults to "global")
VOICE_MCP_URL (or LIGHTHOUSE_URL)                  - MCP server for tools
VOICE_LIVE_MODEL, VOICE_RESPONSE_MODALITY, VOICE_S2S_VOICE, VOICE_S2S_TOOLS, VOICE_SYSTEM_PROMPT, VOICE_GREETING  - optional S2S tuning
VOICE_EMPTY_ROOM_GRACE_MS, VOICE_JOIN_DEADLINE_MS, VOICE_HITL_TIMEOUT_MS, VOICE_METRICS_INTERVAL_MS              - optional timers (must be > 0)
```

## Additional Notes

The `@livekit/agents-plugin-google` dependency is optional and dynamically imported, so the core package doesn't require it unless the realtime agent is used. Naming wart worth a follow-up: `LK_REALTIME_CONNECT_MODE` is read by both the realtime and cascaded paths and really means "worker is in connect mode" — could be renamed `LK_VOICE_CONNECT_MODE`.

---

## Pre-submission Checklist

- [x] Verified all automated pre-commit checks pass (`pnpm run lint` — 0 errors)
- [x] Built the project successfully
- [x] Reviewed your own code for obvious issues
- [x] Ensured commit messages follow semantic format
- [ ] Added tests for new functionality — live-only paths covered manually (see Testing)
