### PR TITLE
fix(landing): prerender homepage so crawlers see content

### DIFF
--- a/landing/src/lib/components/NeuralTopology.svelte
+++ b/landing/src/lib/components/NeuralTopology.svelte
@@ -1690,6 +1690,7 @@
   });
 
   onDestroy(() => {
+    if (typeof window === "undefined") return; // SSR/prerender: no browser resources to clean up
     if (typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(raf);
     if (typeof window !== "undefined") {
       window.removeEventListener("resize", resize);

--- a/landing/src/routes/+page.ts
+++ b/landing/src/routes/+page.ts
@@ -1,3 +1,5 @@
-// Disable SSR for the landing page — it's entirely canvas/animation-driven
-// (NeuralTopology, CustomCursor, GSAP) and requires browser APIs.
-export const ssr = false;
+// Prerender the landing page to static HTML so search crawlers see the real
+// content (was `ssr = false`, which shipped an empty shell — 0 words / 0 <h1> to
+// non-JS crawlers). All browser-only code (NeuralTopology canvas, CustomCursor,
+// GSAP, Lenis) is gated inside onMount(), so it's SSR/prerender-safe.
+export const prerender = true;

--- a/landing/svelte.config.js
+++ b/landing/svelte.config.js
@@ -7,6 +7,21 @@ const config = {
     alias: {
       "@/*": "./src/lib/*",
     },
+    prerender: {
+      // /discord, /docs/*, /sdk/*, /cli/*, /getting-started are Vercel edge
+      // redirects (see vercel.json), not SvelteKit routes — they 404 during
+      // prerender but resolve in production. Don't fail the build on them;
+      // still fail on genuinely broken internal links.
+      handleHttpError: ({ path, message }) => {
+        if (path === "/discord" || path === "/getting-started") {
+          return;
+        }
+        if (/^\/(docs|sdk|cli)(\/|$)/.test(path)) {
+          return;
+        }
+        throw new Error(message);
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Why
neurolink.ink is CSR-only (`ssr = false`): Googlebot, Bingbot, and AI crawlers (GPTBot, ClaudeBot, PerplexityBot) receive an empty HTML shell. All landing-page SEO and AI-answer citation is blocked. Baseline AI share-of-voice measured 2026-07-04: NeuroLink cited in 0/10 LLM probes and 0/3 web searches for its core queries.

## What
- `+page.ts`: replace `ssr = false` with `prerender = true` — homepage becomes static HTML at build time
- `NeuralTopology.svelte`: guard `onDestroy` browser API access with `typeof window === 'undefined'` for the prerender pass
- `svelte.config.js`: `handleHttpError` for the 5 Vercel redirect paths so prerender doesn't fail on them

All other landing components already gate browser APIs inside `onMount()`.

## Verification
- Local build produces populated static HTML for `/`
- Adversarially re-reviewed (feasibility + ROI) 2026-07-04: verdict CONFIRM/CONFIRM, ICE 100 — highest-ranked item in the growth backlog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The landing page now supports static prerendering, improving how content is served to search engines and visitors without JavaScript.
* **Bug Fixes**
  * Prevented browser-only cleanup from running in non-browser environments, reducing prerender/SSR errors.
  * Improved prerender stability by handling expected HTTP errors for selected public routes while still surfacing unexpected issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->