### PR TITLE
fix(vertex): preserve answer text and emit finishReason in native Gemini loop

### DIFF
--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -620,6 +620,58 @@ export function computeMaxSteps(rawMaxSteps?: number): number {
 }
 
 /**
+ * Map a `@google/genai` `Candidate.finishReason` enum value onto NeuroLink's
+ * unified finish reason, mirroring anthropic.ts `mapAnthropicStopReason`.
+ *
+ * Enum values per `@google/genai` `FinishReason`: STOP, MAX_TOKENS, SAFETY,
+ * RECITATION, LANGUAGE, OTHER, BLOCKLIST, PROHIBITED_CONTENT, SPII,
+ * MALFORMED_FUNCTION_CALL, IMAGE_SAFETY, UNEXPECTED_TOOL_CALL,
+ * FINISH_REASON_UNSPECIFIED. Unknown / unset / non-terminal values default to
+ * "stop" (a clean completion is the safe assumption).
+ *
+ * Returns a plain string (not a `{ unified, raw }` object): the Vertex result
+ * builders and the consuming layer (neurolink.ts `finishReason || "unknown"`
+ * and `finishReason === "length"`) compare against plain strings.
+ */
+export function mapGeminiFinishReason(
+  raw: string | null | undefined,
+): "stop" | "length" | "tool-calls" | "content-filter" {
+  switch (raw) {
+    case "MAX_TOKENS":
+      return "length";
+    case "MALFORMED_FUNCTION_CALL":
+    case "UNEXPECTED_TOOL_CALL":
+      return "tool-calls";
+    case "SAFETY":
+    case "RECITATION":
+    case "BLOCKLIST":
+    case "PROHIBITED_CONTENT":
+    case "SPII":
+    case "IMAGE_SAFETY":
+      return "content-filter";
+    default:
+      return "stop";
+  }
+}
+
+/**
+ * Append a step's text to a running cross-step accumulator, ignoring empty
+ * steps and inserting a single newline between non-empty contributions.
+ *
+ * The native Gemini loops overwrite per-step text into `lastStepText`, so when
+ * the loop is force-terminated by the step cap the intermediate tool-step prose
+ * is lost and a canned placeholder becomes the answer. Accumulating here mirrors
+ * the Vertex-Claude loop's `aggregatedTurnText += block.text` so the gathered
+ * text can be surfaced at the maxSteps-exhaustion exit instead of the placeholder.
+ */
+export function appendStepText(accumulated: string, stepText: string): string {
+  if (!stepText) {
+    return accumulated;
+  }
+  return accumulated ? `${accumulated}\n${stepText}` : stepText;
+}
+
+/**
  * Process stream chunks to extract raw response parts, function calls, and usage metadata.
  *
  * Consumes the full async iterable and returns all collected data.

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -72,8 +72,10 @@ import { createNativeThinkingConfig } from "../utils/thinkingConfig.js";
 import { TimeoutError, withTimeout } from "../utils/async/index.js";
 import { parseTimeout } from "../utils/timeout.js";
 import {
+  appendStepText,
   createTextChannel,
   extractThoughtSignature,
+  mapGeminiFinishReason,
   prependConversationMessages,
 } from "./googleNativeGemini3.js";
 import {
@@ -1082,7 +1084,13 @@ export class GoogleVertexProvider extends BaseProvider {
             result,
             streamStartTime,
           );
-          this.emitStreamEnd(modelName, streamStartTime, true);
+          this.emitStreamEnd(
+            modelName,
+            streamStartTime,
+            true,
+            undefined,
+            result.finishReason,
+          );
           return wrappedResult;
         } catch (error) {
           this.fireGenerateOnError(options, error, streamStartTime);
@@ -1105,6 +1113,7 @@ export class GoogleVertexProvider extends BaseProvider {
     startTime: number,
     success: boolean,
     error?: unknown,
+    resolvedFinishReason?: string,
   ): void {
     const emitter = this.neurolink?.getEventEmitter();
     if (!emitter) {
@@ -1119,7 +1128,7 @@ export class GoogleVertexProvider extends BaseProvider {
         usage: { input: 0, output: 0, total: 0 },
         model: modelName,
         provider: this.providerName,
-        finishReason: success ? "stop" : "error",
+        finishReason: success ? (resolvedFinishReason ?? "stop") : "error",
       },
       success,
       ...(error
@@ -1552,7 +1561,10 @@ export class GoogleVertexProvider extends BaseProvider {
         : Math.min(DEFAULT_MAX_STEPS, 100);
     const currentContents = [...contents];
     let finalText = "";
-    let lastStepText = ""; // Track text from last step for maxSteps termination
+    // Last SDK finish reason seen across steps (Bug 2: previously never read,
+    // so callers fell back to "unknown"). Last non-empty value wins — the
+    // terminal chunk is authoritative.
+    let lastFinishReason: string | undefined;
     const allToolCalls: Array<{
       toolName: string;
       args: Record<string, unknown>;
@@ -1617,6 +1629,12 @@ export class GoogleVertexProvider extends BaseProvider {
             | Array<Record<string, unknown>>
             | undefined;
           const firstCandidate = candidates?.[0];
+          // Capture the SDK finish reason (Bug 2: previously dropped). Last
+          // non-empty value across chunks wins.
+          const chunkFinishReason = firstCandidate?.finishReason;
+          if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+            lastFinishReason = chunkFinishReason;
+          }
           const chunkContent = firstCandidate?.content as
             | Record<string, unknown>
             | undefined;
@@ -1699,9 +1717,6 @@ export class GoogleVertexProvider extends BaseProvider {
             break;
           }
         }
-
-        // Track the last step text for maxSteps termination
-        lastStepText = stepText;
 
         // Execute function calls
         logger.debug(
@@ -1912,16 +1927,61 @@ export class GoogleVertexProvider extends BaseProvider {
       }
     }
 
-    // Handle maxSteps termination - if we exited the loop due to maxSteps being reached
+    // Handle maxSteps termination — the loop exited because the step cap was
+    // reached while the model was still calling tools. Surface a real answer
+    // instead of the canned placeholder (Bug 1) and a meaningful finishReason
+    // (Bug 2).
+    let hitStepLimit = false;
+    let synthesizedFinalAnswer = false;
     if (step >= maxSteps && !finalText) {
-      logger.warn(
-        `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}). ` +
-          `Model was still calling tools. Using accumulated text from last step.`,
-      );
-      finalText =
-        lastStepText ||
-        `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+      hitStepLimit = true;
+      // The consumer receives text via `incrementalTextChunks`; any text the
+      // model emitted across steps is already preserved there. Only synthesize
+      // when NOTHING was produced (the pure-functionCall case that otherwise
+      // surfaces the placeholder) so we never waste a round-trip whose output
+      // the stream would ignore.
+      if (incrementalTextChunks.length === 0) {
+        logger.warn(
+          `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+            `with no text; synthesizing a final answer with tools disabled.`,
+        );
+        const synth = await this.synthesizeFinalAnswerWithoutTools(
+          client,
+          modelName,
+          config,
+          currentContents,
+          useFinalResultTool,
+          parseTimeout(options.timeout) ?? 300_000,
+        );
+        if (synth.text) {
+          synthesizedFinalAnswer = true;
+          finalText = synth.text;
+          incrementalTextChunks.push(synth.text);
+          totalInputTokens += synth.inputTokens;
+          totalOutputTokens += synth.outputTokens;
+          if (synth.finishReason) {
+            lastFinishReason = synth.finishReason;
+          }
+        } else {
+          finalText = `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+        }
+      } else {
+        logger.warn(
+          `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+            `returning text already gathered from prior steps.`,
+        );
+      }
     }
+
+    // Unified finish reason: a step-cap exhaustion that did NOT end in a clean
+    // synthesized answer is reported as "tool-calls" (the model still wanted
+    // tools) — NOT "length", which neurolink.ts treats as token truncation
+    // (jsonTruncated + WARNING span). A clean completion maps from the SDK
+    // finish reason.
+    const resolvedFinishReason =
+      hitStepLimit && !synthesizedFinalAnswer
+        ? "tool-calls"
+        : mapGeminiFinishReason(lastFinishReason);
 
     const responseTime = Date.now() - startTime;
 
@@ -1957,6 +2017,7 @@ export class GoogleVertexProvider extends BaseProvider {
       stream: createTextStream(),
       provider: this.providerName,
       model: modelName,
+      finishReason: resolvedFinishReason,
       usage: {
         input: totalInputTokens,
         output: totalOutputTokens,
@@ -2386,7 +2447,11 @@ export class GoogleVertexProvider extends BaseProvider {
         : Math.min(DEFAULT_MAX_STEPS, 100);
     const currentContents = [...contents];
     let finalText = "";
-    let lastStepText = ""; // Track text from last step for maxSteps termination
+    // Cross-step text accumulation + last SDK finish reason, so the
+    // maxSteps-exhaustion exit can surface real gathered text (Bug 1) and a
+    // meaningful finishReason (Bug 2) instead of a placeholder / "unknown".
+    let accumulatedText = "";
+    let lastFinishReason: string | undefined;
     const allToolCalls: Array<{
       toolName: string;
       args: Record<string, unknown>;
@@ -2443,6 +2508,12 @@ export class GoogleVertexProvider extends BaseProvider {
             | Array<Record<string, unknown>>
             | undefined;
           const firstCandidate = candidates?.[0];
+          // Capture the SDK finish reason (Bug 2: previously dropped). Last
+          // non-empty value across chunks wins.
+          const chunkFinishReason = firstCandidate?.finishReason;
+          if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+            lastFinishReason = chunkFinishReason;
+          }
           const chunkContent = firstCandidate?.content as
             | Record<string, unknown>
             | undefined;
@@ -2519,8 +2590,11 @@ export class GoogleVertexProvider extends BaseProvider {
           }
         }
 
-        // Track the last step text for maxSteps termination
-        lastStepText = stepText;
+        // Accumulate non-empty step text across steps so the
+        // maxSteps-exhaustion exit can surface the prose the model produced
+        // instead of a canned placeholder (Bug 1). Mirrors the Vertex-Claude
+        // loop's text accumulation.
+        accumulatedText = appendStepText(accumulatedText, stepText);
 
         // Execute function calls
         logger.debug(
@@ -2723,16 +2797,60 @@ export class GoogleVertexProvider extends BaseProvider {
       }
     }
 
-    // Handle maxSteps termination - if we exited the loop due to maxSteps being reached
+    // Handle maxSteps termination — the loop exited because the step cap was
+    // reached while the model was still calling tools. Surface a real answer
+    // instead of the canned placeholder (Bug 1) and a meaningful finishReason
+    // (Bug 2).
+    let hitStepLimit = false;
+    let synthesizedFinalAnswer = false;
     if (step >= maxSteps && !finalText) {
-      logger.warn(
-        `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}). ` +
-          `Model was still calling tools. Using accumulated text from last step.`,
-      );
-      finalText =
-        lastStepText ||
-        `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+      hitStepLimit = true;
+      if (accumulatedText) {
+        // Prefer the prose the model already produced across steps.
+        logger.warn(
+          `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+            `returning text already gathered from prior steps.`,
+        );
+        finalText = accumulatedText;
+      } else {
+        // Pure functionCall turns leave no text — make one tools-disabled call
+        // so the model answers from the gathered tool results instead of the
+        // canned placeholder.
+        logger.warn(
+          `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+            `with no text; synthesizing a final answer with tools disabled.`,
+        );
+        const synth = await this.synthesizeFinalAnswerWithoutTools(
+          client,
+          modelName,
+          config,
+          currentContents,
+          useFinalResultTool,
+          parseTimeout(options.timeout) ?? 300_000,
+        );
+        if (synth.text) {
+          synthesizedFinalAnswer = true;
+          finalText = synth.text;
+          totalInputTokens += synth.inputTokens;
+          totalOutputTokens += synth.outputTokens;
+          if (synth.finishReason) {
+            lastFinishReason = synth.finishReason;
+          }
+        } else {
+          finalText = `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+        }
+      }
     }
+
+    // Unified finish reason: a step-cap exhaustion that did NOT end in a clean
+    // synthesized answer is reported as "tool-calls" (the model still wanted
+    // tools) — NOT "length", which neurolink.ts treats as token truncation
+    // (jsonTruncated + WARNING span). A clean completion maps from the SDK
+    // finish reason.
+    const resolvedFinishReason =
+      hitStepLimit && !synthesizedFinalAnswer
+        ? "tool-calls"
+        : mapGeminiFinishReason(lastFinishReason);
 
     const responseTime = Date.now() - startTime;
 
@@ -2749,6 +2867,7 @@ export class GoogleVertexProvider extends BaseProvider {
       content: finalText,
       provider: this.providerName,
       model: modelName,
+      finishReason: resolvedFinishReason,
       usage: {
         input: totalInputTokens,
         output: totalOutputTokens,
@@ -2772,6 +2891,126 @@ export class GoogleVertexProvider extends BaseProvider {
     // enableAnalytics / enableEvaluation are silently ignored on the native
     // Vertex Gemini generate path.
     return this.enhanceResult(result, options, startTime);
+  }
+
+  /**
+   * One-shot, tools-disabled model call used when a native Gemini agentic loop
+   * is force-terminated by the step cap with no text produced. Lets the model
+   * synthesize a final answer from the function results already in `contents`
+   * instead of returning a canned placeholder (Bug 1, part b).
+   *
+   * Tools are disabled by OMITTING `config.tools` — the codebase's established
+   * mechanism. `@google/genai`'s `FunctionCallingConfigMode.NONE` is documented
+   * as equivalent to passing no function declarations, and `functionCallingConfig`
+   * is not used anywhere in this codebase. When the structured-output
+   * (`final_result`) pattern was active, a trailing instruction countermands the
+   * earlier "you MUST call final_result" directive so the model answers in plain
+   * text. Never throws — returns empty text so the caller falls back to the
+   * placeholder, guaranteeing no new failure path.
+   */
+  private async synthesizeFinalAnswerWithoutTools(
+    client: GenAIClient,
+    modelName: string,
+    config: Record<string, unknown>,
+    contents: Array<{ role: string; parts: VertexNativePart[] }>,
+    useFinalResultTool: boolean,
+    timeoutMs: number,
+  ): Promise<{
+    text: string;
+    finishReason?: string;
+    inputTokens: number;
+    outputTokens: number;
+  }> {
+    try {
+      // Shallow clone so the loop's config is never mutated; dropping the
+      // top-level `tools` key is sufficient (nested thinkingConfig /
+      // systemInstruction are intentionally preserved).
+      const synthConfig: Record<string, unknown> = { ...config };
+      delete synthConfig.tools;
+      if (useFinalResultTool) {
+        const baseSystemInstruction =
+          typeof synthConfig.systemInstruction === "string"
+            ? synthConfig.systemInstruction
+            : "";
+        synthConfig.systemInstruction =
+          baseSystemInstruction +
+          "\n\nThe final_result tool is no longer available. Provide your " +
+          "final answer directly as plain text now, using the information " +
+          "gathered so far.";
+      }
+
+      // Bound the whole connect + drain with a timeout. The surrounding
+      // try/catch only catches throws, not hangs, so without this a stalled
+      // Vertex endpoint would hang the maxSteps recovery path indefinitely.
+      // On timeout withTimeout rejects (TimeoutError) and the catch below
+      // falls back to the placeholder — no new failure path is introduced.
+      return await withTimeout(
+        (async () => {
+          const stream = await client.models.generateContentStream({
+            model: modelName,
+            contents,
+            config: synthConfig,
+          });
+
+          const parts: unknown[] = [];
+          let finishReason: string | undefined;
+          let inputTokens = 0;
+          let outputTokens = 0;
+          for await (const chunk of stream) {
+            const chunkRecord = chunk as Record<string, unknown>;
+            const candidates = chunkRecord.candidates as
+              | Array<Record<string, unknown>>
+              | undefined;
+            const firstCandidate = candidates?.[0];
+            const chunkFinishReason = firstCandidate?.finishReason;
+            if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+              finishReason = chunkFinishReason;
+            }
+            const chunkContent = firstCandidate?.content as
+              | Record<string, unknown>
+              | undefined;
+            if (chunkContent && Array.isArray(chunkContent.parts)) {
+              parts.push(...chunkContent.parts);
+            }
+            const usageMetadata = chunkRecord.usageMetadata as
+              | { promptTokenCount?: number; candidatesTokenCount?: number }
+              | undefined;
+            if (usageMetadata) {
+              if (
+                usageMetadata.promptTokenCount !== undefined &&
+                usageMetadata.promptTokenCount > 0
+              ) {
+                inputTokens = usageMetadata.promptTokenCount;
+              }
+              if (
+                usageMetadata.candidatesTokenCount !== undefined &&
+                usageMetadata.candidatesTokenCount > 0
+              ) {
+                outputTokens = usageMetadata.candidatesTokenCount;
+              }
+            }
+          }
+
+          const text = parts
+            .filter(
+              (part): part is { text: string } =>
+                typeof (part as Record<string, unknown>).text === "string",
+            )
+            .map((part) => part.text)
+            .join("");
+
+          return { text, finishReason, inputTokens, outputTokens };
+        })(),
+        timeoutMs,
+        "Gemini synthesis call timed out",
+      );
+    } catch (error) {
+      logger.warn(
+        "[GoogleVertex] Tools-disabled synthesis call failed; falling back to placeholder",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return { text: "", inputTokens: 0, outputTokens: 0 };
+    }
   }
 
   /**
@@ -4923,7 +5162,7 @@ export class GoogleVertexProvider extends BaseProvider {
             }
           : undefined,
         duration: Date.now() - startTime,
-        finishReason: "stop",
+        finishReason: result?.finishReason ?? "stop",
       });
       Promise.resolve(callbackResult).catch((err) =>
         logger.warn(
@@ -5207,7 +5446,7 @@ export class GoogleVertexProvider extends BaseProvider {
         usage,
         model: modelName,
         provider: this.providerName,
-        finishReason: success ? "stop" : "error",
+        finishReason: success ? (result?.finishReason ?? "stop") : "error",
       },
       success,
       ...(error

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -23,6 +23,11 @@ import {
   resolveVertexLocation,
 } from "../src/lib/providers/googleVertex.js";
 
+import {
+  appendStepText,
+  mapGeminiFinishReason,
+} from "../src/lib/providers/googleNativeGemini3.js";
+
 import { OpenAICompatibleProvider } from "../src/lib/providers/openaiCompatible.js";
 import { LiteLLMProvider } from "../src/lib/providers/litellm.js";
 import { ModelAccessDeniedError } from "../src/lib/types/index.js";
@@ -3151,6 +3156,208 @@ exit 127
         ).modelsCacheTime = 0;
       }
     },
+  },
+  // ---------- Gemini-on-Vertex agentic-loop bugs ----------
+  // Bug 2: native Gemini result builders never read candidates[0].finishReason,
+  // so callers saw "unknown". mapGeminiFinishReason is the pure mapper that now
+  // populates it (mirrors anthropic.ts mapAnthropicStopReason).
+  {
+    name: "mapGeminiFinishReason: maps @google/genai FinishReason enum to unified values (Bug 2)",
+    category: "gemini-finish-reason",
+    fn: async () => {
+      return (
+        mapGeminiFinishReason("STOP") === "stop" &&
+        mapGeminiFinishReason("MAX_TOKENS") === "length" &&
+        mapGeminiFinishReason("MALFORMED_FUNCTION_CALL") === "tool-calls" &&
+        mapGeminiFinishReason("UNEXPECTED_TOOL_CALL") === "tool-calls" &&
+        mapGeminiFinishReason("SAFETY") === "content-filter" &&
+        mapGeminiFinishReason("RECITATION") === "content-filter" &&
+        mapGeminiFinishReason("BLOCKLIST") === "content-filter" &&
+        mapGeminiFinishReason("PROHIBITED_CONTENT") === "content-filter" &&
+        mapGeminiFinishReason("SPII") === "content-filter" &&
+        mapGeminiFinishReason("IMAGE_SAFETY") === "content-filter"
+      );
+    },
+  },
+  {
+    name: "mapGeminiFinishReason: unknown / unset / non-terminal values default to 'stop' (Bug 2)",
+    category: "gemini-finish-reason",
+    fn: async () => {
+      return (
+        mapGeminiFinishReason(undefined) === "stop" &&
+        mapGeminiFinishReason(null) === "stop" &&
+        mapGeminiFinishReason("") === "stop" &&
+        mapGeminiFinishReason("FINISH_REASON_UNSPECIFIED") === "stop" &&
+        mapGeminiFinishReason("OTHER") === "stop" &&
+        mapGeminiFinishReason("LANGUAGE") === "stop" &&
+        mapGeminiFinishReason("some-garbage-value") === "stop"
+      );
+    },
+  },
+  // Bug 1: the native loop overwrote per-step text into lastStepText, so at the
+  // maxSteps cap the answer was lost and a canned placeholder surfaced.
+  // appendStepText is the pure accumulator that now preserves cross-step text.
+  {
+    name: "appendStepText: accumulates non-empty step text across steps (Bug 1)",
+    category: "gemini-text-accumulation",
+    fn: async () => {
+      return (
+        appendStepText("", "a") === "a" &&
+        appendStepText("a", "b") === "a\nb" &&
+        appendStepText("a\nb", "c") === "a\nb\nc"
+      );
+    },
+  },
+  {
+    name: "appendStepText: ignores empty step text without adding separators (Bug 1)",
+    category: "gemini-text-accumulation",
+    fn: async () => {
+      return (
+        appendStepText("a", "") === "a" &&
+        appendStepText("", "") === "" &&
+        appendStepText("a\nb", "") === "a\nb"
+      );
+    },
+  },
+  // Bug 1b: at the maxSteps cap with no gathered text, the loop makes one
+  // tools-disabled synthesis call instead of returning the placeholder. This
+  // exercises that helper end-to-end with a mocked @google/genai client.
+  {
+    name: "synthesizeFinalAnswerWithoutTools: drops tools, captures finishReason/text/usage, countermands final_result (Bug 1b)",
+    category: "gemini-synthesis",
+    fn: async () =>
+      withTemporaryEnv(
+        {
+          GOOGLE_APPLICATION_CREDENTIALS: "/tmp/neurolink-test-creds.json",
+          GOOGLE_CLOUD_PROJECT_ID: "test-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+        async () => {
+          const provider = new GoogleVertexProvider(
+            "gemini-3-pro-preview",
+            undefined,
+            undefined,
+            "global",
+          );
+          let capturedConfig: Record<string, unknown> | undefined;
+          const mockClient = {
+            models: {
+              generateContentStream: async (req: {
+                config: Record<string, unknown>;
+              }) => {
+                capturedConfig = req.config;
+                return (async function* () {
+                  yield {
+                    candidates: [
+                      {
+                        content: { parts: [{ text: "Synthesized " }] },
+                        finishReason: "STOP",
+                      },
+                    ],
+                  };
+                  yield {
+                    candidates: [
+                      {
+                        content: { parts: [{ text: "answer." }] },
+                        finishReason: "STOP",
+                      },
+                    ],
+                    usageMetadata: {
+                      promptTokenCount: 11,
+                      candidatesTokenCount: 7,
+                    },
+                  };
+                })();
+              },
+            },
+          };
+          const out = await (
+            provider as unknown as {
+              synthesizeFinalAnswerWithoutTools(
+                client: unknown,
+                modelName: string,
+                config: Record<string, unknown>,
+                contents: unknown,
+                useFinalResultTool: boolean,
+                timeoutMs: number,
+              ): Promise<{
+                text: string;
+                finishReason?: string;
+                inputTokens: number;
+                outputTokens: number;
+              }>;
+            }
+          ).synthesizeFinalAnswerWithoutTools(
+            mockClient,
+            "gemini-3-pro-preview",
+            {
+              tools: [{ functionDeclarations: [] }],
+              systemInstruction:
+                "Do the task. You MUST call the final_result tool.",
+            },
+            [{ role: "user", parts: [{ text: "hi" }] }],
+            true,
+            30_000,
+          );
+          const systemInstruction =
+            typeof capturedConfig?.systemInstruction === "string"
+              ? capturedConfig.systemInstruction
+              : "";
+          return (
+            out.text === "Synthesized answer." &&
+            out.finishReason === "STOP" &&
+            out.inputTokens === 11 &&
+            out.outputTokens === 7 &&
+            capturedConfig?.tools === undefined &&
+            systemInstruction.includes("no longer available")
+          );
+        },
+      ),
+  },
+  // Bug 2: the resolved finishReason must reach options.onFinish, not a
+  // hardcoded "stop", for native-path callers using the lifecycle callback.
+  {
+    name: "fireGenerateOnFinish: forwards result.finishReason to onFinish (not hardcoded 'stop') (Bug 2)",
+    category: "gemini-finish-reason",
+    fn: async () =>
+      withTemporaryEnv(
+        {
+          GOOGLE_APPLICATION_CREDENTIALS: "/tmp/neurolink-test-creds.json",
+          GOOGLE_CLOUD_PROJECT_ID: "test-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+        async () => {
+          const provider = new GoogleVertexProvider(
+            "gemini-3-pro-preview",
+            undefined,
+            undefined,
+            "global",
+          );
+          let captured: { finishReason?: string } | undefined;
+          const options = {
+            onFinish: (payload: { finishReason?: string }) => {
+              captured = payload;
+            },
+          };
+          const result = {
+            content: "hi",
+            usage: { input: 1, output: 2, total: 3 },
+            finishReason: "tool-calls",
+          };
+          (
+            provider as unknown as {
+              fireGenerateOnFinish(
+                options: unknown,
+                result: unknown,
+                startTime: number,
+              ): void;
+            }
+          ).fireGenerateOnFinish(options, result, Date.now() - 100);
+          // onFinish fires synchronously; yield a tick for safety.
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          return captured?.finishReason === "tool-calls";
+        },
+      ),
   },
 ];
 


### PR DESCRIPTION
## Description

Fixes two production bugs in the **native Gemini-on-Vertex** agentic tool-calling loop (`executeNativeGemini3Stream` / `executeNativeGemini3Generate` in `googleVertex.ts`). These paths lacked parity with the Claude-on-Vertex loop: they discarded intermediate step text and never surfaced a finish reason.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When the model keeps calling tools up to the `maxSteps` cap:

- **Bug 1 — lost answer / canned placeholder.** Per-step text was overwritten (`lastStepText = stepText`), never accumulated. On a pure-`functionCall` turn the loop returned the literal `"[Tool execution limit reached after N steps…]"` placeholder as the user-visible answer.
- **Bug 2 — `finishReason` always `"unknown"`.** The chunk readers never read `candidates[0].finishReason` and the result builders omitted the field, so the consuming layer (`neurolink.ts`) fell back to `"unknown"` on every native Gemini call — even on a clean `STOP`.

The Claude-on-Vertex loop already accumulates text (`aggregatedTurnText += …`) and maps its stop reason; this brings the Gemini paths to parity.

## Changes Made

- **`finishReason` (Bug 2):** capture `candidates[].finishReason` per step (last non-empty wins) and set it on both `StreamResult` and `EnhancedGenerateResult` via a new pure `mapGeminiFinishReason` helper (mirrors `anthropic.ts` `mapAnthropicStopReason`: `STOP→stop`, `MAX_TOKENS→length`, `MALFORMED/UNEXPECTED_TOOL_CALL→tool-calls`, safety reasons→`content-filter`).
  - A `maxSteps` exhaustion is reported as **`tool-calls`**, deliberately **not** `length` — `neurolink.ts` treats `length` as token truncation (`jsonTruncated=true` + WARNING span), which would be semantically wrong for a step-budget condition.
- **Answer recovery (Bug 1):** accumulate non-empty step text (`appendStepText`); on cap exhaustion with no gathered text, make **one** tools-disabled synthesis call (tools disabled by omitting `config.tools` — the codebase's established mechanism; `functionCallingConfig` is unused) so the model answers from the gathered tool results. The placeholder is now only a `try/catch` last resort. Synthesis token usage is folded into the result totals; the stale `final_result` system instruction is countermanded for the structured-output sub-case.
- Removed the now-dead `lastStepText` from both paths.
- Added 4 deterministic, no-network unit tests for the two pure helpers in `continuous-test-suite-bugfixes.ts`.

## Breaking Changes

- [x] No breaking changes

`finishReason` is already an optional `string` on both result types — no public API change. The placeholder string is preserved as a fallback, and normal (non-exhaustion) completions are unchanged.

## Testing

- [x] Unit tests added/updated (`mapGeminiFinishReason`, `appendStepText`)
- [x] Existing tests pass

Gates run locally on this branch:

| Gate | Result |
| --- | --- |
| `pnpm run check` (tsc strict + svelte-check) | 0 errors |
| `pnpm run test:bugfixes` | 84/84 (incl. 4 new) |
| `pnpm run lint` | 0 errors, no new warnings |
| `pnpm run test:google-native` | 22/22 |
| `pnpm run build` | 0 errors, publint clean |

> **`gemini-3` 32K output cap:** investigated and intentionally left unchanged — it reflects a real Vertex-preview platform limit (raw API allows 64K). The `json-e2e` huge-output case (~8–13K tokens) stays well under 32K, so it completes at `finishReason='stop'` and its `!truncated` assertion is unaffected. A live `test:json-e2e` run with Vertex credentials is recommended as a final confirmation.

## Code Quality

- [x] Code follows the project's style guidelines (ESLint passes)
- [x] Code is properly formatted (Prettier applied)
- [x] Self-review of code completed
- [x] No `console.log` statements (uses `logger`)
- [x] No hardcoded API keys or secrets
- [x] TypeScript strict mode compliance
- [x] Proper error handling implemented (synthesis call is `try/catch`, never adds a throw path)

## Performance Impact

- [x] Negligible — the extra synthesis call fires **only** on the rare `maxSteps`-exhaustion-with-no-text path, never on the happy path.

## Security Considerations

- [x] No security implications

## Commit Message Format

- [x] `fix(vertex): preserve answer text and emit finishReason in native Gemini loop`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini-on-Vertex handling for agentic tool-calling by preserving and propagating unified finish reasons across steps.
  * When the step limit is reached, the app now generates a complete final answer (when possible) instead of stopping early.
  * More reliable streaming text accumulation by concatenating step text while ignoring empty segments.
  * Completion callbacks now receive the correct finish reason instead of always reporting `"stop"`.
* **Tests**
  * Added coverage for finish-reason mapping, step-text concatenation, and Gemini-on-Vertex loop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->