### PR TITLE
fix(structured-output): disable structured output with tools on native anthropic provider

### DIFF
--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -40,6 +40,7 @@ import {
 } from "../../utils/tokenUtils.js";
 import { DEFAULT_MAX_STEPS } from "../constants.js";
 import {
+  isTemperatureDeprecatedError,
   isToolsSchemaConflictError,
   isToolsSchemaExclusionInForce,
 } from "./structuredOutputPolicy.js";
@@ -527,6 +528,59 @@ export class GenerationHandler {
               );
             }
 
+            span.setStatus({ code: SpanStatusCode.OK });
+            return result;
+          }
+
+          // Retry once without `temperature` when the model deprecated it. The
+          // newest Anthropic models (e.g. claude-opus-4-8 with tools + advanced
+          // beta features) reject `temperature` — "`temperature` is deprecated
+          // for this model." — in favour of reasoning-effort controls. Structured
+          // output is already excluded for the native anthropic surface, so this
+          // is the dominant failure mode for Opus there.
+          if (
+            isTemperatureDeprecatedError(error) &&
+            typeof options.temperature === "number"
+          ) {
+            span.setAttribute("neurolink.has_fallback", true);
+            span.addEvent("retry.initial_failure", {
+              "error.message":
+                error instanceof Error ? error.message : String(error),
+              "retry.attempt": 1,
+              "retry.reason": "temperature_deprecated",
+            });
+            logger.debug(
+              "[GenerationHandler] temperature-deprecated error caught - retrying without temperature",
+              {
+                provider: this.providerName,
+                model: this.modelName,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+            const result = await withProviderRetry(
+              () =>
+                this.callGenerateText(
+                  model,
+                  messages,
+                  tools,
+                  { ...options, temperature: undefined },
+                  shouldUseTools,
+                  true, // mirror the initial call; the structured-output policy still applies
+                ),
+              span,
+              "generateText(no-temperature)",
+            );
+            span.addEvent("retry.recovered", {
+              "retry.attempts": 2,
+              "retry.strategy": "temperature_omitted",
+            });
+            span.setAttribute("retry.count", 1);
+            if (result.finishReason) {
+              span.setAttribute(
+                "gen_ai.response.finish_reason",
+                result.finishReason,
+              );
+            }
             span.setStatus({ code: SpanStatusCode.OK });
             return result;
           }

--- a/src/lib/core/modules/structuredOutputPolicy.ts
+++ b/src/lib/core/modules/structuredOutputPolicy.ts
@@ -89,3 +89,23 @@ export function isToolsSchemaConflictError(error: unknown): boolean {
     /response_format[^.]{0,60}(tool|function)/i.test(message)
   );
 }
+
+/**
+ * True when a provider error indicates the request was rejected because the
+ * `temperature` parameter is deprecated / unsupported for the model. The newest
+ * Anthropic models (e.g. claude-opus-4-8, with tools + advanced beta features)
+ * reject `temperature` — "`temperature` is deprecated for this model." — in
+ * favour of reasoning-effort controls. Detect this so the call can be retried
+ * once without `temperature` instead of failing the turn.
+ */
+export function isTemperatureDeprecatedError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return /\btemperature\b[^.]{0,40}\b(deprecated|unsupported|not[\s_-]?(supported|allowed))\b/i.test(
+    message,
+  );
+}

--- a/src/lib/core/modules/structuredOutputPolicy.ts
+++ b/src/lib/core/modules/structuredOutputPolicy.ts
@@ -3,11 +3,17 @@
  * disabled because the provider cannot combine tool calls with JSON-schema
  * enforcement.
  *
- * This is a GEMINI-ONLY API limitation. Anthropic Claude — including when
- * hosted on Vertex (modelName starts with "claude-") — supports tools and
- * structured output simultaneously, so it must NOT be excluded. A gate keyed on
- * "any Vertex model" wrongly disables structured output for Vertex+Claude (the
- * primary production config) and forces fragile hand-parsed JSON.
+ * Two provider surfaces have this conflict:
+ *   - Gemini (google-ai, or Vertex with a non-Claude model).
+ *   - The native Anthropic Messages API surface (provider "anthropic"/"bedrock",
+ *     including via a proxy/base-URL override). experimental_output silently
+ *     drops tool_use blocks when tools are also present (finishReason=tool-calls
+ *     but zero parsed tool calls), so structured output must be disabled there too.
+ *
+ * Vertex+Claude (provider "vertex", modelName starts with "claude-") uses a
+ * different transport that supports both simultaneously and must NOT be excluded —
+ * a gate keyed on "any Vertex model" wrongly disables it for the primary
+ * production config and forces fragile hand-parsed JSON.
  */
 
 /** True when the provider+model is a Gemini model (the only family with the tools↔schema conflict). */
@@ -27,8 +33,20 @@ export function isGeminiProvider(
 }
 
 /**
+ * True when the provider is the native Anthropic Messages API surface
+ * (provider "anthropic" — including via a proxy/base-URL override — or "bedrock").
+ * experimental_output + tools silently drops tool_use blocks on this surface, so
+ * structured output must be disabled when tools are active. Vertex+Claude is NOT
+ * matched here (different transport, no conflict).
+ */
+export function isNativeAnthropicProvider(providerName: string): boolean {
+  return providerName === "anthropic" || providerName === "bedrock";
+}
+
+/**
  * True when structured output must be disabled for this call because tools are
- * active on a Gemini provider. Mirrors the AI-SDK constraint exactly.
+ * active on a provider that cannot combine them (Gemini, or the native Anthropic
+ * Messages API surface). Mirrors the AI-SDK constraint exactly.
  */
 export function isToolsSchemaExclusionInForce(
   providerName: string,
@@ -37,7 +55,10 @@ export function isToolsSchemaExclusionInForce(
   toolCount: number,
 ): boolean {
   return (
-    isGeminiProvider(providerName, modelName) && shouldUseTools && toolCount > 0
+    (isGeminiProvider(providerName, modelName) ||
+      isNativeAnthropicProvider(providerName)) &&
+    shouldUseTools &&
+    toolCount > 0
   );
 }
 

--- a/src/lib/core/modules/structuredOutputPolicy.ts
+++ b/src/lib/core/modules/structuredOutputPolicy.ts
@@ -109,3 +109,21 @@ export function isTemperatureDeprecatedError(error: unknown): boolean {
     message,
   );
 }
+
+/**
+ * True when the model is known to reject the `temperature` parameter (the
+ * reasoning-effort Anthropic models — claude-opus-4-8 and newer — deprecate it
+ * in favour of effort controls). Used to omit `temperature` proactively so the
+ * request does not fail-then-retry on every turn: the reactive
+ * isTemperatureDeprecatedError() retry remains the safety net for any model not
+ * matched here, but a guaranteed-to-fail first request is pure wasted latency.
+ *
+ * Matches opus 4.8+ (4-8, 4-9, 4-10, …) while leaving 4.1/4.5/4.6 and Sonnet/
+ * Haiku — which still accept `temperature` — untouched.
+ */
+export function modelDeprecatesTemperature(
+  modelName: string | undefined,
+): boolean {
+  const m = (modelName ?? "").toLowerCase();
+  return /opus[-_.]?4[-_.]?(?:[89]|\d{2,})\b/.test(m);
+}

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -76,6 +76,11 @@ import {
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
 import { resolveClaudeMaxTokens } from "../utils/tokenLimits.js";
 import {
+  toAnthropicImageBlock,
+  fileToAnthropicBlock,
+} from "./anthropicImageBlocks.js";
+import { modelDeprecatesTemperature } from "../core/modules/structuredOutputPolicy.js";
+import {
   createChunkQueue,
   createDeferredAnalytics,
   stringifyToolInput,
@@ -314,49 +319,6 @@ const parseRateLimitHeaders = (
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Convert an image part (data URL, bare base64, https URL, or byte array)
- * into an Anthropic image block. Returns undefined for unusable inputs.
- */
-const toAnthropicImageBlock = (
-  data: unknown,
-): Anthropic.Messages.ImageBlockParam | undefined => {
-  if (data instanceof Uint8Array) {
-    return {
-      type: "image",
-      source: {
-        type: "base64",
-        media_type: "image/png",
-        data: Buffer.from(data).toString("base64"),
-      },
-    };
-  }
-  if (typeof data !== "string" && !(data instanceof URL)) {
-    return undefined;
-  }
-  const str = data instanceof URL ? data.toString() : data;
-  const dataUrlMatch = str.match(/^data:(image\/[a-z+.-]+);base64,(.+)$/i);
-  if (dataUrlMatch) {
-    return {
-      type: "image",
-      source: {
-        type: "base64",
-        media_type:
-          dataUrlMatch[1] as Anthropic.Messages.Base64ImageSource["media_type"],
-        data: dataUrlMatch[2],
-      },
-    };
-  }
-  if (/^https?:\/\//i.test(str)) {
-    return { type: "image", source: { type: "url", url: str } };
-  }
-  // Bare base64 payload — assume PNG (matches the OpenAI-compat client).
-  return {
-    type: "image",
-    source: { type: "base64", media_type: "image/png", data: str },
-  };
-};
-
-/**
  * Read an Anthropic cache breakpoint from a message/part/tool carrier.
  * MessageBuilder marks system messages (and GenerationHandler marks the last
  * tool definition) with `providerOptions.anthropic.cacheControl` — the
@@ -483,6 +445,28 @@ const messagesToAnthropic = (
             if (img) {
               const cc = cacheControlOf(p);
               blocks.push(cc ? { ...img, cache_control: cc } : img);
+            }
+          } else if (p?.type === "file") {
+            // AI-SDK v6 encodes images AND PDFs as `type:"file"` parts in the
+            // LanguageModel prompt that `doGenerate` receives. Without this
+            // branch the image is dropped on the tool-using generate path and
+            // the model never sees it ("no image detected").
+            const block = fileToAnthropicBlock(
+              p as { mediaType?: string; data?: unknown },
+            );
+            if (block) {
+              const cc = cacheControlOf(p);
+              if (cc) {
+                // block is a fresh object from fileToAnthropicBlock; mutate in
+                // place to keep the discriminated-union type (a spread widens it
+                // past ContentBlockParam).
+                (
+                  block as {
+                    cache_control?: Anthropic.Messages.CacheControlEphemeral;
+                  }
+                ).cache_control = cc;
+              }
+              blocks.push(block);
             }
           }
         }
@@ -1454,7 +1438,9 @@ export class AnthropicProvider extends BaseProvider {
           messages,
           max_tokens: resolveClaudeMaxTokens(modelId, options.maxOutputTokens),
           ...(system ? { system } : {}),
-          ...(options.temperature !== undefined && options.temperature !== null
+          ...(options.temperature !== undefined &&
+          options.temperature !== null &&
+          !modelDeprecatesTemperature(modelId)
             ? { temperature: options.temperature }
             : {}),
           ...(options.topP !== undefined && options.topP !== null
@@ -1783,7 +1769,9 @@ export class AnthropicProvider extends BaseProvider {
           max_tokens: resolveClaudeMaxTokens(modelId, options.maxTokens),
           stream: true,
           ...(payload.system ? { system: payload.system } : {}),
-          ...(options.temperature !== undefined && options.temperature !== null
+          ...(options.temperature !== undefined &&
+          options.temperature !== null &&
+          !modelDeprecatesTemperature(modelId)
             ? { temperature: options.temperature }
             : {}),
           ...(anthropicTools && anthropicTools.length > 0

--- a/src/lib/providers/anthropicImageBlocks.ts
+++ b/src/lib/providers/anthropicImageBlocks.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure converters from multimodal content parts into native Anthropic
+ * Messages-API content blocks (image / document).
+ *
+ * Two input shapes reach the native Anthropic surface:
+ *
+ *  1. NeuroLink/V3 multimodal parts — `{ type: "image", image }` produced by
+ *     the multimodal message builder (base64, data URL, https URL, or bytes).
+ *
+ *  2. AI-SDK LanguageModel prompt parts — `{ type: "file", mediaType, data }`.
+ *     This is how `ai@6` encodes BOTH images and PDFs in the prompt that the
+ *     provider's `doGenerate(options.prompt)` receives. Before this module the
+ *     converter only handled `type:"image"`, so on the tool-using generate
+ *     path (which always normalises images to `type:"file"`) the image part
+ *     was silently dropped — the model never saw the image ("no image
+ *     detected"). Gemini/Vertex are immune because they read `input.images`
+ *     directly in their own builders instead of going through this conversion.
+ *
+ * Media type is taken from the AI-SDK-provided `mediaType` when present, then
+ * sniffed from magic bytes, and only then defaulted — a hardcoded `image/png`
+ * default silently corrupts JPEG/GIF/WebP uploads (the Anthropic API rejects a
+ * mislabeled base64 image with HTTP 400 and the image vanishes).
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+// The base64 image media types the Anthropic Messages API accepts are exactly
+// `Anthropic.Messages.Base64ImageSource["media_type"]` — referenced inline below
+// rather than redeclared as a local alias (project rule: type aliases live in
+// src/lib/types/, and this provider-internal shape does not warrant a barrel entry).
+const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<string> = new Set<string>([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+/** Map a caller-provided MIME hint onto a supported image media type (or undefined). */
+const normalizeImageMediaType = (
+  hint: string | undefined,
+): Anthropic.Messages.Base64ImageSource["media_type"] | undefined => {
+  if (!hint) {
+    return undefined;
+  }
+  const h = hint.toLowerCase().split(";")[0].trim();
+  if (h === "image/jpg") {
+    return "image/jpeg";
+  }
+  return SUPPORTED_IMAGE_MEDIA_TYPES.has(h)
+    ? (h as Anthropic.Messages.Base64ImageSource["media_type"])
+    : undefined;
+};
+
+/**
+ * Detect a supported image media type from a buffer's magic bytes. Returns
+ * undefined when the bytes are not one of the four Anthropic-supported formats.
+ */
+export function sniffImageMediaType(
+  bytes: Uint8Array,
+): Anthropic.Messages.Base64ImageSource["media_type"] | undefined {
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  // GIF: "GIF"
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46
+  ) {
+    return "image/gif";
+  }
+  // WebP: "RIFF"...."WEBP"
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return undefined;
+}
+
+/** Sniff the leading bytes of a base64 payload (best-effort, never throws). */
+const sniffBase64 = (
+  b64: string,
+): Anthropic.Messages.Base64ImageSource["media_type"] | undefined => {
+  try {
+    return sniffImageMediaType(Buffer.from(b64.slice(0, 32), "base64"));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Convert an image part (data URL, bare base64, https URL, byte array, or
+ * ArrayBuffer) into an Anthropic image block. Honors `mediaTypeHint` (the
+ * AI-SDK `mediaType`), falls back to magic-byte sniffing, then to image/png.
+ * Returns undefined for unusable inputs.
+ */
+export function toAnthropicImageBlock(
+  data: unknown,
+  mediaTypeHint?: string,
+): Anthropic.Messages.ImageBlockParam | undefined {
+  if (data instanceof ArrayBuffer) {
+    return toAnthropicImageBlock(new Uint8Array(data), mediaTypeHint);
+  }
+  if (data instanceof Uint8Array) {
+    const media_type =
+      normalizeImageMediaType(mediaTypeHint) ??
+      sniffImageMediaType(data) ??
+      "image/png";
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type,
+        data: Buffer.from(data).toString("base64"),
+      },
+    };
+  }
+  if (typeof data !== "string" && !(data instanceof URL)) {
+    return undefined;
+  }
+  const str = data instanceof URL ? data.toString() : data;
+  const dataUrlMatch = str.match(/^data:(image\/[a-z0-9+.-]+);base64,(.+)$/i);
+  if (dataUrlMatch) {
+    const media_type =
+      normalizeImageMediaType(dataUrlMatch[1]) ?? sniffBase64(dataUrlMatch[2]);
+    if (!media_type) {
+      return undefined;
+    }
+    return {
+      type: "image",
+      source: { type: "base64", media_type, data: dataUrlMatch[2] },
+    };
+  }
+  if (/^https?:\/\//i.test(str)) {
+    return { type: "image", source: { type: "url", url: str } };
+  }
+  // Bare base64 payload — prefer the hint, then sniff, then assume PNG
+  // (matches the OpenAI-compat client's historical default).
+  const media_type =
+    normalizeImageMediaType(mediaTypeHint) ?? sniffBase64(str) ?? "image/png";
+  return {
+    type: "image",
+    source: { type: "base64", media_type, data: str },
+  };
+}
+
+/** Convert a PDF file part into an Anthropic document block. */
+const toAnthropicPdfBlock = (
+  data: unknown,
+): Anthropic.Messages.DocumentBlockParam | undefined => {
+  if (data instanceof ArrayBuffer) {
+    return toAnthropicPdfBlock(new Uint8Array(data));
+  }
+  if (data instanceof Uint8Array) {
+    return {
+      type: "document",
+      source: {
+        type: "base64",
+        media_type: "application/pdf",
+        data: Buffer.from(data).toString("base64"),
+      },
+    };
+  }
+  if (data instanceof URL) {
+    return { type: "document", source: { type: "url", url: data.toString() } };
+  }
+  if (typeof data === "string") {
+    const m = data.match(/^data:application\/pdf;base64,(.+)$/i);
+    if (m) {
+      return {
+        type: "document",
+        source: { type: "base64", media_type: "application/pdf", data: m[1] },
+      };
+    }
+    if (/^https?:\/\//i.test(data)) {
+      return { type: "document", source: { type: "url", url: data } };
+    }
+    return {
+      type: "document",
+      source: { type: "base64", media_type: "application/pdf", data },
+    };
+  }
+  return undefined;
+};
+
+/**
+ * Convert an AI-SDK `{ type: "file", mediaType, data }` content part into the
+ * matching Anthropic content block: image/* → image block (media type honored,
+ * not hardcoded), application/pdf → document block. Returns undefined for
+ * unsupported media types (so the caller simply omits them rather than 400ing).
+ * When `mediaType` is absent, image bytes are still salvaged via sniffing.
+ */
+export function fileToAnthropicBlock(part: {
+  mediaType?: string;
+  data?: unknown;
+}): Anthropic.Messages.ContentBlockParam | undefined {
+  const data = part?.data;
+  if (data === undefined || data === null) {
+    return undefined;
+  }
+  const mediaType =
+    typeof part.mediaType === "string"
+      ? part.mediaType.toLowerCase().split(";")[0].trim()
+      : "";
+
+  if (mediaType.startsWith("image/")) {
+    return toAnthropicImageBlock(data, mediaType);
+  }
+  if (mediaType === "application/pdf") {
+    return toAnthropicPdfBlock(data);
+  }
+  // No / unknown media type: salvage raw image bytes if the magic bytes match.
+  if (!mediaType) {
+    const bytes =
+      data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : data instanceof Uint8Array
+          ? data
+          : undefined;
+    if (bytes && sniffImageMediaType(bytes)) {
+      return toAnthropicImageBlock(bytes);
+    }
+  }
+  return undefined;
+}

--- a/test/continuous-test-suite-anthropic-multimodal.ts
+++ b/test/continuous-test-suite-anthropic-multimodal.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: native-Anthropic multimodal block conversion (pure,
+ * no API).
+ *
+ * Regression guard for the vision defect on the native Anthropic surface: AI-SDK
+ * v6 encodes images AND PDFs in the LanguageModel prompt as `type:"file"` parts
+ * (`{ type:"file", mediaType, data }`). The provider's `doGenerate(options.prompt)`
+ * converts that prompt with messagesToAnthropic, which only handled
+ * text/image/image_url — so the image was silently dropped on the tool-using
+ * generate path and the model answered "no image detected". These tests lock in:
+ *
+ *  - `fileToAnthropicBlock` turns an image file part into an Anthropic image
+ *    block with the CORRECT media type (honoring the AI-SDK `mediaType`, not a
+ *    hardcoded image/png that 400s real JPEG/GIF/WebP uploads).
+ *  - PDF file parts become document blocks.
+ *  - Magic-byte sniffing recovers the media type when no hint is present.
+ *
+ * Run: npx tsx test/continuous-test-suite-anthropic-multimodal.ts
+ */
+
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import {
+  sniffImageMediaType,
+  toAnthropicImageBlock,
+  fileToAnthropicBlock,
+} from "../src/lib/providers/anthropicImageBlocks.js";
+
+const { test, runSuite } = defineSuite(
+  "Native-Anthropic multimodal conversion",
+);
+
+// Minimal valid magic-byte headers for each format.
+const PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+]);
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+const GIF = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]); // GIF89a
+const WEBP = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+const PDF = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]); // %PDF-1.4
+
+const isImageBlock = (
+  b: unknown,
+): b is {
+  type: "image";
+  source: { type: string; media_type?: string; data?: string; url?: string };
+} => !!b && (b as { type?: string }).type === "image";
+
+await test("sniffImageMediaType: detects png/jpeg/gif/webp from magic bytes", () => {
+  assertEqual(sniffImageMediaType(PNG), "image/png", "PNG magic → image/png");
+  assertEqual(
+    sniffImageMediaType(JPEG),
+    "image/jpeg",
+    "JPEG magic → image/jpeg",
+  );
+  assertEqual(sniffImageMediaType(GIF), "image/gif", "GIF magic → image/gif");
+  assertEqual(
+    sniffImageMediaType(WEBP),
+    "image/webp",
+    "WEBP magic → image/webp",
+  );
+  assertEqual(
+    sniffImageMediaType(PDF),
+    undefined,
+    "non-image bytes → undefined",
+  );
+});
+
+await test("toAnthropicImageBlock: byte array honors mediaType hint", () => {
+  const block = toAnthropicImageBlock(JPEG, "image/jpeg");
+  assertEqual(isImageBlock(block), true, "produces image block");
+  assertEqual(block?.source.type, "base64", "base64 source");
+  assertEqual(
+    (block?.source as { media_type?: string }).media_type,
+    "image/jpeg",
+    "media_type from hint (NOT hardcoded png)",
+  );
+  assertEqual(
+    (block?.source as { data?: string }).data,
+    JPEG.toString("base64"),
+    "base64 payload preserved",
+  );
+});
+
+await test("toAnthropicImageBlock: byte array with no hint sniffs the type", () => {
+  const block = toAnthropicImageBlock(GIF);
+  assertEqual(
+    (block?.source as { media_type?: string }).media_type,
+    "image/gif",
+    "GIF bytes sniffed to image/gif (not defaulted to png)",
+  );
+});
+
+await test("toAnthropicImageBlock: https URL → url source", () => {
+  const block = toAnthropicImageBlock("https://example.com/cat.png");
+  assertEqual(block?.source.type, "url", "url source type");
+  assertEqual(
+    (block?.source as { url?: string }).url,
+    "https://example.com/cat.png",
+    "url preserved",
+  );
+});
+
+await test("toAnthropicImageBlock: data URL parses media type + payload", () => {
+  const b64 = PNG.toString("base64");
+  const block = toAnthropicImageBlock(`data:image/png;base64,${b64}`);
+  assertEqual(
+    (block?.source as { media_type?: string }).media_type,
+    "image/png",
+    "data URL media type",
+  );
+  assertEqual(
+    (block?.source as { data?: string }).data,
+    b64,
+    "data URL payload",
+  );
+});
+
+await test("fileToAnthropicBlock: AI-SDK image file part → image block (THE fix)", () => {
+  // Exactly the shape ai@6 puts in the doGenerate prompt for an uploaded PNG.
+  const block = fileToAnthropicBlock({ mediaType: "image/png", data: PNG });
+  assertEqual(isImageBlock(block), true, "image file part → image block");
+  assertEqual(
+    (block as { source?: { media_type?: string } })?.source?.media_type,
+    "image/png",
+    "media type carried through",
+  );
+  assertEqual(
+    (block as { source?: { data?: string } })?.source?.data,
+    PNG.toString("base64"),
+    "image bytes carried through (image is no longer dropped)",
+  );
+});
+
+await test("fileToAnthropicBlock: jpeg file part keeps image/jpeg", () => {
+  const block = fileToAnthropicBlock({ mediaType: "image/jpeg", data: JPEG });
+  assertEqual(
+    (block as { source?: { media_type?: string } })?.source?.media_type,
+    "image/jpeg",
+    "jpeg not mislabeled as png",
+  );
+});
+
+await test("fileToAnthropicBlock: PDF file part → document block", () => {
+  const block = fileToAnthropicBlock({
+    mediaType: "application/pdf",
+    data: PDF,
+  });
+  assertEqual(
+    (block as { type?: string })?.type,
+    "document",
+    "pdf → document block",
+  );
+  assertEqual(
+    (block as { source?: { media_type?: string } })?.source?.media_type,
+    "application/pdf",
+    "document media type",
+  );
+});
+
+await test("fileToAnthropicBlock: missing mediaType still salvages image bytes", () => {
+  const block = fileToAnthropicBlock({ data: WEBP });
+  assertEqual(
+    (block as { source?: { media_type?: string } })?.source?.media_type,
+    "image/webp",
+    "sniffed image/webp from bytes with no hint",
+  );
+});
+
+await test("fileToAnthropicBlock: unsupported non-image file → undefined (skipped, not 400)", () => {
+  assertEqual(
+    fileToAnthropicBlock({ mediaType: "text/plain", data: "hello" }),
+    undefined,
+    "text file part is omitted, not forced into an image block",
+  );
+  assertEqual(
+    fileToAnthropicBlock({ mediaType: "image/png", data: null }),
+    undefined,
+    "null data → undefined",
+  );
+});
+
+await runSuite();

--- a/test/continuous-test-suite-anthropic-tools-policy.ts
+++ b/test/continuous-test-suite-anthropic-tools-policy.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: native-Anthropic tools policy (pure, no API).
+ *
+ * Two related provider-quirk gates for the native Anthropic Messages API
+ * surface (provider "anthropic"/"bedrock", incl. via a proxy/base-URL override):
+ *
+ *  1. structured-output ↔ tools — experimental_output (JSON-schema enforcement)
+ *     silently drops tool_use blocks when combined with tools on this surface
+ *     (finishReason=tool-calls but zero parsed tool calls). isToolsSchema
+ *     ExclusionInForce() must therefore disable structured output for it,
+ *     mirroring the Gemini gate — while leaving Vertex+Claude untouched (a
+ *     different transport that supports both simultaneously).
+ *
+ *  2. temperature deprecation — the newest models (e.g. claude-opus-4-8 with
+ *     tools + advanced betas) reject `temperature` ("`temperature` is deprecated
+ *     for this model.") in favour of reasoning-effort controls. isTemperature
+ *     DeprecatedError() detects this so the call can be retried without it.
+ *
+ * Run: npx tsx test/continuous-test-suite-anthropic-tools-policy.ts
+ */
+
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import {
+  isNativeAnthropicProvider,
+  isGeminiProvider,
+  isToolsSchemaExclusionInForce,
+  isTemperatureDeprecatedError,
+} from "../src/lib/core/modules/structuredOutputPolicy.js";
+
+const { test, runSuite } = defineSuite("Native-Anthropic tools policy");
+
+await test("isNativeAnthropicProvider: anthropic + bedrock only", () => {
+  assertEqual(isNativeAnthropicProvider("anthropic"), true, "anthropic → true");
+  assertEqual(isNativeAnthropicProvider("bedrock"), true, "bedrock → true");
+  assertEqual(isNativeAnthropicProvider("vertex"), false, "vertex → false");
+  assertEqual(
+    isNativeAnthropicProvider("google-ai"),
+    false,
+    "google-ai → false",
+  );
+});
+
+await test("structured-output exclusion now covers native anthropic + tools", () => {
+  assertEqual(
+    isToolsSchemaExclusionInForce("anthropic", "claude-opus-4-8", true, 5),
+    true,
+    "anthropic + tools → exclude structured output",
+  );
+  assertEqual(
+    isToolsSchemaExclusionInForce("bedrock", "claude-sonnet-4-6", true, 3),
+    true,
+    "bedrock + tools → exclude structured output",
+  );
+});
+
+await test("Vertex+Claude is intentionally NOT excluded (different transport)", () => {
+  assertEqual(
+    isGeminiProvider("vertex", "claude-sonnet-4-6"),
+    false,
+    "vertex+claude is not a gemini provider",
+  );
+  assertEqual(
+    isToolsSchemaExclusionInForce("vertex", "claude-sonnet-4-6", true, 9),
+    false,
+    "vertex+claude keeps strict structured output",
+  );
+});
+
+await test("Gemini gate still in force", () => {
+  assertEqual(
+    isToolsSchemaExclusionInForce("vertex", "gemini-2.5-flash", true, 2),
+    true,
+    "vertex+gemini + tools → exclude",
+  );
+  assertEqual(
+    isToolsSchemaExclusionInForce("google-ai", "gemini-2.5-pro", true, 1),
+    true,
+    "google-ai + tools → exclude",
+  );
+});
+
+await test("exclusion requires tools to actually be active", () => {
+  assertEqual(
+    isToolsSchemaExclusionInForce("anthropic", "claude-opus-4-8", true, 0),
+    false,
+    "no tools → no exclusion",
+  );
+  assertEqual(
+    isToolsSchemaExclusionInForce("anthropic", "claude-opus-4-8", false, 5),
+    false,
+    "tools disabled → no exclusion",
+  );
+});
+
+await test("isTemperatureDeprecatedError matches the real Anthropic 400", () => {
+  assertEqual(
+    isTemperatureDeprecatedError(
+      new Error("`temperature` is deprecated for this model."),
+    ),
+    true,
+    "production message → true",
+  );
+  assertEqual(
+    isTemperatureDeprecatedError("temperature is not supported"),
+    true,
+    "not-supported phrasing → true",
+  );
+  assertEqual(
+    isTemperatureDeprecatedError(
+      new Error("temperature parameter not allowed"),
+    ),
+    true,
+    "not-allowed phrasing → true",
+  );
+});
+
+await test("isTemperatureDeprecatedError ignores unrelated errors", () => {
+  assertEqual(
+    isTemperatureDeprecatedError(new Error("rate limit exceeded (429)")),
+    false,
+    "rate limit → false",
+  );
+  assertEqual(
+    isTemperatureDeprecatedError(new Error("max_tokens is too large")),
+    false,
+    "unrelated 400 → false",
+  );
+  assertEqual(isTemperatureDeprecatedError(""), false, "empty → false");
+});
+
+await runSuite();

--- a/test/continuous-test-suite-anthropic-tools-policy.ts
+++ b/test/continuous-test-suite-anthropic-tools-policy.ts
@@ -26,6 +26,7 @@ import {
   isGeminiProvider,
   isToolsSchemaExclusionInForce,
   isTemperatureDeprecatedError,
+  modelDeprecatesTemperature,
 } from "../src/lib/core/modules/structuredOutputPolicy.js";
 
 const { test, runSuite } = defineSuite("Native-Anthropic tools policy");
@@ -127,6 +128,58 @@ await test("isTemperatureDeprecatedError ignores unrelated errors", () => {
     "unrelated 400 → false",
   );
   assertEqual(isTemperatureDeprecatedError(""), false, "empty → false");
+});
+
+await test("modelDeprecatesTemperature: opus 4.8+ only (proactive omission)", () => {
+  // Reasoning-effort models that reject `temperature` → omit it proactively.
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-8"),
+    true,
+    "opus-4-8 → true",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-8-20251101"),
+    true,
+    "opus-4-8 dated id → true",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-9"),
+    true,
+    "opus-4-9 → true",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-10"),
+    true,
+    "opus-4-10 → true",
+  );
+});
+
+await test("modelDeprecatesTemperature: older/other models keep temperature", () => {
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-1"),
+    false,
+    "opus-4-1 → false",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-opus-4-6"),
+    false,
+    "opus-4-6 → false",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-sonnet-4-6"),
+    false,
+    "sonnet-4-6 → false",
+  );
+  assertEqual(
+    modelDeprecatesTemperature("claude-haiku-4-5"),
+    false,
+    "haiku-4-5 → false",
+  );
+  assertEqual(
+    modelDeprecatesTemperature(undefined),
+    false,
+    "undefined → false",
+  );
 });
 
 await runSuite();


### PR DESCRIPTION
## Problem

`experimental_output` (AI-SDK JSON-schema enforcement) combined with tools **silently drops tool calls** on the native Anthropic Messages API surface (provider `anthropic`/`bedrock`, including via a proxy / `ANTHROPIC_BASE_URL` override).

Symptoms observed on an anthropic-via-proxy deployment (Tara):
- The model returns `finishReason=tool-calls` but **zero** tool calls are parsed (`has_tools=false`), so the agent loop ends at step 1.
- Only the assistant's preamble text is returned → the model **fabricates** tool-success ("flag set successfully") while the tool never ran.
- Structured-output recovery then retry-storms (8–23 calls per turn).

## Root cause

`isToolsSchemaExclusionInForce()` disables structured-output-with-tools **only for Gemini**; its comment assumed *"Anthropic Claude … supports tools and structured output simultaneously."* That holds for **Vertex+Claude** (different transport) but **not** for the native Anthropic surface.

## Fix

Extend the static gate to also exclude the native anthropic surface (`anthropic`/`bedrock`) when tools are active, via a new `isNativeAnthropicProvider()` — mirroring the existing Gemini fallback. **Vertex+Claude is intentionally left untouched** (provider `vertex`, `claude-` model), preserving strict structured output for the primary production config.

## Verification

End-to-end on an anthropic-via-proxy deployment with the equivalent change applied:
- **Before:** tool never executes; fabricated reply; retry storm.
- **After:** tool executes (real return values — e.g. reporting the *previous* flag value), clean 2-step tool loop, no retry storm.

Downstream `validateOrRecoverStructured()` recovers the structured shape from text mode, so there is no regression to the response format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for structured output when tools are enabled with native Anthropic providers on Bedrock, while keeping Vertex + Claude supported.
  * Added automatic recovery for requests that fail due to deprecated/unsupported temperature by retrying without the temperature setting.
  * Prevented temperature from being sent for Anthropic models that deprecate it.
* **New Features**
  * Enhanced Anthropic multimodal prompt conversion for file/image parts (including PDF and media-type detection).
* **Tests**
  * Added continuous test coverage for native Anthropic tools policy, temperature deprecation detection, and multimodal conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->