### PR TITLE
fix(vertex): honor abortSignal + graceful step-cap message in native Gemini-3 loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "test:servers": "npx tsx test/continuous-test-suite-servers.ts",
     "test:tool-reliability": "npx tsx test/continuous-test-suite-tool-reliability.ts",
     "test:google-native": "npx tsx test/continuous-test-suite-google-native.ts",
+    "test:gemini-abort": "npx tsx test/continuous-test-suite-gemini-abort.ts",
     "test:tts": "npx tsx test/continuous-test-suite-tts.ts",
     "test:voice": "npx tsx test/continuous-test-suite-voice.ts",
     "test:voice-server": "npx tsx test/continuous-test-suite-voice-server.ts",

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -119,6 +119,9 @@ export const DEFAULT_TIMEOUT = 60000;
 export const DEFAULT_MAX_STEPS = 200;
 export const DEFAULT_TOOL_MAX_RETRIES = 2; // Maximum retries per tool before permanently failing
 
+/** Defensive wall-clock ceiling for a native Gemini-3 agentic turn (generate + stream). */
+export const DEFAULT_GEMINI_STREAM_TIMEOUT_MS = 300_000;
+
 // Fire-and-forget tool storage writes (Redis). 5s is generous for a single
 // Redis write; if breached, the .catch logs a warning.
 export const TOOL_STORAGE_TIMEOUT_MS = 5000;

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -1048,10 +1048,16 @@ export async function executeNativeToolCalls(
 }
 
 /**
- * Handle maxSteps termination by producing a final text when the model
- * was still calling tools when the step limit was reached.
+ * Handle maxSteps termination by producing a final answer when the model was
+ * still calling tools as the step limit was reached.
+ *
+ * Resolution order (always returns a non-empty string): the caller's
+ * `finalText` if present; else the `lastStepText` gathered from the final step;
+ * else a graceful, user-facing cap message from {@link buildToolLoopCapMessage}
+ * — which replaced the legacy bracketed step-limit placeholder string.
  *
  * @param logLabel - Label for log messages (e.g. "[GoogleAIStudio]" or "[GoogleVertex]")
+ * @returns The resolved final answer text (never the legacy placeholder).
  */
 export function handleMaxStepsTermination(
   logLabel: string,
@@ -1065,12 +1071,49 @@ export function handleMaxStepsTermination(
       `${logLabel} Tool call loop terminated after reaching maxSteps (${maxSteps}). ` +
         `Model was still calling tools. Using accumulated text from last step.`,
     );
-    return (
-      lastStepText ||
-      `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`
-    );
+    return lastStepText || buildToolLoopCapMessage(maxSteps, 0);
   }
   return finalText;
+}
+
+/**
+ * Detect whether an error represents an abort/cancellation (from an
+ * AbortSignal firing during a fetch/stream drain). Used by the native
+ * Gemini-3 agentic loops to break gracefully rather than re-throw.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const e = error as { name?: string; message?: string; code?: number };
+  return (
+    e.name === "AbortError" ||
+    (typeof e.message === "string" && /abort/i.test(e.message)) ||
+    (typeof DOMException !== "undefined" &&
+      error instanceof DOMException &&
+      e.code === 20)
+  );
+}
+
+/**
+ * Build a graceful, user-facing message for when a single agentic turn hits
+ * the step cap (or is aborted mid-turn) without producing a final answer.
+ * Replaces the legacy bracketed "Tool execution limit reached" placeholder.
+ */
+export function buildToolLoopCapMessage(
+  maxSteps: number,
+  toolCallCount: number,
+): string {
+  const calls =
+    toolCallCount > 0
+      ? `I gathered information across ${toolCallCount} tool call${
+          toolCallCount === 1 ? "" : "s"
+        } but `
+      : "I ";
+  return (
+    `${calls}reached the ${maxSteps}-step limit for a single turn before I could finish. ` +
+    `Please narrow the request or break it into smaller asks and I'll continue.`
+  );
 }
 
 /**

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -12,6 +12,7 @@ import {
 } from "../constants/enums.js";
 import { BaseProvider } from "../core/baseProvider.js";
 import {
+  DEFAULT_GEMINI_STREAM_TIMEOUT_MS,
   DEFAULT_MAX_STEPS,
   DEFAULT_TOOL_MAX_RETRIES,
   GLOBAL_LOCATION_MODELS,
@@ -77,8 +78,10 @@ import { TimeoutError, withTimeout } from "../utils/async/index.js";
 import { parseTimeout } from "../utils/timeout.js";
 import {
   appendStepText,
+  buildToolLoopCapMessage,
   createTextChannel,
   extractThoughtSignature,
+  isAbortError,
   mapGeminiFinishReason,
   prependConversationMessages,
 } from "./googleNativeGemini3.js";
@@ -1781,241 +1784,306 @@ export class GoogleVertexProvider extends BaseProvider {
     // network stream is genuinely incremental.
     const incrementalTextChunks: string[] = [];
 
-    // Agentic loop for tool calling
-    while (step < maxSteps) {
-      step++;
-      logger.debug(`[GoogleVertex] Native SDK step ${step}/${maxSteps}`);
+    // Abort scaffolding (mirrors executeNativeAnthropicStream). The native
+    // Gemini SDK cancels via config.abortSignal, so drive an internal
+    // AbortController: the caller's signal and a defensive wall-clock timer
+    // both trip it, and every request/tool-exec receives effectiveSignal.
+    const streamTimeoutMs =
+      parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS;
+    const internalAbort = new AbortController();
+    const onCallerAbort = () => internalAbort.abort();
+    options.abortSignal?.addEventListener("abort", onCallerAbort);
+    const defensiveTimer = setTimeout(() => {
+      logger.warn(
+        `[GoogleVertex] Native Gemini turn exceeded ${streamTimeoutMs}ms — aborting`,
+      );
+      internalAbort.abort();
+    }, streamTimeoutMs);
+    const effectiveSignal = internalAbort.signal;
+    if (options.abortSignal?.aborted) {
+      internalAbort.abort();
+    }
+    let wasAborted = false;
 
-      try {
-        const stream = await client.models.generateContentStream({
-          model: modelName,
-          contents: currentContents,
-          config,
-        });
+    // Step-cap flags declared in the outer scope so the terminal block (also
+    // inside the try) and the finishReason mapping (after the finally) can
+    // both read them.
+    let hitStepLimit = false;
+    let synthesizedFinalAnswer = false;
 
-        const stepFunctionCalls: Array<{
-          name: string;
-          args: Record<string, unknown>;
-        }> = [];
-
-        // Capture raw response parts including thoughtSignature
-        const rawResponseParts: unknown[] = [];
-
-        for await (const chunk of stream) {
-          // Extract raw parts from candidates FIRST
-          // This avoids using chunk.text which triggers SDK warning when
-          // non-text parts (thoughtSignature, functionCall) are present
-          const chunkRecord = chunk as Record<string, unknown>;
-          const candidates = chunkRecord.candidates as
-            | Array<Record<string, unknown>>
-            | undefined;
-          const firstCandidate = candidates?.[0];
-          // Capture the SDK finish reason (Bug 2: previously dropped). Last
-          // non-empty value across chunks wins.
-          const chunkFinishReason = firstCandidate?.finishReason;
-          if (typeof chunkFinishReason === "string" && chunkFinishReason) {
-            lastFinishReason = chunkFinishReason;
-          }
-          const chunkContent = firstCandidate?.content as
-            | Record<string, unknown>
-            | undefined;
-          if (chunkContent && Array.isArray(chunkContent.parts)) {
-            for (const part of chunkContent.parts as Array<
-              Record<string, unknown>
-            >) {
-              rawResponseParts.push(part);
-              if (typeof part.text === "string" && part.text.length > 0) {
-                incrementalTextChunks.push(part.text);
-              }
-            }
-          }
-          if (chunk.functionCalls) {
-            stepFunctionCalls.push(...chunk.functionCalls);
-          }
-
-          // Extract usage metadata from chunk
-          // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
-          const usageMetadata = chunkRecord.usageMetadata as
-            | {
-                promptTokenCount?: number;
-                candidatesTokenCount?: number;
-                totalTokenCount?: number;
-              }
-            | undefined;
-          if (usageMetadata) {
-            // Take the latest promptTokenCount (usually only in final chunk)
-            if (
-              usageMetadata.promptTokenCount !== undefined &&
-              usageMetadata.promptTokenCount > 0
-            ) {
-              totalInputTokens = usageMetadata.promptTokenCount;
-            }
-            // Take the latest candidatesTokenCount (accumulates through chunks)
-            if (
-              usageMetadata.candidatesTokenCount !== undefined &&
-              usageMetadata.candidatesTokenCount > 0
-            ) {
-              totalOutputTokens = usageMetadata.candidatesTokenCount;
-            }
-          }
-        }
-
-        // Extract text from raw parts after stream completes
-        // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
-        const stepText = rawResponseParts
-          .filter(
-            (part): part is { text: string } =>
-              typeof (part as Record<string, unknown>).text === "string",
-          )
-          .map((part) => part.text)
-          .join("");
-
-        // If no function calls, we're done
-        if (stepFunctionCalls.length === 0) {
-          finalText = stepText;
+    try {
+      // Agentic loop for tool calling
+      while (step < maxSteps) {
+        if (effectiveSignal.aborted) {
+          wasAborted = true;
           break;
         }
+        step++;
+        logger.debug(`[GoogleVertex] Native SDK step ${step}/${maxSteps}`);
 
-        // Check for final_result tool call - this is our structured output pattern
-        if (useFinalResultTool) {
-          const finalResultCall = stepFunctionCalls.find(
-            (call) => call.name === "final_result",
-          );
-          if (finalResultCall) {
-            // Extract the structured output from final_result arguments
-            finalResultStructuredOutput = finalResultCall.args as Record<
-              string,
-              unknown
-            >;
-            logger.debug(
-              "[GoogleVertex] Received final_result tool call with structured output (stream)",
-              {
-                outputKeys: Object.keys(finalResultStructuredOutput),
-              },
-            );
-            // Return the structured output as JSON text
-            finalText = JSON.stringify(finalResultStructuredOutput);
+        try {
+          const stream = await client.models.generateContentStream({
+            model: modelName,
+            contents: currentContents,
+            config: { ...config, abortSignal: effectiveSignal },
+          });
+
+          const stepFunctionCalls: Array<{
+            name: string;
+            args: Record<string, unknown>;
+          }> = [];
+
+          // Capture raw response parts including thoughtSignature
+          const rawResponseParts: unknown[] = [];
+
+          for await (const chunk of stream) {
+            // Extract raw parts from candidates FIRST
+            // This avoids using chunk.text which triggers SDK warning when
+            // non-text parts (thoughtSignature, functionCall) are present
+            const chunkRecord = chunk as Record<string, unknown>;
+            const candidates = chunkRecord.candidates as
+              | Array<Record<string, unknown>>
+              | undefined;
+            const firstCandidate = candidates?.[0];
+            // Capture the SDK finish reason (Bug 2: previously dropped). Last
+            // non-empty value across chunks wins.
+            const chunkFinishReason = firstCandidate?.finishReason;
+            if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+              lastFinishReason = chunkFinishReason;
+            }
+            const chunkContent = firstCandidate?.content as
+              | Record<string, unknown>
+              | undefined;
+            if (chunkContent && Array.isArray(chunkContent.parts)) {
+              for (const part of chunkContent.parts as Array<
+                Record<string, unknown>
+              >) {
+                rawResponseParts.push(part);
+                if (typeof part.text === "string" && part.text.length > 0) {
+                  incrementalTextChunks.push(part.text);
+                }
+              }
+            }
+            if (chunk.functionCalls) {
+              stepFunctionCalls.push(...chunk.functionCalls);
+            }
+
+            // Extract usage metadata from chunk
+            // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
+            const usageMetadata = chunkRecord.usageMetadata as
+              | {
+                  promptTokenCount?: number;
+                  candidatesTokenCount?: number;
+                  totalTokenCount?: number;
+                }
+              | undefined;
+            if (usageMetadata) {
+              // Take the latest promptTokenCount (usually only in final chunk)
+              if (
+                usageMetadata.promptTokenCount !== undefined &&
+                usageMetadata.promptTokenCount > 0
+              ) {
+                totalInputTokens = usageMetadata.promptTokenCount;
+              }
+              // Take the latest candidatesTokenCount (accumulates through chunks)
+              if (
+                usageMetadata.candidatesTokenCount !== undefined &&
+                usageMetadata.candidatesTokenCount > 0
+              ) {
+                totalOutputTokens = usageMetadata.candidatesTokenCount;
+              }
+            }
+          }
+
+          // Extract text from raw parts after stream completes
+          // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
+          const stepText = rawResponseParts
+            .filter(
+              (part): part is { text: string } =>
+                typeof (part as Record<string, unknown>).text === "string",
+            )
+            .map((part) => part.text)
+            .join("");
+
+          // If no function calls, we're done
+          if (stepFunctionCalls.length === 0) {
+            finalText = stepText;
             break;
           }
-        }
 
-        // Execute function calls
-        logger.debug(
-          `[GoogleVertex] Executing ${stepFunctionCalls.length} function calls`,
-        );
-
-        // Add model response with ALL parts (including thoughtSignature) to history
-        // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
-        currentContents.push({
-          role: "model",
-          parts:
-            rawResponseParts.length > 0
-              ? (rawResponseParts as Array<{ text: string }>)
-              : (stepFunctionCalls.map((fc) => ({
-                  functionCall: fc,
-                })) as unknown as Array<{ text: string }>),
-        });
-
-        // Execute each function and collect responses
-        const functionResponses: Array<{
-          functionResponse: { name: string; response: unknown };
-        }> = [];
-        // Per-step bookkeeping for conversation-memory storage.
-        const stepStorageCalls: Array<{
-          toolName: string;
-          args: Record<string, unknown>;
-        }> = [];
-        const stepStorageResults: Array<{
-          toolName: string;
-          output: unknown;
-        }> = [];
-
-        // Note: tool:start / tool:end events are emitted by ToolsManager's
-        // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
-        for (const call of stepFunctionCalls) {
-          allToolCalls.push({ toolName: call.name, args: call.args });
-          stepStorageCalls.push({ toolName: call.name, args: call.args });
-
-          // Check if this tool has already exceeded retry limit
-          const failedInfo = failedTools.get(call.name);
-          if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
-            logger.warn(
-              `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
+          // Check for final_result tool call - this is our structured output pattern
+          if (useFinalResultTool) {
+            const finalResultCall = stepFunctionCalls.find(
+              (call) => call.name === "final_result",
             );
-            const errorPayload = {
-              error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
-              status: "permanently_failed",
-              do_not_retry: true,
-            };
-            functionResponses.push({
-              functionResponse: {
-                name: call.name,
-                response: errorPayload,
-              },
-            });
-            toolExecutions.push({
-              name: call.name,
-              input: call.args,
-              output: errorPayload,
-            });
-            stepStorageResults.push({
-              toolName: call.name,
-              output: errorPayload,
-            });
-            continue;
+            if (finalResultCall) {
+              // Extract the structured output from final_result arguments
+              finalResultStructuredOutput = finalResultCall.args as Record<
+                string,
+                unknown
+              >;
+              logger.debug(
+                "[GoogleVertex] Received final_result tool call with structured output (stream)",
+                {
+                  outputKeys: Object.keys(finalResultStructuredOutput),
+                },
+              );
+              // Return the structured output as JSON text
+              finalText = JSON.stringify(finalResultStructuredOutput);
+              break;
+            }
           }
 
-          const execute = executeMap.get(call.name);
-          if (execute) {
-            try {
-              // AI SDK Tool execute requires (args, options) - provide minimal options
-              const toolOptions = {
-                toolCallId: `${call.name}-${Date.now()}`,
-                messages: [],
-                abortSignal: undefined as AbortSignal | undefined,
+          // Execute function calls
+          logger.debug(
+            `[GoogleVertex] Executing ${stepFunctionCalls.length} function calls`,
+          );
+
+          // Add model response with ALL parts (including thoughtSignature) to history
+          // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
+          currentContents.push({
+            role: "model",
+            parts:
+              rawResponseParts.length > 0
+                ? (rawResponseParts as Array<{ text: string }>)
+                : (stepFunctionCalls.map((fc) => ({
+                    functionCall: fc,
+                  })) as unknown as Array<{ text: string }>),
+          });
+
+          // Execute each function and collect responses
+          const functionResponses: Array<{
+            functionResponse: { name: string; response: unknown };
+          }> = [];
+          // Per-step bookkeeping for conversation-memory storage.
+          const stepStorageCalls: Array<{
+            toolName: string;
+            args: Record<string, unknown>;
+          }> = [];
+          const stepStorageResults: Array<{
+            toolName: string;
+            output: unknown;
+          }> = [];
+
+          // Note: tool:start / tool:end events are emitted by ToolsManager's
+          // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
+          for (const call of stepFunctionCalls) {
+            allToolCalls.push({ toolName: call.name, args: call.args });
+            stepStorageCalls.push({ toolName: call.name, args: call.args });
+
+            // Check if this tool has already exceeded retry limit
+            const failedInfo = failedTools.get(call.name);
+            if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
+              logger.warn(
+                `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
+              );
+              const errorPayload = {
+                error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
+                status: "permanently_failed",
+                do_not_retry: true,
               };
-              const result = await execute(call.args, toolOptions);
+              functionResponses.push({
+                functionResponse: {
+                  name: call.name,
+                  response: errorPayload,
+                },
+              });
               toolExecutions.push({
                 name: call.name,
                 input: call.args,
-                output: result,
-              });
-              functionResponses.push({
-                functionResponse: { name: call.name, response: { result } },
+                output: errorPayload,
               });
               stepStorageResults.push({
                 toolName: call.name,
-                output: result,
+                output: errorPayload,
               });
-            } catch (error) {
-              const errorMessage =
-                error instanceof Error ? error.message : "Unknown error";
+              continue;
+            }
 
-              // Track this failure
-              const currentFailInfo = failedTools.get(call.name) || {
-                count: 0,
-                lastError: "",
-              };
-              currentFailInfo.count++;
-              currentFailInfo.lastError = errorMessage;
-              failedTools.set(call.name, currentFailInfo);
+            const execute = executeMap.get(call.name);
+            if (execute) {
+              try {
+                // AI SDK Tool execute requires (args, options) - provide minimal options
+                const toolOptions = {
+                  toolCallId: `${call.name}-${Date.now()}`,
+                  messages: [],
+                  abortSignal: effectiveSignal,
+                };
+                const result = await execute(call.args, toolOptions);
+                toolExecutions.push({
+                  name: call.name,
+                  input: call.args,
+                  output: result,
+                });
+                functionResponses.push({
+                  functionResponse: { name: call.name, response: { result } },
+                });
+                stepStorageResults.push({
+                  toolName: call.name,
+                  output: result,
+                });
+              } catch (error) {
+                // An abort during tool execution ends the turn gracefully — it
+                // must NOT be recorded as a spurious tool failure. Both checks
+                // matter: effectiveSignal.aborted catches an abort WE triggered
+                // (even if the throw isn't abort-shaped); isAbortError(error)
+                // catches an abort-shaped throw (e.g. a tool raising AbortError)
+                // even when the signal itself never fired.
+                if (effectiveSignal.aborted || isAbortError(error)) {
+                  wasAborted = true;
+                  break;
+                }
+                const errorMessage =
+                  error instanceof Error ? error.message : "Unknown error";
 
-              logger.warn(
-                `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
-              );
+                // Track this failure
+                const currentFailInfo = failedTools.get(call.name) || {
+                  count: 0,
+                  lastError: "",
+                };
+                currentFailInfo.count++;
+                currentFailInfo.lastError = errorMessage;
+                failedTools.set(call.name, currentFailInfo);
 
-              // Determine if this is a permanent failure
-              const isPermanentFailure =
-                currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
+                logger.warn(
+                  `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
+                );
 
+                // Determine if this is a permanent failure
+                const isPermanentFailure =
+                  currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
+
+                const errorPayload = {
+                  error: isPermanentFailure
+                    ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
+                    : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
+                  status: isPermanentFailure ? "permanently_failed" : "failed",
+                  do_not_retry: isPermanentFailure,
+                  retry_count: currentFailInfo.count,
+                  max_retries: DEFAULT_TOOL_MAX_RETRIES,
+                };
+                functionResponses.push({
+                  functionResponse: {
+                    name: call.name,
+                    response: errorPayload,
+                  },
+                });
+                toolExecutions.push({
+                  name: call.name,
+                  input: call.args,
+                  output: errorPayload,
+                });
+                stepStorageResults.push({
+                  toolName: call.name,
+                  output: errorPayload,
+                });
+              }
+            } else {
+              // Tool not found is a permanent error
               const errorPayload = {
-                error: isPermanentFailure
-                  ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
-                  : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
-                status: isPermanentFailure ? "permanently_failed" : "failed",
-                do_not_retry: isPermanentFailure,
-                retry_count: currentFailInfo.count,
-                max_retries: DEFAULT_TOOL_MAX_RETRIES,
+                error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
+                status: "permanently_failed",
+                do_not_retry: true,
               };
               functionResponses.push({
                 functionResponse: {
@@ -2033,125 +2101,137 @@ export class GoogleVertexProvider extends BaseProvider {
                 output: errorPayload,
               });
             }
-          } else {
-            // Tool not found is a permanent error
-            const errorPayload = {
-              error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
-              status: "permanently_failed",
-              do_not_retry: true,
-            };
-            functionResponses.push({
-              functionResponse: {
-                name: call.name,
-                response: errorPayload,
-              },
-            });
-            toolExecutions.push({
-              name: call.name,
-              input: call.args,
-              output: errorPayload,
-            });
-            stepStorageResults.push({
-              toolName: call.name,
-              output: errorPayload,
+          }
+
+          // An abort inside the tool-exec loop only breaks that inner for-loop.
+          // Break the while too so no further model call is issued and control
+          // reaches the terminal step-cap handling below.
+          if (wasAborted) {
+            break;
+          }
+
+          // Persist this step's tool calls/results into conversation memory.
+          // Without this, tool_call / tool_result rows never reach Redis and
+          // the chat-history UI loses every tool invocation.
+          //
+          // `thoughtSignature` rides as a sibling on the first call of the
+          // step — Gemini 3 needs it to match thinking patterns when the
+          // conversation is replayed on the next turn.
+          if (stepStorageCalls.length > 0 || stepStorageResults.length > 0) {
+            const stepThoughtSig = extractThoughtSignature(rawResponseParts);
+            withTimeout(
+              this.handleToolExecutionStorage(
+                stepStorageCalls.map((c, i) => ({
+                  ...c,
+                  ...(i === 0 && stepThoughtSig
+                    ? { thoughtSignature: stepThoughtSig }
+                    : {}),
+                  stepIndex: step,
+                })),
+                stepStorageResults.map((r) => ({ ...r, stepIndex: step })),
+                options,
+                new Date(),
+              ),
+              TOOL_STORAGE_TIMEOUT_MS,
+              "tool storage write timed out",
+            ).catch((error: unknown) => {
+              logger.warn(
+                "[GoogleVertex] Failed to store native Gemini stream tool executions",
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
             });
           }
-        }
 
-        // Persist this step's tool calls/results into conversation memory.
-        // Without this, tool_call / tool_result rows never reach Redis and
-        // the chat-history UI loses every tool invocation.
-        //
-        // `thoughtSignature` rides as a sibling on the first call of the
-        // step — Gemini 3 needs it to match thinking patterns when the
-        // conversation is replayed on the next turn.
-        if (stepStorageCalls.length > 0 || stepStorageResults.length > 0) {
-          const stepThoughtSig = extractThoughtSignature(rawResponseParts);
-          withTimeout(
-            this.handleToolExecutionStorage(
-              stepStorageCalls.map((c, i) => ({
-                ...c,
-                ...(i === 0 && stepThoughtSig
-                  ? { thoughtSignature: stepThoughtSig }
-                  : {}),
-                stepIndex: step,
-              })),
-              stepStorageResults.map((r) => ({ ...r, stepIndex: step })),
-              options,
-              new Date(),
-            ),
-            TOOL_STORAGE_TIMEOUT_MS,
-            "tool storage write timed out",
-          ).catch((error: unknown) => {
-            logger.warn(
-              "[GoogleVertex] Failed to store native Gemini stream tool executions",
-              {
-                error: error instanceof Error ? error.message : String(error),
-              },
-            );
+          // The @google/genai SDK only accepts "user" and "model" as valid
+          // roles in contents — function/tool responses must use role: "user"
+          // (matching the SDK's automaticFunctionCalling implementation and
+          // the Google AI Studio path). Sending role: "function" was causing
+          // native Vertex Gemini tool loops to be silently rejected by the
+          // request validator.
+          currentContents.push({
+            role: "user",
+            parts: functionResponses as unknown as Array<{ text: string }>,
           });
-        }
-
-        // The @google/genai SDK only accepts "user" and "model" as valid
-        // roles in contents — function/tool responses must use role: "user"
-        // (matching the SDK's automaticFunctionCalling implementation and
-        // the Google AI Studio path). Sending role: "function" was causing
-        // native Vertex Gemini tool loops to be silently rejected by the
-        // request validator.
-        currentContents.push({
-          role: "user",
-          parts: functionResponses as unknown as Array<{ text: string }>,
-        });
-      } catch (error) {
-        logger.error("[GoogleVertex] Native SDK error", error);
-        throw this.handleProviderError(error);
-      }
-    }
-
-    // Handle maxSteps termination — the loop exited because the step cap was
-    // reached while the model was still calling tools. Surface a real answer
-    // instead of the canned placeholder (Bug 1) and a meaningful finishReason
-    // (Bug 2).
-    let hitStepLimit = false;
-    let synthesizedFinalAnswer = false;
-    if (step >= maxSteps && !finalText) {
-      hitStepLimit = true;
-      // The consumer receives text via `incrementalTextChunks`; any text the
-      // model emitted across steps is already preserved there. Only synthesize
-      // when NOTHING was produced (the pure-functionCall case that otherwise
-      // surfaces the placeholder) so we never waste a round-trip whose output
-      // the stream would ignore.
-      if (incrementalTextChunks.length === 0) {
-        logger.warn(
-          `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
-            `with no text; synthesizing a final answer with tools disabled.`,
-        );
-        const synth = await this.synthesizeFinalAnswerWithoutTools(
-          client,
-          modelName,
-          config,
-          currentContents,
-          useFinalResultTool,
-          parseTimeout(options.timeout) ?? 300_000,
-        );
-        if (synth.text) {
-          synthesizedFinalAnswer = true;
-          finalText = synth.text;
-          incrementalTextChunks.push(synth.text);
-          totalInputTokens += synth.inputTokens;
-          totalOutputTokens += synth.outputTokens;
-          if (synth.finishReason) {
-            lastFinishReason = synth.finishReason;
+        } catch (error) {
+          // A mid-drain abort surfaces as an AbortError from the `for await`.
+          // Break gracefully into the terminal block instead of re-throwing
+          // (a re-throw would route the caller's abort into a second unbounded
+          // fallback stream()). Dual check as with the inner catch:
+          // effectiveSignal.aborted (a signal we tripped) OR isAbortError(error)
+          // (an abort-shaped throw) — either means "stop", not a real failure.
+          if (effectiveSignal.aborted || isAbortError(error)) {
+            wasAborted = true;
+            break;
           }
-        } else {
-          finalText = `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+          logger.error("[GoogleVertex] Native SDK error", error);
+          throw this.handleProviderError(error);
         }
-      } else {
-        logger.warn(
-          `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
-            `returning text already gathered from prior steps.`,
-        );
       }
+
+      // Handle maxSteps termination / abort — the loop exited because the step
+      // cap was reached (or the turn was aborted) while the model was still
+      // calling tools. Surface a real answer instead of the canned placeholder
+      // (Bug 1) and a meaningful finishReason (Bug 2).
+      if (!finalText && (step >= maxSteps || wasAborted)) {
+        hitStepLimit = step >= maxSteps && !wasAborted;
+        const toolCallCount = allToolCalls.filter(
+          (tc) => tc.toolName !== "final_result",
+        ).length;
+        // The consumer receives text via `incrementalTextChunks`; any text the
+        // model emitted across steps is already preserved there. Only produce a
+        // terminal message when NOTHING was produced (the pure-functionCall /
+        // abort case that otherwise surfaces the placeholder). When chunks
+        // exist, leave `finalText` empty so `textPartsToYield` keeps replaying
+        // the gathered chunks instead of collapsing to a single one.
+        if (incrementalTextChunks.length > 0) {
+          logger.warn(
+            `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+              `returning text already gathered from prior steps.`,
+          );
+        } else if (wasAborted) {
+          // Aborted turn — skip synth entirely so it can never add +300s after
+          // a blown budget. Deliver exactly one graceful cap chunk.
+          logger.warn(
+            `[GoogleVertex] Tool call loop aborted mid-turn; ` +
+              `returning a graceful cap message.`,
+          );
+          finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+        } else {
+          logger.warn(
+            `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+              `with no text; synthesizing a final answer with tools disabled.`,
+          );
+          // synth self-bounds its connect+drain via withTimeout(timeoutMs) and
+          // never throws (returns empty on timeout/error), so it needs no outer
+          // withTimeout wrapper — see synthesizeFinalAnswerWithoutTools.
+          const synth = await this.synthesizeFinalAnswerWithoutTools(
+            client,
+            modelName,
+            config,
+            currentContents,
+            useFinalResultTool,
+            parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS,
+            effectiveSignal,
+          );
+          if (synth.text) {
+            synthesizedFinalAnswer = true;
+            finalText = synth.text;
+            incrementalTextChunks.push(synth.text);
+            totalInputTokens += synth.inputTokens;
+            totalOutputTokens += synth.outputTokens;
+            if (synth.finishReason) {
+              lastFinishReason = synth.finishReason;
+            }
+          } else {
+            finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+          }
+        }
+      }
+    } finally {
+      clearTimeout(defensiveTimer);
+      options.abortSignal?.removeEventListener("abort", onCallerAbort);
     }
 
     // Unified finish reason: a step-cap exhaustion that did NOT end in a clean
@@ -2656,237 +2736,300 @@ export class GoogleVertexProvider extends BaseProvider {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
 
-    // Agentic loop for tool calling
-    while (step < maxSteps) {
-      step++;
-      logger.debug(
-        `[GoogleVertex] Native SDK generate step ${step}/${maxSteps}`,
+    // Abort scaffolding (mirrors executeNativeAnthropicStream). The native
+    // Gemini SDK cancels via config.abortSignal, so drive an internal
+    // AbortController: the caller's signal and a defensive wall-clock timer
+    // both trip it, and every request/tool-exec receives effectiveSignal.
+    const streamTimeoutMs =
+      parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS;
+    const internalAbort = new AbortController();
+    const onCallerAbort = () => internalAbort.abort();
+    options.abortSignal?.addEventListener("abort", onCallerAbort);
+    const defensiveTimer = setTimeout(() => {
+      logger.warn(
+        `[GoogleVertex] Native Gemini turn exceeded ${streamTimeoutMs}ms — aborting`,
       );
+      internalAbort.abort();
+    }, streamTimeoutMs);
+    const effectiveSignal = internalAbort.signal;
+    if (options.abortSignal?.aborted) {
+      internalAbort.abort();
+    }
+    let wasAborted = false;
 
-      try {
-        // Use generateContentStream and collect all chunks (same as GoogleAIStudio)
-        const stream = await client.models.generateContentStream({
-          model: modelName,
-          contents: currentContents,
-          config,
-        });
+    // Step-cap flags declared in the outer scope so the terminal block (also
+    // inside the try) and the finishReason mapping (after the finally) can
+    // both read them.
+    let hitStepLimit = false;
+    let synthesizedFinalAnswer = false;
 
-        const stepFunctionCalls: Array<{
-          name: string;
-          args: Record<string, unknown>;
-        }> = [];
-
-        // Capture raw response parts including thoughtSignature
-        const rawResponseParts: unknown[] = [];
-
-        // Collect all chunks from stream
-        for await (const chunk of stream) {
-          // Extract raw parts from candidates FIRST
-          // This avoids using chunk.text which triggers SDK warning when
-          // non-text parts (thoughtSignature, functionCall) are present
-          const chunkRecord = chunk as Record<string, unknown>;
-          const candidates = chunkRecord.candidates as
-            | Array<Record<string, unknown>>
-            | undefined;
-          const firstCandidate = candidates?.[0];
-          // Capture the SDK finish reason (Bug 2: previously dropped). Last
-          // non-empty value across chunks wins.
-          const chunkFinishReason = firstCandidate?.finishReason;
-          if (typeof chunkFinishReason === "string" && chunkFinishReason) {
-            lastFinishReason = chunkFinishReason;
-          }
-          const chunkContent = firstCandidate?.content as
-            | Record<string, unknown>
-            | undefined;
-          if (chunkContent && Array.isArray(chunkContent.parts)) {
-            rawResponseParts.push(...chunkContent.parts);
-          }
-          if (chunk.functionCalls) {
-            stepFunctionCalls.push(...chunk.functionCalls);
-          }
-
-          // Extract usage metadata from chunk
-          // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
-          const usageMetadata = chunkRecord.usageMetadata as
-            | {
-                promptTokenCount?: number;
-                candidatesTokenCount?: number;
-                totalTokenCount?: number;
-              }
-            | undefined;
-          if (usageMetadata) {
-            // Take the latest promptTokenCount (usually only in final chunk)
-            if (
-              usageMetadata.promptTokenCount !== undefined &&
-              usageMetadata.promptTokenCount > 0
-            ) {
-              totalInputTokens = usageMetadata.promptTokenCount;
-            }
-            // Take the latest candidatesTokenCount (accumulates through chunks)
-            if (
-              usageMetadata.candidatesTokenCount !== undefined &&
-              usageMetadata.candidatesTokenCount > 0
-            ) {
-              totalOutputTokens = usageMetadata.candidatesTokenCount;
-            }
-          }
-        }
-
-        // Extract text from raw parts after stream completes
-        // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
-        const stepText = rawResponseParts
-          .filter(
-            (part): part is { text: string } =>
-              typeof (part as Record<string, unknown>).text === "string",
-          )
-          .map((part) => part.text)
-          .join("");
-
-        // If no function calls, we're done
-        if (stepFunctionCalls.length === 0) {
-          finalText = stepText;
+    try {
+      // Agentic loop for tool calling
+      while (step < maxSteps) {
+        if (effectiveSignal.aborted) {
+          wasAborted = true;
           break;
         }
-
-        // Check for final_result tool call - this is our structured output pattern
-        if (useFinalResultTool) {
-          const finalResultCall = stepFunctionCalls.find(
-            (call) => call.name === "final_result",
-          );
-          if (finalResultCall) {
-            // Extract the structured output from final_result arguments
-            finalResultStructuredOutput = finalResultCall.args as Record<
-              string,
-              unknown
-            >;
-            logger.debug(
-              "[GoogleVertex] Received final_result tool call with structured output (generate)",
-              {
-                outputKeys: Object.keys(finalResultStructuredOutput),
-              },
-            );
-            // Return the structured output as JSON text
-            finalText = JSON.stringify(finalResultStructuredOutput);
-            break;
-          }
-        }
-
-        // Accumulate non-empty step text across steps so the
-        // maxSteps-exhaustion exit can surface the prose the model produced
-        // instead of a canned placeholder (Bug 1). Mirrors the Vertex-Claude
-        // loop's text accumulation.
-        accumulatedText = appendStepText(accumulatedText, stepText);
-
-        // Execute function calls
+        step++;
         logger.debug(
-          `[GoogleVertex] Generate executing ${stepFunctionCalls.length} function calls`,
+          `[GoogleVertex] Native SDK generate step ${step}/${maxSteps}`,
         );
 
-        // Add model response with ALL parts (including thoughtSignature) to history
-        // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
-        currentContents.push({
-          role: "model",
-          parts:
-            rawResponseParts.length > 0
-              ? (rawResponseParts as Array<{ text: string }>)
-              : (stepFunctionCalls.map((fc) => ({
-                  functionCall: fc,
-                })) as unknown as Array<{ text: string }>),
-        });
+        try {
+          // Use generateContentStream and collect all chunks (same as GoogleAIStudio)
+          const stream = await client.models.generateContentStream({
+            model: modelName,
+            contents: currentContents,
+            config: { ...config, abortSignal: effectiveSignal },
+          });
 
-        // Execute each function and collect responses
-        const functionResponses: Array<{
-          functionResponse: { name: string; response: unknown };
-        }> = [];
-        const toolCallsBefore = allToolCalls.length;
-        const toolExecsBefore = toolExecutions.length;
-        // Note: tool:start / tool:end events are emitted by ToolsManager's
-        // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
+          const stepFunctionCalls: Array<{
+            name: string;
+            args: Record<string, unknown>;
+          }> = [];
 
-        for (const call of stepFunctionCalls) {
-          allToolCalls.push({ toolName: call.name, args: call.args });
+          // Capture raw response parts including thoughtSignature
+          const rawResponseParts: unknown[] = [];
 
-          // Check if this tool has already exceeded retry limit
-          const failedInfo = failedTools.get(call.name);
-          if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
-            logger.warn(
-              `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
-            );
+          // Collect all chunks from stream
+          for await (const chunk of stream) {
+            // Extract raw parts from candidates FIRST
+            // This avoids using chunk.text which triggers SDK warning when
+            // non-text parts (thoughtSignature, functionCall) are present
+            const chunkRecord = chunk as Record<string, unknown>;
+            const candidates = chunkRecord.candidates as
+              | Array<Record<string, unknown>>
+              | undefined;
+            const firstCandidate = candidates?.[0];
+            // Capture the SDK finish reason (Bug 2: previously dropped). Last
+            // non-empty value across chunks wins.
+            const chunkFinishReason = firstCandidate?.finishReason;
+            if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+              lastFinishReason = chunkFinishReason;
+            }
+            const chunkContent = firstCandidate?.content as
+              | Record<string, unknown>
+              | undefined;
+            if (chunkContent && Array.isArray(chunkContent.parts)) {
+              rawResponseParts.push(...chunkContent.parts);
+            }
+            if (chunk.functionCalls) {
+              stepFunctionCalls.push(...chunk.functionCalls);
+            }
 
-            const errorOutput = {
-              error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
-              status: "permanently_failed",
-              do_not_retry: true,
-            };
-
-            toolExecutions.push({
-              name: call.name,
-              input: call.args,
-              output: errorOutput,
-            });
-
-            functionResponses.push({
-              functionResponse: {
-                name: call.name,
-                response: errorOutput,
-              },
-            });
-            continue;
+            // Extract usage metadata from chunk
+            // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
+            const usageMetadata = chunkRecord.usageMetadata as
+              | {
+                  promptTokenCount?: number;
+                  candidatesTokenCount?: number;
+                  totalTokenCount?: number;
+                }
+              | undefined;
+            if (usageMetadata) {
+              // Take the latest promptTokenCount (usually only in final chunk)
+              if (
+                usageMetadata.promptTokenCount !== undefined &&
+                usageMetadata.promptTokenCount > 0
+              ) {
+                totalInputTokens = usageMetadata.promptTokenCount;
+              }
+              // Take the latest candidatesTokenCount (accumulates through chunks)
+              if (
+                usageMetadata.candidatesTokenCount !== undefined &&
+                usageMetadata.candidatesTokenCount > 0
+              ) {
+                totalOutputTokens = usageMetadata.candidatesTokenCount;
+              }
+            }
           }
 
-          const execute = executeMap.get(call.name);
-          if (execute) {
-            try {
-              // AI SDK Tool execute requires (args, options) - provide minimal options
-              const toolOptions = {
-                toolCallId: `${call.name}-${Date.now()}`,
-                messages: [],
-                abortSignal: undefined as AbortSignal | undefined,
-              };
-              const execResult = await execute(call.args, toolOptions);
+          // Extract text from raw parts after stream completes
+          // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
+          const stepText = rawResponseParts
+            .filter(
+              (part): part is { text: string } =>
+                typeof (part as Record<string, unknown>).text === "string",
+            )
+            .map((part) => part.text)
+            .join("");
 
-              // Track execution
+          // If no function calls, we're done
+          if (stepFunctionCalls.length === 0) {
+            finalText = stepText;
+            break;
+          }
+
+          // Check for final_result tool call - this is our structured output pattern
+          if (useFinalResultTool) {
+            const finalResultCall = stepFunctionCalls.find(
+              (call) => call.name === "final_result",
+            );
+            if (finalResultCall) {
+              // Extract the structured output from final_result arguments
+              finalResultStructuredOutput = finalResultCall.args as Record<
+                string,
+                unknown
+              >;
+              logger.debug(
+                "[GoogleVertex] Received final_result tool call with structured output (generate)",
+                {
+                  outputKeys: Object.keys(finalResultStructuredOutput),
+                },
+              );
+              // Return the structured output as JSON text
+              finalText = JSON.stringify(finalResultStructuredOutput);
+              break;
+            }
+          }
+
+          // Accumulate non-empty step text across steps so the
+          // maxSteps-exhaustion exit can surface the prose the model produced
+          // instead of a canned placeholder (Bug 1). Mirrors the Vertex-Claude
+          // loop's text accumulation.
+          accumulatedText = appendStepText(accumulatedText, stepText);
+
+          // Execute function calls
+          logger.debug(
+            `[GoogleVertex] Generate executing ${stepFunctionCalls.length} function calls`,
+          );
+
+          // Add model response with ALL parts (including thoughtSignature) to history
+          // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
+          currentContents.push({
+            role: "model",
+            parts:
+              rawResponseParts.length > 0
+                ? (rawResponseParts as Array<{ text: string }>)
+                : (stepFunctionCalls.map((fc) => ({
+                    functionCall: fc,
+                  })) as unknown as Array<{ text: string }>),
+          });
+
+          // Execute each function and collect responses
+          const functionResponses: Array<{
+            functionResponse: { name: string; response: unknown };
+          }> = [];
+          const toolCallsBefore = allToolCalls.length;
+          const toolExecsBefore = toolExecutions.length;
+          // Note: tool:start / tool:end events are emitted by ToolsManager's
+          // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
+
+          for (const call of stepFunctionCalls) {
+            allToolCalls.push({ toolName: call.name, args: call.args });
+
+            // Check if this tool has already exceeded retry limit
+            const failedInfo = failedTools.get(call.name);
+            if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
+              logger.warn(
+                `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
+              );
+
+              const errorOutput = {
+                error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
+                status: "permanently_failed",
+                do_not_retry: true,
+              };
+
               toolExecutions.push({
                 name: call.name,
                 input: call.args,
-                output: execResult,
+                output: errorOutput,
               });
 
               functionResponses.push({
                 functionResponse: {
                   name: call.name,
-                  response: { result: execResult },
+                  response: errorOutput,
                 },
               });
-            } catch (error) {
-              const errorMessage =
-                error instanceof Error ? error.message : "Unknown error";
+              continue;
+            }
 
-              // Track this failure
-              const currentFailInfo = failedTools.get(call.name) || {
-                count: 0,
-                lastError: "",
-              };
-              currentFailInfo.count++;
-              currentFailInfo.lastError = errorMessage;
-              failedTools.set(call.name, currentFailInfo);
+            const execute = executeMap.get(call.name);
+            if (execute) {
+              try {
+                // AI SDK Tool execute requires (args, options) - provide minimal options
+                const toolOptions = {
+                  toolCallId: `${call.name}-${Date.now()}`,
+                  messages: [],
+                  abortSignal: effectiveSignal,
+                };
+                const execResult = await execute(call.args, toolOptions);
 
-              logger.warn(
-                `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
-              );
+                // Track execution
+                toolExecutions.push({
+                  name: call.name,
+                  input: call.args,
+                  output: execResult,
+                });
 
-              // Determine if this is a permanent failure
-              const isPermanentFailure =
-                currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
+                functionResponses.push({
+                  functionResponse: {
+                    name: call.name,
+                    response: { result: execResult },
+                  },
+                });
+              } catch (error) {
+                // An abort during tool execution ends the turn gracefully — it
+                // must NOT be recorded as a spurious tool failure. Both checks
+                // matter: effectiveSignal.aborted catches an abort WE triggered
+                // (even if the throw isn't abort-shaped); isAbortError(error)
+                // catches an abort-shaped throw (e.g. a tool raising AbortError)
+                // even when the signal itself never fired.
+                if (effectiveSignal.aborted || isAbortError(error)) {
+                  wasAborted = true;
+                  break;
+                }
+                const errorMessage =
+                  error instanceof Error ? error.message : "Unknown error";
 
+                // Track this failure
+                const currentFailInfo = failedTools.get(call.name) || {
+                  count: 0,
+                  lastError: "",
+                };
+                currentFailInfo.count++;
+                currentFailInfo.lastError = errorMessage;
+                failedTools.set(call.name, currentFailInfo);
+
+                logger.warn(
+                  `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
+                );
+
+                // Determine if this is a permanent failure
+                const isPermanentFailure =
+                  currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
+
+                const errorOutput = {
+                  error: isPermanentFailure
+                    ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
+                    : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
+                  status: isPermanentFailure ? "permanently_failed" : "failed",
+                  do_not_retry: isPermanentFailure,
+                  retry_count: currentFailInfo.count,
+                  max_retries: DEFAULT_TOOL_MAX_RETRIES,
+                };
+
+                toolExecutions.push({
+                  name: call.name,
+                  input: call.args,
+                  output: errorOutput,
+                });
+
+                functionResponses.push({
+                  functionResponse: {
+                    name: call.name,
+                    response: errorOutput,
+                  },
+                });
+              }
+            } else {
+              // Tool not found is a permanent error
               const errorOutput = {
-                error: isPermanentFailure
-                  ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
-                  : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
-                status: isPermanentFailure ? "permanently_failed" : "failed",
-                do_not_retry: isPermanentFailure,
-                retry_count: currentFailInfo.count,
-                max_retries: DEFAULT_TOOL_MAX_RETRIES,
+                error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
+                status: "permanently_failed",
+                do_not_retry: true,
               };
 
               toolExecutions.push({
@@ -2902,125 +3045,138 @@ export class GoogleVertexProvider extends BaseProvider {
                 },
               });
             }
-          } else {
-            // Tool not found is a permanent error
-            const errorOutput = {
-              error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
-              status: "permanently_failed",
-              do_not_retry: true,
-            };
+          }
 
-            toolExecutions.push({
-              name: call.name,
-              input: call.args,
-              output: errorOutput,
-            });
+          // An abort inside the tool-exec loop only breaks that inner for-loop.
+          // Break the while too so no further model call is issued and control
+          // reaches the terminal step-cap handling below.
+          if (wasAborted) {
+            break;
+          }
 
-            functionResponses.push({
-              functionResponse: {
-                name: call.name,
-                response: errorOutput,
-              },
+          // Persist this step's tool calls/results into conversation memory.
+          // Without this, tool_call / tool_result rows never reach Redis and
+          // the chat-history UI loses every tool invocation. The first call
+          // of the step carries the step's `thoughtSignature` so Gemini 3 can
+          // match thinking patterns on replay.
+          const stepToolCalls = allToolCalls.slice(toolCallsBefore);
+          const stepToolExecs = toolExecutions.slice(toolExecsBefore);
+          if (stepToolCalls.length > 0 || stepToolExecs.length > 0) {
+            const stepThoughtSig = extractThoughtSignature(rawResponseParts);
+            withTimeout(
+              this.handleToolExecutionStorage(
+                stepToolCalls.map((tc, i) => ({
+                  toolName: tc.toolName,
+                  args: tc.args,
+                  ...(i === 0 && stepThoughtSig
+                    ? { thoughtSignature: stepThoughtSig }
+                    : {}),
+                  stepIndex: step,
+                })),
+                stepToolExecs.map((te) => ({
+                  toolName: te.name,
+                  output: te.output,
+                  stepIndex: step,
+                })),
+                options,
+                new Date(),
+              ),
+              TOOL_STORAGE_TIMEOUT_MS,
+              "tool storage write timed out",
+            ).catch((error: unknown) => {
+              logger.warn(
+                "[GoogleVertex] Failed to store native Gemini generate tool executions",
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
             });
           }
-        }
 
-        // Persist this step's tool calls/results into conversation memory.
-        // Without this, tool_call / tool_result rows never reach Redis and
-        // the chat-history UI loses every tool invocation. The first call
-        // of the step carries the step's `thoughtSignature` so Gemini 3 can
-        // match thinking patterns on replay.
-        const stepToolCalls = allToolCalls.slice(toolCallsBefore);
-        const stepToolExecs = toolExecutions.slice(toolExecsBefore);
-        if (stepToolCalls.length > 0 || stepToolExecs.length > 0) {
-          const stepThoughtSig = extractThoughtSignature(rawResponseParts);
-          withTimeout(
-            this.handleToolExecutionStorage(
-              stepToolCalls.map((tc, i) => ({
-                toolName: tc.toolName,
-                args: tc.args,
-                ...(i === 0 && stepThoughtSig
-                  ? { thoughtSignature: stepThoughtSig }
-                  : {}),
-                stepIndex: step,
-              })),
-              stepToolExecs.map((te) => ({
-                toolName: te.name,
-                output: te.output,
-                stepIndex: step,
-              })),
-              options,
-              new Date(),
-            ),
-            TOOL_STORAGE_TIMEOUT_MS,
-            "tool storage write timed out",
-          ).catch((error: unknown) => {
-            logger.warn(
-              "[GoogleVertex] Failed to store native Gemini generate tool executions",
-              {
-                error: error instanceof Error ? error.message : String(error),
-              },
-            );
+          // The @google/genai SDK only accepts "user" and "model" as valid
+          // roles in contents — function/tool responses must use role: "user"
+          // (matching the SDK's automaticFunctionCalling implementation and
+          // the Google AI Studio path). See note in executeNativeGemini3Stream.
+          currentContents.push({
+            role: "user",
+            parts: functionResponses as unknown as VertexNativePart[],
           });
-        }
-
-        // The @google/genai SDK only accepts "user" and "model" as valid
-        // roles in contents — function/tool responses must use role: "user"
-        // (matching the SDK's automaticFunctionCalling implementation and
-        // the Google AI Studio path). See note in executeNativeGemini3Stream.
-        currentContents.push({
-          role: "user",
-          parts: functionResponses as unknown as VertexNativePart[],
-        });
-      } catch (error) {
-        logger.error("[GoogleVertex] Native SDK generate error", error);
-        throw this.handleProviderError(error);
-      }
-    }
-
-    // Handle maxSteps termination — the loop exited because the step cap was
-    // reached while the model was still calling tools. Surface a real answer
-    // instead of the canned placeholder (Bug 1) and a meaningful finishReason
-    // (Bug 2).
-    let hitStepLimit = false;
-    let synthesizedFinalAnswer = false;
-    if (step >= maxSteps && !finalText) {
-      hitStepLimit = true;
-      if (accumulatedText) {
-        // Prefer the prose the model already produced across steps.
-        logger.warn(
-          `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
-            `returning text already gathered from prior steps.`,
-        );
-        finalText = accumulatedText;
-      } else {
-        // Pure functionCall turns leave no text — make one tools-disabled call
-        // so the model answers from the gathered tool results instead of the
-        // canned placeholder.
-        logger.warn(
-          `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
-            `with no text; synthesizing a final answer with tools disabled.`,
-        );
-        const synth = await this.synthesizeFinalAnswerWithoutTools(
-          client,
-          modelName,
-          config,
-          currentContents,
-          useFinalResultTool,
-          parseTimeout(options.timeout) ?? 300_000,
-        );
-        if (synth.text) {
-          synthesizedFinalAnswer = true;
-          finalText = synth.text;
-          totalInputTokens += synth.inputTokens;
-          totalOutputTokens += synth.outputTokens;
-          if (synth.finishReason) {
-            lastFinishReason = synth.finishReason;
+        } catch (error) {
+          // A mid-drain abort surfaces as an AbortError from the `for await`.
+          // Break gracefully into the terminal block instead of re-throwing
+          // (a re-throw would route the caller's abort into a second unbounded
+          // fallback generate()). Dual check as with the inner catch:
+          // effectiveSignal.aborted (a signal we tripped) OR isAbortError(error)
+          // (an abort-shaped throw) — either means "stop", not a real failure.
+          if (effectiveSignal.aborted || isAbortError(error)) {
+            wasAborted = true;
+            break;
           }
-        } else {
-          finalText = `[Tool execution limit reached after ${maxSteps} steps. The model continued requesting tool calls beyond the limit.]`;
+          logger.error("[GoogleVertex] Native SDK generate error", error);
+          throw this.handleProviderError(error);
         }
       }
+
+      // Handle maxSteps termination / abort — the loop exited because the step
+      // cap was reached (or the turn was aborted) while the model was still
+      // calling tools. Surface a real answer instead of the canned placeholder
+      // (Bug 1) and a meaningful finishReason (Bug 2).
+      if (!finalText && (step >= maxSteps || wasAborted)) {
+        hitStepLimit = step >= maxSteps && !wasAborted;
+        const toolCallCount = allToolCalls.filter(
+          (tc) => tc.toolName !== "final_result",
+        ).length;
+        if (accumulatedText) {
+          // Prefer the prose the model already produced across steps.
+          logger.warn(
+            `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+              `returning text already gathered from prior steps.`,
+          );
+          finalText = accumulatedText;
+        } else if (wasAborted) {
+          // Aborted turn — skip synth entirely so it can never add +300s after
+          // a blown budget. Deliver a graceful cap message as ordinary prose.
+          logger.warn(
+            `[GoogleVertex] Generate tool call loop aborted mid-turn; ` +
+              `returning a graceful cap message.`,
+          );
+          finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+        } else {
+          // Pure functionCall turns leave no text — make one tools-disabled call
+          // so the model answers from the gathered tool results instead of the
+          // canned placeholder.
+          logger.warn(
+            `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+              `with no text; synthesizing a final answer with tools disabled.`,
+          );
+          // synth self-bounds its connect+drain via withTimeout(timeoutMs) and
+          // never throws (returns empty on timeout/error), so it needs no outer
+          // withTimeout wrapper — see synthesizeFinalAnswerWithoutTools.
+          const synth = await this.synthesizeFinalAnswerWithoutTools(
+            client,
+            modelName,
+            config,
+            currentContents,
+            useFinalResultTool,
+            parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS,
+            effectiveSignal,
+          );
+          if (synth.text) {
+            synthesizedFinalAnswer = true;
+            finalText = synth.text;
+            totalInputTokens += synth.inputTokens;
+            totalOutputTokens += synth.outputTokens;
+            if (synth.finishReason) {
+              lastFinishReason = synth.finishReason;
+            }
+          } else {
+            finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+          }
+        }
+      }
+    } finally {
+      clearTimeout(defensiveTimer);
+      options.abortSignal?.removeEventListener("abort", onCallerAbort);
     }
 
     // Unified finish reason: a step-cap exhaustion that did NOT end in a clean
@@ -3087,8 +3243,10 @@ export class GoogleVertexProvider extends BaseProvider {
    * (`final_result`) pattern was active, a trailing instruction countermands the
    * earlier "you MUST call final_result" directive so the model answers in plain
    * text. Never throws — returns empty text so the caller falls back to the
-   * placeholder, guaranteeing no new failure path.
+   * graceful cap message (buildToolLoopCapMessage), guaranteeing no new failure
+   * path.
    */
+  // eslint-disable-next-line max-params -- trailing optional abortSignal keeps the positional call sites stable
   private async synthesizeFinalAnswerWithoutTools(
     client: GenAIClient,
     modelName: string,
@@ -3096,17 +3254,27 @@ export class GoogleVertexProvider extends BaseProvider {
     contents: Array<{ role: string; parts: VertexNativePart[] }>,
     useFinalResultTool: boolean,
     timeoutMs: number,
+    abortSignal?: AbortSignal,
   ): Promise<{
     text: string;
     finishReason?: string;
     inputTokens: number;
     outputTokens: number;
   }> {
+    // Already aborted — never issue the synth request (would add +300s after a
+    // blown budget). Return empty so the caller maps to the graceful message.
+    if (abortSignal?.aborted) {
+      return { text: "", inputTokens: 0, outputTokens: 0 };
+    }
     try {
       // Shallow clone so the loop's config is never mutated; dropping the
       // top-level `tools` key is sufficient (nested thinkingConfig /
-      // systemInstruction are intentionally preserved).
-      const synthConfig: Record<string, unknown> = { ...config };
+      // systemInstruction are intentionally preserved). Fold in the abort
+      // signal so the synth request is cancellable too.
+      const synthConfig: Record<string, unknown> = {
+        ...config,
+        ...(abortSignal ? { abortSignal } : {}),
+      };
       delete synthConfig.tools;
       if (useFinalResultTool) {
         const baseSystemInstruction =

--- a/test/continuous-test-suite-gemini-abort.ts
+++ b/test/continuous-test-suite-gemini-abort.ts
@@ -1,0 +1,998 @@
+#!/usr/bin/env tsx
+/**
+ * Gemini-3 native Vertex loop: abortSignal wiring + graceful step-cap message.
+ *
+ * Covers the SPEC "UNIT TESTS" list for
+ * `fix(vertex): honor abortSignal + graceful step-cap message in native
+ *  Gemini-3 loop`:
+ *   - pure exported helpers (buildToolLoopCapMessage / isAbortError /
+ *     handleMaxStepsTermination)
+ *   - the generate loop (executeNativeGemini3Generate) driven through a
+ *     mock-injected `client.models.generateContentStream` (the private
+ *     `createVertexGenAIClient` is overridden with a cast, matching the
+ *     precedent in continuous-test-suite-bugfixes.ts)
+ *   - the stream twin (executeNativeGemini3Stream)
+ *   - synthesizeFinalAnswerWithoutTools abort-awareness
+ *   - a source-level regression grep for the removed placeholder
+ *
+ * Runner: `npx tsx test/continuous-test-suite-gemini-abort.ts`
+ * (package.json: `pnpm run test:gemini-abort`).
+ */
+import "dotenv/config";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import {
+  defineSuite,
+  assert,
+  assertEqual,
+  assertIncludes,
+} from "./helpers/harness.js";
+import {
+  buildToolLoopCapMessage,
+  isAbortError,
+  handleMaxStepsTermination,
+} from "../src/lib/providers/googleNativeGemini3.js";
+import { GoogleVertexProvider } from "../src/lib/providers/googleVertex.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+// ---------------------------------------------------------------------------
+// Env: satisfy the GoogleVertexProvider constructor without live network.
+// The provider only reads project/location + validates creds at construct
+// time; the mock-injected createVertexGenAIClient means no client is ever
+// really built. (Mirrors continuous-test-suite-bugfixes.ts withTemporaryEnv.)
+// ---------------------------------------------------------------------------
+/** Run `fn` with `updates` applied to `process.env`, restoring prior values after. */
+async function withTemporaryEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const next = updates[key];
+    if (next === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = next;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const VERTEX_ENV = {
+  GOOGLE_APPLICATION_CREDENTIALS: "/tmp/neurolink-gemini-abort-creds.json",
+  GOOGLE_CLOUD_PROJECT_ID: "test-project",
+  GOOGLE_CLOUD_PROJECT: "test-project",
+  GOOGLE_CLOUD_LOCATION: "global",
+};
+
+const MODEL = "gemini-3-pro-preview";
+
+// ---------------------------------------------------------------------------
+// Mock @google/genai client
+// ---------------------------------------------------------------------------
+
+type GenParams = {
+  model: string;
+  contents: unknown;
+  config: Record<string, unknown>;
+};
+
+type Chunk = Record<string, unknown>;
+
+/** Async iterable over a static list of chunks. */
+function chunks(list: Chunk[]): AsyncIterable<Chunk> {
+  return (async function* () {
+    for (const c of list) {
+      yield c;
+    }
+  })();
+}
+
+/** A chunk that only requests a tool call (no text) — the "runaway" step. */
+function functionCallChunk(name: string, args: Record<string, unknown>): Chunk {
+  return {
+    functionCalls: [{ name, args }],
+    candidates: [
+      {
+        content: { parts: [{ functionCall: { name, args } }] },
+        // no finishReason on a mid-turn tool-call chunk
+      },
+    ],
+    usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+  };
+}
+
+/** A plain-text terminal chunk (model stopped on its own). */
+function textChunk(text: string, finishReason = "STOP"): Chunk {
+  return {
+    candidates: [
+      {
+        finishReason,
+        content: { parts: [{ text }] },
+      },
+    ],
+    usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 },
+  };
+}
+
+type MockClient = {
+  models: {
+    generateContentStream: (p: GenParams) => Promise<AsyncIterable<Chunk>>;
+  };
+};
+
+type Recorder = {
+  calls: GenParams[];
+  client: MockClient;
+};
+
+/**
+ * Build a recording mock whose generateContentStream returns chunks decided
+ * by `plan(callIndex, params)`. Returning `null` from `plan` means "throw an
+ * AbortError" (used to simulate a mid-drain cancel).
+ */
+function makeMock(
+  plan: (callIndex: number, params: GenParams) => Chunk[] | null,
+): Recorder {
+  const calls: GenParams[] = [];
+  const client: MockClient = {
+    models: {
+      generateContentStream: async (p: GenParams) => {
+        const index = calls.length;
+        calls.push(p);
+        const result = plan(index, p);
+        if (result === null) {
+          const e = new Error("The operation was aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        return chunks(result);
+      },
+    },
+  };
+  return { calls, client };
+}
+
+/** Construct a provider with the mock client injected. */
+async function makeProvider(client: MockClient): Promise<GoogleVertexProvider> {
+  const provider = new GoogleVertexProvider(
+    MODEL,
+    undefined,
+    undefined,
+    "global",
+  );
+  (
+    provider as unknown as {
+      createVertexGenAIClient: () => Promise<MockClient>;
+    }
+  ).createVertexGenAIClient = async () => client;
+  return provider;
+}
+
+type GenResult = {
+  content: string;
+  finishReason: string;
+  usage: { input: number; output: number; total: number };
+  structuredOutput?: unknown;
+  toolExecutions?: unknown[];
+};
+
+/** Invoke the private native-Gemini generate loop against the injected mock client. */
+async function runGenerate(
+  provider: GoogleVertexProvider,
+  options: Record<string, unknown>,
+): Promise<GenResult> {
+  return (
+    provider as unknown as {
+      executeNativeGemini3Generate(o: unknown): Promise<GenResult>;
+    }
+  ).executeNativeGemini3Generate(options);
+}
+
+type StreamResultShape = {
+  finishReason: string;
+  usage: { input: number; output: number; total: number };
+  structuredOutput?: unknown;
+  stream: AsyncIterable<{ content: string }>;
+};
+
+/** Invoke the private native-Gemini stream loop and drain its chunks plus result. */
+async function runStream(
+  provider: GoogleVertexProvider,
+  options: Record<string, unknown>,
+): Promise<{ chunks: string[]; result: StreamResultShape }> {
+  const result = (await (
+    provider as unknown as {
+      executeNativeGemini3Stream(o: unknown): Promise<StreamResultShape>;
+    }
+  ).executeNativeGemini3Stream(options)) as StreamResultShape;
+  const collected: string[] = [];
+  for await (const c of result.stream) {
+    collected.push(c.content);
+  }
+  return { chunks: collected, result };
+}
+
+/** A simple echo tool the loop can execute. Records the options it received. */
+function makeTool(
+  onExecute?: (args: unknown, opts: { abortSignal?: AbortSignal }) => void,
+) {
+  return {
+    myTool: {
+      description: "A test tool",
+      parameters: {
+        type: "object",
+        properties: { q: { type: "string" } },
+      },
+      execute: async (
+        args: unknown,
+        opts: { abortSignal?: AbortSignal },
+      ): Promise<{ ok: true }> => {
+        onExecute?.(args, opts);
+        return { ok: true };
+      },
+    },
+  };
+}
+
+// ===========================================================================
+// Suite
+// ===========================================================================
+
+const { test, runSuite } = defineSuite("Gemini-3 Abort + Step-Cap");
+
+/** Registers and runs every case in the Gemini-3 abort + step-cap suite. */
+async function main(): Promise<void> {
+  // -------------------------------------------------------------------------
+  // 1. Pure helper: buildToolLoopCapMessage
+  // -------------------------------------------------------------------------
+  await test("buildToolLoopCapMessage: contains maxSteps + exact count, plural", () => {
+    const msg = buildToolLoopCapMessage(200, 3);
+    assertIncludes(msg, "200-step limit");
+    assertIncludes(msg, "across 3 tool calls");
+    assert(
+      !msg.includes("Tool execution limit reached"),
+      "no legacy placeholder",
+    );
+  });
+
+  await test("buildToolLoopCapMessage: singular 'tool call' for count 1", () => {
+    const msg = buildToolLoopCapMessage(50, 1);
+    assertIncludes(msg, "across 1 tool call ");
+    assert(!msg.includes("1 tool calls"), "must be singular for count 1");
+    assertIncludes(msg, "50-step limit");
+  });
+
+  await test("buildToolLoopCapMessage: count 0 uses the 'I reached...' variant", () => {
+    const msg = buildToolLoopCapMessage(100, 0);
+    assertIncludes(msg, "I reached the 100-step limit");
+    assert(!msg.includes("tool call"), "no tool-call clause when count is 0");
+    assert(
+      !msg.includes("Tool execution limit reached"),
+      "no legacy placeholder",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Pure helper: isAbortError
+  // -------------------------------------------------------------------------
+  await test("isAbortError: true for { name: 'AbortError' }", () => {
+    assertEqual(isAbortError({ name: "AbortError" }), true);
+  });
+
+  await test("isAbortError: true for Error message matching /abort/i", () => {
+    assertEqual(isAbortError(new Error("The operation was ABORTED")), true);
+    assertEqual(isAbortError(new Error("request aborted by caller")), true);
+  });
+
+  await test("isAbortError: true for DOMException code 20", () => {
+    // Node exposes DOMException globally; AbortError has code 20.
+    const e = new DOMException("aborted", "AbortError");
+    assertEqual(e.code, 20);
+    assertEqual(isAbortError(e), true);
+  });
+
+  await test("isAbortError: false for generic error / null / undefined", () => {
+    assertEqual(isAbortError(new Error("boom")), false);
+    assertEqual(isAbortError({ name: "TypeError" }), false);
+    assertEqual(isAbortError(null), false);
+    assertEqual(isAbortError(undefined), false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Pure helper: handleMaxStepsTermination
+  // -------------------------------------------------------------------------
+  await test("handleMaxStepsTermination: both empty -> buildToolLoopCapMessage(maxSteps,0)", () => {
+    const out = handleMaxStepsTermination("[X]", 5, 5, "", "");
+    assertEqual(out, buildToolLoopCapMessage(5, 0));
+  });
+
+  await test("handleMaxStepsTermination: lastStepText present -> returns it", () => {
+    const out = handleMaxStepsTermination("[X]", 5, 5, "", "gathered text");
+    assertEqual(out, "gathered text");
+  });
+
+  await test("handleMaxStepsTermination: finalText non-empty -> returns finalText (below cap)", () => {
+    const out = handleMaxStepsTermination("[X]", 2, 5, "answer", "ignored");
+    assertEqual(out, "answer");
+  });
+
+  await test("handleMaxStepsTermination: finalText non-empty at cap -> returns finalText", () => {
+    const out = handleMaxStepsTermination("[X]", 5, 5, "answer", "ignored");
+    assertEqual(out, "answer");
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Generate: pure functionCall runaway, synth returns "" -> cap message
+  // -------------------------------------------------------------------------
+  await test("generate: pure-runaway, synth empty -> buildToolLoopCapMessage + finishReason 'tool-calls'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 3;
+      // Every loop step (indices 0..maxSteps-1) returns a tool-call-only chunk.
+      // The trailing synth call (index maxSteps) returns NO text -> empty synth.
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      assertEqual(
+        result.content,
+        buildToolLoopCapMessage(maxSteps, maxSteps),
+        "content must be the graceful cap message",
+      );
+      assertEqual(result.finishReason, "tool-calls");
+      assert(
+        !result.content.includes("Tool execution limit reached"),
+        "must not be the bracketed placeholder",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Generate: synth returns text -> content===synth, finishReason maps
+  // -------------------------------------------------------------------------
+  await test("generate: synth returns text -> content is synth text, finishReason maps (not 'tool-calls'), tokens added", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 2;
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("SYNTHESIZED ANSWER", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      assertEqual(result.content, "SYNTHESIZED ANSWER");
+      // synthesizedFinalAnswer true -> maps STOP -> "stop", NOT "tool-calls".
+      assertEqual(result.finishReason, "stop");
+      assert(result.usage.output > 0, "synth output tokens should be added");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Generate: accumulatedText non-empty at cap -> synth NOT called
+  // -------------------------------------------------------------------------
+  await test("generate: accumulatedText at cap -> content is accumulated prose, synth NOT called", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 2;
+      // Each step emits BOTH text and a functionCall so accumulatedText grows
+      // while the loop keeps going to the cap.
+      const mock = makeMock((i) => {
+        if (i < maxSteps) {
+          return [
+            {
+              functionCalls: [{ name: "myTool", args: { q: "x" } }],
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      { text: `step${i} prose` },
+                      { functionCall: { name: "myTool", args: { q: "x" } } },
+                    ],
+                  },
+                },
+              ],
+              usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+            },
+          ];
+        }
+        // If reached, this would be the synth call — it must NOT happen.
+        return [textChunk("SHOULD NOT BE CALLED", "STOP")];
+      });
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      // Exactly maxSteps calls — no trailing synth call.
+      assertEqual(mock.calls.length, maxSteps, "synth must NOT be called");
+      assertIncludes(result.content, "step0 prose");
+      assertIncludes(result.content, "step1 prose");
+      assert(
+        !result.content.includes("SHOULD NOT BE CALLED"),
+        "synth text must not appear",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Generate: abort mid-drain -> BREAK, synth skipped, cap message
+  // -------------------------------------------------------------------------
+  await test("generate: abort mid-drain -> loop breaks (no throw), synth skipped, cap message, call count < maxSteps", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 10;
+      const controller = new AbortController();
+      // Step 0: normal runaway chunk. Step 1: the mock aborts the caller signal
+      // then throws AbortError (simulating a cancelled drain). No synth call
+      // should follow.
+      const mock = makeMock((i) => {
+        if (i === 0) {
+          return [functionCallChunk("myTool", { q: "x" })];
+        }
+        // Simulate the caller aborting right as the 2nd request starts to drain.
+        controller.abort();
+        return null; // -> throw AbortError from the mock iterable
+      });
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+        abortSignal: controller.signal,
+      });
+      // No throw escaped (we got a result). Cap message delivered, synth skipped.
+      assert(
+        result.content.includes("step limit for a single turn"),
+        `expected graceful cap message, got: ${result.content}`,
+      );
+      assert(
+        mock.calls.length < maxSteps,
+        `expected < ${maxSteps} generateContentStream calls, got ${mock.calls.length}`,
+      );
+      assertEqual(mock.calls.length, 2, "only 2 requests before abort break");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Generate: abort BETWEEN steps (loop-entry guard)
+  // -------------------------------------------------------------------------
+  await test("generate: abort BETWEEN steps (loop-entry guard) -> graceful cap message", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 10;
+      const controller = new AbortController();
+      // Genuinely exercise the loop-entry guard (NOT the mid-drain / tool-exec
+      // abort paths): step 0's stream drains fully & the tool executes
+      // normally, then the signal aborts. On the next while-iteration the
+      // loop-entry guard (`if (effectiveSignal.aborted) break`) trips before a
+      // second generateContentStream is issued. The custom iterable aborts in
+      // its finally (after the last yield is consumed) so the abort lands
+      // strictly between steps.
+      const calls: GenParams[] = [];
+      const client: MockClient = {
+        models: {
+          generateContentStream: async (p: GenParams) => {
+            const index = calls.length;
+            calls.push(p);
+            if (index > 0) {
+              throw new Error(
+                "should not reach a second request after between-step abort",
+              );
+            }
+            return (async function* () {
+              try {
+                yield functionCallChunk("myTool", { q: "x" });
+              } finally {
+                // Drain of step 0 is complete — abort now so the tool runs
+                // normally and the NEXT loop-entry guard breaks the turn.
+                controller.abort();
+              }
+            })();
+          },
+        },
+      };
+      const provider = await makeProvider(client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        // The tool runs normally (returns without throwing). The abort fires in
+        // the iterable's finally, AFTER step 0's drain, so the break comes from
+        // the next iteration's loop-entry guard — not the tool-exec inner catch.
+        tools: {
+          myTool: {
+            description: "A test tool",
+            parameters: { type: "object", properties: {} },
+            execute: async (): Promise<{ ok: true }> => {
+              return { ok: true };
+            },
+          },
+        },
+        maxSteps,
+        abortSignal: controller.signal,
+      });
+      assert(
+        result.content.includes("step limit for a single turn"),
+        `expected graceful cap message, got: ${result.content}`,
+      );
+      assertEqual(
+        calls.length,
+        1,
+        "no second model request after between-step abort",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Generate: config.abortSignal wiring + original config not mutated
+  // -------------------------------------------------------------------------
+  await test("generate: every request config.abortSignal === effectiveSignal; original config not mutated", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 3;
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      assert(mock.calls.length >= 2, "need multiple requests");
+      const signals = mock.calls.map((c) => c.config.abortSignal);
+      // All requests carry an AbortSignal, and it is the SAME reference (the
+      // internal effectiveSignal) across every step.
+      for (const s of signals) {
+        assert(
+          typeof AbortSignal !== "undefined" && s instanceof AbortSignal,
+          "config.abortSignal must be an AbortSignal",
+        );
+      }
+      const first = signals[0];
+      assert(
+        signals.every((s) => s === first),
+        "config.abortSignal must be the same reference across all requests",
+      );
+      // The shallow-clone contract: each per-request config is a DISTINCT
+      // object (so the shared config is never mutated with abortSignal).
+      const configs = mock.calls.map((c) => c.config);
+      assert(
+        new Set(configs).size === configs.length,
+        "each request must receive its own shallow-cloned config object",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Generate: tool-exec abort propagation
+  // -------------------------------------------------------------------------
+  await test("generate: tool execute receives the same abortSignal as the request; aborted tool call does not count as failure", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 4;
+      let toolSignal: AbortSignal | undefined;
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool((_args, opts) => {
+          toolSignal = opts.abortSignal;
+        }),
+        maxSteps,
+      });
+      assert(
+        typeof AbortSignal !== "undefined" && toolSignal instanceof AbortSignal,
+        "tool execute must receive an AbortSignal",
+      );
+      // Same reference as the one wired into the request config.
+      assertEqual(
+        toolSignal,
+        mock.calls[0].config.abortSignal as AbortSignal,
+        "toolOptions.abortSignal === request config.abortSignal",
+      );
+    });
+  });
+
+  await test("generate: an aborted tool call does NOT increment failedTools (no spurious failure)", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      // maxSteps is generous so that IF the abort were mis-handled (recorded
+      // as an ordinary tool failure instead of breaking the turn) the loop
+      // would keep issuing model requests — which the call-count assertion
+      // below catches. Crucially we do NOT abort a caller signal here: the
+      // tool throws an AbortError-named error, so `isAbortError(error)` is the
+      // SOLE discriminator that must break the turn. (A prior version
+      // pre-aborted a controller, which let the next-iteration loop-entry
+      // guard mask a broken inner-catch guard and made this test vacuous.)
+      const maxSteps = 6;
+      let executeCount = 0;
+      const mock = makeMock(() => [functionCallChunk("myTool", { q: "x" })]);
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: {
+          myTool: {
+            description: "throws an AbortError",
+            parameters: { type: "object", properties: {} },
+            execute: async (
+              _args: unknown,
+              _opts: { abortSignal?: AbortSignal },
+            ) => {
+              executeCount++;
+              const e = new Error("aborted mid-tool");
+              e.name = "AbortError";
+              throw e;
+            },
+          },
+        },
+        maxSteps,
+      });
+      // Correct handling breaks the turn on the FIRST aborted tool call:
+      //   - the tool runs exactly once (no retry from a recorded failure)
+      //   - no further model request is issued (loop broke, not continued)
+      //   - the aborted call is NOT surfaced as a failed tool execution
+      assertEqual(executeCount, 1, "aborted tool must not be retried");
+      assertEqual(
+        mock.calls.length,
+        1,
+        "aborted tool must break the turn — no further model request",
+      );
+      assert(
+        !JSON.stringify(result.toolExecutions ?? []).includes(
+          "TOOL_EXECUTION_ERROR",
+        ),
+        "aborted tool must not be recorded as a failed execution",
+      );
+      assert(
+        result.content.includes("step limit for a single turn"),
+        "graceful cap message after tool-exec abort",
+      );
+      // toolCallCount in the message reflects the single call.
+      assertIncludes(result.content, "across 1 tool call ");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. Generate: final_result before cap -> structured output preserved
+  // -------------------------------------------------------------------------
+  await test("generate: final_result before cap -> structuredOutput preserved, finishReason not 'tool-calls'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      // Step 0: model calls final_result with the structured payload.
+      const payload = { answer: 42 };
+      const mock = makeMock(() => [
+        {
+          functionCalls: [{ name: "final_result", args: payload }],
+          candidates: [
+            {
+              finishReason: "STOP",
+              content: {
+                parts: [
+                  { functionCall: { name: "final_result", args: payload } },
+                ],
+              },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+        },
+      ]);
+      const provider = await makeProvider(mock.client);
+      // Provide a schema so useFinalResultTool becomes true.
+      const { z } = await import("zod");
+      const result = await runGenerate(provider, {
+        input: { text: "give me the answer" },
+        tools: makeTool(),
+        schema: z.object({ answer: z.number() }),
+        maxSteps: 5,
+      });
+      assertEqual(
+        mock.calls.length,
+        1,
+        "should break at final_result, not loop",
+      );
+      assertEqual(result.content, JSON.stringify(payload));
+      assertEqual(
+        JSON.stringify(result.structuredOutput),
+        JSON.stringify(payload),
+      );
+      assert(
+        result.finishReason !== "tool-calls",
+        "final_result path must not force 'tool-calls'",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. Stream twin: normal multi-part completion -> >1 chunk
+  // -------------------------------------------------------------------------
+  await test("stream: normal multi-part completion yields >1 chunk", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      // Single request, no function calls, multiple text parts across chunks.
+      const mock = makeMock(() => [
+        {
+          candidates: [{ content: { parts: [{ text: "Hello " }] } }],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+        },
+        {
+          candidates: [
+            {
+              finishReason: "STOP",
+              content: { parts: [{ text: "world" }] },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 4 },
+        },
+      ]);
+      const provider = await makeProvider(mock.client);
+      const { chunks: out } = await runStream(provider, {
+        input: { text: "hi" },
+        maxSteps: 3,
+      });
+      assert(
+        out.length > 1,
+        `expected >1 chunk, got ${out.length}: ${JSON.stringify(out)}`,
+      );
+      assertEqual(out.join(""), "Hello world");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. Stream twin: pure-runaway synth-empty -> EXACTLY ONE graceful chunk
+  // -------------------------------------------------------------------------
+  await test("stream: pure-runaway, synth empty -> exactly ONE non-empty graceful chunk", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 3;
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const { chunks: out, result } = await runStream(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      assertEqual(out.length, 1, "exactly one graceful chunk");
+      assertEqual(out[0], buildToolLoopCapMessage(maxSteps, maxSteps));
+      assert(out[0].length > 0, "graceful chunk must be non-empty");
+      assert(
+        !out[0].includes("Tool execution limit reached"),
+        "no legacy placeholder",
+      );
+      // The step-cap-without-synth path must map finishReason to 'tool-calls'
+      // (parity with the generate twin); a regression to 'stop'/'length' here
+      // would otherwise go unnoticed by the stream suite.
+      assertEqual(
+        result.finishReason,
+        "tool-calls",
+        "stream step-cap without synth -> finishReason 'tool-calls'",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 14. Stream twin: abort mid-drain -> exactly ONE graceful chunk, synth skipped
+  // -------------------------------------------------------------------------
+  await test("stream: abort mid-drain -> one graceful chunk, no throw, call count < maxSteps", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 10;
+      const controller = new AbortController();
+      const mock = makeMock((i) => {
+        if (i === 0) {
+          return [functionCallChunk("myTool", { q: "x" })];
+        }
+        controller.abort();
+        return null;
+      });
+      const provider = await makeProvider(mock.client);
+      const { chunks: out } = await runStream(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+        abortSignal: controller.signal,
+      });
+      assertEqual(out.length, 1, "exactly one graceful chunk on abort");
+      assert(
+        out[0].includes("step limit for a single turn"),
+        `expected cap message, got: ${out[0]}`,
+      );
+      assert(mock.calls.length < maxSteps, "call count < maxSteps");
+      assertEqual(mock.calls.length, 2, "aborted on 2nd request");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 15. Stream twin: config.abortSignal wiring
+  // -------------------------------------------------------------------------
+  await test("stream: every request config.abortSignal is same AbortSignal; original config not mutated", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 3;
+      const mock = makeMock((i) =>
+        i < maxSteps
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      await runStream(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps,
+      });
+      const signals = mock.calls.map((c) => c.config.abortSignal);
+      for (const s of signals) {
+        assert(
+          typeof AbortSignal !== "undefined" && s instanceof AbortSignal,
+          "config.abortSignal must be an AbortSignal",
+        );
+      }
+      const first = signals[0];
+      assert(
+        signals.every((s) => s === first),
+        "same abortSignal reference across all stream requests",
+      );
+      const configs = mock.calls.map((c) => c.config);
+      assert(
+        new Set(configs).size === configs.length,
+        "each stream request receives its own shallow-cloned config",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 16. synthesizeFinalAnswerWithoutTools: already-aborted -> no request
+  // -------------------------------------------------------------------------
+  await test("synth: already-aborted signal -> returns {text:''} WITHOUT calling generateContentStream", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock(() => {
+        throw new Error(
+          "generateContentStream must NOT be called when pre-aborted",
+        );
+      });
+      const provider = await makeProvider(mock.client);
+      const controller = new AbortController();
+      controller.abort();
+      const synth = await (
+        provider as unknown as {
+          synthesizeFinalAnswerWithoutTools(
+            client: MockClient,
+            model: string,
+            config: Record<string, unknown>,
+            contents: unknown,
+            useFinalResultTool: boolean,
+            timeoutMs: number,
+            abortSignal?: AbortSignal,
+          ): Promise<{
+            text: string;
+            inputTokens: number;
+            outputTokens: number;
+          }>;
+        }
+      ).synthesizeFinalAnswerWithoutTools(
+        mock.client,
+        MODEL,
+        { temperature: 1, tools: [{ functionDeclarations: [] }] },
+        [{ role: "user", parts: [{ text: "hi" }] }],
+        false,
+        300_000,
+        controller.signal,
+      );
+      assertEqual(synth.text, "");
+      assertEqual(mock.calls.length, 0, "no request when already aborted");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 17. synthesizeFinalAnswerWithoutTools: live signal -> config carries
+  //     abortSignal AND tools deleted
+  // -------------------------------------------------------------------------
+  await test("synth: live signal -> request config carries abortSignal and tools deleted; source config untouched", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock(() => [textChunk("synth answer", "STOP")]);
+      const provider = await makeProvider(mock.client);
+      const controller = new AbortController();
+      const sourceConfig = {
+        temperature: 1,
+        tools: [{ functionDeclarations: [{ name: "myTool" }] }],
+      };
+      const synth = await (
+        provider as unknown as {
+          synthesizeFinalAnswerWithoutTools(
+            client: MockClient,
+            model: string,
+            config: Record<string, unknown>,
+            contents: unknown,
+            useFinalResultTool: boolean,
+            timeoutMs: number,
+            abortSignal?: AbortSignal,
+          ): Promise<{
+            text: string;
+            inputTokens: number;
+            outputTokens: number;
+          }>;
+        }
+      ).synthesizeFinalAnswerWithoutTools(
+        mock.client,
+        MODEL,
+        sourceConfig,
+        [{ role: "user", parts: [{ text: "hi" }] }],
+        false,
+        300_000,
+        controller.signal,
+      );
+      assertEqual(synth.text, "synth answer");
+      assertEqual(mock.calls.length, 1, "exactly one synth request");
+      const reqConfig = mock.calls[0].config;
+      assertEqual(
+        reqConfig.abortSignal,
+        controller.signal,
+        "synth request config carries the abortSignal",
+      );
+      assert(
+        reqConfig.tools === undefined,
+        "tools must be deleted on synth config",
+      );
+      // The shared source config must be untouched (still has tools, no signal).
+      assert(
+        (sourceConfig as Record<string, unknown>).tools !== undefined,
+        "source config.tools must NOT be deleted",
+      );
+      assert(
+        (sourceConfig as Record<string, unknown>).abortSignal === undefined,
+        "source config must not gain an abortSignal",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 18. Regression grep: placeholder gone from both source files
+  // -------------------------------------------------------------------------
+  await test("regression: 'Tool execution limit reached after' absent from googleVertex.ts and googleNativeGemini3.ts", () => {
+    const vertexSrc = readFileSync(
+      resolve(REPO_ROOT, "src/lib/providers/googleVertex.ts"),
+      "utf8",
+    );
+    const nativeSrc = readFileSync(
+      resolve(REPO_ROOT, "src/lib/providers/googleNativeGemini3.ts"),
+      "utf8",
+    );
+    // NOTE: keep these messages free of words the harness treats as an
+    // "expected provider error" (e.g. "gone" → HTTP 410), otherwise a real
+    // regression would be swallowed as a SKIP instead of failing the suite.
+    assert(
+      !vertexSrc.includes("Tool execution limit reached after"),
+      "legacy step-cap placeholder text still present in googleVertex.ts",
+    );
+    assert(
+      !nativeSrc.includes("Tool execution limit reached after"),
+      "legacy step-cap placeholder text still present in googleNativeGemini3.ts",
+    );
+  });
+}
+
+await runSuite(main);


### PR DESCRIPTION
## Problem

On a Gemini-3 model over `provider=vertex`, a **pure function-call runaway** (the model keeps requesting tool calls, emitting reasoning only as `thoughtSignature`/`functionCall` parts with **no user-visible text**) hit the caller's `maxSteps`. NeuroLink then surfaced the literal placeholder

> `[Tool execution limit reached after N steps. The model continued requesting tool calls beyond the limit.]`

as the assistant answer, which callers post verbatim. Worse, a caller-supplied `abortSignal` (wall-clock timeout) was **ignored** by the Gemini loop — an 18-minute turn with 74 tool calls was observed, **30 of them after the abort was requested**.

This **extends the 9.79.3 lost-prose fix** (`preserve answer text + emit finishReason in native Gemini loop`). That fix only handled the case where the model emitted prose across steps (`accumulatedText` non-empty). It did **not** handle the pure function-call runaway, because on Gemini-3 `accumulatedText` is empty (no text parts) so the prose branch never fired, the recovery synth made another unbounded `generateContentStream` call with no `abortSignal`, and the loop never honored `options.abortSignal`.

## Changes

Applied identically to **both** native Gemini loops — `executeNativeGemini3Generate` (`.generate()`) and `executeNativeGemini3Stream` (`.stream()`):

- **`abortSignal` wiring.** An internal `AbortController` is tripped by the caller's signal *and* a defensive wall-clock timer (`DEFAULT_GEMINI_STREAM_TIMEOUT_MS = 300s`, overridable via `options.timeout`). `effectiveSignal` is passed as a **shallow-cloned** `config.abortSignal` on every `generateContentStream` request (the shared `config` is never mutated) and into tool execution (`toolOptions.abortSignal`). `@google/genai` forwards it to the underlying `fetch`, cancelling the in-flight drain. Listener + timer are cleaned up symmetrically in a `finally`.
- **Break, not throw.** A mid-drain / between-steps / tool-exec abort is converted to a graceful `break` into the terminal handler — **not** a re-throw. A re-throw would route the caller's wall-clock abort into a *second* unbounded fallback `generate()`/synth; breaking preserves the gathered tool results and degrades gracefully. An aborted tool call breaks the turn instead of being recorded as a spurious tool failure.
- **Abort-aware synth.** `synthesizeFinalAnswerWithoutTools` gained a trailing optional `abortSignal`, returns early (no request) when already aborted, and folds the signal into its own cloned config. The recovery synth is **skipped entirely** on the aborted path (so it can never add +300s after a blown budget); the clean step-cap path keeps its 300s synth budget.
- **Graceful message.** The bracketed placeholder is replaced in both loops **and** the shared `handleMaxStepsTermination` with a single-source `buildToolLoopCapMessage(maxSteps, toolCallCount)`.
- **`finishReason` mapping unchanged.** `"tool-calls"` on a clean step-cap without synth; SDK-mapped otherwise (an aborted turn maps from the SDK and the graceful message is delivered as ordinary prose). No new `"error"` value; no new public result fields.

## Non-regression

- `final_result` / structured output: a `final_result` turn sets `finalText` and breaks **before** the terminal block; the new guard `!finalText && (step >= maxSteps || wasAborted)` stays false, so `structuredOutput` and its SDK-mapped `finishReason` are preserved.
- Stream contract: normal multi-part completions still yield **>1 chunk**; the empty step-cap/abort case yields **exactly one** non-empty graceful chunk (never the placeholder, never zero).
- Token accounting: synth tokens still added on synth-success; the graceful message adds none.
- Config immutability: shallow-clone per request; shared `config` never mutated.

## Testing

New suite `test/continuous-test-suite-gemini-abort.ts` — **27 cases, all green** (`pnpm run test:gemini-abort`): the pure helpers (`buildToolLoopCapMessage` / `isAbortError` / `handleMaxStepsTermination`); the generate loop (pure-runaway → cap message + `tool-calls`; synth-returns-text; `accumulatedText`; abort mid-drain & between-steps; `config.abortSignal` wiring + config-not-mutated; tool-exec abort does not increment `failedTools`; `final_result` preserved); the stream twin (>1 chunk vs exactly-one graceful chunk; abort); and synth abort-awareness, plus a regression grep for the removed placeholder.

Verified locally: `tsc --noEmit` exit 0, `eslint` on all changed files exit 0. A **mutation test** (disabling the abort catch-guards) fails the relevant abort tests, confirming they are load-bearing rather than vacuous.

> Note: `pnpm run check`'s `svelte-kit sync` preamble fails locally on the unrelated `landing/` subproject (`@sveltejs/adapter-vercel` not installed) — pre-existing on `release`, independent of this diff. The `tsc --noEmit --strict` gate itself passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, user-facing messaging when Gemini turns reach step limits, including friendlier tool-loop cap text.
  * Improved abort and timeout behavior for Gemini streaming and generation, allowing turns to stop more gracefully.
  * Added continuous test coverage for Gemini abort and step-cap scenarios, plus a dedicated test command.

* **Bug Fixes**
  * Reduced cases where capped/aborted Gemini runs could continue, retry unexpectedly, or show legacy placeholder text.
  * Improved terminal output behavior after tool execution, including safer synthesis fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->