### PR TITLE
fix(ci): cap Yama ai.maxTokens to 16000 so large PRs fit the model window

### DIFF
--- a/yama.config.yaml
+++ b/yama.config.yaml
@@ -35,6 +35,15 @@ ai:
   # provider/model OMITTED on purpose — see header note. Controlled by the
   # workflow (litellm / private-large) via AI_PROVIDER / AI_MODEL env.
   temperature: 0.2 # deterministic, review-grade output
+  # Cap review-generation OUTPUT tokens. @juspay/yama's default ai.maxTokens is
+  # 128000 (DefaultConfig.ts); on the private-large model (262144 ctx) that
+  # leaves only ~134K for INPUT, so medium/large PRs (diff + explored context +
+  # project rules) exceed the window and LiteLLM rejects the call with a 400
+  # ("input_tokens > maximum input length"). A review never emits anywhere near
+  # 128K output tokens, so cap it at 16000 — this raises the usable input
+  # ceiling to ~246K and lets large diffs be reviewed. (The explore worker
+  # defaults to 32000, which is unaffected.)
+  maxTokens: 16000
   timeout: "15m"
   retryAttempts: 3
   enableAnalytics: true


### PR DESCRIPTION
## Problem

The **Yama PR Review** required check fails **deterministically on large PRs** with a LiteLLM 400:

```
You passed 235072 input tokens and requested 128000 output tokens.
However, the model's context length is only 262144, resulting in a
maximum input length of 134144. (parameter=input_tokens)
```

Root cause: the review-generation call inherits `@juspay/yama`'s **default `ai.maxTokens = 128000`** (`src/v2/config/DefaultConfig.ts`). Our `yama.config.yaml` never overrides it, so on the `private-large` model (262 144-token context) Yama reserves 128K for output and leaves only **~134K for input**. A medium/large PR's review payload — diff + explored file context + the injected `<project-rules>` (CLAUDE.md + CONTRIBUTING.md) — exceeds that, and the provider rejects the request.

The verdict gate then sees `OUTCOME=failure` with no `DECISION` and (correctly) classifies it as an *infrastructure error* and fails the check. It is **not a code verdict**, it's deterministic, and **re-running does not help**.

## Fix

Set `ai.maxTokens: 16000` in `yama.config.yaml`. A code review never emits anywhere near 128K output tokens, so this is a safe cap that **raises the usable input ceiling to ~246 144 tokens** — enough to review large diffs with headroom. The explore worker's own `32000` default is unaffected.

| | input ceiling = 262144 − maxTokens |
|---|---|
| before (`maxTokens: 128000`) | **134 144** ← too small |
| after (`maxTokens: 16000`) | **246 144** |

Measured review payloads that currently overflow: **226 412** tokens (a +1733 LOC / 10-file PR) and **235 072** tokens (a +2596 LOC / 13-file PR) — both fit comfortably after this change.

## Impact / blast radius

- One-line config value (plus an explanatory comment). No code change.
- Affects only the Yama reviewer's output-token budget; verdict logic, blocking criteria, focus areas, and exploration are unchanged.
- Unblocks the Yama check on the stacked tool-routing PRs (#1107, #1108), which are otherwise fully green with all review threads resolved.

> Note: `16000` is a conservative choice with large headroom; reviewers may prefer a higher value (e.g. `24000`–`32000`) — anything `≤ ~27000` keeps current large PRs within the window. The math and rationale are in the file comment.