### PR TITLE
fix(anthropic): prompt-cache breakpoints + accounting parity for the direct-Anthropic path

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -53,6 +53,12 @@ import {
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlCredentials } from "../utils/logSanitize.js";
+import {
+  ANTHROPIC_MAX_CACHE_BREAKPOINTS,
+  applyAnthropicHistoryCacheBreakpoints,
+  countAnthropicCacheMarkers,
+} from "../utils/anthropicCacheBreakpoints.js";
+import type { VertexAnthropicMessage } from "../types/index.js";
 import { calculateCost } from "../utils/pricing.js";
 import {
   createAnthropicConfig,
@@ -1446,9 +1452,27 @@ export class AnthropicProvider extends BaseProvider {
           | { type: "enabled"; budget_tokens: number }
           | undefined;
 
+        // Prompt-cache parity with the native Vertex+Claude path: upstream
+        // layers mark only the stable prefix (system via MessageBuilder,
+        // last tool via GenerationHandler) — the growing conversation
+        // history has no breakpoint, so on every turn it falls after the
+        // last marker and is re-billed as fresh input. Add rolling history
+        // breakpoints in whatever budget remains under Anthropic's
+        // four-marker ceiling; pre-existing markers are counted so the
+        // request can never exceed the cap.
+        const cacheMarkersUsed = countAnthropicCacheMarkers({
+          system,
+          tools,
+          messages: messages as unknown as VertexAnthropicMessage[],
+        });
+        const cachedMessages = applyAnthropicHistoryCacheBreakpoints(
+          messages as unknown as VertexAnthropicMessage[],
+          ANTHROPIC_MAX_CACHE_BREAKPOINTS - cacheMarkersUsed,
+        ) as unknown as Anthropic.Messages.MessageParam[];
+
         const params: Anthropic.Messages.MessageCreateParamsNonStreaming = {
           model: modelId,
-          messages,
+          messages: cachedMessages,
           max_tokens: resolveClaudeMaxTokens(modelId, options.maxOutputTokens),
           ...(system ? { system } : {}),
           ...(options.temperature !== undefined &&
@@ -1741,10 +1765,22 @@ export class AnthropicProvider extends BaseProvider {
           "gen_ai.usage.output_tokens",
           usage.completionTokens || 0,
         );
+        if (usage.cacheReadTokens) {
+          streamSpan.setAttribute(
+            "gen_ai.usage.cached_input_tokens",
+            usage.cacheReadTokens,
+          );
+        }
         const cost = calculateCost(this.providerName, this.modelName, {
           input: usage.promptTokens || 0,
           output: usage.completionTokens || 0,
           total: usage.totalTokens || 0,
+          ...(usage.cacheReadTokens
+            ? { cacheReadTokens: usage.cacheReadTokens }
+            : {}),
+          ...(usage.cacheCreationTokens
+            ? { cacheCreationTokens: usage.cacheCreationTokens }
+            : {}),
         });
         if (cost && cost > 0) {
           streamSpan.setAttribute("neurolink.cost", cost);
@@ -1773,12 +1809,30 @@ export class AnthropicProvider extends BaseProvider {
       const conversation = payload.messages.slice();
       let totalInput = 0;
       let totalOutput = 0;
+      let totalCacheRead = 0;
+      let totalCacheWrite = 0;
       let lastStop: string | null = null;
 
       for (let step = 0; step < maxSteps; step++) {
+        // Prompt-cache parity with the native Vertex+Claude path — rolling
+        // history breakpoints, re-applied per step so the stable prefix
+        // stays byte-identical while the breakpoint follows the growing
+        // tail. Budget respects markers upstream layers already placed
+        // (system / last tool / message blocks) so the request never
+        // exceeds Anthropic's four-marker cap. Pure: `conversation` itself
+        // is never mutated, so re-counting per step stays stable.
+        const cacheMarkersUsed = countAnthropicCacheMarkers({
+          system: payload.system,
+          tools: anthropicTools,
+          messages: conversation as unknown as VertexAnthropicMessage[],
+        });
+        const cachedConversation = applyAnthropicHistoryCacheBreakpoints(
+          conversation as unknown as VertexAnthropicMessage[],
+          ANTHROPIC_MAX_CACHE_BREAKPOINTS - cacheMarkersUsed,
+        ) as unknown as Anthropic.Messages.MessageParam[];
         const params: Anthropic.Messages.MessageCreateParamsStreaming = {
           model: modelId,
-          messages: conversation,
+          messages: cachedConversation,
           max_tokens: resolveClaudeMaxTokens(modelId, options.maxTokens),
           stream: true,
           ...(payload.system ? { system: payload.system } : {}),
@@ -1816,6 +1870,12 @@ export class AnthropicProvider extends BaseProvider {
           if (event.type === "message_start") {
             totalInput += event.message.usage.input_tokens ?? 0;
             totalOutput += event.message.usage.output_tokens ?? 0;
+            // Anthropic reports cache reads/writes SEPARATELY from
+            // input_tokens on the same message_start event — without these
+            // the streaming path silently drops all cache accounting.
+            totalCacheRead += event.message.usage.cache_read_input_tokens ?? 0;
+            totalCacheWrite +=
+              event.message.usage.cache_creation_input_tokens ?? 0;
           } else if (event.type === "content_block_start") {
             blockTypes.set(event.index, event.content_block.type);
             if (event.content_block.type === "tool_use") {
@@ -2016,7 +2076,12 @@ export class AnthropicProvider extends BaseProvider {
       resolveUsage({
         promptTokens: totalInput,
         completionTokens: totalOutput,
-        totalTokens: totalInput + totalOutput,
+        totalTokens:
+          totalInput + totalCacheRead + totalCacheWrite + totalOutput,
+        ...(totalCacheRead > 0 ? { cacheReadTokens: totalCacheRead } : {}),
+        ...(totalCacheWrite > 0
+          ? { cacheCreationTokens: totalCacheWrite }
+          : {}),
       });
       resolveFinish(lastStop ?? "stop");
     };

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -31,6 +31,7 @@ import type {
   OpenAICompatToolChoiceWire,
   OpenAICompatV3CallToolChoice,
   OpenAICompatV3CallTools,
+  DeferredUsage,
   Tool,
 } from "../types/index.js";
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
@@ -639,16 +640,8 @@ export const buildAPIError = async (
 // collector resolves with the actual aggregated values after the multi-step
 // loop ends, not the zeros they had at result-construction time.
 export const createDeferredAnalytics = () => {
-  let resolveUsage: (u: {
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-  }) => void = () => {};
-  const usagePromise = new Promise<{
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-  }>((r) => {
+  let resolveUsage: (u: DeferredUsage) => void = () => {};
+  const usagePromise = new Promise<DeferredUsage>((r) => {
     resolveUsage = r;
   });
   let resolveFinish: (reason: string) => void = () => {};

--- a/src/lib/types/common.ts
+++ b/src/lib/types/common.ts
@@ -357,6 +357,16 @@ export type RawUsageObject = {
   cacheCreationTokens?: number;
   cacheReadTokens?: number;
 
+  // ai@6 normalized usage (generateText/streamText result.usage) — the SDK's
+  // asLanguageModelUsage() exposes cache reads flat as `cachedInputTokens`
+  // and the read/write split nested under `inputTokenDetails`. The native
+  // direct-Anthropic V3 model reports cache tokens ONLY through this shape.
+  cachedInputTokens?: number;
+  inputTokenDetails?: {
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+
   // OpenAI/DeepSeek/NIM/OpenAI-compatible nested cache field (overlapping:
   // cached_tokens is a SUBSET already included in prompt_tokens)
   prompt_tokens_details?: { cached_tokens?: number };
@@ -369,6 +379,19 @@ export type RawUsageObject = {
 
   // Nested usage object (some providers wrap usage)
   usage?: RawUsageObject;
+};
+
+/**
+ * Aggregated usage resolved by a provider's deferred-analytics pair after a
+ * multi-step stream loop ends. The cache fields are optional — only providers
+ * with prompt caching (Anthropic) populate them.
+ */
+export type DeferredUsage = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
 };
 
 /**

--- a/src/lib/utils/anthropicCacheBreakpoints.ts
+++ b/src/lib/utils/anthropicCacheBreakpoints.ts
@@ -26,7 +26,8 @@ import type {
 const EPHEMERAL: VertexAnthropicCacheControl = { type: "ephemeral" };
 
 /** Anthropic allows at most four `cache_control` breakpoints per request. */
-const MAX_BREAKPOINTS = 4;
+export const ANTHROPIC_MAX_CACHE_BREAKPOINTS = 4;
+const MAX_BREAKPOINTS = ANTHROPIC_MAX_CACHE_BREAKPOINTS;
 
 /**
  * Annotate a native Vertex+Claude request with prompt-cache breakpoints.
@@ -80,6 +81,72 @@ export function applyVertexAnthropicCacheBreakpoints(
   }
 
   return { system, tools, messages };
+}
+
+/**
+ * Count the `cache_control` markers already present on a request. The direct
+ * Anthropic path (AI-SDK pipeline) arrives with markers the upstream layers
+ * placed — MessageBuilder tags the system prompt, GenerationHandler tags the
+ * last tool definition, and message content blocks may carry translated
+ * AI-SDK markers. Anthropic rejects requests with more than four markers, so
+ * any additional history breakpoints must fit in the remaining budget.
+ */
+export function countAnthropicCacheMarkers(input: {
+  system?: string | ReadonlyArray<{ cache_control?: unknown }> | undefined;
+  tools?: ReadonlyArray<{ cache_control?: unknown }> | undefined;
+  messages: ReadonlyArray<VertexAnthropicMessage>;
+}): number {
+  let count = 0;
+  if (Array.isArray(input.system)) {
+    count += input.system.filter((b) => b.cache_control).length;
+  }
+  if (input.tools) {
+    count += input.tools.filter((t) => t.cache_control).length;
+  }
+  for (const message of input.messages) {
+    if (Array.isArray(message.content)) {
+      count += message.content.filter(
+        (b) => (b as { cache_control?: unknown }).cache_control,
+      ).length;
+    }
+  }
+  return count;
+}
+
+/**
+ * Rolling history breakpoints for request paths whose stable-prefix markers
+ * are managed upstream (direct Anthropic: system via MessageBuilder, last
+ * tool via GenerationHandler). Marks the last content block of up to `budget`
+ * tail messages; a tail block that already carries a marker is left as-is
+ * without consuming budget (it already serves as that breakpoint). Pure —
+ * the input array is cloned, never mutated.
+ */
+export function applyAnthropicHistoryCacheBreakpoints(
+  input: ReadonlyArray<VertexAnthropicMessage>,
+  budget: number,
+): VertexAnthropicMessage[] {
+  const messages = input.map((m) => ({ ...m }));
+  let remaining = Math.max(0, Math.min(budget, MAX_BREAKPOINTS));
+  for (let i = messages.length - 1; i >= 0 && remaining > 0; i--) {
+    if (lastContentBlockHasMarker(messages[i])) {
+      continue;
+    }
+    if (markLastContentBlock(messages, i)) {
+      remaining--;
+    }
+  }
+  return messages;
+}
+
+/** True when the last content block of a message already carries `cache_control`. */
+function lastContentBlockHasMarker(message: VertexAnthropicMessage): boolean {
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return false;
+  }
+  const last = message.content[message.content.length - 1] as {
+    cache_control?: unknown;
+  };
+  return !!last.cache_control;
 }
 
 /**

--- a/src/lib/utils/tokenUtils.ts
+++ b/src/lib/utils/tokenUtils.ts
@@ -93,7 +93,9 @@ export function extractReasoningTokens(
 
 /**
  * Extract cache creation token count from various provider formats
- * Supports: cacheCreationInputTokens, cacheCreationTokens
+ * Supports: cacheCreationInputTokens, cacheCreationTokens, and the ai@6
+ * normalized `inputTokenDetails.cacheWriteTokens` (the only shape the native
+ * direct-Anthropic path reports through generateText).
  */
 export function extractCacheCreationTokens(
   usage: RawUsageObject,
@@ -110,12 +112,21 @@ export function extractCacheCreationTokens(
   ) {
     return usage.cacheCreationTokens;
   }
+  if (
+    typeof usage.inputTokenDetails?.cacheWriteTokens === "number" &&
+    usage.inputTokenDetails.cacheWriteTokens > 0
+  ) {
+    return usage.inputTokenDetails.cacheWriteTokens;
+  }
   return undefined;
 }
 
 /**
  * Extract cache read token count from various provider formats
- * Supports: cacheReadInputTokens, cacheReadTokens
+ * Supports: cacheReadInputTokens, cacheReadTokens, and the ai@6 normalized
+ * shapes — flat `cachedInputTokens` and nested
+ * `inputTokenDetails.cacheReadTokens` (the only shapes the native
+ * direct-Anthropic path reports through generateText).
  */
 export function extractCacheReadTokens(
   usage: RawUsageObject,
@@ -128,6 +139,18 @@ export function extractCacheReadTokens(
   }
   if (typeof usage.cacheReadTokens === "number" && usage.cacheReadTokens > 0) {
     return usage.cacheReadTokens;
+  }
+  if (
+    typeof usage.cachedInputTokens === "number" &&
+    usage.cachedInputTokens > 0
+  ) {
+    return usage.cachedInputTokens;
+  }
+  if (
+    typeof usage.inputTokenDetails?.cacheReadTokens === "number" &&
+    usage.inputTokenDetails.cacheReadTokens > 0
+  ) {
+    return usage.inputTokenDetails.cacheReadTokens;
   }
   return undefined;
 }

--- a/test/continuous-test-suite-cache-breakpoints.ts
+++ b/test/continuous-test-suite-cache-breakpoints.ts
@@ -13,10 +13,17 @@ import "dotenv/config";
  *      pnpm run test:cache
  */
 
-import { applyVertexAnthropicCacheBreakpoints } from "../src/lib/utils/anthropicCacheBreakpoints.js";
+import {
+  applyVertexAnthropicCacheBreakpoints,
+  applyAnthropicHistoryCacheBreakpoints,
+  countAnthropicCacheMarkers,
+  ANTHROPIC_MAX_CACHE_BREAKPOINTS,
+} from "../src/lib/utils/anthropicCacheBreakpoints.js";
 import {
   extractTokenUsage,
   extractCachedInputTokensOverlapping,
+  extractCacheReadTokens,
+  extractCacheCreationTokens,
 } from "../src/lib/utils/tokenUtils.js";
 import { calculateCost } from "../src/lib/utils/pricing.js";
 import { defineSuite, logSection } from "./helpers/harness.js";
@@ -403,6 +410,129 @@ function testOverlappingCacheExtraction(): void {
   }
 }
 
+function testDirectAnthropicHistoryBreakpoints(): void {
+  logSection(
+    "Direct-Anthropic path — history breakpoints under a pre-marked budget",
+  );
+  try {
+    // The direct path arrives with markers upstream layers placed: system
+    // (MessageBuilder) + last tool (GenerationHandler). Both must be counted.
+    const system = [
+      { type: "text", text: "sys", cache_control: { type: "ephemeral" } },
+    ];
+    const tools = [
+      { name: "a" },
+      { name: "b", cache_control: { type: "ephemeral" } },
+    ];
+    const messages = [
+      { role: "user" as const, content: "one" },
+      { role: "assistant" as const, content: [{ type: "text", text: "two" }] },
+      { role: "user" as const, content: [{ type: "text", text: "three" }] },
+    ];
+    const used = countAnthropicCacheMarkers({ system, tools, messages });
+    recordTest("pre-existing system + tool markers counted", used === 2);
+
+    const out = applyAnthropicHistoryCacheBreakpoints(
+      messages,
+      ANTHROPIC_MAX_CACHE_BREAKPOINTS - used,
+    );
+    recordTest(
+      "history markers fill only the remaining budget (2 of 3 messages)",
+      countHistoryBreakpoints(out) === 2,
+    );
+    recordTest(
+      "markers placed on the newest messages first",
+      lastBlockHasCC(out[2]) &&
+        lastBlockHasCC(out[1]) &&
+        !lastBlockHasCC(out[0]),
+    );
+    recordTest(
+      "total request markers stay within Anthropic's cap",
+      used + countHistoryBreakpoints(out) <= ANTHROPIC_MAX_CACHE_BREAKPOINTS,
+    );
+    recordTest(
+      "input messages are not mutated (pure)",
+      !lastBlockHasCC(messages[2]),
+    );
+
+    // A tail block that already carries a marker is left as-is and does not
+    // consume budget — re-application on multi-step loops stays idempotent.
+    const preMarked = [
+      { role: "user" as const, content: [{ type: "text", text: "a" }] },
+      {
+        role: "user" as const,
+        content: [
+          { type: "text", text: "b", cache_control: { type: "ephemeral" } },
+        ],
+      },
+    ];
+    const outPre = applyAnthropicHistoryCacheBreakpoints(preMarked, 1);
+    recordTest(
+      "already-marked tail block is skipped without consuming budget",
+      lastBlockHasCC(outPre[1]) && lastBlockHasCC(outPre[0]),
+    );
+
+    const outZero = applyAnthropicHistoryCacheBreakpoints(messages, 0);
+    recordTest(
+      "zero budget adds no markers",
+      countHistoryBreakpoints(outZero) === 0,
+    );
+    const outNeg = applyAnthropicHistoryCacheBreakpoints(messages, -1);
+    recordTest(
+      "negative budget (over-marked request) adds no markers",
+      countHistoryBreakpoints(outNeg) === 0,
+    );
+  } catch (error) {
+    recordTest(
+      "direct-anthropic history breakpoints",
+      false,
+      false,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function testAi6CacheUsageExtraction(): void {
+  logSection("ai@6 normalized usage — cache token extraction");
+  try {
+    recordTest(
+      "flat cachedInputTokens recognized as cache reads",
+      extractCacheReadTokens({ cachedInputTokens: 128 }) === 128,
+    );
+    recordTest(
+      "nested inputTokenDetails.cacheReadTokens recognized",
+      extractCacheReadTokens({
+        inputTokenDetails: { cacheReadTokens: 64 },
+      }) === 64,
+    );
+    recordTest(
+      "nested inputTokenDetails.cacheWriteTokens recognized as cache creation",
+      extractCacheCreationTokens({
+        inputTokenDetails: { cacheWriteTokens: 32 },
+      }) === 32,
+    );
+    recordTest(
+      "legacy cacheReadInputTokens still takes precedence",
+      extractCacheReadTokens({
+        cacheReadInputTokens: 10,
+        cachedInputTokens: 999,
+      }) === 10,
+    );
+    recordTest(
+      "no cache fields → undefined (unchanged behaviour)",
+      extractCacheReadTokens({ inputTokens: 100 }) === undefined &&
+        extractCacheCreationTokens({ inputTokens: 100 }) === undefined,
+    );
+  } catch (error) {
+    recordTest(
+      "ai@6 cache usage extraction",
+      false,
+      false,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
 await runSuite(async () => {
   testSystemAndRollingHistory();
   testNoSystemMarksLastTool();
@@ -410,4 +540,6 @@ await runSuite(async () => {
   testHistoryBreakpointCap();
   testEdgeCases();
   testOverlappingCacheExtraction();
+  testDirectAnthropicHistoryBreakpoints();
+  testAi6CacheUsageExtraction();
 });


### PR DESCRIPTION
## Problem

The native **Vertex+Claude** path has had full prompt caching since 9.79.1 (`applyVertexAnthropicCacheBreakpoints`: system + tools + rolling history markers, cache-token capture, discounted pricing). The **direct `anthropic` provider** was left behind in three ways:

1. **No rolling history breakpoints.** Only the system prompt (via MessageBuilder) and the last tool definition (via GenerationHandler) carry `cache_control` — the growing, tool-result-heavy conversation history falls *after* the last marker and is re-billed at full input price on every turn.
2. **generate()-path cache accounting silently dropped.** The native V3 delegating model reports cache reads/writes only through ai\@6's normalized usage shape — flat `cachedInputTokens` and nested `inputTokenDetails.{cacheReadTokens,cacheWriteTokens}` (`asLanguageModelUsage()`) — none of which `extractCacheReadTokens`/`extractCacheCreationTokens` recognized. Caching happened and Anthropic billed the discount, but NeuroLink reported the cache tokens as undefined. (Bedrock hits the same GenerationHandler path.)
3. **stream()-path cache accounting never attempted.** `executeStream()` accumulated only `input_tokens`/`output_tokens` off `message_start`; `cache_read_input_tokens`/`cache_creation_input_tokens` on the same event were never read.

## Fix

- **`utils/anthropicCacheBreakpoints.ts`** — new `applyAnthropicHistoryCacheBreakpoints()` (rolling tail markers for paths whose stable-prefix markers are managed upstream) + `countAnthropicCacheMarkers()`. The count feeds the budget so a request can **never exceed Anthropic's four-marker cap** — critical on the direct path, where the AI-SDK pipeline has already placed system/tool markers before the provider sees the request. Already-marked tail blocks are skipped without consuming budget, so per-step re-application stays idempotent. `applyVertexAnthropicCacheBreakpoints` is untouched (all 34 existing tests pass unchanged).
- **`providers/anthropic.ts`** — `doGenerate` and the `executeStream` step loop apply the history breakpoints (re-applied per step, mirroring the Vertex loops); `executeStream` now accumulates cache reads/writes and threads them through `resolveUsage` into the OTel span (`gen_ai.usage.cached_input_tokens`) and `calculateCost` (which already prices `cacheReadTokens`/`cacheCreationTokens`).
- **`utils/tokenUtils.ts` + `types/common.ts`** — extractors recognize the ai\@6 shapes; legacy field names keep precedence, so no behavior change for any existing provider.

## Tests

Extended `test/continuous-test-suite-cache-breakpoints.ts` (`pnpm run test:cache`): **47/47 pass** — 13 new assertions covering marker counting, budget clamping (incl. zero/negative), newest-first placement, purity, idempotent re-application, and the ai\@6 extraction shapes.

## Origin

Found while investigating cached-token accounting for curator (Claude-on-Vertex works today; this brings the currently-dormant direct-Anthropic path to parity before anyone switches to it, e.g. for OAuth/Claude-subscription access).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Anthropic prompt caching across standard and multi-step streaming requests.
  - Improved cache breakpoint handling for ongoing conversations while respecting existing cache markers.
  - Added support for reporting cache read and cache creation token usage.

- **Bug Fixes**
  - Updated token accounting and cost calculations to include cached input tokens.
  - Improved compatibility with normalized provider usage formats for cache metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->