### PR TITLE
feat(tools): emit per-invocation executionId on tool start/end events

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -673,6 +673,7 @@ export class NeuroLink {
     success: boolean,
     result?: unknown,
     error?: Error,
+    executionId?: string,
   ): void {
     // Emit tool end event (NeuroLink format - enhanced with result/error)
     // Serialize error to string for consumer compatibility (event listeners
@@ -685,6 +686,7 @@ export class NeuroLink {
         timestamp: Date.now(),
         result,
         error: error ? error.message : undefined,
+        executionId,
       }) as Record<string, unknown>,
     );
   }
@@ -10888,6 +10890,7 @@ Current user's request: ${currentInput}`;
   ): {
     functionTag: string;
     executionStartTime: number;
+    executionId: string;
     externalTool:
       | ReturnType<NeuroLink["externalServerManager"]["getAllTools"]>[number]
       | undefined;
@@ -10912,9 +10915,17 @@ Current user's request: ${currentInput}`;
           ? JSON.stringify(params)
           : "";
 
+    const executionStartTime = Date.now();
+    // Per-invocation id so consumers can correlate a tool:start with its matching
+    // tool:end even when the same tool runs multiple times concurrently.
+    const executionId = `${toolName}-${executionStartTime}-${Math.random()
+      .toString(36)
+      .slice(2, 11)}`;
+
     return {
       functionTag: "NeuroLink.executeTool",
-      executionStartTime: Date.now(),
+      executionStartTime,
+      executionId,
       externalTool,
       toolType,
       inputSize: inputStr.length,
@@ -11065,6 +11076,7 @@ Current user's request: ${currentInput}`;
       createToolEventPayload(toolName, {
         timestamp: executionContext.executionStartTime,
         input: params,
+        executionId: executionContext.executionId,
       }),
     );
 
@@ -11324,6 +11336,7 @@ Current user's request: ${currentInput}`;
       !isToolError,
       result,
       isToolError && errorText ? new Error(errorText) : undefined,
+      executionContext.executionId,
     );
     toolSpan.setAttribute(
       "tool.result.status",
@@ -11368,6 +11381,7 @@ Current user's request: ${currentInput}`;
         new Error(
           `Circuit breaker open for ${toolName} (state=${error.breakerState}, failures=${error.failureCount})`,
         ),
+        executionContext.executionId,
       );
       toolSpan.setAttribute("tool.result.status", "circuit_breaker_open");
       toolSpan.setAttribute("tool.duration_ms", executionTime);
@@ -11451,6 +11465,7 @@ Current user's request: ${currentInput}`;
       false,
       undefined,
       structuredError,
+      executionContext.executionId,
     );
     // Gate on listenerCount: Node EventEmitter rethrows the original error
     // from emit("error", e) when no listener is registered, which would


### PR DESCRIPTION
# Pull Request

## Description

**What does this PR do?**

Mints a unique `executionId` per tool invocation and includes it in the `tool:start` and `tool:end` event payloads across every terminal path (success, circuit-breaker, error). This lets consumers correlate a tool's start with its matching end — and its input with its output — even when the same tool runs multiple times concurrently, instead of relying on fragile matching by tool name.

Def proof:
<img width="1024" height="912" alt="Screenshot 2026-06-22 at 3 52 02 PM" src="https://github.com/user-attachments/assets/daacf3bf-b53d-43e1-afe6-2a2ce41632ac" />

plane-ticket: https://plane.breezehq.dev/breeze/browse/BZ-4052/


## Related Issues

**Does this PR close any issues?**

Relates to the tool start/end correlation issue surfaced by the Lighthouse AI chat observability pipeline.

## Type of Change

Please select the type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build/CI configuration
- [ ] Other (please describe):

## Motivation and Context

**Why is this change needed? What problem does it solve?**

Consumers (e.g. the Lighthouse dashboard's AI chat route) build observability spans by pairing `tool:start` and `tool:end` events. The only correlation key available was the tool name, so two concurrent invocations of the same tool (e.g. `surcharge-server_GetSurchargeRules`) collided: the end event could be matched to the wrong start, swapping inputs/outputs and start/end timestamps in the resulting trace. A per-invocation `executionId` makes the pairing deterministic.

- Background: tool spans were previously correlated by a `findLast`-by-name strategy on the consumer side.
- Use case: concurrent execution of the same tool within a single turn.
- Result: each invocation now carries a stable, unique id from start to end.

## Changes Made

**What specific changes were made?**

- Mint a per-invocation `executionId` of the form `` `${toolName}-${executionStartTime}-${Math.random().toString(36).slice(2, 11)}` `` when a tool begins executing.
- Add `executionId` to the tool execution context so it is available throughout the invocation lifecycle.
- Add an optional `executionId` parameter to the tool-event payload helper and include it in the emitted payload.
- Emit `executionId` on `tool:start`.
- Emit `executionId` on `tool:end` across all terminal paths: success, circuit-breaker-open (`tool.result.status = "circuit_breaker_open"`), and error.
- Single file touched: `src/lib/neurolink.ts` (+16 / −1).

## Breaking Changes

**Does this PR introduce breaking changes?**

- [x] No breaking changes
- [ ] Yes, breaking changes (describe below)

`executionId` is purely additive. Existing consumers that do not read the field are unaffected.

## Testing

**How has this been tested?**

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests pass
- [x] Manual testing completed
- [x] Tested with multiple providers: Vertex (Anthropic + Gemini)
- [ ] Tested on multiple platforms: [list platforms]

### Test Coverage

- [ ] All new code is covered by tests
- [x] Existing tests pass
- [ ] Coverage percentage maintained or improved

### Manual Testing Steps

1. Link this NeuroLink build into a consumer (Lighthouse) and run an AI chat request that triggers a tool call.
2. Inspect the emitted `tool:start` / `tool:end` events and the resulting Langfuse spans.
3. Verify both events carry the same `executionId`, and that input↔output and start↔end pair correctly for concurrent same-named tool calls.

Observed: `tool:start` and `tool:end` both carry the same id (e.g. `surcharge-server_GetSurchargeRules-1782111899542-r...`); the consumer's tool span shows the matching `executionId` on both input and output.

## Code Quality

**Have you followed code quality standards?**

- [x] Code follows the project's style guidelines (ESLint passes)
- [x] Code is properly formatted (Prettier applied)
- [x] Self-review of code completed
- [x] No console.log statements (using logger instead)
- [x] No hardcoded API keys or secrets
- [x] TypeScript strict mode compliance
- [x] Proper error handling implemented
- [ ] TODO/FIXME comments reference issues

## Documentation

**Have you updated documentation?**

- [ ] JSDoc comments added/updated for public APIs
- [ ] README.md updated (if needed)
- [ ] Documentation in /docs updated (if needed)
- [ ] Code examples added/updated (if needed)
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Migration guide provided (if breaking changes)

No documentation changes required — the change is internal to tool event emission. An inline comment explains why the id exists (concurrent same-name correlation).

## Commit Message Format

**Does your commit follow semantic commit conventions?**

- [x] Commit message follows format: `type(scope): description`
- [x] Valid type used: feat, fix, docs, style, refactor, test, chore, build, ci, perf, revert
- [x] Scope specified (e.g., providers, cli, docs, middleware)

Commit: `feat(tools): emit per-invocation executionId on tool start/end events`

## Dependencies

**Does this PR add, update, or remove dependencies?**

- [x] No dependency changes
- [ ] Dependencies added (list below)
- [ ] Dependencies updated (list below)
- [ ] Dependencies removed (list below)

## Performance Impact

**Does this change affect performance?**

- [x] No performance impact
- [ ] Performance improved (provide metrics)
- [ ] Performance degraded (justify why acceptable)

The only added work is constructing one short string per tool invocation.

## Security Considerations

**Are there any security implications?**

- [x] No security implications
- [ ] Security review needed
- [ ] Security vulnerability fixed

`executionId` is a non-sensitive correlation identifier (tool name + timestamp + random suffix). It carries no user or secret data.

## Deployment Notes

**Special deployment instructions?**

- [x] No special deployment steps
- [ ] Requires environment variable changes (list below)
- [ ] Requires database migration
- [ ] Requires Redis schema update
- [ ] Other (describe below)

## Screenshots / Videos

**If applicable, add screenshots or videos to demonstrate changes:**

N/A — observability-only change; verified via Langfuse trace inspection.

## Reviewer Checklist

For reviewers:

- [ ] Code follows project style and conventions
- [ ] Changes are well-documented
- [ ] Tests provide adequate coverage
- [ ] No obvious performance issues
- [ ] No security vulnerabilities introduced
- [ ] Breaking changes are properly documented
- [ ] Documentation is clear and accurate

## Additional Notes

**Any additional information for reviewers:**

The matching `executionId` field is consumed on the Lighthouse side: `tool:start` data becomes the tool span input and `tool:end` data becomes the output, with the span paired via an `executionId`-keyed map rather than by tool name.

---

## Pre-submission Checklist

Before submitting, ensure you have:

- [ ] Read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] Verified all automated pre-commit checks pass
- [ ] Tested changes locally with `pnpm test`
- [ ] Built the project successfully with `pnpm build`
- [ ] Run `pnpm run validate:all` and all checks pass
- [x] Reviewed your own code for obvious issues
- [x] Ensured commit messages follow semantic format
- [ ] Updated relevant documentation
- [ ] Added tests for new functionality
- [ ] Checked that CI/CD pipeline passes (after creating PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution event tracking to reliably identify and correlate concurrent tool operations. Each execution now receives a unique identifier, ensuring accurate matching of start and end lifecycle events during simultaneous runs. This enhancement improves system reliability and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->