### PR TITLE
fix(core): vertex schema fallback, mcp log dedup, safe serialization, timeout handling

### DIFF
--- a/src/lib/context/stages/structuredSummarizer.ts
+++ b/src/lib/context/stages/structuredSummarizer.ts
@@ -30,11 +30,21 @@ function findSplitIndexByTokens(
   let splitIndex = messages.length;
 
   for (let i = messages.length - 1; i >= 0; i--) {
-    const content =
-      typeof messages[i].content === "string"
-        ? messages[i].content
-        : JSON.stringify(messages[i].content);
-    const msgTokens = estimateTokens(content, provider);
+    // Guarded: JSON.stringify on a giant single message can throw RangeError
+    // (V8 max string length). A message that big cannot be "recent-window"
+    // material anyway — treat it as effectively infinite tokens so it (and
+    // everything older) lands on the summarized side instead of aborting
+    // compaction.
+    let msgTokens: number;
+    try {
+      const content =
+        typeof messages[i].content === "string"
+          ? (messages[i].content as string)
+          : (JSON.stringify(messages[i].content) ?? "");
+      msgTokens = estimateTokens(content, provider);
+    } catch {
+      msgTokens = Number.MAX_SAFE_INTEGER;
+    }
     if (recentTokens + msgTokens > targetRecentTokens) {
       splitIndex = i + 1;
       break;

--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -41,6 +41,7 @@ import {
 import { DEFAULT_MAX_STEPS } from "../constants.js";
 import {
   isTemperatureDeprecatedError,
+  isSchemaComplexityError,
   isToolsSchemaConflictError,
   isToolsSchemaExclusionInForce,
 } from "./structuredOutputPolicy.js";
@@ -431,16 +432,22 @@ export class GenerationHandler {
           return result;
         } catch (error) {
           // Fall back to text-mode (no experimental_output) when structured
-          // output + tools failed, in two cases:
+          // output + tools failed, in three cases:
           //   1. NoObjectGeneratedError — the SDK couldn't coerce the object.
           //   2. The provider rejected json-mode-with-tools outright (e.g. Groq:
           //      "json mode cannot be combined with tool/function calling").
-          // In both cases we retry without structured output and let
+          //   3. The provider rejected the schema as too complex for its
+          //      constrained decoding (Vertex Gemini 400 "too many states") —
+          //      deterministic, so re-sending the schema can never succeed.
+          // In all cases we retry without structured output and let
           // formatEnhancedResult coerce the text response into valid JSON.
+          const schemaTooComplex =
+            useStructuredOutput && isSchemaComplexityError(error);
           const isStructuredOutputConflict =
             useStructuredOutput &&
             (error instanceof NoObjectGeneratedError ||
-              isToolsSchemaConflictError(error));
+              isToolsSchemaConflictError(error) ||
+              schemaTooComplex);
           if (isStructuredOutputConflict) {
             span.setAttribute("neurolink.has_fallback", true);
 
@@ -452,17 +459,32 @@ export class GenerationHandler {
               "retry.reason":
                 error instanceof NoObjectGeneratedError
                   ? "NoObjectGeneratedError_structured_output_fallback"
-                  : "tools_schema_conflict_structured_output_fallback",
+                  : schemaTooComplex
+                    ? "schema_complexity_structured_output_fallback"
+                    : "tools_schema_conflict_structured_output_fallback",
             });
 
-            logger.debug(
-              "[GenerationHandler] structured-output conflict caught - falling back to manual JSON extraction",
-              {
-                provider: this.providerName,
-                model: this.modelName,
-                error: error instanceof Error ? error.message : String(error),
-              },
-            );
+            if (schemaTooComplex) {
+              // warn (not debug): callers should simplify their schema — the
+              // fallback keeps the turn alive but skips native enforcement.
+              logger.warn(
+                "[GenerationHandler] schema too complex for provider constrained decoding — retrying with prompt-based JSON",
+                {
+                  provider: this.providerName,
+                  model: this.modelName,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
+            } else {
+              logger.debug(
+                "[GenerationHandler] structured-output conflict caught - falling back to manual JSON extraction",
+                {
+                  provider: this.providerName,
+                  model: this.modelName,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
 
             // Retry without experimental_output - the formatEnhancedResult method
             // will extract JSON from the text response

--- a/src/lib/core/modules/structuredOutputPolicy.ts
+++ b/src/lib/core/modules/structuredOutputPolicy.ts
@@ -92,6 +92,34 @@ export function isToolsSchemaConflictError(error: unknown): boolean {
 
 /**
  * True when a provider error indicates the request was rejected because the
+ * JSON schema is too complex for the provider's constrained decoding. Vertex
+ * Gemini enforces response schemas as a state machine and rejects
+ * "complex" schemas (regex patterns, string min/max lengths, nested array
+ * caps, long enums) with a deterministic 400 INVALID_ARGUMENT:
+ *
+ *   "The specified schema produces a constraint that has too many states
+ *    for serving. Typical causes of this error are schemas with lots of
+ *    text …, schemas with long array length limits …, or schemas using
+ *    complex value matchers …"
+ *
+ * The error arrives wrapped (provider error formatter + upstream JSON
+ * envelope), so match on the distinctive substring. Retrying with the same
+ * schema can never succeed — the correct recovery is to drop native schema
+ * enforcement and coerce the text response into the schema instead
+ * (same flow as isToolsSchemaConflictError).
+ */
+export function isSchemaComplexityError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return /too many states/i.test(message);
+}
+
+/**
+ * True when a provider error indicates the request was rejected because the
  * `temperature` parameter is deprecated / unsupported for the model. The newest
  * Anthropic models (e.g. claude-opus-4-8, with tools + advanced beta features)
  * reject `temperature` — "`temperature` is deprecated for this model." — in

--- a/src/lib/mcp/externalServerManager.ts
+++ b/src/lib/mcp/externalServerManager.ts
@@ -463,7 +463,9 @@ export class ExternalServerManager extends EventEmitter {
             const errorMsg = `Failed to load MCP server ${serverId}: ${
               error instanceof Error ? error.message : String(error)
             }`;
-            mcpLogger.warn(`[ExternalServerManager] ${errorMsg}`);
+            // No log here: the result-processing loop below owns the single
+            // ERROR record for this failure (logging in both places
+            // double-counted every parallel-load failure).
             return { serverId, error: errorMsg };
           }
         },
@@ -486,10 +488,17 @@ export class ExternalServerManager extends EventEmitter {
             );
           } else if (error) {
             errors.push(error);
+            // Config-loaded servers never pass through
+            // NeuroLink.addExternalMCPServer, so this is the outermost point
+            // for them — it owns the single ERROR record per failed server.
+            mcpLogger.error(
+              `[ExternalServerManager] Failed to load server ${serverId}: ${error}`,
+            );
           } else if (serverResult && !serverResult.success) {
             const errorMsg = `Failed to load server ${serverId}: ${serverResult.error}`;
             errors.push(errorMsg);
-            mcpLogger.warn(`[ExternalServerManager] ${errorMsg}`);
+            // See above: outermost point for config-loaded servers.
+            mcpLogger.error(`[ExternalServerManager] ${errorMsg}`);
           }
         } else {
           // Promise.allSettled rejected - this shouldn't happen with our error handling
@@ -642,14 +651,18 @@ export class ExternalServerManager extends EventEmitter {
           } else {
             const error = `Failed to load server ${serverId}: ${result.error}`;
             errors.push(error);
-            mcpLogger.warn(`[ExternalServerManager] ${error}`);
+            // Config-loaded servers never pass through
+            // NeuroLink.addExternalMCPServer — this sequential-load branch is
+            // their outermost point and owns the single ERROR record.
+            mcpLogger.error(`[ExternalServerManager] ${error}`);
           }
         } catch (error) {
           const errorMsg = `Failed to load MCP server ${serverId}: ${
             error instanceof Error ? error.message : String(error)
           }`;
           errors.push(errorMsg);
-          mcpLogger.warn(`[ExternalServerManager] ${errorMsg}`);
+          // See above: outermost point for config-loaded servers.
+          mcpLogger.error(`[ExternalServerManager] ${errorMsg}`);
           // Continue with other servers - don't let one failure break everything
         }
       }
@@ -927,7 +940,9 @@ export class ExternalServerManager extends EventEmitter {
         },
       };
     } catch (error) {
-      mcpLogger.error(
+      // debug, not error: NeuroLink.addExternalMCPServer (the public entry
+      // point) emits the single ERROR record for a failed registration.
+      mcpLogger.debug(
         `[ExternalServerManager] Failed to add server ${serverId}:`,
         error,
       );
@@ -1124,7 +1139,9 @@ export class ExternalServerManager extends EventEmitter {
         `[ExternalServerManager] Server started successfully: ${serverId}`,
       );
     } catch (error) {
-      mcpLogger.error(
+      // debug, not error: the failure is rethrown below and surfaces once at
+      // the NeuroLink.addExternalMCPServer entry point.
+      mcpLogger.debug(
         `[ExternalServerManager] Failed to start server ${serverId}:`,
         error,
       );

--- a/src/lib/mcp/mcpClientFactory.ts
+++ b/src/lib/mcp/mcpClientFactory.ts
@@ -219,7 +219,11 @@ export class MCPClientFactory {
         };
       }
 
-      mcpLogger.error(
+      // debug, not error: this failure propagates up through
+      // ExternalServerManager to NeuroLink.addExternalMCPServer, which emits
+      // the single ERROR record. Logging at every layer turned one failed
+      // server registration into 5 ERROR lines in production.
+      mcpLogger.debug(
         `[MCPClientFactory] Failed to create client for ${config.id}:`,
         error,
       );

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -228,6 +228,12 @@ import {
   validateFactoryConfig,
 } from "./utils/factoryProcessing.js";
 import { logger, mcpLogger } from "./utils/logger.js";
+import {
+  redactUrlCredentials,
+  safeDebugSerialize,
+  sanitizeRecord,
+  stringifyContentSafe,
+} from "./utils/logSanitize.js";
 import { extractMcpErrorText } from "./utils/mcpErrorText.js";
 import {
   createCustomToolServerInfo,
@@ -2946,9 +2952,7 @@ Current user's request: ${currentInput}`;
     };
     if (anyOptions.messages && anyOptions.messages.length > 0) {
       const lastMessage = anyOptions.messages[anyOptions.messages.length - 1];
-      return typeof lastMessage.content === "string"
-        ? lastMessage.content
-        : JSON.stringify(lastMessage.content);
+      return stringifyContentSafe(lastMessage.content);
     }
 
     // Handle input.text format
@@ -5218,10 +5222,7 @@ Current user's request: ${currentInput}`;
           ?.filter((m) => m.role === "user" || m.role === "assistant")
           .map((m) => ({
             role: m.role as "user" | "assistant",
-            content:
-              typeof m.content === "string"
-                ? m.content
-                : JSON.stringify(m.content),
+            content: stringifyContentSafe(m.content),
           })) ??
         (options.conversationHistory as
           | Array<{ role: "user" | "assistant"; content: string }>
@@ -5338,10 +5339,7 @@ Current user's request: ${currentInput}`;
           ?.filter((m) => m.role === "user" || m.role === "assistant")
           .map((m) => ({
             role: m.role as "user" | "assistant",
-            content:
-              typeof m.content === "string"
-                ? m.content
-                : JSON.stringify(m.content),
+            content: stringifyContentSafe(m.content),
           })) ??
         (options.conversationHistory as
           | Array<{ role: "user" | "assistant"; content: string }>
@@ -6268,6 +6266,12 @@ Current user's request: ${currentInput}`;
   ): Promise<TextGenerationResult | null> {
     const maxMcpRetries = RETRY_ATTEMPTS.QUICK;
 
+    // Captured BEFORE the first attempt: ensureMCPGenerationBudget (inside
+    // tryMCPGeneration) auto-scales options.timeout for >100K-token contexts
+    // when the caller left it unset, so checking options.timeout inside the
+    // catch below could not tell caller-set apart from auto-scaled.
+    const callerSetTimeout = options.timeout !== undefined;
+
     // NL-007: Track retry metadata for observability
     const retryErrors: Array<{ code: string; message: string }> = [];
     let retryCount = 0;
@@ -6322,6 +6326,25 @@ Current user's request: ${currentInput}`;
         if (isAbortError(error)) {
           logger.debug(
             `[${functionTag}] AbortError detected on attempt ${attempt}, stopping retries`,
+          );
+          throw error;
+        }
+
+        // A TimeoutError against an explicit caller-set options.timeout is
+        // deterministic-by-construction: every remaining retry AND the
+        // direct-generation fallback would re-run the same provider+model
+        // under the same per-step budget. Observed in production as ~650s
+        // of doomed follow-ups after a 90s step timeout. Surface it now.
+        // Name check (not instanceof): two TimeoutError classes exist
+        // (utils/timeout.ts and utils/async/withTimeout.ts) and both stamp
+        // name = "TimeoutError".
+        if (
+          callerSetTimeout &&
+          error instanceof Error &&
+          error.name === "TimeoutError"
+        ) {
+          logger.warn(
+            `[${functionTag}] Per-step timeout (${String(options.timeout)}) exhausted on attempt ${attempt} — surfacing instead of retrying with the same budget`,
           );
           throw error;
         }
@@ -9813,14 +9836,21 @@ Current user's request: ${currentInput}`;
       eventSequence,
     } = params;
 
-    logger.debug(
-      "[NeuroLink.stream] Preparing to store conversation turn in memory",
-      {
-        options: JSON.stringify(enhancedOptions),
-        sessionId: (enhancedOptions.context as Record<string, unknown>)
-          ?.sessionId,
-      },
-    );
+    // Logger Guard: the full options object (history + tool outputs) can be
+    // enormous — an eager JSON.stringify here threw RangeError: Invalid
+    // string length in production and killed the turn. Serialize lazily,
+    // bounded, and only when debug is actually enabled; sanitizeRecord
+    // redacts credentials/PII keys before anything reaches the sink.
+    if (logger.shouldLog("debug")) {
+      logger.debug(
+        "[NeuroLink.stream] Preparing to store conversation turn in memory",
+        {
+          options: safeDebugSerialize(sanitizeRecord(enhancedOptions)),
+          sessionId: (enhancedOptions.context as Record<string, unknown>)
+            ?.sessionId,
+        },
+      );
+    }
 
     // Guard: skip storing if no meaningful content was produced (no text AND no tool activity)
     const hasToolEvents = eventSequence.some(
@@ -9837,12 +9867,16 @@ Current user's request: ${currentInput}`;
       return;
     }
 
-    logger.debug("[NeuroLink.stream] Storing conversation turn in memory", {
-      options: JSON.stringify(enhancedOptions),
-      sessionId: (enhancedOptions.context as Record<string, unknown>)
-        ?.sessionId,
-      conversationMemoryExists: this.conversationMemory ? true : false,
-    });
+    // Logger Guard: see the matching block above — never eagerly stringify
+    // the full options object, and always redact before serializing.
+    if (logger.shouldLog("debug")) {
+      logger.debug("[NeuroLink.stream] Storing conversation turn in memory", {
+        options: safeDebugSerialize(sanitizeRecord(enhancedOptions)),
+        sessionId: (enhancedOptions.context as Record<string, unknown>)
+          ?.sessionId,
+        conversationMemoryExists: this.conversationMemory ? true : false,
+      });
+    }
 
     // Store memory after stream consumption is complete
     if (this.conversationMemory && enhancedOptions.context?.sessionId) {
@@ -11809,12 +11843,7 @@ Current user's request: ${currentInput}`;
       : this.getCustomTools().has(toolName)
         ? "custom"
         : "external";
-    const inputStr =
-      typeof params === "string"
-        ? params
-        : params
-          ? JSON.stringify(params)
-          : "";
+    const inputStr = params ? stringifyContentSafe(params) : "";
 
     const executionStartTime = Date.now();
     // Per-invocation id so consumers can correlate a tool:start with its matching
@@ -14125,10 +14154,17 @@ Current user's request: ${currentInput}`;
           timestamp: Date.now(),
         });
       } else {
+        // Single ERROR record for a failed registration — the inner layers
+        // (client factory, server manager) log at debug so one root cause no
+        // longer fans out into 5 ERROR lines. Carry enough context here to
+        // diagnose without the inner lines.
         mcpLogger.error(
           `[NeuroLink] Failed to add external MCP server: ${serverId}`,
           {
             error: result.error,
+            transport: config.transport,
+            command: config.command,
+            url: config.url ? redactUrlCredentials(config.url) : undefined,
           },
         );
       }
@@ -14172,6 +14208,12 @@ Current user's request: ${currentInput}`;
           serverName,
           timestamp: Date.now(),
         });
+      } else if (result.error?.includes("not found")) {
+        // Expected no-op: consumers commonly call remove as cleanup after a
+        // failed add, when the server never registered. Not an error.
+        mcpLogger.debug(
+          `[NeuroLink] Remove skipped — external MCP server not registered: ${serverId}`,
+        );
       } else {
         mcpLogger.error(
           `[NeuroLink] Failed to remove external MCP server: ${serverId}`,

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -20,6 +20,8 @@ import {
   TOOL_STORAGE_TIMEOUT_MS,
 } from "../core/constants.js";
 import { ModelConfigurationManager } from "../core/modelConfiguration.js";
+import { isSchemaComplexityError } from "../core/modules/structuredOutputPolicy.js";
+import { stringifyContentSafe } from "../utils/logSanitize.js";
 import type { NeuroLink } from "../neurolink.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type {
@@ -3115,7 +3117,24 @@ export class GoogleVertexProvider extends BaseProvider {
             wasAborted = true;
             break;
           }
-          logger.error("[GoogleVertex] Native SDK generate error", error);
+          logger.error("[GoogleVertex] Native SDK generate error", {
+            error,
+            model: modelName,
+            location: effectiveLocation,
+            status: (error as { status?: number })?.status,
+          });
+          // Best-effort request context for formatProviderError —
+          // this.modelName can be stale when options.model overrides the
+          // instance default.
+          try {
+            if (error && typeof error === "object") {
+              const e = error as Record<string, unknown>;
+              e.requestModel = modelName;
+              e.requestRegion = effectiveLocation;
+            }
+          } catch {
+            /* frozen/sealed error — context stays best-effort */
+          }
           throw this.handleProviderError(error);
         }
       }
@@ -3437,10 +3456,7 @@ export class GoogleVertexProvider extends BaseProvider {
         if (msg.role === "user" || msg.role === "assistant") {
           messages.push({
             role: msg.role,
-            content:
-              typeof msg.content === "string"
-                ? msg.content
-                : JSON.stringify(msg.content),
+            content: stringifyContentSafe(msg.content),
           });
         }
       }
@@ -4242,7 +4258,7 @@ export class GoogleVertexProvider extends BaseProvider {
                 const resultContent =
                   typeof result === "string"
                     ? result
-                    : (JSON.stringify(result ?? null) ?? String(result));
+                    : stringifyContentSafe(result ?? null);
                 toolResults.push({
                   type: "tool_result",
                   tool_use_id: toolUse.id,
@@ -4821,10 +4837,7 @@ export class GoogleVertexProvider extends BaseProvider {
         if (msg.role === "user" || msg.role === "assistant") {
           messages.push({
             role: msg.role,
-            content:
-              typeof msg.content === "string"
-                ? msg.content
-                : JSON.stringify(msg.content),
+            content: stringifyContentSafe(msg.content),
           });
         }
       }
@@ -5329,7 +5342,7 @@ export class GoogleVertexProvider extends BaseProvider {
               const resultContent =
                 typeof result === "string"
                   ? result
-                  : (JSON.stringify(result ?? null) ?? String(result));
+                  : stringifyContentSafe(result ?? null);
               toolResults.push({
                 type: "tool_result",
                 tool_use_id: toolUse.id,
@@ -5472,10 +5485,21 @@ export class GoogleVertexProvider extends BaseProvider {
           wasAborted = true;
           break;
         }
-        logger.error(
-          "[GoogleVertex] Native Anthropic SDK generate error",
+        logger.error("[GoogleVertex] Native Anthropic SDK generate error", {
           error,
-        );
+          model: modelName,
+          step,
+          status: (error as { status?: number })?.status,
+        });
+        // Best-effort request context for formatProviderError — see the
+        // native Gemini catch for rationale.
+        try {
+          if (error && typeof error === "object") {
+            (error as Record<string, unknown>).requestModel = modelName;
+          }
+        } catch {
+          /* frozen/sealed error — context stays best-effort */
+        }
         throw this.handleProviderError(error);
       }
     }
@@ -6126,8 +6150,55 @@ export class GoogleVertexProvider extends BaseProvider {
                     totalToolCount: Object.keys(mergedOptions.tools).length,
                   },
                 );
-                nativeResult =
-                  await this.executeNativeGemini3Generate(mergedOptions);
+                try {
+                  nativeResult =
+                    await this.executeNativeGemini3Generate(mergedOptions);
+                } catch (nativeError) {
+                  // Vertex rejects over-constrained responseSchemas with a
+                  // deterministic 400 ("too many states" — constrained-decoding
+                  // state explosion). Re-sending the same schema can never
+                  // succeed, so retry ONCE with the schema dropped but JSON
+                  // mode kept: output.format "json" still sets
+                  // responseMimeType application/json on the no-tools path,
+                  // so the model is forced to emit JSON — just without the
+                  // offending schema constraints. The NeuroLink layer then
+                  // coerces the JSON text into the caller's original schema
+                  // (generate({schema}) guarantee holds).
+                  const requestedStructured =
+                    mergedOptions.schema !== undefined ||
+                    mergedOptions.output?.format === "json";
+                  // Tools present → the executor skips responseMimeType, so a
+                  // schema-less retry would NOT actually run in JSON mode and
+                  // the structured-output contract would silently degrade to
+                  // prose. Only the no-tools case retries faithfully; with
+                  // tools, surface the 400 to the caller instead.
+                  const hasTools =
+                    !mergedOptions.disableTools &&
+                    Object.keys(mergedOptions.tools ?? {}).length > 0;
+                  if (
+                    requestedStructured &&
+                    !hasTools &&
+                    isSchemaComplexityError(nativeError)
+                  ) {
+                    logger.warn(
+                      "[GoogleVertex] responseSchema too complex for constrained decoding — retrying native generate in schema-less JSON mode",
+                      {
+                        model: modelName,
+                        error:
+                          nativeError instanceof Error
+                            ? nativeError.message
+                            : String(nativeError),
+                      },
+                    );
+                    nativeResult = await this.executeNativeGemini3Generate({
+                      ...mergedOptions,
+                      schema: undefined,
+                      output: { format: "json" },
+                    });
+                  } else {
+                    throw nativeError;
+                  }
+                }
               }
               executionSpan.setAttribute(
                 LANGFUSE_ATTR.OBSERVATION_OUTPUT,
@@ -6601,20 +6672,50 @@ export class GoogleVertexProvider extends BaseProvider {
       );
     }
 
-    // Rate limit and quota errors
+    // Rate limit / quota / capacity errors. Anthropic-on-Vertex capacity
+    // exhaustion surfaces as overloaded_error (HTTP 529) — same operational
+    // meaning as a 429, so classify it here instead of the generic 5xx branch.
     if (
       message.includes("QUOTA_EXCEEDED") ||
       message.includes("RATE_LIMIT_EXCEEDED") ||
       message.includes("rate limit") ||
       message.includes("429") ||
-      statusCode === 429
+      statusCode === 429 ||
+      statusCode === 529 ||
+      /overloaded/i.test(message)
     ) {
+      // Surface retry guidance when the SDK error carries it. @google/genai
+      // ApiError nests RetryInfo inside the JSON error body's details array,
+      // so fall back to scraping retryDelay out of the raw message.
+      const retryDelay =
+        typeof errorRecord?.retryDelay === "string"
+          ? errorRecord.retryDelay
+          : (/["']?retryDelay["']?\s*[:=]\s*["']?(\d+(?:\.\d+)?s)/.exec(
+              message,
+            )?.[1] ?? undefined);
+      // Prefer the per-request context the native catches attach to the
+      // error (this.modelName can be stale when options.model overrides the
+      // instance default). Gemini models are force-routed to the "global"
+      // endpoint regardless of configured location — report the region the
+      // request actually hit.
+      const requestModel =
+        typeof errorRecord?.requestModel === "string"
+          ? errorRecord.requestModel
+          : this.modelName;
+      const effectiveRegion =
+        typeof errorRecord?.requestRegion === "string"
+          ? errorRecord.requestRegion
+          : resolveVertexRegionForModel(requestModel, this.location);
       return new RateLimitError(
-        `Google Vertex AI quota/rate limit exceeded. ` +
-          `Solutions: 1. Check your Vertex AI quotas in Google Cloud Console ` +
-          `2. Request quota increase if needed ` +
-          `3. Try a different model or reduce request frequency ` +
-          `4. Consider using a different region`,
+        `Google Vertex AI rate limit / shared-capacity exhausted (429 RESOURCE_EXHAUSTED / overloaded) ` +
+          `for model '${requestModel}' in region '${effectiveRegion}'.` +
+          (retryDelay
+            ? ` Upstream suggests retrying after ${retryDelay}.`
+            : "") +
+          ` Solutions: 1. Retry with backoff ` +
+          `2. Check your Vertex AI quotas in Google Cloud Console (shared-capacity 429s can occur below quota) ` +
+          `3. Try a different region or model ` +
+          `4. Request provisioned throughput for sustained load`,
         this.providerName,
       );
     }

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -317,6 +317,19 @@ export type GenerateOptions = {
    * ```
    */
   enabledToolNames?: string[];
+  /**
+   * Request timeout (e.g. 30000, '30s', '2m').
+   *
+   * PER-STEP semantics in agentic loops: on providers that run a native
+   * multi-step tool loop (Vertex Gemini / Vertex Claude), this bounds EACH
+   * model call in the loop, not the whole turn — a tool-heavy turn may run
+   * far longer than this value in total. Size it for the slowest single
+   * step (default 300s), and use `abortSignal` for a total-turn deadline.
+   *
+   * When set explicitly, a step timeout is surfaced immediately instead of
+   * burning internal retries/fallbacks that would re-run the same
+   * provider+model with the same doomed budget.
+   */
   timeout?: number | string;
   /** AbortSignal for external cancellation of the AI call */
   abortSignal?: AbortSignal;

--- a/src/lib/utils/conversationMemory.ts
+++ b/src/lib/utils/conversationMemory.ts
@@ -6,6 +6,7 @@
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import { tracers } from "../telemetry/tracers.js";
 import { withTimeout } from "./errorHandling.js";
+import { safeDebugSerialize, sanitizeRecord } from "./logSanitize.js";
 import {
   DEFAULT_FALLBACK_THRESHOLD,
   getConversationMemoryDefaults,
@@ -141,13 +142,19 @@ export async function getConversationMessages(
     | undefined,
   options: TextGenerationOptions,
 ): Promise<ChatMessage[]> {
-  logger.debug("[conversationMemoryUtils] getConversationMessages called", {
-    hasMemory: !!conversationMemory,
-    memoryType: conversationMemory?.constructor?.name || "NONE",
-    hasContext: !!options.context,
-    enableSummarization: options.enableSummarization ?? false,
-    options: JSON.stringify(options, null, 2),
-  });
+  // Logger Guard: options carries the full conversation history + tool
+  // outputs; eager JSON.stringify of it can throw RangeError: Invalid string
+  // length and abort the turn. Serialize lazily, bounded, never-throwing,
+  // and redacted (sanitizeRecord strips credential/PII keys).
+  if (logger.shouldLog("debug")) {
+    logger.debug("[conversationMemoryUtils] getConversationMessages called", {
+      hasMemory: !!conversationMemory,
+      memoryType: conversationMemory?.constructor?.name || "NONE",
+      hasContext: !!options.context,
+      enableSummarization: options.enableSummarization ?? false,
+      options: safeDebugSerialize(sanitizeRecord(options)),
+    });
+  }
   if (!conversationMemory || !options.context) {
     logger.warn(
       "[conversationMemoryUtils] No memory or context, returning empty messages",
@@ -156,7 +163,11 @@ export async function getConversationMessages(
         memoryType: conversationMemory?.constructor?.name || "NONE",
         hasContext: !!options.context,
         enableSummarization: options.enableSummarization ?? false,
-        options: JSON.stringify(options, null, 2),
+        // The options dump is debug-grade detail — don't pay for (or leak)
+        // the serialization on every memory-disabled call at warn level.
+        ...(logger.shouldLog("debug")
+          ? { options: safeDebugSerialize(sanitizeRecord(options)) }
+          : {}),
       },
     );
     return [];

--- a/src/lib/utils/logSanitize.ts
+++ b/src/lib/utils/logSanitize.ts
@@ -81,6 +81,13 @@ const SENSITIVE_OBJECT_KEYS = [
   "oauth",
   "oauthToken",
   "credentials",
+  "authContext",
+  "authToken",
+  "sessionToken",
+  "serviceAccountKey",
+  "secretAccessKey",
+  // PII, not a secret — but it has no business in debug log dumps.
+  "userEmail",
 ];
 
 /**
@@ -98,6 +105,55 @@ export function sanitizeForLog(text: string, maxLen = 500): string {
     return text;
   }
   return text.slice(0, maxLen).replace(SECRET_PATTERN, "***");
+}
+
+/**
+ * Stringify non-string message/tool content without ever throwing.
+ * JSON.stringify on a giant multimodal/tool-result payload can exceed V8's
+ * maximum string length and throw `RangeError: Invalid string length` — a
+ * generation turn must degrade to a placeholder, not abort, when that
+ * happens. Shared by the SDK core and providers (single source of truth).
+ */
+export function stringifyContentSafe(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  try {
+    return JSON.stringify(content) ?? String(content);
+  } catch {
+    return "[content too large to serialize]";
+  }
+}
+
+/**
+ * Serialize an arbitrary value for a debug log without ever throwing or
+ * producing an unbounded string.
+ *
+ * `JSON.stringify` on a full options object (conversation history + tool
+ * outputs) can exceed V8's maximum string length and throw
+ * `RangeError: Invalid string length`, which — when evaluated eagerly inside
+ * a logger call — aborts the surrounding generation turn (observed in
+ * production). This helper caps the output and converts any stringify
+ * failure (RangeError, circular structure, BigInt, …) into a placeholder.
+ *
+ * Callers MUST still gate on `logger.shouldLog("debug")` per the Logger
+ * Guard rule — this helper makes serialization safe, not free.
+ *
+ * @param value  - Arbitrary value to serialize.
+ * @param maxLen - Maximum number of characters to keep (default 10 000).
+ */
+export function safeDebugSerialize(value: unknown, maxLen = 10_000): string {
+  try {
+    const json = JSON.stringify(value);
+    if (json === undefined) {
+      return String(value);
+    }
+    return json.length > maxLen
+      ? `${json.slice(0, maxLen)}…[truncated ${json.length - maxLen} chars]`
+      : json;
+  } catch (error) {
+    return `[unserializable: ${error instanceof Error ? error.message : String(error)}]`;
+  }
 }
 
 /**

--- a/test/continuous-test-suite-json.ts
+++ b/test/continuous-test-suite-json.ts
@@ -22,6 +22,7 @@ import {
 } from "./helpers/harness.js";
 import {
   isGeminiProvider,
+  isSchemaComplexityError,
   isToolsSchemaConflictError,
   isToolsSchemaExclusionInForce,
 } from "../src/lib/core/modules/structuredOutputPolicy.js";
@@ -112,6 +113,36 @@ await test("conflict detector: recognises Groq json+tools rejection", () => {
     false,
     "undefined must not match",
   );
+});
+
+await test("complexity detector: recognises Vertex 'too many states' 400", () => {
+  // Real production shape: the Vertex 400 arrives double-wrapped in the
+  // provider error formatter + upstream JSON envelope.
+  assert(
+    isSchemaComplexityError(
+      new Error(
+        '[vertex] Google Vertex AI Invalid Request: {"error":{"message":"{\\n  \\"error\\": {\\n    \\"code\\": 400,\\n    \\"message\\": \\"The specified schema produces a constraint that has too many states for serving.\\",\\n    \\"status\\": \\"INVALID_ARGUMENT\\"\\n  }\\n}\\n","code":400}}',
+      ),
+    ),
+    "wrapped Vertex too-many-states message should match",
+  );
+  assert(
+    isSchemaComplexityError(
+      "The specified schema produces a constraint that has too many states for serving.",
+    ),
+    "plain string form should match",
+  );
+  assertEqual(
+    isSchemaComplexityError(new Error("INVALID_ARGUMENT: bad field name")),
+    false,
+    "other INVALID_ARGUMENT errors must not match",
+  );
+  assertEqual(
+    isSchemaComplexityError(undefined),
+    false,
+    "undefined must not match",
+  );
+  assertEqual(isSchemaComplexityError(null), false, "null must not match");
 });
 
 // ── Balanced-brace extractor ────────────────────────────────────────────────


### PR DESCRIPTION
# Pull Request

## Description

**What does this PR do?**

Production-hardening fixes driven by a curator (consumer) log audit on OpenObserve, where these SDK behaviors showed up as recurring error signatures over the last 7 days.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

A 7-day production log audit of the curator service surfaced five SDK-side failure classes:

- Vertex Gemini rejects complex response schemas with a deterministic 400 ("schema produces a constraint that has too many states for serving") and the call hard-failed (~850 consumer failures/week).
- One failed external MCP server registration emitted 5 ERROR log lines through the layers (~1,700 duplicate records/week).
- Eager `JSON.stringify` of full options/history in log metadata threw `RangeError: Invalid string length` on huge conversations and aborted the turn.
- `options.timeout` is applied per SDK step in the native Vertex loops, but a step TimeoutError was retried through the whole fallback chain with the same doomed budget (one 90s timeout became ~650s of retries).
- Vertex 429s surfaced as bare `ApiError status 429` with no model/region/retry context; Anthropic-on-Vertex 529 `overloaded_error` fell into the generic 5xx branch.

## Changes Made

- `structuredOutputPolicy.ts`: new `isSchemaComplexityError()`; `GenerationHandler` retries without structured output on that 400 (same flow as `isToolsSchemaConflictError`), and the native Gemini generate path retries once in schema-less JSON mode (`responseMimeType` kept, `responseSchema` dropped) — `generate({schema})` still returns coerced `structuredData`.
- MCP registration failures now log ONE error at the outermost owner (`NeuroLink.addExternalMCPServer`, enriched with transport/command/redacted url); inner layers log at debug; `.mcp-config.json` loader keeps its own per-server ERROR (it bypasses the public entry point); remove-after-failed-add "not found" is a debug no-op.
- New `safeDebugSerialize()` (bounded, never-throws) + `logger.shouldLog("debug")` gates for options dumps; `stringifyContentSafe()` for message/tool content on functional paths (`neurolink.ts`, `conversationMemory.ts`, `structuredSummarizer.ts`, native Anthropic history builders).
- Per-step timeout semantics documented on `TextGenerationOptions.timeout`; MCP retry loop surfaces a caller-set step TimeoutError immediately (auto-scaled internal timeouts still retry).
- Vertex rate-limit errors now report model + effective region (Gemini routes to `global`), scrape `retryDelay` from the error body, and classify 529/overloaded as rate-limit.

## Breaking Changes

- [x] No breaking changes

## Testing

- [x] Unit tests added/updated — `test/continuous-test-suite-json.ts` covers `isSchemaComplexityError` (21/21 pass)
- [x] Existing tests pass — `continuous-test-suite-mcp-infra.ts` 84/84
- [x] `tsc --noEmit --strict` exit 0; `pnpm run lint` 0 errors
- Changes were additionally reviewed by a multi-agent adversarial review pass (per-area reviewers + 3-refuter verification per finding).

## Commit Message Format

- [x] Commit message follows format: `type(scope): description`

## Dependencies

- [x] No dependency changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced structured-output recovery: added a new “schema too complex” failure mode with targeted fallback/retry behavior.
  * More resilient processing of prompts, tool inputs/outputs, and conversation history to handle unusual/large payloads safely.

* **Bug Fixes**
  * Prevented token estimation and debug logging from crashing on extremely large or unserializable content.
  * Reduced duplicate or overly noisy logging during external server and client setup; adjusted log levels for expected failures.
  * Improved timeout enforcement so explicitly set step limits halt further retry escalation.

* **Documentation / Tests**
  * Clarified per-step timeout behavior and added deterministic coverage for schema-complexity classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->