### PR TITLE
feat(routing): add classifier router for dynamic model and tool selection

### DIFF
--- a/docs/features/classifier-router.md
+++ b/docs/features/classifier-router.md
@@ -1,0 +1,250 @@
+---
+title: "Classifier Router"
+description: Automatically classify each request and route it to the right model (and tool set) from a configurable base pool — cheaper/faster models for easy tasks, more capable models for hard ones
+keywords:
+  [
+    classifier,
+    router,
+    model-routing,
+    multi-model,
+    dynamic-model-selection,
+    tool-filtering,
+    litellm,
+    cost-optimization,
+  ]
+---
+
+# Classifier Router
+
+> **Status**: Stable | **Availability**: SDK + CLI | **Opt-in** (disabled by default)
+
+## Overview
+
+The **Classifier Router** lets NeuroLink decide, per request, **which model to use** (and, optionally, **which tools to expose**) from a pool you declare — routing hard/complex tasks to more capable models and easy tasks to cheaper, faster ones. You give it a pool of models; it classifies the incoming prompt and switches to the best one transparently before the call runs.
+
+```
+                 ┌─────────────── classifier router ───────────────┐
+  generate()  →  │  classify difficulty  →  pick model + tools  →   │  →  chosen model runs
+                 └──────────────────────────────────────────────────┘
+```
+
+It is **opt-in** (`classifierRouter.enabled` defaults to `false`), **fails open** (any classifier/selection error leaves the call exactly as it would have been), and is fully **backward compatible** — a default `new NeuroLink()` is unchanged.
+
+Typical use cases:
+
+- **Cost optimization** — send `"hi"` to a cheap model and a multi-step architecture question to a powerful one, automatically.
+- **Latency optimization** — keep simple turns on fast models.
+- **Custom / self-hosted fleets** — route across LiteLLM, OpenAI-compatible, or Ollama models that aren't in any registry.
+- **Per-difficulty tool scoping** — expose fewer tools for trivial tasks.
+
+## How it works
+
+Each request flows through two stages:
+
+1. **Classify** — produce a difficulty bucket (`trivial | simple | moderate | hard | expert`) plus optional `requiredCapabilities` and tool hints. Two strategies:
+   - `heuristic` (default): zero-cost keyword/length scoring of the prompt text. No LLM call, fully deterministic, provider-agnostic.
+   - `llm`: a cheap "classifier model" reads the prompt and returns a difficulty — and, when given your pool, **picks a model directly** by id.
+2. **Select** — turn that into a concrete `{ provider, model, region }` from your `pool`, optionally narrowing `tools`.
+
+The router runs **before** the provider/model is constructed (it reuses the same pre-call seam as `requestRouter`). It is skipped when the caller pinned both `provider` and `model`, or when a [`modelPool`](/docs/features/provider-orchestration) is configured (the pool owns selection).
+
+## Quick start (heuristic, SDK)
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const nl = new NeuroLink({
+  classifierRouter: {
+    enabled: true,
+    classifier: "heuristic", // default — no LLM cost
+    pool: [
+      { provider: "vertex", model: "gemini-2.5-flash" }, // cost/quality auto-enriched
+      { provider: "vertex", model: "gemini-2.5-pro" },
+    ],
+  },
+});
+
+await nl.generate({ input: { text: "hi" } }); // → routed to gemini-2.5-flash
+await nl.generate({
+  input: {
+    text: "Design a fault-tolerant multi-region event architecture and justify the consistency trade-offs.",
+  },
+}); // → routed to gemini-2.5-pro
+```
+
+## Defining "which model for which case"
+
+The router resolves a model using the **first** of these that applies:
+
+| #   | Mechanism              | How you define it                                                                  | Best for                              |
+| --- | ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------- |
+| 1   | **LLM direct pick**    | `classifier: "llm"` + a `description` on each pool member                          | Custom/registry-less models; smartest |
+| 2   | **`tierMap`**          | Explicit `difficulty → members` map                                                | Full, deterministic control           |
+| 3   | **Per-member `tiers`** | `tiers: ["hard","expert"]` on a member                                             | Simple, explicit, generic             |
+| 4   | **Metadata scoring**   | `cost` / `quality` per member (declared, or auto-enriched from the model registry) | Known models with comparable metadata |
+
+> When two members can't be separated (e.g. equal declared quality, or the model registry only knows both as "high" quality), the router keeps the declared pool order. For reliable hard-vs-easy separation, prefer mechanisms 1–3, or give members distinct `quality` values.
+
+### Metadata scoring rules
+
+- `trivial` / `simple` → cheapest first (`cost` ascending)
+- `moderate` → best `quality − cost`
+- `hard` / `expert` → most capable first (`quality` descending)
+
+Members may declare `cost` (relative, lower = cheaper) and `quality` (relative, higher = more capable). If omitted, NeuroLink tries to enrich them from its model registry; if the model is unknown (e.g. a custom LiteLLM endpoint), use mechanisms 1–3 instead.
+
+## Custom & self-hosted models (LiteLLM, OpenAI-compatible, Ollama)
+
+These models aren't in any registry, so define routing explicitly — both approaches are fully generic:
+
+**Heuristic + `tiers` (deterministic, no LLM cost):**
+
+```typescript
+new NeuroLink({
+  classifierRouter: {
+    enabled: true,
+    classifier: "heuristic",
+    pool: [
+      {
+        provider: "litellm",
+        model: "my-fast-endpoint",
+        tiers: ["trivial", "simple", "moderate"],
+      },
+      {
+        provider: "litellm",
+        model: "my-strong-endpoint",
+        tiers: ["hard", "expert"],
+      },
+    ],
+  },
+});
+```
+
+**LLM picks per-prompt from plain-English descriptions (most flexible):**
+
+```typescript
+new NeuroLink({
+  classifierRouter: {
+    enabled: true,
+    classifier: "llm",
+    classifierModel: { provider: "litellm", model: "cheap-classifier-model" },
+    pool: [
+      {
+        provider: "litellm",
+        model: "my-fast-endpoint",
+        description: "cheap & fast; greetings, simple lookups, short Q&A",
+      },
+      {
+        provider: "litellm",
+        model: "my-strong-endpoint",
+        description:
+          "powerful reasoning; complex multi-step analysis, architecture, hard math/code",
+      },
+    ],
+  },
+});
+```
+
+The classifier model is shown each candidate's `id` (defaults to `provider/model`) and description, and returns the best `id` for the prompt. An invalid or absent pick falls back to difficulty-based selection; any classifier failure falls back to the heuristic.
+
+## Narrowing tools per difficulty
+
+Filter the tool set per difficulty with `toolDirectives` (and/or let the LLM classifier suggest tools). `toolFilter` is an allowlist; `excludeTools` is a denylist — both are enforced by the provider before the model call.
+
+```typescript
+new NeuroLink({
+  classifierRouter: {
+    enabled: true,
+    pool: [...],
+    toolDirectives: {
+      trivial: { toolFilter: [] }, // no tools for trivial turns
+      expert: { excludeTools: ["delete_resource"] },
+    },
+  },
+});
+```
+
+## CLI usage
+
+```bash
+# Heuristic routing across a pool (inline JSON or a file path)
+neurolink generate "hi" \
+  --classifier-router \
+  --classifier-pool '[{"provider":"vertex","model":"gemini-2.5-flash","tiers":["trivial","simple","moderate"]},{"provider":"vertex","model":"gemini-2.5-pro","tiers":["hard","expert"]}]'
+
+# LLM classifier picks the model per prompt (descriptions drive the choice)
+neurolink generate "Design a multi-region architecture" \
+  --classifier-router \
+  --classifier-strategy llm \
+  --classifier-model-provider vertex --classifier-model-name gemini-2.5-flash \
+  --classifier-pool ./pool.json
+```
+
+| Flag                          | Description                                             |
+| ----------------------------- | ------------------------------------------------------- |
+| `--classifier-router`         | Enable the classifier router.                           |
+| `--classifier-strategy`       | `heuristic` (default) or `llm`.                         |
+| `--classifier-model-provider` | Provider for the LLM classifier model (`strategy=llm`). |
+| `--classifier-model-name`     | Model name for the LLM classifier model.                |
+| `--classifier-model-region`   | Region for the LLM classifier model.                    |
+| `--classifier-pool`           | JSON file path or inline JSON array of pool members.    |
+| `--classifier-timeout`        | LLM classifier hard timeout (ms).                       |
+
+> CLI flags cover the common case (strategy, classifier model, pool). For `tierMap` and `toolDirectives`, use the SDK config.
+
+## Configuration reference
+
+```typescript
+type ClassifierRouterConfig = {
+  enabled: boolean; // master switch; false/absent → router never built
+  classifier?: "heuristic" | "llm"; // default: "heuristic"
+  classifierModel?: {
+    provider?: string;
+    model?: string;
+    region?: string;
+    temperature?: number;
+  }; // for "llm"
+  pool: ClassifierRouterPoolMember[]; // the available base
+  tierMap?: Partial<Record<ClassifierDifficulty, ClassifierRouterPoolMember[]>>;
+  toolDirectives?: Partial<
+    Record<
+      ClassifierDifficulty,
+      { toolFilter?: string[]; excludeTools?: string[] }
+    >
+  >;
+  timeoutMs?: number; // LLM classifier hard timeout (default 8000)
+};
+
+type ClassifierRouterPoolMember = {
+  provider: string;
+  model?: string;
+  region?: string;
+  id?: string; // stable id for LLM selection (default `provider/model`)
+  description?: string; // drives LLM selection
+  tiers?: ClassifierDifficulty[]; // restrict member to these difficulties
+  cost?: number; // relative cost (lower = cheaper)
+  quality?: number; // relative quality (higher = more capable)
+  capabilities?: string[]; // e.g. ["vision","tools","reasoning"]
+  weight?: number; // tiebreak
+};
+```
+
+## Precedence & interactions
+
+Model selection resolves in this order: **caller-pinned `provider`+`model`** > **classifierRouter** > **`requestRouter`** > legacy `enableOrchestration`. The classifier marks the request so the downstream selectors stand down.
+
+- **`modelPool`** — when a `modelPool` is configured the classifier stands down (the pool owns selection); use one or the other for model choice.
+- **`toolRouting`** — the dedicated tool-routing feature still applies; classifier `toolDirectives` are additive.
+
+## Caveats
+
+- **Registry quality is coarse.** Auto-enrichment maps a model to a 3-bucket quality (`high/medium/low`), so two "high" models can't be separated on capability alone — declare `quality`/`tiers`/`tierMap` or use the LLM pick for reliable hard-vs-easy routing.
+- **LLM classifier latency/cost.** The `llm` strategy adds one cheap call per uncached turn; prefer a small, fast, non-Gemini model and keep `heuristic` as the default where determinism matters.
+- **Gemini tools + JSON schema.** The classifier call uses a schema with tools disabled, so the Gemini exclusivity rule doesn't apply to it; when routing a tools + structured-output request, prefer a non-Gemini target model.
+- **Prompt privacy (LLM strategy).** The `llm` classifier sends a truncated copy of the prompt to the classifier model, so the same data-handling/retention considerations as any provider call apply. The `heuristic` default keeps classification fully in-process (no prompt leaves your environment) — prefer it where that matters.
+
+## See also
+
+- [Provider Orchestration & Model Pool](/docs/features/provider-orchestration)
+- [Provider Fallback](/docs/features/provider-fallback)
+- [Per-Request Credentials](/docs/features/per-request-credentials)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -342,7 +342,7 @@ npx @juspay/neurolink generate "Complex analysis" --provider litellm --model "an
 npx @juspay/neurolink generate "Write code" # Automatically chooses optimal provider
 ```
 
-**Learn more:** [Provider Orchestration Guide](provider-orchestration.md)
+**Learn more:** [Provider Orchestration Guide](provider-orchestration.md) · [Classifier Router](/docs/features/classifier-router) — classify each request and route it to a cheaper or more capable model (and tool set) from a pool you define.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "// CI tier — fast, no live AI calls, safe for every commit": "",
     "test:unit:vitest": "pnpm exec vitest run test/toolRouting.test.ts",
     "test:tool-routing": "pnpm run test:unit:vitest && npx tsx test/continuous-test-suite-tool-routing.ts",
+    "test:classifier-router": "npx tsx test/continuous-test-suite-classifier-router.ts",
     "test:tool-routing-semantic:vitest": "pnpm exec vitest run test/toolRoutingSemantic.test.ts",
     "test:tool-routing-semantic": "pnpm run test:tool-routing-semantic:vitest && npx tsx test/continuous-test-suite-tool-routing-semantic.ts",
     "test:unit": "pnpm run test:envguard && pnpm run test:bugfixes && pnpm run test:mcp:infra && pnpm run test:mcp:bash && pnpm run test:mcp:limits && pnpm run test:mcp:spans && pnpm run test:autoresearch:redis && pnpm run test:unit:vitest && pnpm run test:tool-routing-cli:vitest && pnpm run test:tool-dedup:vitest && pnpm run test:model-pool:vitest && pnpm run test:tool-routing-semantic:vitest && pnpm run test:anthropic-tools-policy && pnpm run test:anthropic-multimodal && pnpm run test:excel-interop",

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -32,6 +32,7 @@ import { normalizeEvaluationData } from "../../lib/utils/evaluationUtils.js";
 import { logger } from "../../lib/utils/logger.js";
 import { createThinkingConfigFromRecord } from "../../lib/utils/thinkingConfig.js";
 import { buildToolRoutingConfigFromCli } from "../utils/toolRoutingFlags.js";
+import { buildClassifierRouterConfigFromCli } from "../utils/classifierRouterFlags.js";
 import { configManager } from "../commands/config.js";
 import { MCPCommandFactory } from "../commands/mcp.js";
 import { ModelsCommandFactory } from "../commands/models.js";
@@ -656,6 +657,47 @@ export class CLICommandFactory {
       alias: "tool-routing-servers",
     },
 
+    // Classifier-router options
+    classifierRouter: {
+      type: "boolean" as const,
+      description:
+        "Enable the classifier router: classify each request and pick a model (and tools) from --classifier-pool.",
+      alias: "classifier-router",
+    },
+    classifierStrategy: {
+      type: "string" as const,
+      description:
+        "Classifier strategy: 'heuristic' (default, no LLM) or 'llm' (a cheap model picks per prompt).",
+      choices: ["heuristic", "llm"] as const,
+      alias: "classifier-strategy",
+    },
+    classifierModelProvider: {
+      type: "string" as const,
+      description: "Provider for the LLM classifier model (strategy=llm).",
+      alias: "classifier-model-provider",
+    },
+    classifierModelName: {
+      type: "string" as const,
+      description: "Model name for the LLM classifier model (strategy=llm).",
+      alias: "classifier-model-name",
+    },
+    classifierModelRegion: {
+      type: "string" as const,
+      description: "Region for the LLM classifier model (strategy=llm).",
+      alias: "classifier-model-region",
+    },
+    classifierPool: {
+      type: "string" as const,
+      description:
+        "Path to a JSON file OR inline JSON array of pool members: { provider, model?, region?, description?, tiers?, cost?, quality?, id? }.",
+      alias: "classifier-pool",
+    },
+    classifierTimeout: {
+      type: "number" as const,
+      description: "LLM classifier hard timeout in milliseconds.",
+      alias: "classifier-timeout",
+    },
+
     region: {
       type: "string" as const,
       description:
@@ -1047,6 +1089,16 @@ export class CLICommandFactory {
         | string[]
         | undefined,
       toolRoutingServers: argv.toolRoutingServers as string | undefined,
+      // Classifier-router flags — constructor-level config (see note above).
+      classifierRouter: argv.classifierRouter as boolean | undefined,
+      classifierStrategy: argv.classifierStrategy as string | undefined,
+      classifierModelProvider: argv.classifierModelProvider as
+        | string
+        | undefined,
+      classifierModelName: argv.classifierModelName as string | undefined,
+      classifierModelRegion: argv.classifierModelRegion as string | undefined,
+      classifierPool: argv.classifierPool as string | undefined,
+      classifierTimeout: argv.classifierTimeout as number | undefined,
     };
   }
 
@@ -3068,6 +3120,14 @@ export class CLICommandFactory {
         globalSession.setToolRoutingConfig(toolRoutingConfig);
       }
 
+      // Inject classifier-router config into the SDK instance before constructing it.
+      const classifierRouterConfig = buildClassifierRouterConfigFromCli(
+        options as Record<string, unknown>,
+      );
+      if (classifierRouterConfig) {
+        globalSession.setClassifierRouterConfig(classifierRouterConfig);
+      }
+
       // Initialize SDK and session
       const sdk = globalSession.getOrCreateNeuroLink();
       const sessionVariables = CLICommandFactory.normalizeLoopSessionVariables(
@@ -3387,6 +3447,14 @@ export class CLICommandFactory {
     );
     if (toolRoutingConfig) {
       globalSession.setToolRoutingConfig(toolRoutingConfig);
+    }
+
+    // Inject classifier-router config into the SDK instance before constructing it.
+    const classifierRouterConfig = buildClassifierRouterConfigFromCli(
+      options as Record<string, unknown>,
+    );
+    if (classifierRouterConfig) {
+      globalSession.setClassifierRouterConfig(classifierRouterConfig);
     }
 
     const sdk = globalSession.getOrCreateNeuroLink();
@@ -4036,6 +4104,14 @@ export class CLICommandFactory {
       );
       if (toolRoutingConfig) {
         globalSession.setToolRoutingConfig(toolRoutingConfig);
+      }
+
+      // Inject classifier-router config into the SDK instance before constructing it.
+      const classifierRouterConfig = buildClassifierRouterConfigFromCli(
+        options as Record<string, unknown>,
+      );
+      if (classifierRouterConfig) {
+        globalSession.setClassifierRouterConfig(classifierRouterConfig);
       }
 
       const sdk = globalSession.getOrCreateNeuroLink();

--- a/src/cli/utils/classifierRouterFlags.ts
+++ b/src/cli/utils/classifierRouterFlags.ts
@@ -1,0 +1,154 @@
+/**
+ * CLI helper: parse --classifier-* flags into a ClassifierRouterConfig.
+ *
+ * Side-effect-free so it can be unit-tested without a running NeuroLink
+ * instance. Mirrors the `--tool-routing-*` flag parser.
+ */
+
+import fs from "node:fs";
+import type {
+  CliClassifierRouterFlags,
+  ClassifierRouterConfig,
+  ClassifierRouterPoolMember,
+  ClassifierStrategyKind,
+} from "../../lib/types/index.js";
+import { logger } from "../../lib/utils/logger.js";
+
+// Trust model: --classifier-pool is a local, user-supplied CLI flag. The
+// invoking user already holds the process's OS permissions, so absolute and
+// home-dir config paths are fully supported — there is no cross-trust boundary
+// to enforce (a local CLI reading a path its own operator passed is not a
+// path-traversal vector). The caps below are a robustness guard against
+// accidentally pointing at a huge file (e.g. a log or binary), not a security
+// boundary.
+const MAX_POOL_INPUT_BYTES = 1_000_000; // 1 MB
+const MAX_POOL_ENTRIES = 1_000;
+
+/**
+ * Build a {@link ClassifierRouterConfig} from the parsed CLI flags.
+ *
+ * Returns `undefined` when `--classifier-router` is absent or false, so callers
+ * can skip the setter entirely with a simple truthiness check.
+ *
+ * `--classifier-pool` is parsed permissively:
+ * - If the value is an existing file path, the file is read and JSON-parsed.
+ * - Otherwise the value is treated as an inline JSON string.
+ * - On any parse error a warning is logged and the pool is left empty.
+ */
+export function buildClassifierRouterConfigFromCli(
+  flags: CliClassifierRouterFlags & Record<string, unknown>,
+): ClassifierRouterConfig | undefined {
+  if (!flags.classifierRouter) {
+    return undefined;
+  }
+
+  const strategy: ClassifierStrategyKind =
+    flags.classifierStrategy === "llm" ? "llm" : "heuristic";
+
+  const pool =
+    typeof flags.classifierPool === "string" &&
+    flags.classifierPool.trim() !== ""
+      ? parsePoolFlag(flags.classifierPool)
+      : [];
+
+  if (pool.length === 0) {
+    logger.warn(
+      "[classifier-router] --classifier-router is enabled but --classifier-pool is empty/missing; model routing is a no-op until a pool is provided.",
+    );
+  }
+
+  const config: ClassifierRouterConfig = {
+    enabled: true,
+    classifier: strategy,
+    pool,
+  };
+
+  if (flags.classifierTimeout !== undefined) {
+    const t = flags.classifierTimeout as number;
+    if (Number.isFinite(t) && t > 0) {
+      config.timeoutMs = t;
+    } else {
+      logger.warn(
+        `[classifier-router] --classifier-timeout value ${String(t)} is not a positive finite number; ignoring (SDK default applies).`,
+      );
+    }
+  }
+
+  const hasProvider = typeof flags.classifierModelProvider === "string";
+  const hasModel = typeof flags.classifierModelName === "string";
+  const hasRegion = typeof flags.classifierModelRegion === "string";
+  if (hasProvider || hasModel || hasRegion) {
+    config.classifierModel = {
+      ...(hasProvider && {
+        provider: flags.classifierModelProvider as string,
+      }),
+      ...(hasModel && { model: flags.classifierModelName as string }),
+      ...(hasRegion && { region: flags.classifierModelRegion as string }),
+    };
+  }
+
+  return config;
+}
+
+/**
+ * Parse the `--classifier-pool` value (file path first, then inline JSON).
+ * Logs a warning and returns `[]` on any error (fail open).
+ */
+function parsePoolFlag(value: string): ClassifierRouterPoolMember[] {
+  try {
+    const resolved = fs.existsSync(value) ? value : null;
+
+    if (resolved !== null) {
+      const { size } = fs.statSync(resolved);
+      if (size > MAX_POOL_INPUT_BYTES) {
+        logger.warn(
+          `[classifier-router] --classifier-pool file exceeds ${MAX_POOL_INPUT_BYTES} bytes (got ${size}); ignoring.`,
+        );
+        return [];
+      }
+    } else if (Buffer.byteLength(value, "utf8") > MAX_POOL_INPUT_BYTES) {
+      logger.warn(
+        `[classifier-router] --classifier-pool inline JSON exceeds ${MAX_POOL_INPUT_BYTES} bytes; ignoring.`,
+      );
+      return [];
+    }
+
+    const jsonText = resolved ? fs.readFileSync(resolved, "utf8") : value;
+    const parsed: unknown = JSON.parse(jsonText);
+
+    if (!Array.isArray(parsed)) {
+      logger.warn(
+        "[classifier-router] --classifier-pool must be a JSON array; ignoring.",
+      );
+      return [];
+    }
+
+    // Validate loosely — every member must at least name a provider.
+    const valid = parsed.filter(
+      (entry): entry is ClassifierRouterPoolMember =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as Record<string, unknown>).provider === "string",
+    );
+
+    if (valid.length !== parsed.length) {
+      logger.warn(
+        `[classifier-router] ${parsed.length - valid.length} pool member(s) skipped — each must have a string "provider" field.`,
+      );
+    }
+
+    if (valid.length > MAX_POOL_ENTRIES) {
+      logger.warn(
+        `[classifier-router] --classifier-pool has ${valid.length} entries; truncating to ${MAX_POOL_ENTRIES}.`,
+      );
+      return valid.slice(0, MAX_POOL_ENTRIES);
+    }
+
+    return valid;
+  } catch (err) {
+    logger.warn(
+      `[classifier-router] Failed to parse --classifier-pool: ${(err as Error).message}. Using empty pool (fail open).`,
+    );
+    return [];
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1035,6 +1035,8 @@ export {
   classifyProviderError,
   ModelPool,
   createDefaultRequestRouter,
+  ClassifierRouter,
+  classifyHeuristic,
 } from "./routing/index.js";
 
 // ============================================================================

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -256,6 +256,7 @@ import { isNonNullObject } from "./utils/typeUtils.js";
 import { getWorkflow } from "./workflow/core/workflowRegistry.js";
 import { runWorkflow } from "./workflow/core/workflowRunner.js";
 import { ModelPool, classifyProviderError } from "./routing/index.js";
+import { ClassifierRouter } from "./routing/classifierRouter.js";
 import {
   looksLikeModelAccessDenied as sharedLooksLikeModelAccessDenied,
   isNonRetryableProviderError as sharedIsNonRetryableProviderError,
@@ -652,6 +653,10 @@ export class NeuroLink {
   // RequestRouter: pluggable pre-call provider/model selector.
   // Stored directly from config.requestRouter; null when not configured.
   private readonly requestRouter: RequestRouter | null;
+
+  // ClassifierRouter: opt-in "classify → pick model + tools" pre-call router.
+  // Built from config.classifierRouter; null when not configured.
+  private readonly classifierRouter: ClassifierRouter | null;
 
   /**
    * Merge instance-level credentials with per-call credentials.
@@ -1157,6 +1162,21 @@ export class NeuroLink {
 
     // RequestRouter: store the host-supplied function; null when not configured.
     this.requestRouter = config?.requestRouter ?? null;
+
+    // ClassifierRouter: opt-in. The LLM strategy reuses this instance's
+    // generate() (marked so it never recursively re-routes). Fails open.
+    this.classifierRouter = config?.classifierRouter?.enabled
+      ? new ClassifierRouter(config.classifierRouter, {
+          generate: (genOptions) =>
+            this.generate(genOptions as unknown as GenerateOptions),
+          logger: {
+            debug: (message, meta) =>
+              logger.debug(message, meta as Record<string, unknown>),
+            warn: (message, meta) =>
+              logger.warn(message, meta as Record<string, unknown>),
+          },
+        })
+      : null;
 
     logger.setEventEmitter(this.emitter);
 
@@ -4189,6 +4209,20 @@ Current user's request: ${currentInput}`;
   ): Promise<GenerateResult> {
     const startTime = Date.now();
 
+    // Pre-call classifier router: opt-in. Classifies the request and selects a
+    // provider/model from the configured base pool (and optionally narrows the
+    // tool set) BEFORE orchestration/requestRouter, so it takes precedence.
+    // Fails open.
+    await this.applyClassifierRouting(
+      options,
+      options.input?.text ?? originalPrompt ?? "",
+      !options.disableTools &&
+        (!!(options.tools && Object.keys(options.tools).length > 0) ||
+          this.getCustomTools().size > 0),
+      !!(options.input?.images && options.input.images.length > 0),
+      options.thinkingConfig?.thinkingLevel,
+    );
+
     await this.maybeApplyGenerateOrchestration(options);
 
     // Pre-call request router: opt-in, only when the caller did not set both
@@ -4365,6 +4399,14 @@ Current user's request: ${currentInput}`;
     if (!this.requestRouter) {
       return;
     }
+    // Stand down if the classifier router already selected a provider/model on
+    // this turn — one explicit precedence order: classifierRouter wins.
+    if (
+      (options as { context?: Record<string, unknown> }).context
+        ?.__classifierRouted
+    ) {
+      return;
+    }
     // Skip if the caller explicitly set both provider AND model — they know
     // what they want; the router should not override an intentional choice.
     if (options.provider && options.model) {
@@ -4431,6 +4473,128 @@ Current user's request: ${currentInput}`;
       logger.warn("[NeuroLink] requestRouter threw — proceeding unrouted", {
         error:
           routerErr instanceof Error ? routerErr.message : String(routerErr),
+      });
+    }
+  }
+
+  /**
+   * Applies the host-configured `classifierRouter` to `options` in place.
+   *
+   * Classifies the request by difficulty and selects a provider/model from the
+   * configured base pool (cheaper/faster for easy tasks, more capable for hard
+   * ones), and optionally narrows the tool set via `toolFilter`/`excludeTools`.
+   *
+   * Skipped when: no router is configured; the inbound call is the classifier's
+   * own generate() (marked `__classifierRouted`); the caller pinned BOTH
+   * provider and model; or a ModelPool is configured (the pool owns selection).
+   * Fails open — any error leaves options unchanged.
+   */
+  private async applyClassifierRouting(
+    options: { provider?: string; model?: string; region?: string },
+    promptText: string,
+    hasTools: boolean,
+    requiresVision: boolean,
+    thinkingLevel?: string,
+  ): Promise<void> {
+    if (!this.classifierRouter) {
+      return;
+    }
+    const opt = options as {
+      provider?: string;
+      model?: string;
+      region?: string;
+      context?: Record<string, unknown>;
+      disableTools?: boolean;
+      excludeTools?: string[];
+      toolFilter?: string[];
+    };
+    // Prevent recursion: the LLM classifier itself calls generate() with this
+    // marker set. Also respect any explicit prior routing decision.
+    if (opt.context?.__classifierRouted) {
+      return;
+    }
+    // Honor an intentional caller choice of BOTH provider and model.
+    if (options.provider && options.model) {
+      return;
+    }
+    // A ModelPool overrides provider/model per member unconditionally; let it
+    // own selection (mirrors applyRequestRouter precedence).
+    if (this.modelPool) {
+      logger.debug(
+        "[NeuroLink] applyClassifierRouting: skipped — modelPool takes precedence",
+      );
+      return;
+    }
+
+    const sessionId =
+      typeof opt.context?.sessionId === "string"
+        ? opt.context.sessionId
+        : undefined;
+
+    try {
+      const decision = await this.classifierRouter.route({
+        prompt: promptText,
+        estimatedInputTokens: Math.ceil((promptText?.length ?? 0) / 4),
+        hasTools,
+        requiresVision,
+        thinkingLevel,
+        sessionId,
+      });
+      if (!decision) {
+        return;
+      }
+
+      // Apply provider/model/region as a coherent set (same discipline as
+      // applyRequestRouter): only fill fields the caller did not pin.
+      if (decision.provider && !options.provider) {
+        options.provider = decision.provider;
+        if (decision.model && !options.model) {
+          options.model = decision.model;
+        }
+        if (decision.region && !options.region) {
+          options.region = decision.region;
+        }
+      } else if (!decision.provider && decision.model && !options.model) {
+        options.model = decision.model;
+      }
+
+      // Narrow tools unless the caller disabled tools entirely.
+      if (!opt.disableTools) {
+        if (decision.excludeTools && decision.excludeTools.length > 0) {
+          opt.excludeTools = Array.from(
+            new Set([...(opt.excludeTools ?? []), ...decision.excludeTools]),
+          );
+        }
+        if (decision.toolFilter && decision.toolFilter.length > 0) {
+          const allow = decision.toolFilter;
+          opt.toolFilter =
+            opt.toolFilter && opt.toolFilter.length > 0
+              ? opt.toolFilter.filter((t) => allow.includes(t))
+              : [...allow];
+        }
+      }
+
+      // Mark routed so orchestration/requestRouter stand down this turn.
+      if (decision.provider || decision.model) {
+        const ctx = opt.context ?? {};
+        ctx.__classifierRouted = true;
+        opt.context = ctx;
+      }
+
+      if (decision.reason) {
+        logger.debug("[NeuroLink] classifierRouter decision", {
+          reason: decision.reason,
+          difficulty: decision.difficulty,
+          provider: options.provider,
+          model: options.model,
+        });
+      }
+    } catch (classifierErr) {
+      logger.warn("[NeuroLink] classifierRouter threw — proceeding unrouted", {
+        error:
+          classifierErr instanceof Error
+            ? classifierErr.message
+            : String(classifierErr),
       });
     }
   }
@@ -7925,6 +8089,19 @@ Current user's request: ${currentInput}`;
         this.setLangfuseContextFromOptions(options, () =>
           this.applyToolRoutingExclusions(options, originalPrompt),
         ),
+      );
+
+      // Pre-call classifier router for stream: opt-in, fails open. Runs before
+      // the request router so it takes precedence.
+      await this.applyClassifierRouting(
+        options,
+        originalPrompt,
+        !options.disableTools &&
+          (!!(options.tools && Object.keys(options.tools).length > 0) ||
+            this.getCustomTools().size > 0),
+        !!(options.input?.images && options.input.images.length > 0),
+        (options as StreamOptions & { thinking?: { thinkingLevel?: string } })
+          .thinking?.thinkingLevel,
       );
 
       // Pre-call request router for stream: opt-in, fails open.

--- a/src/lib/routing/classifierRouter.ts
+++ b/src/lib/routing/classifierRouter.ts
@@ -1,0 +1,341 @@
+/**
+ * ClassifierRouter — the single "classify → pick model + tools → run" engine.
+ *
+ * Given a request snapshot it (1) classifies difficulty (heuristic or a cheap
+ * LLM), (2) selects the best provider/model from the host-declared base pool —
+ * cheaper/faster for easy tiers, more capable for hard tiers — enriching pool
+ * members with real cost/quality metadata from the model registry, and
+ * (3) narrows the tool set via per-difficulty directives or classifier hints.
+ *
+ * Pure of provider imports (mirrors ModelPool): the LLM caller is injected.
+ * The only data dependency is the read-only `ModelResolver` registry lookup,
+ * used purely for metadata enrichment and never for provider construction.
+ */
+
+import { classifyHeuristic, classifyLlm } from "./classifierStrategies.js";
+import { ModelResolver } from "../models/modelResolver.js";
+import type {
+  ClassifierCandidate,
+  ClassifierDecision,
+  ClassifierDifficulty,
+  ClassifierModelMeta,
+  ClassifierRouterConfig,
+  ClassifierRouterDecision,
+  ClassifierRouterDeps,
+  ClassifierRouterInput,
+  ClassifierRouterPoolMember,
+} from "../types/index.js";
+
+/** Maps a registry quality enum to a comparable numeric score. */
+const QUALITY_SCORE: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** How each difficulty ranks candidate members. */
+const DIFFICULTY_RANK_MODE: Record<
+  ClassifierDifficulty,
+  "cost-asc" | "quality-desc" | "balanced"
+> = {
+  trivial: "cost-asc",
+  simple: "cost-asc",
+  moderate: "balanced",
+  hard: "quality-desc",
+  expert: "quality-desc",
+};
+
+/** Neutral default for an unknown numeric metric (keeps ordering stable). */
+const NEUTRAL = 0.5;
+
+/**
+ * Cap on the per-(provider,model) metadata cache so it can't grow unbounded in
+ * long-lived processes with large or dynamic pools. FIFO eviction.
+ */
+const MAX_META_CACHE_ENTRIES = 1000;
+
+export class ClassifierRouter {
+  private readonly metaCache = new Map<string, ClassifierModelMeta>();
+
+  constructor(
+    private readonly config: ClassifierRouterConfig,
+    private readonly deps: ClassifierRouterDeps = {},
+  ) {}
+
+  /**
+   * Classify the request and produce a combined model + tool decision, or
+   * `null` when nothing should change. Never throws (fails open).
+   */
+  async route(
+    input: ClassifierRouterInput,
+  ): Promise<ClassifierRouterDecision | null> {
+    try {
+      // For the LLM strategy, hand the pool to the classifier so it can select
+      // a model directly — the generic path for custom/registry-less models.
+      const useLlm = this.config.classifier === "llm" && !!this.deps.generate;
+      const built = useLlm ? this.buildCandidates() : undefined;
+
+      const decision = await this.classify(input, built?.descriptors);
+
+      const ranked = this.selectModels(decision, built?.byId);
+      const primary = ranked[0];
+      const { toolFilter, excludeTools } = this.selectTools(decision);
+
+      if (!primary && !toolFilter && !excludeTools) {
+        return null;
+      }
+
+      return {
+        provider: primary?.provider,
+        model: primary?.model,
+        region: primary?.region,
+        difficulty: decision.difficulty,
+        modelFallbacks: ranked.slice(1),
+        toolFilter,
+        excludeTools,
+        reason: decision.reason,
+      };
+    } catch (err) {
+      this.deps.logger?.warn?.("[ClassifierRouter] route failed — no-op", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /** Run the configured strategy; LLM falls back to heuristic on failure. */
+  private async classify(
+    input: ClassifierRouterInput,
+    candidates?: ClassifierCandidate[],
+  ): Promise<ClassifierDecision> {
+    if (this.config.classifier === "llm" && this.deps.generate) {
+      try {
+        return await classifyLlm(
+          input,
+          this.deps.generate,
+          this.config.classifierModel,
+          this.config.timeoutMs,
+          candidates,
+        );
+      } catch (err) {
+        this.deps.logger?.warn?.(
+          "[ClassifierRouter] LLM classify failed — using heuristic",
+          { error: err instanceof Error ? err.message : String(err) },
+        );
+      }
+    }
+    return classifyHeuristic(input);
+  }
+
+  /**
+   * Build LLM-facing model descriptors + an id→member map so the classifier can
+   * pick a model directly. Works for ANY pool, registry-backed or not.
+   */
+  private buildCandidates(): {
+    descriptors: ClassifierCandidate[];
+    byId: Map<string, ClassifierRouterPoolMember>;
+  } {
+    const pool = this.config.pool ?? [];
+    const byId = new Map<string, ClassifierRouterPoolMember>();
+    const used = new Set<string>();
+    const descriptors: ClassifierCandidate[] = [];
+    pool.forEach((m, i) => {
+      let id = m.id ?? (m.model ? `${m.provider}/${m.model}` : m.provider);
+      if (used.has(id)) {
+        id = `${id}#${i}`;
+      }
+      used.add(id);
+      byId.set(id, m);
+      descriptors.push({
+        id,
+        provider: m.provider,
+        model: m.model,
+        description: m.description,
+        tiers: m.tiers,
+        capabilities: this.metaFor(m).capabilities,
+      });
+    });
+    return { descriptors, byId };
+  }
+
+  /**
+   * Resolve the ranked model list for a decision. Prefers the LLM's direct pick
+   * (`selectedModelId`); otherwise falls back to difficulty-based tierMap /
+   * metadata scoring.
+   */
+  private selectModels(
+    decision: ClassifierDecision,
+    byId?: Map<string, ClassifierRouterPoolMember>,
+  ): ClassifierRouterPoolMember[] {
+    if (decision.selectedModelId && byId) {
+      const picked = byId.get(decision.selectedModelId);
+      if (picked) {
+        const rest = (this.config.pool ?? []).filter((m) => m !== picked);
+        const rankedRest = this.rank(
+          this.filterByCapabilities(rest, decision.requiredCapabilities),
+          decision.difficulty,
+        );
+        return [picked, ...rankedRest];
+      }
+    }
+    const eligible = this.candidatesFor(decision);
+    const capable = this.filterByCapabilities(
+      eligible,
+      decision.requiredCapabilities,
+    );
+    return this.rank(capable, decision.difficulty);
+  }
+
+  /** Candidate members for a difficulty: explicit tierMap or eligible pool. */
+  private candidatesFor(
+    decision: ClassifierDecision,
+  ): ClassifierRouterPoolMember[] {
+    const tierMembers = this.config.tierMap?.[decision.difficulty];
+    if (tierMembers && tierMembers.length > 0) {
+      return tierMembers;
+    }
+    const pool = this.config.pool ?? [];
+    const eligible = pool.filter(
+      (m) => !m.tiers || m.tiers.includes(decision.difficulty),
+    );
+    return eligible.length > 0 ? eligible : pool;
+  }
+
+  /** Drop members that cannot satisfy the required capabilities (lenient). */
+  private filterByCapabilities(
+    members: ClassifierRouterPoolMember[],
+    required?: string[],
+  ): ClassifierRouterPoolMember[] {
+    if (!required || required.length === 0) {
+      return members;
+    }
+    const kept = members.filter((m) => {
+      const caps = this.metaFor(m).capabilities;
+      // Unknown capabilities → keep (don't starve the pool on missing metadata).
+      if (!caps || caps.length === 0) {
+        return true;
+      }
+      return required.every((c) => caps.includes(c));
+    });
+    return kept.length > 0 ? kept : members;
+  }
+
+  /** Rank candidates best-first for the difficulty's strategy. */
+  private rank(
+    members: ClassifierRouterPoolMember[],
+    difficulty: ClassifierDifficulty,
+  ): ClassifierRouterPoolMember[] {
+    const mode = DIFFICULTY_RANK_MODE[difficulty];
+    const originalIndex = new Map(members.map((m, i) => [m, i] as const));
+    const num = (v?: number): number => (typeof v === "number" ? v : NEUTRAL);
+
+    return [...members].sort((a, b) => {
+      const ma = this.metaFor(a);
+      const mb = this.metaFor(b);
+      let delta: number;
+      if (mode === "cost-asc") {
+        delta = num(ma.cost) - num(mb.cost);
+      } else if (mode === "quality-desc") {
+        delta = num(mb.quality) - num(ma.quality);
+      } else {
+        // balanced: maximize quality-minus-cost
+        delta =
+          num(mb.quality) - num(mb.cost) - (num(ma.quality) - num(ma.cost));
+      }
+      if (delta !== 0) {
+        return delta;
+      }
+      const weightDelta = (b.weight ?? 1) - (a.weight ?? 1);
+      if (weightDelta !== 0) {
+        return weightDelta;
+      }
+      // Stable: preserve declared pool order on a tie.
+      return (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0);
+    });
+  }
+
+  /** Tool narrowing: per-difficulty directive, then classifier hints. */
+  private selectTools(decision: ClassifierDecision): {
+    toolFilter?: string[];
+    excludeTools?: string[];
+  } {
+    const directive = this.config.toolDirectives?.[decision.difficulty];
+    let toolFilter = directive?.toolFilter
+      ? [...directive.toolFilter]
+      : undefined;
+    const excludeTools = directive?.excludeTools
+      ? [...directive.excludeTools]
+      : undefined;
+    // When no explicit allowlist is configured, honor the classifier's hint.
+    if (
+      (!toolFilter || toolFilter.length === 0) &&
+      decision.suggestedTools &&
+      decision.suggestedTools.length > 0
+    ) {
+      toolFilter = [...decision.suggestedTools];
+    }
+    return { toolFilter, excludeTools };
+  }
+
+  /**
+   * Resolve cost/quality/capabilities for a member. Declared values win;
+   * gaps are filled from the model registry (by model name/alias) when known.
+   * Results are cached per (provider/model) for the router's lifetime.
+   */
+  private metaFor(member: ClassifierRouterPoolMember): ClassifierModelMeta {
+    const key = `${member.provider}::${member.model ?? ""}`;
+    const cached = this.metaCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    let cost = member.cost;
+    let quality = member.quality;
+    let capabilities = member.capabilities
+      ? [...member.capabilities]
+      : undefined;
+
+    const needsEnrichment =
+      cost === undefined || quality === undefined || capabilities === undefined;
+    if (needsEnrichment && member.model) {
+      try {
+        const info = ModelResolver.resolveModel(member.model);
+        if (info) {
+          if (cost === undefined) {
+            cost = info.pricing.inputCostPer1K + info.pricing.outputCostPer1K;
+          }
+          if (quality === undefined) {
+            quality = QUALITY_SCORE[info.performance.quality] ?? NEUTRAL;
+          }
+          if (capabilities === undefined) {
+            const caps: string[] = [];
+            if (info.capabilities.vision) {
+              caps.push("vision");
+            }
+            if (info.capabilities.functionCalling) {
+              caps.push("tools");
+            }
+            if (info.capabilities.reasoning) {
+              caps.push("reasoning");
+            }
+            if (info.capabilities.codeGeneration) {
+              caps.push("code");
+            }
+            if (info.capabilities.multimodal) {
+              caps.push("multimodal");
+            }
+            capabilities = caps;
+          }
+        }
+      } catch {
+        // Enrichment is best-effort; ignore registry lookup failures.
+      }
+    }
+
+    const meta: ClassifierModelMeta = { cost, quality, capabilities };
+    if (this.metaCache.size >= MAX_META_CACHE_ENTRIES) {
+      const oldest = this.metaCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.metaCache.delete(oldest);
+      }
+    }
+    this.metaCache.set(key, meta);
+    return meta;
+  }
+}

--- a/src/lib/routing/classifierStrategies.ts
+++ b/src/lib/routing/classifierStrategies.ts
@@ -1,0 +1,195 @@
+/**
+ * Classification strategies for the ClassifierRouter.
+ *
+ * - `classifyHeuristic` — zero-cost, no LLM. Generalizes the existing binary
+ *   task classifier scorer (fast vs reasoning) into five difficulty tiers.
+ * - `classifyLlm` — runs a cheap "classifier model" via an injected generate
+ *   function, asking for a schema-constrained difficulty verdict. Falls back to
+ *   the heuristic on any failure.
+ */
+
+import { z } from "zod";
+import {
+  analyzePrompt,
+  calculateConfidence,
+} from "../utils/taskClassificationUtils.js";
+import { withTimeout } from "../utils/async/index.js";
+import type {
+  ClassifierCandidate,
+  ClassifierDecision,
+  ClassifierDifficulty,
+  ClassifierGenerateFn,
+  ClassifierModelRef,
+  ClassifierRouterInput,
+} from "../types/index.js";
+
+/** Difficulty tiers, ordered easiest → hardest. */
+export const CLASSIFIER_DIFFICULTIES: ClassifierDifficulty[] = [
+  "trivial",
+  "simple",
+  "moderate",
+  "hard",
+  "expert",
+];
+
+/**
+ * Add capability tags implied by the request shape (vision/tools) to a set the
+ * classifier already produced.
+ */
+function withRequestCapabilities(
+  input: ClassifierRouterInput,
+  base?: string[],
+): string[] | undefined {
+  const caps = new Set<string>(base ?? []);
+  if (input.requiresVision) {
+    caps.add("vision");
+  }
+  if (input.hasTools) {
+    caps.add("tools");
+  }
+  return caps.size > 0 ? Array.from(caps) : undefined;
+}
+
+/**
+ * Heuristic classifier — maps the binary fast/reasoning scores plus prompt
+ * length into one of five difficulty tiers. Deterministic and dependency-free.
+ */
+export function classifyHeuristic(
+  input: ClassifierRouterInput,
+): ClassifierDecision {
+  const prompt = input.prompt ?? "";
+  const { fastScore, reasoningScore, reasons } = analyzePrompt(prompt);
+  const net = reasoningScore - fastScore;
+  const len = prompt.trim().length;
+
+  let difficulty: ClassifierDifficulty;
+  if (fastScore === 0 && reasoningScore === 0) {
+    // No signal — fall back to length as a weak proxy.
+    difficulty = len < 80 ? "simple" : len < 400 ? "moderate" : "hard";
+  } else if (net <= -2) {
+    difficulty = "trivial";
+  } else if (net <= 0) {
+    difficulty = "simple";
+  } else if (net <= 3) {
+    difficulty = "moderate";
+  } else if (net <= 7) {
+    difficulty = "hard";
+  } else {
+    difficulty = "expert";
+  }
+
+  return {
+    difficulty,
+    confidence: calculateConfidence(fastScore, reasoningScore),
+    requiredCapabilities: withRequestCapabilities(input),
+    reason: `heuristic: net=${net}, len=${len}${
+      reasons.length ? ` (${reasons.slice(0, 3).join("; ")})` : ""
+    }`,
+  };
+}
+
+/** Schema the LLM classifier is forced to answer with. */
+const classifierOutputSchema = z.object({
+  difficulty: z.enum(["trivial", "simple", "moderate", "hard", "expert"]),
+  confidence: z.number().min(0).max(1).optional(),
+  requiredCapabilities: z.array(z.string()).optional(),
+  suggestedTools: z.array(z.string()).optional(),
+  selectedModelId: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+const CLASSIFIER_SYSTEM_PROMPT = [
+  "You are a routing classifier inside an AI gateway.",
+  "Classify the user's task by difficulty into EXACTLY one of:",
+  "trivial, simple, moderate, hard, expert.",
+  "Judge by reasoning depth, number of steps, domain expertise required, and ambiguity.",
+  "Greetings/lookups/one-liners are trivial/simple; multi-step analysis, design,",
+  "or expert-domain work is hard/expert.",
+  'Also list required model capabilities (e.g. "vision", "tools", "reasoning")',
+  "and, only if obvious, the names of tools the task needs.",
+  "If a list of available models is provided, also set selectedModelId to the",
+  "single best model id for this task.",
+  "Respond ONLY via the structured schema.",
+].join(" ");
+
+/**
+ * LLM classifier — asks a cheap model for a schema-constrained verdict.
+ * Falls back to the heuristic if the model is unavailable, times out, or
+ * returns output that does not match the schema.
+ */
+export async function classifyLlm(
+  input: ClassifierRouterInput,
+  generate: ClassifierGenerateFn,
+  classifierModel?: ClassifierModelRef,
+  timeoutMs?: number,
+  candidates?: ClassifierCandidate[],
+): Promise<ClassifierDecision> {
+  const lines = [
+    "Task to classify:",
+    '"""',
+    (input.prompt ?? "").slice(0, 4000),
+    '"""',
+    `hasTools=${!!input.hasTools} requiresVision=${!!input.requiresVision}`,
+  ];
+  if (candidates && candidates.length > 0) {
+    lines.push(
+      "",
+      "Available models — pick the single best `id` for THIS task:",
+    );
+    for (const c of candidates) {
+      const bits = [c.provider + (c.model ? `/${c.model}` : "")];
+      if (c.description) {
+        bits.push(c.description);
+      }
+      if (c.tiers && c.tiers.length > 0) {
+        bits.push(`tiers: ${c.tiers.join("/")}`);
+      }
+      if (c.capabilities && c.capabilities.length > 0) {
+        bits.push(`caps: ${c.capabilities.join(",")}`);
+      }
+      lines.push(`- id="${c.id}": ${bits.join(" — ")}`);
+    }
+    lines.push("", "Set selectedModelId to the chosen id (omit if unsure).");
+  }
+
+  // `timeout` lets the provider abort its own request; withTimeout adds a hard
+  // wall-clock ceiling so a stalled classifier call can never block the turn.
+  // A TimeoutError propagates to ClassifierRouter.classify(), which falls back
+  // to the heuristic (fail-open).
+  const hardTimeoutMs = timeoutMs ?? 8000;
+  const result = await withTimeout(
+    generate({
+      input: { text: lines.join("\n") },
+      systemPrompt: CLASSIFIER_SYSTEM_PROMPT,
+      provider: classifierModel?.provider,
+      model: classifierModel?.model,
+      region: classifierModel?.region,
+      temperature: classifierModel?.temperature ?? 0,
+      disableTools: true,
+      schema: classifierOutputSchema,
+      timeout: hardTimeoutMs,
+      // Marker consumed by NeuroLink.applyClassifierRouting to prevent the
+      // classifier's own generate() call from recursively re-routing.
+      context: { __classifierRouted: true },
+    }),
+    hardTimeoutMs,
+    `Classifier LLM call exceeded ${hardTimeoutMs}ms`,
+  );
+
+  const parsed = classifierOutputSchema.safeParse(result?.structuredData);
+  if (!parsed.success) {
+    return classifyHeuristic(input);
+  }
+  const d = parsed.data;
+  return {
+    difficulty: d.difficulty,
+    confidence: d.confidence ?? 0.7,
+    requiredCapabilities: withRequestCapabilities(
+      input,
+      d.requiredCapabilities,
+    ),
+    suggestedTools: d.suggestedTools,
+    selectedModelId: d.selectedModelId,
+    reason: d.reason ?? "llm classifier",
+  };
+}

--- a/src/lib/routing/index.ts
+++ b/src/lib/routing/index.ts
@@ -6,3 +6,5 @@
 
 export { classifyProviderError, ModelPool } from "./modelPool.js";
 export { createDefaultRequestRouter } from "./requestRouter.js";
+export { ClassifierRouter } from "./classifierRouter.js";
+export { classifyHeuristic, classifyLlm } from "./classifierStrategies.js";

--- a/src/lib/session/globalSessionState.ts
+++ b/src/lib/session/globalSessionState.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { NeuroLink } from "../neurolink.js";
 import type {
+  ClassifierRouterConfig,
   ConversationMemoryConfig,
   LoopSessionState,
   McpOutputStrategy,
@@ -51,6 +52,9 @@ export class GlobalSessionManager {
   private loopSession: LoopSessionState | null = null;
   /** Optional tool-routing config set by CLI handlers before SDK construction. */
   private _toolRoutingConfig: ToolRoutingConfig | undefined = undefined;
+  /** Optional classifier-router config set by CLI handlers before SDK construction. */
+  private _classifierRouterConfig: ClassifierRouterConfig | undefined =
+    undefined;
 
   static getInstance(): GlobalSessionManager {
     if (!GlobalSessionManager.instance) {
@@ -187,6 +191,19 @@ export class GlobalSessionManager {
     this._toolRoutingConfig = config;
   }
 
+  /**
+   * Store a classifier-router config to be injected at SDK construction time.
+   * Call this BEFORE `getOrCreateNeuroLink()` inside a command handler.
+   * When a loop session is already active the config is ignored (the instance
+   * already exists).
+   */
+  setClassifierRouterConfig(config: ClassifierRouterConfig): void {
+    if (this.hasActiveSession()) {
+      return;
+    }
+    this._classifierRouterConfig = config;
+  }
+
   getOrCreateNeuroLink(): NeuroLink {
     const session = this.getLoopSession();
     if (session) {
@@ -207,6 +224,10 @@ export class GlobalSessionManager {
     if (this._toolRoutingConfig) {
       options.toolRouting = this._toolRoutingConfig;
       this._toolRoutingConfig = undefined;
+    }
+    if (this._classifierRouterConfig) {
+      options.classifierRouter = this._classifierRouterConfig;
+      this._classifierRouterConfig = undefined;
     }
 
     return new NeuroLink(Object.keys(options).length ? options : undefined);

--- a/src/lib/types/classifierRouter.ts
+++ b/src/lib/types/classifierRouter.ts
@@ -1,0 +1,216 @@
+/**
+ * ClassifierRouter types — generic "classify → pick model + tools → run".
+ *
+ * A ClassifierRouter inspects an incoming request, classifies it by difficulty
+ * (and optional required capabilities / suggested tools), then selects a
+ * provider/model from a host-declared "available base" pool — routing harder
+ * tasks to more capable models and easier tasks to cheaper/faster ones — and
+ * optionally narrows the tool set for that request.
+ *
+ * It is entirely opt-in (constructor config, `enabled: false` by default) and
+ * fails open: any classifier or selection error leaves the call unrouted.
+ *
+ * Type names are domain-prefixed `Classifier*` to stay globally unique across
+ * `src/lib/types/` (see CLAUDE.md rule 9).
+ */
+
+/** Coarse difficulty buckets the classifier maps a request into. */
+export type ClassifierDifficulty =
+  | "trivial"
+  | "simple"
+  | "moderate"
+  | "hard"
+  | "expert";
+
+/** Which classification strategy to run. */
+export type ClassifierStrategyKind = "heuristic" | "llm";
+
+/**
+ * The classifier's verdict for a single request. Strategy-agnostic: produced
+ * by both the heuristic and the LLM classifier.
+ */
+export type ClassifierDecision = {
+  /** The classified difficulty bucket. */
+  difficulty: ClassifierDifficulty;
+  /** Confidence in the classification (0–1). */
+  confidence: number;
+  /** Capability tags the request needs (e.g. "vision", "tools", "reasoning"). */
+  requiredCapabilities?: string[];
+  /** Tool names the classifier thinks the task needs (allowlist hint). */
+  suggestedTools?: string[];
+  /**
+   * When the LLM classifier picks a model directly, the chosen candidate id
+   * (matches a `ClassifierCandidate.id`). Ignored by the heuristic classifier.
+   */
+  selectedModelId?: string;
+  /** Human-readable explanation, emitted at debug level. */
+  reason?: string;
+};
+
+/**
+ * Lightweight model descriptor handed to the LLM classifier so it can select a
+ * model directly from the pool by `id` — the generic path for custom models.
+ */
+export type ClassifierCandidate = {
+  id: string;
+  provider: string;
+  model?: string;
+  description?: string;
+  tiers?: ClassifierDifficulty[];
+  capabilities?: string[];
+};
+
+/**
+ * One candidate (provider, model, region) in the available base pool, with
+ * optional routing metadata. When `cost`/`quality`/`capabilities` are omitted,
+ * the router enriches them from the model registry (by `model` name/alias).
+ */
+export type ClassifierRouterPoolMember = {
+  provider: string;
+  model?: string;
+  region?: string;
+  /**
+   * Stable id the LLM classifier references when selecting a model directly.
+   * Defaults to `${provider}/${model}` (or just `provider`) when omitted.
+   */
+  id?: string;
+  /**
+   * Plain-English description of when to use this model (e.g. "cheap & fast,
+   * for simple Q&A" / "powerful reasoning model for complex analysis"). Drives
+   * LLM-based model selection — the only metadata needed for custom models that
+   * are NOT in the registry (LiteLLM, OpenAI-compatible, self-hosted, …).
+   */
+  description?: string;
+  /** Difficulty tiers this member is eligible for. Omit = eligible for all. */
+  tiers?: ClassifierDifficulty[];
+  /** Relative cost (lower = cheaper). Preferred for easy tiers. */
+  cost?: number;
+  /** Relative quality/capability (higher = more capable). Preferred for hard tiers. */
+  quality?: number;
+  /** Capability tags this member supports (e.g. "vision", "tools"). */
+  capabilities?: string[];
+  /** Tiebreak weight when scores are equal. Default: 1. */
+  weight?: number;
+};
+
+/** Per-difficulty tool policy applied to the request. */
+export type ClassifierToolDirective = {
+  /** Allowlist of tool names to keep (maps to `options.toolFilter`). */
+  toolFilter?: string[];
+  /** Denylist of tool names to drop (appended to `options.excludeTools`). */
+  excludeTools?: string[];
+};
+
+/** Provider/model the LLM classifier strategy itself runs on. */
+export type ClassifierModelRef = {
+  provider?: string;
+  model?: string;
+  region?: string;
+  temperature?: number;
+};
+
+/** Constructor-level configuration for the classifier router. */
+export type ClassifierRouterConfig = {
+  /** Master switch. When false/absent, the router is never built. */
+  enabled: boolean;
+  /**
+   * Classification strategy. Default: "heuristic" (no LLM, zero added latency).
+   * "llm" runs a cheap classifier model (see `classifierModel`).
+   */
+  classifier?: ClassifierStrategyKind;
+  /** Model used by the "llm" strategy. Defaults to provider/model auto. */
+  classifierModel?: ClassifierModelRef;
+  /** The available base pool the router selects a model from. */
+  pool: ClassifierRouterPoolMember[];
+  /**
+   * Explicit difficulty → members map. When a difficulty has entries here they
+   * take precedence over metadata scoring of `pool`.
+   */
+  tierMap?: Partial<Record<ClassifierDifficulty, ClassifierRouterPoolMember[]>>;
+  /** Per-difficulty tool directives applied to the request. */
+  toolDirectives?: Partial<
+    Record<ClassifierDifficulty, ClassifierToolDirective>
+  >;
+  /** Hard timeout (ms) for the LLM classifier call. Default: 8000. */
+  timeoutMs?: number;
+};
+
+/**
+ * The router's combined decision: a provider/model/region override plus an
+ * optional tool narrowing. Any undefined field means "keep what the caller
+ * already configured". Returning `null` from the router is a valid no-op.
+ */
+export type ClassifierRouterDecision = {
+  provider?: string;
+  model?: string;
+  region?: string;
+  /** Allowlist applied to `options.toolFilter`. */
+  toolFilter?: string[];
+  /** Denylist appended to `options.excludeTools`. */
+  excludeTools?: string[];
+  /** The difficulty this decision was made for (debug/telemetry). */
+  difficulty?: ClassifierDifficulty;
+  /** Remaining ranked candidates, best-first, for downstream failover. */
+  modelFallbacks?: ClassifierRouterPoolMember[];
+  /** Human-readable explanation, emitted at debug level. */
+  reason?: string;
+};
+
+/** Lightweight request snapshot handed to the router. */
+export type ClassifierRouterInput = {
+  prompt: string;
+  estimatedInputTokens?: number;
+  hasTools?: boolean;
+  requiresVision?: boolean;
+  thinkingLevel?: string;
+  sessionId?: string;
+};
+
+/** Enriched per-model metadata used while ranking pool members. */
+export type ClassifierModelMeta = {
+  cost?: number;
+  quality?: number;
+  capabilities?: string[];
+};
+
+/** Minimal options accepted by the injected LLM-classifier `generate` fn. */
+export type ClassifierGenerateOptions = {
+  input: { text: string };
+  systemPrompt?: string;
+  provider?: string;
+  model?: string;
+  region?: string;
+  temperature?: number;
+  maxTokens?: number;
+  disableTools?: boolean;
+  schema?: unknown;
+  timeout?: number | string;
+  context?: Record<string, unknown>;
+};
+
+/** Minimal result shape the LLM classifier reads back. */
+export type ClassifierGenerateResult = {
+  content?: string;
+  structuredData?: unknown;
+};
+
+/** Injected LLM caller — typically a bound `NeuroLink.generate`. */
+export type ClassifierGenerateFn = (
+  options: ClassifierGenerateOptions,
+) => Promise<ClassifierGenerateResult>;
+
+/** Minimal logger surface the router uses (debug/warn). */
+export type ClassifierLogger = {
+  debug: (message: string, meta?: unknown) => void;
+  warn: (message: string, meta?: unknown) => void;
+};
+
+/**
+ * Injected dependencies — keep `ClassifierRouter` provider-import-free and
+ * unit-testable (mirrors the `toolRouting` generateFn-injection pattern).
+ */
+export type ClassifierRouterDeps = {
+  /** LLM caller for the "llm" strategy. Omit to disable LLM classification. */
+  generate?: ClassifierGenerateFn;
+  logger?: ClassifierLogger;
+};

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -59,7 +59,8 @@ export type BaseCommandArgs = {
  * Generate command arguments
  */
 export type GenerateCommandArgs = BaseCommandArgs &
-  CliToolRoutingFlags & {
+  CliToolRoutingFlags &
+  CliClassifierRouterFlags & {
     /** Input text or prompt */
     input?: string;
     /** AI provider to use */
@@ -128,7 +129,8 @@ export type GenerateCommandArgs = BaseCommandArgs &
  * Stream command arguments
  */
 export type StreamCommandArgs = BaseCommandArgs &
-  CliToolRoutingFlags & {
+  CliToolRoutingFlags &
+  CliClassifierRouterFlags & {
     /** Input text or prompt */
     input?: string;
     /** AI provider to use */
@@ -157,7 +159,8 @@ export type StreamCommandArgs = BaseCommandArgs &
  * Batch command arguments
  */
 export type BatchCommandArgs = BaseCommandArgs &
-  CliToolRoutingFlags & {
+  CliToolRoutingFlags &
+  CliClassifierRouterFlags & {
     /** Input file path */
     file?: string;
     /** AI provider to use */
@@ -1841,4 +1844,29 @@ export type CliToolRoutingFlags = {
    * (--tool-routing-servers).
    */
   toolRoutingServers?: string;
+};
+
+/**
+ * CLI flags for the classifier router (`--classifier-*`). Builds a
+ * ClassifierRouterConfig that is injected at SDK construction time.
+ */
+export type CliClassifierRouterFlags = {
+  /** Master enable switch (--classifier-router). */
+  classifierRouter?: boolean;
+  /** Strategy: "heuristic" (default) or "llm" (--classifier-strategy). */
+  classifierStrategy?: string;
+  /** LLM-classifier provider override (--classifier-model-provider). */
+  classifierModelProvider?: string;
+  /** LLM-classifier model override (--classifier-model-name). */
+  classifierModelName?: string;
+  /** LLM-classifier region override (--classifier-model-region). */
+  classifierModelRegion?: string;
+  /**
+   * Path to a JSON file OR inline JSON array of pool members
+   * (--classifier-pool). Each entry: { provider, model?, region?, description?,
+   * tiers?, cost?, quality?, capabilities?, id? }.
+   */
+  classifierPool?: string;
+  /** LLM-classifier hard timeout in ms (--classifier-timeout). */
+  classifierTimeout?: number;
 };

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -27,6 +27,7 @@ import type {
 import type { NeurolinkCredentials } from "./providers.js";
 import type { ModelPoolConfig } from "./modelPool.js";
 import type { RequestRouter } from "./requestRouter.js";
+import type { ClassifierRouterConfig } from "./classifierRouter.js";
 
 /**
  * Main NeuroLink configuration type
@@ -123,6 +124,15 @@ export type NeurolinkConstructorConfig = {
    * error proceeds unrouted.
    */
   requestRouter?: RequestRouter;
+  /**
+   * Pre-call classifier router: classifies each request by difficulty and
+   * selects a provider/model from a configured "available base" pool — routing
+   * harder tasks to more capable models and easier tasks to cheaper/faster
+   * ones — and optionally narrows the tool set. Opt-in (`enabled: false` by
+   * default) and fails open. Skipped when a `modelPool` is configured or the
+   * caller pinned both `provider` and `model`. See {@link ClassifierRouterConfig}.
+   */
+  classifierRouter?: ClassifierRouterConfig;
 };
 
 /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -89,3 +89,6 @@ export * from "./modelPool.js";
 
 // RequestRouter — pluggable pre-call provider/model selection (M9.x+)
 export * from "./requestRouter.js";
+
+// ClassifierRouter — classify → pick model + tools from a base pool (M9.x+)
+export * from "./classifierRouter.js";

--- a/test/continuous-test-suite-classifier-router.ts
+++ b/test/continuous-test-suite-classifier-router.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous test suite for the ClassifierRouter subsystem.
+ *
+ * Coverage (no API keys required — uses a fake LLM generate fn):
+ *   A. Heuristic classification → difficulty buckets
+ *   B. Metadata-driven model selection (cost-asc / quality-desc / balanced)
+ *   C. tierMap precedence over pool scoring
+ *   D. Capability filtering
+ *   E. Tool narrowing (directives + classifier-suggested tools)
+ *   F. LLM strategy parse + fail-open fallback to heuristic
+ *   G. No-op cases (empty pool, no tools → null)
+ *
+ * Run: pnpm run test:classifier-router
+ */
+
+import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
+
+import {
+  ClassifierRouter,
+  classifyHeuristic,
+} from "../src/lib/routing/index.js";
+import type {
+  ClassifierGenerateFn,
+  ClassifierRouterPoolMember,
+} from "../src/lib/types/index.js";
+
+const { test, runSuite } = defineSuite("ClassifierRouter");
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+// Model ids deliberately NOT in the registry, so enrichment is a no-op and the
+// declared cost/quality drive ranking deterministically.
+const CHEAP: ClassifierRouterPoolMember = {
+  provider: "alpha",
+  model: "cheap-1",
+  cost: 0.1,
+  quality: 1,
+};
+const MID: ClassifierRouterPoolMember = {
+  provider: "beta",
+  model: "mid-1",
+  cost: 0.5,
+  quality: 2,
+};
+const CAPABLE: ClassifierRouterPoolMember = {
+  provider: "gamma",
+  model: "capable-1",
+  cost: 2,
+  quality: 3,
+};
+// Intentionally unordered to prove ranking, not declared order.
+const POOL: ClassifierRouterPoolMember[] = [CAPABLE, MID, CHEAP];
+
+/** A fake LLM classifier that returns canned structured output. */
+const fakeGen =
+  (out: Record<string, unknown>): ClassifierGenerateFn =>
+  async () => ({ structuredData: out });
+
+/** A fake LLM classifier that always fails (exercises fail-open). */
+const throwingGen: ClassifierGenerateFn = async () => {
+  throw new Error("classifier model unavailable");
+};
+
+// ── A. Heuristic classification ───────────────────────────────────────────────
+
+await test("heuristic: greeting classifies as trivial/simple", () => {
+  const d = classifyHeuristic({ prompt: "hi" });
+  assert(
+    d.difficulty === "trivial" || d.difficulty === "simple",
+    `expected trivial/simple, got ${d.difficulty}`,
+  );
+});
+
+await test("heuristic: deep multi-step analysis classifies as hard/expert", () => {
+  const d = classifyHeuristic({
+    prompt:
+      "Analyze and compare the architectural trade-offs between microservices " +
+      "and a monolith. Design a phased migration strategy, evaluate the " +
+      "performance and scalability impact, and explain why each option " +
+      "optimizes cost differently.",
+  });
+  assert(
+    d.difficulty === "hard" || d.difficulty === "expert",
+    `expected hard/expert, got ${d.difficulty}`,
+  );
+});
+
+await test("heuristic: vision/tools request flags required capabilities", () => {
+  const d = classifyHeuristic({
+    prompt: "describe this",
+    requiresVision: true,
+    hasTools: true,
+  });
+  assert(
+    !!d.requiredCapabilities?.includes("vision"),
+    "expected 'vision' capability",
+  );
+  assert(
+    !!d.requiredCapabilities?.includes("tools"),
+    "expected 'tools' capability",
+  );
+});
+
+// ── B. Metadata-driven model selection (difficulty forced via fake LLM) ───────
+
+await test("select: trivial → cheapest member (cost-asc)", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "trivial" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assert(d !== null, "decision should not be null");
+  assertEqual(d?.provider, "alpha", "trivial routes to cheapest provider");
+  assertEqual(d?.model, "cheap-1", "trivial routes to cheapest model");
+});
+
+await test("select: expert → most capable member (quality-desc)", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "expert" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assertEqual(d?.provider, "gamma", "expert routes to most capable provider");
+  assertEqual(d?.model, "capable-1", "expert routes to most capable model");
+});
+
+await test("select: moderate → balanced (best quality-minus-cost)", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "moderate" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  // mid: 2-0.5=1.5 ; capable: 3-2=1 ; cheap: 1-0.1=0.9  → mid wins
+  assertEqual(d?.provider, "beta", "moderate routes to the balanced member");
+});
+
+await test("select: modelFallbacks are ranked best-first", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "expert" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assertEqual(
+    d?.modelFallbacks?.[0]?.provider,
+    "beta",
+    "first fallback after capable is mid",
+  );
+  assertEqual(
+    d?.modelFallbacks?.[1]?.provider,
+    "alpha",
+    "second fallback is cheap",
+  );
+});
+
+// ── C. tierMap precedence ─────────────────────────────────────────────────────
+
+await test("tierMap overrides pool scoring for its difficulty", async () => {
+  const router = new ClassifierRouter(
+    {
+      enabled: true,
+      classifier: "llm",
+      pool: POOL,
+      tierMap: { expert: [{ provider: "special", model: "sp-1" }] },
+    },
+    { generate: fakeGen({ difficulty: "expert" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assertEqual(d?.provider, "special", "tierMap entry wins");
+  assertEqual(d?.model, "sp-1", "tierMap model wins");
+});
+
+// ── D. Capability filtering ───────────────────────────────────────────────────
+
+await test("capability filter drops members that can't satisfy requirement", async () => {
+  const noVision: ClassifierRouterPoolMember = {
+    provider: "q",
+    model: "q-1",
+    quality: 3,
+    capabilities: ["tools"],
+  };
+  const vision: ClassifierRouterPoolMember = {
+    provider: "v",
+    model: "v-1",
+    quality: 2,
+    capabilities: ["vision", "tools"],
+  };
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: [noVision, vision] },
+    {
+      generate: fakeGen({
+        difficulty: "expert",
+        requiredCapabilities: ["vision"],
+      }),
+    },
+  );
+  const d = await router.route({ prompt: "anything" });
+  // Even though noVision has higher quality, it lacks "vision" and is dropped.
+  assertEqual(d?.provider, "v", "only the vision-capable member survives");
+});
+
+// ── E. Tool narrowing ─────────────────────────────────────────────────────────
+
+await test("toolDirectives apply per difficulty", async () => {
+  const router = new ClassifierRouter(
+    {
+      enabled: true,
+      classifier: "llm",
+      pool: POOL,
+      toolDirectives: {
+        simple: { excludeTools: ["heavyTool"], toolFilter: ["a", "b"] },
+      },
+    },
+    { generate: fakeGen({ difficulty: "simple" }) },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assert(
+    !!d?.excludeTools?.includes("heavyTool"),
+    "directive excludeTools applied",
+  );
+  assertEqual(d?.toolFilter?.length, 2, "directive toolFilter applied");
+});
+
+await test("classifier-suggested tools become the allowlist when no directive", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    {
+      generate: fakeGen({
+        difficulty: "moderate",
+        suggestedTools: ["search_knowledge_base"],
+      }),
+    },
+  );
+  const d = await router.route({ prompt: "anything" });
+  assertEqual(
+    d?.toolFilter?.[0],
+    "search_knowledge_base",
+    "suggestedTools → toolFilter",
+  );
+});
+
+// ── F. LLM strategy parse + fail-open ─────────────────────────────────────────
+
+await test("llm strategy uses the model's difficulty verdict", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "trivial", confidence: 0.9 }) },
+  );
+  const d = await router.route({ prompt: "this prompt text is irrelevant" });
+  assertEqual(d?.difficulty, "trivial", "uses the LLM verdict, not heuristic");
+});
+
+await test("llm failure falls back to heuristic (still routes)", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: throwingGen },
+  );
+  const d = await router.route({ prompt: "hi" });
+  assert(d !== null, "should still produce a decision via heuristic fallback");
+  // "hi" is trivial/simple → cost-asc → cheapest.
+  assertEqual(d?.provider, "alpha", "heuristic fallback still selects a model");
+});
+
+// ── G. Heuristic default + no-op cases ────────────────────────────────────────
+
+await test("default strategy (heuristic) routes an easy prompt to a cheap model", async () => {
+  const router = new ClassifierRouter({ enabled: true, pool: POOL });
+  const d = await router.route({ prompt: "hi" });
+  assertEqual(d?.provider, "alpha", "easy prompt → cheapest via heuristic");
+});
+
+await test("empty pool with no tool directives → null (no-op)", async () => {
+  const router = new ClassifierRouter({ enabled: true, pool: [] });
+  const d = await router.route({ prompt: "hello there" });
+  assertEqual(d, null, "nothing to route and no tools → null");
+});
+
+// ── H. Generic custom models (LiteLLM/OpenAI-compatible — NOT in registry) ────
+
+await test("heuristic + custom models via `tiers` (no registry, no cost/quality)", async () => {
+  // Pure host-defined mapping; model ids are arbitrary/custom.
+  const liteFast: ClassifierRouterPoolMember = {
+    provider: "litellm",
+    model: "my-fast-endpoint",
+    tiers: ["trivial", "simple", "moderate"],
+  };
+  const liteStrong: ClassifierRouterPoolMember = {
+    provider: "litellm",
+    model: "my-strong-endpoint",
+    tiers: ["hard", "expert"],
+  };
+  const router = new ClassifierRouter({
+    enabled: true,
+    classifier: "heuristic",
+    pool: [liteStrong, liteFast], // order shouldn't matter
+  });
+  const easy = await router.route({ prompt: "hi" });
+  assertEqual(easy?.model, "my-fast-endpoint", "easy → fast custom model");
+  const hard = await router.route({
+    prompt:
+      "Analyze and compare the architectural trade-offs between microservices " +
+      "and a monolith, design a migration strategy, and evaluate the " +
+      "scalability and performance implications in depth.",
+  });
+  assertEqual(hard?.model, "my-strong-endpoint", "hard → strong custom model");
+});
+
+await test("llm classifier selects a custom model directly by id (description-driven)", async () => {
+  const alpha: ClassifierRouterPoolMember = {
+    provider: "litellm",
+    model: "alpha-endpoint",
+    description: "cheap & fast, for simple Q&A",
+  };
+  const beta: ClassifierRouterPoolMember = {
+    provider: "litellm",
+    model: "beta-endpoint",
+    description: "powerful reasoning model for complex analysis",
+  };
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: [alpha, beta] },
+    {
+      generate: fakeGen({
+        difficulty: "hard",
+        selectedModelId: "litellm/beta-endpoint",
+      }),
+    },
+  );
+  const d = await router.route({ prompt: "x" });
+  assertEqual(d?.model, "beta-endpoint", "uses the LLM's direct model pick");
+  assertEqual(
+    d?.modelFallbacks?.[0]?.model,
+    "alpha-endpoint",
+    "the unpicked model becomes the fallback",
+  );
+});
+
+await test("llm direct pick honors an explicit member `id`", async () => {
+  const router = new ClassifierRouter(
+    {
+      enabled: true,
+      classifier: "llm",
+      pool: [
+        { provider: "litellm", model: "x", id: "smart" },
+        { provider: "litellm", model: "y", id: "cheap" },
+      ],
+    },
+    { generate: fakeGen({ difficulty: "moderate", selectedModelId: "smart" }) },
+  );
+  const d = await router.route({ prompt: "x" });
+  assertEqual(d?.model, "x", "resolves the explicit id 'smart'");
+});
+
+await test("llm invalid/absent pick falls back to difficulty selection", async () => {
+  const router = new ClassifierRouter(
+    { enabled: true, classifier: "llm", pool: POOL },
+    { generate: fakeGen({ difficulty: "expert", selectedModelId: "nope" }) },
+  );
+  const d = await router.route({ prompt: "x" });
+  assertEqual(
+    d?.provider,
+    "gamma",
+    "bad id → difficulty path (expert → most capable)",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## Summary

Adds an opt-in **Classifier Router**: NeuroLink classifies each request and selects a provider/model from a configurable "available base" pool — routing hard tasks to more capable models and easy tasks to cheaper/faster ones — and can narrow the tool set per request. Disabled by default, fails open, fully backward compatible.

## What's included

- **Types** — `src/lib/types/classifierRouter.ts` (`Classifier*`), plus `classifierRouter` on the constructor config.
- **Strategies** — `src/lib/routing/classifierStrategies.ts`:
  - `classifyHeuristic` — zero-cost, 5-tier generalization of the existing task scorer (pure prompt-text, provider-agnostic).
  - `classifyLlm` — a cheap classifier model returns a difficulty and can pick a model **directly** from described candidates.
- **Router** — `src/lib/routing/classifierRouter.ts`: difficulty → model via LLM direct pick / `tierMap` / per-member `tiers` / `cost`+`quality` scoring (auto-enriched from the model registry), with capability filtering and per-difficulty tool directives.
- **Wiring** — `neurolink.ts` `generate()`/`stream()` pre-call seam (before `requestRouter`). Precedence: caller-pins > classifierRouter > requestRouter > orchestration; stands down when a `modelPool` is configured; the LLM classifier's own call can't recurse (guarded via `context.__classifierRouted`).
- **CLI flags** — `--classifier-router`, `--classifier-strategy`, `--classifier-model-provider/-name/-region`, `--classifier-pool` (file or inline JSON), `--classifier-timeout` (threaded via `globalSessionState`, mirroring `--tool-routing-*`).
- **Docs** — `docs/features/classifier-router.md` (+ pointer from the features index).

## Generic for custom models (LiteLLM / OpenAI-compatible / Ollama)

No registry dependency: route via per-member `tiers`/`tierMap`, or let the LLM classifier pick by plain-English `description`.

## Testing

- New suite `test/continuous-test-suite-classifier-router.ts` — **19 cases** (heuristic tiers, metadata scoring, `tierMap`, capability filter, tool directives, LLM direct-pick + invalid/absent fallbacks). Run: `pnpm run test:classifier-router`.
- `pnpm run check` (tsc strict) clean · `lint` 0 errors · full `build` 0 errors / publint OK.
- Live (Vertex): easy prompt → `gemini-2.5-flash`, hard prompt → `gemini-2.5-pro`, verified via both SDK and CLI.

## Backward compatibility

Opt-in (`enabled: false` by default); a default `new NeuroLink()` is byte-for-byte unchanged; all new config/exports are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Classifier Router that can automatically route requests to a more suitable model based on request difficulty.
  * Expanded CLI support so the router can be enabled and configured from the command line.
  * Added support for per-difficulty tool selection and model-pool routing options.

* **Documentation**
  * Added a new guide for the Classifier Router and updated the product docs index with a reference to it.

* **Tests**
  * Added coverage for routing behavior, fallback handling, and tool-scoping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->