### PR TITLE
fix(vertex): in-loop context guard, consecutive tool-failure breaker, per-tool abort

### DIFF
--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -159,6 +159,8 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
   },
   anthropic: {
     _default: 200_000,
+    // Claude 5 (mid 2026) — 1M context window
+    "claude-sonnet-5": 1_000_000,
     // Claude 4.6 (Feb 2026) — 1M context window
     "claude-opus-4-6": 1_000_000,
     "claude-sonnet-4-6": 1_000_000,
@@ -248,6 +250,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
   vertex: {
     _default: 1_048_576,
     // Claude on Vertex
+    "claude-sonnet-5": 1_000_000,
     "claude-opus-4-6": 1_000_000,
     "claude-sonnet-4-6": 1_000_000,
     "claude-sonnet-4-5": 200_000,
@@ -257,6 +260,13 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
     "claude-sonnet-4-20250514": 200_000,
     "claude-opus-4-20250514": 200_000,
     "claude-opus-4": 200_000,
+    // Catch-all for UNKNOWN Claude models on Vertex (prefix match runs after
+    // the specific keys above). Without this, an unlisted Claude model falls
+    // to the Gemini-shaped _default (1,048,576) — ABOVE Anthropic's real 1M
+    // API cap — so the pre-dispatch budget check and the in-loop context
+    // guard both under-guard it (the claude-sonnet-5 1,005,647-token 400s).
+    // 200K is the conservative Anthropic floor; list real models explicitly.
+    "claude-": 200_000,
     // Gemini 3.1 on Vertex (all require -preview suffix)
     "gemini-3.1-pro-preview": 1_048_576,
     "gemini-3.1-flash-lite-preview": 1_048_576,

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -137,6 +137,24 @@ export const DEFAULT_TOOL_EXECUTION_TIMEOUT_MS = 300_000;
  */
 export const DEFAULT_WRAPUP_TIME_LEAD_MS = 120_000;
 
+/**
+ * In-loop context guard threshold for native agentic loops: when the last
+ * model call's actual prompt size (provider-reported usage) plus the
+ * estimated growth from this step's tool results crosses this fraction of
+ * the model's context window, the loop stops calling tools and synthesizes a
+ * final answer instead of stepping into a provider 400 ("prompt is too
+ * long") that would destroy the whole turn's work.
+ */
+export const DEFAULT_CONTEXT_GUARD_RATIO = 0.85;
+
+/**
+ * Floor for the turn budget handed to the post-overflow recovery retry.
+ * The retry inherits the REMAINING `turnTimeoutMs` (whole-turn semantics —
+ * one generate() must not stack two full budgets), but never less than this,
+ * so a compacted retry still gets a workable window.
+ */
+export const MIN_RECOVERY_TURN_BUDGET_MS = 30_000;
+
 // Fire-and-forget tool storage writes (Redis). 5s is generous for a single
 // Redis write; if breached, the .catch logs a warning.
 export const TOOL_STORAGE_TIMEOUT_MS = 5000;

--- a/src/lib/core/modules/ToolsManager.ts
+++ b/src/lib/core/modules/ToolsManager.ts
@@ -18,6 +18,56 @@ import type { NeuroLink } from "../../neurolink.js";
 import type { Tool } from "../../types/index.js";
 import { tool as createAISDKTool, jsonSchema } from "../../utils/tool.js";
 
+/** Abort-shaped error so provider loops route it to their cancellation path. */
+function makeToolAbortError(): Error {
+  const e = new Error("Tool execution aborted");
+  e.name = "AbortError";
+  return e;
+}
+
+/**
+ * Race a tool-execution promise against an AbortSignal so the calling loop
+ * observes a deadline/caller abort IMMEDIATELY instead of waiting for the
+ * tool to finish or its execution timeout to expire. The underlying call is
+ * not cancelled (bounded ghost execution — the same tradeoff as the tool
+ * timeout); real transport-level cancellation (executeExternalMCPTool → MCP
+ * client RequestOptions.signal) is tracked as a follow-up.
+ */
+function raceWithAbortSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    // Swallow the abandoned settlement so it can't become an unhandled
+    // rejection later.
+    promise.catch(() => {
+      // Swallow the abandoned settlement — it must never surface as an
+      // unhandled rejection after the race has already been decided.
+    });
+    return Promise.reject(makeToolAbortError());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      promise.catch(() => {
+        // Swallow the abandoned settlement — it must never surface as an
+        // unhandled rejection after the race has already been decided.
+      });
+      reject(makeToolAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 /**
  * ToolsManager class - Handles all tool management operations
  */
@@ -47,13 +97,31 @@ export class ToolsManager {
   /**
    * BZ-666: Wrap tool execute with output truncation to prevent
    * context overflow when large results flow into the AI SDK accumulator.
+   *
+   * Passes the AI-SDK second argument (execution options: abortSignal,
+   * toolCallId, messages) through to the inner execute — the native loops
+   * provide an abortSignal there, and dropping it at this wrapper made
+   * every tool uncancellable (deadline overshoot / ghost executions).
    */
   private wrapExecuteWithTruncation(
     toolName: string,
-    originalExecute: (params: unknown) => Promise<unknown>,
-  ): (params: unknown) => Promise<unknown> {
-    return async (params: unknown): Promise<unknown> => {
-      const result = await originalExecute(params);
+    originalExecute: (
+      params: unknown,
+      execOptions?: unknown,
+    ) => Promise<unknown>,
+  ): (params: unknown, execOptions?: unknown) => Promise<unknown> {
+    return async (params: unknown, execOptions?: unknown): Promise<unknown> => {
+      const signal = (execOptions as { abortSignal?: AbortSignal } | undefined)
+        ?.abortSignal;
+      const inner = originalExecute(params, execOptions);
+      // Inner executes that ignore the signal (external MCP / custom tools —
+      // the signal isn't plumbed to their transports yet) still return
+      // promptly on abort via the race; the loop's isAbortError handling
+      // treats the rejection as a cancellation, not a tool failure.
+      const result =
+        signal && typeof signal.addEventListener === "function"
+          ? await raceWithAbortSignal(inner, signal)
+          : await inner;
       return this.truncateToolResult(toolName, result);
     };
   }
@@ -323,7 +391,12 @@ export class ToolsManager {
         "execute" in directTool
       ) {
         const originalExecute = (
-          directTool as { execute: (params: unknown) => Promise<unknown> }
+          directTool as {
+            execute: (
+              params: unknown,
+              execOptions?: unknown,
+            ) => Promise<unknown>;
+          }
         ).execute;
 
         // Create a new tool with wrapped execute function (BZ-666/BZ-664 guards applied)
@@ -333,12 +406,12 @@ export class ToolsManager {
         );
         tools[toolName] = {
           ...(directTool as Tool),
-          execute: async (params: unknown) => {
+          execute: async (params: unknown, execOptions?: unknown) => {
             const startTime = Date.now();
             this.emitToolEvent("tool:start", toolName, { input: params });
 
             try {
-              const result = await guardedExecute(params);
+              const result = await guardedExecute(params, execOptions);
               this.emitToolEvent("tool:end", toolName, {
                 result,
                 success: true,
@@ -396,7 +469,9 @@ export class ToolsManager {
         if (tool && !tools[toolName]) {
           // BZ-666/BZ-664: Wrap custom tool execute with guards
           const origExec = (
-            tool as { execute?: (p: unknown) => Promise<unknown> }
+            tool as {
+              execute?: (p: unknown, o?: unknown) => Promise<unknown>;
+            }
           ).execute;
           if (origExec) {
             const guarded = this.wrapExecuteWithTruncation(toolName, origExec);
@@ -768,12 +843,12 @@ export class ToolsManager {
       return createAISDKTool<unknown, unknown>({
         description: tool.description || `External MCP tool ${tool.name}`,
         inputSchema: finalSchema, // AI SDK v6 uses inputSchema (not parameters)
-        execute: async (params: unknown) => {
+        execute: async (params: unknown, execOptions?: unknown) => {
           const startTime = Date.now();
           this.emitToolEvent("tool:start", tool.name, { input: params });
 
           try {
-            const result = await guardedExecute(params);
+            const result = await guardedExecute(params, execOptions);
             this.emitToolEvent("tool:end", tool.name, {
               result,
               success: true,

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -120,6 +120,7 @@ import { repairToolPairs } from "./context/toolPairRepair.js";
 import {
   SYSTEM_LIMITS,
   DEFAULT_TOOL_ROUTING_TIMEOUT_MS,
+  MIN_RECOVERY_TURN_BUDGET_MS,
 } from "./core/constants.js";
 import { ConversationMemoryManager } from "./core/conversationMemoryManager.js";
 import {
@@ -5809,6 +5810,7 @@ Current user's request: ${currentInput}`;
       options,
       context.functionTag,
       error,
+      context.generateInternalStartTime,
     );
     if (recoveredResult) {
       return recoveredResult;
@@ -5862,6 +5864,7 @@ Current user's request: ${currentInput}`;
     options: TextGenerationOptions,
     functionTag: string,
     error: unknown,
+    attemptStartTimeMs?: number,
   ): Promise<TextGenerationResult | null> {
     // Reviewer Finding #3: drop the `!this.conversationMemory` gate so
     // inline-conversationMessages callers also benefit from post-provider
@@ -6056,6 +6059,26 @@ Current user's request: ${currentInput}`;
         );
       }
 
+      // Whole-turn budget semantics: the retry inherits the REMAINING
+      // turnTimeoutMs, not a fresh clock — attempt 1 already spent part of
+      // the caller's budget, and a fresh clock let one generate() run ~2×
+      // the configured deadline (the 66-minute-turn incident shape).
+      // Floored so a compacted retry still gets a workable window — but the
+      // floor never exceeds the caller's own turnTimeoutMs (a 10s caller
+      // budget must not receive a 30s retry).
+      let retryTurnTimeoutMs = options.turnTimeoutMs;
+      if (
+        typeof options.turnTimeoutMs === "number" &&
+        Number.isFinite(options.turnTimeoutMs) &&
+        attemptStartTimeMs !== undefined
+      ) {
+        const elapsedMs = Date.now() - attemptStartTimeMs;
+        retryTurnTimeoutMs = Math.max(
+          options.turnTimeoutMs - elapsedMs,
+          Math.min(MIN_RECOVERY_TURN_BUDGET_MS, options.turnTimeoutMs),
+        );
+      }
+
       logger.info(
         `[${functionTag}] Smart recovery verified, retrying generation`,
         {
@@ -6064,12 +6087,16 @@ Current user's request: ${currentInput}`;
           verifiedTokens: verifiedBudget.estimatedInputTokens,
           verifiedBudget: verifiedBudget.availableInputTokens,
           recoveredFraction,
+          retryTurnTimeoutMs,
         },
       );
 
       return this.directProviderGeneration({
         ...options,
         conversationMessages: compactedMessages,
+        ...(retryTurnTimeoutMs !== undefined && {
+          turnTimeoutMs: retryTurnTimeoutMs,
+        }),
       } as TextGenerationOptions);
     } catch (retryError) {
       if (retryError instanceof ContextBudgetExceededError) {

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -13,6 +13,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { extname } from "node:path";
 import {
+  DEFAULT_CONTEXT_GUARD_RATIO,
   DEFAULT_MAX_STEPS,
   DEFAULT_TOOL_MAX_RETRIES,
   DEFAULT_WRAPUP_TIME_LEAD_MS,
@@ -1129,6 +1130,26 @@ export function buildToolLoopCapMessage(
   );
 }
 
+/**
+ * Honest message for a turn stopped by the in-loop context guard
+ * (stopReason "context-cap") without a synthesized answer. Sibling of
+ * {@link buildToolLoopCapMessage} — context exits must never claim a step
+ * limit was reached.
+ */
+export function buildContextCapMessage(toolCallCount: number): string {
+  const calls =
+    toolCallCount > 0
+      ? `I gathered information across ${toolCallCount} tool call${
+          toolCallCount === 1 ? "" : "s"
+        } but `
+      : "I ";
+  return (
+    `${calls}had to stop because the gathered material filled this turn's ` +
+    `context window before I could finish. Please narrow the request or ` +
+    `break it into smaller asks and I'll continue.`
+  );
+}
+
 /** Format an elapsed duration as "Xm Ys" (or "Ys" under a minute). */
 function formatElapsed(elapsedMs: number): string {
   const totalSeconds = Math.max(0, Math.round(elapsedMs / 1000));
@@ -1221,6 +1242,8 @@ export function resolveTurnStopReason(params: {
   wasAborted: boolean;
   /** Step budget ran out AND no clean/forced answer was produced. */
   cappedWithoutAnswer: boolean;
+  /** Context guard stopped the loop AND no clean/forced answer was produced. */
+  contextCappedWithoutAnswer?: boolean;
   /** The turn's resolved unified finishReason. */
   finishReason?: string;
 }): GenerateStopReason {
@@ -1232,6 +1255,9 @@ export function resolveTurnStopReason(params: {
   }
   if (params.wasAborted) {
     return "aborted";
+  }
+  if (params.contextCappedWithoutAnswer) {
+    return "context-cap";
   }
   if (params.cappedWithoutAnswer) {
     return "step-cap";
@@ -1348,6 +1374,67 @@ export function createTurnClock(params: {
       if (stallTimer) {
         clearInterval(stallTimer);
       }
+    },
+  };
+}
+
+/**
+ * In-loop context guard for native agentic turns.
+ *
+ * The provider reports the ACTUAL prompt size of every model call
+ * (usage.input_tokens + cache reads/writes on Anthropic;
+ * usageMetadata.promptTokenCount on Gemini). The guard tracks that number
+ * plus an estimate of what the current step appends (assistant output, tool
+ * results), and tells the loop to stop calling tools once the projected next
+ * prompt crosses `thresholdRatio` of the model's context window — the turn
+ * then synthesizes a final answer from what it has instead of stepping into
+ * a provider 400 ("prompt is too long") that destroys all completed work.
+ *
+ * Fail-open: until the first usage report arrives, `shouldStop()` is false.
+ */
+export function createContextGuard(
+  contextWindowTokens: number,
+  thresholdRatio: number = DEFAULT_CONTEXT_GUARD_RATIO,
+) {
+  const thresholdTokens = Math.floor(contextWindowTokens * thresholdRatio);
+  let observedPromptTokens = 0;
+  let projectedGrowthTokens = 0;
+  return {
+    /** Tokens at which the guard trips (ratio × window). */
+    get thresholdTokens(): number {
+      return thresholdTokens;
+    },
+    /** Last observed prompt size plus estimated growth since. */
+    get projectedNextPromptTokens(): number {
+      return observedPromptTokens + projectedGrowthTokens;
+    },
+    /**
+     * Record a model call's reported usage. `promptTokens` must be the FULL
+     * prompt size (uncached input + cache read + cache creation for
+     * Anthropic). The response's own output is counted as growth — it is
+     * appended to the conversation for the next call.
+     */
+    noteUsage(promptTokens: number, outputTokens: number): void {
+      if (promptTokens > 0) {
+        observedPromptTokens = promptTokens;
+        projectedGrowthTokens = Math.max(0, outputTokens);
+      }
+    },
+    /**
+     * Add growth for content appended since the last model call (tool
+     * results, nudge text) using the ~4 chars/token heuristic.
+     */
+    noteAppendedChars(chars: number): void {
+      if (chars > 0) {
+        projectedGrowthTokens += Math.ceil(chars / 4);
+      }
+    },
+    /** True when issuing another model call risks crossing the threshold. */
+    shouldStop(): boolean {
+      return (
+        observedPromptTokens > 0 &&
+        observedPromptTokens + projectedGrowthTokens >= thresholdTokens
+      );
     },
   };
 }

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -78,15 +78,21 @@ import {
   ensureNestedSchemaTypes,
 } from "../utils/schemaConversion.js";
 import { createNativeThinkingConfig } from "../utils/thinkingConfig.js";
-import { TimeoutError, withTimeout } from "../utils/async/index.js";
+import {
+  TimeoutError,
+  raceWithAbort,
+  withTimeout,
+} from "../utils/async/index.js";
 import { parseTimeout } from "../utils/timeout.js";
 import {
   appendStepText,
   buildAbortedTurnMessage,
+  buildContextCapMessage,
   buildToolLoopCapMessage,
   buildTurnStalledMessage,
   buildTurnTimeoutMessage,
   buildWrapupNudgeText,
+  createContextGuard,
   createTextChannel,
   createTurnClock,
   extractThoughtSignature,
@@ -95,6 +101,7 @@ import {
   prependConversationMessages,
   resolveTurnStopReason,
 } from "./googleNativeGemini3.js";
+import { getContextWindowSize } from "../constants/contextWindows.js";
 import {
   ATTR,
   LANGFUSE_ATTR,
@@ -113,7 +120,10 @@ import {
 import { calculateCost } from "../utils/pricing.js";
 import { transformToolExecutions } from "../utils/transformationUtils.js";
 import { sanitizeAnthropicMessagesForTrace } from "../utils/anthropicTraceSanitizer.js";
-import { extractMcpToolErrorMessage } from "../utils/mcpErrorText.js";
+import {
+  extractMcpToolErrorMessage,
+  extractToolFailureText,
+} from "../utils/mcpErrorText.js";
 import type { Schema, LanguageModel, Tool } from "../types/index.js";
 
 // Import proper types for multimodal message handling
@@ -1784,6 +1794,14 @@ export class GoogleVertexProvider extends BaseProvider {
     // Key: tool name, Value: { count: retry attempts, lastError: error message }
     const failedTools = new Map<string, { count: number; lastError: string }>();
 
+    // In-loop context guard: stop calling tools when the accumulated
+    // conversation approaches the model's context window instead of stepping
+    // into a provider "prompt too long" rejection mid-loop.
+    const contextGuard = createContextGuard(
+      getContextWindowSize("vertex", modelName),
+    );
+    let hitContextLimit = false;
+
     // Track token usage across all steps
     // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
     let totalInputTokens = 0;
@@ -1846,6 +1864,18 @@ export class GoogleVertexProvider extends BaseProvider {
       while (step < maxSteps) {
         if (effectiveSignal.aborted) {
           wasAborted = true;
+          break;
+        }
+        // Context guard: stop the tool loop before the accumulated
+        // conversation crosses the window threshold — synthesize from what
+        // we have instead of stepping into a provider rejection.
+        if (contextGuard.shouldStop()) {
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          );
           break;
         }
         step++;
@@ -1921,6 +1951,11 @@ export class GoogleVertexProvider extends BaseProvider {
                 usageMetadata.promptTokenCount > 0
               ) {
                 totalInputTokens = usageMetadata.promptTokenCount;
+                // Feed the context guard the REAL prompt size of this call.
+                contextGuard.noteUsage(
+                  usageMetadata.promptTokenCount,
+                  usageMetadata.candidatesTokenCount ?? 0,
+                );
               }
               // Take the latest candidatesTokenCount (accumulates through chunks)
               if (
@@ -2042,6 +2077,14 @@ export class GoogleVertexProvider extends BaseProvider {
           // Note: tool:start / tool:end events are emitted by ToolsManager's
           // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
           for (const call of stepFunctionCalls) {
+            // Honor a deadline/stall/caller abort BETWEEN tool executions —
+            // without this check a multi-tool step keeps executing its whole
+            // batch (up to N × toolTimeoutMs past the deadline) before the
+            // while-top check finally breaks.
+            if (effectiveSignal.aborted) {
+              wasAborted = true;
+              break;
+            }
             allToolCalls.push({ toolName: call.name, args: call.args });
             stepStorageCalls.push({ toolName: call.name, args: call.args });
 
@@ -2085,13 +2128,37 @@ export class GoogleVertexProvider extends BaseProvider {
                 };
                 turnClock.noteProgress();
                 // Bound the execute() await — a wedged tool costs one step
-                // (error tool_result), not the whole turn.
+                // (error tool_result), not the whole turn — and race it
+                // against the turn's abort so a deadline/caller abort is
+                // observed IMMEDIATELY instead of after the tool settles.
                 const result = await withTimeout(
-                  Promise.resolve(execute(call.args, toolOptions)),
+                  raceWithAbort(
+                    Promise.resolve(execute(call.args, toolOptions)),
+                    effectiveSignal,
+                  ),
                   toolExecTimeoutMs,
                   `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
                 );
                 turnClock.noteProgress();
+                // Error-shaped success (MCP isError / { error } payloads —
+                // e.g. proxy-blocked tools) counts toward the breaker too:
+                // these fail without throwing, and only counting throws lets
+                // the model grind on a blocked tool for the whole budget.
+                const resultErrorText = extractToolFailureText(result);
+                if (resultErrorText) {
+                  const info = failedTools.get(call.name) || {
+                    count: 0,
+                    lastError: "",
+                  };
+                  info.count++;
+                  info.lastError = resultErrorText;
+                  failedTools.set(call.name, info);
+                } else {
+                  // Genuinely consecutive: a success clears the strike count
+                  // (argument-dependent soft errors — file-not-found on
+                  // different paths — must not disable a working tool).
+                  failedTools.delete(call.name);
+                }
                 toolExecutions.push({
                   name: call.name,
                   input: call.args,
@@ -2170,12 +2237,23 @@ export class GoogleVertexProvider extends BaseProvider {
                 });
               }
             } else {
-              // Tool not found is a permanent error
+              // Tool not found is a permanent error. Count it toward the
+              // breaker too (parity with the Anthropic loops) — a model that
+              // ignores the do_not_retry hint and keeps calling a
+              // hallucinated/stale tool name must not burn the whole step
+              // budget on TOOL_NOT_FOUND round-trips.
               const errorPayload = {
                 error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
                 status: "permanently_failed",
                 do_not_retry: true,
               };
+              const notFoundInfo = failedTools.get(call.name) || {
+                count: 0,
+                lastError: "",
+              };
+              notFoundInfo.count++;
+              notFoundInfo.lastError = errorPayload.error;
+              failedTools.set(call.name, notFoundInfo);
               functionResponses.push({
                 functionResponse: {
                   name: call.name,
@@ -2255,6 +2333,16 @@ export class GoogleVertexProvider extends BaseProvider {
             role: "user",
             parts: functionResponses as unknown as Array<{ text: string }>,
           });
+          // Project this step's growth for the context guard: the appended
+          // tool results ride the next prompt (Gemini reports usage per call,
+          // but only for content it has already seen).
+          try {
+            contextGuard.noteAppendedChars(
+              JSON.stringify(functionResponses).length,
+            );
+          } catch {
+            /* estimation is best-effort — never break the loop */
+          }
         } catch (error) {
           // A mid-drain abort surfaces as an AbortError from the `for await`.
           // Break gracefully into the terminal block instead of re-throwing
@@ -2275,7 +2363,7 @@ export class GoogleVertexProvider extends BaseProvider {
       // cap was reached (or the turn was aborted) while the model was still
       // calling tools. Surface a real answer instead of the canned placeholder
       // (Bug 1) and a meaningful finishReason (Bug 2).
-      if (!finalText && (step >= maxSteps || wasAborted)) {
+      if (!finalText && (step >= maxSteps || wasAborted || hitContextLimit)) {
         hitStepLimit = step >= maxSteps && !wasAborted;
         const toolCallCount = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
@@ -2288,8 +2376,11 @@ export class GoogleVertexProvider extends BaseProvider {
         // the gathered chunks instead of collapsing to a single one.
         if (incrementalTextChunks.length > 0) {
           logger.warn(
-            `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
-              `returning text already gathered from prior steps.`,
+            hitContextLimit
+              ? `[GoogleVertex] Tool call loop stopped by the context guard; ` +
+                  `returning text already gathered from prior steps.`
+              : `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+                  `returning text already gathered from prior steps.`,
           );
         } else if (wasAborted) {
           // Turn ended on a time condition or caller abort — skip synth
@@ -2311,8 +2402,11 @@ export class GoogleVertexProvider extends BaseProvider {
           });
         } else {
           logger.warn(
-            `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
-              `with no text; synthesizing a final answer with tools disabled.`,
+            hitContextLimit
+              ? `[GoogleVertex] Tool call loop stopped by the context guard ` +
+                  `with no text; synthesizing a final answer with tools disabled.`
+              : `[GoogleVertex] Tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+                  `with no text; synthesizing a final answer with tools disabled.`,
           );
           // synth self-bounds its connect+drain via withTimeout(timeoutMs) and
           // never throws (returns empty on timeout/error), so it needs no outer
@@ -2336,7 +2430,9 @@ export class GoogleVertexProvider extends BaseProvider {
               lastFinishReason = synth.finishReason;
             }
           } else {
-            finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+            finalText = hitContextLimit
+              ? buildContextCapMessage(toolCallCount)
+              : buildToolLoopCapMessage(maxSteps, toolCallCount);
           }
         }
       }
@@ -2362,6 +2458,7 @@ export class GoogleVertexProvider extends BaseProvider {
       stalled: turnClock.stalled,
       wasAborted,
       cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      contextCappedWithoutAnswer: hitContextLimit && !synthesizedFinalAnswer,
       finishReason: resolvedFinishReason,
     });
     if (stopReason !== "completed") {
@@ -2868,6 +2965,14 @@ export class GoogleVertexProvider extends BaseProvider {
     // Key: tool name, Value: { count: retry attempts, lastError: error message }
     const failedTools = new Map<string, { count: number; lastError: string }>();
 
+    // In-loop context guard: stop calling tools when the accumulated
+    // conversation approaches the model's context window instead of stepping
+    // into a provider "prompt too long" rejection mid-loop.
+    const contextGuard = createContextGuard(
+      getContextWindowSize("vertex", modelName),
+    );
+    let hitContextLimit = false;
+
     // Track token usage across all steps
     // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
     let totalInputTokens = 0;
@@ -2922,6 +3027,18 @@ export class GoogleVertexProvider extends BaseProvider {
       while (step < maxSteps) {
         if (effectiveSignal.aborted) {
           wasAborted = true;
+          break;
+        }
+        // Context guard: stop the tool loop before the accumulated
+        // conversation crosses the window threshold — synthesize from what
+        // we have instead of stepping into a provider rejection.
+        if (contextGuard.shouldStop()) {
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          );
           break;
         }
         step++;
@@ -2994,6 +3111,11 @@ export class GoogleVertexProvider extends BaseProvider {
                 usageMetadata.promptTokenCount > 0
               ) {
                 totalInputTokens = usageMetadata.promptTokenCount;
+                // Feed the context guard the REAL prompt size of this call.
+                contextGuard.noteUsage(
+                  usageMetadata.promptTokenCount,
+                  usageMetadata.candidatesTokenCount ?? 0,
+                );
               }
               // Take the latest candidatesTokenCount (accumulates through chunks)
               if (
@@ -3114,6 +3236,14 @@ export class GoogleVertexProvider extends BaseProvider {
           // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
 
           for (const call of stepFunctionCalls) {
+            // Honor a deadline/stall/caller abort BETWEEN tool executions —
+            // without this check a multi-tool step keeps executing its whole
+            // batch (up to N × toolTimeoutMs past the deadline) before the
+            // while-top check finally breaks.
+            if (effectiveSignal.aborted) {
+              wasAborted = true;
+              break;
+            }
             allToolCalls.push({ toolName: call.name, args: call.args });
 
             // Check if this tool has already exceeded retry limit
@@ -3157,11 +3287,33 @@ export class GoogleVertexProvider extends BaseProvider {
                 // Bound the execute() await — a wedged tool costs one step
                 // (error tool_result), not the whole turn.
                 const execResult = await withTimeout(
-                  Promise.resolve(execute(call.args, toolOptions)),
+                  raceWithAbort(
+                    Promise.resolve(execute(call.args, toolOptions)),
+                    effectiveSignal,
+                  ),
                   toolExecTimeoutMs,
                   `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
                 );
                 turnClock.noteProgress();
+                // Error-shaped success (MCP isError / { error } payloads —
+                // e.g. proxy-blocked tools) counts toward the breaker too:
+                // these fail without throwing, and only counting throws lets
+                // the model grind on a blocked tool for the whole budget.
+                const resultErrorText = extractToolFailureText(execResult);
+                if (resultErrorText) {
+                  const info = failedTools.get(call.name) || {
+                    count: 0,
+                    lastError: "",
+                  };
+                  info.count++;
+                  info.lastError = resultErrorText;
+                  failedTools.set(call.name, info);
+                } else {
+                  // Genuinely consecutive: a success clears the strike count
+                  // (argument-dependent soft errors — file-not-found on
+                  // different paths — must not disable a working tool).
+                  failedTools.delete(call.name);
+                }
 
                 // Track execution
                 toolExecutions.push({
@@ -3326,6 +3478,16 @@ export class GoogleVertexProvider extends BaseProvider {
             role: "user",
             parts: functionResponses as unknown as VertexNativePart[],
           });
+          // Project this step's growth for the context guard: the appended
+          // tool results ride the next prompt (Gemini reports usage per call,
+          // but only for content it has already seen).
+          try {
+            contextGuard.noteAppendedChars(
+              JSON.stringify(functionResponses).length,
+            );
+          } catch {
+            /* estimation is best-effort — never break the loop */
+          }
         } catch (error) {
           // A mid-drain abort surfaces as an AbortError from the `for await`.
           // Break gracefully into the terminal block instead of re-throwing
@@ -3363,7 +3525,7 @@ export class GoogleVertexProvider extends BaseProvider {
       // cap was reached (or the turn was aborted) while the model was still
       // calling tools. Surface a real answer instead of the canned placeholder
       // (Bug 1) and a meaningful finishReason (Bug 2).
-      if (!finalText && (step >= maxSteps || wasAborted)) {
+      if (!finalText && (step >= maxSteps || wasAborted || hitContextLimit)) {
         hitStepLimit = step >= maxSteps && !wasAborted;
         const toolCallCount = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
@@ -3371,8 +3533,11 @@ export class GoogleVertexProvider extends BaseProvider {
         if (accumulatedText) {
           // Prefer the prose the model already produced across steps.
           logger.warn(
-            `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
-              `returning text already gathered from prior steps.`,
+            hitContextLimit
+              ? `[GoogleVertex] Generate tool call loop stopped by the context guard; ` +
+                  `returning text already gathered from prior steps.`
+              : `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}); ` +
+                  `returning text already gathered from prior steps.`,
           );
           finalText = accumulatedText;
         } else if (wasAborted) {
@@ -3397,8 +3562,11 @@ export class GoogleVertexProvider extends BaseProvider {
           // so the model answers from the gathered tool results instead of the
           // canned placeholder.
           logger.warn(
-            `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
-              `with no text; synthesizing a final answer with tools disabled.`,
+            hitContextLimit
+              ? `[GoogleVertex] Generate tool call loop stopped by the context guard ` +
+                  `with no text; synthesizing a final answer with tools disabled.`
+              : `[GoogleVertex] Generate tool call loop terminated after reaching maxSteps (${maxSteps}) ` +
+                  `with no text; synthesizing a final answer with tools disabled.`,
           );
           // synth self-bounds its connect+drain via withTimeout(timeoutMs) and
           // never throws (returns empty on timeout/error), so it needs no outer
@@ -3421,7 +3589,9 @@ export class GoogleVertexProvider extends BaseProvider {
               lastFinishReason = synth.finishReason;
             }
           } else {
-            finalText = buildToolLoopCapMessage(maxSteps, toolCallCount);
+            finalText = hitContextLimit
+              ? buildContextCapMessage(toolCallCount)
+              : buildToolLoopCapMessage(maxSteps, toolCallCount);
           }
         }
       }
@@ -3447,6 +3617,7 @@ export class GoogleVertexProvider extends BaseProvider {
       stalled: turnClock.stalled,
       wasAborted,
       cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      contextCappedWithoutAnswer: hitContextLimit && !synthesizedFinalAnswer,
       finishReason: resolvedFinishReason,
     });
     if (stopReason !== "completed") {
@@ -4183,9 +4354,19 @@ export class GoogleVertexProvider extends BaseProvider {
       // mapping written into finishReasonRef.
       let wasAborted = false;
       let hitStepLimit = false;
+      let hitContextLimit = false;
       let synthesizedFinalAnswer = false;
       let modelFinished = false;
       let lastStopReason: string | null | undefined;
+      // In-loop context guard + consecutive-failure breaker — same rationale
+      // as the generate twin (see executeNativeAnthropicGenerate).
+      const contextGuard = createContextGuard(
+        getContextWindowSize("vertex", modelName),
+      );
+      const failedTools = new Map<
+        string,
+        { count: number; lastError: string }
+      >();
 
       try {
         while (step < agenticStepBudget) {
@@ -4196,6 +4377,17 @@ export class GoogleVertexProvider extends BaseProvider {
           // a stream failure and route consumers into fallback retries.
           if (internalAbort.signal.aborted) {
             wasAborted = true;
+            break;
+          }
+          // Context guard: stop the tool loop before the accumulated
+          // conversation crosses the window threshold (see generate twin).
+          if (contextGuard.shouldStop()) {
+            hitContextLimit = true;
+            logger.warn(
+              `[GoogleVertex] Anthropic stream turn stopped by the context guard: ` +
+                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            );
             break;
           }
           step++;
@@ -4338,6 +4530,14 @@ export class GoogleVertexProvider extends BaseProvider {
             usage.output += response.usage?.output_tokens || 0;
             usage.total = usage.input + usage.output;
             lastStopReason = response.stop_reason;
+            // Feed the context guard the FULL prompt size of this call
+            // (uncached input + cache reads/writes).
+            contextGuard.noteUsage(
+              (response.usage?.input_tokens || 0) +
+                stepCacheRead +
+                stepCacheCreation,
+              response.usage?.output_tokens || 0,
+            );
 
             for (const block of response.content) {
               if (block.type === "text" && typeof block.text === "string") {
@@ -4454,6 +4654,15 @@ export class GoogleVertexProvider extends BaseProvider {
           // Note: tool:start / tool:end events are emitted by ToolsManager's
           // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
           for (const toolUse of toolUseBlocks) {
+            // Honor a deadline/stall/caller abort BETWEEN tool executions —
+            // without this check a multi-tool step keeps executing its whole
+            // batch (up to N × toolTimeoutMs past the deadline) before the
+            // while-top check finally breaks. Skipped tools get neither a
+            // call row nor a result row, so persisted history stays paired.
+            if (internalAbort.signal.aborted) {
+              wasAborted = true;
+              break;
+            }
             allToolCalls.push({
               toolName: toolUse.name,
               args: toolUse.input,
@@ -4464,6 +4673,34 @@ export class GoogleVertexProvider extends BaseProvider {
               toolName: toolUse.name,
               args: toolUse.input,
             });
+
+            // Consecutive-failure breaker (ports the Gemini loops' failedTools
+            // map): a tool that has already failed DEFAULT_TOOL_MAX_RETRIES
+            // times this turn is short-circuited instead of re-executed.
+            const failedInfo = failedTools.get(toolUse.name);
+            if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
+              logger.warn(
+                `[GoogleVertex] Tool "${toolUse.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
+              );
+              const errMsg = `TOOL_PERMANENTLY_FAILED: The tool "${toolUse.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`;
+              const errorPayload = { error: errMsg };
+              toolExecutions.push({
+                name: toolUse.name,
+                input: toolUse.input,
+                output: errorPayload,
+              });
+              toolResults.push({
+                type: "tool_result",
+                tool_use_id: toolUse.id,
+                content: errMsg,
+              });
+              stepStorageResults.push({
+                toolCallId: toolUse.id,
+                toolName: toolUse.name,
+                output: errorPayload,
+              });
+              continue;
+            }
 
             // One tool observation per execution. ai.toolCall.* names follow the
             // Vercel AI SDK convention so existing tooling keeps working.
@@ -4526,11 +4763,17 @@ export class GoogleVertexProvider extends BaseProvider {
                 // (neurolink.tool.execute) nest under this observation instead
                 // of becoming disconnected siblings. Bound the await — a
                 // wedged tool costs one step (error tool_result), not the
-                // whole turn.
+                // whole turn — and race it against the turn's abort so a
+                // deadline/caller abort is observed IMMEDIATELY instead of
+                // after the tool settles.
                 const result = await withTimeout(
-                  otelContext.with(
-                    otelTrace.setSpan(turnContext, toolSpan),
-                    () => Promise.resolve(execute(toolUse.input, toolOptions)),
+                  raceWithAbort(
+                    otelContext.with(
+                      otelTrace.setSpan(turnContext, toolSpan),
+                      () =>
+                        Promise.resolve(execute(toolUse.input, toolOptions)),
+                    ),
+                    internalAbort.signal,
                   ),
                   toolExecTimeoutMs,
                   `Tool "${toolUse.name}" execution timed out after ${toolExecTimeoutMs}ms`,
@@ -4539,6 +4782,23 @@ export class GoogleVertexProvider extends BaseProvider {
                 // MCP failures are returned, not thrown — surface them on
                 // the span so failed calls show as ERROR in Langfuse.
                 endToolSpan(result, extractMcpToolErrorMessage(result));
+                // Error-shaped success (MCP isError / { error } payloads)
+                // counts toward the breaker too — see the generate twin.
+                const resultErrorText = extractToolFailureText(result);
+                if (resultErrorText) {
+                  const info = failedTools.get(toolUse.name) || {
+                    count: 0,
+                    lastError: "",
+                  };
+                  info.count++;
+                  info.lastError = resultErrorText;
+                  failedTools.set(toolUse.name, info);
+                } else {
+                  // Genuinely consecutive: a success clears the strike count
+                  // (argument-dependent soft errors — file-not-found on
+                  // different paths — must not disable a working tool).
+                  failedTools.delete(toolUse.name);
+                }
                 toolExecutions.push({
                   name: toolUse.name,
                   input: toolUse.input,
@@ -4588,7 +4848,20 @@ export class GoogleVertexProvider extends BaseProvider {
                     toolName: toolUse.name,
                   });
                 }
-                const errMsg = `Error executing tool "${toolUse.name}": ${err instanceof Error ? err.message : String(err)}`;
+                // Count the failure toward the consecutive-failure breaker.
+                const thrownErrorText =
+                  err instanceof Error ? err.message : String(err);
+                const info = failedTools.get(toolUse.name) || {
+                  count: 0,
+                  lastError: "",
+                };
+                info.count++;
+                info.lastError = thrownErrorText;
+                failedTools.set(toolUse.name, info);
+                logger.warn(
+                  `[GoogleVertex] Tool "${toolUse.name}" failed (attempt ${info.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${thrownErrorText}`,
+                );
+                const errMsg = `Error executing tool "${toolUse.name}": ${thrownErrorText}`;
                 const errorPayload = { error: errMsg };
                 endToolSpan(errorPayload, errMsg);
                 toolExecutions.push({
@@ -4610,6 +4883,16 @@ export class GoogleVertexProvider extends BaseProvider {
             } else {
               const errMsg = `TOOL_NOT_FOUND: The tool "${toolUse.name}" does not exist.`;
               const errorPayload = { error: errMsg };
+              // A missing tool counts toward the breaker too — a model
+              // grinding on a hallucinated/stale tool name must not burn the
+              // whole step budget on TOOL_NOT_FOUND round-trips.
+              const notFoundInfo = failedTools.get(toolUse.name) || {
+                count: 0,
+                lastError: "",
+              };
+              notFoundInfo.count++;
+              notFoundInfo.lastError = errMsg;
+              failedTools.set(toolUse.name, notFoundInfo);
               endToolSpan(errorPayload, errMsg);
               toolExecutions.push({
                 name: toolUse.name,
@@ -4698,6 +4981,18 @@ export class GoogleVertexProvider extends BaseProvider {
             role: "user",
             content: toolResults,
           });
+          // Project this step's growth for the context guard: everything
+          // just appended (tool results + nudge text) rides the next prompt.
+          contextGuard.noteAppendedChars(
+            toolResults.reduce(
+              (sum, block) =>
+                sum +
+                ("content" in block
+                  ? block.content.length
+                  : (block as { text: string }).text.length),
+              0,
+            ),
+          );
         }
 
         // Terminal handling — the loop exited without a model-initiated
@@ -4719,6 +5014,21 @@ export class GoogleVertexProvider extends BaseProvider {
           const externalToolCallCount = allToolCalls.filter(
             (tc) => tc.toolName !== "final_result",
           ).length;
+          // Clamp the terminal calls' max_tokens so prompt + output stays
+          // inside the model window: pre-4.5 Claude models 400 on
+          // input + max_tokens > window, which would defeat the very
+          // synthesis these calls exist for on context-capped turns. Only
+          // bites when the prompt is near the window (min() is a no-op on
+          // ordinary step-cap turns).
+          const terminalMaxTokens = Math.max(
+            1024,
+            Math.min(
+              requestParams.max_tokens,
+              getContextWindowSize("vertex", modelName) -
+                contextGuard.projectedNextPromptTokens -
+                4_000,
+            ),
+          );
           if (wasAborted) {
             // Budget already blown — never issue another model call. Deliver
             // exactly one HONEST terminal chunk matching the actual exit
@@ -4746,9 +5056,13 @@ export class GoogleVertexProvider extends BaseProvider {
               aggregatedTurnText = exitMessage;
             }
           } else if (useFinalResultTool) {
-            hitStepLimit = true;
+            if (!hitContextLimit) {
+              hitStepLimit = true;
+            }
             logger.warn(
-              `[GoogleVertex] Native Anthropic stream loop reached maxSteps (${maxSteps}) without final_result; forcing a finalization call.`,
+              hitContextLimit
+                ? `[GoogleVertex] Native Anthropic stream loop stopped by the context guard without final_result; forcing a finalization call.`
+                : `[GoogleVertex] Native Anthropic stream loop reached maxSteps (${maxSteps}) without final_result; forcing a finalization call.`,
             );
             try {
               // Reserved finalization step: identical request except
@@ -4763,6 +5077,7 @@ export class GoogleVertexProvider extends BaseProvider {
               });
               const finalizationStream = await client.messages.stream({
                 ...requestParams,
+                max_tokens: terminalMaxTokens,
                 tool_choice: {
                   type: "tool" as const,
                   name: "final_result",
@@ -4821,10 +5136,9 @@ export class GoogleVertexProvider extends BaseProvider {
                   { keys: Object.keys(forcedFinalResult.input) },
                 );
               } else {
-                const capMessage = buildToolLoopCapMessage(
-                  maxSteps,
-                  externalToolCallCount,
-                );
+                const capMessage = hitContextLimit
+                  ? buildContextCapMessage(externalToolCallCount)
+                  : buildToolLoopCapMessage(maxSteps, externalToolCallCount);
                 channel.push(capMessage);
                 aggregatedTurnText += capMessage;
               }
@@ -4844,18 +5158,23 @@ export class GoogleVertexProvider extends BaseProvider {
                   error: error instanceof Error ? error.message : String(error),
                 },
               );
-              const exitMessage = this.buildLoopExitMessage({
-                turnClock,
-                wasAborted,
-                stallTimeoutMs: options.stallTimeoutMs,
-                maxSteps,
-                toolCallCount: externalToolCallCount,
-              });
+              const exitMessage =
+                hitContextLimit && !wasAborted
+                  ? buildContextCapMessage(externalToolCallCount)
+                  : this.buildLoopExitMessage({
+                      turnClock,
+                      wasAborted,
+                      stallTimeoutMs: options.stallTimeoutMs,
+                      maxSteps,
+                      toolCallCount: externalToolCallCount,
+                    });
               channel.push(exitMessage);
               aggregatedTurnText += exitMessage;
             }
           } else {
-            hitStepLimit = true;
+            if (!hitContextLimit) {
+              hitStepLimit = true;
+            }
             if (aggregatedTurnText.length === 0) {
               // Pure tool-loop with no streamed text: one tools-disabled call
               // so the model answers from the gathered tool results, pushed
@@ -4865,7 +5184,9 @@ export class GoogleVertexProvider extends BaseProvider {
               // tools param — so "tools disabled" is tool_choice:"none",
               // which also keeps the cached tools prefix byte-identical.
               logger.warn(
-                `[GoogleVertex] Native Anthropic stream loop reached maxSteps (${maxSteps}) with no text; synthesizing a final answer with tools disabled.`,
+                hitContextLimit
+                  ? `[GoogleVertex] Native Anthropic stream loop stopped by the context guard with no text; synthesizing a final answer with tools disabled.`
+                  : `[GoogleVertex] Native Anthropic stream loop reached maxSteps (${maxSteps}) with no text; synthesizing a final answer with tools disabled.`,
               );
               try {
                 const backstopSystem =
@@ -4882,6 +5203,7 @@ export class GoogleVertexProvider extends BaseProvider {
                 });
                 const backstopStream = await client.messages.stream({
                   ...requestParams,
+                  max_tokens: terminalMaxTokens,
                   tool_choice: { type: "none" as const },
                   system: cachedBackstop.system as Parameters<
                     typeof client.messages.stream
@@ -4927,10 +5249,9 @@ export class GoogleVertexProvider extends BaseProvider {
                   channel.push(backstopText);
                   aggregatedTurnText = backstopText;
                 } else {
-                  const capMessage = buildToolLoopCapMessage(
-                    maxSteps,
-                    externalToolCallCount,
-                  );
+                  const capMessage = hitContextLimit
+                    ? buildContextCapMessage(externalToolCallCount)
+                    : buildToolLoopCapMessage(maxSteps, externalToolCallCount);
                   channel.push(capMessage);
                   aggregatedTurnText = capMessage;
                 }
@@ -4951,13 +5272,16 @@ export class GoogleVertexProvider extends BaseProvider {
                       error instanceof Error ? error.message : String(error),
                   },
                 );
-                const exitMessage = this.buildLoopExitMessage({
-                  turnClock,
-                  wasAborted,
-                  stallTimeoutMs: options.stallTimeoutMs,
-                  maxSteps,
-                  toolCallCount: externalToolCallCount,
-                });
+                const exitMessage =
+                  hitContextLimit && !wasAborted
+                    ? buildContextCapMessage(externalToolCallCount)
+                    : this.buildLoopExitMessage({
+                        turnClock,
+                        wasAborted,
+                        stallTimeoutMs: options.stallTimeoutMs,
+                        maxSteps,
+                        toolCallCount: externalToolCallCount,
+                      });
                 channel.push(exitMessage);
                 aggregatedTurnText = exitMessage;
               }
@@ -4979,13 +5303,16 @@ export class GoogleVertexProvider extends BaseProvider {
           (tc) => tc.toolName !== "final_result",
         ).length;
         if (deliveredNothing && externalToolCallTotal > 0) {
-          const exitMessage = this.buildLoopExitMessage({
-            turnClock,
-            wasAborted,
-            stallTimeoutMs: options.stallTimeoutMs,
-            maxSteps,
-            toolCallCount: externalToolCallTotal,
-          });
+          const exitMessage =
+            hitContextLimit && !wasAborted
+              ? buildContextCapMessage(externalToolCallTotal)
+              : this.buildLoopExitMessage({
+                  turnClock,
+                  wasAborted,
+                  stallTimeoutMs: options.stallTimeoutMs,
+                  maxSteps,
+                  toolCallCount: externalToolCallTotal,
+                });
           channel.push(exitMessage);
           aggregatedTurnText = exitMessage;
         }
@@ -5016,6 +5343,8 @@ export class GoogleVertexProvider extends BaseProvider {
           stalled: turnClock.stalled,
           wasAborted,
           cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+          contextCappedWithoutAnswer:
+            hitContextLimit && !synthesizedFinalAnswer,
           finishReason: finishReasonRef.value,
         });
         stopReasonRef.value = resolvedStopReason;
@@ -5536,9 +5865,24 @@ export class GoogleVertexProvider extends BaseProvider {
     // these to distinguish clean finishes, capped turns, and aborted turns.
     let wasAborted = false;
     let hitStepLimit = false;
+    let hitContextLimit = false;
     let synthesizedFinalAnswer = false;
     let modelFinished = false;
     const currentMessages = [...messages];
+
+    // In-loop context guard: stop calling tools when the accumulated
+    // conversation approaches the model's real context window, instead of
+    // stepping into an Anthropic 400 "prompt is too long" at step N that
+    // destroys the whole turn's work (claude-sonnet-5 1,005,647-token RCA).
+    const contextGuard = createContextGuard(
+      getContextWindowSize("vertex", modelName),
+    );
+    // Consecutive-failure breaker (ports the Gemini loops' failedTools map):
+    // a tool that keeps failing — thrown errors, timeouts, or error-shaped
+    // results like mcp-proxy blocks — is short-circuited after
+    // DEFAULT_TOOL_MAX_RETRIES instead of being retried for the remaining
+    // step budget.
+    const failedTools = new Map<string, { count: number; lastError: string }>();
 
     // Internal abort fan-in: the caller's signal and the turn clock's
     // watchdogs all trip it; it rides every SDK request and tool execution.
@@ -5582,6 +5926,18 @@ export class GoogleVertexProvider extends BaseProvider {
       // retries — observed in production as a 600s abort no-op).
       if (internalAbort.signal.aborted) {
         wasAborted = true;
+        break;
+      }
+      // Context guard: the projected next prompt (last call's REAL usage +
+      // this step's appended tool results/output) would cross the window
+      // threshold — stop the tool loop and synthesize from what we have.
+      if (contextGuard.shouldStop()) {
+        hitContextLimit = true;
+        logger.warn(
+          `[GoogleVertex] Anthropic generate turn stopped by the context guard: ` +
+            `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+            `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+        );
         break;
       }
       step++;
@@ -5639,6 +5995,14 @@ export class GoogleVertexProvider extends BaseProvider {
         totalCacheCreationTokens +=
           response.usage?.cache_creation_input_tokens || 0;
         lastStopReason = response.stop_reason;
+        // Feed the context guard the FULL prompt size of this call (uncached
+        // input + cache reads/writes) — the API reports it every step.
+        contextGuard.noteUsage(
+          (response.usage?.input_tokens || 0) +
+            (response.usage?.cache_read_input_tokens || 0) +
+            (response.usage?.cache_creation_input_tokens || 0),
+          response.usage?.output_tokens || 0,
+        );
 
         // Check if we need to handle tool use
         const toolUseBlocks = (
@@ -5715,6 +6079,15 @@ export class GoogleVertexProvider extends BaseProvider {
         // Note: tool:start / tool:end events are emitted by ToolsManager's
         // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
         for (const toolUse of toolUseBlocks) {
+          // Honor a deadline/stall/caller abort BETWEEN tool executions —
+          // without this check a multi-tool step keeps executing its whole
+          // batch (up to N × toolTimeoutMs past the deadline) before the
+          // while-top check finally breaks. Skipped tools get neither a call
+          // row nor a result row, so persisted history stays paired.
+          if (internalAbort.signal.aborted) {
+            wasAborted = true;
+            break;
+          }
           allToolCalls.push({
             toolName: toolUse.name,
             args: toolUse.input,
@@ -5724,6 +6097,35 @@ export class GoogleVertexProvider extends BaseProvider {
             toolName: toolUse.name,
             args: toolUse.input,
           });
+
+          // Consecutive-failure breaker: stop re-executing a tool that has
+          // already failed DEFAULT_TOOL_MAX_RETRIES times this turn (ports
+          // the Gemini loops' failedTools map — the Anthropic loops let a
+          // blocked tool be retried for the entire remaining step budget).
+          const failedInfo = failedTools.get(toolUse.name);
+          if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
+            logger.warn(
+              `[GoogleVertex] Tool "${toolUse.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
+            );
+            const errMsg = `TOOL_PERMANENTLY_FAILED: The tool "${toolUse.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`;
+            const errorPayload = { error: errMsg };
+            toolExecutions.push({
+              name: toolUse.name,
+              input: toolUse.input,
+              output: errorPayload,
+            });
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: errMsg,
+            });
+            stepStorageResults.push({
+              toolCallId: toolUse.id,
+              toolName: toolUse.name,
+              output: errorPayload,
+            });
+            continue;
+          }
 
           const execute = executeMap.get(toolUse.name);
           if (execute) {
@@ -5735,13 +6137,38 @@ export class GoogleVertexProvider extends BaseProvider {
               };
               turnClock.noteProgress();
               // Bound the execute() await — a wedged tool costs one step
-              // (error tool_result), not the whole turn.
+              // (error tool_result), not the whole turn — and race it against
+              // the turn's abort so a deadline/caller abort is observed
+              // IMMEDIATELY instead of after the tool settles (live-verified:
+              // an 8s deadline previously waited out a 60s tool).
               const result = await withTimeout(
-                Promise.resolve(execute(toolUse.input, toolOptions)),
+                raceWithAbort(
+                  Promise.resolve(execute(toolUse.input, toolOptions)),
+                  internalAbort.signal,
+                ),
                 toolExecTimeoutMs,
                 `Tool "${toolUse.name}" execution timed out after ${toolExecTimeoutMs}ms`,
               );
               turnClock.noteProgress();
+              // Error-shaped success (MCP isError / { error } payloads —
+              // e.g. proxy-blocked tools) counts toward the breaker too:
+              // these fail without throwing, and only counting throws lets
+              // the model grind on a blocked tool for the whole budget.
+              const resultErrorText = extractToolFailureText(result);
+              if (resultErrorText) {
+                const info = failedTools.get(toolUse.name) || {
+                  count: 0,
+                  lastError: "",
+                };
+                info.count++;
+                info.lastError = resultErrorText;
+                failedTools.set(toolUse.name, info);
+              } else {
+                // Genuinely consecutive: a success clears the strike count
+                // (argument-dependent soft errors — file-not-found on
+                // different paths — must not disable a working tool).
+                failedTools.delete(toolUse.name);
+              }
               toolExecutions.push({
                 name: toolUse.name,
                 input: toolUse.input,
@@ -5789,7 +6216,20 @@ export class GoogleVertexProvider extends BaseProvider {
                   toolName: toolUse.name,
                 });
               }
-              const errMsg = `Error executing tool "${toolUse.name}": ${err instanceof Error ? err.message : String(err)}`;
+              // Count the failure toward the consecutive-failure breaker.
+              const thrownErrorText =
+                err instanceof Error ? err.message : String(err);
+              const info = failedTools.get(toolUse.name) || {
+                count: 0,
+                lastError: "",
+              };
+              info.count++;
+              info.lastError = thrownErrorText;
+              failedTools.set(toolUse.name, info);
+              logger.warn(
+                `[GoogleVertex] Tool "${toolUse.name}" failed (attempt ${info.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${thrownErrorText}`,
+              );
+              const errMsg = `Error executing tool "${toolUse.name}": ${thrownErrorText}`;
               const errorPayload = { error: errMsg };
               toolExecutions.push({
                 name: toolUse.name,
@@ -5810,6 +6250,16 @@ export class GoogleVertexProvider extends BaseProvider {
           } else {
             const errMsg = `TOOL_NOT_FOUND: The tool "${toolUse.name}" does not exist.`;
             const errorPayload = { error: errMsg };
+            // A missing tool counts toward the breaker too — a model
+            // grinding on a hallucinated/stale tool name must not burn the
+            // whole step budget on TOOL_NOT_FOUND round-trips.
+            const notFoundInfo = failedTools.get(toolUse.name) || {
+              count: 0,
+              lastError: "",
+            };
+            notFoundInfo.count++;
+            notFoundInfo.lastError = errMsg;
+            failedTools.set(toolUse.name, notFoundInfo);
             toolExecutions.push({
               name: toolUse.name,
               input: toolUse.input,
@@ -5897,6 +6347,19 @@ export class GoogleVertexProvider extends BaseProvider {
           role: "user",
           content: toolResults,
         });
+        // Project this step's growth for the context guard: everything just
+        // appended (tool results + nudge text) rides the next prompt. The
+        // assistant output was already counted via noteUsage.
+        contextGuard.noteAppendedChars(
+          toolResults.reduce(
+            (sum, block) =>
+              sum +
+              ("content" in block
+                ? block.content.length
+                : (block as { text: string }).text.length),
+            0,
+          ),
+        );
 
         // Accumulate the step's prose so a capped turn can still surface it —
         // finalText is reserved for model-initiated finishes.
@@ -5948,6 +6411,20 @@ export class GoogleVertexProvider extends BaseProvider {
       const externalToolCallCount = allToolCalls.filter(
         (tc) => tc.toolName !== "final_result",
       ).length;
+      // Clamp the terminal calls' max_tokens so prompt + output stays inside
+      // the model window: pre-4.5 Claude models 400 on input + max_tokens >
+      // window, which would defeat the very synthesis these calls exist for
+      // on context-capped turns. Only bites when the prompt is near the
+      // window (min() is a no-op on ordinary step-cap turns).
+      const terminalMaxTokens = Math.max(
+        1024,
+        Math.min(
+          requestParams.max_tokens,
+          getContextWindowSize("vertex", modelName) -
+            contextGuard.projectedNextPromptTokens -
+            4_000,
+        ),
+      );
       if (wasAborted) {
         // Budget already blown — never issue another model call; prefer the
         // prose the model already produced (mirrors the Gemini abort path),
@@ -5970,9 +6447,13 @@ export class GoogleVertexProvider extends BaseProvider {
             toolCallCount: externalToolCallCount,
           });
       } else if (useFinalResultTool) {
-        hitStepLimit = true;
+        if (!hitContextLimit) {
+          hitStepLimit = true;
+        }
         logger.warn(
-          `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}) without final_result; forcing a finalization call.`,
+          hitContextLimit
+            ? `[GoogleVertex] Native Anthropic generate loop stopped by the context guard without final_result; forcing a finalization call.`
+            : `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}) without final_result; forcing a finalization call.`,
         );
         try {
           // Reserved finalization step: identical request except tool_choice
@@ -5989,6 +6470,7 @@ export class GoogleVertexProvider extends BaseProvider {
             client.messages.create(
               {
                 ...requestParams,
+                max_tokens: terminalMaxTokens,
                 tool_choice: {
                   type: "tool" as const,
                   name: "final_result",
@@ -6040,10 +6522,9 @@ export class GoogleVertexProvider extends BaseProvider {
               { keys: Object.keys(structuredOutput) },
             );
           } else {
-            finalText = buildToolLoopCapMessage(
-              maxSteps,
-              externalToolCallCount,
-            );
+            finalText = hitContextLimit
+              ? buildContextCapMessage(externalToolCallCount)
+              : buildToolLoopCapMessage(maxSteps, externalToolCallCount);
           }
         } catch (error) {
           // An aborted finalization is a cancellation (caller abort or a
@@ -6058,20 +6539,27 @@ export class GoogleVertexProvider extends BaseProvider {
             "[GoogleVertex] Forced finalization call failed; falling back to a terminal message",
             { error: error instanceof Error ? error.message : String(error) },
           );
-          finalText = this.buildLoopExitMessage({
-            turnClock,
-            wasAborted,
-            stallTimeoutMs: options.stallTimeoutMs,
-            maxSteps,
-            toolCallCount: externalToolCallCount,
-          });
+          finalText =
+            hitContextLimit && !wasAborted
+              ? buildContextCapMessage(externalToolCallCount)
+              : this.buildLoopExitMessage({
+                  turnClock,
+                  wasAborted,
+                  stallTimeoutMs: options.stallTimeoutMs,
+                  maxSteps,
+                  toolCallCount: externalToolCallCount,
+                });
         }
       } else {
-        hitStepLimit = true;
+        if (!hitContextLimit) {
+          hitStepLimit = true;
+        }
         if (accumulatedStepText) {
           // Prefer the prose the model already produced across steps.
           logger.warn(
-            `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}); returning text already gathered from prior steps.`,
+            hitContextLimit
+              ? `[GoogleVertex] Native Anthropic generate loop stopped by the context guard; returning text already gathered from prior steps.`
+              : `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}); returning text already gathered from prior steps.`,
           );
           finalText = accumulatedStepText;
         } else {
@@ -6083,7 +6571,9 @@ export class GoogleVertexProvider extends BaseProvider {
           // param — so "tools disabled" is expressed as tool_choice:"none",
           // which also keeps the cached tools prefix byte-identical.
           logger.warn(
-            `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}) with no text; synthesizing a final answer with tools disabled.`,
+            hitContextLimit
+              ? `[GoogleVertex] Native Anthropic generate loop stopped by the context guard with no text; synthesizing a final answer with tools disabled.`
+              : `[GoogleVertex] Native Anthropic generate loop reached maxSteps (${maxSteps}) with no text; synthesizing a final answer with tools disabled.`,
           );
           try {
             const backstopSystem =
@@ -6100,6 +6590,7 @@ export class GoogleVertexProvider extends BaseProvider {
               client.messages.create(
                 {
                   ...requestParams,
+                  max_tokens: terminalMaxTokens,
                   tool_choice: { type: "none" as const },
                   system: cachedBackstop.system as Parameters<
                     typeof client.messages.create
@@ -6139,10 +6630,9 @@ export class GoogleVertexProvider extends BaseProvider {
               synthesizedFinalAnswer = true;
               finalText = backstopText;
             } else {
-              finalText = buildToolLoopCapMessage(
-                maxSteps,
-                externalToolCallCount,
-              );
+              finalText = hitContextLimit
+                ? buildContextCapMessage(externalToolCallCount)
+                : buildToolLoopCapMessage(maxSteps, externalToolCallCount);
             }
           } catch (error) {
             // An aborted backstop is a cancellation (caller abort or a
@@ -6159,13 +6649,16 @@ export class GoogleVertexProvider extends BaseProvider {
                 error: error instanceof Error ? error.message : String(error),
               },
             );
-            finalText = this.buildLoopExitMessage({
-              turnClock,
-              wasAborted,
-              stallTimeoutMs: options.stallTimeoutMs,
-              maxSteps,
-              toolCallCount: externalToolCallCount,
-            });
+            finalText =
+              hitContextLimit && !wasAborted
+                ? buildContextCapMessage(externalToolCallCount)
+                : this.buildLoopExitMessage({
+                    turnClock,
+                    wasAborted,
+                    stallTimeoutMs: options.stallTimeoutMs,
+                    maxSteps,
+                    toolCallCount: externalToolCallCount,
+                  });
           }
         }
       }
@@ -6186,13 +6679,16 @@ export class GoogleVertexProvider extends BaseProvider {
     // Cause-aware: an aborted/timed-out turn gets the honest exit message,
     // a genuine budget exhaustion gets the step-cap message.
     if (!finalText && externalToolCalls.length > 0) {
-      finalText = this.buildLoopExitMessage({
-        turnClock,
-        wasAborted,
-        stallTimeoutMs: options.stallTimeoutMs,
-        maxSteps,
-        toolCallCount: externalToolCalls.length,
-      });
+      finalText =
+        hitContextLimit && !wasAborted
+          ? buildContextCapMessage(externalToolCalls.length)
+          : this.buildLoopExitMessage({
+              turnClock,
+              wasAborted,
+              stallTimeoutMs: options.stallTimeoutMs,
+              maxSteps,
+              toolCallCount: externalToolCalls.length,
+            });
     }
 
     // Honest finish reason. "length" (token truncation) takes precedence; a
@@ -6213,6 +6709,7 @@ export class GoogleVertexProvider extends BaseProvider {
       stalled: turnClock.stalled,
       wasAborted,
       cappedWithoutAnswer: hitStepLimit && !synthesizedFinalAnswer,
+      contextCappedWithoutAnswer: hitContextLimit && !synthesizedFinalAnswer,
       finishReason: resolvedFinishReason,
     });
     if (stopReason !== "completed") {
@@ -7108,6 +7605,7 @@ export class GoogleVertexProvider extends BaseProvider {
   private emitTurnEvent(payload: {
     phase:
       | "step-cap"
+      | "context-cap"
       | "time-limit"
       | "stalled"
       | "aborted"

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -669,6 +669,10 @@ export type AdditionalMemoryUser = {
  *
  * - `completed` — the model finished on its own (text answer or final_result)
  * - `step-cap` — the `maxSteps` budget ran out while the model still wanted tools
+ * - `context-cap` — the in-loop context guard stopped the tool loop because the
+ *   accumulated conversation approached the model's context window (and the
+ *   terminal synthesis could not produce an answer); without the guard these
+ *   turns died mid-loop on a provider 400 "prompt is too long"
  * - `time-limit` — the `turnTimeoutMs` wall-clock deadline passed
  * - `stalled` — no progress (no chunk, no tool start/finish) for `stallTimeoutMs`
  * - `aborted` — the caller's `abortSignal` ended the turn
@@ -678,6 +682,7 @@ export type AdditionalMemoryUser = {
 export type GenerateStopReason =
   | "completed"
   | "step-cap"
+  | "context-cap"
   | "time-limit"
   | "stalled"
   | "aborted"

--- a/src/lib/utils/async/index.ts
+++ b/src/lib/utils/async/index.ts
@@ -27,4 +27,9 @@ export {
   RetryExhaustedError,
   retry,
 } from "./retry.js";
-export { TimeoutError, withTimeout, withTimeoutFn } from "./withTimeout.js";
+export {
+  TimeoutError,
+  raceWithAbort,
+  withTimeout,
+  withTimeoutFn,
+} from "./withTimeout.js";

--- a/src/lib/utils/async/withTimeout.ts
+++ b/src/lib/utils/async/withTimeout.ts
@@ -85,6 +85,58 @@ export async function withTimeout<T>(
 }
 
 /**
+ * Race a promise against an AbortSignal so the caller observes an abort
+ * IMMEDIATELY instead of waiting for the operation to settle (or for a
+ * separate timeout to expire). Rejects with an abort-shaped error
+ * (`name === "AbortError"`) so provider loops route it to their existing
+ * cancellation handling.
+ *
+ * The underlying operation is NOT cancelled — it continues as a bounded
+ * ghost (the same tradeoff as {@link withTimeout}); its eventual settlement
+ * is swallowed so it can never surface as an unhandled rejection.
+ */
+export async function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal || typeof signal.addEventListener !== "function") {
+    return promise;
+  }
+  const makeAbortError = (): Error => {
+    const e = new Error("Operation aborted");
+    e.name = "AbortError";
+    return e;
+  };
+  if (signal.aborted) {
+    promise.catch(() => {
+      // Swallow the abandoned settlement — it must never surface as an
+      // unhandled rejection after the race has already been decided.
+    });
+    return Promise.reject(makeAbortError());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      promise.catch(() => {
+        // Swallow the abandoned settlement — it must never surface as an
+        // unhandled rejection after the race has already been decided.
+      });
+      reject(makeAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
  * Execute a function with timeout protection.
  *
  * Alternative signature that accepts a function instead of a promise,

--- a/src/lib/utils/mcpErrorText.ts
+++ b/src/lib/utils/mcpErrorText.ts
@@ -73,3 +73,29 @@ export function extractMcpToolErrorMessage(
     ? `MCP tool returned isError: ${text}`
     : "MCP tool returned isError: true";
 }
+
+/**
+ * Detect a tool result that REPORTS failure without throwing, for the native
+ * loops' consecutive-failure breaker. Covers the two shapes NeuroLink itself
+ * produces or forwards:
+ * - MCP CallToolResult with `isError: true` (e.g. proxy-blocked tools) —
+ *   delegated to {@link extractMcpToolErrorMessage}
+ * - our own `{ error: "..." }` payloads
+ * Plain strings are never classified (too false-positive-prone).
+ * Returns the error text, or null when the result looks like a success.
+ */
+export function extractToolFailureText(result: unknown): string | null {
+  const mcpError = extractMcpToolErrorMessage(result);
+  if (mcpError) {
+    return mcpError;
+  }
+  if (
+    result !== null &&
+    typeof result === "object" &&
+    typeof (result as { error?: unknown }).error === "string" &&
+    (result as { error: string }).error.length > 0
+  ) {
+    return (result as { error: string }).error;
+  }
+  return null;
+}

--- a/test/continuous-test-suite-anthropic-cap.ts
+++ b/test/continuous-test-suite-anthropic-cap.ts
@@ -1517,6 +1517,255 @@ async function main(): Promise<void> {
       assertEqual(calls.length, 2, "aborted during the 2nd model call");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Context guard: stop the tool loop before the model window overflows
+  // (claude-sonnet-4-5 on vertex → 200K window, guard threshold 170K).
+  // -------------------------------------------------------------------------
+  await test("generate: context guard trips -> tools-disabled backstop synthesis, stopReason 'completed'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeGenerateMock((i) =>
+        i === 0
+          ? {
+              response: {
+                content: [
+                  {
+                    type: "tool_use",
+                    id: "tu_big",
+                    name: "myTool",
+                    input: { q: "x" },
+                  },
+                ],
+                // Reported prompt already past the 170K threshold — the loop
+                // must stop BEFORE issuing another agentic step.
+                usage: { input_tokens: 180_000, output_tokens: 3 },
+                stop_reason: "tool_use",
+              },
+            }
+          : { response: textResponse("synthesized from gathered results") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "research everything" },
+        tools: makeTool(),
+        maxSteps: 10,
+      });
+      assertEqual(
+        mock.calls.length,
+        2,
+        "1 agentic step + 1 backstop synthesis — no further tool steps",
+      );
+      assertEqual(
+        mock.calls[1].tool_choice?.type,
+        "none",
+        "backstop must disable tools",
+      );
+      assertEqual(result.content, "synthesized from gathered results");
+      assertEqual(
+        result.stopReason,
+        "completed",
+        "a synthesized answer counts as completed",
+      );
+      assertEqual(result.finishReason, "stop");
+    });
+  });
+
+  await test("generate: context guard trips and backstop returns no text -> honest context-cap message, stopReason 'context-cap'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeGenerateMock((i) =>
+        i === 0
+          ? {
+              response: {
+                content: [
+                  {
+                    type: "tool_use",
+                    id: "tu_big",
+                    name: "myTool",
+                    input: { q: "x" },
+                  },
+                ],
+                usage: { input_tokens: 180_000, output_tokens: 3 },
+                stop_reason: "tool_use",
+              },
+            }
+          : { response: textResponse("") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "research everything" },
+        tools: makeTool(),
+        maxSteps: 10,
+      });
+      assertEqual(result.stopReason, "context-cap");
+      assertEqual(
+        result.finishReason,
+        "stop",
+        "context-cap must NOT masquerade as the step-cap 'tool-calls'",
+      );
+      assertIncludes(
+        result.content,
+        "context window",
+        "honest context-cap message",
+      );
+      assert(
+        !result.content.includes("step limit"),
+        "context exits must never claim a step limit was reached",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Consecutive-failure breaker (ported from the Gemini loops)
+  // -------------------------------------------------------------------------
+  await test("generate: a tool that throws twice is short-circuited on the 3rd call (TOOL_PERMANENTLY_FAILED)", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      let execCount = 0;
+      const tools = makeTool(async () => {
+        execCount++;
+        throw new Error("boom");
+      });
+      const mock = makeGenerateMock((i) =>
+        i < 3
+          ? { response: toolUseResponse("myTool", { q: `try${i}` }) }
+          : { response: textResponse("done without the tool") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "keep trying" },
+        tools,
+        maxSteps: 10,
+      });
+      assertEqual(
+        execCount,
+        2,
+        "execution stops at DEFAULT_TOOL_MAX_RETRIES failures",
+      );
+      assertIncludes(
+        JSON.stringify(mock.calls[3].messages),
+        "TOOL_PERMANENTLY_FAILED",
+        "the 3rd attempt returns a permanent-failure tool_result to the model",
+      );
+      assertEqual(result.content, "done without the tool");
+      assertEqual(result.stopReason, "completed");
+    });
+  });
+
+  await test("generate: error-shaped RESULTS (MCP isError) count toward the breaker — proxy-blocked tools stop being retried", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      let execCount = 0;
+      const tools = makeTool(async () => {
+        execCount++;
+        // MCP tools report failure by RETURNING isError, not throwing —
+        // the shape curator's mcp-proxy uses for blocked tools.
+        return {
+          isError: true,
+          content: [{ type: "text", text: "Tool blocked by proxy" }],
+        };
+      });
+      const mock = makeGenerateMock((i) =>
+        i < 3
+          ? { response: toolUseResponse("myTool", { q: `try${i}` }) }
+          : { response: textResponse("done without the tool") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "keep trying" },
+        tools,
+        maxSteps: 10,
+      });
+      assertEqual(
+        execCount,
+        2,
+        "error-shaped results must trip the breaker without a single throw",
+      );
+      assertIncludes(
+        JSON.stringify(mock.calls[3].messages),
+        "TOOL_PERMANENTLY_FAILED",
+        "the 3rd attempt returns a permanent-failure tool_result to the model",
+      );
+      assertEqual(result.content, "done without the tool");
+    });
+  });
+
+  await test("generate: the breaker is genuinely CONSECUTIVE — a success between failures resets the strike count", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      let execCount = 0;
+      // Alternates: fail, succeed, fail, succeed — the strike count resets on
+      // every success, so the tool must NEVER be short-circuited.
+      const tools = makeTool(async () => {
+        execCount++;
+        if (execCount % 2 === 1) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: `not found #${execCount}` }],
+          };
+        }
+        return { ok: true };
+      });
+      const mock = makeGenerateMock((i) =>
+        i < 4
+          ? { response: toolUseResponse("myTool", { q: `try${i}` }) }
+          : { response: textResponse("all four attempts executed") },
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "alternating outcomes" },
+        tools,
+        maxSteps: 10,
+      });
+      assertEqual(
+        execCount,
+        4,
+        "interleaved successes must reset the breaker — no short-circuit",
+      );
+      assert(
+        !JSON.stringify(mock.calls.map((c) => c.messages)).includes(
+          "TOOL_PERMANENTLY_FAILED",
+        ),
+        "no permanent-failure result may appear when failures never run consecutively",
+      );
+      assertEqual(result.content, "all four attempts executed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-tool abort check: a multi-tool step must stop executing its batch
+  // the moment the turn is aborted (deadline overshoot fix).
+  // -------------------------------------------------------------------------
+  await test("generate: abort between tool executions skips the remaining batch (stopReason 'aborted')", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const controller = new AbortController();
+      let execCount = 0;
+      const tools = makeTool(async () => {
+        execCount++;
+        // The turn is aborted while the FIRST tool of the batch runs; the
+        // second tool_use in the same step must never execute.
+        controller.abort();
+        return { ok: true };
+      });
+      const mock = makeGenerateMock(() => ({
+        response: {
+          content: [
+            { type: "tool_use", id: "tu_a", name: "myTool", input: { q: "a" } },
+            { type: "tool_use", id: "tu_b", name: "myTool", input: { q: "b" } },
+          ],
+          usage: { input_tokens: 5, output_tokens: 3 },
+          stop_reason: "tool_use",
+        },
+      }));
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "run both tools" },
+        tools,
+        maxSteps: 5,
+        abortSignal: controller.signal,
+      });
+      assertEqual(execCount, 1, "second tool in the batch must be skipped");
+      assertEqual(mock.calls.length, 1, "no further model calls after abort");
+      assertEqual(result.stopReason, "aborted");
+      assertIncludes(result.content, "stopped before I could finish");
+    });
+  });
 }
 
 await runSuite(main);

--- a/test/continuous-test-suite-gemini-abort.ts
+++ b/test/continuous-test-suite-gemini-abort.ts
@@ -572,16 +572,19 @@ async function main(): Promise<void> {
         },
       };
       const provider = await makeProvider(client);
+      let toolExecuted = false;
       const result = await runGenerate(provider, {
         input: { text: "run tools" },
-        // The tool runs normally (returns without throwing). The abort fires in
-        // the iterable's finally, AFTER step 0's drain, so the break comes from
-        // the next iteration's loop-entry guard — not the tool-exec inner catch.
+        // The abort fires in the iterable's finally, AFTER step 0's drain but
+        // BEFORE the tool batch runs — the per-tool abort check must skip the
+        // batch entirely (an aborted turn executes no further tools), and the
+        // next loop-entry guard prevents a second model request.
         tools: {
           myTool: {
             description: "A test tool",
             parameters: { type: "object", properties: {} },
             execute: async (): Promise<{ ok: true }> => {
+              toolExecuted = true;
               return { ok: true };
             },
           },
@@ -589,9 +592,13 @@ async function main(): Promise<void> {
         maxSteps,
         abortSignal: controller.signal,
       });
+      assert(
+        !toolExecuted,
+        "an already-aborted turn must not execute its pending tool batch",
+      );
       assertEqual(
         result.content,
-        buildAbortedTurnMessage(1),
+        buildAbortedTurnMessage(0),
         `expected honest aborted-turn message, got: ${result.content}`,
       );
       assertEqual(result.stopReason, "aborted", "stopReason must be 'aborted'");
@@ -1366,6 +1373,105 @@ async function main(): Promise<void> {
     const abortedNoTools = buildAbortedTurnMessage(0);
     assertEqual(abortedNoTools, "This turn was stopped before I could finish.");
     assertIncludes(buildAbortedTurnMessage(1), "1 tool call before stopping");
+  });
+
+  // -------------------------------------------------------------------------
+  // 27. Context guard: stop the tool loop before the model window overflows
+  // (gemini-3-pro-preview on vertex → 1,048,576 window, threshold ~891K).
+  // -------------------------------------------------------------------------
+  await test("generate: context guard trips -> tools-disabled synthesis, stopReason 'completed'", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      const mock = makeMock((i) =>
+        i === 0
+          ? [
+              {
+                functionCalls: [{ name: "myTool", args: { q: "x" } }],
+                candidates: [
+                  {
+                    content: {
+                      parts: [
+                        { functionCall: { name: "myTool", args: { q: "x" } } },
+                      ],
+                    },
+                  },
+                ],
+                // Reported prompt already past the ~891K threshold — the loop
+                // must stop BEFORE issuing another agentic step.
+                usageMetadata: {
+                  promptTokenCount: 950_000,
+                  candidatesTokenCount: 3,
+                },
+              },
+            ]
+          : [textChunk("synthesized from gathered results")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "research everything" },
+        tools: makeTool(),
+        maxSteps: 10,
+      });
+      assertEqual(
+        mock.calls.length,
+        2,
+        "1 agentic step + 1 synthesis call — no further tool steps",
+      );
+      assertEqual(result.content, "synthesized from gathered results");
+      assertEqual(
+        result.stopReason,
+        "completed",
+        "a synthesized answer counts as completed",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 28. Breaker counts error-shaped RESULTS (MCP isError), not just throws
+  // -------------------------------------------------------------------------
+  await test("generate: error-shaped results (MCP isError) trip the failedTools breaker without a throw", async () => {
+    await withTemporaryEnv(VERTEX_ENV, async () => {
+      let execCount = 0;
+      const tools = {
+        myTool: {
+          description: "A test tool",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } },
+          },
+          execute: async (): Promise<unknown> => {
+            execCount++;
+            // MCP tools report failure by RETURNING isError, not throwing —
+            // the shape curator's mcp-proxy uses for blocked tools.
+            return {
+              isError: true,
+              content: [{ type: "text", text: "Tool blocked by proxy" }],
+            };
+          },
+        },
+      };
+      const mock = makeMock((i) =>
+        i < 3
+          ? [functionCallChunk("myTool", { q: `try${i}` })]
+          : [textChunk("done without the tool")],
+      );
+      const provider = await makeProvider(mock.client);
+      const result = await runGenerate(provider, {
+        input: { text: "keep trying" },
+        tools,
+        maxSteps: 10,
+      });
+      assertEqual(
+        execCount,
+        2,
+        "error-shaped results must trip the breaker without a single throw",
+      );
+      assertIncludes(
+        JSON.stringify(mock.calls[3].contents),
+        "TOOL_PERMANENTLY_FAILED",
+        "the 3rd attempt returns a permanent-failure functionResponse",
+      );
+      assertEqual(result.content, "done without the tool");
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes the runaway-turn incident class from the 2026-07-06 production RCA (claude-sonnet-5 turns accumulating 1,005,647 tokens over 78 tool steps and dying on Anthropic 400 "prompt is too long"; MCP-proxy-blocked tools retried for up to 200 steps; multi-tool steps overshooting `turnTimeoutMs` by N × 300s). Releases as a **patch** via the `fix` commit. All changes are inside the four native Vertex loops (Gemini + Claude-on-Vertex, generate + stream) plus their shared helpers — no public API breaks; one additive `GenerateStopReason` member.

### In-loop context guard (new stopReason `context-cap`)
- `createContextGuard` (googleNativeGemini3.ts) tracks the provider-reported prompt size of every step (`input + cache read/write` on Anthropic, `promptTokenCount` on Gemini) plus projected growth from appended tool results.
- At 85% of the model window (`DEFAULT_CONTEXT_GUARD_RATIO`) the loop stops calling tools and synthesizes a final answer from gathered results instead of stepping into a provider 400 that destroys the whole turn.
- A synthesized answer returns `stopReason: "completed"`; only a failed synthesis surfaces the new `"context-cap"` with an honest message (never the step-cap text).
- Terminal synthesis calls clamp `max_tokens` to the remaining window (pre-4.5 Claude models reject `input + max_tokens > window`).

### contextWindows: claude-sonnet-5 + Claude catch-all on vertex
- `claude-sonnet-5` → 1,000,000 (vertex + anthropic maps).
- New `"claude-"` prefix catch-all (200K) on vertex so unknown Claude models no longer inherit the Gemini-shaped `_default` (1,048,576) — which sits ABOVE Anthropic's real 1M cap and let the overflow through the pre-dispatch check.

### Consecutive tool-failure breaker on the Anthropic loops
- Ports the Gemini loops' `failedTools` breaker (2 strikes → `TOOL_PERMANENTLY_FAILED` short-circuit) to both Anthropic loops.
- All four loops now count **error-shaped results** (`isError: true` / `{error}` payloads via `extractToolFailureText`) — the shape proxy-blocked tools return without throwing — and `TOOL_NOT_FOUND` calls.
- Genuinely consecutive: a success clears the strike count, so argument-dependent soft errors (file-not-found on different paths) never disable a working tool.

### Abort correctness
- Per-tool-iteration abort checks in all four loops: a multi-tool step stops executing its batch the moment the turn is aborted (was: up to N × `toolTimeoutMs` past the deadline).
- New `raceWithAbort` (utils/async) races each tool execution against the turn's abort signal — live-verified: an 8s `turnTimeoutMs` with a 60s tool previously returned at ~68s, now returns at ~11.7s with `stopReason: "time-limit"`. The abandoned call remains a bounded ghost (same tradeoff as the tool timeout); transport-level MCP cancellation is a tracked follow-up.
- ToolsManager execute wrappers pass the AI-SDK second argument (`abortSignal`, `toolCallId`) through instead of dropping it.

### Overflow-recovery budget
- The post-overflow recovery retry now inherits the REMAINING `turnTimeoutMs` (floored at `MIN_RECOVERY_TURN_BUDGET_MS` = 30s) instead of a fresh full clock — one `generate()` can no longer stack ~2× the configured budget.

## Verification

- `test:anthropic-cap` 39/39 (6 new tests: guard-trip → synthesis, context-cap message, throw-breaker, isError-breaker, consecutive-reset, batch-abort), `test:gemini-abort` 39/39 (2 new; 1 updated for the stricter per-tool abort semantics), `test:mcp` / `test:mcp:bash` / `test:mcp:limits` pass; `tsc --strict`, lint, full build + publint clean.
- **Live-driven against Vertex through the built package**: (1) context guard tripped on a real ~190K-token claude-sonnet-4-5 turn → `stopReason: "context-cap"`, 1 step, honest message, no 400-destroyed turn — and the guard correctly observed the prompt via cache read/creation tokens; (2) an always-`isError` tool was executed exactly 2× while the model requested it 3×, then the turn completed with a graceful summary; (3) the 8s-deadline/60s-tool run above.
- Adversarially reviewed (multi-agent diff review, every finding independently verified); the five real findings — cumulative-vs-consecutive breaker, TOOL_NOT_FOUND bypass, unclamped terminal `max_tokens`, missing Gemini growth projection, non-prompt mid-tool abort — are all fixed in this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude 5 context-window support and improved handling for unknown Claude variants.
  * Introduced a per-turn context guard that can halt tool loops early and return clearer end-of-turn context-cap behavior.

* **Bug Fixes**
  * Preserved turn timeouts during context-overflow recovery retries.
  * Improved tool-loop control with consecutive-failure short-circuiting and better handling of error-shaped tool results.
  * Enhanced abort handling to stop tool execution promptly and avoid extra model calls.
  * Safer forced final-answer sizing to reduce provider “prompt too long” failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->