### PR TITLE
fix(mcp): do not cache error tool results (BZ-664 follow-up)

### DIFF
--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -14368,13 +14368,38 @@ Current user's request: ${currentInput}`;
         options,
       );
 
-      // BZ-664: Store result in cache after successful execution
-      if (cacheEnabled && this.mcpToolResultCache) {
+      // BZ-664: Store result in cache after successful execution.
+      // Only cache SUCCESSFUL results. Caching an error result (isError:true /
+      // success:false — e.g. an upstream 403/timeout surfaced as a tool error)
+      // replays that identical failure to every caller with the same args for
+      // the whole TTL, turning a single transient upstream error into a storm
+      // of cached failures and preventing a retry from re-hitting the server
+      // once it recovers. Errors must always re-execute. (Detection mirrors the
+      // isToolError check used elsewhere in this file.)
+      const resultObj =
+        result && typeof result === "object"
+          ? (result as Record<string, unknown>)
+          : undefined;
+      const isErrorResult = Boolean(
+        (resultObj && "isError" in resultObj && resultObj.isError === true) ||
+        (resultObj && "success" in resultObj && resultObj.success === false),
+      );
+      // Also skip an `undefined` result: the cache read side treats `undefined`
+      // as a miss (`cached !== undefined`), so storing it is a dead entry that can
+      // never be read back — keep write/read symmetric with the other cache sites.
+      if (
+        cacheEnabled &&
+        this.mcpToolResultCache &&
+        !isErrorResult &&
+        result !== undefined
+      ) {
         this.mcpToolResultCache.cacheResult(toolName, cacheKeyArgs, result);
       }
 
       mcpLogger.debug(
-        `[NeuroLink] External MCP tool executed successfully: ${toolName}`,
+        `[NeuroLink] External MCP tool ${
+          isErrorResult ? "returned error" : "executed successfully"
+        }: ${toolName}`,
       );
       return result;
     } catch (error) {

--- a/test/mcpResultCacheErrorSkip.test.ts
+++ b/test/mcpResultCacheErrorSkip.test.ts
@@ -1,0 +1,151 @@
+/**
+ * BZ-664 follow-up: the MCP tool result cache must NOT store error results.
+ *
+ * Caching an error result (isError:true / success:false — e.g. an upstream 403
+ * or timeout surfaced as a tool error) replays that identical failure to every
+ * caller with the same args for the whole TTL, turning a single transient
+ * upstream error into a storm of cached failures and preventing a retry from
+ * re-hitting the server once it recovers.
+ *
+ * These tests drive `executeExternalMCPTool` with a stubbed external server and
+ * assert the cache stores successful results but skips error results.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+type CacheLike = {
+  cacheResult: (tool: string, args: unknown, result: unknown) => void;
+  getCachedResult: (tool: string, args: unknown) => unknown;
+};
+
+type NeuroLinkInternals = {
+  mcpToolResultCache?: CacheLike;
+  externalServerManager: { executeTool: ReturnType<typeof vi.fn> };
+};
+
+describe("MCP tool result cache — error results are not cached (BZ-664 follow-up)", () => {
+  let instance: unknown;
+  let internals: NeuroLinkInternals;
+  let cacheSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    const { NeuroLink } = await import("../src/lib/neurolink.js");
+    // Empty config => MCP result cache is enabled by default (mcp.cache.enabled !== false).
+    instance = new NeuroLink({});
+    internals = instance as unknown as NeuroLinkInternals;
+
+    // Spy on the REAL ExternalServerManager.executeTool instead of swapping the
+    // whole instance out. Swapping would orphan the manager the constructor built
+    // — its process/event listeners would stay attached for the rest of the suite,
+    // because afterEach's dispose()/shutdown() would then run against the bare stub.
+    // Spying keeps the single real instance, so teardown actually reaches it.
+    vi.spyOn(
+      internals.externalServerManager as unknown as {
+        executeTool: (...args: unknown[]) => unknown;
+      },
+      "executeTool",
+    ).mockResolvedValue(undefined);
+
+    expect(internals.mcpToolResultCache).toBeDefined();
+    cacheSpy = vi.spyOn(
+      internals.mcpToolResultCache as CacheLike,
+      "cacheResult",
+    );
+  });
+
+  afterEach(async () => {
+    // The NeuroLink constructor spins up an ExternalServerManager, event emitters
+    // and circuit breakers; dispose the instance so listeners/timers don't leak
+    // across the suite. Guarded because the teardown method name is version-tied.
+    const disposable = instance as {
+      dispose?: () => Promise<void> | void;
+      shutdown?: () => Promise<void> | void;
+    };
+    await disposable.dispose?.();
+    await disposable.shutdown?.();
+    vi.restoreAllMocks();
+  });
+
+  const call = (tool: string, args: Record<string, unknown>) =>
+    (
+      instance as {
+        executeExternalMCPTool: (
+          s: string,
+          t: string,
+          a: Record<string, unknown>,
+        ) => Promise<unknown>;
+      }
+    ).executeExternalMCPTool("srv", tool, args);
+
+  it("does NOT cache a result with isError:true", async () => {
+    internals.externalServerManager.executeTool.mockResolvedValue({
+      isError: true,
+      content: [{ type: "text", text: "Permission denied (403)" }],
+    });
+
+    await call("bb_search", { q: "x" });
+
+    expect(cacheSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT cache a result with success:false", async () => {
+    internals.externalServerManager.executeTool.mockResolvedValue({
+      success: false,
+      content: [{ type: "text", text: "boom" }],
+    });
+
+    await call("bb_list", { p: "PROJ" });
+
+    expect(cacheSpy).not.toHaveBeenCalled();
+  });
+
+  it("DOES cache a successful result and serves the 2nd identical call from cache", async () => {
+    const executeTool = internals.externalServerManager.executeTool;
+    executeTool.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const first = await call("bb_get", { path: "a.ts" });
+    const second = await call("bb_get", { path: "a.ts" });
+
+    // Proves the cache is functional end-to-end, not just that cacheResult() was
+    // invoked: the 2nd identical call must be served from cache, so the external
+    // server is hit exactly once and both calls return the same value.
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    expect(cacheSpy).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it("does NOT cache an undefined result", async () => {
+    internals.externalServerManager.executeTool.mockResolvedValue(undefined);
+
+    await call("bb_none", { p: "x" });
+
+    // undefined is a cache-read miss (`cached !== undefined`), so storing it is a
+    // dead entry — the write side must skip it to stay symmetric with the read.
+    expect(cacheSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-executes (does not replay) after an error, so recovery is possible", async () => {
+    const executeTool = internals.externalServerManager.executeTool;
+    // First call fails (403), second call — same args — succeeds.
+    executeTool
+      .mockResolvedValueOnce({
+        isError: true,
+        content: [{ type: "text", text: "403" }],
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "recovered" }],
+      });
+
+    const first = await call("bb_get", { path: "b.ts" });
+    const second = await call("bb_get", { path: "b.ts" });
+
+    // The error was not cached, so the identical second call re-hit the server
+    // and got the recovered result instead of replaying the cached 403.
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    expect(first).toMatchObject({ isError: true });
+    expect(second).toMatchObject({
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The MCP tool result cache (BZ-664, `mcpToolResultCache`, default-on, 300s TTL) stores **every** result that doesn't throw — including **error** results (`isError: true` / `success: false`). The store site had no success guard:

```ts
// BZ-664: Store result in cache after successful execution   <-- comment, but no guard
if (cacheEnabled && this.mcpToolResultCache) {
  this.mcpToolResultCache.cacheResult(toolName, cacheKeyArgs, result);
}
```

When an external MCP server surfaces a **transient** upstream failure (e.g. a 403 or timeout) as a tool error result, that error is cached for the full TTL and replayed to every caller with the same args — turning a single transient failure into a **storm of identical cached failures**, and preventing a retry from re-hitting the server after it recovers (the "retry" just replays the stale cached error).

## Evidence (downstream production analysis)

Investigating a downstream service (Curator/Tara) whose Bitbucket MCP was "failing constantly and burning tokens":
- **~79%** of the "permission denied" failures completed in **~6ms** vs **~363ms** for a real network call (a 404 from the same server takes ~119ms) — i.e. they never hit the network; they were cache replays.
- **34%** were exact duplicates; one `search_code` 403 was replayed **59×**.
- **81%** of duplicate-failure gaps fell within the 300s cache TTL.
- Net effect: a few hundred real transient 403s were amplified into **thousands** of logged failures and wasted LLM tokens/turns.

## Fix

Guard `cacheResult()` so only **successful** results are cached; error results always re-execute. Error detection mirrors the existing `isToolError` check in this file (`isError: true` or `success: false`). Successful-call dedup (the intended BZ-664 benefit) is preserved.

## Tests

New `test/mcpResultCacheErrorSkip.test.ts` (4 tests, all passing):
- error result (`isError: true`) is **not** cached
- error result (`success: false`) is **not** cached
- successful result **is** cached
- after an error, an identical retry **re-executes** and gets the recovered result (no stale replay)

`tsc --noEmit --strict` clean; prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failed external tool responses from being saved to cache, including error-shaped and `undefined` outputs.
  * Ensured identical requests re-execute after a failure instead of replaying a cached error.
  * Confirmed successful tool results are still cached and reused.
  * Added verification that recovery after an initial failure works correctly.
* **Tests**
  * Added Vitest coverage for cache behavior across success, error-shaped, undefined, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->