### PR TITLE
feat(vertex): turn time budget + stopReason; MALFORMED_FUNCTION_CALL maps to 'error' not 'tool-calls'

### DIFF
--- a/docs/features/turn-time-budget.md
+++ b/docs/features/turn-time-budget.md
@@ -1,0 +1,105 @@
+# Turn Time Budget
+
+Turn-lifecycle limits for agentic (multi-step tool-calling) turns, enforced
+inside NeuroLink's native Vertex loops (Gemini and Claude-on-Vertex, both
+`generate()` and `stream()`). NeuroLink sees every model call, every tool
+start/finish, and every stream chunk — so it is the layer that can tell a
+productive long turn from a wedged one, and end each with an honest message
+and a machine-readable reason.
+
+## Options
+
+All four options ride `generate()` / `stream()` alongside `maxSteps` and the
+per-model-call `timeout`:
+
+| Option             | Meaning                                                                                                     | Default                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `turnTimeoutMs`    | Hard wall-clock cap for the WHOLE agentic turn (all model calls + tool executions)                          | see "Defensive defaults" below        |
+| `stallTimeoutMs`   | Max time with **no progress** (no stream chunk, no tool start/finish, no step start) before the turn ends   | disabled                              |
+| `wrapupTimeLeadMs` | With less than this much turn time remaining, a wrap-up nudge rides the next tool-result turn               | `120_000` when `turnTimeoutMs` is set |
+| `toolTimeoutMs`    | Per-tool-execution timeout; a timed-out tool fails **that step** (error tool_result) and the turn continues | `300_000`                             |
+
+```typescript
+const result = await neurolink.generate({
+  input: { text: "Investigate the amount mismatch across services" },
+  provider: "vertex",
+  maxSteps: 50,
+  turnTimeoutMs: 1_800_000, // 30 min whole-turn budget
+  stallTimeoutMs: 300_000, // no progress for 5 min => end the turn
+  toolTimeoutMs: 300_000, // a wedged tool costs one step, not the turn
+});
+```
+
+### Defensive defaults
+
+When `turnTimeoutMs` is **unset**, each loop keeps its pre-existing behavior:
+
+- **Vertex Gemini (generate + stream)** and **Vertex Claude stream**: the
+  defensive whole-turn bound of `timeout ?? 300_000` ms still applies (a turn
+  must never hang forever) — but its firing is now labeled honestly as a
+  time-limit exit instead of masquerading as a step-cap exit.
+- **Vertex Claude generate**: historically had no whole-turn bound (only the
+  per-call `timeout`), and still has none — long multi-step turns keep
+  running. Set `turnTimeoutMs` explicitly to bound them.
+
+## `stopReason` — the turn-exit discriminator
+
+`finishReason` is provider-shaped and historically overloaded ("tool-calls"
+covered both step-cap exits and Gemini `MALFORMED_FUNCTION_CALL` failures).
+Branch on `result.stopReason` instead:
+
+| `stopReason`     | Meaning                                                            |
+| ---------------- | ------------------------------------------------------------------ |
+| `completed`      | The model finished on its own (text answer or `final_result`)      |
+| `step-cap`       | The `maxSteps` budget ran out while the model still wanted tools   |
+| `time-limit`     | The `turnTimeoutMs` (or defensive) wall-clock deadline passed      |
+| `stalled`        | No progress for `stallTimeoutMs`                                   |
+| `aborted`        | The caller's `abortSignal` ended the turn                          |
+| `provider-error` | Provider/model failure (e.g. persistent `MALFORMED_FUNCTION_CALL`) |
+
+Also on the result: `rawFinishReason` (the verbatim provider value, e.g.
+`MALFORMED_FUNCTION_CALL`, `max_tokens`) and `stepsUsed`. On `stream()`
+results, read `metadata.stopReason` / `metadata.rawFinishReason` /
+`metadata.stepsUsed` **after draining the stream** — background loops resolve
+them at close, and metadata is the mutable reference that survives wrapper
+spreads.
+
+Providers without a native loop leave `stopReason` undefined — keep any
+legacy `finishReason` heuristics as a fallback.
+
+## Honest terminal messages
+
+Each exit cause has its own user-facing message; the step-cap text
+("...reached the N-step limit...") is emitted **only** when `step >= maxSteps`
+genuinely terminated the loop:
+
+- time-limit: _"I had to stop after Xm Ys — this turn hit its processing time
+  limit. I completed N tool calls before stopping; ask me to continue and
+  I'll pick up from there."_
+- stalled: _"I had to stop because this turn made no progress for Xs — a tool
+  or model call appears to be stuck. ..."_
+- aborted: _"This turn was stopped before I could finish. ..."_
+
+## MALFORMED_FUNCTION_CALL handling
+
+Gemini's `MALFORMED_FUNCTION_CALL` / `UNEXPECTED_TOOL_CALL` finish reasons
+map to unified `finishReason: "error"` (never `"tool-calls"`). A
+`MALFORMED_FUNCTION_CALL` step is retried **once** with a corrective note;
+if it persists, the turn ends with `stopReason: "provider-error"` — usually
+worth a caller-side retry.
+
+## Telemetry
+
+- `result.analytics` (when `enableAnalytics` is on) carries `stepsUsed`,
+  `toolCallCount`, `stopReason`, `elapsedMs`, `rawFinishReason`.
+- The SDK emitter fires `turn:lifecycle` events (alongside
+  `tool:start`/`tool:end`) for non-completed exits, tool timeouts, and
+  malformed-call retries:
+
+```typescript
+neurolink.getEventEmitter().on("turn:lifecycle", (event) => {
+  // { provider, timestamp, phase: "time-limit" | "stalled" | "aborted" |
+  //   "step-cap" | "provider-error" | "tool-timeout" | "malformed-retry",
+  //   step?, maxSteps?, toolName?, toolCallCount?, elapsedMs? }
+});
+```

--- a/src/cli/loop/optionsSchema.ts
+++ b/src/cli/loop/optionsSchema.ts
@@ -90,6 +90,26 @@ export const textGenerationOptionsSchema: Record<
     type: "number",
     description: "Timeout for the generation request in milliseconds.",
   },
+  turnTimeoutMs: {
+    type: "number",
+    description:
+      "Wall-clock cap for the whole agentic turn in milliseconds (all steps + tool executions).",
+  },
+  stallTimeoutMs: {
+    type: "number",
+    description:
+      "Maximum time with no progress (no chunk, no tool activity) before the turn ends as stalled, in milliseconds.",
+  },
+  wrapupTimeLeadMs: {
+    type: "number",
+    description:
+      "Remaining-turn-time threshold that triggers a wrap-up nudge to the model, in milliseconds.",
+  },
+  toolTimeoutMs: {
+    type: "number",
+    description:
+      "Per-tool-execution timeout in milliseconds (default 300000). A timed-out tool fails that step; the turn continues.",
+  },
   disableTools: {
     type: "boolean",
     description: "Disable all tool usage for the AI.",

--- a/src/lib/core/analytics.ts
+++ b/src/lib/core/analytics.ts
@@ -36,6 +36,23 @@ export function createAnalytics(
     // Estimate cost based on provider and tokens
     const cost = estimateCost(provider, model, tokens);
 
+    // Turn-lifecycle telemetry from native agentic loops (Vertex
+    // Gemini/Claude): stopReason / rawFinishReason / stepsUsed ride the
+    // provider result; toolCallCount and elapsedMs derive from it.
+    const turnResult = result as {
+      stopReason?: string;
+      rawFinishReason?: string;
+      stepsUsed?: number;
+      responseTime?: number;
+      toolExecutions?: unknown[];
+      toolsUsed?: string[];
+    };
+    const toolCallCount = Array.isArray(turnResult.toolExecutions)
+      ? turnResult.toolExecutions.length
+      : Array.isArray(turnResult.toolsUsed)
+        ? turnResult.toolsUsed.length
+        : undefined;
+
     const analytics: AnalyticsData = {
       provider,
       model,
@@ -44,6 +61,19 @@ export function createAnalytics(
       requestDuration: responseTime,
       context: context as Record<string, JsonValue> | undefined,
       timestamp: new Date().toISOString(),
+      ...(typeof turnResult.stepsUsed === "number" && {
+        stepsUsed: turnResult.stepsUsed,
+      }),
+      ...(toolCallCount !== undefined && { toolCallCount }),
+      ...(typeof turnResult.stopReason === "string" && {
+        stopReason: turnResult.stopReason,
+      }),
+      ...(typeof turnResult.responseTime === "number" && {
+        elapsedMs: turnResult.responseTime,
+      }),
+      ...(typeof turnResult.rawFinishReason === "string" && {
+        rawFinishReason: turnResult.rawFinishReason,
+      }),
     };
 
     logger.debug(`[${functionTag}] Analytics created`, {

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -122,6 +122,21 @@ export const DEFAULT_TOOL_MAX_RETRIES = 2; // Maximum retries per tool before pe
 /** Defensive wall-clock ceiling for a native Gemini-3 agentic turn (generate + stream). */
 export const DEFAULT_GEMINI_STREAM_TIMEOUT_MS = 300_000;
 
+/**
+ * Default per-tool-execution timeout for native agentic loops. A tool that
+ * exceeds it fails with an error tool_result and costs one step — the turn
+ * continues instead of hanging on a wedged tool. Override per call with
+ * `toolTimeoutMs`.
+ */
+export const DEFAULT_TOOL_EXECUTION_TIMEOUT_MS = 300_000;
+
+/**
+ * Default wrap-up lead applied when `turnTimeoutMs` is set but
+ * `wrapupTimeLeadMs` is not: with less than this much turn time remaining,
+ * a wrap-up nudge rides the next tool-result turn.
+ */
+export const DEFAULT_WRAPUP_TIME_LEAD_MS = 120_000;
+
 // Fire-and-forget tool storage writes (Redis). 5s is generous for a single
 // Redis write; if breached, the .catch logs a warning.
 export const TOOL_STORAGE_TIMEOUT_MS = 5000;

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -4707,6 +4707,10 @@ Current user's request: ${currentInput}`;
       stt: options.stt,
       fileRegistry: this.fileRegistry,
       timeout: options.timeout,
+      turnTimeoutMs: options.turnTimeoutMs,
+      stallTimeoutMs: options.stallTimeoutMs,
+      wrapupTimeLeadMs: options.wrapupTimeLeadMs,
+      toolTimeoutMs: options.toolTimeoutMs,
       abortSignal: options.abortSignal,
       skipToolPromptInjection: options.skipToolPromptInjection,
       middleware: options.middleware,
@@ -4884,6 +4888,12 @@ Current user's request: ${currentInput}`;
       content: textResult.content,
       structuredData: textResult.structuredData,
       finishReason: textResult.finishReason,
+      // Turn-exit discriminator + raw provider stop reason + step count from
+      // native agentic loops — this DTO is an explicit field list, so new
+      // provider-result fields MUST be copied here or they silently vanish.
+      stopReason: textResult.stopReason,
+      rawFinishReason: textResult.rawFinishReason,
+      stepsUsed: textResult.stepsUsed,
       jsonRepaired: textResult.jsonRepaired,
       jsonTruncated: textResult.jsonTruncated,
       provider: textResult.provider,
@@ -6964,6 +6974,9 @@ Current user's request: ${currentInput}`;
       usage: result.usage,
       responseTime,
       finishReason: result.finishReason,
+      stopReason: result.stopReason,
+      rawFinishReason: result.rawFinishReason,
+      stepsUsed: result.stepsUsed,
       toolsUsed: result.toolsUsed || [],
       toolExecutions: transformedToolExecutions,
       enhancedWithTools: Boolean(hasToolExecutions),
@@ -7139,6 +7152,9 @@ Current user's request: ${currentInput}`;
             usage: poolResult.usage,
             responseTime,
             finishReason: poolResult.finishReason,
+            stopReason: poolResult.stopReason,
+            rawFinishReason: poolResult.rawFinishReason,
+            stepsUsed: poolResult.stepsUsed,
             toolsUsed: poolResult.toolsUsed || [],
             toolExecutions: poolResult.toolExecutions?.map((te) => {
               const t = te as Record<string, unknown>;
@@ -7504,6 +7520,9 @@ Current user's request: ${currentInput}`;
           usage: result.usage,
           responseTime,
           finishReason: result.finishReason,
+          stopReason: result.stopReason,
+          rawFinishReason: result.rawFinishReason,
+          stepsUsed: result.stepsUsed,
           toolsUsed: result.toolsUsed || [],
           // Map toolExecutions from EnhancedGenerateResult shape ({name,input,output})
           // to TextGenerationResult shape ({toolName,executionTime,success}).
@@ -8802,6 +8821,7 @@ Current user's request: ${currentInput}`;
         toolCalls: streamToolCalls,
         toolResults: streamToolResults,
         analytics: streamAnalytics,
+        metadata: providerStreamMetadata,
       } = await this.createMCPStream(enhancedOptions);
       const streamState = {
         finishReason: streamFinishReason ?? "stop",
@@ -9208,6 +9228,7 @@ Current user's request: ${currentInput}`;
         guardrailsBlocked: metadata.guardrailsBlocked,
         error: metadata.error,
         events: eventSequence,
+        providerMetadata: providerStreamMetadata,
       });
     } catch (error) {
       if (options.disableInternalFallback) {
@@ -10020,6 +10041,8 @@ Current user's request: ${currentInput}`;
     toolCalls: StreamToolCall[];
     toolResults: StreamToolResult[];
     analytics?: AnalyticsData | Promise<AnalyticsData>;
+    /** Provider metadata, passed through by reference (see return site). */
+    metadata?: StreamResult["metadata"];
   }> {
     // Simplified placeholder - in the actual implementation this would contain the complex MCP stream logic
     const providerName = await getBestProvider(options.provider);
@@ -10375,6 +10398,7 @@ Current user's request: ${currentInput}`;
             toolCalls: poolStreamResult.toolCalls ?? [],
             toolResults: poolStreamResult.toolResults ?? [],
             analytics: poolStreamResult.analytics,
+            metadata: poolStreamResult.metadata,
           };
         } catch (poolStreamError) {
           if (isAbortError(poolStreamError)) {
@@ -10443,6 +10467,12 @@ Current user's request: ${currentInput}`;
       toolCalls: streamResult.toolCalls ?? [],
       toolResults: streamResult.toolResults ?? [],
       analytics: streamResult.analytics,
+      // Pass the provider's metadata object THROUGH BY REFERENCE: native
+      // background-loop streams (Vertex Gemini/Claude) resolve
+      // finishReason/stopReason/rawFinishReason/stepsUsed onto it only when
+      // the loop finishes — snapshotting fields here would freeze them as
+      // undefined before the stream is drained.
+      metadata: streamResult.metadata,
     };
   }
 
@@ -10524,6 +10554,14 @@ Current user's request: ${currentInput}`;
         timestamp: number;
         [key: string]: unknown;
       }>;
+      /**
+       * The provider StreamResult's metadata object. Merged IN PLACE (not
+       * spread): native background-loop streams resolve finishReason /
+       * stopReason / rawFinishReason / stepsUsed onto this same object only
+       * after the consumer drains the stream — a copy would freeze them as
+       * undefined.
+       */
+      providerMetadata?: StreamResult["metadata"];
     },
   ): StreamResult {
     return {
@@ -10538,14 +10576,14 @@ Current user's request: ${currentInput}`;
       evaluation: streamResult.evaluation,
       events:
         config.events && config.events.length > 0 ? config.events : undefined,
-      metadata: {
+      metadata: Object.assign(config.providerMetadata ?? {}, {
         streamId: config.streamId,
         startTime: config.startTime,
         responseTime: config.responseTime,
         fallback: config.fallback || false,
         guardrailsBlocked: config.guardrailsBlocked,
         error: config.error,
-      },
+      }),
     };
   }
 

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -15,8 +15,10 @@ import { extname } from "node:path";
 import {
   DEFAULT_MAX_STEPS,
   DEFAULT_TOOL_MAX_RETRIES,
+  DEFAULT_WRAPUP_TIME_LEAD_MS,
 } from "../core/constants.js";
 import type {
+  GenerateStopReason,
   ZodUnknownSchema,
   ThinkingConfig,
   ChatMessage,
@@ -632,16 +634,22 @@ export function computeMaxSteps(rawMaxSteps?: number): number {
  * Returns a plain string (not a `{ unified, raw }` object): the Vertex result
  * builders and the consuming layer (neurolink.ts `finishReason || "unknown"`
  * and `finishReason === "length"`) compare against plain strings.
+ *
+ * MALFORMED_FUNCTION_CALL / UNEXPECTED_TOOL_CALL map to "error", NOT
+ * "tool-calls": they are provider/model failures, while "tool-calls" is the
+ * exclusive contract for "step budget exhausted while the model still wanted
+ * tools" — consumers (e.g. curator's step-cap intercept) branch on it and
+ * were rendering fake step-limit messages for 2-4-step malformed-call turns.
  */
 export function mapGeminiFinishReason(
   raw: string | null | undefined,
-): "stop" | "length" | "tool-calls" | "content-filter" {
+): "stop" | "length" | "tool-calls" | "content-filter" | "error" {
   switch (raw) {
     case "MAX_TOKENS":
       return "length";
     case "MALFORMED_FUNCTION_CALL":
     case "UNEXPECTED_TOOL_CALL":
-      return "tool-calls";
+      return "error";
     case "SAFETY":
     case "RECITATION":
     case "BLOCKLIST":
@@ -1097,8 +1105,13 @@ export function isAbortError(error: unknown): boolean {
 
 /**
  * Build a graceful, user-facing message for when a single agentic turn hits
- * the step cap (or is aborted mid-turn) without producing a final answer.
- * Replaces the legacy bracketed "Tool execution limit reached" placeholder.
+ * the step cap without producing a final answer. Replaces the legacy
+ * bracketed "Tool execution limit reached" placeholder.
+ *
+ * Emit this ONLY when `step >= maxSteps` genuinely terminated the loop —
+ * aborted/timed-out/stalled turns must use {@link buildAbortedTurnMessage},
+ * {@link buildTurnTimeoutMessage}, or {@link buildTurnStalledMessage}, never
+ * this text (a killed 23-step turn once claimed "reached the 200-step limit").
  */
 export function buildToolLoopCapMessage(
   maxSteps: number,
@@ -1114,6 +1127,229 @@ export function buildToolLoopCapMessage(
     `${calls}reached the ${maxSteps}-step limit for a single turn before I could finish. ` +
     `Please narrow the request or break it into smaller asks and I'll continue.`
   );
+}
+
+/** Format an elapsed duration as "Xm Ys" (or "Ys" under a minute). */
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+/**
+ * Honest message for a turn ended by the `turnTimeoutMs` wall-clock deadline
+ * (stopReason "time-limit"). Sibling of {@link buildToolLoopCapMessage} —
+ * time exits must never claim a step limit was reached.
+ */
+export function buildTurnTimeoutMessage(
+  elapsedMs: number,
+  toolCallCount: number,
+): string {
+  const calls =
+    toolCallCount > 0
+      ? ` I completed ${toolCallCount} tool call${
+          toolCallCount === 1 ? "" : "s"
+        } before stopping;`
+      : "";
+  return (
+    `I had to stop after ${formatElapsed(elapsedMs)} — this turn hit its ` +
+    `processing time limit.${calls} ask me to continue and I'll pick up from there.`
+  );
+}
+
+/**
+ * Honest message for a turn ended by the `stallTimeoutMs` no-progress
+ * watchdog (stopReason "stalled") — typically a wedged tool or a hung
+ * model call.
+ */
+export function buildTurnStalledMessage(
+  stallTimeoutMs: number,
+  toolCallCount: number,
+): string {
+  const calls =
+    toolCallCount > 0
+      ? ` I completed ${toolCallCount} tool call${
+          toolCallCount === 1 ? "" : "s"
+        } before stopping;`
+      : "";
+  return (
+    `I had to stop because this turn made no progress for ` +
+    `${formatElapsed(stallTimeoutMs)} — a tool or model call appears to be stuck.` +
+    `${calls} ask me to continue and I'll pick up from there.`
+  );
+}
+
+/**
+ * Honest message for a caller-aborted turn (admin kill, coding-task
+ * short-circuit — stopReason "aborted").
+ */
+export function buildAbortedTurnMessage(toolCallCount: number): string {
+  const calls =
+    toolCallCount > 0
+      ? ` I completed ${toolCallCount} tool call${
+          toolCallCount === 1 ? "" : "s"
+        } before stopping.`
+      : "";
+  return `This turn was stopped before I could finish.${calls}`;
+}
+
+/**
+ * Wrap-up nudge injected when the remaining turn time drops inside the
+ * `wrapupTimeLeadMs` window — the time-budget twin of the soft step-budget
+ * nudge. Rides as a trailing text block on the tool-result user turn.
+ */
+export function buildWrapupNudgeText(useFinalResultTool: boolean): string {
+  return (
+    "NOTE: processing time for this turn is nearly up. Consolidate what you have and " +
+    (useFinalResultTool
+      ? "call final_result with your best answer now."
+      : "provide your final answer now.")
+  );
+}
+
+/**
+ * Resolve the turn's `stopReason` discriminator from the loop's exit
+ * bookkeeping. Precedence: time conditions beat the generic abort flag
+ * (the deadline/stall watchdogs abort through the same internal controller),
+ * abort beats step-cap, and a provider-error finishReason (e.g. persistent
+ * MALFORMED_FUNCTION_CALL) beats "completed".
+ */
+export function resolveTurnStopReason(params: {
+  timedOut: boolean;
+  stalled: boolean;
+  wasAborted: boolean;
+  /** Step budget ran out AND no clean/forced answer was produced. */
+  cappedWithoutAnswer: boolean;
+  /** The turn's resolved unified finishReason. */
+  finishReason?: string;
+}): GenerateStopReason {
+  if (params.timedOut) {
+    return "time-limit";
+  }
+  if (params.stalled) {
+    return "stalled";
+  }
+  if (params.wasAborted) {
+    return "aborted";
+  }
+  if (params.cappedWithoutAnswer) {
+    return "step-cap";
+  }
+  if (params.finishReason === "error") {
+    return "provider-error";
+  }
+  return "completed";
+}
+
+/**
+ * Wall-clock + progress watchdogs for a native agentic turn.
+ *
+ * - Deadline: `turnTimeoutMs` (caller knob) or `defaultTurnTimeoutMs` (the
+ *   loop's pre-existing defensive bound) arms a whole-turn timer.
+ * - Stall: when `stallTimeoutMs` is set, a low-frequency interval checks the
+ *   time since the last recorded progress (chunk received, tool started or
+ *   finished, step started).
+ *
+ * Both fire `onDeadline(kind)` exactly once each and latch a flag the loop's
+ * terminal handling reads to pick the honest exit message and `stopReason`.
+ * Timers are unref'd so they never hold the process open; call `dispose()`
+ * in the loop's finally.
+ */
+export function createTurnClock(params: {
+  /** Explicit whole-turn deadline (ms); wins over defaultTurnTimeoutMs. */
+  turnTimeoutMs?: number;
+  /** Loop-specific defensive default when turnTimeoutMs is unset (undefined = no deadline). */
+  defaultTurnTimeoutMs?: number;
+  /** No-progress watchdog (ms); undefined = disabled. */
+  stallTimeoutMs?: number;
+  /** Wrap-up lead (ms); only honored when turnTimeoutMs is explicitly set. */
+  wrapupTimeLeadMs?: number;
+  onDeadline: (kind: "timeout" | "stall") => void;
+}) {
+  const startedAt = Date.now();
+  const isValidMs = (value: number | undefined): value is number =>
+    value !== undefined && Number.isFinite(value) && value > 0;
+  const effectiveTurnTimeoutMs = isValidMs(params.turnTimeoutMs)
+    ? params.turnTimeoutMs
+    : isValidMs(params.defaultTurnTimeoutMs)
+      ? params.defaultTurnTimeoutMs
+      : undefined;
+  // Nudging against the loop's defensive default would inject prompt text
+  // into turns whose caller never opted into a time budget — only nudge
+  // against an explicit turnTimeoutMs.
+  const wrapupLeadMs = isValidMs(params.turnTimeoutMs)
+    ? (params.wrapupTimeLeadMs ?? DEFAULT_WRAPUP_TIME_LEAD_MS)
+    : undefined;
+  let timedOut = false;
+  let stalled = false;
+  let lastProgressAt = startedAt;
+  let deadlineTimer: NodeJS.Timeout | undefined;
+  let stallTimer: NodeJS.Timeout | undefined;
+  if (effectiveTurnTimeoutMs !== undefined) {
+    deadlineTimer = setTimeout(() => {
+      timedOut = true;
+      params.onDeadline("timeout");
+    }, effectiveTurnTimeoutMs);
+    deadlineTimer.unref?.();
+  }
+  if (isValidMs(params.stallTimeoutMs)) {
+    const stallTimeoutMs = params.stallTimeoutMs;
+    const checkEveryMs = Math.min(
+      Math.max(1000, Math.floor(stallTimeoutMs / 4)),
+      15_000,
+    );
+    stallTimer = setInterval(() => {
+      if (
+        !stalled &&
+        !timedOut &&
+        Date.now() - lastProgressAt >= stallTimeoutMs
+      ) {
+        stalled = true;
+        params.onDeadline("stall");
+      }
+    }, checkEveryMs);
+    stallTimer.unref?.();
+  }
+  return {
+    get timedOut(): boolean {
+      return timedOut;
+    },
+    get stalled(): boolean {
+      return stalled;
+    },
+    /** True when the turn ended on a time condition (deadline or stall). */
+    get expired(): boolean {
+      return timedOut || stalled;
+    },
+    /** The effective whole-turn deadline in ms (explicit or defensive default). */
+    get turnTimeoutMs(): number | undefined {
+      return effectiveTurnTimeoutMs;
+    },
+    elapsedMs(): number {
+      return Date.now() - startedAt;
+    },
+    /** Record progress: chunk received, tool started/finished, step started. */
+    noteProgress(): void {
+      lastProgressAt = Date.now();
+    },
+    /** True when an explicit deadline exists and remaining time is inside the wrap-up lead. */
+    shouldNudgeWrapup(): boolean {
+      if (effectiveTurnTimeoutMs === undefined || wrapupLeadMs === undefined) {
+        return false;
+      }
+      const remaining = effectiveTurnTimeoutMs - (Date.now() - startedAt);
+      return remaining > 0 && remaining <= wrapupLeadMs;
+    },
+    dispose(): void {
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer);
+      }
+      if (stallTimer) {
+        clearInterval(stallTimer);
+      }
+    },
+  };
 }
 
 /**

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -14,6 +14,7 @@ import { BaseProvider } from "../core/baseProvider.js";
 import {
   DEFAULT_GEMINI_STREAM_TIMEOUT_MS,
   DEFAULT_MAX_STEPS,
+  DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
   DEFAULT_TOOL_MAX_RETRIES,
   GLOBAL_LOCATION_MODELS,
   IMAGE_GENERATION_MODELS,
@@ -28,6 +29,7 @@ import type {
   UnknownRecord,
   ZodUnknownSchema,
   EnhancedGenerateResult,
+  GenerateStopReason,
   TextGenerationOptions,
   GenAIClient,
   GoogleGenAIClass,
@@ -80,12 +82,18 @@ import { TimeoutError, withTimeout } from "../utils/async/index.js";
 import { parseTimeout } from "../utils/timeout.js";
 import {
   appendStepText,
+  buildAbortedTurnMessage,
   buildToolLoopCapMessage,
+  buildTurnStalledMessage,
+  buildTurnTimeoutMessage,
+  buildWrapupNudgeText,
   createTextChannel,
+  createTurnClock,
   extractThoughtSignature,
   isAbortError,
   mapGeminiFinishReason,
   prependConversationMessages,
+  resolveTurnStopReason,
 } from "./googleNativeGemini3.js";
 import {
   ATTR,
@@ -1791,24 +1799,41 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Abort scaffolding (mirrors executeNativeAnthropicStream). The native
     // Gemini SDK cancels via config.abortSignal, so drive an internal
-    // AbortController: the caller's signal and a defensive wall-clock timer
-    // both trip it, and every request/tool-exec receives effectiveSignal.
+    // AbortController: the caller's signal and the turn clock's watchdogs
+    // (whole-turn deadline + optional stall detector) all trip it, and every
+    // request/tool-exec receives effectiveSignal.
     const streamTimeoutMs =
       parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS;
+    const toolExecTimeoutMs =
+      options.toolTimeoutMs ?? DEFAULT_TOOL_EXECUTION_TIMEOUT_MS;
+    const effectiveTurnDeadlineMs = options.turnTimeoutMs ?? streamTimeoutMs;
     const internalAbort = new AbortController();
     const onCallerAbort = () => internalAbort.abort();
     options.abortSignal?.addEventListener("abort", onCallerAbort);
-    const defensiveTimer = setTimeout(() => {
-      logger.warn(
-        `[GoogleVertex] Native Gemini turn exceeded ${streamTimeoutMs}ms — aborting`,
-      );
-      internalAbort.abort();
-    }, streamTimeoutMs);
+    const turnClock = createTurnClock({
+      turnTimeoutMs: options.turnTimeoutMs,
+      // Preserve the pre-existing defensive whole-turn bound when the caller
+      // sets no explicit turn budget — a turn must never hang forever.
+      defaultTurnTimeoutMs: streamTimeoutMs,
+      stallTimeoutMs: options.stallTimeoutMs,
+      wrapupTimeLeadMs: options.wrapupTimeLeadMs,
+      onDeadline: (kind) => {
+        logger.warn(
+          kind === "timeout"
+            ? `[GoogleVertex] Native Gemini turn exceeded its ${effectiveTurnDeadlineMs}ms time budget — aborting`
+            : `[GoogleVertex] Native Gemini turn made no progress for ${options.stallTimeoutMs}ms — aborting`,
+        );
+        internalAbort.abort();
+      },
+    });
     const effectiveSignal = internalAbort.signal;
     if (options.abortSignal?.aborted) {
       internalAbort.abort();
     }
     let wasAborted = false;
+    // One retry per turn for MALFORMED_FUNCTION_CALL steps (see the retry
+    // block after the step drain).
+    let malformedRetryCount = 0;
 
     // Step-cap flags declared in the outer scope so the terminal block (also
     // inside the try) and the finishReason mapping (after the finally) can
@@ -1824,6 +1849,7 @@ export class GoogleVertexProvider extends BaseProvider {
           break;
         }
         step++;
+        turnClock.noteProgress();
         logger.debug(`[GoogleVertex] Native SDK step ${step}/${maxSteps}`);
 
         try {
@@ -1840,8 +1866,13 @@ export class GoogleVertexProvider extends BaseProvider {
 
           // Capture raw response parts including thoughtSignature
           const rawResponseParts: unknown[] = [];
+          // This step's own finish reason (vs the cross-step
+          // lastFinishReason) — drives the single MALFORMED_FUNCTION_CALL
+          // retry below.
+          let stepFinishReason: string | undefined;
 
           for await (const chunk of stream) {
+            turnClock.noteProgress();
             // Extract raw parts from candidates FIRST
             // This avoids using chunk.text which triggers SDK warning when
             // non-text parts (thoughtSignature, functionCall) are present
@@ -1855,6 +1886,7 @@ export class GoogleVertexProvider extends BaseProvider {
             const chunkFinishReason = firstCandidate?.finishReason;
             if (typeof chunkFinishReason === "string" && chunkFinishReason) {
               lastFinishReason = chunkFinishReason;
+              stepFinishReason = chunkFinishReason;
             }
             const chunkContent = firstCandidate?.content as
               | Record<string, unknown>
@@ -1909,6 +1941,43 @@ export class GoogleVertexProvider extends BaseProvider {
             )
             .map((part) => part.text)
             .join("");
+
+          // MALFORMED_FUNCTION_CALL is usually a transient formatting failure
+          // (the model emitted an unparseable call): retry the step ONCE with
+          // a corrective note instead of hard-ending the turn with empty
+          // content — automated alert-RCA turns were dying at step 2-4 on
+          // this, mislabeled as step-cap exits.
+          if (
+            stepFunctionCalls.length === 0 &&
+            !stepText &&
+            stepFinishReason === "MALFORMED_FUNCTION_CALL" &&
+            malformedRetryCount < 1 &&
+            !effectiveSignal.aborted
+          ) {
+            malformedRetryCount++;
+            logger.warn(
+              `[GoogleVertex] Model returned MALFORMED_FUNCTION_CALL at step ${step}/${maxSteps}; retrying once with a corrective note.`,
+            );
+            this.emitTurnEvent({ phase: "malformed-retry", step, maxSteps });
+            if (rawResponseParts.length > 0) {
+              currentContents.push({
+                role: "model",
+                parts: rawResponseParts as VertexNativePart[],
+              });
+            }
+            currentContents.push({
+              role: "user",
+              parts: [
+                {
+                  text:
+                    "Your previous function call was malformed and could not " +
+                    "be parsed. Re-issue it as a single valid function call, " +
+                    "or answer in plain text.",
+                },
+              ],
+            });
+            continue;
+          }
 
           // If no function calls, we're done
           if (stepFunctionCalls.length === 0) {
@@ -2014,7 +2083,15 @@ export class GoogleVertexProvider extends BaseProvider {
                   messages: [],
                   abortSignal: effectiveSignal,
                 };
-                const result = await execute(call.args, toolOptions);
+                turnClock.noteProgress();
+                // Bound the execute() await — a wedged tool costs one step
+                // (error tool_result), not the whole turn.
+                const result = await withTimeout(
+                  Promise.resolve(execute(call.args, toolOptions)),
+                  toolExecTimeoutMs,
+                  `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
+                );
+                turnClock.noteProgress();
                 toolExecutions.push({
                   name: call.name,
                   input: call.args,
@@ -2037,6 +2114,15 @@ export class GoogleVertexProvider extends BaseProvider {
                 if (effectiveSignal.aborted || isAbortError(error)) {
                   wasAborted = true;
                   break;
+                }
+                turnClock.noteProgress();
+                if (error instanceof TimeoutError) {
+                  this.emitTurnEvent({
+                    phase: "tool-timeout",
+                    step,
+                    maxSteps,
+                    toolName: call.name,
+                  });
                 }
                 const errorMessage =
                   error instanceof Error ? error.message : "Unknown error";
@@ -2149,6 +2235,16 @@ export class GoogleVertexProvider extends BaseProvider {
             });
           }
 
+          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft
+          // step nudge): with the turn deadline approaching, tell the model
+          // to consolidate. Rides as a trailing text part on the
+          // tool-response user turn.
+          if (turnClock.shouldNudgeWrapup()) {
+            functionResponses.push({
+              text: buildWrapupNudgeText(useFinalResultTool),
+            } as unknown as (typeof functionResponses)[number]);
+          }
+
           // The @google/genai SDK only accepts "user" and "model" as valid
           // roles in contents — function/tool responses must use role: "user"
           // (matching the SDK's automaticFunctionCalling implementation and
@@ -2196,13 +2292,23 @@ export class GoogleVertexProvider extends BaseProvider {
               `returning text already gathered from prior steps.`,
           );
         } else if (wasAborted) {
-          // Aborted turn — skip synth entirely so it can never add +300s after
-          // a blown budget. Deliver exactly one graceful cap chunk.
+          // Turn ended on a time condition or caller abort — skip synth
+          // entirely so it can never add +300s after a blown budget, and
+          // deliver exactly one HONEST terminal chunk matching the actual
+          // exit cause (never the step-cap text — a killed healthy turn must
+          // not claim it "reached the step limit").
           logger.warn(
-            `[GoogleVertex] Tool call loop aborted mid-turn; ` +
-              `returning a graceful cap message.`,
+            `[GoogleVertex] Tool call loop ended mid-turn ` +
+              `(${turnClock.timedOut ? "turn time limit" : turnClock.stalled ? "stall watchdog" : "caller abort"}); ` +
+              `returning an honest terminal message.`,
           );
-          finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+          finalText = this.buildLoopExitMessage({
+            turnClock,
+            wasAborted,
+            stallTimeoutMs: options.stallTimeoutMs,
+            maxSteps,
+            toolCallCount,
+          });
         } else {
           logger.warn(
             `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
@@ -2235,7 +2341,7 @@ export class GoogleVertexProvider extends BaseProvider {
         }
       }
     } finally {
-      clearTimeout(defensiveTimer);
+      turnClock.dispose();
       options.abortSignal?.removeEventListener("abort", onCallerAbort);
     }
 
@@ -2248,6 +2354,27 @@ export class GoogleVertexProvider extends BaseProvider {
       hitStepLimit && !synthesizedFinalAnswer
         ? "tool-calls"
         : mapGeminiFinishReason(lastFinishReason);
+
+    // Turn-exit discriminator, independent of the provider-shaped
+    // finishReason — consumers branch on this instead of sniffing strings.
+    const stopReason = resolveTurnStopReason({
+      timedOut: turnClock.timedOut,
+      stalled: turnClock.stalled,
+      wasAborted,
+      cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      finishReason: resolvedFinishReason,
+    });
+    if (stopReason !== "completed") {
+      this.emitTurnEvent({
+        phase: stopReason,
+        step,
+        maxSteps,
+        toolCallCount: allToolCalls.filter(
+          (tc) => tc.toolName !== "final_result",
+        ).length,
+        elapsedMs: turnClock.elapsedMs(),
+      });
+    }
 
     const responseTime = Date.now() - startTime;
 
@@ -2284,6 +2411,8 @@ export class GoogleVertexProvider extends BaseProvider {
       provider: this.providerName,
       model: modelName,
       finishReason: resolvedFinishReason,
+      stopReason,
+      rawFinishReason: lastFinishReason,
       usage: {
         input: totalInputTokens,
         output: totalOutputTokens,
@@ -2306,6 +2435,9 @@ export class GoogleVertexProvider extends BaseProvider {
         startTime,
         responseTime,
         totalToolExecutions: externalToolCalls.length,
+        stopReason,
+        rawFinishReason: lastFinishReason,
+        stepsUsed: step,
       },
     };
 
@@ -2743,24 +2875,41 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Abort scaffolding (mirrors executeNativeAnthropicStream). The native
     // Gemini SDK cancels via config.abortSignal, so drive an internal
-    // AbortController: the caller's signal and a defensive wall-clock timer
-    // both trip it, and every request/tool-exec receives effectiveSignal.
+    // AbortController: the caller's signal and the turn clock's watchdogs
+    // (whole-turn deadline + optional stall detector) all trip it, and every
+    // request/tool-exec receives effectiveSignal.
     const streamTimeoutMs =
       parseTimeout(options.timeout) ?? DEFAULT_GEMINI_STREAM_TIMEOUT_MS;
+    const toolExecTimeoutMs =
+      options.toolTimeoutMs ?? DEFAULT_TOOL_EXECUTION_TIMEOUT_MS;
+    const effectiveTurnDeadlineMs = options.turnTimeoutMs ?? streamTimeoutMs;
     const internalAbort = new AbortController();
     const onCallerAbort = () => internalAbort.abort();
     options.abortSignal?.addEventListener("abort", onCallerAbort);
-    const defensiveTimer = setTimeout(() => {
-      logger.warn(
-        `[GoogleVertex] Native Gemini turn exceeded ${streamTimeoutMs}ms — aborting`,
-      );
-      internalAbort.abort();
-    }, streamTimeoutMs);
+    const turnClock = createTurnClock({
+      turnTimeoutMs: options.turnTimeoutMs,
+      // Preserve the pre-existing defensive whole-turn bound when the caller
+      // sets no explicit turn budget — a turn must never hang forever.
+      defaultTurnTimeoutMs: streamTimeoutMs,
+      stallTimeoutMs: options.stallTimeoutMs,
+      wrapupTimeLeadMs: options.wrapupTimeLeadMs,
+      onDeadline: (kind) => {
+        logger.warn(
+          kind === "timeout"
+            ? `[GoogleVertex] Native Gemini turn exceeded its ${effectiveTurnDeadlineMs}ms time budget — aborting`
+            : `[GoogleVertex] Native Gemini turn made no progress for ${options.stallTimeoutMs}ms — aborting`,
+        );
+        internalAbort.abort();
+      },
+    });
     const effectiveSignal = internalAbort.signal;
     if (options.abortSignal?.aborted) {
       internalAbort.abort();
     }
     let wasAborted = false;
+    // One retry per turn for MALFORMED_FUNCTION_CALL steps (see the retry
+    // block after the step drain).
+    let malformedRetryCount = 0;
 
     // Step-cap flags declared in the outer scope so the terminal block (also
     // inside the try) and the finishReason mapping (after the finally) can
@@ -2776,6 +2925,7 @@ export class GoogleVertexProvider extends BaseProvider {
           break;
         }
         step++;
+        turnClock.noteProgress();
         logger.debug(
           `[GoogleVertex] Native SDK generate step ${step}/${maxSteps}`,
         );
@@ -2795,9 +2945,14 @@ export class GoogleVertexProvider extends BaseProvider {
 
           // Capture raw response parts including thoughtSignature
           const rawResponseParts: unknown[] = [];
+          // This step's own finish reason (vs the cross-step
+          // lastFinishReason) — drives the single MALFORMED_FUNCTION_CALL
+          // retry below.
+          let stepFinishReason: string | undefined;
 
           // Collect all chunks from stream
           for await (const chunk of stream) {
+            turnClock.noteProgress();
             // Extract raw parts from candidates FIRST
             // This avoids using chunk.text which triggers SDK warning when
             // non-text parts (thoughtSignature, functionCall) are present
@@ -2811,6 +2966,7 @@ export class GoogleVertexProvider extends BaseProvider {
             const chunkFinishReason = firstCandidate?.finishReason;
             if (typeof chunkFinishReason === "string" && chunkFinishReason) {
               lastFinishReason = chunkFinishReason;
+              stepFinishReason = chunkFinishReason;
             }
             const chunkContent = firstCandidate?.content as
               | Record<string, unknown>
@@ -2858,6 +3014,43 @@ export class GoogleVertexProvider extends BaseProvider {
             )
             .map((part) => part.text)
             .join("");
+
+          // MALFORMED_FUNCTION_CALL is usually a transient formatting failure
+          // (the model emitted an unparseable call): retry the step ONCE with
+          // a corrective note instead of hard-ending the turn with empty
+          // content — automated alert-RCA turns were dying at step 2-4 on
+          // this, mislabeled as step-cap exits.
+          if (
+            stepFunctionCalls.length === 0 &&
+            !stepText &&
+            stepFinishReason === "MALFORMED_FUNCTION_CALL" &&
+            malformedRetryCount < 1 &&
+            !effectiveSignal.aborted
+          ) {
+            malformedRetryCount++;
+            logger.warn(
+              `[GoogleVertex] Model returned MALFORMED_FUNCTION_CALL at step ${step}/${maxSteps}; retrying once with a corrective note.`,
+            );
+            this.emitTurnEvent({ phase: "malformed-retry", step, maxSteps });
+            if (rawResponseParts.length > 0) {
+              currentContents.push({
+                role: "model",
+                parts: rawResponseParts as VertexNativePart[],
+              });
+            }
+            currentContents.push({
+              role: "user",
+              parts: [
+                {
+                  text:
+                    "Your previous function call was malformed and could not " +
+                    "be parsed. Re-issue it as a single valid function call, " +
+                    "or answer in plain text.",
+                },
+              ],
+            });
+            continue;
+          }
 
           // If no function calls, we're done
           if (stepFunctionCalls.length === 0) {
@@ -2960,7 +3153,15 @@ export class GoogleVertexProvider extends BaseProvider {
                   messages: [],
                   abortSignal: effectiveSignal,
                 };
-                const execResult = await execute(call.args, toolOptions);
+                turnClock.noteProgress();
+                // Bound the execute() await — a wedged tool costs one step
+                // (error tool_result), not the whole turn.
+                const execResult = await withTimeout(
+                  Promise.resolve(execute(call.args, toolOptions)),
+                  toolExecTimeoutMs,
+                  `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
+                );
+                turnClock.noteProgress();
 
                 // Track execution
                 toolExecutions.push({
@@ -2985,6 +3186,15 @@ export class GoogleVertexProvider extends BaseProvider {
                 if (effectiveSignal.aborted || isAbortError(error)) {
                   wasAborted = true;
                   break;
+                }
+                turnClock.noteProgress();
+                if (error instanceof TimeoutError) {
+                  this.emitTurnEvent({
+                    phase: "tool-timeout",
+                    step,
+                    maxSteps,
+                    toolName: call.name,
+                  });
                 }
                 const errorMessage =
                   error instanceof Error ? error.message : "Unknown error";
@@ -3098,6 +3308,16 @@ export class GoogleVertexProvider extends BaseProvider {
             });
           }
 
+          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft
+          // step nudge): with the turn deadline approaching, tell the model
+          // to consolidate. Rides as a trailing text part on the
+          // tool-response user turn.
+          if (turnClock.shouldNudgeWrapup()) {
+            functionResponses.push({
+              text: buildWrapupNudgeText(useFinalResultTool),
+            } as unknown as (typeof functionResponses)[number]);
+          }
+
           // The @google/genai SDK only accepts "user" and "model" as valid
           // roles in contents — function/tool responses must use role: "user"
           // (matching the SDK's automaticFunctionCalling implementation and
@@ -3156,13 +3376,22 @@ export class GoogleVertexProvider extends BaseProvider {
           );
           finalText = accumulatedText;
         } else if (wasAborted) {
-          // Aborted turn — skip synth entirely so it can never add +300s after
-          // a blown budget. Deliver a graceful cap message as ordinary prose.
+          // Turn ended on a time condition or caller abort — skip synth
+          // entirely so it can never add +300s after a blown budget, and
+          // answer with an HONEST message matching the actual exit cause
+          // (never the step-cap text).
           logger.warn(
-            `[GoogleVertex] Generate tool call loop aborted mid-turn; ` +
-              `returning a graceful cap message.`,
+            `[GoogleVertex] Generate tool call loop ended mid-turn ` +
+              `(${turnClock.timedOut ? "turn time limit" : turnClock.stalled ? "stall watchdog" : "caller abort"}); ` +
+              `returning an honest terminal message.`,
           );
-          finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+          finalText = this.buildLoopExitMessage({
+            turnClock,
+            wasAborted,
+            stallTimeoutMs: options.stallTimeoutMs,
+            maxSteps,
+            toolCallCount,
+          });
         } else {
           // Pure functionCall turns leave no text — make one tools-disabled call
           // so the model answers from the gathered tool results instead of the
@@ -3197,7 +3426,7 @@ export class GoogleVertexProvider extends BaseProvider {
         }
       }
     } finally {
-      clearTimeout(defensiveTimer);
+      turnClock.dispose();
       options.abortSignal?.removeEventListener("abort", onCallerAbort);
     }
 
@@ -3210,6 +3439,27 @@ export class GoogleVertexProvider extends BaseProvider {
       hitStepLimit && !synthesizedFinalAnswer
         ? "tool-calls"
         : mapGeminiFinishReason(lastFinishReason);
+
+    // Turn-exit discriminator, independent of the provider-shaped
+    // finishReason — consumers branch on this instead of sniffing strings.
+    const stopReason = resolveTurnStopReason({
+      timedOut: turnClock.timedOut,
+      stalled: turnClock.stalled,
+      wasAborted,
+      cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      finishReason: resolvedFinishReason,
+    });
+    if (stopReason !== "completed") {
+      this.emitTurnEvent({
+        phase: stopReason,
+        step,
+        maxSteps,
+        toolCallCount: allToolCalls.filter(
+          (tc) => tc.toolName !== "final_result",
+        ).length,
+        elapsedMs: turnClock.elapsedMs(),
+      });
+    }
 
     const responseTime = Date.now() - startTime;
 
@@ -3227,6 +3477,9 @@ export class GoogleVertexProvider extends BaseProvider {
       provider: this.providerName,
       model: modelName,
       finishReason: resolvedFinishReason,
+      stopReason,
+      rawFinishReason: lastFinishReason,
+      stepsUsed: step,
       usage: {
         input: totalInputTokens,
         output: totalOutputTokens,
@@ -3806,6 +4059,11 @@ export class GoogleVertexProvider extends BaseProvider {
       // ({ ...result }) snapshot the top-level getter to undefined before the
       // background loop resolves, while the metadata object reference survives.
       finishReason?: string;
+      // Same mutable-reference contract for the turn-exit discriminator, the
+      // raw provider stop reason, and the step count.
+      stopReason?: GenerateStopReason;
+      rawFinishReason?: string;
+      stepsUsed?: number;
     } = {
       streamId: `native-anthropic-vertex-${Date.now()}`,
       startTime,
@@ -3818,6 +4076,8 @@ export class GoogleVertexProvider extends BaseProvider {
     // via a getter (consumers read it after draining the stream), mirroring
     // the Gemini stream path's finishReason field.
     const finishReasonRef: { value?: string } = {};
+    const stopReasonRef: { value?: GenerateStopReason } = {};
+    const rawFinishReasonRef: { value?: string } = {};
 
     // Langfuse/OTel: the native SDK bypasses the Vercel AI SDK's
     // experimental_telemetry, so emit spans manually — one turn span, one
@@ -3870,8 +4130,8 @@ export class GoogleVertexProvider extends BaseProvider {
       creation1h: 0,
     };
 
-    // Track the active Anthropic stream so options.abortSignal can cancel it
-    // mid-flight (pre-rewrite code had no abort handling — fixed for free).
+    // Track the active Anthropic stream so aborts can cancel it mid-flight
+    // (pre-rewrite code had no abort handling — fixed for free).
     let activeStream:
       | Awaited<ReturnType<typeof client.messages.stream>>
       | undefined;
@@ -3882,18 +4142,38 @@ export class GoogleVertexProvider extends BaseProvider {
         /* ignore — stream may already be finalized */
       }
     };
-    options.abortSignal?.addEventListener("abort", abortHandler);
-
-    // Defensive upper bound: if neither the caller nor the SDK ever fires,
-    // abort the stream after the configured timeout so a stalled
-    // Vertex/Anthropic endpoint can't hang forever. options.timeout wins
-    // if set; otherwise 5 min — generous for tool-heavy turns.
-    const streamTimeoutHandle = setTimeout(() => {
-      logger.warn(
-        `[GoogleVertex] Anthropic stream exceeded ${streamTimeoutMs}ms — aborting`,
-      );
-      abortHandler();
-    }, streamTimeoutMs);
+    // Internal abort fan-in: the caller's signal and the turn clock's
+    // watchdogs (whole-turn deadline + optional stall detector) all trip it;
+    // it cancels the in-flight SDK stream and is the signal tool executions
+    // receive.
+    const internalAbort = new AbortController();
+    internalAbort.signal.addEventListener("abort", abortHandler);
+    const onCallerAbort = () => internalAbort.abort();
+    options.abortSignal?.addEventListener("abort", onCallerAbort);
+    if (options.abortSignal?.aborted) {
+      internalAbort.abort();
+    }
+    const toolExecTimeoutMs =
+      options.toolTimeoutMs ?? DEFAULT_TOOL_EXECUTION_TIMEOUT_MS;
+    const effectiveTurnDeadlineMs = options.turnTimeoutMs ?? streamTimeoutMs;
+    // Whole-turn deadline + optional stall watchdog. When the caller sets no
+    // explicit turn budget, keep the pre-existing defensive bound
+    // (options.timeout, else 5 min) so a stalled Vertex/Anthropic endpoint
+    // can't hang forever.
+    const turnClock = createTurnClock({
+      turnTimeoutMs: options.turnTimeoutMs,
+      defaultTurnTimeoutMs: streamTimeoutMs,
+      stallTimeoutMs: options.stallTimeoutMs,
+      wrapupTimeLeadMs: options.wrapupTimeLeadMs,
+      onDeadline: (kind) => {
+        logger.warn(
+          kind === "timeout"
+            ? `[GoogleVertex] Anthropic stream turn exceeded its ${effectiveTurnDeadlineMs}ms time budget — aborting`
+            : `[GoogleVertex] Anthropic stream turn made no progress for ${options.stallTimeoutMs}ms — aborting`,
+        );
+        internalAbort.abort();
+      },
+    });
 
     const loopPromise = (async () => {
       let step = 0;
@@ -3909,15 +4189,17 @@ export class GoogleVertexProvider extends BaseProvider {
 
       try {
         while (step < agenticStepBudget) {
-          // Honor caller aborts BETWEEN steps: break into terminal handling
-          // (one graceful cap chunk, clean close) instead of throwing —
-          // channel.error would surface the caller's own abort as a stream
-          // failure and route consumers into fallback retries.
-          if (options.abortSignal?.aborted) {
+          // Honor aborts BETWEEN steps (caller signal OR the turn clock's
+          // watchdogs — all fan into internalAbort): break into terminal
+          // handling (one honest terminal chunk, clean close) instead of
+          // throwing — channel.error would surface the caller's own abort as
+          // a stream failure and route consumers into fallback retries.
+          if (internalAbort.signal.aborted) {
             wasAborted = true;
             break;
           }
           step++;
+          turnClock.noteProgress();
 
           // One generation observation per API call: request in, content + usage out.
           const generationSpan = tracers.generation.startSpan(
@@ -3992,6 +4274,7 @@ export class GoogleVertexProvider extends BaseProvider {
             // giving Langfuse the generation's time-to-first-token.
             let firstDeltaSeen = false;
             stream.on("text", (delta: string) => {
+              turnClock.noteProgress();
               if (delta.length > 0) {
                 if (!firstDeltaSeen) {
                   firstDeltaSeen = true;
@@ -4022,11 +4305,12 @@ export class GoogleVertexProvider extends BaseProvider {
               generationSpan.recordException(modelCallError);
             }
             generationSpan.end();
-            // A mid-flight abort (caller signal or the defensive timer
-            // tripping abortHandler) rejects finalMessage() with an
-            // abort-shaped error. Break gracefully into the terminal handling
-            // instead of routing it through channel.error as a failure.
-            if (options.abortSignal?.aborted || isAbortError(modelCallError)) {
+            // A mid-flight abort (caller signal or a turn-clock watchdog
+            // tripping internalAbort/abortHandler) rejects finalMessage()
+            // with an abort-shaped error. Break gracefully into the terminal
+            // handling instead of routing it through channel.error as a
+            // failure.
+            if (internalAbort.signal.aborted || isAbortError(modelCallError)) {
               activeStream = undefined;
               wasAborted = true;
               break;
@@ -4235,15 +4519,23 @@ export class GoogleVertexProvider extends BaseProvider {
                 const toolOptions = {
                   toolCallId: toolUse.id,
                   messages: [],
-                  abortSignal: options.abortSignal,
+                  abortSignal: internalAbort.signal,
                 };
+                turnClock.noteProgress();
                 // Run with toolSpan active so spans inside execute
                 // (neurolink.tool.execute) nest under this observation instead
-                // of becoming disconnected siblings.
-                const result = await otelContext.with(
-                  otelTrace.setSpan(turnContext, toolSpan),
-                  () => execute(toolUse.input, toolOptions),
+                // of becoming disconnected siblings. Bound the await — a
+                // wedged tool costs one step (error tool_result), not the
+                // whole turn.
+                const result = await withTimeout(
+                  otelContext.with(
+                    otelTrace.setSpan(turnContext, toolSpan),
+                    () => Promise.resolve(execute(toolUse.input, toolOptions)),
+                  ),
+                  toolExecTimeoutMs,
+                  `Tool "${toolUse.name}" execution timed out after ${toolExecTimeoutMs}ms`,
                 );
+                turnClock.noteProgress();
                 // MCP failures are returned, not thrown — surface them on
                 // the span so failed calls show as ERROR in Langfuse.
                 endToolSpan(result, extractMcpToolErrorMessage(result));
@@ -4273,7 +4565,7 @@ export class GoogleVertexProvider extends BaseProvider {
                 // An aborted tool call is a cancellation, not a tool failure —
                 // end the span without recording an error execution/result and
                 // break the turn.
-                if (options.abortSignal?.aborted || isAbortError(err)) {
+                if (internalAbort.signal.aborted || isAbortError(err)) {
                   endToolSpan({ aborted: true });
                   // Keep persisted tool history paired: the call row was
                   // already pushed above, so record a neutral cancellation
@@ -4286,6 +4578,15 @@ export class GoogleVertexProvider extends BaseProvider {
                   });
                   wasAborted = true;
                   break;
+                }
+                turnClock.noteProgress();
+                if (err instanceof TimeoutError) {
+                  this.emitTurnEvent({
+                    phase: "tool-timeout",
+                    step,
+                    maxSteps,
+                    toolName: toolUse.name,
+                  });
                 }
                 const errMsg = `Error executing tool "${toolUse.name}": ${err instanceof Error ? err.message : String(err)}`;
                 const errorPayload = { error: errMsg };
@@ -4364,6 +4665,8 @@ export class GoogleVertexProvider extends BaseProvider {
           // to wrap up so the reserved forced-finalization call below stays a
           // fallback, not the norm. Rides as a trailing text block on the
           // tool_result user turn (cache-safe: it lives in the growing tail).
+          // The time-budget twin fires when the turn deadline is inside the
+          // wrap-up lead window instead.
           const stepsRemaining = agenticStepBudget - step;
           if (stepsRemaining > 0 && stepsRemaining <= 3) {
             toolResults.push({
@@ -4373,6 +4676,11 @@ export class GoogleVertexProvider extends BaseProvider {
                 (useFinalResultTool
                   ? "call final_result with your best answer."
                   : "provide your final answer."),
+            });
+          } else if (turnClock.shouldNudgeWrapup()) {
+            toolResults.push({
+              type: "text",
+              text: buildWrapupNudgeText(useFinalResultTool),
             });
           }
 
@@ -4402,10 +4710,10 @@ export class GoogleVertexProvider extends BaseProvider {
         // Gemini synthesizeFinalAnswerWithoutTools precedent); their tokens
         // still land in `usage` and the turn-span metadata.
         if (!modelFinished) {
-          // A caller abort that landed during the FINAL budgeted step's tool
+          // An abort that landed during the FINAL budgeted step's tool
           // execution leaves wasAborted=false (no loop-entry check runs after
           // a budget exit) — re-check before issuing any terminal model call.
-          if (options.abortSignal?.aborted) {
+          if (internalAbort.signal.aborted) {
             wasAborted = true;
           }
           const externalToolCallCount = allToolCalls.filter(
@@ -4413,22 +4721,29 @@ export class GoogleVertexProvider extends BaseProvider {
           ).length;
           if (wasAborted) {
             // Budget already blown — never issue another model call. Deliver
-            // exactly one graceful cap chunk if nothing reached the consumer
-            // (live deltas already delivered count as "something reached").
+            // exactly one HONEST terminal chunk matching the actual exit
+            // cause (time limit / stall / caller abort — never the step-cap
+            // text) if nothing reached the consumer (live deltas already
+            // delivered count as "something reached").
             logger.warn(
-              "[GoogleVertex] Native Anthropic stream loop aborted mid-turn; returning a graceful cap message.",
+              `[GoogleVertex] Native Anthropic stream loop ended mid-turn ` +
+                `(${turnClock.timedOut ? "turn time limit" : turnClock.stalled ? "stall watchdog" : "caller abort"}); ` +
+                `returning an honest terminal message.`,
             );
             if (
               aggregatedTurnText.length === 0 &&
               liveTextPushedLength === 0 &&
               !structuredOutputRef.value
             ) {
-              const capMessage = buildToolLoopCapMessage(
+              const exitMessage = this.buildLoopExitMessage({
+                turnClock,
+                wasAborted,
+                stallTimeoutMs: options.stallTimeoutMs,
                 maxSteps,
-                externalToolCallCount,
-              );
-              channel.push(capMessage);
-              aggregatedTurnText = capMessage;
+                toolCallCount: externalToolCallCount,
+              });
+              channel.push(exitMessage);
+              aggregatedTurnText = exitMessage;
             }
           } else if (useFinalResultTool) {
             hitStepLimit = true;
@@ -4515,23 +4830,29 @@ export class GoogleVertexProvider extends BaseProvider {
               }
             } catch (error) {
               activeStream = undefined;
-              // An aborted finalization is a cancellation, not a step-cap
-              // turn — keep finishReason mapping from lastStopReason.
-              if (options.abortSignal?.aborted || isAbortError(error)) {
+              // An aborted finalization is a cancellation (caller abort or a
+              // turn-clock watchdog), not a step-cap turn — keep finishReason
+              // mapping from lastStopReason and pick the exit message by the
+              // actual cause.
+              if (internalAbort.signal.aborted || isAbortError(error)) {
                 hitStepLimit = false;
+                wasAborted = true;
               }
               logger.warn(
-                "[GoogleVertex] Forced finalization call failed; falling back to cap message",
+                "[GoogleVertex] Forced finalization call failed; falling back to a terminal message",
                 {
                   error: error instanceof Error ? error.message : String(error),
                 },
               );
-              const capMessage = buildToolLoopCapMessage(
+              const exitMessage = this.buildLoopExitMessage({
+                turnClock,
+                wasAborted,
+                stallTimeoutMs: options.stallTimeoutMs,
                 maxSteps,
-                externalToolCallCount,
-              );
-              channel.push(capMessage);
-              aggregatedTurnText += capMessage;
+                toolCallCount: externalToolCallCount,
+              });
+              channel.push(exitMessage);
+              aggregatedTurnText += exitMessage;
             }
           } else {
             hitStepLimit = true;
@@ -4615,24 +4936,30 @@ export class GoogleVertexProvider extends BaseProvider {
                 }
               } catch (error) {
                 activeStream = undefined;
-                // An aborted backstop is a cancellation, not a step-cap
-                // turn — keep finishReason mapping from lastStopReason.
-                if (options.abortSignal?.aborted || isAbortError(error)) {
+                // An aborted backstop is a cancellation (caller abort or a
+                // turn-clock watchdog), not a step-cap turn — keep
+                // finishReason mapping from lastStopReason and pick the exit
+                // message by the actual cause.
+                if (internalAbort.signal.aborted || isAbortError(error)) {
                   hitStepLimit = false;
+                  wasAborted = true;
                 }
                 logger.warn(
-                  "[GoogleVertex] Tools-disabled backstop call failed; falling back to cap message",
+                  "[GoogleVertex] Tools-disabled backstop call failed; falling back to a terminal message",
                   {
                     error:
                       error instanceof Error ? error.message : String(error),
                   },
                 );
-                const capMessage = buildToolLoopCapMessage(
+                const exitMessage = this.buildLoopExitMessage({
+                  turnClock,
+                  wasAborted,
+                  stallTimeoutMs: options.stallTimeoutMs,
                   maxSteps,
-                  externalToolCallCount,
-                );
-                channel.push(capMessage);
-                aggregatedTurnText = capMessage;
+                  toolCallCount: externalToolCallCount,
+                });
+                channel.push(exitMessage);
+                aggregatedTurnText = exitMessage;
               }
             }
             // else: prose already streamed to the consumer across steps —
@@ -4652,12 +4979,15 @@ export class GoogleVertexProvider extends BaseProvider {
           (tc) => tc.toolName !== "final_result",
         ).length;
         if (deliveredNothing && externalToolCallTotal > 0) {
-          const capMessage = buildToolLoopCapMessage(
+          const exitMessage = this.buildLoopExitMessage({
+            turnClock,
+            wasAborted,
+            stallTimeoutMs: options.stallTimeoutMs,
             maxSteps,
-            externalToolCallTotal,
-          );
-          channel.push(capMessage);
-          aggregatedTurnText = capMessage;
+            toolCallCount: externalToolCallTotal,
+          });
+          channel.push(exitMessage);
+          aggregatedTurnText = exitMessage;
         }
 
         // Honest finish reason (same mapping as the generate twin): "length"
@@ -4677,6 +5007,31 @@ export class GoogleVertexProvider extends BaseProvider {
         metadata.totalToolExecutions = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
         ).length;
+
+        // Turn-exit discriminator + raw provider stop reason + step count —
+        // mirrored onto metadata (mutable reference) for wrapper spreads,
+        // like finishReason above.
+        const resolvedStopReason = resolveTurnStopReason({
+          timedOut: turnClock.timedOut,
+          stalled: turnClock.stalled,
+          wasAborted,
+          cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+          finishReason: finishReasonRef.value,
+        });
+        stopReasonRef.value = resolvedStopReason;
+        rawFinishReasonRef.value = lastStopReason ?? undefined;
+        metadata.stopReason = resolvedStopReason;
+        metadata.rawFinishReason = rawFinishReasonRef.value;
+        metadata.stepsUsed = step;
+        if (resolvedStopReason !== "completed") {
+          this.emitTurnEvent({
+            phase: resolvedStopReason,
+            step,
+            maxSteps,
+            toolCallCount: metadata.totalToolExecutions,
+            elapsedMs: turnClock.elapsedMs(),
+          });
+        }
 
         // Surface cache metrics once, after the agentic loop, from the
         // cumulative turnCacheUsage running totals (accumulated via += on every
@@ -4737,8 +5092,9 @@ export class GoogleVertexProvider extends BaseProvider {
         channel.error(this.handleProviderError(err));
       } finally {
         turnSpan.end();
-        options.abortSignal?.removeEventListener("abort", abortHandler);
-        clearTimeout(streamTimeoutHandle);
+        options.abortSignal?.removeEventListener("abort", onCallerAbort);
+        internalAbort.signal.removeEventListener("abort", abortHandler);
+        turnClock.dispose();
       }
     })();
     // Suppress unhandled-rejection: errors funnel through channel.error()
@@ -4789,6 +5145,16 @@ export class GoogleVertexProvider extends BaseProvider {
       enumerable: true,
       configurable: true,
       get: () => finishReasonRef.value,
+    });
+    Object.defineProperty(result, "stopReason", {
+      enumerable: true,
+      configurable: true,
+      get: () => stopReasonRef.value,
+    });
+    Object.defineProperty(result, "rawFinishReason", {
+      enumerable: true,
+      configurable: true,
+      get: () => rawFinishReasonRef.value,
     });
 
     return result;
@@ -5174,15 +5540,52 @@ export class GoogleVertexProvider extends BaseProvider {
     let modelFinished = false;
     const currentMessages = [...messages];
 
+    // Internal abort fan-in: the caller's signal and the turn clock's
+    // watchdogs all trip it; it rides every SDK request and tool execution.
+    const internalAbort = new AbortController();
+    const onCallerAbort = () => internalAbort.abort();
+    options.abortSignal?.addEventListener("abort", onCallerAbort);
+    if (options.abortSignal?.aborted) {
+      internalAbort.abort();
+    }
+    const toolExecTimeoutMs =
+      options.toolTimeoutMs ?? DEFAULT_TOOL_EXECUTION_TIMEOUT_MS;
+    // Whole-turn deadline + optional stall watchdog. NOTE: unlike the stream
+    // twin, this path historically had NO whole-turn bound (only the per-call
+    // withTimeout) — so no defensive default is introduced here: without an
+    // explicit turnTimeoutMs, long multi-step turns keep running as before.
+    const turnClock = createTurnClock({
+      turnTimeoutMs: options.turnTimeoutMs,
+      stallTimeoutMs: options.stallTimeoutMs,
+      wrapupTimeLeadMs: options.wrapupTimeLeadMs,
+      onDeadline: (kind) => {
+        logger.warn(
+          kind === "timeout"
+            ? `[GoogleVertex] Anthropic generate turn exceeded its ${options.turnTimeoutMs}ms time budget — aborting`
+            : `[GoogleVertex] Anthropic generate turn made no progress for ${options.stallTimeoutMs}ms — aborting`,
+        );
+        internalAbort.abort();
+      },
+    });
+    // No top-level try/finally wraps this loop (pre-existing shape); release
+    // watchdog timers + the caller-signal listener at both exits — the
+    // provider-error throw in the per-step catch and the normal return path.
+    const releaseTurnResources = () => {
+      turnClock.dispose();
+      options.abortSignal?.removeEventListener("abort", onCallerAbort);
+    };
+
     while (step < agenticStepBudget) {
-      // Honor caller aborts BETWEEN steps: break into terminal handling
-      // instead of throwing (a throw routes consumers into abortSignal-less
-      // fallback retries — observed in production as a 600s abort no-op).
-      if (options.abortSignal?.aborted) {
+      // Honor aborts BETWEEN steps (caller signal OR turn-clock watchdogs —
+      // all fan into internalAbort): break into terminal handling instead of
+      // throwing (a throw routes consumers into abortSignal-less fallback
+      // retries — observed in production as a 600s abort no-op).
+      if (internalAbort.signal.aborted) {
         wasAborted = true;
         break;
       }
       step++;
+      turnClock.noteProgress();
 
       try {
         // Bound the SDK wait so a stalled Vertex/Anthropic call can't hang
@@ -5221,7 +5624,7 @@ export class GoogleVertexProvider extends BaseProvider {
                 typeof client.messages.create
               >[0]["messages"],
             },
-            { signal: options.abortSignal },
+            { signal: internalAbort.signal },
           ),
           generateTimeoutMs,
           "Anthropic generate timed out",
@@ -5328,9 +5731,17 @@ export class GoogleVertexProvider extends BaseProvider {
               const toolOptions = {
                 toolCallId: toolUse.id,
                 messages: [],
-                abortSignal: options.abortSignal,
+                abortSignal: internalAbort.signal,
               };
-              const result = await execute(toolUse.input, toolOptions);
+              turnClock.noteProgress();
+              // Bound the execute() await — a wedged tool costs one step
+              // (error tool_result), not the whole turn.
+              const result = await withTimeout(
+                Promise.resolve(execute(toolUse.input, toolOptions)),
+                toolExecTimeoutMs,
+                `Tool "${toolUse.name}" execution timed out after ${toolExecTimeoutMs}ms`,
+              );
+              turnClock.noteProgress();
               toolExecutions.push({
                 name: toolUse.name,
                 input: toolUse.input,
@@ -5356,7 +5767,7 @@ export class GoogleVertexProvider extends BaseProvider {
             } catch (err) {
               // An aborted tool call is a cancellation, not a tool failure —
               // break the turn without recording an error execution/result.
-              if (options.abortSignal?.aborted || isAbortError(err)) {
+              if (internalAbort.signal.aborted || isAbortError(err)) {
                 // Keep persisted tool history paired: the call row was
                 // already pushed above, so record a neutral cancellation
                 // result (NOT an error) — an unpaired tool_use replayed on
@@ -5368,6 +5779,15 @@ export class GoogleVertexProvider extends BaseProvider {
                 });
                 wasAborted = true;
                 break;
+              }
+              turnClock.noteProgress();
+              if (err instanceof TimeoutError) {
+                this.emitTurnEvent({
+                  phase: "tool-timeout",
+                  step,
+                  maxSteps,
+                  toolName: toolUse.name,
+                });
               }
               const errMsg = `Error executing tool "${toolUse.name}": ${err instanceof Error ? err.message : String(err)}`;
               const errorPayload = { error: errMsg };
@@ -5445,6 +5865,8 @@ export class GoogleVertexProvider extends BaseProvider {
         // wrap up so the reserved forced-finalization call below stays a
         // fallback, not the norm. Rides as a trailing text block on the
         // tool_result user turn (cache-safe: it lives in the growing tail).
+        // The time-budget twin fires when the turn deadline is inside the
+        // wrap-up lead window instead.
         const stepsRemaining = agenticStepBudget - step;
         if (stepsRemaining > 0 && stepsRemaining <= 3) {
           toolResults.push({
@@ -5454,6 +5876,11 @@ export class GoogleVertexProvider extends BaseProvider {
               (useFinalResultTool
                 ? "call final_result with your best answer."
                 : "provide your final answer."),
+          });
+        } else if (turnClock.shouldNudgeWrapup()) {
+          toolResults.push({
+            type: "text",
+            text: buildWrapupNudgeText(useFinalResultTool),
           });
         }
 
@@ -5476,12 +5903,13 @@ export class GoogleVertexProvider extends BaseProvider {
         accumulatedStepText = appendStepText(accumulatedStepText, responseText);
       } catch (error) {
         // A mid-request abort surfaces as an abort-shaped SDK rejection (we
-        // pass options.abortSignal as the request signal above). Break
+        // pass internalAbort.signal as the request signal above, and the
+        // caller's signal + turn-clock watchdogs all fan into it). Break
         // gracefully into the terminal handling instead of re-throwing — a
         // re-throw routes the caller's abort into abortSignal-less fallback
-        // retries. Dual check as in the Gemini loops: the caller's signal OR
+        // retries. Dual check as in the Gemini loops: the internal signal OR
         // an abort-shaped error either way means "stop", not a real failure.
-        if (options.abortSignal?.aborted || isAbortError(error)) {
+        if (internalAbort.signal.aborted || isAbortError(error)) {
           wasAborted = true;
           break;
         }
@@ -5500,6 +5928,7 @@ export class GoogleVertexProvider extends BaseProvider {
         } catch {
           /* frozen/sealed error — context stays best-effort */
         }
+        releaseTurnResources();
         throw this.handleProviderError(error);
       }
     }
@@ -5510,10 +5939,10 @@ export class GoogleVertexProvider extends BaseProvider {
     // synthesize a plain-text answer on tool turns, or fall back to a
     // graceful cap message. Mirrors the Gemini paths (ed289b7 / PR #1123).
     if (!modelFinished && !finalText) {
-      // A caller abort that landed during the FINAL budgeted step's tool
+      // An abort that landed during the FINAL budgeted step's tool
       // execution leaves wasAborted=false (no loop-entry check runs after a
       // budget exit) — re-check before issuing any terminal model call.
-      if (options.abortSignal?.aborted) {
+      if (internalAbort.signal.aborted) {
         wasAborted = true;
       }
       const externalToolCallCount = allToolCalls.filter(
@@ -5522,14 +5951,24 @@ export class GoogleVertexProvider extends BaseProvider {
       if (wasAborted) {
         // Budget already blown — never issue another model call; prefer the
         // prose the model already produced (mirrors the Gemini abort path),
-        // else answer with a graceful cap message. finishReason keeps mapping
-        // from lastStopReason (an aborted turn is not a step-cap turn).
+        // else answer with an HONEST message matching the actual exit cause
+        // (time limit / stall / caller abort — never the step-cap text).
+        // finishReason keeps mapping from lastStopReason (an aborted turn is
+        // not a step-cap turn).
         logger.warn(
-          "[GoogleVertex] Native Anthropic generate loop aborted mid-turn; returning gathered text or a graceful cap message.",
+          `[GoogleVertex] Native Anthropic generate loop ended mid-turn ` +
+            `(${turnClock.timedOut ? "turn time limit" : turnClock.stalled ? "stall watchdog" : "caller abort"}); ` +
+            `returning gathered text or an honest terminal message.`,
         );
         finalText =
           accumulatedStepText ||
-          buildToolLoopCapMessage(maxSteps, externalToolCallCount);
+          this.buildLoopExitMessage({
+            turnClock,
+            wasAborted,
+            stallTimeoutMs: options.stallTimeoutMs,
+            maxSteps,
+            toolCallCount: externalToolCallCount,
+          });
       } else if (useFinalResultTool) {
         hitStepLimit = true;
         logger.warn(
@@ -5569,7 +6008,7 @@ export class GoogleVertexProvider extends BaseProvider {
                   typeof client.messages.create
                 >[0]["messages"],
               },
-              { signal: options.abortSignal },
+              { signal: internalAbort.signal },
             ),
             generateTimeoutMs,
             "Anthropic finalization call timed out",
@@ -5607,16 +6046,25 @@ export class GoogleVertexProvider extends BaseProvider {
             );
           }
         } catch (error) {
-          // An aborted finalization is a cancellation, not a step-cap turn —
-          // keep finishReason mapping from lastStopReason, not "tool-calls".
-          if (options.abortSignal?.aborted || isAbortError(error)) {
+          // An aborted finalization is a cancellation (caller abort or a
+          // turn-clock watchdog), not a step-cap turn — keep finishReason
+          // mapping from lastStopReason and pick the exit message by the
+          // actual cause.
+          if (internalAbort.signal.aborted || isAbortError(error)) {
             hitStepLimit = false;
+            wasAborted = true;
           }
           logger.warn(
-            "[GoogleVertex] Forced finalization call failed; falling back to cap message",
+            "[GoogleVertex] Forced finalization call failed; falling back to a terminal message",
             { error: error instanceof Error ? error.message : String(error) },
           );
-          finalText = buildToolLoopCapMessage(maxSteps, externalToolCallCount);
+          finalText = this.buildLoopExitMessage({
+            turnClock,
+            wasAborted,
+            stallTimeoutMs: options.stallTimeoutMs,
+            maxSteps,
+            toolCallCount: externalToolCallCount,
+          });
         }
       } else {
         hitStepLimit = true;
@@ -5666,7 +6114,7 @@ export class GoogleVertexProvider extends BaseProvider {
                     typeof client.messages.create
                   >[0]["messages"],
                 },
-                { signal: options.abortSignal },
+                { signal: internalAbort.signal },
               ),
               generateTimeoutMs,
               "Anthropic backstop call timed out",
@@ -5697,25 +6145,33 @@ export class GoogleVertexProvider extends BaseProvider {
               );
             }
           } catch (error) {
-            // An aborted backstop is a cancellation, not a step-cap turn —
-            // keep finishReason mapping from lastStopReason, not "tool-calls".
-            if (options.abortSignal?.aborted || isAbortError(error)) {
+            // An aborted backstop is a cancellation (caller abort or a
+            // turn-clock watchdog), not a step-cap turn — keep finishReason
+            // mapping from lastStopReason and pick the exit message by the
+            // actual cause.
+            if (internalAbort.signal.aborted || isAbortError(error)) {
               hitStepLimit = false;
+              wasAborted = true;
             }
             logger.warn(
-              "[GoogleVertex] Tools-disabled backstop call failed; falling back to cap message",
+              "[GoogleVertex] Tools-disabled backstop call failed; falling back to a terminal message",
               {
                 error: error instanceof Error ? error.message : String(error),
               },
             );
-            finalText = buildToolLoopCapMessage(
+            finalText = this.buildLoopExitMessage({
+              turnClock,
+              wasAborted,
+              stallTimeoutMs: options.stallTimeoutMs,
               maxSteps,
-              externalToolCallCount,
-            );
+              toolCallCount: externalToolCallCount,
+            });
           }
         }
       }
     }
+
+    releaseTurnResources();
 
     const responseTime = Date.now() - startTime;
     const externalToolCalls = allToolCalls.filter(
@@ -5727,23 +6183,54 @@ export class GoogleVertexProvider extends BaseProvider {
 
     // Absolute backstop — no code path may surface empty content on a turn
     // that ran tools (the consumer-facing "empty response" incident shape).
+    // Cause-aware: an aborted/timed-out turn gets the honest exit message,
+    // a genuine budget exhaustion gets the step-cap message.
     if (!finalText && externalToolCalls.length > 0) {
-      finalText = buildToolLoopCapMessage(maxSteps, externalToolCalls.length);
+      finalText = this.buildLoopExitMessage({
+        turnClock,
+        wasAborted,
+        stallTimeoutMs: options.stallTimeoutMs,
+        maxSteps,
+        toolCallCount: externalToolCalls.length,
+      });
+    }
+
+    // Honest finish reason. "length" (token truncation) takes precedence; a
+    // step-cap exhaustion without a clean/forced answer surfaces as
+    // "tool-calls" (aligned with the Gemini paths, so consumers detect
+    // capped turns uniformly); everything else — including a successful
+    // forced finalization or backstop synthesis — is a normal "stop".
+    const resolvedFinishReason =
+      lastStopReason === "max_tokens"
+        ? "length"
+        : hitStepLimit && !synthesizedFinalAnswer
+          ? "tool-calls"
+          : "stop";
+    // Turn-exit discriminator, independent of the provider-shaped
+    // finishReason — consumers branch on this instead of sniffing strings.
+    const stopReason = resolveTurnStopReason({
+      timedOut: turnClock.timedOut,
+      stalled: turnClock.stalled,
+      wasAborted,
+      cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      finishReason: resolvedFinishReason,
+    });
+    if (stopReason !== "completed") {
+      this.emitTurnEvent({
+        phase: stopReason,
+        step,
+        maxSteps,
+        toolCallCount: externalToolCalls.length,
+        elapsedMs: turnClock.elapsedMs(),
+      });
     }
 
     const result: EnhancedGenerateResult = {
       content: finalText,
-      // Honest finish reason. "length" (token truncation) takes precedence; a
-      // step-cap exhaustion without a clean/forced answer surfaces as
-      // "tool-calls" (aligned with the Gemini paths, so consumers detect
-      // capped turns uniformly); everything else — including a successful
-      // forced finalization or backstop synthesis — is a normal "stop".
-      finishReason:
-        lastStopReason === "max_tokens"
-          ? "length"
-          : hitStepLimit && !synthesizedFinalAnswer
-            ? "tool-calls"
-            : "stop",
+      finishReason: resolvedFinishReason,
+      stopReason,
+      rawFinishReason: lastStopReason ?? undefined,
+      stepsUsed: step,
       provider: this.providerName,
       model: modelName,
       usage: {
@@ -6610,6 +7097,70 @@ export class GoogleVertexProvider extends BaseProvider {
       (result as { _generationEndEmitted?: boolean })._generationEndEmitted =
         true;
     }
+  }
+
+  /**
+   * Emit a `turn:lifecycle` event on the SDK emitter (alongside
+   * tool:start/tool:end) so loop conditions that previously only reached
+   * process logs — step-cap, time-limit, stall, abort, tool timeouts,
+   * malformed-call retries — are observable by consumers' own pipelines.
+   */
+  private emitTurnEvent(payload: {
+    phase:
+      | "step-cap"
+      | "time-limit"
+      | "stalled"
+      | "aborted"
+      | "provider-error"
+      | "tool-timeout"
+      | "malformed-retry";
+    step?: number;
+    maxSteps?: number;
+    toolName?: string;
+    toolCallCount?: number;
+    elapsedMs?: number;
+  }): void {
+    try {
+      this.neurolink?.getEventEmitter()?.emit("turn:lifecycle", {
+        provider: this.providerName,
+        timestamp: Date.now(),
+        ...payload,
+      });
+    } catch {
+      /* listener errors are non-fatal */
+    }
+  }
+
+  /**
+   * Pick the honest terminal message for a native-loop exit by its ACTUAL
+   * cause. The step-cap text is the fallback for genuine budget exhaustion
+   * only — time/stall/abort exits must never claim a step limit was reached
+   * (the 2026-07-03 "reached the 200-step limit" incident was a wall-clock
+   * abort wearing the cap message).
+   */
+  private buildLoopExitMessage(params: {
+    turnClock: { timedOut: boolean; stalled: boolean; elapsedMs(): number };
+    wasAborted: boolean;
+    stallTimeoutMs?: number;
+    maxSteps: number;
+    toolCallCount: number;
+  }): string {
+    if (params.turnClock.timedOut) {
+      return buildTurnTimeoutMessage(
+        params.turnClock.elapsedMs(),
+        params.toolCallCount,
+      );
+    }
+    if (params.turnClock.stalled) {
+      return buildTurnStalledMessage(
+        params.stallTimeoutMs ?? 0,
+        params.toolCallCount,
+      );
+    }
+    if (params.wasAborted) {
+      return buildAbortedTurnMessage(params.toolCallCount);
+    }
+    return buildToolLoopCapMessage(params.maxSteps, params.toolCallCount);
   }
 
   protected formatProviderError(error: unknown): Error {

--- a/src/lib/types/analytics.ts
+++ b/src/lib/types/analytics.ts
@@ -39,6 +39,18 @@ export type AnalyticsData = {
   timestamp: string;
   cost?: number;
   context?: JsonValue;
+  // Turn-lifecycle telemetry (populated when the provider ran a native
+  // agentic loop — Vertex Gemini/Claude) so an RCA is a one-line query:
+  /** Number of agentic steps (model calls) the turn used. */
+  stepsUsed?: number;
+  /** Number of external tool calls the turn made (final_result excluded). */
+  toolCallCount?: number;
+  /** Why the turn ended — see GenerateStopReason. */
+  stopReason?: string;
+  /** Wall-clock duration of the turn in milliseconds. */
+  elapsedMs?: number;
+  /** Verbatim provider finish/stop reason for the terminal model call. */
+  rawFinishReason?: string;
 };
 
 /**

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -331,6 +331,38 @@ export type GenerateOptions = {
    * provider+model with the same doomed budget.
    */
   timeout?: number | string;
+  /**
+   * Hard wall-clock cap for the WHOLE agentic turn (all model calls + tool
+   * executions), in milliseconds. When the deadline passes the turn ends
+   * gracefully with `stopReason: "time-limit"` and an honest time message —
+   * never the step-cap text. Unset = no turn-level deadline (the library
+   * imposes no product policy).
+   *
+   * Enforced by the native Vertex loops (Gemini + Claude); AI-SDK-driven
+   * providers currently ignore it.
+   */
+  turnTimeoutMs?: number;
+  /**
+   * Maximum time with NO progress — no stream chunk received, no tool
+   * execution started or finished, no step started — before the turn ends
+   * with `stopReason: "stalled"`. Catches wedged tools and hung model calls
+   * that a whole-turn deadline would let run to the bitter end.
+   * Unset = disabled.
+   */
+  stallTimeoutMs?: number;
+  /**
+   * When the remaining turn time drops below this, a wrap-up nudge rides the
+   * next tool-result turn telling the model to consolidate what it has and
+   * produce its final answer. Defaults to 120_000 when `turnTimeoutMs` is
+   * set; ignored when it is not.
+   */
+  wrapupTimeLeadMs?: number;
+  /**
+   * Per-tool-execution timeout in milliseconds (default 300_000). A tool
+   * that exceeds it fails with an error tool_result and costs one step —
+   * the turn continues instead of hanging on a wedged tool.
+   */
+  toolTimeoutMs?: number;
   /** AbortSignal for external cancellation of the AI call */
   abortSignal?: AbortSignal;
   /**
@@ -630,6 +662,28 @@ export type AdditionalMemoryUser = {
 };
 
 /**
+ * Why an agentic turn ended — the discriminator consumers should branch on
+ * instead of sniffing the provider-shaped `finishReason` (whose values are
+ * overloaded: e.g. "tool-calls" historically covered both step-cap exits and
+ * Gemini MALFORMED_FUNCTION_CALL provider errors).
+ *
+ * - `completed` — the model finished on its own (text answer or final_result)
+ * - `step-cap` — the `maxSteps` budget ran out while the model still wanted tools
+ * - `time-limit` — the `turnTimeoutMs` wall-clock deadline passed
+ * - `stalled` — no progress (no chunk, no tool start/finish) for `stallTimeoutMs`
+ * - `aborted` — the caller's `abortSignal` ended the turn
+ * - `provider-error` — the provider/model failed the turn (e.g. persistent
+ *   MALFORMED_FUNCTION_CALL after retry); usually worth a caller-side retry
+ */
+export type GenerateStopReason =
+  | "completed"
+  | "step-cap"
+  | "time-limit"
+  | "stalled"
+  | "aborted"
+  | "provider-error";
+
+/**
  * Generate function result type - Primary output format
  * Future-ready for multi-modal outputs while maintaining text focus
  */
@@ -731,6 +785,21 @@ export type GenerateResult = {
 
   // Finish reason from the AI provider (e.g., "stop", "length", "tool-calls")
   finishReason?: string;
+
+  /**
+   * Why the agentic turn ended, independent of the provider-shaped
+   * `finishReason`. Populated by the native Vertex loops (Gemini + Claude);
+   * undefined on providers that don't run a native loop — fall back to
+   * `finishReason` heuristics there.
+   */
+  stopReason?: GenerateStopReason;
+  /**
+   * Verbatim provider finish/stop reason for the turn's terminal model call
+   * (e.g. "MALFORMED_FUNCTION_CALL", "MAX_TOKENS", "max_tokens", "tool_use").
+   */
+  rawFinishReason?: string;
+  /** Number of agentic steps (model calls) the turn used. */
+  stepsUsed?: number;
 
   /**
    * True when the schema JSON in `content`/`structuredData` was repaired from
@@ -972,6 +1041,14 @@ export type TextGenerationOptions = {
    */
   enabledToolNames?: string[];
   timeout?: number | string; // Optional timeout (e.g., 30000, '30s', '2m', '1h')
+  /** Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs. */
+  turnTimeoutMs?: number;
+  /** Max time with no progress before the turn ends as "stalled" (ms). See GenerateOptions.stallTimeoutMs. */
+  stallTimeoutMs?: number;
+  /** Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs. */
+  wrapupTimeLeadMs?: number;
+  /** Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeoutMs. */
+  toolTimeoutMs?: number;
   /** AbortSignal for external cancellation of the AI call */
   abortSignal?: AbortSignal;
   disableTools?: boolean; // Disable tools (tools are enabled by default)
@@ -1263,6 +1340,12 @@ export type TextGenerationResult = {
   /** Parsed structured object when a `schema` was requested (see GenerateResult.structuredData). */
   structuredData?: unknown;
   finishReason?: string;
+  /** Turn-exit discriminator from native agentic loops (see GenerateStopReason). */
+  stopReason?: GenerateStopReason;
+  /** Verbatim provider finish/stop reason for the turn's terminal model call. */
+  rawFinishReason?: string;
+  /** Number of agentic steps (model calls) the turn used. */
+  stepsUsed?: number;
   /** True when the schema JSON was repaired from malformed model text. */
   jsonRepaired?: boolean;
   /** True when the schema JSON appears truncated (output hit the token cap). */

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -17,7 +17,7 @@ import type { JsonValue, UnknownRecord } from "./common.js";
 import type { Content, ImageWithAltText } from "./content.js";
 import type { ChatMessage } from "./conversation.js";
 import type { StreamNoOutputSentinel } from "./noOutputSentinel.js";
-import type { AdditionalMemoryUser } from "./generate.js";
+import type { AdditionalMemoryUser, GenerateStopReason } from "./generate.js";
 import type {
   AIModelProviderConfig,
   NeurolinkCredentials,
@@ -376,6 +376,14 @@ export type StreamOptions = {
   schema?: ValidationSchema;
   tools?: Record<string, Tool>;
   timeout?: number | string;
+  /** Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs. */
+  turnTimeoutMs?: number;
+  /** Max time with no progress before the turn ends as "stalled" (ms). See GenerateOptions.stallTimeoutMs. */
+  stallTimeoutMs?: number;
+  /** Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs. */
+  wrapupTimeLeadMs?: number;
+  /** Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeoutMs. */
+  toolTimeoutMs?: number;
   /** AbortSignal for external cancellation of the AI call */
   abortSignal?: AbortSignal;
   disableTools?: boolean;
@@ -618,6 +626,16 @@ export type StreamResult = {
   // Finish reason
   finishReason?: string;
 
+  /**
+   * Why the agentic turn ended (see GenerateStopReason). For background-loop
+   * streams (native Vertex paths) prefer `metadata.stopReason` after draining
+   * the stream — this top-level field may be a getter that resolves late, and
+   * wrapper spreads can snapshot it before the loop finishes.
+   */
+  stopReason?: GenerateStopReason;
+  /** Verbatim provider finish/stop reason for the turn's terminal model call. */
+  rawFinishReason?: string;
+
   // Tool integration (from Vercel AI SDK)
   toolCalls?: StreamToolCall[]; // Tool calls made during generation
   toolResults?: StreamToolResult[]; // Results from tool execution
@@ -646,6 +664,12 @@ export type StreamResult = {
     // (a mutable reference the loop fills in) because result-object spreads
     // in stream wrappers snapshot top-level getters before the loop resolves.
     finishReason?: string;
+    // Resolved turn stop reason / raw provider finish reason / step count —
+    // same mutable-reference contract as `finishReason` above: read them
+    // after draining the stream.
+    stopReason?: GenerateStopReason;
+    rawFinishReason?: string;
+    stepsUsed?: number;
     // Thought/reasoning metadata
     thoughtSignature?: string;
     thoughts?: Array<{ id?: string; type?: string; content?: string }>;

--- a/test/continuous-test-suite-anthropic-cap.ts
+++ b/test/continuous-test-suite-anthropic-cap.ts
@@ -35,7 +35,10 @@ import {
   assertEqual,
   assertIncludes,
 } from "./helpers/harness.js";
-import { buildToolLoopCapMessage } from "../src/lib/providers/googleNativeGemini3.js";
+import {
+  buildAbortedTurnMessage,
+  buildToolLoopCapMessage,
+} from "../src/lib/providers/googleNativeGemini3.js";
 import { GoogleVertexProvider } from "../src/lib/providers/googleVertex.js";
 
 // ---------------------------------------------------------------------------
@@ -294,6 +297,9 @@ async function makeProvider(client: unknown): Promise<GoogleVertexProvider> {
 type GenResult = {
   content: string;
   finishReason: string;
+  stopReason?: string;
+  rawFinishReason?: string;
+  stepsUsed?: number;
   usage: { input: number; output: number; total: number };
   toolsUsed?: string[];
   toolExecutions?: unknown[];
@@ -314,9 +320,16 @@ async function runGenerate(
 
 type StreamResultShape = {
   finishReason?: string;
+  stopReason?: string;
+  rawFinishReason?: string;
   usage: { input: number; output: number; total: number };
   structuredOutput?: unknown;
   stream: AsyncIterable<{ content: string }>;
+  metadata?: {
+    stopReason?: string;
+    rawFinishReason?: string;
+    stepsUsed?: number;
+  };
 };
 
 /** Invoke the private native-Anthropic stream loop and drain its chunks plus result. */
@@ -505,6 +518,11 @@ async function main(): Promise<void> {
       });
       assertEqual(result.content, buildToolLoopCapMessage(maxSteps, 1));
       assertEqual(result.finishReason, "tool-calls");
+      assertEqual(
+        result.stopReason,
+        "step-cap",
+        "genuine budget exhaustion must report stopReason 'step-cap'",
+      );
       assert(result.content.length > 0, "content must never be empty");
     });
   });
@@ -679,13 +697,26 @@ async function main(): Promise<void> {
         mock.calls.every((c) => c.tool_choice?.type !== "tool"),
         "no finalization call after abort (budget already blown)",
       );
-      // The caller's signal must actually be forwarded as the SDK request
-      // option — not just simulated by the mock's injected rejection.
+      // The request signal is the loop's internal fan-in signal (caller
+      // signal + turn-clock watchdogs): one stable AbortSignal that must be
+      // aborted once the caller's signal fires — not just simulated by the
+      // mock's injected rejection.
       assert(
-        mock.signals.every((s) => s === controller.signal),
-        "options.abortSignal must ride every create() as the request signal",
+        mock.signals.every(
+          (s) => typeof AbortSignal !== "undefined" && s instanceof AbortSignal,
+        ),
+        "every create() must carry an AbortSignal request option",
       );
-      assertIncludes(result.content, "step limit for a single turn");
+      assert(
+        new Set(mock.signals).size === 1,
+        "the same internal signal must ride every create()",
+      );
+      assert(
+        (mock.signals[0] as AbortSignal).aborted,
+        "the internal request signal must be aborted after the caller aborts",
+      );
+      // Honest abort message — never the step-cap text on an aborted turn.
+      assertEqual(result.content, buildAbortedTurnMessage(1));
       // Aborted turns map finishReason from lastStopReason, not "tool-calls".
       assertEqual(result.finishReason, "stop");
     });
@@ -707,7 +738,7 @@ async function main(): Promise<void> {
         abortSignal: controller.signal,
       });
       assertEqual(mock.calls.length, 0, "no request when already aborted");
-      assertIncludes(result.content, "step limit for a single turn");
+      assertEqual(result.content, buildAbortedTurnMessage(0));
     });
   });
 
@@ -740,7 +771,7 @@ async function main(): Promise<void> {
         ),
         "aborted tool must not be recorded as a failed execution",
       );
-      assertIncludes(result.content, "step limit for a single turn");
+      assertEqual(result.content, buildAbortedTurnMessage(1));
     });
   });
 
@@ -949,8 +980,14 @@ async function main(): Promise<void> {
         "no finalization call after abort",
       );
       assertEqual(chunks.length, 1, "exactly one graceful chunk on abort");
-      assertIncludes(chunks[0], "step limit for a single turn");
+      assertEqual(chunks[0], buildAbortedTurnMessage(1));
       assertEqual(result.finishReason, "stop");
+      assertEqual(
+        result.metadata?.stopReason,
+        "aborted",
+        "metadata.stopReason must resolve to 'aborted' after drain",
+      );
+      assertEqual(result.stopReason, "aborted", "top-level getter too");
     });
   });
 
@@ -1154,7 +1191,7 @@ async function main(): Promise<void> {
         mock.calls.every((c) => c.tool_choice?.type !== "tool"),
         "tool_choice:'tool' must never be issued post-abort",
       );
-      assertIncludes(result.content, "step limit for a single turn");
+      assertEqual(result.content, buildAbortedTurnMessage(1));
     });
   });
 
@@ -1177,7 +1214,7 @@ async function main(): Promise<void> {
       });
       assertEqual(mock.calls.length, 1, "no terminal model call post-abort");
       assertEqual(chunks.length, 1, "exactly one graceful chunk");
-      assertIncludes(chunks[0], "step limit for a single turn");
+      assertEqual(chunks[0], buildAbortedTurnMessage(1));
     });
   });
 
@@ -1292,6 +1329,192 @@ async function main(): Promise<void> {
         JSON.stringify(PAYLOAD),
         "structuredOutput getter must survive the lifecycle wrapper spread",
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 20. Turn time budget on the generate loop (no defensive default here)
+  // -------------------------------------------------------------------------
+  await test("generate: turnTimeoutMs exceeded mid tool -> honest time message + stopReason 'time-limit', no step-cap text", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeGenerateMock(() => ({
+        response: toolUseResponse("myTool", { q: "x" }),
+      }));
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(async () => {
+          // Sleeps past the 120ms turn deadline (ignores the signal), so the
+          // deadline fires mid-tool and the next loop-entry check breaks.
+          await new Promise<void>((resolvePromise) => {
+            const t = setTimeout(resolvePromise, 400);
+            (t as { unref?: () => void }).unref?.();
+          });
+          return { ok: true };
+        }),
+        maxSteps: 10,
+        turnTimeoutMs: 120,
+      });
+      assert(
+        result.content.includes("processing time limit"),
+        `expected the turn-timeout message, got: ${result.content}`,
+      );
+      assert(
+        !result.content.includes("step limit"),
+        "a timed-out turn must not claim a step limit was reached",
+      );
+      assertEqual(
+        result.stopReason,
+        "time-limit",
+        "stopReason must be 'time-limit'",
+      );
+      assert(mock.calls.length < 10, "turn ends well before the step budget");
+    });
+  });
+
+  await test("generate: toolTimeoutMs bounds a wedged tool -> error tool_result, turn continues and completes", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeGenerateMock((i) =>
+        i === 0
+          ? { response: toolUseResponse("myTool", { q: "x" }) }
+          : { response: textResponse("done after tool timeout", "end_turn") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(async () => {
+          await new Promise<void>((resolvePromise) => {
+            const t = setTimeout(resolvePromise, 5_000);
+            (t as { unref?: () => void }).unref?.();
+          });
+          return { ok: true };
+        }),
+        maxSteps: 5,
+        toolTimeoutMs: 100,
+      });
+      assertEqual(
+        result.content,
+        "done after tool timeout",
+        "turn must continue past the timed-out tool and complete",
+      );
+      assertEqual(result.stopReason, "completed");
+      assert(
+        JSON.stringify(result.toolExecutions ?? []).includes("timed out"),
+        "the timed-out tool must surface as an error tool execution",
+      );
+      assertEqual(mock.calls.length, 2, "loop continued to the next step");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 21. Deadline fires MID-MODEL-CALL: the cancelled request must resolve the
+  //     turn as 'time-limit' — never reject out of generate()/stream()
+  //     (a rejection routes callers into abortSignal-less fallback retries:
+  //     the doubled-runaway hazard).
+  // -------------------------------------------------------------------------
+  await test("generate: turn deadline mid-model-call -> resolves with stopReason 'time-limit', never rejects", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const calls: AnthropicRequestParams[] = [];
+      // First call: normal tool_use step. Second call: hangs until the
+      // request signal (the loop's internal fan-in) fires, then rejects
+      // abort-shaped — the SDK cancelling an in-flight request.
+      const client = {
+        messages: {
+          create: async (
+            p: AnthropicRequestParams,
+            opts?: { signal?: AbortSignal },
+          ) => {
+            const index = calls.length;
+            calls.push(p);
+            if (index === 0) {
+              return toolUseResponse("myTool", { q: "x" });
+            }
+            const signal = opts?.signal;
+            await new Promise<void>((resolvePromise) => {
+              if (!signal || signal.aborted) {
+                resolvePromise();
+                return;
+              }
+              signal.addEventListener("abort", () => resolvePromise(), {
+                once: true,
+              });
+            });
+            throw abortError();
+          },
+        },
+      };
+      const provider = await makeProvider(client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+        turnTimeoutMs: 120,
+      });
+      assertEqual(
+        result.stopReason,
+        "time-limit",
+        "internal deadline cancellation must attribute as time-limit, not 'aborted'",
+      );
+      assert(
+        result.content.includes("processing time limit"),
+        `expected the turn-timeout message, got: ${result.content}`,
+      );
+      assertEqual(calls.length, 2, "aborted during the 2nd model call");
+    });
+  });
+
+  await test("stream: turn deadline mid-model-call -> resolves with stopReason 'time-limit', never rejects", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const calls: AnthropicRequestParams[] = [];
+      // First call resolves a tool_use step; the second hangs until the
+      // loop's abortHandler calls controller.abort() (deadline -> internal
+      // abort -> active stream cancel), then rejects abort-shaped.
+      const client = {
+        messages: {
+          stream: (p: AnthropicRequestParams) => {
+            const index = calls.length;
+            calls.push(p);
+            if (index === 0) {
+              const first: MockMessageStream = {
+                on: () => first,
+                controller: { abort: () => undefined },
+                finalMessage: async () => toolUseResponse("myTool", { q: "x" }),
+              };
+              return first;
+            }
+            let onAbort: (() => void) | undefined;
+            const hanging: MockMessageStream = {
+              on: () => hanging,
+              controller: {
+                abort: () => onAbort?.(),
+              },
+              finalMessage: () =>
+                new Promise<AnthropicResponse>((_resolve, reject) => {
+                  onAbort = () => reject(abortError());
+                }),
+            };
+            return hanging;
+          },
+        },
+      };
+      const provider = await makeProvider(client);
+      const { chunks, result } = await runStream(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+        turnTimeoutMs: 120,
+      });
+      assertEqual(
+        result.metadata?.stopReason,
+        "time-limit",
+        "internal deadline cancellation must attribute as time-limit, not 'aborted'",
+      );
+      assertEqual(chunks.length, 1, "exactly one honest terminal chunk");
+      assert(
+        chunks[0].includes("processing time limit"),
+        `expected the turn-timeout message, got: ${chunks[0]}`,
+      );
+      assertEqual(calls.length, 2, "aborted during the 2nd model call");
     });
   });
 }

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -3168,8 +3168,10 @@ exit 127
       return (
         mapGeminiFinishReason("STOP") === "stop" &&
         mapGeminiFinishReason("MAX_TOKENS") === "length" &&
-        mapGeminiFinishReason("MALFORMED_FUNCTION_CALL") === "tool-calls" &&
-        mapGeminiFinishReason("UNEXPECTED_TOOL_CALL") === "tool-calls" &&
+        // Provider/model failures map to "error" — NOT "tool-calls", which is
+        // reserved for step-cap exits (consumers branch on it).
+        mapGeminiFinishReason("MALFORMED_FUNCTION_CALL") === "error" &&
+        mapGeminiFinishReason("UNEXPECTED_TOOL_CALL") === "error" &&
         mapGeminiFinishReason("SAFETY") === "content-filter" &&
         mapGeminiFinishReason("RECITATION") === "content-filter" &&
         mapGeminiFinishReason("BLOCKLIST") === "content-filter" &&

--- a/test/continuous-test-suite-gemini-abort.ts
+++ b/test/continuous-test-suite-gemini-abort.ts
@@ -30,7 +30,9 @@ import {
   assertIncludes,
 } from "./helpers/harness.js";
 import {
+  buildAbortedTurnMessage,
   buildToolLoopCapMessage,
+  buildTurnTimeoutMessage,
   isAbortError,
   handleMaxStepsTermination,
 } from "../src/lib/providers/googleNativeGemini3.js";
@@ -187,6 +189,9 @@ async function makeProvider(client: MockClient): Promise<GoogleVertexProvider> {
 type GenResult = {
   content: string;
   finishReason: string;
+  stopReason?: string;
+  rawFinishReason?: string;
+  stepsUsed?: number;
   usage: { input: number; output: number; total: number };
   structuredOutput?: unknown;
   toolExecutions?: unknown[];
@@ -206,10 +211,47 @@ async function runGenerate(
 
 type StreamResultShape = {
   finishReason: string;
+  stopReason?: string;
+  rawFinishReason?: string;
   usage: { input: number; output: number; total: number };
   structuredOutput?: unknown;
   stream: AsyncIterable<{ content: string }>;
 };
+
+/**
+ * Mock client whose FIRST call is a normal tool-call step and whose SECOND
+ * call hangs until the request's abortSignal fires, then rejects
+ * abort-shaped — simulating the SDK cancelling an in-flight request when an
+ * internal watchdog (turn deadline / stall) aborts mid-model-call.
+ */
+function makeHangingSecondCallMock(): Recorder {
+  const calls: GenParams[] = [];
+  const client: MockClient = {
+    models: {
+      generateContentStream: async (p: GenParams) => {
+        const index = calls.length;
+        calls.push(p);
+        if (index === 0) {
+          return chunks([functionCallChunk("myTool", { q: "x" })]);
+        }
+        const signal = p.config.abortSignal as AbortSignal;
+        await new Promise<void>((resolvePromise) => {
+          if (signal.aborted) {
+            resolvePromise();
+            return;
+          }
+          signal.addEventListener("abort", () => resolvePromise(), {
+            once: true,
+          });
+        });
+        const e = new Error("The operation was aborted");
+        e.name = "AbortError";
+        throw e;
+      },
+    },
+  };
+  return { calls, client };
+}
 
 /** Invoke the private native-Gemini stream loop and drain its chunks plus result. */
 async function runStream(
@@ -362,6 +404,12 @@ async function main(): Promise<void> {
         "content must be the graceful cap message",
       );
       assertEqual(result.finishReason, "tool-calls");
+      assertEqual(
+        result.stopReason,
+        "step-cap",
+        "genuine budget exhaustion must report stopReason 'step-cap'",
+      );
+      assertEqual(result.stepsUsed, maxSteps, "stepsUsed reflects the budget");
       assert(
         !result.content.includes("Tool execution limit reached"),
         "must not be the bracketed placeholder",
@@ -441,9 +489,9 @@ async function main(): Promise<void> {
   });
 
   // -------------------------------------------------------------------------
-  // 7. Generate: abort mid-drain -> BREAK, synth skipped, cap message
+  // 7. Generate: abort mid-drain -> BREAK, synth skipped, honest abort message
   // -------------------------------------------------------------------------
-  await test("generate: abort mid-drain -> loop breaks (no throw), synth skipped, cap message, call count < maxSteps", async () => {
+  await test("generate: abort mid-drain -> loop breaks (no throw), synth skipped, honest abort message, call count < maxSteps", async () => {
     await withTemporaryEnv(VERTEX_ENV, async () => {
       const maxSteps = 10;
       const controller = new AbortController();
@@ -465,11 +513,19 @@ async function main(): Promise<void> {
         maxSteps,
         abortSignal: controller.signal,
       });
-      // No throw escaped (we got a result). Cap message delivered, synth skipped.
-      assert(
-        result.content.includes("step limit for a single turn"),
-        `expected graceful cap message, got: ${result.content}`,
+      // No throw escaped (we got a result). Honest abort message delivered —
+      // NEVER the step-cap text on an aborted turn (2026-07-03 incident) —
+      // and synth skipped.
+      assertEqual(
+        result.content,
+        buildAbortedTurnMessage(1),
+        `expected honest aborted-turn message, got: ${result.content}`,
       );
+      assert(
+        !result.content.includes("step limit"),
+        "aborted turn must not claim a step limit was reached",
+      );
+      assertEqual(result.stopReason, "aborted", "stopReason must be 'aborted'");
       assert(
         mock.calls.length < maxSteps,
         `expected < ${maxSteps} generateContentStream calls, got ${mock.calls.length}`,
@@ -481,7 +537,7 @@ async function main(): Promise<void> {
   // -------------------------------------------------------------------------
   // 8. Generate: abort BETWEEN steps (loop-entry guard)
   // -------------------------------------------------------------------------
-  await test("generate: abort BETWEEN steps (loop-entry guard) -> graceful cap message", async () => {
+  await test("generate: abort BETWEEN steps (loop-entry guard) -> honest abort message", async () => {
     await withTemporaryEnv(VERTEX_ENV, async () => {
       const maxSteps = 10;
       const controller = new AbortController();
@@ -533,10 +589,12 @@ async function main(): Promise<void> {
         maxSteps,
         abortSignal: controller.signal,
       });
-      assert(
-        result.content.includes("step limit for a single turn"),
-        `expected graceful cap message, got: ${result.content}`,
+      assertEqual(
+        result.content,
+        buildAbortedTurnMessage(1),
+        `expected honest aborted-turn message, got: ${result.content}`,
       );
+      assertEqual(result.stopReason, "aborted", "stopReason must be 'aborted'");
       assertEqual(
         calls.length,
         1,
@@ -669,12 +727,13 @@ async function main(): Promise<void> {
         ),
         "aborted tool must not be recorded as a failed execution",
       );
-      assert(
-        result.content.includes("step limit for a single turn"),
-        "graceful cap message after tool-exec abort",
+      assertEqual(
+        result.content,
+        buildAbortedTurnMessage(1),
+        "honest aborted-turn message after tool-exec abort",
       );
       // toolCallCount in the message reflects the single call.
-      assertIncludes(result.content, "across 1 tool call ");
+      assertIncludes(result.content, "I completed 1 tool call before stopping");
     });
   });
 
@@ -818,9 +877,14 @@ async function main(): Promise<void> {
         abortSignal: controller.signal,
       });
       assertEqual(out.length, 1, "exactly one graceful chunk on abort");
+      assertEqual(
+        out[0],
+        buildAbortedTurnMessage(1),
+        `expected honest aborted-turn message, got: ${out[0]}`,
+      );
       assert(
-        out[0].includes("step limit for a single turn"),
-        `expected cap message, got: ${out[0]}`,
+        !out[0].includes("step limit"),
+        "aborted stream turn must not claim a step limit was reached",
       );
       assert(mock.calls.length < maxSteps, "call count < maxSteps");
       assertEqual(mock.calls.length, 2, "aborted on 2nd request");
@@ -992,6 +1056,316 @@ async function main(): Promise<void> {
       !nativeSrc.includes("Tool execution limit reached after"),
       "legacy step-cap placeholder text still present in googleNativeGemini3.ts",
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // 19. Turn time budget: turnTimeoutMs ends the turn honestly (time-limit)
+  // -------------------------------------------------------------------------
+  await test("generate: turnTimeoutMs exceeded -> honest time message + stopReason 'time-limit', never the step-cap text", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const maxSteps = 10;
+      const mock = makeMock(() => [functionCallChunk("myTool", { q: "x" })]);
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: {
+          myTool: {
+            description: "slow tool",
+            parameters: { type: "object", properties: {} },
+            // Sleeps past the 120ms turn deadline (ignores the abort signal),
+            // so the deadline fires mid-tool and the next loop-entry check
+            // breaks the turn.
+            execute: async () => {
+              await new Promise<void>((resolvePromise) => {
+                const t = setTimeout(resolvePromise, 400);
+                (t as { unref?: () => void }).unref?.();
+              });
+              return { ok: true };
+            },
+          },
+        },
+        maxSteps,
+        turnTimeoutMs: 120,
+      });
+      assert(
+        result.content.includes("processing time limit"),
+        `expected the turn-timeout message, got: ${result.content}`,
+      );
+      assert(
+        !result.content.includes("step limit"),
+        "a timed-out turn must not claim a step limit was reached",
+      );
+      assertEqual(
+        result.stopReason,
+        "time-limit",
+        "stopReason must be 'time-limit'",
+      );
+      assert(
+        mock.calls.length < maxSteps,
+        "turn must end well before the step budget",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 20. Stall watchdog: no progress past stallTimeoutMs -> 'stalled'
+  // -------------------------------------------------------------------------
+  await test("generate: stallTimeoutMs with a wedged tool -> honest stall message + stopReason 'stalled'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock(() => [functionCallChunk("myTool", { q: "x" })]);
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: {
+          myTool: {
+            description: "wedged tool",
+            parameters: { type: "object", properties: {} },
+            // Sleeps past the stall watchdog's first check tick (the watchdog
+            // polls at >=1s granularity), producing no progress signals.
+            execute: async () => {
+              await new Promise<void>((resolvePromise) => {
+                const t = setTimeout(resolvePromise, 1_600);
+                (t as { unref?: () => void }).unref?.();
+              });
+              return { ok: true };
+            },
+          },
+        },
+        maxSteps: 10,
+        stallTimeoutMs: 300,
+      });
+      assert(
+        result.content.includes("no progress"),
+        `expected the stall message, got: ${result.content}`,
+      );
+      assertEqual(result.stopReason, "stalled", "stopReason must be 'stalled'");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 21. toolTimeoutMs: a wedged tool costs one step, not the turn
+  // -------------------------------------------------------------------------
+  await test("generate: toolTimeoutMs bounds a wedged tool -> error tool_result, turn continues and completes", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock((i) =>
+        i === 0
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("done after tool timeout", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: {
+          myTool: {
+            description: "wedged tool",
+            parameters: { type: "object", properties: {} },
+            execute: async () => {
+              await new Promise<void>((resolvePromise) => {
+                const t = setTimeout(resolvePromise, 5_000);
+                (t as { unref?: () => void }).unref?.();
+              });
+              return { ok: true };
+            },
+          },
+        },
+        maxSteps: 5,
+        toolTimeoutMs: 100,
+      });
+      assertEqual(
+        result.content,
+        "done after tool timeout",
+        "turn must continue past the timed-out tool and complete",
+      );
+      assertEqual(result.stopReason, "completed");
+      assert(
+        JSON.stringify(result.toolExecutions ?? []).includes("timed out"),
+        "the timed-out tool must surface as an error tool execution",
+      );
+      assertEqual(mock.calls.length, 2, "loop continued to the next step");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 22. MALFORMED_FUNCTION_CALL: one retry with corrective note, then recover
+  // -------------------------------------------------------------------------
+  await test("generate: MALFORMED_FUNCTION_CALL retries once with corrective note and recovers", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const malformedChunk: Chunk = {
+        candidates: [
+          { finishReason: "MALFORMED_FUNCTION_CALL", content: { parts: [] } },
+        ],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 0 },
+      };
+      const mock = makeMock((i) =>
+        i === 0 ? [malformedChunk] : [textChunk("recovered answer", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 5,
+      });
+      assertEqual(result.content, "recovered answer");
+      assertEqual(result.stopReason, "completed");
+      assertEqual(result.finishReason, "stop");
+      assertEqual(mock.calls.length, 2, "exactly one retry request");
+      assert(
+        JSON.stringify(mock.calls[1].contents).includes("malformed"),
+        "the retry request must carry the corrective note",
+      );
+    });
+  });
+
+  await test("generate: persistent MALFORMED_FUNCTION_CALL -> finishReason 'error' + stopReason 'provider-error' (not 'tool-calls')", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const malformedChunk: Chunk = {
+        candidates: [
+          { finishReason: "MALFORMED_FUNCTION_CALL", content: { parts: [] } },
+        ],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 0 },
+      };
+      const mock = makeMock(() => [malformedChunk]);
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 5,
+      });
+      assertEqual(
+        result.finishReason,
+        "error",
+        "malformed calls are provider errors, not 'tool-calls'",
+      );
+      assertEqual(
+        result.stopReason,
+        "provider-error",
+        "stopReason must be 'provider-error'",
+      );
+      assertEqual(result.rawFinishReason, "MALFORMED_FUNCTION_CALL");
+      assertEqual(mock.calls.length, 2, "one retry, then give up");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 23. Wrap-up nudge rides the tool-response turn inside the lead window
+  // -------------------------------------------------------------------------
+  await test("generate: wrap-up nudge injected when remaining turn time is inside wrapupTimeLeadMs", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock((i) =>
+        i === 0
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("wrapped up", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+        // Lead window == full budget -> the very first tool-response turn is
+        // already inside the wrap-up window.
+        turnTimeoutMs: 60_000,
+        wrapupTimeLeadMs: 60_000,
+      });
+      assertEqual(result.content, "wrapped up");
+      assert(
+        JSON.stringify(mock.calls[1].contents).includes(
+          "processing time for this turn is nearly up",
+        ),
+        "second request must carry the wrap-up nudge text",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 24. Clean completion carries the new telemetry fields
+  // -------------------------------------------------------------------------
+  await test("generate: clean completion -> stopReason 'completed', rawFinishReason 'STOP', stepsUsed counted", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock((i) =>
+        i === 0
+          ? [functionCallChunk("myTool", { q: "x" })]
+          : [textChunk("all done", "STOP")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+      });
+      assertEqual(result.content, "all done");
+      assertEqual(result.stopReason, "completed");
+      assertEqual(result.rawFinishReason, "STOP");
+      assertEqual(result.stepsUsed, 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 25. Deadline fires MID-MODEL-CALL: the cancelled request must resolve the
+  //     turn as 'time-limit' — never reject out of generate()/stream()
+  //     (a rejection routes callers into abortSignal-less fallback retries:
+  //     the doubled-runaway hazard).
+  // -------------------------------------------------------------------------
+  await test("generate: turn deadline mid-model-call -> resolves with stopReason 'time-limit', never rejects", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeHangingSecondCallMock();
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+        turnTimeoutMs: 120,
+      });
+      assertEqual(
+        result.stopReason,
+        "time-limit",
+        "internal deadline cancellation must attribute as time-limit, not 'aborted'",
+      );
+      assert(
+        result.content.includes("processing time limit"),
+        `expected the turn-timeout message, got: ${result.content}`,
+      );
+      assertEqual(mock.calls.length, 2, "aborted during the 2nd model call");
+    });
+  });
+
+  await test("stream: turn deadline mid-model-call -> resolves with stopReason 'time-limit', never rejects", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeHangingSecondCallMock();
+      const provider = await makeProvider(mock.client);
+      const { chunks: out, result } = await runStream(provider, {
+        input: { text: "run tools" },
+        tools: makeTool(),
+        maxSteps: 10,
+        turnTimeoutMs: 120,
+      });
+      assertEqual(
+        result.stopReason,
+        "time-limit",
+        "internal deadline cancellation must attribute as time-limit, not 'aborted'",
+      );
+      assertEqual(out.length, 1, "exactly one honest terminal chunk");
+      assert(
+        out[0].includes("processing time limit"),
+        `expected the turn-timeout message, got: ${out[0]}`,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 26. Pure helpers: honest-message builders
+  // -------------------------------------------------------------------------
+  await test("buildTurnTimeoutMessage / buildAbortedTurnMessage: shape and counts", () => {
+    const timeoutMsg = buildTurnTimeoutMessage(125_000, 3);
+    assertIncludes(timeoutMsg, "2m 5s");
+    assertIncludes(timeoutMsg, "3 tool calls");
+    assertIncludes(timeoutMsg, "processing time limit");
+    assert(
+      !timeoutMsg.includes("step limit"),
+      "timeout message must not mention a step limit",
+    );
+    const abortedNoTools = buildAbortedTurnMessage(0);
+    assertEqual(abortedNoTools, "This turn was stopped before I could finish.");
+    assertIncludes(buildAbortedTurnMessage(1), "1 tool call before stopping");
   });
 }
 


### PR DESCRIPTION
## Summary

Implements the turn-time-budget proposal (N1–N5, RCA of the fake "reached the 200-step limit" messages, 2026-07-03) in the four native Vertex loops — Gemini + Claude-on-Vertex, `generate()` + `stream()`. Releases as a **minor** (9.81.0) via the `feat` commit: new public options, new result fields, and one finishReason semantic change.

### N1 — Turn time budget
- New options: `turnTimeoutMs` (whole-turn wall clock), `stallTimeoutMs` (no-progress watchdog: no chunk, no tool start/finish, no step start), `wrapupTimeLeadMs` (default 120s when a turn timeout is set — injects a wrap-up nudge on the tool-result turn, same machinery as the step-budget nudge).
- Watchdogs fan into each loop's internal `AbortController`, which cancels in-flight SDK requests and rides tool executions. The Claude generate loop gains an internal controller (it had none).
- Defaults preserve current behavior per loop: Vertex Gemini (both) and Claude stream keep their pre-existing defensive whole-turn bound (`timeout ?? 300s`), now honestly labeled; **Claude generate keeps NO default turn deadline** — callers opt in with `turnTimeoutMs`.

### N2 — Honest exit messages
`buildToolLoopCapMessage` is emitted **only** on genuine `step >= maxSteps` exits. Time-limit, stall, and caller-abort exits get their own messages (`buildTurnTimeoutMessage` / `buildTurnStalledMessage` / `buildAbortedTurnMessage`) at every fallback site, including the finalization/backstop catches and absolute backstops.

### N3 — finishReason de-overload ⚠️ behavior change
- `MALFORMED_FUNCTION_CALL` / `UNEXPECTED_TOOL_CALL` now map to unified `finishReason: "error"` — **never** `"tool-calls"`, which is now exclusively the step-cap signal. Consumers pattern-matching either value change behavior on upgrade.
- `MALFORMED_FUNCTION_CALL` steps are retried once with a corrective note before giving up.
- New result fields: `stopReason` (`completed | step-cap | time-limit | stalled | aborted | provider-error`), `rawFinishReason`, `stepsUsed` — threaded through every explicit DTO field list (generate DTO, MCP/pool/direct DTOs, `buildGenerateTextOptions`, `TextGenerationResult`). Stream results carry them on `metadata` (passed through **by reference** so post-drain resolution survives the wrappers) plus top-level getters.

### N4 — Bounded tool executions
Every `execute()` await is wrapped in `withTimeout` (`toolTimeoutMs`, default 300s). A wedged tool costs one step (error tool_result); the turn continues.

### N5 — Telemetry
`analytics` gains `stepsUsed`, `toolCallCount`, `stopReason`, `elapsedMs`, `rawFinishReason`; new `turn:lifecycle` emitter event for non-completed exits, tool timeouts, and malformed retries.

## Safety properties verified by tests
- **No-throw on internal deadline aborts** (doubled-runaway hazard): a deadline firing mid-model-call resolves the turn with `stopReason: "time-limit"` — never rejects out of `generate()`/`stream()`. Covered on all four loops.
- **Cause attribution**: internal deadline/stall cancellations (which are abort-shaped) attribute as `time-limit`/`stalled`; only genuine caller aborts report `aborted`.

## Testing
- `pnpm run test:gemini-abort` — 37/37 (10 new: time-limit, stall, tool-timeout, malformed retry/persist, wrap-up nudge, telemetry fields, mid-model-call deadline ×2)
- `pnpm run test:anthropic-cap` — 33/33 (4 new incl. mid-model-call deadline ×2)
- `test:bugfixes` 86/86, `google-native` 30/30
- `pnpm run check`, `pnpm run lint`, `pnpm run build` all pass

## Docs
`docs/features/turn-time-budget.md` — options, stopReason contract, defensive-default matrix, telemetry.

## Out of scope (follow-up issue)
The `googleAiStudio.ts` Gemini loop twins and the direct `anthropic.ts` native loop don't get the rework yet — they ignore the new options and retain the old exit-labeling pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable turn, stall, wrap-up, and tool execution time limits for AI-powered generation and streaming.
  * Added clearer end-of-turn status reporting, including completed, time limit, stalled, aborted, and provider error outcomes.
  * Improved streaming metadata so final results can include more detailed turn information.

* **Bug Fixes**
  * Added more accurate user-facing messages when a turn ends due to timeout, stall, abort, or step cap.
  * Improved handling of malformed or unexpected tool calls, including one automatic retry before returning an error state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->