### PR TITLE
feat(skills): add native skills support (stores, tools, prompt index, CLI, API)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ pnpm run test:mcp:limits  # Output limits + artifacts (mcp-output-limits.ts) —
 pnpm run test:mcp:spans   # Issue#5 span attributes (mcp-spans.ts) — no API
 pnpm run test:mcp:full    # All seven mcp-* suites in dependency order
 pnpm run test:rag         # RAG suite
+pnpm run test:skills      # Native skills suite (mostly no-API; live test skips without keys)
 pnpm run test:providers   # Provider-specific feature tests
 pnpm run test:matrix      # Capability sweep across all 17 providers
 pnpm run test:media       # Media generation suite

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,0 +1,246 @@
+---
+title: Skills Guide
+description: Native skills — versioned, discoverable instruction packs (SOPs, playbooks) with progressive disclosure via built-in tools and a system-prompt index
+keywords:
+  [
+    skills,
+    sops,
+    playbooks,
+    progressive-disclosure,
+    search_skills,
+    list_skills,
+    skill-tools,
+    maker-checker,
+    custom-storage,
+  ]
+---
+
+# Skills Guide
+
+> **Since**: v9.82.0 | **Status**: New | **Availability**: SDK
+
+## Overview
+
+NeuroLink includes native **skills** support: versioned, discoverable instruction packs (SOPs, playbooks, workflows) that agents consult before answering from general knowledge. Skills use **progressive disclosure** to stay cheap:
+
+- A compact **index** (name + description, never instructions) is injected into the system prompt of each `generate()`/`stream()` call, so the model knows what exists.
+- Full **instructions** are loaded on demand through the built-in `search_skills` tool — only for skills that actually match the user's request.
+
+This is the same architecture proven in production by curator's skills system, generalized and moved into the SDK: enable it with one config block instead of building stores, matchers, and tools in app code.
+
+## Quick Start
+
+```typescript
+import { NeuroLink } from "@juspay/neurolink";
+
+const neurolink = new NeuroLink({
+  skills: {
+    enabled: true,
+    storage: { type: "filesystem", path: "./skills" },
+  },
+});
+
+// The model now sees the skills index in its system prompt and can call
+// search_skills / list_skills automatically during any generate/stream.
+const result = await neurolink.generate({
+  input: { text: "A refund is disputed — how do I escalate?" },
+});
+```
+
+## Skill Format
+
+Three on-disk layouts are supported by the filesystem store (mixable in one directory):
+
+**JSON** (`./skills/<id>.json`):
+
+```json
+{
+  "id": "refund-escalation",
+  "name": "refund_dispute_escalation",
+  "displayName": "Refund Dispute Escalation",
+  "description": "How to escalate a disputed refund to the payments on-call team.",
+  "instructions": "1. Collect the transaction id.\n2. Verify the dispute.\n3. Page payments-oncall.",
+  "tags": ["payments", "escalation"]
+}
+```
+
+**Frontmatter markdown** (`./skills/<name>.md`):
+
+```markdown
+---
+name: oncall_handover
+description: Checklist for handing over the on-call shift.
+tags: [devops, oncall]
+---
+
+1. Summarize open incidents.
+2. Hand over the pager.
+```
+
+**Claude-skills directory layout** (`./skills/<name>/SKILL.md`) — same frontmatter format, interoperable with Claude-style skill directories.
+
+Optional fields: `scope: "scoped"` + `scopeIds: [...]` restrict a skill to specific scopes (channels/teams/tenants); `status: "deprecated"` hides it from matching.
+
+## Storage Backends
+
+| Type         | Config                                    | Use case                                     |
+| ------------ | ----------------------------------------- | -------------------------------------------- |
+| `memory`     | `{ type: "memory", skills?: [...] }`      | Tests, embedded, host-managed                |
+| `filesystem` | `{ type: "filesystem", path: "./dir" }`   | Local dev, git-versioned skill repos         |
+| `s3`         | `{ type: "s3", bucket, prefix? }`         | Shared team skills (curator-style)           |
+| `redis`      | `{ type: "redis", keyPrefix? }`           | Low-latency shared store, reuses core client |
+| `custom`     | `{ type: "custom", store: mySkillStore }` | Anything else — implement `SkillStore`       |
+
+A custom store implements four methods: `get(id)`, `put(skill)`, `delete(id)`, `index()` (index entries must be cheap — they back every search).
+
+### S3
+
+```typescript
+skills: {
+  enabled: true,
+  storage: {
+    type: "s3",
+    bucket: "team-skills",
+    prefix: "tara/",          // default "neurolink-skills/"
+    region: "us-east-1",
+    // endpoint + forcePathStyle for MinIO/LocalStack;
+    // credentials default to the standard AWS provider chain
+  },
+}
+```
+
+Layout: `<prefix>skills/<id>.json` per skill plus a `<prefix>index.json` that is upserted on writes and **rebuilt automatically from a bucket listing** when missing or corrupt. The AWS SDK is an optional peer — install `@aws-sdk/client-s3` in your app (NeuroLink core does not depend on it; without it, S3-configured skills fail open with an actionable error).
+
+### Redis
+
+```typescript
+skills: {
+  enabled: true,
+  storage: { type: "redis", keyPrefix: "neurolink:skills:" },
+  // url / host / port / password / db — defaults match the core Redis client
+}
+```
+
+Uses NeuroLink's pooled Redis client (`redis` v5, already a core dependency — shared with Redis conversation memory). One JSON value per skill; the index is derived with SCAN + MGET. Skills are persistent — no TTL.
+
+## Built-in Tools
+
+When enabled, these tools are auto-registered and reach the model on every call:
+
+- **`search_skills`** — index-first search by `query` and/or `tag`; hydrates at most `maxMatches` (default 5) matching skills with full instructions. A zero-match result returns `{ skills: [], reason: "no_match" }` as a **success**, telling the model to fall back to general knowledge.
+- **`list_skills`** — lightweight discovery listing (no instructions), for "what can you do?" questions.
+
+With `allowMutations: true`, three more tools are registered:
+
+- **`skill_create`**, **`skill_update`**, **`skill_delete`** — propose changes, routed through your `onMutationRequest` gate when configured. Deletes are soft (status becomes `deprecated`).
+
+## Approval Gate (Maker-Checker)
+
+Hosts keep full control over writes via `onMutationRequest`:
+
+```typescript
+const neurolink = new NeuroLink({
+  skills: {
+    enabled: true,
+    storage: { type: "custom", store: s3SkillsStore },
+    allowMutations: true,
+    onMutationRequest: async (action) => {
+      // e.g. post a Slack approval block, persist a pending action…
+      const ticket = await queueForApproval(action);
+      return { outcome: "pending", reference: ticket.id };
+      // or { outcome: "approved" } to apply immediately
+      // or { outcome: "rejected", reason: "…" } to block
+    },
+  },
+});
+```
+
+`"pending"` means the host applies the change itself after human approval — NeuroLink writes nothing.
+
+## Configuration Reference
+
+```typescript
+skills: {
+  enabled: true,
+  storage: { type: "filesystem", path: "./skills" },
+  promptIndex: true,        // inject index into system prompt (default true)
+  promptIndexMaxItems: 50,  // truncate the injected index
+  maxMatches: 5,            // max skills hydrated per search
+  indexCacheTtlMs: 30_000,  // index cache TTL (0 = no caching)
+  defaultScopeId: undefined, // default scope filter
+  allowMutations: false,    // register skill_create/update/delete
+  onMutationRequest: undefined, // approval gate
+}
+```
+
+### Per-call options
+
+```typescript
+await neurolink.generate({
+  input: { text: "…" },
+  skills: {
+    enabled: true, // per-call master toggle (prompt index)
+    promptIndex: false, // disable injection for this call only
+    scopeId: "team-alpha", // scope the index for this call
+    tags: ["payments"], // narrow the index by tags
+  },
+});
+```
+
+### Programmatic access
+
+```typescript
+const manager = neurolink.getSkillsManager();
+const matches = await manager?.search({ query: "refund" });
+const index = await manager?.list();
+await manager?.requestMutation({ type: "create", skill: { … } });
+```
+
+## CLI
+
+Manage a filesystem skills store directly:
+
+```bash
+neurolink skills list   --skills-dir ./skills
+neurolink skills show   refund_dispute_escalation --skills-dir ./skills
+neurolink skills search "refund" --skills-dir ./skills
+neurolink skills create --skills-dir ./skills \
+  --name deploy_sop --description "How to deploy" --instructions-file ./sop.md
+neurolink skills delete deploy_sop --skills-dir ./skills
+```
+
+Make skills available to any generation run with the same flag (or `NEUROLINK_SKILLS_DIR`):
+
+```bash
+neurolink generate "A refund is disputed — how do I escalate?" --skills-dir ./skills
+neurolink loop --skills-dir ./skills
+```
+
+Directory precedence: `--skills-dir` > `NEUROLINK_SKILLS_DIR` > `./skills` (for the `skills` command group).
+
+## Server Endpoints
+
+When the server's NeuroLink instance has skills enabled, these routes are available:
+
+| Method   | Path                    | Purpose                                   |
+| -------- | ----------------------- | ----------------------------------------- |
+| `GET`    | `/api/agent/skills`     | List index entries (optional `?scopeId=`) |
+| `GET`    | `/api/agent/skills/:id` | One skill with instructions (id or name)  |
+| `POST`   | `/api/agent/skills`     | Create (routed through the mutation gate) |
+| `PATCH`  | `/api/agent/skills/:id` | Update (patch semantics, version bump)    |
+| `DELETE` | `/api/agent/skills/:id` | Soft-delete (deprecate)                   |
+
+Mutation endpoints honor `onMutationRequest` — a `pending` decision returns `{ decision: { outcome: "pending", reference } }` without writing. When skills are not configured the routes return a 503 `SKILLS_UNAVAILABLE` error envelope. Authenticated user identity (when auth middleware is active) overrides caller-supplied `requestedBy`.
+
+## Behavior Notes
+
+- **Opt-in and fail-open**: with no `skills` config, nothing changes. Store/read errors log a warning and degrade to "no skills" — they never fail a generate/stream call. Mutations fail closed.
+- **Media modes**: the prompt index is skipped for avatar/music/video/ppt outputs (no meaningful text prompt to augment).
+- **Tool routing**: skill tools are registered as custom (direct) tools, so server-granularity tool routing never drops them.
+- Related: [Memory Guide](/docs/features/memory) for the analogous per-user memory subsystem, and [Conversation History](/docs/features/conversation-history).
+
+## Testing
+
+```bash
+pnpm run test:skills   # test/continuous-test-suite-skills.ts (mostly no-API; live test skips without credentials)
+```

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:mcp:infra": "npx tsx test/continuous-test-suite-mcp-infra.ts",
     "test:providers-mocked": "npx tsx test/continuous-test-suite-providers-mocked.ts",
     "test:rag": "npx tsx test/continuous-test-suite-rag.ts",
+    "test:skills": "npx tsx test/continuous-test-suite-skills.ts",
     "test:servers": "npx tsx test/continuous-test-suite-servers.ts",
     "test:tool-reliability": "npx tsx test/continuous-test-suite-tool-reliability.ts",
     "test:google-native": "npx tsx test/continuous-test-suite-google-native.ts",

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -33,6 +33,8 @@ import { logger } from "../../lib/utils/logger.js";
 import { createThinkingConfigFromRecord } from "../../lib/utils/thinkingConfig.js";
 import { buildToolRoutingConfigFromCli } from "../utils/toolRoutingFlags.js";
 import { buildClassifierRouterConfigFromCli } from "../utils/classifierRouterFlags.js";
+import { buildSkillsConfigFromCli } from "../utils/skillsFlags.js";
+import { SkillsManager } from "../../lib/skills/skillsManager.js";
 import { configManager } from "../commands/config.js";
 import { MCPCommandFactory } from "../commands/mcp.js";
 import { ModelsCommandFactory } from "../commands/models.js";
@@ -801,6 +803,16 @@ export class CLICommandFactory {
       description: "Minimum response length (characters)",
       alias: "output-min-length",
     },
+
+    // Skills options
+    skillsDir: {
+      type: "string" as const,
+      description:
+        "Directory of skills (SOPs/playbooks) to make available to the AI. " +
+        "Supports <id>.json, <name>.md, and <name>/SKILL.md layouts. " +
+        "Also settable via NEUROLINK_SKILLS_DIR.",
+      alias: "skills-dir",
+    },
   };
 
   // Helper method to build options for commands
@@ -1151,6 +1163,8 @@ export class CLICommandFactory {
       classifierModelRegion: argv.classifierModelRegion as string | undefined,
       classifierPool: argv.classifierPool as string | undefined,
       classifierTimeout: argv.classifierTimeout as number | undefined,
+      // Skills flag — constructor-level config (see note above).
+      skillsDir: argv.skillsDir as string | undefined,
     };
   }
 
@@ -2167,6 +2181,136 @@ export class CLICommandFactory {
   }
 
   /**
+   * Create skills commands — manage the local skills store
+   * (list / show / search / create / delete). The store directory comes
+   * from --skills-dir, NEUROLINK_SKILLS_DIR, or defaults to ./skills.
+   */
+  static createSkillsCommands(): CommandModule {
+    return {
+      command: "skills <subcommand>",
+      describe: "Manage skills (SOPs/playbooks the AI can follow)",
+      builder: (yargs) => {
+        return yargs
+          .command(
+            "list",
+            "List all active skills (index only, no instructions)",
+            (y) =>
+              CLICommandFactory.buildOptions(y)
+                .example("$0 skills list --skills-dir ./skills", "List skills")
+                .example("$0 skills list --format json", "Export as JSON"),
+            async (argv) =>
+              await CLICommandFactory.executeSkillsList(
+                argv as BaseCommandArgs,
+              ),
+          )
+          .command(
+            "show <skill>",
+            "Show one skill including its full instructions",
+            (y) =>
+              CLICommandFactory.buildOptions(y)
+                .positional("skill", {
+                  type: "string" as const,
+                  description: "Skill id or exact name",
+                  demandOption: true,
+                })
+                .example(
+                  "$0 skills show refund_dispute_escalation",
+                  "Show a skill by name",
+                ),
+            async (argv) =>
+              await CLICommandFactory.executeSkillsShow(
+                argv as BaseCommandArgs & { skill: string },
+              ),
+          )
+          .command(
+            "search <query>",
+            "Search skills by keyword (matches name and description)",
+            (y) =>
+              CLICommandFactory.buildOptions(y)
+                .positional("query", {
+                  type: "string" as const,
+                  description: "Keyword to match",
+                  demandOption: true,
+                })
+                .option("tag", {
+                  type: "string" as const,
+                  description: "Tag filter applied on top of the keyword",
+                })
+                .example('$0 skills search "refund"', "Find refund skills"),
+            async (argv) =>
+              await CLICommandFactory.executeSkillsSearch(
+                argv as BaseCommandArgs & { query: string; tag?: string },
+              ),
+          )
+          .command(
+            "create",
+            "Create a new skill in the store",
+            (y) =>
+              CLICommandFactory.buildOptions(y)
+                .option("name", {
+                  type: "string" as const,
+                  description: "Machine-friendly unique name (snake_case)",
+                  demandOption: true,
+                })
+                .option("description", {
+                  type: "string" as const,
+                  description: "When this skill applies (used for matching)",
+                  demandOption: true,
+                })
+                .option("instructions", {
+                  type: "string" as const,
+                  description: "Full instructions text",
+                })
+                .option("instructions-file", {
+                  type: "string" as const,
+                  description: "Read instructions from a file",
+                })
+                .option("display-name", {
+                  type: "string" as const,
+                  description: "Human-readable display name",
+                })
+                .option("tags", {
+                  type: "array" as const,
+                  string: true,
+                  description: "Domain tags",
+                })
+                .example(
+                  '$0 skills create --name deploy_sop --description "How to deploy" --instructions-file ./sop.md',
+                  "Create from a file",
+                ),
+            async (argv) =>
+              await CLICommandFactory.executeSkillsCreate(
+                argv as BaseCommandArgs & {
+                  name: string;
+                  description: string;
+                  instructions?: string;
+                  instructionsFile?: string;
+                  displayName?: string;
+                  tags?: string[];
+                },
+              ),
+          )
+          .command(
+            "delete <skill>",
+            "Soft-delete (deprecate) a skill",
+            (y) =>
+              CLICommandFactory.buildOptions(y).positional("skill", {
+                type: "string" as const,
+                description: "Skill id or exact name",
+                demandOption: true,
+              }),
+            async (argv) =>
+              await CLICommandFactory.executeSkillsDelete(
+                argv as BaseCommandArgs & { skill: string },
+              ),
+          )
+          .demandCommand(1, "Please specify a skills subcommand");
+      },
+      handler: () => {}, // No-op handler as subcommands handle everything
+    };
+  }
+
+  /**
    * Create config commands
    */
   static createConfigCommands(): CommandModule {
@@ -2507,6 +2651,15 @@ export class CLICommandFactory {
               threshold: compactThreshold as number,
             },
           };
+        }
+
+        // Inject skills config (--skills-dir / NEUROLINK_SKILLS_DIR) before
+        // the loop session constructs its NeuroLink instance.
+        const loopSkillsConfig = buildSkillsConfigFromCli(
+          argv as Record<string, unknown>,
+        );
+        if (loopSkillsConfig) {
+          globalSession.setSkillsConfig(loopSkillsConfig);
         }
 
         // Handle --list-conversations option
@@ -3219,6 +3372,14 @@ export class CLICommandFactory {
         globalSession.setClassifierRouterConfig(classifierRouterConfig);
       }
 
+      // Inject skills config (--skills-dir / NEUROLINK_SKILLS_DIR) before SDK construction.
+      const skillsConfig = buildSkillsConfigFromCli(
+        options as Record<string, unknown>,
+      );
+      if (skillsConfig) {
+        globalSession.setSkillsConfig(skillsConfig);
+      }
+
       // Initialize SDK and session
       const sdk = globalSession.getOrCreateNeuroLink();
       const sessionVariables = CLICommandFactory.normalizeLoopSessionVariables(
@@ -3588,6 +3749,14 @@ export class CLICommandFactory {
     );
     if (classifierRouterConfig) {
       globalSession.setClassifierRouterConfig(classifierRouterConfig);
+    }
+
+    // Inject skills config (--skills-dir / NEUROLINK_SKILLS_DIR) before SDK construction.
+    const skillsConfig = buildSkillsConfigFromCli(
+      options as Record<string, unknown>,
+    );
+    if (skillsConfig) {
+      globalSession.setSkillsConfig(skillsConfig);
     }
 
     const sdk = globalSession.getOrCreateNeuroLink();
@@ -4290,6 +4459,14 @@ export class CLICommandFactory {
         globalSession.setClassifierRouterConfig(classifierRouterConfig);
       }
 
+      // Inject skills config (--skills-dir / NEUROLINK_SKILLS_DIR) before SDK construction.
+      const skillsConfig = buildSkillsConfigFromCli(
+        options as Record<string, unknown>,
+      );
+      if (skillsConfig) {
+        globalSession.setSkillsConfig(skillsConfig);
+      }
+
       const sdk = globalSession.getOrCreateNeuroLink();
       const sessionVariables = CLICommandFactory.normalizeLoopSessionVariables(
         globalSession.getSessionVariables(),
@@ -4491,6 +4668,196 @@ export class CLICommandFactory {
   /**
    * Execute memory stats command
    */
+  /**
+   * Resolve a standalone SkillsManager for the `skills` command group.
+   * Directory precedence: --skills-dir > NEUROLINK_SKILLS_DIR > ./skills.
+   * Cache is disabled so every command sees the directory's current state.
+   */
+  private static resolveSkillsManagerForCli(
+    argv: BaseCommandArgs,
+  ): SkillsManager {
+    const raw = (argv as Record<string, unknown>).skillsDir;
+    const dir =
+      (typeof raw === "string" && raw.trim()) ||
+      process.env.NEUROLINK_SKILLS_DIR?.trim() ||
+      "./skills";
+    return new SkillsManager({
+      enabled: true,
+      storage: { type: "filesystem", path: dir },
+      indexCacheTtlMs: 0,
+    });
+  }
+
+  private static async executeSkillsList(argv: BaseCommandArgs) {
+    const options = CLICommandFactory.processOptions(argv);
+    try {
+      const manager = CLICommandFactory.resolveSkillsManagerForCli(argv);
+      const skills = await manager.list();
+      if (options.format === "json") {
+        CLICommandFactory.handleOutput(
+          { skills, count: skills.length },
+          options,
+        );
+        return;
+      }
+      if (skills.length === 0) {
+        logger.always(chalk.yellow("No active skills found."));
+        return;
+      }
+      logger.always(chalk.blue(`🧩 Skills (${skills.length}):`));
+      for (const skill of skills) {
+        const tags = skill.tags?.length ? ` [${skill.tags.join(", ")}]` : "";
+        logger.always(
+          `   ${chalk.bold(skill.name)} — ${skill.description}${tags}`,
+        );
+      }
+    } catch (error) {
+      handleError(error as Error, "Skills list");
+    }
+  }
+
+  private static async executeSkillsShow(
+    argv: BaseCommandArgs & { skill: string },
+  ) {
+    const options = CLICommandFactory.processOptions(argv);
+    try {
+      const manager = CLICommandFactory.resolveSkillsManagerForCli(argv);
+      const skill = await manager.get(argv.skill);
+      if (!skill) {
+        logger.always(chalk.yellow(`Skill "${argv.skill}" not found.`));
+        process.exitCode = 1;
+        return;
+      }
+      if (options.format === "json") {
+        CLICommandFactory.handleOutput(skill, options);
+        return;
+      }
+      logger.always(chalk.blue(`🧩 ${skill.displayName || skill.name}`));
+      logger.always(`   id: ${skill.id}  version: ${skill.version ?? 1}`);
+      logger.always(`   ${skill.description}`);
+      if (skill.tags?.length) {
+        logger.always(`   tags: ${skill.tags.join(", ")}`);
+      }
+      logger.always("");
+      logger.always(skill.instructions);
+    } catch (error) {
+      handleError(error as Error, "Skills show");
+    }
+  }
+
+  private static async executeSkillsSearch(
+    argv: BaseCommandArgs & { query: string; tag?: string },
+  ) {
+    const options = CLICommandFactory.processOptions(argv);
+    try {
+      const manager = CLICommandFactory.resolveSkillsManagerForCli(argv);
+      const matches = await manager.search({
+        query: argv.query,
+        ...(argv.tag ? { tag: argv.tag } : {}),
+      });
+      if (options.format === "json") {
+        CLICommandFactory.handleOutput(
+          { skills: matches, count: matches.length },
+          options,
+        );
+        return;
+      }
+      if (matches.length === 0) {
+        logger.always(chalk.yellow(`No skills match "${argv.query}".`));
+        return;
+      }
+      logger.always(chalk.blue(`🔎 ${matches.length} match(es):`));
+      for (const skill of matches) {
+        logger.always(`   ${chalk.bold(skill.name)} — ${skill.description}`);
+      }
+      logger.always("");
+      logger.always(
+        "Use `neurolink skills show <name>` for full instructions.",
+      );
+    } catch (error) {
+      handleError(error as Error, "Skills search");
+    }
+  }
+
+  private static async executeSkillsCreate(
+    argv: BaseCommandArgs & {
+      name: string;
+      description: string;
+      instructions?: string;
+      instructionsFile?: string;
+      displayName?: string;
+      tags?: string[];
+    },
+  ) {
+    const options = CLICommandFactory.processOptions(argv);
+    try {
+      let instructions = argv.instructions;
+      if (!instructions && argv.instructionsFile) {
+        instructions = fs.readFileSync(argv.instructionsFile, "utf-8");
+      }
+      if (!instructions?.trim()) {
+        logger.always(
+          chalk.red(
+            "Provide skill instructions via --instructions or --instructions-file.",
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const manager = CLICommandFactory.resolveSkillsManagerForCli(argv);
+      const result = await manager.requestMutation({
+        type: "create",
+        skill: {
+          name: argv.name,
+          description: argv.description,
+          instructions,
+          ...(argv.displayName ? { displayName: argv.displayName } : {}),
+          ...(argv.tags?.length ? { tags: argv.tags.map(String) } : {}),
+        },
+      });
+      if (options.format === "json") {
+        CLICommandFactory.handleOutput(result, options);
+        return;
+      }
+      logger.always(
+        chalk.green(
+          `✅ Skill "${argv.name}" created (id: ${result.skill?.id}).`,
+        ),
+      );
+    } catch (error) {
+      handleError(error as Error, "Skills create");
+    }
+  }
+
+  private static async executeSkillsDelete(
+    argv: BaseCommandArgs & { skill: string },
+  ) {
+    const options = CLICommandFactory.processOptions(argv);
+    try {
+      const manager = CLICommandFactory.resolveSkillsManagerForCli(argv);
+      const existing = await manager.get(argv.skill);
+      if (!existing) {
+        logger.always(chalk.yellow(`Skill "${argv.skill}" not found.`));
+        process.exitCode = 1;
+        return;
+      }
+      const result = await manager.requestMutation({
+        type: "delete",
+        skillId: existing.id,
+      });
+      if (options.format === "json") {
+        CLICommandFactory.handleOutput(result, options);
+        return;
+      }
+      logger.always(
+        chalk.green(`✅ Skill "${existing.name}" deprecated (soft-deleted).`),
+      );
+    } catch (error) {
+      handleError(error as Error, "Skills delete");
+    }
+  }
+
   private static async executeMemoryStats(argv: BaseCommandArgs) {
     const options = CLICommandFactory.processOptions(argv);
     const spinner = options.quiet

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -199,6 +199,9 @@ export function initializeCliParser() {
       // Memory Command Group - Using CLICommandFactory
       .command(CLICommandFactory.createMemoryCommands())
 
+      // Skills Command Group - Using CLICommandFactory
+      .command(CLICommandFactory.createSkillsCommands())
+
       // Get Best Provider Command - Using CLICommandFactory
       .command(CLICommandFactory.createBestProviderCommand())
 

--- a/src/cli/utils/skillsFlags.ts
+++ b/src/cli/utils/skillsFlags.ts
@@ -1,0 +1,29 @@
+/**
+ * CLI → SkillsConfig mapping, following the toolRoutingFlags /
+ * classifierRouterFlags pattern.
+ *
+ * `--skills-dir <path>` (or NEUROLINK_SKILLS_DIR) enables skills with a
+ * filesystem store for generate / stream / batch / loop runs. Returns null
+ * when neither is provided so the SDK stays skills-free by default.
+ */
+
+import type { SkillsConfig } from "../../lib/types/index.js";
+
+export function buildSkillsConfigFromCli(
+  options: Record<string, unknown>,
+): SkillsConfig | null {
+  const dir =
+    (typeof options.skillsDir === "string" && options.skillsDir.trim()) ||
+    (typeof process.env.NEUROLINK_SKILLS_DIR === "string" &&
+      process.env.NEUROLINK_SKILLS_DIR.trim()) ||
+    "";
+
+  if (!dir) {
+    return null;
+  }
+
+  return {
+    enabled: true,
+    storage: { type: "filesystem", path: dir },
+  };
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -155,6 +155,16 @@ export {
 export { dynamicModelProvider } from "./core/dynamicModels.js";
 // Tool Registration utility
 export { validateTool } from "./sdk/toolRegistration.js";
+// Skills subsystem — manager, stores, and the built-in tool factory
+export { SkillsManager } from "./skills/skillsManager.js";
+export {
+  createSkillStore,
+  FileSystemSkillStore,
+  InMemorySkillStore,
+} from "./skills/skillStores.js";
+export { S3SkillStore } from "./skills/skillStoreS3.js";
+export { RedisSkillStore } from "./skills/skillStoreRedis.js";
+export { createSkillTools } from "./skills/skillTools.js";
 // Export ALL types from the centralized type barrel
 export * from "./types/index.js";
 // Error utilities

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -168,9 +168,13 @@ import type {
   DynamicResolutionContext,
   HippocampusConfig,
   HippocampusLike,
+  SkillsCallOptions,
+  SkillsConfig,
 } from "./types/index.js";
 import { initializeHippocampus } from "./memory/hippocampusInitializer.js";
 import { createMemoryRetrievalTools } from "./memory/memoryRetrievalTools.js";
+import { SkillsManager } from "./skills/skillsManager.js";
+import { createSkillTools } from "./skills/skillTools.js";
 import {
   getMetricsAggregator,
   MetricsAggregator,
@@ -749,6 +753,11 @@ export class NeuroLink {
   private memoryInstance?: HippocampusLike | null;
   private memorySDKConfig?: HippocampusConfig;
 
+  // Skills subsystem — lazily initialized manager + instance config.
+  // `undefined` = not yet attempted, `null` = init failed (stay disabled).
+  private skillsManagerInstance?: SkillsManager | null;
+  private skillsConfig?: SkillsConfig;
+
   /**
    * Extract and set Langfuse context from options with proper async scoping
    */
@@ -1233,6 +1242,10 @@ export class NeuroLink {
     this.initializeMCPEnhancements(config);
     this.registerFileTools();
     this.registerMemoryRetrievalTools();
+    if (config?.skills?.enabled) {
+      this.skillsConfig = config.skills;
+      this.registerSkillTools();
+    }
     this.initializeLangfuse(
       constructorId,
       constructorStartTime,
@@ -1793,6 +1806,143 @@ export class NeuroLink {
     });
 
     logger.info("[NeuroLink] Memory retrieval tools registered");
+  }
+
+  /**
+   * Lazy initialization for the skills subsystem — mirrors ensureMemoryReady().
+   * Returns null (and stays null) when skills are not configured or the
+   * store failed to initialize; read paths fail open on that null.
+   */
+  private ensureSkillsReady(): SkillsManager | null {
+    if (this.skillsManagerInstance !== undefined) {
+      return this.skillsManagerInstance;
+    }
+    if (!this.skillsConfig?.enabled) {
+      this.skillsManagerInstance = null;
+      return null;
+    }
+    try {
+      this.skillsManagerInstance = new SkillsManager(this.skillsConfig);
+    } catch (error) {
+      logger.warn(
+        "[NeuroLink] Skills initialization failed — skills disabled for this instance",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      this.skillsManagerInstance = null;
+    }
+    return this.skillsManagerInstance;
+  }
+
+  /**
+   * Register the built-in skill tools (search_skills / list_skills, plus
+   * mutation tools when allowMutations is set). Follows the
+   * registerMemoryRetrievalTools() pattern: registered via registerTool()
+   * so they land in the "user-defined" category that reaches the LLM tool
+   * schema, with the manager resolved lazily at execution time.
+   */
+  private registerSkillTools(): void {
+    const canonicalTools = createSkillTools(() => this.ensureSkillsReady(), {
+      allowMutations: this.skillsConfig?.allowMutations === true,
+    });
+
+    for (const [toolName, toolDef] of Object.entries(canonicalTools)) {
+      this.registerTool(toolName, {
+        name: toolName,
+        description: toolDef.description ?? toolName,
+        // Zod schema — registerTool() detects isZodSchema and preserves it
+        // so ToolsManager gives the LLM full parameter types.
+        inputSchema: (toolDef as unknown as { inputSchema: object })
+          .inputSchema,
+        execute: async (params: unknown) =>
+          withTimeout(
+            (
+              toolDef.execute as (
+                params: unknown,
+                ctx: unknown,
+              ) => Promise<unknown>
+            )(params, { toolCallId: "skill-tool", messages: [] }),
+            TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
+            ErrorFactory.toolTimeout(
+              toolName,
+              TOOL_TIMEOUTS.EXECUTION_DEFAULT_MS,
+            ),
+          ),
+      });
+    }
+
+    logger.info(
+      `[NeuroLink] Registered ${Object.keys(canonicalTools).length} skill tools`,
+      { allowMutations: this.skillsConfig?.allowMutations === true },
+    );
+  }
+
+  /**
+   * Append the compact skills index (names + descriptions, never
+   * instructions) to the system prompt for one generate()/stream() call.
+   * Fails open: any error leaves the prompt untouched.
+   */
+  private async applySkillsPromptIndex(options: {
+    systemPrompt?: string;
+    skills?: SkillsCallOptions;
+    // GenerateOptions.output carries `mode`; StreamOptions.output does not —
+    // keep the field structural and read `mode` defensively below.
+    output?: unknown;
+  }): Promise<void> {
+    if (!this.skillsConfig?.enabled || options.skills?.enabled === false) {
+      return;
+    }
+    // Per-call promptIndex wins over instance config; default is on.
+    const promptIndexEnabled =
+      options.skills?.promptIndex ?? this.skillsConfig.promptIndex ?? true;
+    if (!promptIndexEnabled) {
+      return;
+    }
+    // Media-only modes have no meaningful text prompt to augment.
+    const mode = (options.output as { mode?: string } | undefined)?.mode;
+    if (
+      mode === "avatar" ||
+      mode === "music" ||
+      mode === "video" ||
+      mode === "ppt"
+    ) {
+      return;
+    }
+
+    try {
+      const manager = this.ensureSkillsReady();
+      if (!manager) {
+        return;
+      }
+      const block = await manager.buildPromptIndex({
+        ...(options.skills?.scopeId !== undefined
+          ? { scopeId: options.skills.scopeId }
+          : {}),
+        ...(options.skills?.tags !== undefined
+          ? { tags: options.skills.tags }
+          : {}),
+      });
+      if (block) {
+        options.systemPrompt = options.systemPrompt
+          ? `${options.systemPrompt}\n\n${block}`
+          : block;
+        logger.debug("[NeuroLink] Skills prompt index injected", {
+          blockLength: block.length,
+        });
+      }
+    } catch (error) {
+      logger.warn(
+        "[NeuroLink] Skills prompt index injection failed — continuing without it",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    }
+  }
+
+  /**
+   * Programmatic access to the skills subsystem (search/list/get/mutations).
+   * Returns null when skills are not configured or failed to initialize.
+   */
+  getSkillsManager(): SkillsManager | null {
+    return this.ensureSkillsReady();
   }
 
   /** Format memory context for prompt inclusion */
@@ -4703,6 +4853,10 @@ Current user's request: ${currentInput}`;
         );
       }
     }
+
+    // Skills: append the compact skills index to the system prompt so the
+    // model knows which skills exist (bodies load via search_skills).
+    await this.applySkillsPromptIndex(options);
 
     // Media-only modes (avatar, music, video, ppt) do not have a meaningful
     // text prompt to augment with memory — skip injection to avoid corrupting
@@ -9532,6 +9686,10 @@ Current user's request: ${currentInput}`;
         logger.warn("Memory retrieval failed:", error);
       }
     }
+
+    // Skills: append the compact skills index to the system prompt so the
+    // model knows which skills exist (bodies load via search_skills).
+    await this.applySkillsPromptIndex(options);
 
     // Apply orchestration if enabled and no specific provider/model requested
     if (this.enableOrchestration && !options.provider && !options.model) {

--- a/src/lib/server/routes/agentRoutes.ts
+++ b/src/lib/server/routes/agentRoutes.ts
@@ -24,8 +24,54 @@ import {
   createErrorResponse as createError,
   EmbedManyRequestSchema,
   EmbedRequestSchema,
+  SkillCreateRequestSchema,
+  SkillUpdateRequestSchema,
   validateRequest,
 } from "../utils/validation.js";
+import type { SkillsManager } from "../../skills/skillsManager.js";
+
+/**
+ * Resolve the skills manager from the server's NeuroLink instance, or a
+ * 503 error response when skills are not configured on this server.
+ */
+function resolveSkillsManager(
+  ctx: ServerContext,
+): SkillsManager | ReturnType<typeof createErrorResponse> {
+  const manager = ctx.neurolink.getSkillsManager();
+  if (!manager) {
+    return createError(
+      "SKILLS_UNAVAILABLE",
+      "Skills are not enabled on this server — construct NeuroLink with a `skills` config.",
+      undefined,
+      ctx.requestId,
+    );
+  }
+  return manager;
+}
+
+/**
+ * Resolve the skills manager for a *mutating* route, or an error response when
+ * skills aren't configured (503) or mutations are disabled (allowMutations is
+ * not true). The LLM tools are already registration-gated; this applies the
+ * same switch to the REST create/update/delete endpoints.
+ */
+function resolveMutableSkillsManager(
+  ctx: ServerContext,
+): SkillsManager | ReturnType<typeof createErrorResponse> {
+  const manager = resolveSkillsManager(ctx);
+  if ("error" in manager) {
+    return manager;
+  }
+  if (!manager.mutationsAllowed) {
+    return createError(
+      "SKILLS_MUTATIONS_DISABLED",
+      "Skill mutations are disabled on this server \u2014 construct NeuroLink with `skills.allowMutations: true` to enable create/update/delete.",
+      undefined,
+      ctx.requestId,
+    );
+  }
+  return manager;
+}
 
 /**
  * Create agent routes
@@ -342,6 +388,171 @@ export function createAgentRoutes(basePath: string = "/api"): RouteGroup {
         },
         description: "Generate embeddings for multiple texts in a batch",
         tags: ["agent", "embeddings"],
+      },
+      {
+        method: "GET",
+        path: `${basePath}/agent/skills`,
+        handler: async (ctx: ServerContext) => {
+          const manager = resolveSkillsManager(ctx);
+          if ("error" in manager) {
+            return manager;
+          }
+          try {
+            const skills = await manager.list(ctx.query.scopeId);
+            return { skills, count: skills.length };
+          } catch (error) {
+            return createError(
+              "EXECUTION_FAILED",
+              error instanceof Error ? error.message : "Skills listing failed",
+              undefined,
+              ctx.requestId,
+            );
+          }
+        },
+        description:
+          "List active skills (index only — no instructions). Optional ?scopeId= filter.",
+        tags: ["agent", "skills"],
+      },
+      {
+        method: "GET",
+        path: `${basePath}/agent/skills/:id`,
+        handler: async (ctx: ServerContext) => {
+          const manager = resolveSkillsManager(ctx);
+          if ("error" in manager) {
+            return manager;
+          }
+          try {
+            const skill = await manager.get(ctx.params.id);
+            if (!skill) {
+              return createError(
+                "NOT_FOUND",
+                `Skill "${ctx.params.id}" not found`,
+                undefined,
+                ctx.requestId,
+              );
+            }
+            return skill;
+          } catch (error) {
+            return createError(
+              "EXECUTION_FAILED",
+              error instanceof Error ? error.message : "Skill lookup failed",
+              undefined,
+              ctx.requestId,
+            );
+          }
+        },
+        description: "Fetch one skill (by id or exact name) with instructions",
+        tags: ["agent", "skills"],
+      },
+      {
+        method: "POST",
+        path: `${basePath}/agent/skills`,
+        handler: async (ctx: ServerContext) => {
+          const manager = resolveMutableSkillsManager(ctx);
+          if ("error" in manager) {
+            return manager;
+          }
+          const validation = validateRequest(
+            SkillCreateRequestSchema,
+            ctx.body,
+            ctx.requestId,
+          );
+          if (!validation.success) {
+            return validation.error;
+          }
+          const { requestedBy, ...skill } = validation.data;
+          try {
+            const result = await manager.requestMutation({
+              type: "create",
+              skill,
+              // Authenticated identity wins over caller-supplied attribution.
+              ...(ctx.user?.id || requestedBy
+                ? { requestedBy: ctx.user?.id ?? requestedBy }
+                : {}),
+            });
+            return result;
+          } catch (error) {
+            return createError(
+              "EXECUTION_FAILED",
+              error instanceof Error ? error.message : "Skill create failed",
+              undefined,
+              ctx.requestId,
+            );
+          }
+        },
+        description:
+          "Create a skill (routed through the host's onMutationRequest gate when configured)",
+        tags: ["agent", "skills"],
+      },
+      {
+        method: "PATCH",
+        path: `${basePath}/agent/skills/:id`,
+        handler: async (ctx: ServerContext) => {
+          const manager = resolveMutableSkillsManager(ctx);
+          if ("error" in manager) {
+            return manager;
+          }
+          const validation = validateRequest(
+            SkillUpdateRequestSchema,
+            ctx.body,
+            ctx.requestId,
+          );
+          if (!validation.success) {
+            return validation.error;
+          }
+          const { requestedBy, ...patch } = validation.data;
+          try {
+            const result = await manager.requestMutation({
+              type: "update",
+              skillId: ctx.params.id,
+              patch,
+              ...(ctx.user?.id || requestedBy
+                ? { requestedBy: ctx.user?.id ?? requestedBy }
+                : {}),
+            });
+            return result;
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : "Skill update failed";
+            return createError(
+              message.includes("not found") ? "NOT_FOUND" : "EXECUTION_FAILED",
+              message,
+              undefined,
+              ctx.requestId,
+            );
+          }
+        },
+        description: "Update a skill (patch semantics; version is bumped)",
+        tags: ["agent", "skills"],
+      },
+      {
+        method: "DELETE",
+        path: `${basePath}/agent/skills/:id`,
+        handler: async (ctx: ServerContext) => {
+          const manager = resolveMutableSkillsManager(ctx);
+          if ("error" in manager) {
+            return manager;
+          }
+          try {
+            const result = await manager.requestMutation({
+              type: "delete",
+              skillId: ctx.params.id,
+              ...(ctx.user?.id ? { requestedBy: ctx.user.id } : {}),
+            });
+            return result;
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : "Skill delete failed";
+            return createError(
+              message.includes("not found") ? "NOT_FOUND" : "EXECUTION_FAILED",
+              message,
+              undefined,
+              ctx.requestId,
+            );
+          }
+        },
+        description: "Soft-delete (deprecate) a skill",
+        tags: ["agent", "skills"],
       },
     ],
   };

--- a/src/lib/server/utils/validation.ts
+++ b/src/lib/server/utils/validation.ts
@@ -146,6 +146,25 @@ export const EmbedManyRequestSchema = z.object({
   model: z.string().optional(),
 });
 
+/**
+ * Skill create request schema
+ */
+export const SkillCreateRequestSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  displayName: z.string().optional(),
+  description: z.string().min(1, "Description is required"),
+  instructions: z.string().min(1, "Instructions are required"),
+  tags: z.array(z.string()).optional(),
+  scope: z.enum(["global", "scoped"]).optional(),
+  scopeIds: z.array(z.string()).optional(),
+  requestedBy: z.string().optional(),
+});
+
+/**
+ * Skill update request schema — all fields optional (patch semantics)
+ */
+export const SkillUpdateRequestSchema = SkillCreateRequestSchema.partial();
+
 // ============================================
 // Error Response Type Guards / Helpers
 // ============================================
@@ -182,6 +201,7 @@ function getDefaultHttpStatus(code: string): number {
     RATE_LIMIT_EXCEEDED: 429,
     MCP_UNAVAILABLE: 503,
     MEMORY_UNAVAILABLE: 503,
+    SKILLS_UNAVAILABLE: 503,
     EXECUTION_FAILED: 500,
     INTERNAL_ERROR: 500,
   };

--- a/src/lib/session/globalSessionState.ts
+++ b/src/lib/session/globalSessionState.ts
@@ -7,6 +7,7 @@ import type {
   McpOutputStrategy,
   NeurolinkConstructorConfig,
   SessionVariableValue,
+  SkillsConfig,
   ToolRoutingConfig,
 } from "../types/index.js";
 
@@ -55,6 +56,8 @@ export class GlobalSessionManager {
   /** Optional classifier-router config set by CLI handlers before SDK construction. */
   private _classifierRouterConfig: ClassifierRouterConfig | undefined =
     undefined;
+  /** Optional skills config set by CLI handlers before SDK construction. */
+  private _skillsConfig: SkillsConfig | undefined = undefined;
 
   static getInstance(): GlobalSessionManager {
     if (!GlobalSessionManager.instance) {
@@ -204,6 +207,19 @@ export class GlobalSessionManager {
     this._classifierRouterConfig = config;
   }
 
+  /**
+   * Store a skills config to be injected at SDK construction time.
+   * Call this BEFORE `getOrCreateNeuroLink()` inside a command handler.
+   * When a loop session is already active the config is ignored (the instance
+   * already exists).
+   */
+  setSkillsConfig(config: SkillsConfig): void {
+    if (this.hasActiveSession()) {
+      return;
+    }
+    this._skillsConfig = config;
+  }
+
   getOrCreateNeuroLink(): NeuroLink {
     const session = this.getLoopSession();
     if (session) {
@@ -228,6 +244,10 @@ export class GlobalSessionManager {
     if (this._classifierRouterConfig) {
       options.classifierRouter = this._classifierRouterConfig;
       this._classifierRouterConfig = undefined;
+    }
+    if (this._skillsConfig) {
+      options.skills = this._skillsConfig;
+      this._skillsConfig = undefined;
     }
 
     return new NeuroLink(Object.keys(options).length ? options : undefined);

--- a/src/lib/skills/skillMatcher.ts
+++ b/src/lib/skills/skillMatcher.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure index-filtering + prompt-index formatting helpers.
+ *
+ * Matching semantics are ported from curator's battle-tested
+ * `searchSkillsFromIndex`: case-insensitive substring match on
+ * name/displayName/description, optional tag filter on top, scope filter
+ * that always admits global skills, and active-only visibility.
+ */
+
+import type {
+  SkillDefinition,
+  SkillIndexItem,
+  SkillSearchQuery,
+} from "../types/index.js";
+
+/** Strip instructions from a full definition to form an index entry. */
+export function toSkillIndexItem(skill: SkillDefinition): SkillIndexItem {
+  const { instructions: _instructions, ...indexItem } = skill;
+  return indexItem;
+}
+
+/** Filter index entries by query/tag/scope. Active skills only. */
+export function filterSkillIndex(
+  items: SkillIndexItem[],
+  query: SkillSearchQuery,
+): SkillIndexItem[] {
+  const lowerQuery = query.query?.toLowerCase();
+  const lowerTag = query.tag?.toLowerCase();
+
+  const matched = items.filter((item) => {
+    if ((item.status ?? "active") !== "active") {
+      return false;
+    }
+
+    // Scope filter: global skills always pass; scoped skills require a
+    // matching scopeId. When the caller provides no scopeId, scoped skills
+    // still pass (curator semantics — unscoped callers see everything).
+    if (query.scopeId && item.scope === "scoped") {
+      if (!(item.scopeIds ?? []).includes(query.scopeId)) {
+        return false;
+      }
+    }
+
+    if (lowerQuery) {
+      const nameMatch =
+        item.name.toLowerCase().includes(lowerQuery) ||
+        (item.displayName ?? "").toLowerCase().includes(lowerQuery) ||
+        item.description.toLowerCase().includes(lowerQuery);
+      if (!nameMatch) {
+        return false;
+      }
+    }
+
+    if (lowerTag) {
+      const tagMatch = (item.tags ?? []).some((t) =>
+        t.toLowerCase().includes(lowerTag),
+      );
+      if (!tagMatch) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  return query.limit !== undefined ? matched.slice(0, query.limit) : matched;
+}
+
+/**
+ * Render the compact skills index injected into the system prompt.
+ * Names + descriptions only — instructions are never included; the model
+ * loads them via search_skills. Returns null when nothing is visible so
+ * callers can skip injection entirely.
+ */
+export function formatSkillsPromptIndex(
+  items: SkillIndexItem[],
+  maxItems: number,
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const visible = items.slice(0, maxItems);
+  const lines = visible.map((item) => {
+    const label = item.displayName
+      ? `${item.name} (${item.displayName})`
+      : item.name;
+    const tags =
+      item.tags && item.tags.length > 0
+        ? ` [tags: ${item.tags.join(", ")}]`
+        : "";
+    return `- ${label}: ${item.description}${tags}`;
+  });
+
+  const truncationNote =
+    items.length > visible.length
+      ? `\n(${items.length - visible.length} more skills exist — use search_skills or list_skills to discover them.)`
+      : "";
+
+  return (
+    [
+      "## Available Skills",
+      "The following team-defined skills (SOPs, playbooks, workflows) are available.",
+      "Before answering from general knowledge, check whether one applies to the user's request.",
+      "To use a skill, call the search_skills tool to load its full instructions, then follow them exactly.",
+      "",
+      ...lines,
+    ].join("\n") + truncationNote
+  );
+}

--- a/src/lib/skills/skillStoreRedis.ts
+++ b/src/lib/skills/skillStoreRedis.ts
@@ -1,0 +1,122 @@
+/**
+ * Redis-backed skill store.
+ *
+ * Reuses NeuroLink's pooled Redis client (`redis` v5 is already a core
+ * dependency, shared with Redis conversation memory). One JSON value per
+ * skill under `<keyPrefix><id>`; the index is derived with SCAN + MGET —
+ * no separate index document to drift. Skills are persistent (no TTL).
+ */
+
+import type {
+  RedisClient,
+  SkillDefinition,
+  SkillIndexItem,
+  SkillRedisStorageConfig,
+  SkillStore,
+} from "../types/index.js";
+import {
+  getNormalizedConfig,
+  getPooledRedisClient,
+  scanKeys,
+} from "../utils/redis.js";
+import { logger } from "../utils/logger.js";
+import { toSkillIndexItem } from "./skillMatcher.js";
+
+const DEFAULT_KEY_PREFIX = "neurolink:skills:";
+
+export class RedisSkillStore implements SkillStore {
+  private readonly keyPrefix: string;
+  private readonly normalizedConfig: ReturnType<typeof getNormalizedConfig>;
+  private clientPromise: Promise<RedisClient> | null = null;
+
+  constructor(config: SkillRedisStorageConfig) {
+    this.keyPrefix = config.keyPrefix ?? DEFAULT_KEY_PREFIX;
+    this.normalizedConfig = getNormalizedConfig({
+      ...(config.url ? { url: config.url } : {}),
+      ...(config.host ? { host: config.host } : {}),
+      ...(config.port !== undefined ? { port: config.port } : {}),
+      ...(config.username ? { username: config.username } : {}),
+      ...(config.password ? { password: config.password } : {}),
+      ...(config.db !== undefined ? { db: config.db } : {}),
+      keyPrefix: this.keyPrefix,
+    });
+  }
+
+  private getClient(): Promise<RedisClient> {
+    if (!this.clientPromise) {
+      this.clientPromise = getPooledRedisClient(this.normalizedConfig).catch(
+        (error) => {
+          // Reset so a later call can retry after a transient outage.
+          this.clientPromise = null;
+          throw error;
+        },
+      );
+    }
+    return this.clientPromise;
+  }
+
+  private skillKey(id: string): string {
+    return `${this.keyPrefix}${id}`;
+  }
+
+  async get(id: string): Promise<SkillDefinition | null> {
+    const client = await this.getClient();
+    const raw = await client.get(this.skillKey(id));
+    return raw ? this.parseSkill(String(raw), this.skillKey(id)) : null;
+  }
+
+  async put(skill: SkillDefinition): Promise<void> {
+    const client = await this.getClient();
+    // Persistent — deliberately no TTL: skills must not expire silently.
+    await client.set(this.skillKey(skill.id), JSON.stringify(skill));
+  }
+
+  async delete(id: string): Promise<void> {
+    const client = await this.getClient();
+    await client.del(this.skillKey(id));
+  }
+
+  async index(): Promise<SkillIndexItem[]> {
+    const client = await this.getClient();
+    const keys = await scanKeys(client, `${this.keyPrefix}*`);
+    if (keys.length === 0) {
+      return [];
+    }
+    const values = await client.mGet(keys);
+    const items: SkillIndexItem[] = [];
+    values.forEach((value, i) => {
+      if (!value) {
+        return;
+      }
+      const skill = this.parseSkill(String(value), keys[i]);
+      if (skill) {
+        items.push(toSkillIndexItem(skill));
+      }
+    });
+    return items;
+  }
+
+  private parseSkill(raw: string, key: string): SkillDefinition | null {
+    try {
+      const parsed = JSON.parse(raw) as SkillDefinition;
+      if (
+        typeof parsed?.id === "string" &&
+        typeof parsed?.name === "string" &&
+        typeof parsed?.description === "string" &&
+        typeof parsed?.instructions === "string"
+      ) {
+        return parsed;
+      }
+      logger.warn("[SkillStoreRedis] Value is not a valid skill — skipping", {
+        key,
+      });
+      return null;
+    } catch (error) {
+      logger.warn("[SkillStoreRedis] Failed to parse skill value", {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+}

--- a/src/lib/skills/skillStoreS3.ts
+++ b/src/lib/skills/skillStoreS3.ts
@@ -1,0 +1,275 @@
+/**
+ * S3-backed skill store.
+ *
+ * Layout (curator-compatible):
+ *   <prefix>skills/<id>.json  — one JSON-serialized SkillDefinition per object
+ *   <prefix>index.json        — { lastUpdated, skills: SkillIndexItem[] }
+ *
+ * The index document is upserted on every write and rebuilt from a bucket
+ * listing when missing or unparsable (self-healing). Concurrent writers can
+ * race the index read-modify-write; the rebuild path recovers from any
+ * resulting drift, matching curator's production behavior.
+ *
+ * @aws-sdk/client-s3 is an optional peer — loaded lazily with the same
+ * createRequire pattern as memory's @juspay/hippocampus so importing
+ * NeuroLink core never requires the AWS SDK. Tests (and hosts with
+ * pre-configured clients) inject a SkillS3ObjectOps implementation instead.
+ */
+
+import { createRequire } from "node:module";
+import type {
+  SkillDefinition,
+  SkillIndexItem,
+  SkillS3IndexDocument,
+  SkillS3ModuleSurface,
+  SkillS3ObjectOps,
+  SkillS3StorageConfig,
+  SkillStore,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { toSkillIndexItem } from "./skillMatcher.js";
+
+const lazyRequire = createRequire(import.meta.url);
+
+let cachedS3Module: SkillS3ModuleSurface | null | undefined;
+
+function loadS3Module(): SkillS3ModuleSurface | null {
+  if (cachedS3Module !== undefined) {
+    return cachedS3Module;
+  }
+  try {
+    cachedS3Module = lazyRequire("@aws-sdk/client-s3") as SkillS3ModuleSurface;
+    return cachedS3Module;
+  } catch (error) {
+    cachedS3Module = null;
+    logger.debug(
+      "[SkillStoreS3] @aws-sdk/client-s3 is not installed; S3 skill storage unavailable.",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+    return null;
+  }
+}
+
+/** Build default object ops from @aws-sdk/client-s3. Throws when absent. */
+function createDefaultOps(config: SkillS3StorageConfig): SkillS3ObjectOps {
+  const mod = loadS3Module();
+  if (!mod) {
+    throw new Error(
+      "Skills S3 storage requires @aws-sdk/client-s3. Run `pnpm add @aws-sdk/client-s3` " +
+        "(or your package manager equivalent), or supply a custom store instead.",
+    );
+  }
+
+  const client = new mod.S3Client({
+    ...(config.region ? { region: config.region } : {}),
+    ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+    ...(config.forcePathStyle !== undefined
+      ? { forcePathStyle: config.forcePathStyle }
+      : {}),
+    ...(config.credentials ? { credentials: config.credentials } : {}),
+  });
+  const bucket = config.bucket;
+
+  return {
+    async getObject(key: string): Promise<string | null> {
+      try {
+        const response = (await client.send(
+          new mod.GetObjectCommand({ Bucket: bucket, Key: key }),
+        )) as { Body?: { transformToString: () => Promise<string> } };
+        return (await response.Body?.transformToString()) ?? null;
+      } catch (error) {
+        const name = (error as { name?: string }).name;
+        if (name === "NoSuchKey" || name === "NotFound") {
+          return null;
+        }
+        throw error;
+      }
+    },
+    async putObject(key: string, body: string): Promise<void> {
+      await client.send(
+        new mod.PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          ContentType: "application/json",
+        }),
+      );
+    },
+    async deleteObject(key: string): Promise<void> {
+      await client.send(
+        new mod.DeleteObjectCommand({ Bucket: bucket, Key: key }),
+      );
+    },
+    async listKeys(prefix: string): Promise<string[]> {
+      const keys: string[] = [];
+      let continuationToken: string | undefined;
+      do {
+        const response = (await client.send(
+          new mod.ListObjectsV2Command({
+            Bucket: bucket,
+            Prefix: prefix,
+            ...(continuationToken
+              ? { ContinuationToken: continuationToken }
+              : {}),
+          }),
+        )) as {
+          Contents?: Array<{ Key?: string }>;
+          NextContinuationToken?: string;
+          IsTruncated?: boolean;
+        };
+        for (const item of response.Contents ?? []) {
+          if (item.Key) {
+            keys.push(item.Key);
+          }
+        }
+        continuationToken = response.IsTruncated
+          ? response.NextContinuationToken
+          : undefined;
+      } while (continuationToken);
+      return keys;
+    },
+  };
+}
+
+export class S3SkillStore implements SkillStore {
+  private readonly prefix: string;
+  private ops: SkillS3ObjectOps | null = null;
+
+  constructor(
+    private readonly config: SkillS3StorageConfig,
+    /** Test/host seam — omit to build ops from @aws-sdk/client-s3 lazily. */
+    private readonly injectedOps?: SkillS3ObjectOps,
+  ) {
+    const rawPrefix = config.prefix ?? "neurolink-skills/";
+    this.prefix =
+      rawPrefix === "" || rawPrefix.endsWith("/") ? rawPrefix : `${rawPrefix}/`;
+  }
+
+  private getOps(): SkillS3ObjectOps {
+    if (!this.ops) {
+      this.ops = this.injectedOps ?? createDefaultOps(this.config);
+    }
+    return this.ops;
+  }
+
+  private skillKey(id: string): string {
+    return `${this.prefix}skills/${id}.json`;
+  }
+
+  private indexKey(): string {
+    return `${this.prefix}index.json`;
+  }
+
+  async get(id: string): Promise<SkillDefinition | null> {
+    const body = await this.getOps().getObject(this.skillKey(id));
+    if (!body) {
+      return null;
+    }
+    try {
+      return JSON.parse(body) as SkillDefinition;
+    } catch (error) {
+      logger.warn("[SkillStoreS3] Failed to parse skill object", {
+        id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  async put(skill: SkillDefinition): Promise<void> {
+    const ops = this.getOps();
+    await ops.putObject(
+      this.skillKey(skill.id),
+      JSON.stringify(skill, null, 2),
+    );
+    const index = await this.readOrRebuildIndex();
+    const entry = toSkillIndexItem(skill);
+    const position = index.skills.findIndex((s) => s.id === skill.id);
+    if (position >= 0) {
+      index.skills[position] = entry;
+    } else {
+      index.skills.push(entry);
+    }
+    await this.writeIndex(index);
+  }
+
+  async delete(id: string): Promise<void> {
+    const ops = this.getOps();
+    await ops.deleteObject(this.skillKey(id));
+    const index = await this.readOrRebuildIndex();
+    index.skills = index.skills.filter((s) => s.id !== id);
+    await this.writeIndex(index);
+  }
+
+  async index(): Promise<SkillIndexItem[]> {
+    const index = await this.readOrRebuildIndex();
+    return index.skills;
+  }
+
+  private async writeIndex(index: SkillS3IndexDocument): Promise<void> {
+    index.lastUpdated = new Date().toISOString();
+    await this.getOps().putObject(
+      this.indexKey(),
+      JSON.stringify(index, null, 2),
+    );
+  }
+
+  /**
+   * Read index.json; when missing or unparsable, rebuild it from a listing
+   * of the skills/ prefix and persist the rebuilt document (self-heal).
+   */
+  private async readOrRebuildIndex(): Promise<SkillS3IndexDocument> {
+    const ops = this.getOps();
+    const raw = await ops.getObject(this.indexKey());
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as SkillS3IndexDocument;
+        if (Array.isArray(parsed.skills)) {
+          return parsed;
+        }
+      } catch (error) {
+        logger.warn("[SkillStoreS3] index.json unparsable — rebuilding", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const skillsPrefix = `${this.prefix}skills/`;
+    const keys = await ops.listKeys(skillsPrefix);
+    const skills: SkillIndexItem[] = [];
+    for (const key of keys) {
+      if (!key.endsWith(".json")) {
+        continue;
+      }
+      const body = await ops.getObject(key);
+      if (!body) {
+        continue;
+      }
+      try {
+        skills.push(toSkillIndexItem(JSON.parse(body) as SkillDefinition));
+      } catch {
+        logger.warn("[SkillStoreS3] Skipping unparsable skill during rebuild", {
+          key,
+        });
+      }
+    }
+
+    const rebuilt: SkillS3IndexDocument = {
+      lastUpdated: new Date().toISOString(),
+      skills,
+    };
+    try {
+      await this.writeIndex(rebuilt);
+      logger.info("[SkillStoreS3] Rebuilt skills index", {
+        count: skills.length,
+      });
+    } catch (error) {
+      // Index persistence is best-effort; the rebuilt in-memory copy is
+      // still returned so reads keep working.
+      logger.warn("[SkillStoreS3] Failed to persist rebuilt index", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return rebuilt;
+  }
+}

--- a/src/lib/skills/skillStores.ts
+++ b/src/lib/skills/skillStores.ts
@@ -1,0 +1,294 @@
+/**
+ * Built-in skill stores + the storage-config factory.
+ *
+ * First-party backends: in-process memory (tests, embedded), filesystem
+ * (curator-style JSON alongside Claude-skills-style markdown — `<name>.md`
+ * or `<name>/SKILL.md` with YAML frontmatter), S3 (skillStoreS3.ts, optional
+ * @aws-sdk/client-s3 peer), and Redis (skillStoreRedis.ts, pooled core
+ * client). Anything else plugs in via `{ type: "custom", store }`.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
+import type {
+  SkillDefinition,
+  SkillIndexItem,
+  SkillStore,
+  SkillsStorageConfig,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { toSkillIndexItem } from "./skillMatcher.js";
+import { S3SkillStore } from "./skillStoreS3.js";
+import { RedisSkillStore } from "./skillStoreRedis.js";
+
+/** Fill defaulted fields so downstream logic never branches on undefined. */
+function normalizeSkill(skill: SkillDefinition): SkillDefinition {
+  return {
+    ...skill,
+    scope: skill.scope ?? "global",
+    status: skill.status ?? "active",
+    version: skill.version ?? 1,
+    tags: skill.tags ?? [],
+  };
+}
+
+/** Minimal structural validation for skills loaded from external sources. */
+function isValidSkill(candidate: unknown): candidate is SkillDefinition {
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const record = candidate as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    record.id.length > 0 &&
+    typeof record.name === "string" &&
+    record.name.length > 0 &&
+    typeof record.description === "string" &&
+    typeof record.instructions === "string"
+  );
+}
+
+/** In-process store backed by a Map. */
+export class InMemorySkillStore implements SkillStore {
+  private skills = new Map<string, SkillDefinition>();
+
+  constructor(seed?: SkillDefinition[]) {
+    for (const skill of seed ?? []) {
+      this.skills.set(skill.id, normalizeSkill(skill));
+    }
+  }
+
+  async get(id: string): Promise<SkillDefinition | null> {
+    return this.skills.get(id) ?? null;
+  }
+
+  async put(skill: SkillDefinition): Promise<void> {
+    this.skills.set(skill.id, normalizeSkill(skill));
+  }
+
+  async delete(id: string): Promise<void> {
+    this.skills.delete(id);
+  }
+
+  async index(): Promise<SkillIndexItem[]> {
+    return Array.from(this.skills.values()).map(toSkillIndexItem);
+  }
+}
+
+/**
+ * Parse a markdown document with optional YAML frontmatter into a skill.
+ * The body becomes `instructions`; frontmatter supplies index metadata.
+ * Returns null when required fields are missing (logged, not thrown —
+ * one malformed file must not take down the whole store).
+ */
+function parseSkillMarkdown(
+  raw: string,
+  fallbackId: string,
+): SkillDefinition | null {
+  const frontmatterMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  let meta: Record<string, unknown> = {};
+  let body = raw;
+
+  if (frontmatterMatch) {
+    try {
+      const parsed = yaml.load(frontmatterMatch[1]);
+      if (typeof parsed === "object" && parsed !== null) {
+        meta = parsed as Record<string, unknown>;
+      }
+    } catch (error) {
+      logger.warn("[SkillStore] Invalid YAML frontmatter in skill markdown", {
+        fallbackId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+    body = raw.slice(frontmatterMatch[0].length);
+  }
+
+  const name = typeof meta.name === "string" ? meta.name : fallbackId;
+  const description =
+    typeof meta.description === "string" ? meta.description : "";
+  const instructions = body.trim();
+
+  if (!name || !description || !instructions) {
+    logger.warn(
+      "[SkillStore] Skipping skill markdown missing name/description/body",
+      { fallbackId },
+    );
+    return null;
+  }
+
+  const candidate: SkillDefinition = normalizeSkill({
+    id: typeof meta.id === "string" ? meta.id : name,
+    name,
+    description,
+    instructions,
+    ...(typeof meta.displayName === "string"
+      ? { displayName: meta.displayName }
+      : {}),
+    ...(Array.isArray(meta.tags)
+      ? { tags: meta.tags.map((t) => String(t)) }
+      : {}),
+    ...(meta.scope === "scoped" || meta.scope === "global"
+      ? { scope: meta.scope }
+      : {}),
+    ...(Array.isArray(meta.scopeIds)
+      ? { scopeIds: meta.scopeIds.map((s) => String(s)) }
+      : {}),
+    ...(typeof meta.version === "number" ? { version: meta.version } : {}),
+  });
+  return candidate;
+}
+
+/**
+ * Directory-backed store. Read layouts:
+ *  - `<dir>/<id>.json`      — JSON SkillDefinition (mutable)
+ *  - `<dir>/<name>.md`      — frontmatter markdown (read-only source)
+ *  - `<dir>/<name>/SKILL.md` — Claude-skills directory layout (read-only source)
+ * Mutations always write `<id>.json`; a JSON file shadows a markdown skill
+ * with the same id, so updating a markdown-sourced skill "copies up" to JSON.
+ */
+export class FileSystemSkillStore implements SkillStore {
+  private cache: Map<string, SkillDefinition> | null = null;
+
+  constructor(private readonly baseDir: string) {}
+
+  invalidate(): void {
+    this.cache = null;
+  }
+
+  async get(id: string): Promise<SkillDefinition | null> {
+    const all = this.load();
+    return all.get(id) ?? null;
+  }
+
+  async put(skill: SkillDefinition): Promise<void> {
+    fs.mkdirSync(this.baseDir, { recursive: true });
+    const filePath = path.join(this.baseDir, `${skill.id}.json`);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(normalizeSkill(skill), null, 2),
+      "utf-8",
+    );
+    this.invalidate();
+  }
+
+  async delete(id: string): Promise<void> {
+    const filePath = path.join(this.baseDir, `${id}.json`);
+    try {
+      fs.unlinkSync(filePath);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+    this.invalidate();
+  }
+
+  async index(): Promise<SkillIndexItem[]> {
+    return Array.from(this.load().values()).map(toSkillIndexItem);
+  }
+
+  /**
+   * Scan the directory into an id→skill map. Markdown sources load first
+   * so JSON files (the mutable layer) shadow them on id collision.
+   */
+  private load(): Map<string, SkillDefinition> {
+    if (this.cache) {
+      return this.cache;
+    }
+
+    const skills = new Map<string, SkillDefinition>();
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(this.baseDir, { withFileTypes: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        logger.warn("[SkillStore] Failed to read skills directory", {
+          baseDir: this.baseDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      this.cache = skills;
+      return skills;
+    }
+
+    const jsonFiles: string[] = [];
+    for (const entry of entries) {
+      const fullPath = path.join(this.baseDir, entry.name);
+      try {
+        if (entry.isDirectory()) {
+          const skillMd = path.join(fullPath, "SKILL.md");
+          if (fs.existsSync(skillMd)) {
+            const parsed = parseSkillMarkdown(
+              fs.readFileSync(skillMd, "utf-8"),
+              entry.name,
+            );
+            if (parsed) {
+              skills.set(parsed.id, parsed);
+            }
+          }
+        } else if (entry.name.endsWith(".md")) {
+          const parsed = parseSkillMarkdown(
+            fs.readFileSync(fullPath, "utf-8"),
+            entry.name.replace(/\.md$/, ""),
+          );
+          if (parsed) {
+            skills.set(parsed.id, parsed);
+          }
+        } else if (entry.name.endsWith(".json")) {
+          jsonFiles.push(fullPath);
+        }
+      } catch (error) {
+        logger.warn("[SkillStore] Failed to load skill file", {
+          file: fullPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    // JSON layer last — shadows markdown-sourced skills with the same id.
+    for (const filePath of jsonFiles) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+        if (isValidSkill(parsed)) {
+          skills.set(parsed.id, normalizeSkill(parsed));
+        } else {
+          logger.warn("[SkillStore] Skipping invalid skill JSON", {
+            file: filePath,
+          });
+        }
+      } catch (error) {
+        logger.warn("[SkillStore] Failed to parse skill JSON", {
+          file: filePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    this.cache = skills;
+    return skills;
+  }
+}
+
+/** Resolve a storage config to a concrete store. Defaults to memory. */
+export function createSkillStore(config?: SkillsStorageConfig): SkillStore {
+  if (!config || config.type === "memory") {
+    return new InMemorySkillStore(
+      config?.type === "memory" ? config.skills : undefined,
+    );
+  }
+  if (config.type === "filesystem") {
+    return new FileSystemSkillStore(config.path);
+  }
+  if (config.type === "s3") {
+    return new S3SkillStore(config);
+  }
+  if (config.type === "redis") {
+    return new RedisSkillStore(config);
+  }
+  return config.store;
+}

--- a/src/lib/skills/skillTools.ts
+++ b/src/lib/skills/skillTools.ts
@@ -1,0 +1,395 @@
+/**
+ * Built-in skill tools, following the createMemoryRetrievalTools /
+ * createFileTools / createTaskTools factory pattern.
+ *
+ * The manager is resolved lazily via a resolver callback so tools can be
+ * registered at construction time while the store initializes on first
+ * use (mirrors how retrieve_context resolves conversationMemory lazily).
+ *
+ * Tool descriptions are ported from curator's production skills tools —
+ * the "always check skills first / no_match is expected, not an error /
+ * pick the best of 2-5 or ask" prompt engineering is proven in prod.
+ */
+
+import { z } from "zod";
+import type {
+  SkillDefinition,
+  SkillMutationAction,
+  SkillsManagerLike,
+  SkillToolsOptions,
+  Tool,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { tool } from "../utils/tool.js";
+
+/** Trim a hydrated skill to the fields the model needs. */
+function toToolSkill(skill: SkillDefinition) {
+  return {
+    id: skill.id,
+    name: skill.name,
+    ...(skill.displayName ? { displayName: skill.displayName } : {}),
+    description: skill.description,
+    instructions: skill.instructions,
+    tags: skill.tags ?? [],
+    scope: skill.scope ?? "global",
+    version: skill.version ?? 1,
+  };
+}
+
+/**
+ * Create the built-in skill tools bound to a lazily-resolved manager.
+ * Returns Vercel AI SDK tool() objects (description + Zod inputSchema +
+ * execute) keyed by tool name.
+ */
+export function createSkillTools(
+  resolveManager: () => SkillsManagerLike | null,
+  options?: SkillToolsOptions,
+): Record<string, Tool> {
+  const notConfigured = {
+    success: false as const,
+    error:
+      "Skills are not available — the skills store failed to initialize. " +
+      "Answer from general knowledge.",
+    data: { skills: [] },
+  };
+
+  const tools: Record<string, Tool> = {
+    search_skills: tool({
+      description:
+        "ALWAYS call this at the start of every user request before answering from general knowledge. " +
+        "Searches team-defined skills (SOPs, playbooks, workflows) using an index-first approach — " +
+        "fast, low-cost, and does not load skills that do not match. " +
+        "You MUST provide at least one of: query (keyword from the user message) or tag (domain category). " +
+        "If 1 match is found, follow its instructions exactly. " +
+        "If 2-5 matches are found, use your judgment based on the user message to pick the best one, " +
+        "or ask the user to clarify if the instructions would lead to meaningfully different actions. " +
+        "Only skip this call for purely conversational messages like greetings. " +
+        'Returns `{ skills: [], reason: "no_match" }` when nothing matches — this is expected, NOT an ' +
+        "error. In that case, answer from general knowledge.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Keyword from the user message, matched against skill name, display name, and description. " +
+              'E.g. "deployment", "refund process", "on-call escalation".',
+          ),
+        tag: z
+          .string()
+          .optional()
+          .describe(
+            'Domain category tag to narrow results (e.g. "payments", "devops"). ' +
+              "Applied on top of the query filter when both are provided.",
+          ),
+        scopeId: z
+          .string()
+          .optional()
+          .describe(
+            "Scope identifier (channel/team/tenant id) to include scoped skills alongside global ones. " +
+              "Usually omit — the host default applies.",
+          ),
+      }),
+      execute: async (args) => {
+        if (!args.query && !args.tag) {
+          return {
+            success: false,
+            error:
+              'At least one of "query" or "tag" must be provided to search_skills.',
+            data: { skills: [] },
+          };
+        }
+        const manager = resolveManager();
+        if (!manager) {
+          return notConfigured;
+        }
+        try {
+          const skills = await manager.search(args);
+          if (skills.length === 0) {
+            return {
+              success: true,
+              data: {
+                skills: [],
+                reason: "no_match" as const,
+                message: `No skills found${args.query ? ` matching "${args.query}"` : ""}${args.tag ? ` with tag "${args.tag}"` : ""}. Answer from general knowledge.`,
+              },
+            };
+          }
+          return {
+            success: true,
+            data: {
+              skills: skills.map(toToolSkill),
+              count: skills.length,
+              ...(skills.length > 1
+                ? {
+                    hint: "Multiple skills matched. Pick the most relevant one for the user message, or ask the user to clarify.",
+                  }
+                : {}),
+            },
+          };
+        } catch (error) {
+          logger.warn("[SkillTools] search_skills failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            data: { skills: [] },
+          };
+        }
+      },
+    }),
+
+    list_skills: tool({
+      description:
+        "Returns a lightweight list of all available skills — name, display name, description, and " +
+        "tags only. No instructions are returned, keeping context cost minimal. " +
+        'Use this only when a user explicitly asks "what skills do you have?" or "what can you help ' +
+        'me with?". Do NOT use this for skill lookup before answering — use search_skills instead.',
+      inputSchema: z.object({
+        scopeId: z
+          .string()
+          .optional()
+          .describe(
+            "Scope identifier to include scoped skills alongside global ones. Usually omit.",
+          ),
+      }),
+      execute: async (args) => {
+        const manager = resolveManager();
+        if (!manager) {
+          return notConfigured;
+        }
+        try {
+          const items = await manager.list(args.scopeId);
+          return {
+            success: true,
+            data: {
+              skills: items.map((item) => ({
+                name: item.name,
+                ...(item.displayName ? { displayName: item.displayName } : {}),
+                description: item.description,
+                tags: item.tags ?? [],
+                scope: item.scope ?? "global",
+              })),
+              count: items.length,
+            },
+          };
+        } catch (error) {
+          logger.warn("[SkillTools] list_skills failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            data: { skills: [] },
+          };
+        }
+      },
+    }),
+  };
+
+  if (options?.allowMutations) {
+    Object.assign(tools, createSkillMutationTools(resolveManager));
+  }
+
+  return tools;
+}
+
+/** Shared executor for the three mutation tools. */
+async function runMutation(
+  resolveManager: () => SkillsManagerLike | null,
+  action: SkillMutationAction,
+) {
+  const manager = resolveManager();
+  if (!manager) {
+    return {
+      success: false,
+      error:
+        "Skills are not available — the skills store failed to initialize.",
+    };
+  }
+  try {
+    const result = await manager.requestMutation(action);
+    if (result.decision.outcome === "rejected") {
+      return {
+        success: false,
+        error: `Skill ${action.type} was rejected${result.decision.reason ? `: ${result.decision.reason}` : "."}`,
+      };
+    }
+    if (result.decision.outcome === "pending") {
+      return {
+        success: true,
+        data: {
+          status: "pending_approval",
+          ...(result.decision.reference
+            ? { reference: result.decision.reference }
+            : {}),
+          message: `Skill ${action.type} was submitted for approval. It takes effect once an approver accepts it.`,
+        },
+      };
+    }
+    return {
+      success: true,
+      data: {
+        status: "applied",
+        ...(result.skill
+          ? {
+              skillId: result.skill.id,
+              name: result.skill.name,
+              version: result.skill.version,
+              skillStatus: result.skill.status,
+            }
+          : {}),
+      },
+    };
+  } catch (error) {
+    logger.warn(`[SkillTools] skill_${action.type} failed`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function createSkillMutationTools(
+  resolveManager: () => SkillsManagerLike | null,
+): Record<string, Tool> {
+  const scopeFields = {
+    scope: z
+      .enum(["global", "scoped"])
+      .optional()
+      .describe(
+        '"global" = available everywhere; "scoped" = only for specific scope ids.',
+      ),
+    scopeIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Required when scope="scoped": the scope ids (channel/team/tenant) the skill applies to.',
+      ),
+  };
+
+  return {
+    skill_create: tool({
+      description:
+        "Propose a NEW skill (SOP/playbook). Depending on host configuration the skill is either " +
+        "applied immediately or queued for human approval. " +
+        "INVOKE ONLY WHEN the user explicitly asks to create a new skill and has supplied the name, " +
+        "description, and full instructions text. DO NOT INVENT CONTENT — the instructions must come " +
+        "from the user verbatim or nearly so. If the user has not given the full text, ask. " +
+        "Do not use this to modify an existing skill (use skill_update).",
+      inputSchema: z.object({
+        name: z
+          .string()
+          .min(1)
+          .describe(
+            'Short machine-friendly skill name (snake_case recommended), unique. E.g. "refund_dispute_escalation".',
+          ),
+        displayName: z
+          .string()
+          .optional()
+          .describe(
+            'Human-readable display name. E.g. "Refund Dispute Escalation".',
+          ),
+        description: z
+          .string()
+          .min(1)
+          .describe(
+            "One or two sentences explaining when this skill applies. Used for matching.",
+          ),
+        instructions: z
+          .string()
+          .min(1)
+          .describe(
+            "The full step-by-step instructions to follow when this skill matches. " +
+              "Must come from the user — do not invent steps.",
+          ),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Domain tags for filtering (e.g. ["payments", "escalation"]).',
+          ),
+        ...scopeFields,
+        requestedBy: z
+          .string()
+          .optional()
+          .describe("Identifier of the requesting user, when known."),
+      }),
+      execute: async (args) => {
+        if (args.scope === "scoped" && (args.scopeIds ?? []).length === 0) {
+          return {
+            success: false,
+            error:
+              '"scopeIds" must contain at least one scope id when scope="scoped".',
+          };
+        }
+        const { requestedBy, ...skill } = args;
+        return runMutation(resolveManager, {
+          type: "create",
+          skill,
+          ...(requestedBy ? { requestedBy } : {}),
+        });
+      },
+    }),
+
+    skill_update: tool({
+      description:
+        "Propose an update to an EXISTING skill. Only the provided fields change; the version is " +
+        "bumped. Depending on host configuration the change is applied immediately or queued for " +
+        "human approval. Look the skill up with search_skills or list_skills first to get its id or " +
+        "exact name. Do not paraphrase or expand the user's instructions.",
+      inputSchema: z.object({
+        skillId: z
+          .string()
+          .min(1)
+          .describe("Id (or exact unique name) of the skill to update."),
+        displayName: z.string().optional(),
+        description: z.string().optional(),
+        instructions: z
+          .string()
+          .optional()
+          .describe("Replacement instructions text, verbatim from the user."),
+        tags: z.array(z.string()).optional(),
+        ...scopeFields,
+        requestedBy: z.string().optional(),
+      }),
+      execute: async (args) => {
+        const { skillId, requestedBy, ...patch } = args;
+        if (Object.values(patch).every((v) => v === undefined)) {
+          return {
+            success: false,
+            error: "Provide at least one field to update.",
+          };
+        }
+        return runMutation(resolveManager, {
+          type: "update",
+          skillId,
+          patch,
+          ...(requestedBy ? { requestedBy } : {}),
+        });
+      },
+    }),
+
+    skill_delete: tool({
+      description:
+        "Propose deleting (deprecating) an EXISTING skill. The skill stops matching but stays in " +
+        "storage for audit. Depending on host configuration this is applied immediately or queued " +
+        "for human approval. INVOKE ONLY WHEN the user explicitly asks to delete a skill.",
+      inputSchema: z.object({
+        skillId: z
+          .string()
+          .min(1)
+          .describe("Id (or exact unique name) of the skill to delete."),
+        requestedBy: z.string().optional(),
+      }),
+      execute: async (args) =>
+        runMutation(resolveManager, {
+          type: "delete",
+          skillId: args.skillId,
+          ...(args.requestedBy ? { requestedBy: args.requestedBy } : {}),
+        }),
+    }),
+  };
+}

--- a/src/lib/skills/skillsManager.ts
+++ b/src/lib/skills/skillsManager.ts
@@ -1,0 +1,277 @@
+/**
+ * SkillsManager — orchestrates the skill store, cached index, index-first
+ * search (hydrating instructions only for matches), prompt-index rendering,
+ * and the mutation gate.
+ *
+ * Read paths fail open (errors surface as empty results + a warn log);
+ * write paths fail closed (errors reject the mutation).
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  SkillCreateInput,
+  SkillDefinition,
+  SkillIndexItem,
+  SkillMutationAction,
+  SkillMutationResult,
+  SkillSearchQuery,
+  SkillStore,
+  SkillUpdateInput,
+  SkillsConfig,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { filterSkillIndex, formatSkillsPromptIndex } from "./skillMatcher.js";
+import { createSkillStore } from "./skillStores.js";
+
+const DEFAULT_MAX_MATCHES = 5;
+const DEFAULT_PROMPT_INDEX_MAX_ITEMS = 50;
+const DEFAULT_INDEX_CACHE_TTL_MS = 30_000;
+
+export class SkillsManager {
+  private readonly store: SkillStore;
+  private cachedIndex: SkillIndexItem[] | null = null;
+  private cachedIndexAt = 0;
+  /** Serializes writes within this process — see requestMutation(). */
+  private mutationQueue: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly config: SkillsConfig) {
+    this.store = createSkillStore(config.storage);
+  }
+
+  /** Cached index read. TTL 0 disables caching. */
+  async getIndex(forceRefresh = false): Promise<SkillIndexItem[]> {
+    const ttl = this.config.indexCacheTtlMs ?? DEFAULT_INDEX_CACHE_TTL_MS;
+    const fresh =
+      this.cachedIndex !== null &&
+      ttl > 0 &&
+      Date.now() - this.cachedIndexAt < ttl;
+    if (fresh && !forceRefresh && this.cachedIndex) {
+      return this.cachedIndex;
+    }
+    const index = await this.store.index();
+    this.cachedIndex = index;
+    this.cachedIndexAt = Date.now();
+    return index;
+  }
+
+  private invalidateIndex(): void {
+    this.cachedIndex = null;
+    this.store.invalidate?.();
+  }
+
+  /**
+   * Index-first search: filter the cached index, hydrate only the matched
+   * entries (max `limit`) with instructions. Cost: one cached index read +
+   * N_matched store gets.
+   */
+  async search(query: SkillSearchQuery): Promise<SkillDefinition[]> {
+    const limit = query.limit ?? this.config.maxMatches ?? DEFAULT_MAX_MATCHES;
+    const scopeId = query.scopeId ?? this.config.defaultScopeId;
+    const index = await this.getIndex();
+    const matched = filterSkillIndex(index, {
+      ...query,
+      ...(scopeId !== undefined ? { scopeId } : {}),
+      limit,
+    });
+
+    const hydrated = await Promise.all(
+      matched.map((item) => this.store.get(item.id)),
+    );
+    return hydrated.filter((s): s is SkillDefinition => s !== null);
+  }
+
+  /** Index entries only — no instructions. For discovery/listing. */
+  async list(scopeId?: string): Promise<SkillIndexItem[]> {
+    const effectiveScopeId = scopeId ?? this.config.defaultScopeId;
+    const index = await this.getIndex();
+    return filterSkillIndex(index, {
+      ...(effectiveScopeId !== undefined ? { scopeId: effectiveScopeId } : {}),
+    });
+  }
+
+  /** Fetch one skill by id, falling back to name lookup. */
+  async get(idOrName: string): Promise<SkillDefinition | null> {
+    const byId = await this.store.get(idOrName);
+    if (byId) {
+      return byId;
+    }
+    const index = await this.getIndex();
+    // Prefer an active skill when resolving by name: a soft-deleted skill and a
+    // later same-named active skill can coexist in the index, so a bare
+    // name-find would resolve non-deterministically to the stale deprecated one
+    // across store backends. Fall back to any match only when no active skill
+    // carries the name.
+    const entry =
+      index.find(
+        (item) =>
+          item.name === idOrName && (item.status ?? "active") === "active",
+      ) ?? index.find((item) => item.name === idOrName);
+    return entry ? this.store.get(entry.id) : null;
+  }
+
+  /**
+   * Render the system-prompt skills index for one call, or null when
+   * nothing is visible. Never includes instructions.
+   */
+  async buildPromptIndex(options?: {
+    scopeId?: string;
+    tags?: string[];
+  }): Promise<string | null> {
+    let items = await this.list(options?.scopeId);
+    if (options?.tags && options.tags.length > 0) {
+      const wanted = options.tags.map((t) => t.toLowerCase());
+      items = items.filter((item) =>
+        (item.tags ?? []).some((t) => wanted.includes(t.toLowerCase())),
+      );
+    }
+    return formatSkillsPromptIndex(
+      items,
+      this.config.promptIndexMaxItems ?? DEFAULT_PROMPT_INDEX_MAX_ITEMS,
+    );
+  }
+
+  /**
+   * Whether skill create/update/delete is enabled on this instance. Gates the
+   * LLM-facing `skill_*` tools (registration) and the server REST mutation
+   * routes. Direct programmatic `requestMutation` calls are intentionally not
+   * gated, so a host can still seed skills at startup.
+   */
+  get mutationsAllowed(): boolean {
+    return this.config.allowMutations ?? false;
+  }
+
+  /**
+   * Gate a proposed mutation through the host's onMutationRequest hook,
+   * then apply it when approved. No hook configured means direct apply
+   * (the tools themselves are already gated by allowMutations).
+   */
+  async requestMutation(
+    action: SkillMutationAction,
+  ): Promise<SkillMutationResult> {
+    let decision: SkillMutationResult["decision"] = { outcome: "approved" };
+    if (this.config.onMutationRequest) {
+      decision = await this.config.onMutationRequest(action);
+    }
+    if (decision.outcome !== "approved") {
+      return { decision };
+    }
+    // Serialize writes within this process so the name-uniqueness check and
+    // the store write can never interleave across concurrent mutations.
+    // Cross-process races remain possible with plain-object stores (S3,
+    // Redis) — hosts needing strict global uniqueness should serialize via
+    // their onMutationRequest gate; the S3 index additionally self-heals.
+    const run = this.mutationQueue.then(() => this.applyMutation(action));
+    this.mutationQueue = run.catch(() => undefined);
+    const skill = await run;
+    return { decision, ...(skill ? { skill } : {}) };
+  }
+
+  private async applyMutation(
+    action: SkillMutationAction,
+  ): Promise<SkillDefinition | undefined> {
+    const now = new Date().toISOString();
+
+    if (action.type === "create") {
+      await this.assertNameAvailable(action.skill.name);
+      const skill: SkillDefinition = {
+        id: randomUUID(),
+        version: 1,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+        ...action.skill,
+      };
+      assertScopeConsistent(skill);
+      await this.store.put(skill);
+      this.invalidateIndex();
+      logger.info("[SkillsManager] Skill created", {
+        skillId: skill.id,
+        name: skill.name,
+      });
+      return skill;
+    }
+
+    if (action.type === "update") {
+      const existing = await this.get(action.skillId);
+      if (!existing) {
+        throw new Error(`Skill "${action.skillId}" not found`);
+      }
+      if (action.patch.name && action.patch.name !== existing.name) {
+        await this.assertNameAvailable(action.patch.name, existing.id);
+      }
+      const updated: SkillDefinition = {
+        ...existing,
+        ...definedFields(action.patch),
+        id: existing.id,
+        version: (existing.version ?? 1) + 1,
+        updatedAt: now,
+      };
+      assertScopeConsistent(updated);
+      await this.store.put(updated);
+      this.invalidateIndex();
+      logger.info("[SkillsManager] Skill updated", {
+        skillId: updated.id,
+        version: updated.version,
+      });
+      return updated;
+    }
+
+    // delete — soft: mark deprecated so the skill drops out of active
+    // listings but stays in storage for audit/undo.
+    const existing = await this.get(action.skillId);
+    if (!existing) {
+      throw new Error(`Skill "${action.skillId}" not found`);
+    }
+    if (existing.status === "deprecated") {
+      throw new Error(`Skill "${existing.name}" is already deleted`);
+    }
+    const deprecated: SkillDefinition = {
+      ...existing,
+      status: "deprecated",
+      updatedAt: now,
+    };
+    await this.store.put(deprecated);
+    this.invalidateIndex();
+    logger.info("[SkillsManager] Skill deprecated", {
+      skillId: existing.id,
+      name: existing.name,
+    });
+    return deprecated;
+  }
+
+  private async assertNameAvailable(
+    name: string,
+    excludeId?: string,
+  ): Promise<void> {
+    const index = await this.getIndex(true);
+    const clash = index.find(
+      (item) =>
+        item.id !== excludeId &&
+        item.name.toLowerCase() === name.toLowerCase() &&
+        (item.status ?? "active") === "active",
+    );
+    if (clash) {
+      throw new Error(`A skill named "${name}" already exists`);
+    }
+  }
+}
+
+/**
+ * A scoped skill without scopeIds can never match anything — reject the
+ * write instead of persisting an unmatchable skill. Validated post-merge so
+ * both create and patch-style update paths are covered.
+ */
+function assertScopeConsistent(skill: SkillDefinition): void {
+  if (skill.scope === "scoped" && (skill.scopeIds ?? []).length === 0) {
+    throw new Error(
+      'A skill with scope "scoped" must have at least one entry in scopeIds',
+    );
+  }
+}
+
+/** Shallow-copy only the defined fields of a patch (undefined must not overwrite). */
+function definedFields(patch: SkillUpdateInput): Partial<SkillCreateInput> {
+  return Object.fromEntries(
+    Object.entries(patch).filter(([, value]) => value !== undefined),
+  ) as Partial<SkillCreateInput>;
+}

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -28,6 +28,7 @@ import type { NeurolinkCredentials } from "./providers.js";
 import type { ModelPoolConfig } from "./modelPool.js";
 import type { RequestRouter } from "./requestRouter.js";
 import type { ClassifierRouterConfig } from "./classifierRouter.js";
+import type { SkillsConfig } from "./skills.js";
 
 /**
  * Main NeuroLink configuration type
@@ -133,6 +134,15 @@ export type NeurolinkConstructorConfig = {
    * caller pinned both `provider` and `model`. See {@link ClassifierRouterConfig}.
    */
   classifierRouter?: ClassifierRouterConfig;
+  /**
+   * Native skills: versioned, discoverable instruction packs (SOPs,
+   * playbooks) with progressive disclosure. When enabled, built-in
+   * search_skills / list_skills tools are registered (plus gated mutation
+   * tools) and a compact skills index is injected into the system prompt
+   * of each generate()/stream() call. Opt-in and fails open on read paths.
+   * See {@link SkillsConfig}.
+   */
+  skills?: SkillsConfig;
 };
 
 /**

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -1,5 +1,6 @@
 import type { AIProviderName } from "../constants/enums.js";
 import type { RAGConfig } from "./rag.js";
+import type { SkillsCallOptions } from "./skills.js";
 import type { AnalyticsData, TokenUsage } from "./analytics.js";
 import type { JsonValue } from "./common.js";
 import type { Content, ImageWithAltText } from "./content.js";
@@ -695,6 +696,14 @@ export type GenerateOptions = {
    * @deprecated Use `piiDetection`, `responseValidation`, and `inputValidation` instead.
    */
   processors?: ProcessorPipelineConfig;
+
+  /**
+   * Per-call skills control. Only effective when the instance was
+   * constructed with `skills.enabled: true`. Lets a call disable the
+   * prompt index, or narrow it by scope/tags. Per-call wins over
+   * instance config.
+   */
+  skills?: SkillsCallOptions;
 };
 
 /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -48,6 +48,7 @@ export * from "./scorer.js";
 export * from "./sdk.js";
 export * from "./server.js";
 export * from "./service.js";
+export * from "./skills.js";
 export * from "./stream.js";
 export * from "./subscription.js";
 export * from "./task.js";

--- a/src/lib/types/skills.ts
+++ b/src/lib/types/skills.ts
@@ -1,0 +1,319 @@
+/**
+ * Native skills support — versioned, discoverable instruction packs
+ * (SOPs, playbooks, workflows) exposed to the model via progressive
+ * disclosure: a cheap name+description index up front, full instructions
+ * loaded on demand through built-in skill tools.
+ *
+ * Architecture mirrors the Hippocampus memory subsystem: a `skills` config
+ * on the NeuroLink constructor lazily initializes a SkillsManager, which
+ * auto-registers built-in tools (search_skills / list_skills, plus gated
+ * mutation tools) and optionally injects a compact skills index into the
+ * system prompt of each generate()/stream() call.
+ *
+ * Naming: every exported type carries a `Skill` prefix to satisfy the
+ * `unique-type-names` ESLint rule.
+ */
+
+/** Visibility of a skill: available everywhere, or only in specific scopes. */
+export type SkillScopeKind = "global" | "scoped";
+
+/** Lifecycle status. Deletes are soft — deprecated skills stay in storage. */
+export type SkillLifecycleStatus = "active" | "deprecated";
+
+/**
+ * A complete skill: index metadata plus the full `instructions` body.
+ * `instructions` is the expensive part — it is only hydrated for matched
+ * skills, never included in index listings or the prompt index.
+ */
+export type SkillDefinition = {
+  /** Stable unique identifier (UUID for created skills, or derived from filename). */
+  id: string;
+  /** Machine-friendly unique name (snake_case recommended), used for matching. */
+  name: string;
+  /** Human-readable display name shown in listings. */
+  displayName?: string;
+  /** One or two sentences describing when the skill applies — the matching signal. */
+  description: string;
+  /** Full step-by-step instructions the model follows when the skill matches. */
+  instructions: string;
+  /** Domain tags for filtering (e.g. ["payments", "escalation"]). */
+  tags?: string[];
+  /** Visibility. Default: "global". */
+  scope?: SkillScopeKind;
+  /** Scope identifiers this skill is limited to when scope === "scoped" (e.g. channel/team/tenant ids). */
+  scopeIds?: string[];
+  /** Monotonic version, bumped on every approved update. Default: 1. */
+  version?: number;
+  /** Lifecycle status. Default: "active". */
+  status?: SkillLifecycleStatus;
+  /** ISO timestamp of creation. */
+  createdAt?: string;
+  /** ISO timestamp of last update. */
+  updatedAt?: string;
+  /** Free-form host metadata (audit fields, approval references, …). */
+  metadata?: Record<string, unknown>;
+};
+
+/** Lightweight index entry — everything except the instructions body. */
+export type SkillIndexItem = Omit<SkillDefinition, "instructions">;
+
+/**
+ * Pluggable persistence backend. NeuroLink ships memory and filesystem
+ * stores; hosts plug their own (S3, database, …) via the "custom" storage
+ * type. `index()` must be cheap relative to `get()` — it backs every
+ * search and prompt-index build.
+ */
+export type SkillStore = {
+  /** Fetch one skill (with instructions) by id. Null when absent. */
+  get(id: string): Promise<SkillDefinition | null>;
+  /** Create or replace a skill. */
+  put(skill: SkillDefinition): Promise<void>;
+  /** Hard-remove a skill from storage. (Soft deletes go through put().) */
+  delete(id: string): Promise<void>;
+  /** List index entries (no instructions) for all stored skills. */
+  index(): Promise<SkillIndexItem[]>;
+  /** Optional: drop any internal caches (called after mutations). */
+  invalidate?(): void;
+};
+
+/** In-process store, optionally seeded. Good for tests and embedded use. */
+export type SkillMemoryStorageConfig = {
+  type: "memory";
+  /** Initial skills to seed the store with. */
+  skills?: SkillDefinition[];
+};
+
+/**
+ * Directory-backed store. Reads three layouts:
+ *  - `<dir>/<id>.json` — one JSON-serialized SkillDefinition per file
+ *  - `<dir>/<name>.md` — markdown with YAML frontmatter; body = instructions
+ *  - `<dir>/<name>/SKILL.md` — Claude-skills-style directory layout
+ * Mutations always write `<id>.json`; markdown sources are read-only.
+ */
+export type SkillFilesystemStorageConfig = {
+  type: "filesystem";
+  /** Directory containing skill files. Created on first write if absent. */
+  path: string;
+};
+
+/** Host-provided store implementation (e.g. curator's S3 repository). */
+export type SkillCustomStorageConfig = {
+  type: "custom";
+  store: SkillStore;
+};
+
+/**
+ * S3-backed store. Layout: `<prefix>skills/<id>.json` per skill plus a
+ * `<prefix>index.json` document that is upserted on writes and rebuilt
+ * from a bucket listing when missing or corrupt (self-healing).
+ *
+ * Requires the optional peer `@aws-sdk/client-s3` to be installed in the
+ * host application (same pattern as memory's optional @juspay/hippocampus).
+ * Credentials default to the standard AWS provider chain when omitted.
+ */
+export type SkillS3StorageConfig = {
+  type: "s3";
+  bucket: string;
+  /** Key prefix inside the bucket. Default: "neurolink-skills/". */
+  prefix?: string;
+  region?: string;
+  /** Custom endpoint (MinIO, LocalStack, …). */
+  endpoint?: string;
+  /** Use path-style addressing (required by most S3-compatible stores). */
+  forcePathStyle?: boolean;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+  };
+};
+
+/**
+ * Redis-backed store using NeuroLink's pooled Redis client (`redis` v5,
+ * already a core dependency). One JSON value per skill under
+ * `<keyPrefix><id>`; the index is derived via SCAN + MGET. Skills are
+ * persistent — no TTL is applied.
+ */
+export type SkillRedisStorageConfig = {
+  type: "redis";
+  url?: string;
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  db?: number;
+  /** Key prefix. Default: "neurolink:skills:". */
+  keyPrefix?: string;
+};
+
+/**
+ * Structural surface of the lazily-required @aws-sdk/client-s3 module —
+ * only the pieces the S3 skill store touches (same pattern as
+ * HippocampusModule for the optional memory peer).
+ */
+export type SkillS3ModuleSurface = {
+  S3Client: new (config: Record<string, unknown>) => {
+    send: (command: unknown) => Promise<unknown>;
+  };
+  GetObjectCommand: new (input: Record<string, unknown>) => unknown;
+  PutObjectCommand: new (input: Record<string, unknown>) => unknown;
+  DeleteObjectCommand: new (input: Record<string, unknown>) => unknown;
+  ListObjectsV2Command: new (input: Record<string, unknown>) => unknown;
+};
+
+/** Shape of the `<prefix>index.json` document maintained by the S3 store. */
+export type SkillS3IndexDocument = {
+  lastUpdated: string;
+  skills: SkillIndexItem[];
+};
+
+/**
+ * Minimal object-storage operations the S3 skill store runs on. The
+ * default implementation is created lazily from @aws-sdk/client-s3;
+ * tests and hosts with pre-built clients can inject their own.
+ */
+export type SkillS3ObjectOps = {
+  /** Fetch an object's body as a UTF-8 string. Null when the key is absent. */
+  getObject(key: string): Promise<string | null>;
+  putObject(key: string, body: string): Promise<void>;
+  deleteObject(key: string): Promise<void>;
+  /** List all object keys under a prefix (paginated internally). */
+  listKeys(prefix: string): Promise<string[]>;
+};
+
+export type SkillsStorageConfig =
+  | SkillMemoryStorageConfig
+  | SkillFilesystemStorageConfig
+  | SkillS3StorageConfig
+  | SkillRedisStorageConfig
+  | SkillCustomStorageConfig;
+
+/** Query accepted by SkillsManager.search() and the search_skills tool. */
+export type SkillSearchQuery = {
+  /** Keyword matched (case-insensitive substring) against name, displayName, and description. */
+  query?: string;
+  /** Tag filter, applied on top of the keyword match. */
+  tag?: string;
+  /** Scope filter: include global skills plus skills scoped to this id. */
+  scopeId?: string;
+  /** Maximum matches to hydrate. Defaults to SkillsConfig.maxMatches. */
+  limit?: number;
+};
+
+/** Input for creating a skill (id/version/status/timestamps are assigned by the manager). */
+export type SkillCreateInput = {
+  name: string;
+  displayName?: string;
+  description: string;
+  instructions: string;
+  tags?: string[];
+  scope?: SkillScopeKind;
+  scopeIds?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+/** Patch for updating a skill. Only provided fields change; version is bumped. */
+export type SkillUpdateInput = Partial<SkillCreateInput>;
+
+/** A proposed mutation, passed to the host's onMutationRequest gate. */
+export type SkillMutationAction =
+  | { type: "create"; skill: SkillCreateInput; requestedBy?: string }
+  | {
+      type: "update";
+      skillId: string;
+      patch: SkillUpdateInput;
+      requestedBy?: string;
+    }
+  | { type: "delete"; skillId: string; requestedBy?: string };
+
+/**
+ * Host decision for a proposed mutation.
+ *  - "approved": NeuroLink applies the mutation immediately.
+ *  - "rejected": nothing is written; `reason` is surfaced to the model.
+ *  - "pending": the host queued the action for out-of-band approval
+ *    (e.g. a Slack maker-checker flow) and will apply it itself later;
+ *    `reference` is surfaced to the model (e.g. an approval ticket id).
+ */
+export type SkillMutationDecision =
+  | { outcome: "approved" }
+  | { outcome: "rejected"; reason?: string }
+  | { outcome: "pending"; reference?: string };
+
+/** Result envelope returned by SkillsManager.requestMutation(). */
+export type SkillMutationResult = {
+  decision: SkillMutationDecision;
+  /** The resulting skill after an applied create/update (absent for delete/pending/rejected). */
+  skill?: SkillDefinition;
+};
+
+/**
+ * Instance-level skills configuration (NeuroLink constructor `skills` option).
+ * Opt-in: nothing is registered or injected unless `enabled: true`.
+ */
+export type SkillsConfig = {
+  enabled: boolean;
+  /** Persistence backend. Default: `{ type: "memory" }`. */
+  storage?: SkillsStorageConfig;
+  /**
+   * Inject a compact skills index (names + descriptions, never instructions)
+   * into the system prompt of each generate()/stream() call. Default: true.
+   * Set false for curator-style pure tool-driven disclosure.
+   */
+  promptIndex?: boolean;
+  /** Maximum skills hydrated (with instructions) per search. Default: 5. */
+  maxMatches?: number;
+  /** Maximum entries rendered in the prompt index before truncation. Default: 50. */
+  promptIndexMaxItems?: number;
+  /** Index cache TTL in milliseconds. Default: 30000. 0 disables caching. */
+  indexCacheTtlMs?: number;
+  /** Default scope filter applied when a call/tool provides none. */
+  defaultScopeId?: string;
+  /**
+   * Register skill_create / skill_update / skill_delete tools so the model
+   * can propose skill changes. Default: false. Combine with
+   * `onMutationRequest` to gate writes behind host approval.
+   */
+  allowMutations?: boolean;
+  /**
+   * Host approval gate invoked before any mutation is applied. When absent
+   * and allowMutations is true, mutations apply directly. Errors thrown
+   * here reject the mutation (fail closed for writes).
+   */
+  onMutationRequest?: (
+    action: SkillMutationAction,
+  ) => Promise<SkillMutationDecision>;
+};
+
+/**
+ * Structural view of SkillsManager consumed by the skill tools factory —
+ * keeps skillTools.ts decoupled from the concrete manager class.
+ */
+export type SkillsManagerLike = {
+  search: (query: SkillSearchQuery) => Promise<SkillDefinition[]>;
+  list: (scopeId?: string) => Promise<SkillIndexItem[]>;
+  requestMutation: (
+    action: SkillMutationAction,
+  ) => Promise<SkillMutationResult>;
+};
+
+/** Options for the createSkillTools factory. */
+export type SkillToolsOptions = {
+  /** Include skill_create / skill_update / skill_delete. Default: false. */
+  allowMutations?: boolean;
+};
+
+/**
+ * Per-call skills control on generate()/stream(). Only effective when the
+ * instance was constructed with skills enabled; per-call wins over instance
+ * config (same precedence convention as per-call credentials).
+ */
+export type SkillsCallOptions = {
+  /** Master toggle for this call (prompt index only — tools stay registered). Default: true. */
+  enabled?: boolean;
+  /** Per-call override of SkillsConfig.promptIndex. */
+  promptIndex?: boolean;
+  /** Scope filter for the prompt index on this call. Overrides defaultScopeId. */
+  scopeId?: string;
+  /** Restrict the prompt index to skills carrying at least one of these tags. */
+  tags?: string[];
+};

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -1,6 +1,7 @@
 import type { AIProviderName } from "../constants/enums.js";
 import type { EvaluationData } from "./evaluation.js";
 import type { RAGConfig } from "./rag.js";
+import type { SkillsCallOptions } from "./skills.js";
 import type {
   AnalyticsData,
   ToolExecutionEvent,
@@ -646,6 +647,14 @@ export type StreamOptions = {
 
   /** @deprecated Use `piiDetection`, `responseValidation`, and `inputValidation` instead. */
   processors?: ProcessorPipelineConfig;
+
+  /**
+   * Per-call skills control. Only effective when the instance was
+   * constructed with `skills.enabled: true`. Lets a call disable the
+   * prompt index, or narrow it by scope/tags. Per-call wins over
+   * instance config.
+   */
+  skills?: SkillsCallOptions;
 };
 
 /**

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -1,0 +1,1457 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite: Skills
+ *
+ * Tests the native skills subsystem end-to-end:
+ * - Built-in tool registration (search_skills / list_skills, gated mutation tools)
+ * - InMemory + FileSystem stores (JSON, frontmatter .md, <dir>/SKILL.md layouts)
+ * - S3 store (hermetic via injected object ops: round-trip, index upsert, self-heal,
+ *   fail-open error when @aws-sdk/client-s3 is absent)
+ * - Redis store (round-trip + SCAN index; SKIPs when Redis is unreachable)
+ * - Custom store plug-in
+ * - Index-first search semantics (no_match envelope, scope/tag filters, maxMatches)
+ * - SkillsManager API via getSkillsManager()
+ * - Prompt-index injection (block content, per-call disable, media-mode skip)
+ * - Mutation gate (approve / reject / pending / direct apply, soft delete, version bump)
+ * - CLI: skills create/list/show/search/delete + --skills-dir flag
+ * - Server routes: /api/agent/skills CRUD handlers + 503 when unconfigured
+ * - Live generate() with skills (SKIPs without provider credentials)
+ *
+ * Most tests are no-API. Run: npx tsx test/continuous-test-suite-skills.ts [--provider=vertex]
+ */
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { NeuroLink, RedisSkillStore, S3SkillStore } from "../dist/index.js";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+// ============================================================
+// HARNESS
+// ============================================================
+
+const providerArg = process.argv
+  .find((a) => a.startsWith("--provider="))
+  ?.split("=")[1];
+const TEST_PROVIDER = providerArg || "vertex";
+
+type ColorName = "green" | "red" | "yellow" | "cyan" | "reset";
+const COLORS: Record<ColorName, string> = {
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  reset: "\x1b[0m",
+};
+
+function log(message: string, color: ColorName = "reset"): void {
+  console.log(`${COLORS[color]}${message}${COLORS.reset}`);
+}
+
+const testResults: Array<{ name: string; result: "PASS" | "FAIL" | "SKIP" }> =
+  [];
+
+function logTest(
+  name: string,
+  status: "PASS" | "FAIL" | "SKIP",
+  details?: string,
+): void {
+  const icon = status === "PASS" ? "✅" : status === "FAIL" ? "❌" : "⏭️";
+  const color: ColorName =
+    status === "PASS" ? "green" : status === "FAIL" ? "red" : "yellow";
+  log(`${icon} ${name}`, color);
+  if (details) {
+    log(`   ${details}`);
+  }
+  testResults.push({ name, result: status });
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+async function runTest(name: string, fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+    logTest(name, "PASS");
+  } catch (error) {
+    logTest(
+      name,
+      "FAIL",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+// ============================================================
+// FIXTURES
+// ============================================================
+
+const SEED_SKILLS = [
+  {
+    id: "skill-refund",
+    name: "refund_dispute_escalation",
+    displayName: "Refund Dispute Escalation",
+    description:
+      "How to escalate a disputed refund to the payments on-call team.",
+    instructions:
+      "1. Collect the transaction id.\n2. Verify the dispute in the dashboard.\n3. Page payments-oncall with severity P2.",
+    tags: ["payments", "escalation"],
+  },
+  {
+    id: "skill-deploy",
+    name: "service_deployment",
+    displayName: "Service Deployment",
+    description: "Standard operating procedure for deploying a service.",
+    instructions:
+      "1. Run the pre-deploy checklist.\n2. Deploy to staging.\n3. Smoke test.\n4. Promote to production.",
+    tags: ["devops"],
+  },
+  {
+    id: "skill-channel-only",
+    name: "team_alpha_standup",
+    description: "Standup format used only by team alpha.",
+    instructions: "Post yesterday/today/blockers in the alpha channel thread.",
+    tags: ["process"],
+    scope: "scoped" as const,
+    scopeIds: ["team-alpha"],
+  },
+];
+
+function makeSkillsInstance(
+  overrides: Record<string, unknown> = {},
+): NeuroLink {
+  return new NeuroLink({
+    skills: {
+      enabled: true,
+      storage: { type: "memory", skills: SEED_SKILLS },
+      ...overrides,
+    },
+  });
+}
+
+// ============================================================
+// TESTS — tool registration
+// ============================================================
+
+async function testToolRegistration(): Promise<void> {
+  await runTest(
+    "1. search_skills + list_skills registered when enabled",
+    async () => {
+      const nl = makeSkillsInstance();
+      const tools = nl.getCustomTools();
+      assert(tools.has("search_skills"), "search_skills missing");
+      assert(tools.has("list_skills"), "list_skills missing");
+      assert(
+        !tools.has("skill_create"),
+        "skill_create must be gated off by default",
+      );
+      assert(
+        !tools.has("skill_update"),
+        "skill_update must be gated off by default",
+      );
+      assert(
+        !tools.has("skill_delete"),
+        "skill_delete must be gated off by default",
+      );
+    },
+  );
+
+  await runTest("2. No skill tools when skills not configured", async () => {
+    const nl = new NeuroLink();
+    const tools = nl.getCustomTools();
+    assert(!tools.has("search_skills"), "search_skills must not be registered");
+    assert(!tools.has("list_skills"), "list_skills must not be registered");
+  });
+
+  await runTest(
+    "3. Mutation tools registered with allowMutations",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const tools = nl.getCustomTools();
+      assert(tools.has("skill_create"), "skill_create missing");
+      assert(tools.has("skill_update"), "skill_update missing");
+      assert(tools.has("skill_delete"), "skill_delete missing");
+    },
+  );
+}
+
+// ============================================================
+// TESTS — search semantics through the registered tool
+// ============================================================
+
+type ToolExecute = (params: unknown, ctx?: unknown) => Promise<unknown>;
+
+function getToolExecute(nl: NeuroLink, name: string): ToolExecute {
+  const tool = nl.getCustomTools().get(name);
+  assert(tool, `${name} not registered`);
+  return tool.execute as ToolExecute;
+}
+
+async function testSearchTool(): Promise<void> {
+  await runTest(
+    "4. search_skills returns hydrated match with instructions",
+    async () => {
+      const nl = makeSkillsInstance();
+      const execute = getToolExecute(nl, "search_skills");
+      const result = (await execute({ query: "refund" })) as {
+        success: boolean;
+        data: { skills: Array<{ name: string; instructions: string }> };
+      };
+      assert(result.success, "expected success");
+      assert(
+        result.data.skills.length === 1,
+        `expected 1 match, got ${result.data.skills.length}`,
+      );
+      assert(
+        result.data.skills[0].name === "refund_dispute_escalation",
+        "wrong skill matched",
+      );
+      assert(
+        result.data.skills[0].instructions.includes("payments-oncall"),
+        "instructions not hydrated",
+      );
+    },
+  );
+
+  await runTest("5. search_skills no_match is success, not error", async () => {
+    const nl = makeSkillsInstance();
+    const execute = getToolExecute(nl, "search_skills");
+    const result = (await execute({ query: "quantum-chromodynamics" })) as {
+      success: boolean;
+      data: { skills: unknown[]; reason?: string };
+    };
+    assert(result.success, "no_match must be success:true");
+    assert(result.data.reason === "no_match", "expected reason=no_match");
+    assert(result.data.skills.length === 0, "expected empty skills");
+  });
+
+  await runTest("6. search_skills requires query or tag", async () => {
+    const nl = makeSkillsInstance();
+    const execute = getToolExecute(nl, "search_skills");
+    const result = (await execute({})) as { success: boolean; error?: string };
+    assert(!result.success, "parameterless call must fail");
+    assert(
+      (result.error ?? "").includes("query"),
+      "error should mention required params",
+    );
+  });
+
+  await runTest("7. tag filter applies on top of query", async () => {
+    const nl = makeSkillsInstance();
+    const execute = getToolExecute(nl, "search_skills");
+    // "procedure"/"deploy" matches service_deployment; wrong tag excludes it
+    const result = (await execute({ query: "deploy", tag: "payments" })) as {
+      success: boolean;
+      data: { skills: unknown[]; reason?: string };
+    };
+    assert(result.success, "expected success");
+    assert(result.data.reason === "no_match", "wrong tag must exclude match");
+  });
+
+  await runTest(
+    "8. scoped skills excluded for other scopes, included for own",
+    async () => {
+      const nl = makeSkillsInstance();
+      const execute = getToolExecute(nl, "search_skills");
+      const foreign = (await execute({
+        query: "standup",
+        scopeId: "team-beta",
+      })) as { data: { skills: unknown[] } };
+      assert(
+        foreign.data.skills.length === 0,
+        "scoped skill leaked into foreign scope",
+      );
+      const own = (await execute({
+        query: "standup",
+        scopeId: "team-alpha",
+      })) as { data: { skills: Array<{ name: string }> } };
+      assert(
+        own.data.skills.length === 1 &&
+          own.data.skills[0].name === "team_alpha_standup",
+        "scoped skill missing in own scope",
+      );
+    },
+  );
+
+  await runTest(
+    "9. list_skills returns index without instructions",
+    async () => {
+      const nl = makeSkillsInstance();
+      const execute = getToolExecute(nl, "list_skills");
+      const result = (await execute({})) as {
+        success: boolean;
+        data: { skills: Array<Record<string, unknown>>; count: number };
+      };
+      assert(result.success, "expected success");
+      assert(
+        result.data.count === 3,
+        `expected 3 skills, got ${result.data.count}`,
+      );
+      assert(
+        result.data.skills.every((s) => !("instructions" in s)),
+        "list_skills must not include instructions",
+      );
+    },
+  );
+
+  await runTest("10. maxMatches caps hydrated results", async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      id: `bulk-${i}`,
+      name: `bulk_skill_${i}`,
+      description: "A bulk generated skill for capping tests.",
+      instructions: `Instructions ${i}`,
+    }));
+    const nl = new NeuroLink({
+      skills: {
+        enabled: true,
+        storage: { type: "memory", skills: many },
+        maxMatches: 3,
+      },
+    });
+    const execute = getToolExecute(nl, "search_skills");
+    const result = (await execute({ query: "bulk" })) as {
+      data: { skills: unknown[] };
+    };
+    assert(
+      result.data.skills.length === 3,
+      `expected 3 (maxMatches), got ${result.data.skills.length}`,
+    );
+  });
+}
+
+// ============================================================
+// TESTS — filesystem store
+// ============================================================
+
+async function testFilesystemStore(): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-skills-"));
+
+  // Layout 1: JSON skill
+  fs.writeFileSync(
+    path.join(dir, "json-skill.json"),
+    JSON.stringify({
+      id: "json-skill",
+      name: "incident_postmortem",
+      description: "How to write an incident postmortem.",
+      instructions: "Use the 5-whys template and file within 48 hours.",
+      tags: ["process"],
+    }),
+  );
+  // Layout 2: frontmatter markdown
+  fs.writeFileSync(
+    path.join(dir, "oncall_handover.md"),
+    [
+      "---",
+      "name: oncall_handover",
+      "description: Checklist for handing over the on-call shift.",
+      "tags:",
+      "  - devops",
+      "  - oncall",
+      "---",
+      "1. Summarize open incidents.",
+      "2. Hand over the pager.",
+    ].join("\n"),
+  );
+  // Layout 3: Claude-skills directory
+  fs.mkdirSync(path.join(dir, "release-notes"));
+  fs.writeFileSync(
+    path.join(dir, "release-notes", "SKILL.md"),
+    [
+      "---",
+      "name: release_notes",
+      "description: How to draft weekly release notes.",
+      "---",
+      "Collect merged PRs and group by feature area.",
+    ].join("\n"),
+  );
+
+  await runTest(
+    "11. Filesystem store loads JSON + .md + SKILL.md layouts",
+    async () => {
+      const nl = new NeuroLink({
+        skills: { enabled: true, storage: { type: "filesystem", path: dir } },
+      });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const index = await manager.list();
+      const names = index.map((i) => i.name).sort();
+      assert(
+        JSON.stringify(names) ===
+          JSON.stringify([
+            "incident_postmortem",
+            "oncall_handover",
+            "release_notes",
+          ]),
+        `unexpected index: ${names.join(", ")}`,
+      );
+      const md = await manager.get("oncall_handover");
+      assert(
+        md?.instructions.includes("Hand over the pager"),
+        "markdown body must become instructions",
+      );
+      assert(
+        (md?.tags ?? []).includes("oncall"),
+        "frontmatter tags must be parsed",
+      );
+    },
+  );
+
+  await runTest(
+    "12. Filesystem store: malformed file skipped, rest loads",
+    async () => {
+      fs.writeFileSync(path.join(dir, "broken.json"), "{not json");
+      const nl = new NeuroLink({
+        skills: {
+          enabled: true,
+          storage: { type: "filesystem", path: dir },
+          indexCacheTtlMs: 0,
+        },
+      });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const index = await manager.list();
+      assert(
+        index.length === 3,
+        `expected 3 valid skills, got ${index.length}`,
+      );
+    },
+  );
+
+  await runTest(
+    "13. Filesystem store: mutation writes JSON and survives reload",
+    async () => {
+      const nl = new NeuroLink({
+        skills: {
+          enabled: true,
+          storage: { type: "filesystem", path: dir },
+          indexCacheTtlMs: 0,
+        },
+      });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const { skill } = await manager.requestMutation({
+        type: "create",
+        skill: {
+          name: "written_skill",
+          description: "Created through the mutation path.",
+          instructions: "Persist me.",
+        },
+      });
+      assert(skill, "create returned no skill");
+      assert(
+        fs.existsSync(path.join(dir, `${skill.id}.json`)),
+        "JSON file not written",
+      );
+      // Fresh instance — reload from disk
+      const nl2 = new NeuroLink({
+        skills: { enabled: true, storage: { type: "filesystem", path: dir } },
+      });
+      const reloaded = await nl2.getSkillsManager()?.get("written_skill");
+      assert(
+        reloaded?.instructions === "Persist me.",
+        "skill did not survive reload",
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — custom store
+// ============================================================
+
+async function testCustomStore(): Promise<void> {
+  await runTest(
+    "14. Custom store plugs in (curator-style adapter)",
+    async () => {
+      const backing = new Map<string, (typeof SEED_SKILLS)[number]>();
+      backing.set(SEED_SKILLS[0].id, SEED_SKILLS[0]);
+      const calls: string[] = [];
+      const nl = new NeuroLink({
+        skills: {
+          enabled: true,
+          storage: {
+            type: "custom",
+            store: {
+              async get(id: string) {
+                calls.push(`get:${id}`);
+                return backing.get(id) ?? null;
+              },
+              async put() {},
+              async delete() {},
+              async index() {
+                calls.push("index");
+                return Array.from(backing.values()).map(
+                  ({ instructions: _i, ...rest }) => rest,
+                );
+              },
+            },
+          },
+        },
+      });
+      const execute = getToolExecute(nl, "search_skills");
+      const result = (await execute({ query: "refund" })) as {
+        data: { skills: Array<{ instructions: string }> };
+      };
+      assert(result.data.skills.length === 1, "custom store match failed");
+      assert(calls.includes("index"), "index() not called");
+      assert(
+        calls.includes("get:skill-refund"),
+        "get() not called for hydration",
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — prompt index
+// ============================================================
+
+async function testPromptIndex(): Promise<void> {
+  await runTest(
+    "15. buildPromptIndex: names+descriptions, no instructions",
+    async () => {
+      const nl = makeSkillsInstance();
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const block = await manager.buildPromptIndex();
+      assert(block, "expected a prompt block");
+      assert(block.includes("## Available Skills"), "missing header");
+      assert(block.includes("refund_dispute_escalation"), "missing skill name");
+      assert(block.includes("search_skills"), "missing tool guidance");
+      assert(
+        !block.includes("payments-oncall"),
+        "instructions leaked into prompt index",
+      );
+    },
+  );
+
+  await runTest(
+    "16. applySkillsPromptIndex appends to systemPrompt",
+    async () => {
+      const nl = makeSkillsInstance();
+      // Private at the TS level only — dist is plain JS. Reaching in keeps this
+      // a no-API test of the exact injection path generate()/stream() use.
+      const apply = (
+        nl as unknown as {
+          applySkillsPromptIndex: (o: Record<string, unknown>) => Promise<void>;
+        }
+      ).applySkillsPromptIndex.bind(nl);
+
+      const options: Record<string, unknown> = {
+        systemPrompt: "You are Tara.",
+      };
+      await apply(options);
+      const prompt = options.systemPrompt as string;
+      assert(prompt.startsWith("You are Tara."), "base prompt lost");
+      assert(prompt.includes("## Available Skills"), "index not appended");
+
+      // Per-call disable
+      const disabled: Record<string, unknown> = {
+        systemPrompt: "base",
+        skills: { enabled: false },
+      };
+      await apply(disabled);
+      assert(disabled.systemPrompt === "base", "per-call disable ignored");
+
+      // promptIndex=false per call
+      const noIndex: Record<string, unknown> = {
+        systemPrompt: "base",
+        skills: { promptIndex: false },
+      };
+      await apply(noIndex);
+      assert(
+        noIndex.systemPrompt === "base",
+        "per-call promptIndex=false ignored",
+      );
+
+      // Media-only mode skipped
+      const media: Record<string, unknown> = {
+        systemPrompt: "base",
+        output: { mode: "video" },
+      };
+      await apply(media);
+      assert(media.systemPrompt === "base", "media mode must skip injection");
+
+      // Scope filter narrows the block
+      const scoped: Record<string, unknown> = {
+        systemPrompt: "",
+        skills: { scopeId: "team-beta" },
+      };
+      await apply(scoped);
+      assert(
+        !(scoped.systemPrompt as string).includes("team_alpha_standup"),
+        "foreign-scope skill leaked into prompt index",
+      );
+    },
+  );
+
+  await runTest(
+    "17. Instance promptIndex=false disables injection",
+    async () => {
+      const nl = makeSkillsInstance({ promptIndex: false });
+      const apply = (
+        nl as unknown as {
+          applySkillsPromptIndex: (o: Record<string, unknown>) => Promise<void>;
+        }
+      ).applySkillsPromptIndex.bind(nl);
+      const options: Record<string, unknown> = { systemPrompt: "base" };
+      await apply(options);
+      assert(options.systemPrompt === "base", "instance-level disable ignored");
+    },
+  );
+}
+
+// ============================================================
+// TESTS — mutations
+// ============================================================
+
+async function testMutations(): Promise<void> {
+  await runTest(
+    "18. skill_create applies directly without a hook",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const execute = getToolExecute(nl, "skill_create");
+      const result = (await execute({
+        name: "new_skill",
+        description: "A new skill.",
+        instructions: "Do the new thing.",
+      })) as { success: boolean; data?: { status: string; skillId?: string } };
+      assert(result.success, "create failed");
+      assert(result.data?.status === "applied", "expected applied");
+      const found = await nl.getSkillsManager()?.get("new_skill");
+      assert(found?.instructions === "Do the new thing.", "skill not stored");
+    },
+  );
+
+  await runTest("19. onMutationRequest reject blocks the write", async () => {
+    const nl = makeSkillsInstance({
+      allowMutations: true,
+      onMutationRequest: async () => ({
+        outcome: "rejected" as const,
+        reason: "needs approver",
+      }),
+    });
+    const execute = getToolExecute(nl, "skill_create");
+    const result = (await execute({
+      name: "blocked_skill",
+      description: "Should never be written.",
+      instructions: "Nope.",
+    })) as { success: boolean; error?: string };
+    assert(!result.success, "rejected mutation must fail");
+    assert(
+      (result.error ?? "").includes("needs approver"),
+      "reject reason not surfaced",
+    );
+    const found = await nl.getSkillsManager()?.get("blocked_skill");
+    assert(!found, "rejected skill must not be stored");
+  });
+
+  await runTest(
+    "20. onMutationRequest pending defers the write (maker-checker)",
+    async () => {
+      const pendingActions: unknown[] = [];
+      const nl = makeSkillsInstance({
+        allowMutations: true,
+        onMutationRequest: async (action: unknown) => {
+          pendingActions.push(action);
+          return { outcome: "pending" as const, reference: "APPROVAL-42" };
+        },
+      });
+      const execute = getToolExecute(nl, "skill_create");
+      const result = (await execute({
+        name: "pending_skill",
+        description: "Waits for approval.",
+        instructions: "Later.",
+      })) as {
+        success: boolean;
+        data?: { status: string; reference?: string };
+      };
+      assert(result.success, "pending must be success");
+      assert(
+        result.data?.status === "pending_approval",
+        "expected pending_approval",
+      );
+      assert(
+        result.data?.reference === "APPROVAL-42",
+        "reference not surfaced",
+      );
+      assert(pendingActions.length === 1, "hook not invoked");
+      const found = await nl.getSkillsManager()?.get("pending_skill");
+      assert(!found, "pending skill must not be stored yet");
+    },
+  );
+
+  await runTest("21. skill_update bumps version, patch merges", async () => {
+    const nl = makeSkillsInstance({ allowMutations: true });
+    const execute = getToolExecute(nl, "skill_update");
+    const result = (await execute({
+      skillId: "skill-deploy",
+      description: "Updated SOP for deploying a service.",
+    })) as { success: boolean; data?: { version?: number } };
+    assert(result.success, "update failed");
+    assert(
+      result.data?.version === 2,
+      `expected version 2, got ${result.data?.version}`,
+    );
+    const updated = await nl.getSkillsManager()?.get("skill-deploy");
+    assert(
+      updated?.description === "Updated SOP for deploying a service.",
+      "patch not applied",
+    );
+    assert(
+      updated?.instructions.includes("pre-deploy checklist"),
+      "unpatched field lost",
+    );
+  });
+
+  await runTest(
+    "22. skill_delete soft-deletes; skill drops from search/list",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const del = getToolExecute(nl, "skill_delete");
+      const result = (await del({ skillId: "skill-refund" })) as {
+        success: boolean;
+      };
+      assert(result.success, "delete failed");
+      const search = getToolExecute(nl, "search_skills");
+      const after = (await search({ query: "refund" })) as {
+        data: { skills: unknown[]; reason?: string };
+      };
+      assert(
+        after.data.reason === "no_match",
+        "deprecated skill still matches",
+      );
+      const list = getToolExecute(nl, "list_skills");
+      const listed = (await list({})) as { data: { count: number } };
+      assert(listed.data.count === 2, "deprecated skill still listed");
+    },
+  );
+
+  await runTest(
+    "22c. get() by name resolves the active skill after soft-delete + same-name recreate (integrity)",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const del = getToolExecute(nl, "skill_delete");
+      const create = getToolExecute(nl, "skill_create");
+      // Soft-delete skill-refund (name "REFUND_dispute_escalation"), then create
+      // a new active skill reusing that exact name — allowed, since the clash
+      // check only guards active skills. Both entries now share the name.
+      await del({ skillId: "skill-refund" });
+      const created = (await create({
+        name: "REFUND_dispute_escalation",
+        description: "Fresh active version of the refund SOP.",
+        instructions: "NEW refund handling instructions.",
+      })) as { success: boolean };
+      assert(created.success, "recreate with the reused name should succeed");
+      // Name resolution must be deterministic: the ACTIVE skill, never the stale
+      // deprecated one (which a bare index.find would non-deterministically hit).
+      const resolved = await nl
+        .getSkillsManager()
+        ?.get("REFUND_dispute_escalation");
+      assert(
+        resolved?.status === "active" &&
+          resolved?.instructions === "NEW refund handling instructions.",
+        `get(name) must resolve the active skill, got status=${resolved?.status}`,
+      );
+    },
+  );
+
+  await runTest("23. Duplicate active name rejected on create", async () => {
+    const nl = makeSkillsInstance({ allowMutations: true });
+    const execute = getToolExecute(nl, "skill_create");
+    const result = (await execute({
+      name: "REFUND_dispute_escalation",
+      description: "Case-insensitive clash.",
+      instructions: "Should clash.",
+    })) as { success: boolean; error?: string };
+    assert(!result.success, "duplicate name must be rejected");
+    assert(
+      (result.error ?? "").includes("already exists"),
+      "clash error not surfaced",
+    );
+  });
+
+  await runTest(
+    "23b. Case-only rename does not self-clash; scoped update without scopeIds rejected",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+
+      // Case-only rename of the same skill must be allowed (no self-clash).
+      const renamed = await manager.requestMutation({
+        type: "update",
+        skillId: "skill-deploy",
+        patch: { name: "Service_Deployment" },
+      });
+      assert(
+        renamed.skill?.name === "Service_Deployment",
+        "case-only rename was blocked by self-clash",
+      );
+
+      // Update that flips scope to "scoped" without scopeIds must be rejected
+      // post-merge (would create an unmatchable skill).
+      let rejected = false;
+      try {
+        await manager.requestMutation({
+          type: "update",
+          skillId: "skill-refund",
+          patch: { scope: "scoped" },
+        });
+      } catch (error) {
+        rejected = (error as Error).message.includes("scopeIds");
+      }
+      assert(rejected, "scoped-without-scopeIds update must be rejected");
+
+      // Same guard on create through the manager (covers server POST path).
+      let createRejected = false;
+      try {
+        await manager.requestMutation({
+          type: "create",
+          skill: {
+            name: "unmatchable_skill",
+            description: "Scoped with no scope ids.",
+            instructions: "Never matchable.",
+            scope: "scoped",
+          },
+        });
+      } catch (error) {
+        createRejected = (error as Error).message.includes("scopeIds");
+      }
+      assert(createRejected, "scoped-without-scopeIds create must be rejected");
+    },
+  );
+
+  await runTest(
+    "23c. Concurrent same-name creates are serialized (single winner)",
+    async () => {
+      const nl = makeSkillsInstance({ allowMutations: true });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const attempts = await Promise.allSettled(
+        Array.from({ length: 5 }, (_, i) =>
+          manager.requestMutation({
+            type: "create",
+            skill: {
+              name: "raced_skill",
+              description: `Racer ${i}.`,
+              instructions: "First one wins.",
+            },
+          }),
+        ),
+      );
+      const winners = attempts.filter((a) => a.status === "fulfilled");
+      assert(
+        winners.length === 1,
+        `expected exactly 1 winner, got ${winners.length}`,
+      );
+      const index = await manager.list();
+      const copies = index.filter((s) => s.name === "raced_skill");
+      assert(
+        copies.length === 1,
+        `expected 1 stored copy, got ${copies.length}`,
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — S3 store (hermetic via injected object ops)
+// ============================================================
+
+function makeStubS3(seed?: Record<string, string>) {
+  const objects = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    objects,
+    ops: {
+      async getObject(key: string) {
+        return objects.get(key) ?? null;
+      },
+      async putObject(key: string, body: string) {
+        objects.set(key, body);
+      },
+      async deleteObject(key: string) {
+        objects.delete(key);
+      },
+      async listKeys(prefix: string) {
+        return [...objects.keys()].filter((k) => k.startsWith(prefix));
+      },
+    },
+  };
+}
+
+async function testS3Store(): Promise<void> {
+  await runTest(
+    "25. S3 store: put/get/delete + index.json upsert",
+    async () => {
+      const stub = makeStubS3();
+      const store = new S3SkillStore(
+        { type: "s3", bucket: "test-bucket", prefix: "tara/" },
+        stub.ops,
+      );
+      await store.put(SEED_SKILLS[0]);
+      await store.put(SEED_SKILLS[1]);
+
+      assert(
+        stub.objects.has("tara/skills/skill-refund.json"),
+        "skill object not written under prefix",
+      );
+      const index = JSON.parse(stub.objects.get("tara/index.json") ?? "{}");
+      assert(index.skills?.length === 2, "index.json not upserted");
+      assert(
+        index.skills.every(
+          (s: Record<string, unknown>) => !("instructions" in s),
+        ),
+        "index.json must not contain instructions",
+      );
+
+      const fetched = await store.get("skill-refund");
+      assert(
+        fetched?.instructions.includes("payments-oncall"),
+        "get() did not round-trip",
+      );
+
+      await store.delete("skill-refund");
+      assert(
+        !stub.objects.has("tara/skills/skill-refund.json"),
+        "delete() left the object",
+      );
+      const afterDelete = await store.index();
+      assert(afterDelete.length === 1, "index not updated after delete");
+    },
+  );
+
+  await runTest(
+    "26. S3 store: corrupt index.json self-heals from listing",
+    async () => {
+      const stub = makeStubS3({
+        "tara/index.json": "{corrupt",
+        "tara/skills/skill-a.json": JSON.stringify(SEED_SKILLS[0]),
+        "tara/skills/skill-b.json": JSON.stringify(SEED_SKILLS[1]),
+        "tara/skills/garbage.json": "not-json",
+      });
+      const store = new S3SkillStore(
+        { type: "s3", bucket: "test-bucket", prefix: "tara/" },
+        stub.ops,
+      );
+      const index = await store.index();
+      assert(
+        index.length === 2,
+        `rebuild expected 2 skills, got ${index.length}`,
+      );
+      const persisted = JSON.parse(stub.objects.get("tara/index.json") ?? "{}");
+      assert(
+        persisted.skills?.length === 2,
+        "rebuilt index.json not persisted back",
+      );
+    },
+  );
+
+  await runTest(
+    "27. S3 via factory with unusable SDK/config fails openly",
+    async () => {
+      // Depending on the runner, @aws-sdk/client-s3 is either not resolvable
+      // (error tells the user to install it) or resolvable but unconfigured
+      // (e.g. "Region is missing"). Either way the contract is the same:
+      // the tool returns a success:false envelope with a real error message
+      // and never throws into the generate/stream path.
+      const nl = new NeuroLink({
+        skills: {
+          enabled: true,
+          storage: { type: "s3", bucket: "no-sdk-installed" },
+        },
+      });
+      const execute = getToolExecute(nl, "search_skills");
+      const result = (await execute({ query: "anything" })) as {
+        success: boolean;
+        error?: string;
+      };
+      assert(!result.success, "expected tool-level error envelope");
+      assert(
+        (result.error ?? "").length > 0,
+        "error message must be surfaced to the model",
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — Redis store (SKIPs when Redis is unreachable)
+// ============================================================
+
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+async function testRedisStore(): Promise<void> {
+  const name = "28. Redis store: round-trip + index via SCAN";
+  const keyPrefix = `neurolink:test:skills:${Date.now().toString(36)}:`;
+  const store = new RedisSkillStore({ type: "redis", keyPrefix });
+  try {
+    await withDeadline(store.put(SEED_SKILLS[0]), 5000);
+  } catch (error) {
+    logTest(
+      name,
+      "SKIP",
+      `Redis unreachable: ${error instanceof Error ? error.message.slice(0, 100) : error}`,
+    );
+    return;
+  }
+
+  try {
+    await store.put(SEED_SKILLS[1]);
+    const fetched = await store.get("skill-refund");
+    assert(
+      fetched?.instructions.includes("payments-oncall"),
+      "get() did not round-trip",
+    );
+    const index = await store.index();
+    assert(index.length === 2, `index expected 2, got ${index.length}`);
+    assert(
+      index.every((s) => !("instructions" in s)),
+      "index must strip instructions",
+    );
+
+    // Full path through NeuroLink config + built-in tool
+    const nl = new NeuroLink({
+      skills: {
+        enabled: true,
+        storage: { type: "redis", keyPrefix },
+        indexCacheTtlMs: 0,
+      },
+    });
+    const execute = getToolExecute(nl, "search_skills");
+    const result = (await execute({ query: "refund" })) as {
+      data: { skills: Array<{ name: string }> };
+    };
+    assert(
+      result.data.skills[0]?.name === "refund_dispute_escalation",
+      "tool search through redis store failed",
+    );
+
+    await store.delete("skill-refund");
+    await store.delete("skill-deploy");
+    const after = await store.index();
+    assert(after.length === 0, "cleanup delete failed");
+    logTest(name, "PASS");
+  } catch (error) {
+    logTest(
+      name,
+      "FAIL",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+// ============================================================
+// TESTS — CLI (spawns the built CLI against a temp skills dir)
+// ============================================================
+
+function runCli(
+  args: string[],
+  timeoutMs = 60_000,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [path.join(REPO_ROOT, "dist", "cli", "index.js"), ...args],
+      { cwd: REPO_ROOT, env: { ...process.env, NO_COLOR: "1" } },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += String(d)));
+    child.stderr.on("data", (d) => (stderr += String(d)));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`CLI timed out: ${args.join(" ")}`));
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+function extractJson(stdout: string): unknown {
+  const start = stdout.indexOf("{");
+  const end = stdout.lastIndexOf("}");
+  assert(
+    start >= 0 && end > start,
+    `no JSON found in output: ${stdout.slice(0, 200)}`,
+  );
+  return JSON.parse(stdout.slice(start, end + 1));
+}
+
+async function testCli(): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-skills-cli-"));
+
+  await runTest(
+    "29. CLI: skills create → list → show → search → delete",
+    async () => {
+      const create = await runCli([
+        "skills",
+        "create",
+        "--skills-dir",
+        dir,
+        "--name",
+        "cli_test_skill",
+        "--description",
+        "A skill created from the CLI test suite.",
+        "--instructions",
+        "Step 1: exist. Step 2: be found.",
+        "--tags",
+        "testing",
+      ]);
+      assert(
+        create.code === 0,
+        `create exited ${create.code}: ${create.stderr.slice(0, 200)}`,
+      );
+
+      const list = await runCli([
+        "skills",
+        "list",
+        "--skills-dir",
+        dir,
+        "--format",
+        "json",
+      ]);
+      assert(list.code === 0, `list exited ${list.code}`);
+      const listed = extractJson(list.stdout) as {
+        skills: Array<{ name: string }>;
+        count: number;
+      };
+      assert(listed.count === 1, `expected 1 skill, got ${listed.count}`);
+      assert(listed.skills[0].name === "cli_test_skill", "wrong skill listed");
+
+      const show = await runCli([
+        "skills",
+        "show",
+        "cli_test_skill",
+        "--skills-dir",
+        dir,
+      ]);
+      assert(show.code === 0, `show exited ${show.code}`);
+      assert(
+        show.stdout.includes("Step 2: be found."),
+        "show must print full instructions",
+      );
+
+      const search = await runCli([
+        "skills",
+        "search",
+        "created from the CLI",
+        "--skills-dir",
+        dir,
+        "--format",
+        "json",
+      ]);
+      const found = extractJson(search.stdout) as { count: number };
+      assert(found.count === 1, "search did not match");
+
+      const del = await runCli([
+        "skills",
+        "delete",
+        "cli_test_skill",
+        "--skills-dir",
+        dir,
+      ]);
+      assert(del.code === 0, `delete exited ${del.code}`);
+
+      const after = await runCli([
+        "skills",
+        "list",
+        "--skills-dir",
+        dir,
+        "--format",
+        "json",
+      ]);
+      const remaining = extractJson(after.stdout) as { count: number };
+      assert(remaining.count === 0, "deleted skill still listed");
+    },
+  );
+
+  await runTest("30. CLI: generate --help documents --skills-dir", async () => {
+    const help = await runCli(["generate", "--help"]);
+    assert(help.code === 0, `help exited ${help.code}`);
+    assert(
+      help.stdout.includes("skills-dir"),
+      "--skills-dir missing from generate --help",
+    );
+  });
+}
+
+// ============================================================
+// TESTS — server routes (handler-level, no HTTP transport)
+// ============================================================
+
+type RouteHandler = (ctx: Record<string, unknown>) => Promise<unknown>;
+
+async function loadSkillsRoutes(): Promise<Map<string, RouteHandler>> {
+  const serverModule = (await import("../dist/server/index.js")) as {
+    createAgentRoutes: (basePath?: string) => {
+      routes: Array<{ method: string; path: string; handler: RouteHandler }>;
+    };
+  };
+  const group = serverModule.createAgentRoutes("/api");
+  const handlers = new Map<string, RouteHandler>();
+  for (const route of group.routes) {
+    if (route.path.includes("/agent/skills")) {
+      handlers.set(`${route.method} ${route.path}`, route.handler);
+    }
+  }
+  return handlers;
+}
+
+function makeServerCtx(
+  nl: NeuroLink,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    requestId: "test-req",
+    method: "GET",
+    path: "/api/agent/skills",
+    headers: {},
+    query: {},
+    params: {},
+    neurolink: nl,
+    toolRegistry: {},
+    timestamp: Date.now(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+async function testServerRoutes(): Promise<void> {
+  await runTest(
+    "31. Server: skills routes registered (5 endpoints)",
+    async () => {
+      const handlers = await loadSkillsRoutes();
+      for (const key of [
+        "GET /api/agent/skills",
+        "GET /api/agent/skills/:id",
+        "POST /api/agent/skills",
+        "PATCH /api/agent/skills/:id",
+        "DELETE /api/agent/skills/:id",
+      ]) {
+        assert(handlers.has(key), `missing route: ${key}`);
+      }
+    },
+  );
+
+  await runTest(
+    "32. Server: list → create → get → patch → delete flow",
+    async () => {
+      const handlers = await loadSkillsRoutes();
+      const nl = makeSkillsInstance({ allowMutations: true });
+
+      const listed = (await handlers.get("GET /api/agent/skills")!(
+        makeServerCtx(nl),
+      )) as { skills: unknown[]; count: number };
+      assert(listed.count === 3, `expected 3 skills, got ${listed.count}`);
+
+      const created = (await handlers.get("POST /api/agent/skills")!(
+        makeServerCtx(nl, {
+          method: "POST",
+          body: {
+            name: "http_created_skill",
+            description: "Created over the skills API.",
+            instructions: "Serve requests.",
+          },
+        }),
+      )) as { decision?: { outcome: string }; skill?: { id: string } };
+      assert(created.decision?.outcome === "approved", "create not applied");
+      assert(created.skill?.id, "created skill id missing");
+
+      const fetched = (await handlers.get("GET /api/agent/skills/:id")!(
+        makeServerCtx(nl, { params: { id: "http_created_skill" } }),
+      )) as { instructions?: string };
+      assert(
+        fetched.instructions === "Serve requests.",
+        "GET :id did not return instructions",
+      );
+
+      const patched = (await handlers.get("PATCH /api/agent/skills/:id")!(
+        makeServerCtx(nl, {
+          method: "PATCH",
+          params: { id: "http_created_skill" },
+          body: { description: "Updated over the skills API." },
+        }),
+      )) as { skill?: { version?: number } };
+      assert(patched.skill?.version === 2, "PATCH did not bump version");
+
+      const deleted = (await handlers.get("DELETE /api/agent/skills/:id")!(
+        makeServerCtx(nl, {
+          method: "DELETE",
+          params: { id: "http_created_skill" },
+        }),
+      )) as { skill?: { status?: string } };
+      assert(
+        deleted.skill?.status === "deprecated",
+        "DELETE did not deprecate",
+      );
+
+      const missing = (await handlers.get("GET /api/agent/skills/:id")!(
+        makeServerCtx(nl, { params: { id: "does-not-exist" } }),
+      )) as { error?: { code: string } };
+      assert(missing.error?.code === "NOT_FOUND", "missing skill must 404");
+    },
+  );
+
+  await runTest(
+    "32b. Server: mutation routes rejected when allowMutations is false",
+    async () => {
+      const handlers = await loadSkillsRoutes();
+      const nl = makeSkillsInstance(); // allowMutations defaults to false
+      const blocked = (await handlers.get("POST /api/agent/skills")!(
+        makeServerCtx(nl, {
+          method: "POST",
+          body: {
+            name: "blocked_skill",
+            description: "Should never be created over the API.",
+            instructions: "Blocked.",
+          },
+        }),
+      )) as { error?: { code: string } };
+      assert(
+        blocked.error?.code === "SKILLS_MUTATIONS_DISABLED",
+        "create must be rejected when allowMutations is false",
+      );
+      const listed = (await handlers.get("GET /api/agent/skills")!(
+        makeServerCtx(nl),
+      )) as { count: number };
+      assert(listed.count === 3, "blocked create must not have persisted");
+    },
+  );
+
+  await runTest(
+    "33. Server: 503 envelope when skills not configured",
+    async () => {
+      const handlers = await loadSkillsRoutes();
+      const nl = new NeuroLink();
+      const result = (await handlers.get("GET /api/agent/skills")!(
+        makeServerCtx(nl),
+      )) as { error?: { code: string } };
+      assert(
+        result.error?.code === "SKILLS_UNAVAILABLE",
+        "expected SKILLS_UNAVAILABLE",
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — live generate (requires provider credentials)
+// ============================================================
+
+async function testLiveGenerate(): Promise<void> {
+  const liveEnabled = process.env.SKILLS_SUITE_LIVE !== "false";
+  if (!liveEnabled) {
+    logTest(
+      "24. Live: model calls search_skills and follows it",
+      "SKIP",
+      "SKILLS_SUITE_LIVE=false",
+    );
+    return;
+  }
+
+  const nl = makeSkillsInstance();
+  try {
+    const result = await nl.generate({
+      input: {
+        text: "A customer's refund is disputed and I need to escalate. What are the exact steps? Use your skills.",
+      },
+      provider: TEST_PROVIDER,
+      maxSteps: 4,
+      timeout: 120_000,
+    });
+
+    const content = result.content ?? "";
+    const usedTool = JSON.stringify(result.toolExecutions ?? result).includes(
+      "search_skills",
+    );
+    const followedSkill =
+      content.includes("payments-oncall") ||
+      content.toLowerCase().includes("transaction id");
+
+    if (usedTool || followedSkill) {
+      logTest(
+        "24. Live: model calls search_skills and follows it",
+        "PASS",
+        `toolCalled=${usedTool} followedInstructions=${followedSkill}`,
+      );
+    } else {
+      logTest(
+        "24. Live: model calls search_skills and follows it",
+        "FAIL",
+        `Model neither called the tool nor followed instructions. Content: ${content.slice(0, 200)}`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logTest(
+      "24. Live: model calls search_skills and follows it",
+      "SKIP",
+      `Provider "${TEST_PROVIDER}" unavailable: ${message.slice(0, 160)}`,
+    );
+  }
+}
+
+// ============================================================
+// MAIN
+// ============================================================
+
+async function main(): Promise<void> {
+  log("\n============================================================", "cyan");
+  log("  NeuroLink Continuous Test Suite: SKILLS", "cyan");
+  log("============================================================\n", "cyan");
+
+  await testToolRegistration();
+  await testSearchTool();
+  await testFilesystemStore();
+  await testCustomStore();
+  await testPromptIndex();
+  await testMutations();
+  await testS3Store();
+  await testRedisStore();
+  await testCli();
+  await testServerRoutes();
+  await testLiveGenerate();
+
+  const pass = testResults.filter((r) => r.result === "PASS").length;
+  const fail = testResults.filter((r) => r.result === "FAIL").length;
+  const skip = testResults.filter((r) => r.result === "SKIP").length;
+
+  log("\n============================================================", "cyan");
+  log(
+    `  RESULTS: ${pass} passed, ${fail} failed, ${skip} skipped (of ${testResults.length})`,
+    fail > 0 ? "red" : "green",
+  );
+  log("============================================================\n", "cyan");
+
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  log(`Suite crashed: ${error instanceof Error ? error.stack : error}`, "red");
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a native **skills** subsystem to NeuroLink: versioned, discoverable instruction packs (SOPs/playbooks) with progressive disclosure — a compact name+description index is injected into the system prompt while full instructions load on demand via built-in tools. Ports curator's production-proven skills architecture into the SDK so hosts enable it with one config block instead of app code.

## What's included

- **Config**: `skills` option on the NeuroLink constructor (opt-in, fail-open reads / fail-closed writes) + per-call `skills` overrides on `generate()`/`stream()`
- **Built-in tools**: `search_skills` (index-first search, hydrates ≤ maxMatches matches), `list_skills`, and gated `skill_create/update/delete` routed through a host `onMutationRequest` approval gate (maker-checker compatible; soft deletes, version bumps)
- **Prompt index**: names+descriptions appended to the system prompt on both generate and stream paths (skipped for media-only modes; per-call disable)
- **Stores**: memory, filesystem (`<id>.json`, `<name>.md`, `<name>/SKILL.md` frontmatter layouts), **S3** (curator-compatible layout with self-healing `index.json`; optional `@aws-sdk/client-s3` peer, lazy-required like hippocampus), **Redis** (pooled core client, SCAN+MGET index, no TTL), and custom store plug-in
- **CLI**: `neurolink skills list|show|search|create|delete` + `--skills-dir` / `NEUROLINK_SKILLS_DIR` on generate/stream/batch/loop
- **Server**: `/api/agent/skills` CRUD routes (zod-validated, 503 `SKILLS_UNAVAILABLE` when unconfigured, auth identity wins over caller-supplied `requestedBy`)
- **Docs**: `docs/features/skills.md`; **Types**: `src/lib/types/skills.ts` per repo type rules

## Testing

- New suite `pnpm run test:skills` (test/continuous-test-suite-skills.ts): **33/33 passing, 0 skipped** — stores (incl. S3 via injected ops + index self-heal, Redis round-trip against live Redis), search semantics, prompt injection, full mutation matrix, CLI subprocess E2E, server route handlers, and a live generate test where the model calls `search_skills` and follows the loaded instructions
- Regressions green: `test:mcp` 84/84, `test:mcp:limits` 24/24, `test:mcp:spans` 4/4
- `pnpm run check`, `pnpm run lint`, full `pnpm run build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native “Skills” support with prompt-index injection, searchable skill packs, and per-call controls for `generate()` and streaming.
  * Added built-in SDK tools to list/search skills, with optional create/update/delete skill management and soft-deletes.
  * Added CLI skills management (list/show/search/create/delete) and server endpoints for listing, retrieving, and mutating skills, including graceful unavailability and disabled-mutation handling.
  * Added skill storage backends: filesystem, in-memory, S3, and Redis.
* **Documentation**
  * Added a Skills documentation guide.
* **Tests**
  * Added a dedicated continuous end-to-end Skills test suite and a `test:skills` script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->