### PR TITLE
fix(ci): add missing typecheck script for docs PR validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:react-hooks": "npx tsc --jsx react-jsx --module nodenext --moduleResolution nodenext --target esnext --esModuleInterop --skipLibCheck --outDir dist --declaration false src/lib/client/reactHooks.tsx",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc --noEmit --strict",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
     "modelServer": "tsx scripts/modelServer.ts",
     "lint": "prettier --check . && NODE_OPTIONS='--max-old-space-size=8192' eslint .",
     "format": "prettier --write .",


### PR DESCRIPTION
## Problem
The `Documentation PR Validation` workflow (`.github/workflows/docs-pr-validation.yml`) runs a **TypeScript check** step:
```yaml
- name: TypeScript check
  run: pnpm run typecheck
```
But there is **no `typecheck` script** in `package.json`, so this step fails with `ERR_PNPM_NO_SCRIPT` on *every* PR that touches `docs/` or `docs-site/` — making the `Validate Documentation` check fail repo-wide regardless of the PR's actual content.

## Fix
Add a lean `typecheck` script:
```json
"typecheck": "tsc --noEmit"
```
This is what the workflow already expects. Verified locally: `pnpm run typecheck` exits 0 on current `release`.

## Notes
- This PR touches only `package.json`, so it does not itself trigger the docs-validation workflow (which is path-filtered to `docs/`/`docs-site/`), but it unblocks that check for all future docs PRs.
- The heavier `check` script (`svelte-kit sync && svelte-check && tsc --noEmit --strict`) is left as-is; `typecheck` is intentionally the minimal TS-only gate the docs workflow wants.