### PR TITLE
chore(lint): drop forbidden non-null assertion and stale eslint-disable directives

### DIFF
--- a/src/lib/tasks/autoresearchTaskExecutor.ts
+++ b/src/lib/tasks/autoresearchTaskExecutor.ts
@@ -277,11 +277,11 @@ export async function executeAutoresearchTick(
       ...(phasePolicy.forcedTool
         ? {
             prepareStep: ({ stepNumber }: { stepNumber: number }) => {
-              if (stepNumber === 0) {
+              if (stepNumber === 0 && phasePolicy.forcedTool) {
                 return {
                   toolChoice: {
                     type: "tool" as const,
-                    toolName: phasePolicy.forcedTool!,
+                    toolName: phasePolicy.forcedTool,
                   },
                 };
               }

--- a/src/lib/workflow/core/ensembleExecutor.ts
+++ b/src/lib/workflow/core/ensembleExecutor.ts
@@ -196,7 +196,6 @@ async function executeModel(
     let result: Awaited<ReturnType<typeof provider.generate>>;
     let attempts = 0;
     const MAX_ATTEMPTS = 2;
-    /* eslint-disable no-constant-condition */
     while (true) {
       attempts++;
       result = await executeWithTimeout(
@@ -220,7 +219,6 @@ async function executeModel(
         { provider: model.provider, model: model.model, attempt: attempts },
       );
     }
-    /* eslint-enable no-constant-condition */
 
     const responseTime = Date.now() - startTime;
 


### PR DESCRIPTION
## What

Two **behavior-preserving** lint cleanups (no functional change):

1. **`src/lib/tasks/autoresearchTaskExecutor.ts`** — replace the `phasePolicy.forcedTool!` non-null assertion with an in-closure truthiness guard (`stepNumber === 0 && phasePolicy.forcedTool`), satisfying `@typescript-eslint/no-non-null-assertion`. The surrounding config already gates `prepareStep` on `forcedTool`, so behavior is unchanged (and the guard is strictly safer if the value were ever absent at call time).
2. **`src/lib/workflow/core/ensembleExecutor.ts`** — remove the unused `/* eslint-disable no-constant-condition */` + paired `/* eslint-enable */` around the retry `while (true)` loop. ESLint reported the directive as unused (the rule runs with `checkLoops` disabled), so the loop is not flagged once the dead directives are removed.

## Why

These were 2 of the repo's standing `pnpm run lint` warnings. Clearing them takes the count from **17 → 15** with zero behavioral risk.

## Verification

- `pnpm run check`: **0 errors**
- `pnpm run lint`: both targeted warnings cleared (17 → 15)
- `pnpm run build`: `0 errors, 0 warnings` / publint `All good!`

## Out of scope (intentionally)

The remaining **15 warnings are all `max-lines-per-function`** on long hot-path functions (provider `executeStream` paths, `neurolink.ts` generate/stream/MCP loops, the proxy handler, route factories). They are pre-existing, accepted style debt; refactoring shipped streaming/provider code purely to satisfy a soft 300-line rule carries real regression risk for cosmetic gain, so they're left as-is.

> Note: a batch of "type errors" in `src/lib/voice/livekit/realtimeVoiceAgent.ts` seen during recent work turned out to be a **stale-`node_modules` artifact** (a worktree rebased onto release without reinstalling the new `@livekit/*` deps) — **not** a real defect. A correctly-installed `release` reports `pnpm run check` = 0 errors.