### PR TITLE
docs(observability): proxy Cost & Budget dashboard design spec + completion plan

### DIFF
--- a/docs/superpowers/plans/2026-07-05-proxy-cost-budget-dashboard-completion.md
+++ b/docs/superpowers/plans/2026-07-05-proxy-cost-budget-dashboard-completion.md
@@ -1,0 +1,311 @@
+# Proxy Cost & Budget Dashboard — Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the proxy "Cost & Budget" tab (8 → 11 panels), switch the Cost Trend panel to stacked area, then validate every new panel against live OpenObserve data.
+
+**Architecture:** Pure OpenObserve dashboard-JSON edits — no proxy code. New panels are authored by cloning existing Cost & Budget panels (reusing their exact inline pricing `CASE` SQL and config boilerplate) and changing only id / title / layout / query / type. Validation runs the local Podman → OTEL collector → OpenObserve stack, routes proxy traffic, and confirms each panel renders.
+
+**Tech Stack:** OpenObserve v5 dashboard schema, DataFusion SQL, Node.js (`.mjs` scripts), Podman, pnpm.
+
+## Global Constraints
+
+- No proxy source-code changes; the existing 49 baseline panels stay byte-identical (only the "Cost & Budget" tab's `panels` array is edited).
+- Cost panels keep the `(est., USD)` label; their USD is computed via the **inline per-model pricing `CASE`** used by `Panel_cost_04` (mirrors `src/lib/utils/pricing.ts`). The trace-backed quota/session panels instead read `proxy_account` and the proxy-computed `ai_cost_total`.
+- Package manager is **pnpm**. Run node scripts with `node`.
+- The pre-commit hook (`pre-commit.sh`) runs the full `check + format:staged + lint + validate:all + build` gate and then **force-stages every modified tracked file**. Before committing, ensure the dashboard JSON is the only modified tracked file so nothing unintended is swept in.
+- No `git push` / PR without explicit user OK.
+- Dashboard file: `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`.
+- Grid is 48 columns. Built Cost & Budget panels occupy `y=0..33`; next free row is `y=34`. New ids: `Panel_cost_09/10/11`, layout `i` = `9009/9010/9011`.
+
+---
+
+## Implementation outcome (2026-07-05)
+
+**Both tasks are DONE.** Task 1 (panels) is committed as `1fd57e33`; Task 2 (live validation)
+ran against a local OpenObserve. Two corrections vs. the plan as written below:
+
+1. **Stream split.** The three new panels query the **traces** stream, not logs. Live
+   validation showed `session_id` and `proxy_ratelimit_after_*` live only on the traces
+   `proxy.request` root span (together with `proxy_account` and `ai_cost_total`), while the
+   logs stream carries `account_name` + token counts. So the quota panels key off
+   `proxy_account` (not `account_name`) and `CAST(ai_cost_total AS DOUBLE)`; the cost panels
+   stay on logs. All three queries returned real data — per-account 7-day/5-hour utilisation
+   and top sessions by USD.
+2. **Baseline is 49 panels (6 tabs).** The illustrative script
+   below asserts the baseline stays unchanged during this edit (49 → 49).
+
+Panels were inserted as raw text (not `JSON.parse`→`stringify`) so the 66 existing panels
+stay byte-identical — the committed diff is +349/−1, no `0.0`→`0` churn.
+
+---
+
+### Task 1: Complete the Cost & Budget tab JSON (add 3 panels + stacked-area flip)
+
+**Files:**
+
+- Modify: `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json` (the "Cost & Budget" tab `panels` array only)
+
+**Interfaces:**
+
+- Consumes: existing panels `Panel_cost_04` (bar template — its query holds the reusable pricing `CASE`) and `Panel_cost_06` (the Cost Trend line panel to flip).
+- Produces: panels `Panel_cost_09` (7-day Quota Utilization, bar), `Panel_cost_10` (5-hour Quota Utilization, bar), `Panel_cost_11` (Top Sessions by Cost, table); `Panel_cost_06.type = "area-stacked"`.
+
+- [ ] **Step 1: Write the failing validation check**
+
+Save as `/tmp/validate-cost-tab.mjs` (scratch, not committed):
+
+```js
+import { readFileSync } from "node:fs";
+const P = "docs/assets/dashboards/neurolink-proxy-observability-dashboard.json";
+const j = JSON.parse(readFileSync(P, "utf8"));
+const cb = j.v5.tabs.find((t) => t.name === "Cost & Budget");
+if (!cb) {
+  console.error('FAIL: missing "Cost & Budget" tab');
+  process.exit(1);
+}
+const byId = Object.fromEntries(cb.panels.map((p) => [p.id, p]));
+const errs = [];
+if (cb.panels.length !== 11)
+  errs.push(`expected 11 panels, got ${cb.panels.length}`);
+if (byId.Panel_cost_06?.type !== "area-stacked")
+  errs.push(
+    `Panel_cost_06 type = ${byId.Panel_cost_06?.type}, want area-stacked`,
+  );
+for (const [id, type] of [
+  ["Panel_cost_09", "bar"],
+  ["Panel_cost_10", "bar"],
+  ["Panel_cost_11", "table"],
+]) {
+  if (!byId[id]) errs.push(`missing ${id}`);
+  else if (byId[id].type !== type)
+    errs.push(`${id} type = ${byId[id].type}, want ${type}`);
+}
+// baseline untouched: all other tabs still total 49 panels
+const others = j.v5.tabs.filter(
+  (t) => !["Cost & Budget", "Trace Drilldown"].includes(t.name),
+);
+const base = others.reduce((n, t) => n + t.panels.length, 0);
+if (base !== 49)
+  errs.push(`baseline panels = ${base}, want 49 (do not touch other tabs)`);
+if (errs.length) {
+  console.error("FAIL:\n" + errs.join("\n"));
+  process.exit(1);
+}
+console.log(
+  "PASS: 11 Cost & Budget panels, area-stacked trend, 49 baseline untouched",
+);
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `node /tmp/validate-cost-tab.mjs`
+Expected: `FAIL: expected 11 panels, got 8` (and the area-stacked / missing-panel lines).
+
+- [ ] **Step 3: Write the panel-surgery script and apply it**
+
+Save as `/tmp/add-cost-panels.mjs` and run it — it clones existing panels so the pricing `CASE` and config boilerplate are reused verbatim:
+
+```js
+import { readFileSync, writeFileSync } from "node:fs";
+const P = "docs/assets/dashboards/neurolink-proxy-observability-dashboard.json";
+const j = JSON.parse(readFileSync(P, "utf8"));
+const cb = j.v5.tabs.find((t) => t.name === "Cost & Budget");
+const clone = (o) => JSON.parse(JSON.stringify(o));
+const get = (id) => cb.panels.find((p) => p.id === id);
+const bar = get("Panel_cost_04"); // bar template w/ pricing CASE
+
+// 1) Flip Cost Trend (Panel_cost_06) line -> stacked area
+get("Panel_cost_06").type = "area-stacked";
+
+// 2) Quota panels (bar): latest proxy_ratelimit_after_* per account, as a percentage
+const quotaQuery = (col) =>
+  `SELECT proxy_account AS x_axis_1, ` +
+  `CAST(ROUND(MAX(util) * 100, 1) AS DECIMAL(5,1)) AS y_axis_1 FROM (` +
+  `SELECT proxy_account, CAST(${col} AS DOUBLE) AS util, ROW_NUMBER() OVER (` +
+  `PARTITION BY proxy_account ORDER BY _timestamp DESC) AS rn ` +
+  `FROM neurolink_proxy WHERE operation_name = 'proxy.request' AND ${col} IS NOT NULL ` +
+  `AND proxy_account IS NOT NULL AND proxy_account != '') t WHERE rn = 1 ` +
+  `GROUP BY proxy_account ORDER BY y_axis_1 DESC`;
+
+const mkQuota = (id, i, x, col, title) => {
+  const p = clone(bar);
+  p.id = id;
+  p.type = "bar";
+  p.title = title;
+  p.description =
+    "Latest rate-limit utilisation per account (%). Anthropic OAuth only.";
+  p.layout = { x, y: 34, w: 24, h: 9, i };
+  p.queries[0].query = quotaQuery(col);
+  p.queries[0].customQuery = true;
+  p.queries[0].fields.stream_type = "traces";
+  p.queries[0].fields.x = [
+    {
+      label: "Account",
+      alias: "x_axis_1",
+      column: "x_axis_1",
+      color: null,
+      sortBy: "DESC",
+    },
+  ];
+  p.queries[0].fields.y = [
+    {
+      label: "Utilisation %",
+      alias: "y_axis_1",
+      column: "y_axis_1",
+      color: null,
+      aggregationFunction: null,
+    },
+  ];
+  p.queries[0].fields.breakdown = [];
+  return p;
+};
+const p09 = mkQuota(
+  "Panel_cost_09",
+  9009,
+  0,
+  "proxy_ratelimit_after_7d",
+  "7-day Quota Utilization by Account (%)",
+);
+const p10 = mkQuota(
+  "Panel_cost_10",
+  9010,
+  24,
+  "proxy_ratelimit_after_5h",
+  "5-hour Quota Utilization by Account (%)",
+);
+
+// 3) Top Sessions by Cost (table): trace-backed proxy-computed cost, grouped by session_id
+const p11 = clone(bar);
+p11.id = "Panel_cost_11";
+p11.type = "table";
+p11.title = "Top Sessions by Cost (est., USD)";
+p11.description =
+  "Top 20 sessions by estimated USD cost (proxy-computed ai_cost_total, from trace spans).";
+p11.layout = { x: 0, y: 43, w: 48, h: 10, i: 9011 };
+p11.queries[0].fields.stream_type = "traces";
+p11.queries[0].query =
+  `SELECT session_id AS x_axis_1, ` +
+  `CAST(ROUND(SUM(CAST(ai_cost_total AS DOUBLE)), 4) AS DECIMAL(18,4)) AS y_axis_1 FROM neurolink_proxy ` +
+  `WHERE operation_name = 'proxy.request' AND session_id IS NOT NULL AND session_id != '' AND ai_cost_total IS NOT NULL ` +
+  `GROUP BY session_id ORDER BY y_axis_1 DESC LIMIT 20`;
+p11.queries[0].customQuery = true;
+p11.queries[0].fields.x = [
+  {
+    label: "Session",
+    alias: "x_axis_1",
+    column: "x_axis_1",
+    color: null,
+    sortBy: "DESC",
+  },
+];
+p11.queries[0].fields.y = [
+  {
+    label: "Cost (USD)",
+    alias: "y_axis_1",
+    column: "y_axis_1",
+    color: null,
+    aggregationFunction: null,
+  },
+];
+p11.queries[0].fields.breakdown = [];
+
+cb.panels.push(p09, p10, p11);
+writeFileSync(P, JSON.stringify(j, null, 2) + "\n");
+console.log("added Panel_cost_09/10/11; Panel_cost_06 -> area-stacked");
+```
+
+Run: `node /tmp/add-cost-panels.mjs`
+Expected: `added Panel_cost_09/10/11; Panel_cost_06 -> area-stacked`
+
+- [ ] **Step 4: Run validation + prettier to confirm the edit is well-formed**
+
+Run: `node /tmp/validate-cost-tab.mjs && npx prettier --write docs/assets/dashboards/neurolink-proxy-observability-dashboard.json && npx prettier --check docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`
+Expected: `PASS: 11 Cost & Budget panels, area-stacked trend, 49 baseline untouched` then `All matched files use Prettier code style!`
+
+- [ ] **Step 5: Confirm only the dashboard file is modified, then commit through the hook**
+
+Run: `git status --short`
+Expected: exactly ` M docs/assets/dashboards/neurolink-proxy-observability-dashboard.json` (plus the untracked `memory-bank/openai-compat-verification/`, which the hook ignores).
+
+```bash
+git add docs/assets/dashboards/neurolink-proxy-observability-dashboard.json
+git commit -m "docs(observability): complete Cost & Budget tab (quota + top-sessions panels, stacked-area trend)"
+```
+
+Expected: pre-commit hook prints `All pre-commit checks passed!` and `COMMIT VALIDATION PASSED!`.
+
+---
+
+### Task 2: Validate the new panels against live OpenObserve data
+
+**Files:**
+
+- Modify (only if a panel's SQL needs correcting): `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`
+
+**Interfaces:**
+
+- Consumes: panels from Task 1; scripts `scripts/observability/import-openobserve-dashboard.mjs`, `scripts/observability/check-proxy-telemetry.mjs`, and the `neurolink proxy telemetry` CLI.
+- Produces: a dashboard whose 11 Cost & Budget panels + 9 Trace panels all render with real data; the 3 new-idiom panels (quota ×2, table) confirmed or corrected.
+
+- [ ] **Step 1: Bring up the stack**
+
+Run: `podman machine start || true` then `pnpm run build:cli && node dist/cli/index.js proxy telemetry setup`
+(Equivalent: `bash scripts/observability/manage-local-openobserve.sh setup`.)
+Expected: OpenObserve reachable at `http://localhost:5080`; the setup step imports the current dashboard.
+
+- [ ] **Step 2: Generate proxy traffic (must include Anthropic OAuth requests)**
+
+Route several requests through the proxy so `neurolink_proxy` spans and `proxy_*` metrics populate. The quota panels need `proxy_ratelimit_after_5h/_7d`, which **only Anthropic OAuth responses carry** — so at least a few requests must hit an Anthropic OAuth account.
+Expected: traffic returns 200s; a few seconds later data is queryable.
+
+- [ ] **Step 3: Confirm streams + the quota columns exist**
+
+Run: `node scripts/observability/check-proxy-telemetry.mjs`
+Expected: `neurolink_proxy` stream present, non-zero `doc_num`, recent `latest` age.
+Then confirm the exact column names in the OpenObserve UI (`http://localhost:5080`, `<local-user>` / `<local-password>`) by running in the `neurolink_proxy` stream:
+`SELECT proxy_account, proxy_ratelimit_after_7d, proxy_ratelimit_after_5h, session_id FROM neurolink_proxy WHERE proxy_ratelimit_after_7d IS NOT NULL LIMIT 5`
+Expected: rows returned. If a column name differs (e.g. dotted → different underscore form) or `ROW_NUMBER() OVER` errors, note the correction for Step 4.
+
+- [ ] **Step 4: Re-import and eyeball each panel; correct SQL if needed**
+
+Run: `node scripts/observability/import-openobserve-dashboard.mjs --replace-by-title`
+Then open the "Cost & Budget" and "Trace Drilldown" tabs and verify each panel renders non-empty. Focus on the three new idioms:
+
+- **Quota bars (09/10):** `ROW_NUMBER() OVER (... ORDER BY _timestamp DESC)` with `WHERE rn = 1` is confirmed supported in this OpenObserve build (live-validated), so the latest-row query is used as-is — `MAX(util)` then aggregates over the single `rn = 1` row per account, i.e. the latest reading. Do **not** fall back to a bare `MAX(<col>)` over the whole window: that returns the window **peak**, not the latest value, and overstates utilisation.
+- **Top Sessions (11):** confirm the table renders two columns (session, cost). If OpenObserve needs the value column in `fields.y` with `aggregationFunction: "sum"` for tables, set it and re-import.
+- **Cost Trend (06):** confirm it renders as a stacked area (not line). If the type string differs in this OpenObserve build, use the value the UI exports for a stacked-area panel.
+
+Repeat import → eyeball until all render. Expected end state: every Cost & Budget and Trace panel shows real data; quota panels show per-account % matching `node dist/cli/index.js proxy status` (or `/status`).
+
+- [ ] **Step 5: Commit any live-validation SQL corrections**
+
+Only if Step 4 changed the JSON:
+Run: `git status --short` (expect only the dashboard modified), then:
+
+```bash
+npx prettier --write docs/assets/dashboards/neurolink-proxy-observability-dashboard.json
+git add docs/assets/dashboards/neurolink-proxy-observability-dashboard.json
+git commit -m "fix(observability): finalize Cost & Budget panel SQL against live OpenObserve"
+```
+
+Expected: hook passes. If Step 4 required no changes, skip — the panels were correct as authored.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Add 3 panels (7d quota, 5h quota, Top Sessions) → Task 1 Step 3. ✓
+- Cost Trend line → stacked area → Task 1 Step 3 (`Panel_cost_06.type = "area-stacked"`). ✓
+- `(est., USD)` labels / inline pricing `CASE` → Task 1 reuses `Panel_cost_04`'s query; Top Sessions title keeps `(est., USD)`. ✓
+- Bring up stack, generate traffic, validate `proxy_ratelimit_after_*`, re-import, verify render → Task 2 Steps 1–4. ✓
+- Baseline 49 panels unaffected → validation asserts `base === 49`. ✓
+- No push/PR without OK → not in plan; deferred to a later explicit step. ✓
+
+**Placeholder scan:** Queries are concrete; the quota latest-row query is spelled out, not "TBD". Live-validation gates are real verification steps, not deferred implementation. ✓
+
+**Type consistency:** ids `Panel_cost_09/10/11` and layout `i` `9009/10/11` used consistently; `area-stacked` used in both the script and the validation check. ✓
+
+**Note on new idioms:** `table` and `area-stacked` have no existing example in this dashboard and `ROW_NUMBER() OVER` is unverified in this OpenObserve build — these are exactly the items Task 2 Step 4 confirms/corrects live, per the spec's "validate new idioms first."

--- a/docs/superpowers/specs/2026-06-11-proxy-cost-budget-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-11-proxy-cost-budget-dashboard-design.md
@@ -1,0 +1,183 @@
+# Proxy Cost & Budget dashboard enrichment — design
+
+- **Date:** 2026-06-11 (reconciled 2026-07-05)
+- **Status:** Complete — implemented & live-validated. The Cost & Budget tab (11 panels)
+  and the Trace Drilldown tab (9 panels) are committed on `feat/proxy-cost-budget-dashboard`;
+  all panel queries were validated against a running OpenObserve (see the live-validation
+  correction below re: the logs/traces stream split). Remaining: open a PR on request.
+- **Author:** Sachin Sharma
+- **Area:** `scripts/observability/`, `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`
+
+## Goal
+
+Add first-class **cost & usage** observability to the NeuroLink proxy's OpenObserve
+dashboard. Today the dashboard tracks traffic, failures, latency, routing, tokens, and
+cache thoroughly, but **cost (USD) is barely surfaced** — and there is no per-account or
+per-model cost breakdown, no cache dollar-savings, and no spend/quota forecasting.
+
+The operator runs three OAuth accounts behind the proxy (`fill-first`) and routinely hits
+one account's weekly rate-limit ceiling. The missing views are precisely the ones needed
+to answer "which account/model is spending what, how much is cache saving us, and are we
+about to hit the quota wall."
+
+## Current state
+
+- **Stack:** `proxy → OTEL collector (contrib) → OpenObserve`, defined in
+  `scripts/observability/docker-compose.proxy-observability.yaml`. `docker`/`docker-compose`
+  on this host are wrappers that exec `/opt/podman/bin/podman`, so the stack runs on Podman.
+  Ports: OTLP gRPC `14317→4317`, OTLP HTTP `14318→4318`, OpenObserve UI `:5080`.
+- **Proxy already exports OTLP:** `~/.neurolink/.env` has
+  `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:14318` (correct for this stack).
+- **Dashboard:** `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`. The
+  release baseline is 6 tabs / 49 panels; this branch adds the Cost & Budget and Trace
+  Drilldown tabs on top.
+- **Cost coverage in the baseline:** only two panels, both global totals with no breakdown —
+  `Metric Cost in Range (USD)` and `Metric Cost Trend (5m, USD)` (in the "Telemetry
+  Cross-Check" tab, sourced from the `proxy_cost_usd_total` metric). The tab named
+  **"Tokens, Cache & Cost"** has **no USD cost panel at all** — only tokens/cache.
+
+## Key finding: required data is already emitted (no proxy code change)
+
+From `src/lib/proxy/proxyTracer.ts`:
+
+- **Per-request cost is on every root span:** `ai.cost.total` (USD), computed via
+  `calculateCost("anthropic", model, {input, output, total, cacheCreationTokens,
+cacheReadTokens})` from `src/lib/utils/pricing.ts` (cache-aware).
+- **The `proxy_cost_usd_total` metric carries `{model, account}` labels**
+  (proxyTracer.ts:764–795).
+
+**Live-validation correction (2026-07-05).** OpenObserve exposes `neurolink_proxy` as two
+separate streams, and the queryable fields are split between them:
+
+- **logs stream:** `account_name`, `account_type`, `ai_model`, `http_method`, and token
+  counts (`ai_input_tokens`, `ai_output_tokens`, `ai_cache_*`) — used by the cost panels.
+  It does **not** carry `session_id` or `proxy_ratelimit_after_*`.
+- **traces stream** (`proxy.request` root span): `proxy_account`, `proxy_ratelimit_after_5h`
+  / `_7d`, `session_id`, and `ai_cost_total` (stored as a string → `CAST(... AS DOUBLE)`).
+  It does **not** carry `account_name`.
+
+Consequence: the **quota** and **Top Sessions** panels query the **traces** stream and key
+off `proxy_account` (not `account_name`); the cost panels stay on the logs stream. Every
+panel is still **pure dashboard SQL** — no proxy code change.
+
+## Design decisions
+
+1. **New dedicated "Cost & Budget" tab**, rather than expanding the existing 10-panel
+   "Tokens, Cache & Cost" tab into a long scroll. Keeps concerns grouped.
+2. **Source breakdowns from the span stream `neurolink_proxy`** (`SUM(ai_cost_total)
+GROUP BY …`) — simpler SQL, per-request granularity, and consistent with the existing
+   "Tokens by Account / Route" panels. Use the `proxy_cost_usd_total` **metric** only for
+   the run-rate projection (counter deltas are more robust for long-window sums).
+3. **Deploy by editing the repo's source JSON** and importing that exact file into the
+   running OpenObserve via `scripts/observability/import-openobserve-dashboard.mjs`
+   (PR-able; does not rely on the packaged copy, which auto-update overwrites).
+4. **Keep the two bonus Cost panels** added during implementation — **Total Cost in Range**
+   (top-line USD anchor) and **Effective $/1M Tokens by Model** (efficiency lens). They
+   complement the approved set and are cheap `SUM`/ratio SQL over the same span stream.
+5. **Keep the beyond-spec "Trace Drilldown" tab** (9 span-level panels) built during
+   implementation. It reads the same `neurolink_proxy` span stream, rounds out the proxy's
+   observability, and is validated live alongside the cost panels.
+6. **Label every cost figure "(est.)".** All USD values derive from `pricing.ts` /
+   `calculateCost` — a pricing-table estimate from token counts, not invoiced amounts — so
+   the "(est., USD)" suffix is applied uniformly. More honest than labelling only some.
+
+## The "Cost & Budget" tab — 11 panels
+
+Final order below. **built** = present in the committed WIP; **NEW** = still to add;
+**change** = built but needs a viz change.
+
+| #   | Panel                                 | Viz          | Status | Source & query sketch                                                                   |
+| --- | ------------------------------------- | ------------ | ------ | --------------------------------------------------------------------------------------- |
+| 1   | Total Cost in Range (est., USD)       | metric       | built  | span: `SUM(ai_cost_total) WHERE http_method IS NOT NULL`                                |
+| 2   | Cost per Request (est., USD)          | metric       | built  | span: `SUM(ai_cost_total)/COUNT(*) WHERE http_method IS NOT NULL`                       |
+| 3   | Cache $ Savings (est., USD)           | metric       | built  | span: `SUM(ai_cache_read_tokens × input_$/tok × 0.9)` via per-model price `CASE`        |
+| 4   | Cost by Account (est., USD)           | bar          | built  | span: `SUM(ai_cost_total) GROUP BY account_name ORDER BY 2 DESC`                        |
+| 5   | Cost by Model (est., USD)             | bar          | built  | span: `SUM(ai_cost_total) GROUP BY ai_model`                                            |
+| 6   | Cost Trend by Account (5m, est., USD) | stacked area | done   | logs: `histogram(_timestamp,'5 minutes'), account_name, SUM(...)` (line → area)         |
+| 7   | Effective $/1M Tokens by Model (est.) | bar          | done   | logs: `SUM(cost)/SUM(ai_tokens_total) × 1e6 GROUP BY ai_model`                          |
+| 8   | Projected Daily Spend (est., USD)     | metric       | done   | metric: `SUM(cost_delta)/(max(_ts)-min(_ts)) × 86400`                                   |
+| 9   | 7-day Quota Utilization by Account    | bar          | done   | traces: latest `proxy_ratelimit_after_7d` per `proxy_account` via `ROW_NUMBER()`        |
+| 10  | 5-hour Quota Utilization by Account   | bar          | done   | traces: latest `proxy_ratelimit_after_5h` per `proxy_account` via `ROW_NUMBER()`        |
+| 11  | Top Sessions by Cost (est., USD)      | table        | done   | traces: `session_id, SUM(CAST(ai_cost_total AS DOUBLE)) GROUP BY session_id … LIMIT 20` |
+
+All 11 panels are implemented, and their queries are validated live against real OpenObserve
+data (per-account 7d/5h utilisation and top sessions by USD both return real values). Panel 6
+renders as a stacked area. The quota panels depend on `proxy_ratelimit_after_*`, which only
+Anthropic OAuth responses populate.
+
+## The "Trace Drilldown" tab — 9 panels (built)
+
+Beyond-spec span-level tab, built during implementation and kept (decision 5). All read the
+`neurolink_proxy` span stream:
+
+1. Trace Spans in Range (metric)
+2. Unique Request Traces (metric)
+3. Mean Span Duration (s) (metric)
+4. Span Volume by Operation (bar)
+5. Span Duration Trend (5m, s) (line)
+6. Span Status Mix (bar)
+7. Trace Volume Trend (5m) (line)
+8. Slowest Operations (s) (bar)
+9. Span Kind Mix (bar)
+
+Already committed; validate live alongside the cost panels.
+
+## Execution sequence
+
+**Done:** dashboard rebased onto `origin/release` (9.81.1); Cost & Budget tab (8 panels) and
+Trace Drilldown tab (9 panels) built and committed on `feat/proxy-cost-budget-dashboard`.
+
+**Remaining:**
+
+1. **Add 3 panels** to the Cost & Budget tab JSON — 7-day Quota Utilization, 5-hour Quota
+   Utilization (gauge/bar), Top Sessions by Cost (table) — matching existing panel idioms.
+2. **Switch panel 6** (Cost Trend by Account) from line to stacked area.
+3. **Bring up the stack:** `podman machine start`, then `neurolink proxy telemetry setup`
+   (starts collector + OpenObserve, imports the current dashboard).
+4. **Generate + verify traffic:** route a few proxy requests; confirm data lands in the
+   `neurolink_proxy` stream and `proxy_*` metric streams, and that `proxy_ratelimit_after_*`
+   appears (Anthropic OAuth). **Capture the exact live column names and the pricing
+   constants from `pricing.ts`** — finalize the quota/session/cache SQL against reality.
+5. **Re-import** the edited JSON via `scripts/observability/import-openobserve-dashboard.mjs`;
+   verify each panel renders with real data.
+6. **Commit** the additions on this branch; open a PR (no push without explicit OK).
+
+## Deployment / refresh mechanics
+
+- Edit `docs/assets/dashboards/neurolink-proxy-observability-dashboard.json`.
+- Import via `node scripts/observability/import-openobserve-dashboard.mjs` (reads that file)
+  against `http://localhost:5080`, OpenObserve creds from the compose defaults
+  (`<local-user>` / `<local-password>`) unless overridden.
+- The running stack's auto-imported copy comes from the installed package; our PR updates
+  the repo source of truth so future installs ship the enriched dashboard.
+
+## Risks & caveats
+
+- **Cache $ savings is an estimate.** It duplicates per-model input prices into a SQL
+  `CASE` (mirroring `pricing.ts`) and assumes the Anthropic cache-read discount (~0.1×
+  input). It will drift if `pricing.ts` changes. Labelled "(est.)" on the panel. Acceptable
+  for a savings indicator; exact accounting is out of scope.
+- **Run-rate uses the data-span denominator** (`max(_timestamp)-min(_timestamp)`), so it is
+  noisy for very short windows; intended for multi-hour ranges.
+- **Quota-utilisation panels depend on `proxy_ratelimit_after_*` being populated.** Only
+  Anthropic OAuth responses carry these. Confirmed present in code; validated live in
+  execution step 4.
+- **Resource cost:** two containers on the 8 GB Podman VM (OpenObserve + collector) — a
+  modest standing load, acceptable for an on-demand observability stack.
+
+## Acceptance criteria
+
+- "Cost & Budget" tab present with all **11** panels, and the "Trace Drilldown" tab with its
+  9 panels, both imported into the running OpenObserve.
+- Cost by Account and Cost by Model render non-zero USD breakdowns from real proxy traffic.
+- 7-day and 5-hour quota panels show per-account utilisation matching live `/status`.
+- Cost Trend by Account renders as a stacked area.
+- No change to proxy source code; the existing 49 baseline panels are unaffected.
+- Dashboard JSON change committed on `feat/proxy-cost-budget-dashboard`; PR opened on request.
+
+## Out of scope
+
+- Per-request exact cache accounting (counterfactual cost) — estimate only.
+- Budget alerting / thresholds (OpenObserve alerts) — future enhancement.
+- Any proxy code change to emit new attributes.
+- Migrating the stack off Podman or changing ports.


### PR DESCRIPTION
## Summary

Companion planning docs for the NeuroLink proxy **Cost & Budget** + **Trace Drilldown** OpenObserve dashboard tabs. The dashboard JSON itself ships in #1132; this PR adds the design spec and implementation plan under `docs/superpowers/` (matching the existing `docs/superpowers/plans/` convention already in the repo).

## Contents

- `docs/superpowers/specs/2026-06-11-proxy-cost-budget-dashboard-design.md` — design spec: goal, logs/traces stream split, final 11-panel Cost & Budget set + 9-panel Trace Drilldown, design decisions, risks, acceptance criteria.
- `docs/superpowers/plans/2026-07-05-proxy-cost-budget-dashboard-completion.md` — implementation plan: bite-sized tasks with the live-validated SQL.

Both are reconciled against the live-validated implementation:
- cost panels read the **logs** stream (`account_name`, token counts);
- quota + top-sessions panels read the **traces** stream keyed on `proxy_account` (`proxy_ratelimit_after_5h/_7d`, `session_id`, `ai_cost_total`).

## Notes

- **Docs only** — no code or dashboard changes.
- Split out from #1132 to keep the dashboard PR focused on the shippable artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed design spec for the Proxy Cost & Budget dashboard, including panel layouts, labeling, validation notes, and rollout criteria.
  * Added a completion plan covering the dashboard updates, live validation steps, and acceptance checklist for the new cost and trace views.
  * Clarified how the dashboard data is sourced and how different panel types should display cost, quota, and session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->