### PR TITLE
feat(proxy): reuse upstream connections via tuned keep-alive dispatcher

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -45,6 +45,7 @@ import type {
   StatusStats,
 } from "../../lib/types/index.js";
 import type { ModelRouter } from "../../lib/proxy/modelRouter.js";
+import { configureProxyKeepAliveDispatcher } from "../../lib/proxy/proxyDispatcher.js";
 import {
   loadProxyEnvFile,
   resolveProxyEnvFile,
@@ -1676,6 +1677,12 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       await ensureProxyStartAllowed(spinner);
     }
     const loadedEnvFile = await loadProxyStartEnv(argv, spinner);
+
+    // Reuse upstream TCP connections (longer keep-alive + bounded pool) instead
+    // of opening a new flow per request — cuts outbound flow churn through host
+    // content-filters. Runs once, after env load so it can be tuned via env.
+    configureProxyKeepAliveDispatcher();
+
     const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime(
       devPaths?.logsDir,
     );

--- a/src/lib/proxy/proxyDispatcher.ts
+++ b/src/lib/proxy/proxyDispatcher.ts
@@ -1,0 +1,77 @@
+/**
+ * Tuned global undici dispatcher for the proxy's upstream forwards.
+ *
+ * The Claude passthrough (`claudeProxyRoutes.ts`) forwards every request to
+ * Anthropic via the global `fetch` → undici global dispatcher. undici keep-alives
+ * by default, but with a ~4s idle timeout: between Claude Code turns (the user
+ * reads output, a tool runs, the model thinks) the idle socket closes, so the
+ * next request opens a brand-new TCP connection. Under sustained use that is a
+ * high rate of short-lived outbound flows.
+ *
+ * On hosts running a socket content-filter (CFIL) — e.g. SentinelOne or
+ * GlobalProtect network extensions — every new flow allocates per-flow kernel
+ * state, so a high flow rate amplifies any leak in that path. Reusing connections
+ * cuts the flow rate sharply, so we install a dispatcher with a longer keep-alive
+ * and a bounded, reused connection pool.
+ *
+ * Everything is overridable via env so it can be tuned (or disabled) per host:
+ *   NEUROLINK_PROXY_KEEPALIVE=off       disable; keep undici defaults
+ *   NEUROLINK_PROXY_KEEPALIVE_MS        idle keep-alive timeout (default 30000)
+ *   NEUROLINK_PROXY_KEEPALIVE_MAX_MS    keep-alive upper bound  (default 600000)
+ *   NEUROLINK_PROXY_MAX_CONNECTIONS     max pooled connections per origin (default 64)
+ */
+import { Agent, setGlobalDispatcher } from "undici";
+import { logger } from "../utils/logger.js";
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+let configured = false;
+
+/**
+ * Install the tuned global undici dispatcher. Idempotent — safe to call once at
+ * proxy startup. No-op when `NEUROLINK_PROXY_KEEPALIVE` is off/false/0.
+ */
+export function configureProxyKeepAliveDispatcher(): void {
+  if (configured) {
+    return;
+  }
+  configured = true;
+
+  const toggle = (process.env.NEUROLINK_PROXY_KEEPALIVE ?? "").toLowerCase();
+  if (toggle === "off" || toggle === "false" || toggle === "0") {
+    logger.debug("[proxy] keep-alive dispatcher disabled via env");
+    return;
+  }
+
+  const keepAliveTimeout = readPositiveInt(
+    "NEUROLINK_PROXY_KEEPALIVE_MS",
+    30_000,
+  );
+  const keepAliveMaxTimeout = readPositiveInt(
+    "NEUROLINK_PROXY_KEEPALIVE_MAX_MS",
+    600_000,
+  );
+  const connections = readPositiveInt("NEUROLINK_PROXY_MAX_CONNECTIONS", 64);
+
+  setGlobalDispatcher(
+    new Agent({
+      keepAliveTimeout,
+      keepAliveMaxTimeout,
+      connections,
+      pipelining: 1,
+    }),
+  );
+
+  logger.debug(
+    `[proxy] tuned undici dispatcher installed ` +
+      `(keepAliveTimeout=${keepAliveTimeout}ms, ` +
+      `keepAliveMaxTimeout=${keepAliveMaxTimeout}ms, connections=${connections})`,
+  );
+}


### PR DESCRIPTION
## Problem

The Claude passthrough proxy forwards every request to Anthropic via the global
`fetch` → undici's global dispatcher (`claudeProxyRoutes.ts`). undici keep-alives
by default, but with a **~4s idle timeout**. Between Claude Code turns (the user
reads output, a tool runs, the model thinks) the idle socket closes, so the next
request opens a **brand-new TCP connection**. Under sustained use that's a high
rate of short-lived outbound flows.

That churn is normally harmless, but on hosts running a socket **content-filter
(CFIL)** — e.g. SentinelOne / GlobalProtect network extensions — every new flow
allocates per-flow kernel state. On one managed macOS host this amplified a
kernel-memory leak (`data.kalloc.1024` zone exhaustion → watchdog panic) into a
~daily reboot. Reusing connections sharply cuts the new-flow rate.

## Change

Install a **tuned global undici dispatcher** once at proxy startup
(`configureProxyKeepAliveDispatcher()` in `src/lib/proxy/proxyDispatcher.ts`,
called from `startProxyCommandHandler` after env load): a longer keep-alive plus a
bounded, reused connection pool. All upstream `fetch` calls (the Anthropic
passthrough, token refresh, etc.) then reuse connections instead of reopening them.

Existing code already builds on `getGlobalDispatcher()` (`messageBuilder.ts`,
`fileDetector.ts`), so a tuned global dispatcher composes cleanly.

### Config (all env-overridable)

| Env | Default | Meaning |
|-----|---------|---------|
| `NEUROLINK_PROXY_KEEPALIVE=off` | on | disable; keep undici defaults |
| `NEUROLINK_PROXY_KEEPALIVE_MS` | `30000` | idle keep-alive timeout (ms) |
| `NEUROLINK_PROXY_KEEPALIVE_MAX_MS` | `600000` | keep-alive upper bound (ms) |
| `NEUROLINK_PROXY_MAX_CONNECTIONS` | `64` | max pooled connections per origin |

## Testing

- `pnpm run check`, `pnpm run lint`, `pnpm run build`, `pnpm run validate:all` — all pass
  (0 errors; no new lint warnings).
- Deployed to a live proxy and verified upstream connections to `api.anthropic.com`
  now **persist across idle gaps** (same local ports held open for reuse) instead of
  closing after ~4s.

No public API change; behavior is on by default and opt-out via env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled TCP keep-alive and connection reuse for proxy upstream requests with environment variable configuration controls for timeout and pool limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->