### PR TITLE
fix(vertex): replay tool calls/results in native Claude conversation history

### DIFF
--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -38,6 +38,10 @@ import type {
   VertexAnthropicMessage,
   VertexAnthropicTool,
   VertexAnthropicContentBlock,
+  VertexToolStep,
+  VertexSegment,
+  ChatMessage,
+  MinimalChatMessage,
 } from "../types/index.js";
 import {
   AuthenticationError,
@@ -120,6 +124,183 @@ const hasAnthropicSupport = (): boolean => {
   // Actual availability is checked at runtime when creating the client
   return true;
 };
+
+// Parse stored rows into ordered segments, grouping tool_call/tool_result by (turn, step).
+function collectHistorySegments(
+  conversationMessages: Array<ChatMessage | MinimalChatMessage>,
+): VertexSegment[] {
+  const segments: VertexSegment[] = [];
+  const stepMap = new Map<string, VertexToolStep>();
+  let turnCounter = 0;
+
+  const getStep = (stepIndex: number | undefined): VertexToolStep => {
+    const key = `${turnCounter}:${stepIndex ?? "x"}`;
+    let step = stepMap.get(key);
+    if (!step) {
+      step = { type: "tool_step", callParts: [], resultParts: [] };
+      stepMap.set(key, step);
+      segments.push(step);
+    }
+    return step;
+  };
+
+  for (const msg of conversationMessages) {
+    if (msg.role === "tool_call") {
+      getStep(msg.metadata?.stepIndex).callParts.push({
+        name: msg.tool || "unknown",
+        input: msg.args || {},
+      });
+      continue;
+    }
+    if (msg.role === "tool_result") {
+      getStep(msg.metadata?.stepIndex).resultParts.push(
+        msg.content && msg.content.length > 0 ? msg.content : "(no output)",
+      );
+      continue;
+    }
+    const role =
+      msg.role === "assistant"
+        ? "assistant"
+        : msg.role === "user"
+          ? "user"
+          : null;
+    if (!role || !msg.content || msg.content.trim().length === 0) {
+      continue;
+    }
+    // New turn → fresh step namespace for any following tool rows.
+    turnCounter++;
+    segments.push({ type: "regular", role, parts: [msg.content] });
+  }
+  return segments;
+}
+
+// Append blocks to the trailing turn if it shares the role, else start a new turn.
+function pushTurn(
+  messages: VertexAnthropicMessage[],
+  role: "user" | "assistant",
+  blocks: VertexAnthropicContentBlock[],
+): void {
+  const last = messages[messages.length - 1];
+  if (last && last.role === role && Array.isArray(last.content)) {
+    last.content.push(...blocks);
+  } else {
+    messages.push({ role, content: [...blocks] });
+  }
+}
+
+// Pair a tool step's calls/results by position; unbalanced extras are dropped
+// because Anthropic 400s on an orphaned tool_use/tool_result reference.
+function pairToolStep(
+  step: VertexToolStep,
+  ordinal: number,
+): {
+  uses: VertexAnthropicContentBlock[];
+  results: VertexAnthropicContentBlock[];
+} {
+  const calls = step.callParts as Array<{
+    name: string;
+    input: Record<string, unknown>;
+  }>;
+  const resultStrings = step.resultParts as string[];
+  const paired = Math.min(calls.length, resultStrings.length);
+  if (paired !== calls.length || paired !== resultStrings.length) {
+    logger.debug(
+      "[GoogleVertex] Unbalanced tool step in Claude history replay",
+      {
+        calls: calls.length,
+        results: resultStrings.length,
+        paired,
+      },
+    );
+  }
+  const uses: VertexAnthropicContentBlock[] = [];
+  const results: VertexAnthropicContentBlock[] = [];
+  for (let i = 0; i < paired; i++) {
+    const id = `hist_${ordinal}_${i}`;
+    uses.push({
+      type: "tool_use",
+      id,
+      name: calls[i].name,
+      input: calls[i].input,
+    });
+    results.push({
+      type: "tool_result",
+      tool_use_id: id,
+      content: resultStrings[i],
+    });
+  }
+  return { uses, results };
+}
+
+// Drop leading turns until the first is a real user turn — Anthropic requires it
+// (covers a leading assistant/tool step and an orphaned tool_result-only turn).
+function trimLeadingNonUser(messages: VertexAnthropicMessage[]): void {
+  const isToolResultOnly = (m: VertexAnthropicMessage): boolean =>
+    Array.isArray(m.content) &&
+    m.content.length > 0 &&
+    m.content.every((block) => block.type === "tool_result");
+  while (
+    messages.length > 0 &&
+    (messages[0].role !== "user" || isToolResultOnly(messages[0]))
+  ) {
+    messages.shift();
+  }
+}
+
+// Rebuild Anthropic history with paired tool_use/tool_result turns from stored rows.
+export function buildAnthropicHistoryMessages(
+  conversationMessages: Array<ChatMessage | MinimalChatMessage>,
+): VertexAnthropicMessage[] {
+  const messages: VertexAnthropicMessage[] = [];
+  let stepOrdinal = 0;
+  for (const seg of collectHistorySegments(conversationMessages)) {
+    if (seg.type === "regular") {
+      pushTurn(messages, seg.role === "assistant" ? "assistant" : "user", [
+        { type: "text", text: String(seg.parts[0] ?? "") },
+      ]);
+      continue;
+    }
+    const { uses, results } = pairToolStep(seg, stepOrdinal);
+    if (uses.length === 0) {
+      continue;
+    }
+    stepOrdinal++;
+    pushTurn(messages, "assistant", uses);
+    pushTurn(messages, "user", results);
+  }
+  trimLeadingNonUser(messages);
+
+  if (logger.shouldLog("debug")) {
+    const blocks = messages.flatMap((m) =>
+      Array.isArray(m.content) ? m.content : [],
+    );
+    logger.debug("[GoogleVertex] Replayed Claude history with tool turns", {
+      historyMessages: messages.length,
+      toolUseBlocks: blocks.filter((b) => b.type === "tool_use").length,
+      toolResultBlocks: blocks.filter((b) => b.type === "tool_result").length,
+    });
+  }
+  return messages;
+}
+
+// Append the live user turn, merging into a trailing user turn to avoid back-to-back user messages.
+export function appendUserMessage(
+  messages: VertexAnthropicMessage[],
+  content: VertexAnthropicMessage["content"],
+): void {
+  const last = messages[messages.length - 1];
+  if (last && last.role === "user") {
+    const head = Array.isArray(last.content)
+      ? last.content
+      : [{ type: "text" as const, text: last.content }];
+    const tail = Array.isArray(content)
+      ? content
+      : [{ type: "text" as const, text: content }];
+    last.content = [...head, ...tail];
+    return;
+  }
+  messages.push({ role: "user", content });
+}
 
 /**
  * Recursively strip JSON-schema fields that Vertex Gemini's function-call AND
@@ -3069,20 +3250,19 @@ export class GoogleVertexProvider extends BaseProvider {
     // Build messages from input
     const messages: VertexAnthropicMessage[] = [];
 
-    // Add conversation history if present.
-    //
-    // Intentionally text-only. Anthropic's API rejects messages where a
-    // tool_use_id reference appears without its matching tool_use in the
-    // same turn — so synthesising tool_use / tool_result blocks from
-    // stored ChatMessages risks emitting orphaned references that fail
-    // validation. Tool rows are still persisted to Redis (chat-history
-    // UI renders them) but they don't re-enter the model's context on
-    // subsequent turns.
+    // Replay conversationMessages (with tool turns), else the legacy text-only conversationHistory.
     if (
       options.conversationMessages &&
       options.conversationMessages.length > 0
     ) {
-      for (const msg of options.conversationMessages) {
+      messages.push(
+        ...buildAnthropicHistoryMessages(options.conversationMessages),
+      );
+    } else if (
+      options.conversationHistory &&
+      options.conversationHistory.length > 0
+    ) {
+      for (const msg of options.conversationHistory) {
         if (msg.role === "user" || msg.role === "assistant") {
           messages.push({
             role: msg.role,
@@ -3243,14 +3423,13 @@ export class GoogleVertexProvider extends BaseProvider {
       text: multimodalInput.text,
     });
 
-    // Add the user message with appropriate content format
-    messages.push({
-      role: "user",
-      content:
-        userContentParts.length === 1 && userContentParts[0].type === "text"
-          ? multimodalInput.text
-          : userContentParts,
-    });
+    // Append the live user turn (merges into a trailing user turn if present).
+    appendUserMessage(
+      messages,
+      userContentParts.length === 1 && userContentParts[0].type === "text"
+        ? multimodalInput.text
+        : userContentParts,
+    );
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;
@@ -4068,21 +4247,19 @@ export class GoogleVertexProvider extends BaseProvider {
     const inputText =
       options.prompt || options.input?.text || "Please respond.";
 
-    // Add conversation history if present. Prefer `conversationMessages`
-    // (what NeuroLink core injects today via MessageBuilder) and fall back
-    // to the legacy `conversationHistory` field for callers that still use
-    // the older surface. The Vertex Claude STREAM path already follows this
-    // priority — keeping the GENERATE path on `conversationHistory` only
-    // would silently drop multi-turn context for memory/loop sessions.
-    // Intentionally text-only: see the stream sibling for the rationale —
-    // synthesising tool_use / tool_result blocks from stored ChatMessages
-    // risks emitting orphaned references that Anthropic's API rejects.
-    const historyMessages =
-      options.conversationMessages && options.conversationMessages.length > 0
-        ? options.conversationMessages
-        : options.conversationHistory;
-    if (historyMessages && historyMessages.length > 0) {
-      for (const msg of historyMessages) {
+    // Replay conversationMessages (with tool turns), else the legacy text-only conversationHistory.
+    if (
+      options.conversationMessages &&
+      options.conversationMessages.length > 0
+    ) {
+      messages.push(
+        ...buildAnthropicHistoryMessages(options.conversationMessages),
+      );
+    } else if (
+      options.conversationHistory &&
+      options.conversationHistory.length > 0
+    ) {
+      for (const msg of options.conversationHistory) {
         if (msg.role === "user" || msg.role === "assistant") {
           messages.push({
             role: msg.role,
@@ -4245,14 +4422,13 @@ export class GoogleVertexProvider extends BaseProvider {
       text: inputText,
     });
 
-    // Add the user message with appropriate content format
-    messages.push({
-      role: "user",
-      content:
-        userContentParts.length === 1 && userContentParts[0].type === "text"
-          ? inputText
-          : userContentParts,
-    });
+    // Append the live user turn (merges into a trailing user turn if present).
+    appendUserMessage(
+      messages,
+      userContentParts.length === 1 && userContentParts[0].type === "text"
+        ? inputText
+        : userContentParts,
+    );
 
     // Convert tools to Anthropic format if present
     let tools: VertexAnthropicTool[] | undefined;

--- a/test/continuous-test-suite-google-native.ts
+++ b/test/continuous-test-suite-google-native.ts
@@ -27,6 +27,10 @@ import {
   createTextChannel,
   prependConversationMessages,
 } from "../src/lib/providers/googleNativeGemini3.js";
+import {
+  buildAnthropicHistoryMessages,
+  appendUserMessage,
+} from "../src/lib/providers/googleVertex.js";
 
 // ============================================================================
 // Test plumbing (matches sibling continuous-test-suite-* style)
@@ -442,6 +446,290 @@ const tests: TestFunction[] = [
         { role: "user", content: "" },
       ]);
       return contents.length === 1 && contents[0].role === "model";
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages: maps user/assistant text turns",
+    fn: async () => {
+      const messages = buildAnthropicHistoryMessages([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ]);
+      if (messages.length !== 2) {
+        return false;
+      }
+      const first = messages[0].content;
+      return (
+        messages[0].role === "user" &&
+        messages[1].role === "assistant" &&
+        Array.isArray(first) &&
+        first[0].type === "text" &&
+        first[0].text === "hi"
+      );
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages: tool_call/tool_result replay as a paired tool_use/tool_result with the assistant text coalesced",
+    fn: async () => {
+      const messages = buildAnthropicHistoryMessages([
+        { role: "user", content: "weather?" },
+        { role: "assistant", content: "let me check" },
+        {
+          role: "tool_call",
+          content: "",
+          tool: "get_weather",
+          args: { city: "NYC" },
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_result",
+          content: "72F",
+          tool: "get_weather",
+          metadata: { stepIndex: 0 },
+        },
+        { role: "assistant", content: "It's 72F" },
+      ]);
+      // user / assistant(text+tool_use) / user(tool_result) / assistant(text)
+      if (messages.length !== 4) {
+        return false;
+      }
+      const assistantTurn = messages[1].content;
+      const resultTurn = messages[2].content;
+      if (!Array.isArray(assistantTurn) || !Array.isArray(resultTurn)) {
+        return false;
+      }
+      const toolUse = assistantTurn.find((b) => b.type === "tool_use");
+      const toolResult = resultTurn.find((b) => b.type === "tool_result");
+      if (
+        !toolUse ||
+        toolUse.type !== "tool_use" ||
+        !toolResult ||
+        toolResult.type !== "tool_result"
+      ) {
+        return false;
+      }
+      return (
+        messages[1].role === "assistant" &&
+        assistantTurn[0].type === "text" &&
+        assistantTurn[0].text === "let me check" &&
+        toolUse.name === "get_weather" &&
+        messages[2].role === "user" &&
+        toolResult.content === "72F" &&
+        // ids must pair so Anthropic doesn't 400 on an orphaned reference
+        toolUse.id === toolResult.tool_use_id
+      );
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages: parallel calls in one step pair by position",
+    fn: async () => {
+      const messages = buildAnthropicHistoryMessages([
+        { role: "user", content: "two things" },
+        {
+          role: "tool_call",
+          content: "",
+          tool: "a",
+          args: {},
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_call",
+          content: "",
+          tool: "b",
+          args: {},
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_result",
+          content: "ra",
+          tool: "a",
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_result",
+          content: "rb",
+          tool: "b",
+          metadata: { stepIndex: 0 },
+        },
+      ]);
+      // user / assistant(2 tool_use) / user(2 tool_result)
+      if (messages.length !== 3) {
+        return false;
+      }
+      const uses = messages[1].content;
+      const results = messages[2].content;
+      if (!Array.isArray(uses) || !Array.isArray(results)) {
+        return false;
+      }
+      const useBlocks = uses.filter((b) => b.type === "tool_use");
+      const resultBlocks = results.filter((b) => b.type === "tool_result");
+      if (useBlocks.length !== 2 || resultBlocks.length !== 2) {
+        return false;
+      }
+      // Assert per-index correspondence: result[i] pairs with use[i] by id, and
+      // its content lines up with the call at the same position. A swap of the
+      // two tool_use_id values (or contents) must fail this.
+      const expected = [
+        { name: "a", content: "ra" },
+        { name: "b", content: "rb" },
+      ];
+      for (let i = 0; i < 2; i++) {
+        const use = useBlocks[i];
+        const result = resultBlocks[i];
+        if (use.type !== "tool_use" || result.type !== "tool_result") {
+          return false;
+        }
+        if (
+          use.name !== expected[i].name ||
+          result.content !== expected[i].content ||
+          use.id !== result.tool_use_id
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages: orphan tool_call without a result is dropped (no unpaired tool_use)",
+    fn: async () => {
+      const messages = buildAnthropicHistoryMessages([
+        { role: "user", content: "go" },
+        {
+          role: "tool_call",
+          content: "",
+          tool: "stuck",
+          args: {},
+          metadata: { stepIndex: 0 },
+        },
+      ]);
+      // only the user turn survives — an unpaired tool_use would 400 on Anthropic
+      const hasToolUse = messages.some(
+        (m) =>
+          Array.isArray(m.content) &&
+          m.content.some((b) => b.type === "tool_use"),
+      );
+      return messages.length === 1 && !hasToolUse;
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages: history starting on a tool step never replays a leading assistant turn",
+    fn: async () => {
+      // Truncated history that begins with a tool step (no leading user turn).
+      // The replayed sequence would otherwise start with an assistant tool_use,
+      // which Anthropic rejects (first message must be user).
+      const messages = buildAnthropicHistoryMessages([
+        {
+          role: "tool_call",
+          content: "",
+          tool: "a",
+          args: {},
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_result",
+          content: "ra",
+          tool: "a",
+          metadata: { stepIndex: 0 },
+        },
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "next" },
+      ]);
+      // The leading assistant tool_use and its now-orphaned tool_result turn are
+      // dropped; the first surviving message must be a user turn.
+      return messages.length > 0 && messages[0].role === "user";
+    },
+  },
+  {
+    name: "appendUserMessage: merges into a trailing user turn (no back-to-back user messages)",
+    fn: async () => {
+      const messages = [
+        { role: "user" as const, content: "first" },
+        { role: "assistant" as const, content: "reply" },
+        {
+          role: "user" as const,
+          content: [
+            { type: "tool_result" as const, tool_use_id: "x", content: "r" },
+          ],
+        },
+      ];
+      appendUserMessage(messages, "follow up");
+      // still 3 messages — the live turn merged into the trailing user turn
+      if (messages.length !== 3) {
+        return false;
+      }
+      const lastContent = messages[2].content;
+      return (
+        messages[2].role === "user" &&
+        Array.isArray(lastContent) &&
+        lastContent.length === 2 &&
+        lastContent[0].type === "tool_result" &&
+        lastContent[1].type === "text" &&
+        lastContent[1].text === "follow up"
+      );
+    },
+  },
+  {
+    name: "appendUserMessage: pushes a new user turn when history ends on assistant",
+    fn: async () => {
+      const messages = [
+        { role: "user" as const, content: "hi" },
+        { role: "assistant" as const, content: "done" },
+      ];
+      appendUserMessage(messages, "next");
+      return (
+        messages.length === 3 &&
+        messages[2].role === "user" &&
+        messages[2].content === "next"
+      );
+    },
+  },
+  {
+    name: "buildAnthropicHistoryMessages + appendUserMessage: history ending on tool_result never yields back-to-back user turns",
+    fn: async () => {
+      // Final assistant text is empty → skipped, so history ends on the
+      // tool_result (user) turn. Appending the live input must not duplicate it.
+      const messages = buildAnthropicHistoryMessages([
+        { role: "user", content: "weather?" },
+        {
+          role: "tool_call",
+          content: "",
+          tool: "get_weather",
+          args: {},
+          metadata: { stepIndex: 0 },
+        },
+        {
+          role: "tool_result",
+          content: "72F",
+          tool: "get_weather",
+          metadata: { stepIndex: 0 },
+        },
+      ]);
+      appendUserMessage(messages, "and tomorrow?");
+      // no two consecutive user messages anywhere
+      let prevRole = "";
+      for (const m of messages) {
+        if (m.role === "user" && prevRole === "user") {
+          return false;
+        }
+        prevRole = m.role;
+      }
+      const last = messages[messages.length - 1];
+      // Pair against the emitted tool_use id, not its synthetic format.
+      const toolUseId = messages
+        .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+        .find((b) => b.type === "tool_use")?.id;
+      return (
+        last.role === "user" &&
+        Array.isArray(last.content) &&
+        typeof toolUseId === "string" &&
+        last.content.some(
+          (b) => b.type === "tool_result" && b.tool_use_id === toolUseId,
+        ) &&
+        last.content.some(
+          (b) => b.type === "text" && b.text === "and tomorrow?",
+        )
+      );
     },
   },
   {


### PR DESCRIPTION
## Problem

On the native **Vertex + Claude** path, conversation history was replayed **text-only** — only `user`/`assistant` messages were kept, and every stored `tool_call`/`tool_result` row was dropped. On multi-turn sessions the model never saw what its tools returned on prior turns, so it lost all tool context across turns.

Tool rows were dropped deliberately to avoid Anthropic 400s from orphaned `tool_use_id` references (stored rows carry no id) — but the cost was losing tool context entirely. The Vertex **Gemini** path was unaffected; it already reconstructs tool turns.

## Fix

`buildAnthropicHistoryMessages()` rebuilds Anthropic-format history **including tool turns**, split into focused helpers:

- **`collectHistorySegments`** — parse stored rows into ordered segments, grouping `tool_call`/`tool_result` by `(turn, stepIndex)` (reuses the existing `VertexToolStep`/`VertexSegment` shapes — no new types).
- **`pairToolStep`** — pair a step's calls↔results **by position**, synthesizing a deterministic `tool_use_id` per step/position. Unbalanced steps are dropped (Anthropic 400s on orphaned references).
- **`pushTurn`** — coalesce adjacent same-role turns into canonical turns (assistant text + its `tool_use` in one turn).
- **`trimLeadingNonUser`** — drop leading non-`user` turns (and orphaned `tool_result`-only turns) so the request is always `user`-first.
- **`appendUserMessage`** — merge the live user input into a trailing `user` turn so the request never has back-to-back `user` messages.

Both `executeNativeAnthropicStream` and `executeNativeAnthropicGenerate` replay through this. The stream path also gained the legacy `conversationHistory` text-only fallback (parity with generate).

## Scope

- **Vertex + Claude only.** Gemini path, the within-turn multi-step tool loop, provider routing/auth/streaming — all untouched.
- Affects cross-turn context only; requires `conversationMemory` enabled + a stable `context.sessionId` (unchanged behavior).
- Synthesized ids only need to pair within a single request — Anthropic doesn't require them to match storage.
- Debug signal: `[GoogleVertex] Replayed Claude history with tool turns { historyMessages, toolUseBlocks, toolResultBlocks }`.

## Verification

- **Unit:** 7 regression tests in `test/continuous-test-suite-google-native.ts` (text mapping; single-tool round-trip with id + content; parallel pairing by index; orphan-drop; leading tool-step trim; `appendUserMessage` merge; history-ending-on-tool_result has no back-to-back user). Suite **30/30**.
- **Static:** `tsc --strict`, eslint, and the full pre-commit pipeline (check/lint/validate/build) pass.
- **Storage contract traced end-to-end:** the native Claude path persists tool rows with `tool`/`args`/`content`/`metadata.stepIndex`, and calls↔results are recorded in lockstep per tool, so position pairing is exact.

> ⚠️ **Before merge:** run a live multi-turn Vertex+Claude session with a tool call on **both** stream and generate, and confirm the model references the prior tool result on turn 2+ with **no HTTP 400**. The unit tests prove the message shape; only a live round-trip proves the Vertex Anthropic endpoint accepts it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of conversation history when continuing AI chats, including better replay of prior tool activity and message order.
  * User replies are now merged into the latest turn when appropriate, reducing duplicate consecutive user messages.

* **Bug Fixes**
  * Prevents broken or incomplete tool interactions from appearing in continued conversations.
  * Ensures conversation playback starts from the first valid user message and keeps message blocks consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->