### PR TITLE
fix(exports): root import crashes without react (optional peer dep pulled eagerly)

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -51,6 +51,9 @@ export {
 // ============================================================================
 // CLIENT SDK EXPORTS - Type-safe API access for browser and Node.js
 // Note: React hooks are NOT re-exported here. Import from '@juspay/neurolink/client'.
+// These re-exports intentionally bypass ./client/index.js: that barrel statically
+// re-exports ./reactHooks.js, so routing through it makes the ROOT import require
+// `react` (an optional peer dep) and crash react-less installs at import time.
 // ============================================================================
 
 export {
@@ -58,13 +61,19 @@ export {
   NeuroLinkClient,
   createClient,
   NeuroLinkApiError,
+} from "./client/httpClient.js";
+
+export {
   // AI SDK Adapter
   NeuroLinkLanguageModel,
-  NeuroLinkAIProvider,
+  NeuroLinkProvider as NeuroLinkAIProvider,
   createNeuroLinkProvider,
   createNeuroLinkModel,
   createStreamingResponse,
   neurolink as neuroLinkAIInstance,
+} from "./client/aiSdkAdapter.js";
+
+export {
   // Interceptors
   createApiKeyAuthInterceptor,
   createBearerAuthInterceptor,
@@ -79,12 +88,18 @@ export {
   createErrorHandlerInterceptor,
   composeMiddleware,
   conditionalMiddleware,
+} from "./client/interceptors.js";
+
+export {
   // Streaming Client
   SSEClient,
   WebSocketStreamingClient,
   createStreamingClient,
   createAsyncStream,
   collectStream,
+} from "./client/streamingClient.js";
+
+export {
   // Authentication
   OAuth2TokenManager,
   JWTTokenManager,
@@ -94,12 +109,15 @@ export {
   createAuthWithRetryMiddleware,
   createMultiAuthMiddleware,
   OAuth2Error,
-  OAuth2AuthError,
+  OAuth2AuthenticationError as OAuth2AuthError,
   TokenRefreshError,
   decodeJWTPayload,
   isJWTExpired,
   getJWTExpiry,
   getApiKeyFromEnv,
+} from "./client/auth.js";
+
+export {
   // Errors
   ErrorCode as ClientErrorCode,
   NeuroLinkError as ClientNeuroLinkError,
@@ -125,7 +143,7 @@ export {
   isRetryableError,
   isNeuroLinkError,
   isApiError,
-} from "./client/index.js";
+} from "./client/errors.js";
 
 export {
   AIProviderName,


### PR DESCRIPTION
## Bug
Fresh install without react (react is an **optional** peerDependency):
```
import('@juspay/neurolink')
// ERR_MODULE_NOT_FOUND: Cannot find package 'react'
//   imported from .../dist/client/reactHooks.js
```
Root cause: `src/lib/index.ts` re-exports client SDK names through the `./client/index.js` barrel, which statically re-exports `./reactHooks.js` → `react`. ESM resolves the chain eagerly, so the ROOT import requires react even though it's optional. Every non-React consumer's first import crashes — found via a cold-start install test while preparing launch material.

## Fix
Re-export the identical names directly from their react-free modules (`httpClient`, `aiSdkAdapter`, `interceptors`, `streamingClient`, `auth`, `errors`), bypassing the barrel. No API change; `@juspay/neurolink/client` still serves React hooks to React users.

## Verification
- `pnpm run build` clean (publint: All good!)
- `dist/index.js` has zero runtime references to `client/index.js`
- `npm pack` → install in a fresh project where `require.resolve('react')` fails → **root import OK, 686 exports**, aliases (`NeuroLinkAIProvider`, `OAuth2AuthError`, `ClientErrorCode`) all intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the client SDK’s top-level exports to load from dedicated modules, helping avoid unintended optional dependency loading at import time.
  * Updated authentication and error exports for clearer, more consistent access.
  * Kept the `OAuth2AuthError` name available through a compatible alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->