### PR TITLE
feat(skills): progressive disclosure with session-pinned activation

### DIFF
--- a/docs/agents/CONFIGURATION.md
+++ b/docs/agents/CONFIGURATION.md
@@ -464,6 +464,5 @@ timeout: 120000;
 
 ## Related Documentation
 
-- [TESTING.md](./TESTING.md) - Testing guide
-- [VERIFICATION.md](./VERIFICATION.md) - Verification checklist
-- [API Reference](../api/agents.md) - Full API documentation
+- [TESTING.md](/docs/agents/testing) - Testing guide
+- [VERIFICATION.md](/docs/agents/verification) - Verification checklist

--- a/docs/agents/TESTING.md
+++ b/docs/agents/TESTING.md
@@ -266,6 +266,6 @@ TEST_PROVIDER=openai OPENAI_API_KEY=sk-... npx tsx test/continuous-test-suite-ag
 
 ## Related Documentation
 
-- [CONFIGURATION.md](./CONFIGURATION.md) - Configuration options
-- [VERIFICATION.md](./VERIFICATION.md) - Manual verification checklist
-- [CLI-COVERAGE.md](./CLI-COVERAGE.md) - CLI coverage report
+- [CONFIGURATION.md](/docs/agents/configuration) - Configuration options
+- [VERIFICATION.md](/docs/agents/verification) - Manual verification checklist
+- [CLI-COVERAGE.md](/docs/agents/cli-coverage) - CLI coverage report

--- a/docs/agents/VERIFICATION.md
+++ b/docs/agents/VERIFICATION.md
@@ -147,7 +147,7 @@ All agent and network CLI commands are implemented in
 - [ ] `neurolink network execute` - available
 - [ ] `neurolink network run` (alias for execute) - available
 
-See [CLI-COVERAGE.md](./CLI-COVERAGE.md) for full flag reference and usage
+See [CLI-COVERAGE.md](/docs/agents/cli-coverage) for full flag reference and usage
 examples.
 
 ## Final Verification Summary

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,15 +1,17 @@
 ---
 title: Skills Guide
-description: Native skills — versioned, discoverable instruction packs (SOPs, playbooks) with progressive disclosure via built-in tools and a system-prompt index
+description: Native skills — versioned instruction packs (SOPs, playbooks) with progressive disclosure, session-pinned activation, and on-demand resources
 keywords:
   [
     skills,
     sops,
     playbooks,
     progressive-disclosure,
-    search_skills,
+    use_skill,
+    read_skill_resource,
     list_skills,
-    skill-tools,
+    session-persistence,
+    prompt-caching,
     maker-checker,
     custom-storage,
   ]
@@ -17,16 +19,17 @@ keywords:
 
 # Skills Guide
 
-> **Since**: v9.82.0 | **Status**: New | **Availability**: SDK
+> **Since**: v9.82.0 | **Status**: Stable | **Availability**: SDK, CLI, Server
 
 ## Overview
 
-NeuroLink includes native **skills** support: versioned, discoverable instruction packs (SOPs, playbooks, workflows) that agents consult before answering from general knowledge. Skills use **progressive disclosure** to stay cheap:
+NeuroLink includes native **skills** support: versioned, discoverable instruction packs (SOPs, playbooks, workflows) the model consults before answering from general knowledge. Skills follow the [Agent Skills](https://agentskills.io) progressive-disclosure architecture — three levels, each loaded only when needed:
 
-- A compact **index** (name + description, never instructions) is injected into the system prompt of each `generate()`/`stream()` call, so the model knows what exists.
-- Full **instructions** are loaded on demand through the built-in `search_skills` tool — only for skills that actually match the user's request.
+1. **Discovery** — a compact listing (name + description, never instructions) is embedded in the `use_skill` tool description on every `generate()`/`stream()` call. The model decides from context when a skill applies; there is no mandatory pre-flight search call.
+2. **Activation** — when a skill matches the task, the model calls `use_skill(name)` and receives the **full instructions, never truncated**. The activation is **pinned to the session**: the instructions persist in conversation history, replayed byte-identically on every later turn (provider prompt caches bill them at cached rates), and re-invocations return a tiny `already_loaded` note instead of the body.
+3. **Resources** — skills can bundle auxiliary files (`references/*.md`, templates, schemas). They cost zero tokens until the model reads one with `read_skill_resource`.
 
-This is the same architecture proven in production by curator's skills system, generalized and moved into the SDK: enable it with one config block instead of building stores, matchers, and tools in app code.
+A 20-skill catalog costs roughly 500–700 tokens of always-on listing; an activated 4K-token SOP is fetched once per session and cached thereafter.
 
 ## Quick Start
 
@@ -40,207 +43,212 @@ const neurolink = new NeuroLink({
   },
 });
 
-// The model now sees the skills index in its system prompt and can call
-// search_skills / list_skills automatically during any generate/stream.
+// The model sees the skills listing inside the use_skill tool description
+// and loads instructions only when a skill matches the task.
 const result = await neurolink.generate({
   input: { text: "A refund is disputed — how do I escalate?" },
+  context: { sessionId: "thread-42", userId: "u1" },
 });
 ```
 
+With a `sessionId` and conversation memory configured, an activated skill stays loaded for the whole session — later turns replay it from history instead of re-fetching it. Without conversation memory, activation is per-turn (nothing is pinned, and `use_skill` simply re-fetches when asked again).
+
 ## Skill Format
 
-Three on-disk layouts are supported by the filesystem store (mixable in one directory):
+### Directory layout (recommended)
 
-**JSON** (`./skills/<id>.json`):
-
-```json
-{
-  "id": "refund-escalation",
-  "name": "refund_dispute_escalation",
-  "displayName": "Refund Dispute Escalation",
-  "description": "How to escalate a disputed refund to the payments on-call team.",
-  "instructions": "1. Collect the transaction id.\n2. Verify the dispute.\n3. Page payments-oncall.",
-  "tags": ["payments", "escalation"]
-}
+```
+skills/
+  refund_dispute_escalation/
+    SKILL.md               # frontmatter + instructions
+    references/
+      edge-cases.md        # loaded on demand via read_skill_resource
+      escalation-matrix.md
 ```
 
-**Frontmatter markdown** (`./skills/<name>.md`):
+`SKILL.md` starts with YAML frontmatter; the markdown body is the instructions:
 
 ```markdown
 ---
-name: oncall_handover
-description: Checklist for handing over the on-call shift.
-tags: [devops, oncall]
+name: refund_dispute_escalation
+displayName: Refund Dispute Escalation
+description: How to escalate a disputed refund to the payments on-call. Use when a customer contests a refund decision.
+tags: [payments, escalation]
 ---
 
-1. Summarize open incidents.
-2. Hand over the pager.
+1. Verify the dispute in the payments dashboard…
+2. …
 ```
 
-**Claude-skills directory layout** (`./skills/<name>/SKILL.md`) — same frontmatter format, interoperable with Claude-style skill directories.
+Every sibling file of `SKILL.md` becomes an on-demand resource, addressable by its relative path (e.g. `references/edge-cases.md`).
+
+### Other accepted layouts
+
+- `<dir>/<name>.md` — single frontmatter markdown file (no resources)
+- `<dir>/<id>.json` — JSON-serialized `SkillDefinition` (what mutations write)
 
 Optional fields: `scope: "scoped"` + `scopeIds: [...]` restrict a skill to specific scopes (channels/teams/tenants); `status: "deprecated"` hides it from matching.
 
-## Storage Backends
+### Authoring guidance
 
-| Type         | Config                                    | Use case                                     |
-| ------------ | ----------------------------------------- | -------------------------------------------- |
-| `memory`     | `{ type: "memory", skills?: [...] }`      | Tests, embedded, host-managed                |
-| `filesystem` | `{ type: "filesystem", path: "./dir" }`   | Local dev, git-versioned skill repos         |
-| `s3`         | `{ type: "s3", bucket, prefix? }`         | Shared team skills (curator-style)           |
-| `redis`      | `{ type: "redis", keyPrefix? }`           | Low-latency shared store, reuses core client |
-| `custom`     | `{ type: "custom", store: mySkillStore }` | Anything else — implement `SkillStore`       |
+- **Description is the matching signal.** Say _what_ the skill does and _when_ to use it, in one or two sentences. The model selects skills purely from descriptions.
+- **Keep instructions lean** (guideline: under ~5K tokens). Move rarely-needed detail into `references/` — if information is needed 20% of the time, it belongs in a resource file.
+- **Instructions are never truncated or capped** — budgets apply only to the discovery listing, which shortens descriptions uniformly (never drops names) when the catalog outgrows `listingBudgetChars`.
 
-A custom store implements four methods: `get(id)`, `put(skill)`, `delete(id)`, `index()` (index entries must be cheap — they back every search).
+## How Activation Works
 
-### S3
+```
+Turn 1: user asks → model sees listing → use_skill("deploy_sop")
+        → full instructions returned (tool result)
+        → pinned into session history: ask → [Skill loaded: deploy_sop v3] → answer
+
+Turn 2+: history replays the pinned instructions byte-identically
+         (cached prefix for Anthropic cache_control / Gemini implicit caching);
+         use_skill("deploy_sop") again → { status: "already_loaded" }
+```
+
+Guarantees, in order of the pipeline:
+
+- **Version pinning** — a session keeps the version it activated; a mid-session skill update never mutates instructions the model already follows. New sessions get the new version.
+- **Summarization-safe** — when conversation memory summarizes old turns, pinned skill messages are re-included verbatim after the summary.
+- **Truncation-safe** — the context compactor's sliding-window stage re-seats pinned skill messages instead of dropping them, and never content-truncates them.
+- **Restart-safe** — activation state is derived from the stored history itself (messages carry `metadata.isSkill`), so dedup works across process restarts and multiple instances sharing Redis memory.
+
+Without a `sessionId` (or with `sessionPersistence: false`), activation is per-turn: the instructions still arrive as a tool result for the current turn; nothing is pinned.
+
+## Discovery Modes
+
+| Mode               | Where the listing lives                                            | When to use                                                                                                     |
+| ------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `"tool"` (default) | `<available_skills>` block inside the `use_skill` tool description | Best default — keeps the host's system prompt untouched and the listing byte-stable for provider prompt caching |
+| `"system-prompt"`  | `## Available Skills` index appended to the system prompt          | When you want the listing visible in prompt dumps/debugging                                                     |
+| `"none"`           | Nowhere                                                            | Hosts that inject their own discovery or rely on `preload`                                                      |
+
+The listing is rendered from a name-sorted index and is a pure function of it, so calls with the same scope/tag filters render byte-identical listings — a prerequisite for Anthropic `cache_control` prefix caching and Gemini implicit caching. When the catalog exceeds `listingBudgetChars` (default 15000), every description is shortened uniformly (first sentence, then a hard cap); names are never dropped.
+
+## Per-Call Options
 
 ```typescript
-skills: {
-  enabled: true,
-  storage: {
-    type: "s3",
-    bucket: "team-skills",
-    prefix: "tara/",          // default "neurolink-skills/"
-    region: "us-east-1",
-    // endpoint + forcePathStyle for MinIO/LocalStack;
-    // credentials default to the standard AWS provider chain
+await neurolink.generate({
+  input: { text: "…" },
+  context: { sessionId: "thread-42" },
+  skills: {
+    enabled: true, // master toggle for this call
+    discovery: "tool", // override the instance discovery mode
+    scopeId: "channel-123", // include skills scoped to this id
+    tags: ["payments"], // restrict the listing to these tags
+    preload: ["deploy_sop"], // activate up front, no model round-trip
   },
-}
+});
 ```
 
-Layout: `<prefix>skills/<id>.json` per skill plus a `<prefix>index.json` that is upserted on writes and **rebuilt automatically from a bucket listing** when missing or corrupt. The AWS SDK is an optional peer — install `@aws-sdk/client-s3` in your app (NeuroLink core does not depend on it; without it, S3-configured skills fail open with an actionable error).
-
-### Redis
-
-```typescript
-skills: {
-  enabled: true,
-  storage: { type: "redis", keyPrefix: "neurolink:skills:" },
-  // url / host / port / password / db — defaults match the core Redis client
-}
-```
-
-Uses NeuroLink's pooled Redis client (`redis` v5, already a core dependency — shared with Redis conversation memory). One JSON value per skill; the index is derived with SCAN + MGET. Skills are persistent — no TTL.
+`preload` activates skills before the model runs: instructions are injected into the call's system prompt and pinned to the session like a normal activation. Use it when the host already knows which skill applies (e.g. a channel bound to a runbook).
 
 ## Built-in Tools
 
-When enabled, these tools are auto-registered and reach the model on every call:
+| Tool                                             | Injected                         | Purpose                                                                              |
+| ------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------ |
+| `use_skill`                                      | per call                         | Load a skill's full instructions by exact name; returns `already_loaded` when active |
+| `read_skill_resource`                            | per call                         | Read a bundled resource file of a loaded skill                                       |
+| `list_skills`                                    | registered                       | Lightweight catalog for "what can you do?" questions                                 |
+| `skill_create` / `skill_update` / `skill_delete` | registered when `allowMutations` | Model-proposed mutations, gated by `onMutationRequest`                               |
 
-- **`search_skills`** — index-first search by `query` and/or `tag`; hydrates at most `maxMatches` (default 5) matching skills with full instructions. A zero-match result returns `{ skills: [], reason: "no_match" }` as a **success**, telling the model to fall back to general knowledge.
-- **`list_skills`** — lightweight discovery listing (no instructions), for "what can you do?" questions.
+## Storage Backends
 
-With `allowMutations: true`, three more tools are registered:
+```typescript
+// In-process (tests, embedded)
+storage: { type: "memory", skills: [...], resources: { "skill-id": { "references/x.md": "…" } } }
 
-- **`skill_create`**, **`skill_update`**, **`skill_delete`** — propose changes, routed through your `onMutationRequest` gate when configured. Deletes are soft (status becomes `deprecated`).
+// Filesystem (CLI, local development)
+storage: { type: "filesystem", path: "./skills" }
 
-## Approval Gate (Maker-Checker)
+// S3 (production, curator-compatible layout)
+storage: { type: "s3", bucket: "my-bucket", prefix: "team-skills/" }
 
-Hosts keep full control over writes via `onMutationRequest`:
+// Redis (shared store on the pooled core client, no TTL)
+storage: { type: "redis", url: process.env.REDIS_URL }
+
+// Anything else
+storage: { type: "custom", store: mySkillStore }
+```
+
+Resource layouts per backend:
+
+- **Filesystem** — sibling files of `SKILL.md` (see above)
+- **S3** — `<prefix>skills/<id>.json` for the skill, `<prefix>skills/<id>/<path>` for resources; `<prefix>index.json` is self-healing and refreshed with ETag-conditional reads (an unchanged index costs a 304, not a download)
+- **Redis** — `<keyPrefix><id>` for skills, `<keyPrefix>__resources__:<id>:<path>` for resources (the `__resources__:` segment is reserved and excluded from the index scan)
+- **Custom** — implement the optional `getResource(id, path)` on your `SkillStore`
+
+S3 requires the optional peer `@aws-sdk/client-s3`. A custom store implements `get(id)`, `put(skill)`, `delete(id)`, `index()` (index entries must be cheap — they back every listing), plus optionally `getResource` and `invalidate`.
+
+## Mutations & Approval Gate
 
 ```typescript
 const neurolink = new NeuroLink({
   skills: {
     enabled: true,
-    storage: { type: "custom", store: s3SkillsStore },
+    storage: { type: "s3", bucket: "team-skills" },
     allowMutations: true,
     onMutationRequest: async (action) => {
-      // e.g. post a Slack approval block, persist a pending action…
-      const ticket = await queueForApproval(action);
-      return { outcome: "pending", reference: ticket.id };
-      // or { outcome: "approved" } to apply immediately
-      // or { outcome: "rejected", reason: "…" } to block
+      const ticket = await sendToSlackApproval(action);
+      return { outcome: "pending", reference: ticket };
     },
   },
 });
 ```
 
-`"pending"` means the host applies the change itself after human approval — NeuroLink writes nothing.
+- Reads **fail open** (errors → empty results + warn log); writes **fail closed**.
+- Deletes are soft — deprecated skills stop matching but stay in storage for audit.
+- Updates bump `version`; active sessions keep the version they loaded.
 
-## Configuration Reference
+## Observability
 
-```typescript
-skills: {
-  enabled: true,
-  storage: { type: "filesystem", path: "./skills" },
-  promptIndex: true,        // inject index into system prompt (default true)
-  promptIndexMaxItems: 50,  // truncate the injected index
-  maxMatches: 5,            // max skills hydrated per search
-  indexCacheTtlMs: 30_000,  // index cache TTL (0 = no caching)
-  defaultScopeId: undefined, // default scope filter
-  allowMutations: false,    // register skill_create/update/delete
-  onMutationRequest: undefined, // approval gate
-}
-```
-
-### Per-call options
-
-```typescript
-await neurolink.generate({
-  input: { text: "…" },
-  skills: {
-    enabled: true, // per-call master toggle (prompt index)
-    promptIndex: false, // disable injection for this call only
-    scopeId: "team-alpha", // scope the index for this call
-    tags: ["payments"], // narrow the index by tags
-  },
-});
-```
-
-### Programmatic access
-
-```typescript
-const manager = neurolink.getSkillsManager();
-const matches = await manager?.search({ query: "refund" });
-const index = await manager?.list();
-await manager?.requestMutation({ type: "create", skill: { … } });
-```
+Every activation stamps the active span with `skill.name`, `skill.version`, `skill.instructions_chars`, and `skill.pinned`, so traces show exactly which skills a turn loaded and what they cost.
 
 ## CLI
 
-Manage a filesystem skills store directly:
-
 ```bash
-neurolink skills list   --skills-dir ./skills
-neurolink skills show   refund_dispute_escalation --skills-dir ./skills
-neurolink skills search "refund" --skills-dir ./skills
-neurolink skills create --skills-dir ./skills \
-  --name deploy_sop --description "How to deploy" --instructions-file ./sop.md
-neurolink skills delete deploy_sop --skills-dir ./skills
+neurolink skills list --skills-dir ./skills
+neurolink skills show refund_dispute_escalation
+neurolink skills search "refund" --tag payments
+neurolink skills create --name deploy_sop --description "How to deploy" --instructions-file ./sop.md
+neurolink skills delete deploy_sop
+
+# Make skills available to a run
+neurolink generate "how do I deploy?" --skills-dir ./skills
 ```
 
-Make skills available to any generation run with the same flag (or `NEUROLINK_SKILLS_DIR`):
+`NEUROLINK_SKILLS_DIR` works as an alternative to `--skills-dir`.
 
-```bash
-neurolink generate "A refund is disputed — how do I escalate?" --skills-dir ./skills
-neurolink loop --skills-dir ./skills
-```
+## Server
 
-Directory precedence: `--skills-dir` > `NEUROLINK_SKILLS_DIR` > `./skills` (for the `skills` command group).
+`/api/agent/skills` exposes CRUD routes when the server's NeuroLink instance has skills configured (503 `SKILLS_UNAVAILABLE` otherwise); mutation routes additionally require `allowMutations: true`.
 
-## Server Endpoints
+## Config Reference
 
-When the server's NeuroLink instance has skills enabled, these routes are available:
+| Key                   | Default              | Purpose                                                                |
+| --------------------- | -------------------- | ---------------------------------------------------------------------- |
+| `enabled`             | —                    | Master switch (required)                                               |
+| `storage`             | `{ type: "memory" }` | Persistence backend                                                    |
+| `discovery`           | `"tool"`             | Where the listing surfaces (`"tool"` \| `"system-prompt"` \| `"none"`) |
+| `listingBudgetChars`  | `15000`              | Character budget for the `"tool"` listing                              |
+| `sessionPersistence`  | `true`               | Pin activated instructions into session history                        |
+| `maxMatches`          | `5`                  | Max skills hydrated per programmatic `search()`                        |
+| `promptIndexMaxItems` | `50`                 | Max entries in the `"system-prompt"` index                             |
+| `indexCacheTtlMs`     | `30000`              | Index cache TTL (0 disables)                                           |
+| `defaultScopeId`      | —                    | Scope filter applied when a call provides none                         |
+| `allowMutations`      | `false`              | Register the `skill_*` mutation tools                                  |
+| `onMutationRequest`   | —                    | Host approval gate for mutations                                       |
 
-| Method   | Path                    | Purpose                                   |
-| -------- | ----------------------- | ----------------------------------------- |
-| `GET`    | `/api/agent/skills`     | List index entries (optional `?scopeId=`) |
-| `GET`    | `/api/agent/skills/:id` | One skill with instructions (id or name)  |
-| `POST`   | `/api/agent/skills`     | Create (routed through the mutation gate) |
-| `PATCH`  | `/api/agent/skills/:id` | Update (patch semantics, version bump)    |
-| `DELETE` | `/api/agent/skills/:id` | Soft-delete (deprecate)                   |
+## Programmatic Access
 
-Mutation endpoints honor `onMutationRequest` — a `pending` decision returns `{ decision: { outcome: "pending", reference } }` without writing. When skills are not configured the routes return a 503 `SKILLS_UNAVAILABLE` error envelope. Authenticated user identity (when auth middleware is active) overrides caller-supplied `requestedBy`.
-
-## Behavior Notes
-
-- **Opt-in and fail-open**: with no `skills` config, nothing changes. Store/read errors log a warning and degrade to "no skills" — they never fail a generate/stream call. Mutations fail closed.
-- **Media modes**: the prompt index is skipped for avatar/music/video/ppt outputs (no meaningful text prompt to augment).
-- **Tool routing**: skill tools are registered as custom (direct) tools, so server-granularity tool routing never drops them.
-- Related: [Memory Guide](/docs/features/memory) for the analogous per-user memory subsystem, and [Conversation History](/docs/features/conversation-history).
-
-## Testing
-
-```bash
-pnpm run test:skills   # test/continuous-test-suite-skills.ts (mostly no-API; live test skips without credentials)
+```typescript
+const manager = neurolink.getSkillsManager();
+const all = await manager?.list();
+const matches = await manager?.search({ query: "refund", limit: 3 });
+const skill = await manager?.get("refund_dispute_escalation");
+const resource = await manager?.getResource(
+  skill!.id,
+  "references/edge-cases.md",
+);
 ```

--- a/src/lib/context/contextCompactor.ts
+++ b/src/lib/context/contextCompactor.ts
@@ -40,7 +40,7 @@ const DEFAULT_CONFIG: Required<CompactionConfig> = {
   enableTruncate: true,
   pruneProtectTokens: 40_000,
   pruneMinimumSavings: 500,
-  pruneProtectedTools: ["skill"],
+  pruneProtectedTools: ["skill", "use_skill", "read_skill_resource"],
   summarizationProvider: "vertex",
   summarizationModel: "gemini-2.5-flash",
   keepRecentRatio: 0.3,
@@ -180,7 +180,25 @@ export class ContextCompactor {
                 "LLM summarization timed out after 120s",
               );
               if (summarizeResult.summarized) {
-                currentMessages = summarizeResult.messages;
+                // Pinned skill instructions must survive summarization:
+                // re-seat any that the summarized region swallowed right
+                // after the summary message (index 0 of the result).
+                const survivorIds = new Set(
+                  summarizeResult.messages.map((m) => m.id),
+                );
+                const swallowedSkills = currentMessages.filter(
+                  (m) => m.metadata?.isSkill && !survivorIds.has(m.id),
+                );
+                currentMessages =
+                  swallowedSkills.length > 0
+                    ? summarizeResult.messages.length > 0
+                      ? [
+                          summarizeResult.messages[0],
+                          ...swallowedSkills,
+                          ...summarizeResult.messages.slice(1),
+                        ]
+                      : swallowedSkills
+                    : summarizeResult.messages;
                 stagesUsed.push("summarize");
               }
               const stageTokensAfter = estimateMessagesTokens(

--- a/src/lib/context/stages/slidingWindowTruncator.ts
+++ b/src/lib/context/stages/slidingWindowTruncator.ts
@@ -88,8 +88,12 @@ function truncateSmallConversation(
 
   for (let i = 0; i < result.length; i++) {
     const msg = result[i];
-    // Don't truncate system/summary messages
-    if (msg.role === "system" || msg.metadata?.isSummary) {
+    // Don't truncate system/summary messages or pinned skill instructions
+    if (
+      msg.role === "system" ||
+      msg.metadata?.isSummary ||
+      msg.metadata?.isSkill
+    ) {
       continue;
     }
 
@@ -133,8 +137,39 @@ export function truncateWithSlidingWindow(
   messages: ChatMessage[],
   config?: TruncationConfig,
 ): TruncationResult {
-  if (messages.length <= 4) {
-    // Delegate to content truncation for small conversations (BUG-005)
+  // Partition pinned skill messages out so the pair-based arithmetic below
+  // runs on the alternating user/assistant stream (skill pins are extra
+  // user-role messages inside a turn and would misalign every even-count
+  // cut). Each skill anchors to the next conversational message; kept
+  // anchors put their skills back in place, dropped anchors re-seat them
+  // after the truncation marker.
+  const skillsByAnchor = new Map<string, ChatMessage[]>();
+  const trailingSkills: ChatMessage[] = [];
+  const conversational: ChatMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg.metadata?.isSkill) {
+      conversational.push(msg);
+      continue;
+    }
+    const anchor = messages
+      .slice(i + 1)
+      .find((next) => !next.metadata?.isSkill);
+    if (anchor) {
+      const anchored = skillsByAnchor.get(anchor.id);
+      if (anchored) {
+        anchored.push(msg);
+      } else {
+        skillsByAnchor.set(anchor.id, [msg]);
+      }
+    } else {
+      trailingSkills.push(msg);
+    }
+  }
+
+  if (conversational.length <= 4) {
+    // Delegate to content truncation for small conversations (BUG-005);
+    // it never removes messages, so skills keep their positions.
     return truncateSmallConversation(messages, config);
   }
 
@@ -163,8 +198,49 @@ export function truncateWithSlidingWindow(
   }
 
   // Always preserve first user-assistant pair
-  const firstPair = messages.slice(0, 2);
-  const remainingMessages = messages.slice(2);
+  const firstPair = conversational.slice(0, 2);
+  const remainingMessages = conversational.slice(2);
+
+  /** Reassemble a candidate: skills inline before kept anchors, orphans after the marker. */
+  const buildCandidate = (
+    keptAfterTruncation: ChatMessage[],
+    marker: ChatMessage,
+  ): ChatMessage[] => {
+    const keptIds = new Set(
+      [...firstPair, ...keptAfterTruncation].map((m) => m.id),
+    );
+    const orphanedSkills: ChatMessage[] = [];
+    for (const [anchorId, anchored] of skillsByAnchor) {
+      if (!keptIds.has(anchorId)) {
+        orphanedSkills.push(...anchored);
+      }
+    }
+    const withInlineSkills = (msg: ChatMessage): ChatMessage[] => {
+      const anchored = skillsByAnchor.get(msg.id);
+      return anchored ? [...anchored, msg] : [msg];
+    };
+    return [
+      ...firstPair.flatMap(withInlineSkills),
+      marker,
+      ...orphanedSkills,
+      ...keptAfterTruncation.flatMap(withInlineSkills),
+      ...trailingSkills,
+    ];
+  };
+
+  // Insert a truncation marker with machine-readable metadata so
+  // effectiveHistory.ts can detect it via isTruncationMarker /
+  // truncationId and removeTruncationTags can rewind it.
+  const makeMarker = (): ChatMessage => {
+    const truncId = randomUUID();
+    return {
+      id: `truncation-marker-${truncId}`,
+      role: "user",
+      content: TRUNCATION_MARKER_CONTENT,
+      isTruncationMarker: true,
+      truncationId: truncId,
+    };
+  };
 
   // ITERATIVE: if first pass isn't enough, increase fraction
   const maxIterations = config?.maxIterations ?? 3;
@@ -178,21 +254,10 @@ export function truncateWithSlidingWindow(
       break;
     }
 
-    const keptAfterTruncation = remainingMessages.slice(evenRemoveCount);
-
-    // Insert a truncation marker with machine-readable metadata so
-    // effectiveHistory.ts can detect it via isTruncationMarker /
-    // truncationId and removeTruncationTags can rewind it.
-    const truncId = randomUUID();
-    const marker: ChatMessage = {
-      id: `truncation-marker-${truncId}`,
-      role: "user",
-      content: TRUNCATION_MARKER_CONTENT,
-      isTruncationMarker: true,
-      truncationId: truncId,
-    };
-
-    const candidateMessages = [...firstPair, marker, ...keptAfterTruncation];
+    const candidateMessages = buildCandidate(
+      remainingMessages.slice(evenRemoveCount),
+      makeMarker(),
+    );
 
     validateRoleAlternation(candidateMessages);
 
@@ -226,19 +291,10 @@ export function truncateWithSlidingWindow(
   const maxRemove = Math.floor(remainingMessages.length * 0.95);
   const evenMaxRemove = maxRemove - (maxRemove % 2);
   if (evenMaxRemove > 0) {
-    const keptMessages = remainingMessages.slice(evenMaxRemove);
-
-    // Insert a truncation marker (see iterative block above)
-    const fallbackTruncId = randomUUID();
-    const fallbackMarker: ChatMessage = {
-      id: `truncation-marker-${fallbackTruncId}`,
-      role: "user",
-      content: TRUNCATION_MARKER_CONTENT,
-      isTruncationMarker: true,
-      truncationId: fallbackTruncId,
-    };
-
-    const fallbackMessages = [...firstPair, fallbackMarker, ...keptMessages];
+    const fallbackMessages = buildCandidate(
+      remainingMessages.slice(evenMaxRemove),
+      makeMarker(),
+    );
     validateRoleAlternation(fallbackMessages);
 
     return {

--- a/src/lib/core/conversationMemoryManager.ts
+++ b/src/lib/core/conversationMemoryManager.ts
@@ -138,7 +138,14 @@ export class ConversationMemoryManager implements IConversationMemoryManager {
             assistantMsg.events = options.events;
           }
 
-          session.messages.push(userMsg, assistantMsg);
+          session.messages.push(userMsg);
+          // Pinned skill activations ride between ask and answer, mirroring
+          // the actual order (ask → skill loaded → answer). Stored verbatim —
+          // skill instructions are never truncated.
+          if (options.skillMessages && options.skillMessages.length > 0) {
+            session.messages.push(...options.skillMessages);
+          }
+          session.messages.push(assistantMsg);
           session.lastActivity = Date.now();
 
           // Store API-reported token counts if available
@@ -399,8 +406,13 @@ export class ConversationMemoryManager implements IConversationMemoryManager {
     await this.ensureInitialized();
 
     const sessions = Array.from(this.sessions.values());
+    // Pinned skill messages are extra rows inside a turn — exclude them so
+    // a skill-activating turn still counts as one turn.
     const totalTurns = sessions.reduce(
-      (sum, session) => sum + session.messages.length / MESSAGES_PER_TURN,
+      (sum, session) =>
+        sum +
+        session.messages.filter((msg) => !msg.metadata?.isSkill).length /
+          MESSAGES_PER_TURN,
       0,
     );
 

--- a/src/lib/core/redisConversationMemoryManager.ts
+++ b/src/lib/core/redisConversationMemoryManager.ts
@@ -683,6 +683,13 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
             normalizedUserId,
           );
 
+          // Pinned skill activations ride between ask and answer, mirroring
+          // the actual order (ask → skill loaded → answer). Stored verbatim —
+          // skill instructions are never truncated.
+          if (options.skillMessages && options.skillMessages.length > 0) {
+            conversation.messages.push(...options.skillMessages);
+          }
+
           const assistantMsg: ChatMessage = {
             id: randomUUID(),
             timestamp: this.generateTimestamp(),
@@ -1562,7 +1569,12 @@ User message: "${userMessage}"`;
       const conversationData = await this.redisClient.get(key);
       const conversation = deserializeConversation(conversationData);
       if (conversation?.messages) {
-        totalTurns += conversation.messages.length / MESSAGES_PER_TURN;
+        // Pinned skill messages are extra rows inside a turn — exclude them
+        // so a skill-activating turn still counts as one turn.
+        totalTurns +=
+          conversation.messages.filter(
+            (msg: ChatMessage) => !msg.metadata?.isSkill,
+          ).length / MESSAGES_PER_TURN;
       }
     }
 

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -173,8 +173,10 @@ import type {
 } from "./types/index.js";
 import { initializeHippocampus } from "./memory/hippocampusInitializer.js";
 import { createMemoryRetrievalTools } from "./memory/memoryRetrievalTools.js";
+import { isSkillVisibleInScope } from "./skills/skillMatcher.js";
+import { buildSkillActivationMessage } from "./skills/skillSessionTracker.js";
 import { SkillsManager } from "./skills/skillsManager.js";
-import { createSkillTools } from "./skills/skillTools.js";
+import { createSkillCallTools, createSkillTools } from "./skills/skillTools.js";
 import {
   getMetricsAggregator,
   MetricsAggregator,
@@ -1834,7 +1836,7 @@ export class NeuroLink {
   }
 
   /**
-   * Register the built-in skill tools (search_skills / list_skills, plus
+   * Register the built-in skill tools (list_skills, plus
    * mutation tools when allowMutations is set). Follows the
    * registerMemoryRetrievalTools() pattern: registered via registerTool()
    * so they land in the "user-defined" category that reaches the LLM tool
@@ -1877,24 +1879,32 @@ export class NeuroLink {
   }
 
   /**
-   * Append the compact skills index (names + descriptions, never
-   * instructions) to the system prompt for one generate()/stream() call.
-   * Fails open: any error leaves the prompt untouched.
+   * Skills augmentation for one generate()/stream() call:
+   *  1. Discovery — surface the skills listing per the resolved mode:
+   *     embedded in the use_skill tool description ("tool", default) or
+   *     appended to the system prompt ("system-prompt").
+   *  2. Per-call tools — inject use_skill + read_skill_resource into
+   *     options.tools (the RAG-tool pattern; same-name entries shadow
+   *     registered tools) with the sessionId closure-bound so activations
+   *     pin to the session.
+   *  3. Preload — activate host-requested skills up front, injecting their
+   *     instructions into this call's system prompt and pinning them.
+   * Fails open: any error leaves the call untouched.
    */
-  private async applySkillsPromptIndex(options: {
+  private async applySkillsAugmentation(options: {
     systemPrompt?: string;
     skills?: SkillsCallOptions;
+    tools?: unknown;
+    context?: unknown;
+    // Callers may pass sessionId/userId top-level instead of in context —
+    // the platform merges them into context only later in the pipeline.
+    sessionId?: unknown;
+    userId?: unknown;
     // GenerateOptions.output carries `mode`; StreamOptions.output does not —
     // keep the field structural and read `mode` defensively below.
     output?: unknown;
   }): Promise<void> {
     if (!this.skillsConfig?.enabled || options.skills?.enabled === false) {
-      return;
-    }
-    // Per-call promptIndex wins over instance config; default is on.
-    const promptIndexEnabled =
-      options.skills?.promptIndex ?? this.skillsConfig.promptIndex ?? true;
-    if (!promptIndexEnabled) {
       return;
     }
     // Media-only modes have no meaningful text prompt to augment.
@@ -1913,28 +1923,176 @@ export class NeuroLink {
       if (!manager) {
         return;
       }
-      const block = await manager.buildPromptIndex({
-        ...(options.skills?.scopeId !== undefined
-          ? { scopeId: options.skills.scopeId }
-          : {}),
-        ...(options.skills?.tags !== undefined
-          ? { tags: options.skills.tags }
-          : {}),
+      const discovery =
+        options.skills?.discovery ?? this.skillsConfig.discovery ?? "tool";
+      const scopeId =
+        options.skills?.scopeId ?? this.skillsConfig.defaultScopeId;
+      const tags = options.skills?.tags;
+      const sessionId =
+        this.resolveSkillSessionId(options.context) ??
+        this.resolveSkillSessionId(options);
+      const userId =
+        this.resolveSkillUserId(options.context) ??
+        this.resolveSkillUserId(options);
+      // Pinning requires somewhere to pin: without conversation memory the
+      // drained messages would be silently discarded while dedup reports
+      // already_loaded — so persistence is only on when memory is
+      // configured (or already initialized).
+      const memoryAvailable =
+        Boolean(this.conversationMemory) ||
+        Boolean(this.conversationMemoryConfig?.conversationMemory?.enabled);
+      const sessionPersistence =
+        (this.skillsConfig.sessionPersistence ?? true) &&
+        Boolean(sessionId) &&
+        memoryAvailable;
+      const visibility = {
+        ...(scopeId !== undefined ? { scopeId } : {}),
+        ...(tags !== undefined ? { tags } : {}),
+      };
+
+      if (discovery === "system-prompt") {
+        const block = await manager.buildPromptIndex(visibility);
+        if (block) {
+          options.systemPrompt = options.systemPrompt
+            ? `${options.systemPrompt}\n\n${block}`
+            : block;
+        }
+      }
+
+      const listing =
+        discovery === "tool"
+          ? await manager.buildToolListing(visibility)
+          : null;
+
+      const callTools = createSkillCallTools(() => this.ensureSkillsReady(), {
+        ...(sessionId ? { sessionId } : {}),
+        ...(scopeId !== undefined ? { scopeId } : {}),
+        sessionPersistence,
+        discovery,
+        listing,
+        // userId rides by closure: Redis memory keys sessions by
+        // userId:sessionId, so hydration must read the same key the
+        // store-turn path writes.
+        getStoredMessages: async (sid: string) =>
+          this.conversationMemory
+            ? await this.conversationMemory.getSessionMessages(sid, userId)
+            : [],
       });
-      if (block) {
-        options.systemPrompt = options.systemPrompt
-          ? `${options.systemPrompt}\n\n${block}`
-          : block;
-        logger.debug("[NeuroLink] Skills prompt index injected", {
-          blockLength: block.length,
+      // Caller-supplied per-call tools win over the injected ones (a host
+      // may bring its own use_skill); the injected tools still shadow any
+      // registered base tool of the same name via the provider merge.
+      options.tools = {
+        ...callTools,
+        ...((options.tools as Record<string, unknown> | undefined) ?? {}),
+      };
+
+      if (options.skills?.preload?.length) {
+        await this.preloadSkills(manager, options, options.skills.preload, {
+          ...(sessionId ? { sessionId } : {}),
+          ...(userId ? { userId } : {}),
+          sessionPersistence,
+          ...(scopeId !== undefined ? { scopeId } : {}),
         });
       }
+
+      logger.debug("[NeuroLink] Skills augmentation applied", {
+        discovery,
+        listingLength: listing?.length ?? 0,
+        sessionPersistence,
+        preloadCount: options.skills?.preload?.length ?? 0,
+      });
     } catch (error) {
       logger.warn(
-        "[NeuroLink] Skills prompt index injection failed — continuing without it",
+        "[NeuroLink] Skills augmentation failed — continuing without skills",
         { error: error instanceof Error ? error.message : String(error) },
       );
     }
+  }
+
+  /** Session id for skill activation tracking, from the call context. */
+  private resolveSkillSessionId(context: unknown): string | undefined {
+    const fromContext = (context as { sessionId?: unknown } | undefined)
+      ?.sessionId;
+    return typeof fromContext === "string" && fromContext
+      ? fromContext
+      : undefined;
+  }
+
+  /** User id for skill-session hydration (Redis keys sessions by userId). */
+  private resolveSkillUserId(context: unknown): string | undefined {
+    const fromContext = (context as { userId?: unknown } | undefined)?.userId;
+    return typeof fromContext === "string" && fromContext
+      ? fromContext
+      : undefined;
+  }
+
+  /**
+   * Activate host-requested skills before the model runs: instructions go
+   * into this call's system prompt; when persisting, the activation is
+   * pinned so later turns replay it from history instead. Unknown or
+   * already-active names are skipped with a warn/debug log (fail-open).
+   */
+  private async preloadSkills(
+    manager: SkillsManager,
+    options: { systemPrompt?: string },
+    names: string[],
+    call: {
+      sessionId?: string;
+      userId?: string;
+      sessionPersistence: boolean;
+      scopeId?: string;
+    },
+  ): Promise<void> {
+    const { sessionId, userId, sessionPersistence, scopeId } = call;
+    for (const name of names) {
+      const skill = await manager.get(name);
+      if (!skill || !isSkillVisibleInScope(skill, scopeId)) {
+        logger.warn("[NeuroLink] Preload skill not found — skipping", {
+          skill: name,
+        });
+        continue;
+      }
+      let block: string;
+      if (sessionId && sessionPersistence) {
+        // Always hydrate (empty history when memory isn't initialized yet):
+        // the tracker derives truth from stored pins + this turn's pending,
+        // never from stale in-process records.
+        manager.sessions.hydrate(
+          sessionId,
+          this.conversationMemory
+            ? await this.conversationMemory.getSessionMessages(
+                sessionId,
+                userId,
+              )
+            : [],
+        );
+        if (manager.sessions.isActive(sessionId, skill.id, skill.name)) {
+          continue;
+        }
+        block = manager.sessions.recordActivation(sessionId, skill).content;
+      } else {
+        block = buildSkillActivationMessage(skill).content;
+      }
+      options.systemPrompt = options.systemPrompt
+        ? `${options.systemPrompt}\n\n${block}`
+        : block;
+    }
+  }
+
+  /**
+   * Pinned skill messages recorded during this turn, ready for
+   * StoreConversationTurnOptions.skillMessages. Empty when skills are off
+   * or nothing was activated.
+   */
+  private drainPendingSkillMessages(sessionId: unknown): ChatMessage[] {
+    if (typeof sessionId !== "string" || !sessionId) {
+      return [];
+    }
+    const manager = this.skillsManagerInstance;
+    if (!manager) {
+      return [];
+    }
+    return manager.sessions.drainPending(sessionId);
   }
 
   /**
@@ -4854,9 +5012,9 @@ Current user's request: ${currentInput}`;
       }
     }
 
-    // Skills: append the compact skills index to the system prompt so the
-    // model knows which skills exist (bodies load via search_skills).
-    await this.applySkillsPromptIndex(options);
+    // Skills: surface the discovery listing and inject the per-call
+    // use_skill / read_skill_resource tools (bodies load on activation).
+    await this.applySkillsAugmentation(options);
 
     // Media-only modes (avatar, music, video, ppt) do not have a meaningful
     // text prompt to augment with memory — skip injection to avoid corrupting
@@ -5997,6 +6155,9 @@ Current user's request: ${currentInput}`;
         result,
         new Date(startTime),
         requestId,
+        this.drainPendingSkillMessages(
+          (options.context as Record<string, unknown> | undefined)?.sessionId,
+        ),
       );
       this.recordMemorySpan(
         "memory.store",
@@ -9687,9 +9848,9 @@ Current user's request: ${currentInput}`;
       }
     }
 
-    // Skills: append the compact skills index to the system prompt so the
-    // model knows which skills exist (bodies load via search_skills).
-    await this.applySkillsPromptIndex(options);
+    // Skills: surface the discovery listing and inject the per-call
+    // use_skill / read_skill_resource tools (bodies load on activation).
+    await this.applySkillsAugmentation(options);
 
     // Apply orchestration if enabled and no specific provider/model requested
     if (this.enableOrchestration && !options.provider && !options.model) {
@@ -10229,6 +10390,7 @@ Current user's request: ${currentInput}`;
 
       const memStoreStart = Date.now();
       try {
+        const pendingSkillMessages = this.drainPendingSkillMessages(sessionId);
         await this.conversationMemory.storeConversationTurn({
           sessionId,
           userId,
@@ -10240,6 +10402,9 @@ Current user's request: ${currentInput}`;
           events: eventSequence.length > 0 ? eventSequence : undefined,
           requestId: (enhancedOptions.context as Record<string, unknown>)
             ?.requestId as string | undefined,
+          ...(pendingSkillMessages.length > 0
+            ? { skillMessages: pendingSkillMessages }
+            : {}),
         });
 
         this.recordMemorySpan(
@@ -11034,8 +11199,12 @@ Current user's request: ${currentInput}`;
 
           const memStoreStart = Date.now();
           try {
+            const fallbackSessionId =
+              sessionId || (options.context?.sessionId as string);
+            const pendingSkillMessages =
+              self.drainPendingSkillMessages(fallbackSessionId);
             await self.conversationMemory.storeConversationTurn({
-              sessionId: sessionId || (options.context?.sessionId as string),
+              sessionId: fallbackSessionId,
               userId: userId || (options.context?.userId as string),
               userMessage: originalPrompt ?? "",
               aiResponse: fallbackAccumulatedContent,
@@ -11050,6 +11219,9 @@ Current user's request: ${currentInput}`;
                 )?.requestId as string | undefined) ||
                 ((options.context as Record<string, unknown> | undefined)
                   ?.requestId as string | undefined),
+              ...(pendingSkillMessages.length > 0
+                ? { skillMessages: pendingSkillMessages }
+                : {}),
             });
             self.recordMemorySpan(
               "memory.store",

--- a/src/lib/skills/skillMatcher.ts
+++ b/src/lib/skills/skillMatcher.ts
@@ -19,6 +19,19 @@ export function toSkillIndexItem(skill: SkillDefinition): SkillIndexItem {
   return indexItem;
 }
 
+/**
+ * Sort index entries by name (byte order, locale-independent) so every
+ * listing renders byte-identically across calls and store backends.
+ * Store enumeration order (Redis SCAN, fs.readdir, S3 listings) is not
+ * stable — an unsorted listing would shuffle between calls and invalidate
+ * provider prompt caches. Returns a new array.
+ */
+export function sortSkillIndex(items: SkillIndexItem[]): SkillIndexItem[] {
+  return [...items].sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  );
+}
+
 /** Filter index entries by query/tag/scope. Active skills only. */
 export function filterSkillIndex(
   items: SkillIndexItem[],
@@ -67,10 +80,92 @@ export function filterSkillIndex(
 }
 
 /**
- * Render the compact skills index injected into the system prompt.
- * Names + descriptions only — instructions are never included; the model
- * loads them via search_skills. Returns null when nothing is visible so
- * callers can skip injection entirely.
+ * Reject resource paths that could escape a skill's namespace: absolute
+ * paths, traversal segments, and empty segments. The manager validates
+ * before reaching any store — this is defense in depth for stores whose
+ * keys are built by concatenation (S3, Redis) or path joining.
+ */
+export function isSafeSkillResourcePath(resourcePath: string): boolean {
+  const normalized = resourcePath.replace(/\\/g, "/");
+  return (
+    normalized.length > 0 &&
+    !normalized.startsWith("/") &&
+    !normalized.split("/").some((segment) => segment === ".." || segment === "")
+  );
+}
+
+/** Whether a skill is visible from the calling scope. */
+export function isSkillVisibleInScope(
+  skill: Pick<SkillDefinition, "scope" | "scopeIds">,
+  scopeId?: string,
+): boolean {
+  if (!scopeId || skill.scope !== "scoped") {
+    return true;
+  }
+  return (skill.scopeIds ?? []).includes(scopeId);
+}
+
+/** Trim a description to its first sentence (or the whole text when unsplittable). */
+function firstSentence(description: string): string {
+  const match = description.match(/^[^.!?]*[.!?]/);
+  return match ? match[0].trim() : description;
+}
+
+/**
+ * Render the `<available_skills>` block embedded in the use_skill tool
+ * description ("tool" discovery mode). One line per skill — name,
+ * description, tags — instructions never appear here.
+ *
+ * Budget handling is uniform and stateless: over budget, every
+ * description drops to its first sentence, then to a hard 80-char cap.
+ * The render is a pure function of the (sorted) index, so the tool
+ * description stays byte-identical across calls — a prerequisite for
+ * provider prompt caching. Names are never dropped.
+ */
+export function renderSkillListing(
+  items: SkillIndexItem[],
+  budgetChars: number,
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const render = (describe: (item: SkillIndexItem) => string): string => {
+    const lines = items.map((item) => {
+      const tags =
+        item.tags && item.tags.length > 0
+          ? ` [tags: ${item.tags.join(", ")}]`
+          : "";
+      return `- ${item.name}: ${describe(item)}${tags}`;
+    });
+    return ["<available_skills>", ...lines, "</available_skills>"].join("\n");
+  };
+
+  const full = render((item) => item.description);
+  if (full.length <= budgetChars) {
+    return full;
+  }
+
+  const sentences = render((item) => firstSentence(item.description));
+  if (sentences.length <= budgetChars) {
+    return sentences;
+  }
+
+  const HARD_CAP = 80;
+  // Floor render — returned even if it still exceeds the budget.
+  return render((item) => {
+    const sentence = firstSentence(item.description);
+    return sentence.length > HARD_CAP
+      ? `${sentence.slice(0, HARD_CAP - 1)}…`
+      : sentence;
+  });
+}
+
+/**
+ * Render the compact skills index appended to the system prompt
+ * ("system-prompt" discovery mode). Names + descriptions only —
+ * instructions are never included; the model loads them via use_skill.
+ * Returns null when nothing is visible so callers can skip injection.
  */
 export function formatSkillsPromptIndex(
   items: SkillIndexItem[],
@@ -94,7 +189,7 @@ export function formatSkillsPromptIndex(
 
   const truncationNote =
     items.length > visible.length
-      ? `\n(${items.length - visible.length} more skills exist — use search_skills or list_skills to discover them.)`
+      ? `\n(${items.length - visible.length} more skills exist — use list_skills to discover them.)`
       : "";
 
   return (
@@ -102,7 +197,7 @@ export function formatSkillsPromptIndex(
       "## Available Skills",
       "The following team-defined skills (SOPs, playbooks, workflows) are available.",
       "Before answering from general knowledge, check whether one applies to the user's request.",
-      "To use a skill, call the search_skills tool to load its full instructions, then follow them exactly.",
+      "To use a skill, call the use_skill tool with its name to load the full instructions, then follow them exactly.",
       "",
       ...lines,
     ].join("\n") + truncationNote

--- a/src/lib/skills/skillSessionTracker.ts
+++ b/src/lib/skills/skillSessionTracker.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-session skill activation state.
+ *
+ * A skill activated via use_skill is pinned to its session: the tracker
+ * holds the pinned instruction message until the turn is persisted
+ * (drainPending → StoreConversationTurnOptions.skillMessages) and answers
+ * "is this skill already loaded?" so re-invocations return a cheap
+ * already_loaded note instead of the full body.
+ *
+ * The stored session history is the source of truth — pinned messages
+ * carry `metadata.isSkill`. hydrate() rebuilds a session's active set from
+ * stored messages on every activation attempt (use_skill is rare, one
+ * history read per attempt), so dedup stays correct across process
+ * restarts, multiple instances sharing a Redis memory backend, and failed
+ * persistence: a pin that never reached storage simply re-activates on
+ * the next turn instead of being falsely reported as loaded.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  ChatMessage,
+  SkillActivationRecord,
+  SkillDefinition,
+} from "../types/index.js";
+
+/** Upper bound on tracked sessions; oldest are evicted first (insertion order). */
+const MAX_TRACKED_SESSIONS = 1000;
+
+/** Render the pinned history message for an activated skill. */
+export function buildSkillActivationMessage(
+  skill: SkillDefinition,
+): ChatMessage {
+  const version = skill.version ?? 1;
+  return {
+    id: `skill-${randomUUID()}`,
+    role: "user",
+    content: `[Skill loaded: ${skill.name} v${version}]\n\n${skill.instructions}`,
+    timestamp: new Date().toISOString(),
+    metadata: {
+      isSkill: true,
+      skillId: skill.id,
+      skillName: skill.name,
+      skillVersion: version,
+    },
+  };
+}
+
+/** Activation record derived from a pinned history message, when it is one. */
+function recordFromMessage(message: ChatMessage): SkillActivationRecord | null {
+  const meta = message.metadata;
+  if (!meta?.isSkill || !meta.skillId || !meta.skillName) {
+    return null;
+  }
+  return {
+    skillId: meta.skillId,
+    name: meta.skillName,
+    version: meta.skillVersion ?? 1,
+    activatedAt: message.timestamp ?? new Date(0).toISOString(),
+  };
+}
+
+export class SkillSessionTracker {
+  /** sessionId → skillId → activation record. */
+  private active = new Map<string, Map<string, SkillActivationRecord>>();
+  /** sessionId → pinned messages awaiting persistence into the session turn. */
+  private pending = new Map<string, ChatMessage[]>();
+
+  /** Whether the skill is already active (loaded) in this session. */
+  isActive(sessionId: string, skillId: string, name: string): boolean {
+    return Boolean(this.getActivation(sessionId, skillId, name));
+  }
+
+  /** Activation record for an active skill (by id, falling back to name). */
+  getActivation(
+    sessionId: string,
+    skillId: string,
+    name?: string,
+  ): SkillActivationRecord | undefined {
+    const records = this.active.get(sessionId);
+    if (!records) {
+      return undefined;
+    }
+    const byId = records.get(skillId);
+    if (byId || !name) {
+      return byId;
+    }
+    for (const record of records.values()) {
+      if (record.name === name) {
+        return record;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Record an activation: marks the skill active and queues its pinned
+   * message for persistence when the turn is stored.
+   */
+  recordActivation(sessionId: string, skill: SkillDefinition): ChatMessage {
+    const message = buildSkillActivationMessage(skill);
+    const record = recordFromMessage(message) as SkillActivationRecord;
+    this.recordsFor(sessionId).set(skill.id, record);
+    const queue = this.pending.get(sessionId);
+    if (queue) {
+      queue.push(message);
+    } else {
+      this.pending.set(sessionId, [message]);
+    }
+    return message;
+  }
+
+  /**
+   * Rebuild the active set from stored session history, then merge the
+   * in-process pending activations (this turn's pins, not yet stored).
+   * Called before every dedup check — the rebuild keeps state truthful
+   * when other instances pinned skills or when a past pin never reached
+   * storage.
+   */
+  hydrate(sessionId: string, storedMessages: ChatMessage[]): void {
+    const records = new Map<string, SkillActivationRecord>();
+    for (const message of storedMessages) {
+      const record = recordFromMessage(message);
+      if (record && !records.has(record.skillId)) {
+        records.set(record.skillId, record);
+      }
+    }
+    for (const message of this.pending.get(sessionId) ?? []) {
+      const record = recordFromMessage(message);
+      if (record) {
+        records.set(record.skillId, record);
+      }
+    }
+    this.recordsFor(sessionId); // reserve the slot (applies the session cap)
+    this.active.set(sessionId, records);
+  }
+
+  /**
+   * Remove and return the pinned messages queued for this session. Called
+   * once per turn by the memory-store path; an empty result means nothing
+   * was activated this turn.
+   */
+  drainPending(sessionId: string): ChatMessage[] {
+    const queue = this.pending.get(sessionId);
+    if (!queue || queue.length === 0) {
+      return [];
+    }
+    this.pending.delete(sessionId);
+    return queue;
+  }
+
+  /** Active skill records for a session (listing/debugging). */
+  listActive(sessionId: string): SkillActivationRecord[] {
+    return Array.from(this.active.get(sessionId)?.values() ?? []);
+  }
+
+  private recordsFor(sessionId: string): Map<string, SkillActivationRecord> {
+    let records = this.active.get(sessionId);
+    if (!records) {
+      if (this.active.size >= MAX_TRACKED_SESSIONS) {
+        const oldest = this.active.keys().next().value;
+        if (oldest !== undefined) {
+          this.active.delete(oldest);
+          this.pending.delete(oldest);
+        }
+      }
+      records = new Map();
+      this.active.set(sessionId, records);
+    }
+    return records;
+  }
+}

--- a/src/lib/skills/skillStoreRedis.ts
+++ b/src/lib/skills/skillStoreRedis.ts
@@ -20,17 +20,25 @@ import {
   scanKeys,
 } from "../utils/redis.js";
 import { logger } from "../utils/logger.js";
-import { toSkillIndexItem } from "./skillMatcher.js";
+import { isSafeSkillResourcePath, toSkillIndexItem } from "./skillMatcher.js";
 
 const DEFAULT_KEY_PREFIX = "neurolink:skills:";
 
 export class RedisSkillStore implements SkillStore {
   private readonly keyPrefix: string;
+  /**
+   * Resources live under `<keyPrefix>__resources__:` — a reserved segment
+   * inside the skill prefix, explicitly excluded from the index SCAN so
+   * resource values are never mistaken for skills, whatever the
+   * configured keyPrefix looks like.
+   */
+  private readonly resourcePrefix: string;
   private readonly normalizedConfig: ReturnType<typeof getNormalizedConfig>;
   private clientPromise: Promise<RedisClient> | null = null;
 
   constructor(config: SkillRedisStorageConfig) {
     this.keyPrefix = config.keyPrefix ?? DEFAULT_KEY_PREFIX;
+    this.resourcePrefix = `${this.keyPrefix}__resources__:`;
     this.normalizedConfig = getNormalizedConfig({
       ...(config.url ? { url: config.url } : {}),
       ...(config.host ? { host: config.host } : {}),
@@ -59,6 +67,15 @@ export class RedisSkillStore implements SkillStore {
     return `${this.keyPrefix}${id}`;
   }
 
+  async getResource(id: string, resourcePath: string): Promise<string | null> {
+    if (!isSafeSkillResourcePath(resourcePath)) {
+      return null;
+    }
+    const client = await this.getClient();
+    const raw = await client.get(`${this.resourcePrefix}${id}:${resourcePath}`);
+    return raw ? String(raw) : null;
+  }
+
   async get(id: string): Promise<SkillDefinition | null> {
     const client = await this.getClient();
     const raw = await client.get(this.skillKey(id));
@@ -78,7 +95,9 @@ export class RedisSkillStore implements SkillStore {
 
   async index(): Promise<SkillIndexItem[]> {
     const client = await this.getClient();
-    const keys = await scanKeys(client, `${this.keyPrefix}*`);
+    const keys = (await scanKeys(client, `${this.keyPrefix}*`)).filter(
+      (key) => !key.startsWith(this.resourcePrefix),
+    );
     if (keys.length === 0) {
       return [];
     }

--- a/src/lib/skills/skillStoreS3.ts
+++ b/src/lib/skills/skillStoreS3.ts
@@ -20,6 +20,7 @@ import { createRequire } from "node:module";
 import type {
   SkillDefinition,
   SkillIndexItem,
+  SkillS3ConditionalGetResult,
   SkillS3IndexDocument,
   SkillS3ModuleSurface,
   SkillS3ObjectOps,
@@ -27,7 +28,7 @@ import type {
   SkillStore,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import { toSkillIndexItem } from "./skillMatcher.js";
+import { isSafeSkillResourcePath, toSkillIndexItem } from "./skillMatcher.js";
 
 const lazyRequire = createRequire(import.meta.url);
 
@@ -128,12 +129,48 @@ function createDefaultOps(config: SkillS3StorageConfig): SkillS3ObjectOps {
       } while (continuationToken);
       return keys;
     },
+    async getObjectConditional(
+      key: string,
+      etag?: string,
+    ): Promise<SkillS3ConditionalGetResult> {
+      try {
+        const response = (await client.send(
+          new mod.GetObjectCommand({
+            Bucket: bucket,
+            Key: key,
+            ...(etag ? { IfNoneMatch: etag } : {}),
+          }),
+        )) as {
+          Body?: { transformToString: () => Promise<string> };
+          ETag?: string;
+        };
+        const body = (await response.Body?.transformToString()) ?? null;
+        return {
+          body,
+          ...(response.ETag ? { etag: response.ETag } : {}),
+        };
+      } catch (error) {
+        const name = (error as { name?: string }).name;
+        const status = (error as { $metadata?: { httpStatusCode?: number } })
+          .$metadata?.httpStatusCode;
+        if (status === 304 || name === "304" || name === "NotModified") {
+          return { body: null, notModified: true };
+        }
+        if (name === "NoSuchKey" || name === "NotFound") {
+          return { body: null };
+        }
+        throw error;
+      }
+    },
   };
 }
 
 export class S3SkillStore implements SkillStore {
   private readonly prefix: string;
   private ops: SkillS3ObjectOps | null = null;
+  /** Last parsed index + its ETag, revalidated with If-None-Match reads. */
+  private cachedIndexDoc: SkillS3IndexDocument | null = null;
+  private cachedIndexEtag: string | undefined;
 
   constructor(
     private readonly config: SkillS3StorageConfig,
@@ -143,6 +180,11 @@ export class S3SkillStore implements SkillStore {
     const rawPrefix = config.prefix ?? "neurolink-skills/";
     this.prefix =
       rawPrefix === "" || rawPrefix.endsWith("/") ? rawPrefix : `${rawPrefix}/`;
+  }
+
+  invalidate(): void {
+    this.cachedIndexDoc = null;
+    this.cachedIndexEtag = undefined;
   }
 
   private getOps(): SkillS3ObjectOps {
@@ -158,6 +200,18 @@ export class S3SkillStore implements SkillStore {
 
   private indexKey(): string {
     return `${this.prefix}index.json`;
+  }
+
+  /** Resources live beside the skill object: <prefix>skills/<id>/<path>. */
+  private resourceKey(id: string, resourcePath: string): string {
+    return `${this.prefix}skills/${id}/${resourcePath}`;
+  }
+
+  async getResource(id: string, resourcePath: string): Promise<string | null> {
+    if (!isSafeSkillResourcePath(resourcePath)) {
+      return null;
+    }
+    return this.getOps().getObject(this.resourceKey(id, resourcePath));
   }
 
   async get(id: string): Promise<SkillDefinition | null> {
@@ -212,19 +266,49 @@ export class S3SkillStore implements SkillStore {
       this.indexKey(),
       JSON.stringify(index, null, 2),
     );
+    // The write changed the object's ETag; keep the doc, revalidate next read.
+    this.cachedIndexDoc = index;
+    this.cachedIndexEtag = undefined;
   }
 
   /**
-   * Read index.json; when missing or unparsable, rebuild it from a listing
-   * of the skills/ prefix and persist the rebuilt document (self-heal).
+   * Raw index.json read. Returns the body (with its ETag when available),
+   * null body when the object is absent, or notModified when a
+   * conditional read reported the cached copy unchanged.
+   */
+  private async readIndexObject(
+    ops: SkillS3ObjectOps,
+  ): Promise<SkillS3ConditionalGetResult> {
+    if (ops.getObjectConditional) {
+      return ops.getObjectConditional(
+        this.indexKey(),
+        this.cachedIndexDoc ? this.cachedIndexEtag : undefined,
+      );
+    }
+    return { body: await ops.getObject(this.indexKey()) };
+  }
+
+  /**
+   * Read index.json (ETag-revalidated when the ops support conditional
+   * reads — an unchanged index costs a 304, not a download); when missing
+   * or unparsable, rebuild it from a listing of the skills/ prefix and
+   * persist the rebuilt document (self-heal).
    */
   private async readOrRebuildIndex(): Promise<SkillS3IndexDocument> {
     const ops = this.getOps();
-    const raw = await ops.getObject(this.indexKey());
-    if (raw) {
+    const read = await this.readIndexObject(ops);
+    if (read.notModified && this.cachedIndexDoc) {
+      return this.cachedIndexDoc;
+    }
+    if (read.body) {
       try {
-        const parsed = JSON.parse(raw) as SkillS3IndexDocument;
+        const parsed = JSON.parse(read.body) as SkillS3IndexDocument;
         if (Array.isArray(parsed.skills)) {
+          this.cachedIndexDoc = parsed;
+          // Cache the ETag only for a body that parsed: pairing a corrupt
+          // object's ETag with the previous good doc would make every
+          // later conditional read 304 into permanently stale data.
+          this.cachedIndexEtag = read.etag;
           return parsed;
         }
       } catch (error) {
@@ -232,6 +316,7 @@ export class S3SkillStore implements SkillStore {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      this.cachedIndexEtag = undefined;
     }
 
     const skillsPrefix = `${this.prefix}skills/`;
@@ -258,6 +343,10 @@ export class S3SkillStore implements SkillStore {
       lastUpdated: new Date().toISOString(),
       skills,
     };
+    // Cache the rebuilt doc even when persistence below fails, so reads
+    // don't fall back to a stale pre-rebuild copy.
+    this.cachedIndexDoc = rebuilt;
+    this.cachedIndexEtag = undefined;
     try {
       await this.writeIndex(rebuilt);
       logger.info("[SkillStoreS3] Rebuilt skills index", {

--- a/src/lib/skills/skillStores.ts
+++ b/src/lib/skills/skillStores.ts
@@ -14,6 +14,7 @@ import yaml from "js-yaml";
 import type {
   SkillDefinition,
   SkillIndexItem,
+  SkillResourceRef,
   SkillStore,
   SkillsStorageConfig,
 } from "../types/index.js";
@@ -52,10 +53,28 @@ function isValidSkill(candidate: unknown): candidate is SkillDefinition {
 /** In-process store backed by a Map. */
 export class InMemorySkillStore implements SkillStore {
   private skills = new Map<string, SkillDefinition>();
+  /** skill id → relative path → content. */
+  private resources = new Map<string, Map<string, string>>();
 
-  constructor(seed?: SkillDefinition[]) {
+  constructor(
+    seed?: SkillDefinition[],
+    resources?: Record<string, Record<string, string>>,
+  ) {
+    for (const [skillId, files] of Object.entries(resources ?? {})) {
+      this.resources.set(skillId, new Map(Object.entries(files)));
+    }
     for (const skill of seed ?? []) {
-      this.skills.set(skill.id, normalizeSkill(skill));
+      const files = this.resources.get(skill.id);
+      const withRefs: SkillDefinition =
+        files && !skill.resources
+          ? {
+              ...skill,
+              resources: Array.from(files.keys())
+                .sort()
+                .map((p): SkillResourceRef => ({ path: p })),
+            }
+          : skill;
+      this.skills.set(skill.id, normalizeSkill(withRefs));
     }
   }
 
@@ -73,6 +92,10 @@ export class InMemorySkillStore implements SkillStore {
 
   async index(): Promise<SkillIndexItem[]> {
     return Array.from(this.skills.values()).map(toSkillIndexItem);
+  }
+
+  async getResource(id: string, resourcePath: string): Promise<string | null> {
+    return this.resources.get(id)?.get(resourcePath) ?? null;
   }
 }
 
@@ -142,15 +165,52 @@ function parseSkillMarkdown(
 }
 
 /**
+ * List every file bundled beside a skill's SKILL.md as a resource ref,
+ * relative paths, sorted for deterministic listings. Recurses into
+ * subdirectories (references/, assets/, …).
+ */
+function listSkillResourceFiles(skillDir: string): SkillResourceRef[] {
+  const refs: SkillResourceRef[] = [];
+  const walk = (current: string, relative: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const relPath = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(path.join(current, entry.name), relPath);
+      } else if (relPath !== "SKILL.md") {
+        try {
+          refs.push({
+            path: relPath,
+            size: fs.statSync(path.join(current, entry.name)).size,
+          });
+        } catch {
+          refs.push({ path: relPath });
+        }
+      }
+    }
+  };
+  walk(skillDir, "");
+  return refs.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/**
  * Directory-backed store. Read layouts:
  *  - `<dir>/<id>.json`      — JSON SkillDefinition (mutable)
  *  - `<dir>/<name>.md`      — frontmatter markdown (read-only source)
- *  - `<dir>/<name>/SKILL.md` — Claude-skills directory layout (read-only source)
+ *  - `<dir>/<name>/SKILL.md` — Claude-skills directory layout (read-only source);
+ *    sibling files become on-demand resources (read_skill_resource)
  * Mutations always write `<id>.json`; a JSON file shadows a markdown skill
  * with the same id, so updating a markdown-sourced skill "copies up" to JSON.
  */
 export class FileSystemSkillStore implements SkillStore {
   private cache: Map<string, SkillDefinition> | null = null;
+  /** skill id → directory, for skills loaded from the SKILL.md layout. */
+  private skillDirs = new Map<string, string>();
 
   constructor(private readonly baseDir: string) {}
 
@@ -161,6 +221,38 @@ export class FileSystemSkillStore implements SkillStore {
   async get(id: string): Promise<SkillDefinition | null> {
     const all = this.load();
     return all.get(id) ?? null;
+  }
+
+  /**
+   * Resources exist only for directory-layout skills (`<name>/SKILL.md`) —
+   * every sibling file of SKILL.md is addressable by its relative path.
+   * The REAL path must stay inside the skill directory: lexical
+   * containment alone would follow a symlink planted inside the skill dir
+   * to anywhere on the host.
+   */
+  async getResource(id: string, resourcePath: string): Promise<string | null> {
+    this.load();
+    const dir = this.skillDirs.get(id);
+    if (!dir) {
+      return null;
+    }
+    try {
+      const realDir = fs.realpathSync(dir);
+      const realResolved = fs.realpathSync(path.resolve(dir, resourcePath));
+      if (
+        realResolved !== realDir &&
+        !realResolved.startsWith(realDir + path.sep)
+      ) {
+        return null;
+      }
+      return fs.readFileSync(realResolved, "utf-8");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "EISDIR" || code === "ELOOP") {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async put(skill: SkillDefinition): Promise<void> {
@@ -201,6 +293,7 @@ export class FileSystemSkillStore implements SkillStore {
     }
 
     const skills = new Map<string, SkillDefinition>();
+    this.skillDirs = new Map();
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(this.baseDir, { withFileTypes: true });
@@ -228,7 +321,12 @@ export class FileSystemSkillStore implements SkillStore {
               entry.name,
             );
             if (parsed) {
-              skills.set(parsed.id, parsed);
+              const resources = listSkillResourceFiles(fullPath);
+              skills.set(
+                parsed.id,
+                resources.length > 0 ? { ...parsed, resources } : parsed,
+              );
+              this.skillDirs.set(parsed.id, path.resolve(fullPath));
             }
           }
         } else if (entry.name.endsWith(".md")) {
@@ -279,6 +377,7 @@ export function createSkillStore(config?: SkillsStorageConfig): SkillStore {
   if (!config || config.type === "memory") {
     return new InMemorySkillStore(
       config?.type === "memory" ? config.skills : undefined,
+      config?.type === "memory" ? config.resources : undefined,
     );
   }
   if (config.type === "filesystem") {

--- a/src/lib/skills/skillTools.ts
+++ b/src/lib/skills/skillTools.ts
@@ -1,18 +1,29 @@
 /**
- * Built-in skill tools, following the createMemoryRetrievalTools /
- * createFileTools / createTaskTools factory pattern.
+ * Built-in skill tools.
+ *
+ * Two factories, mirroring the two disclosure levels:
+ *
+ * createSkillTools — instance tools registered once at construction:
+ *   list_skills (lightweight catalog) plus the gated skill_create /
+ *   skill_update / skill_delete mutation tools.
+ *
+ * createSkillCallTools — per-call tools injected into options.tools by
+ *   prepareGenerate/prepareStream (the RAG-tool pattern): use_skill, whose
+ *   description embeds the `<available_skills>` listing so the model
+ *   decides from context when a skill applies (no mandatory pre-flight
+ *   call), and read_skill_resource for on-demand auxiliary files. The
+ *   sessionId rides in by closure, so activations pin to the session
+ *   without runtime tool-context plumbing.
  *
  * The manager is resolved lazily via a resolver callback so tools can be
  * registered at construction time while the store initializes on first
  * use (mirrors how retrieve_context resolves conversationMemory lazily).
- *
- * Tool descriptions are ported from curator's production skills tools —
- * the "always check skills first / no_match is expected, not an error /
- * pick the best of 2-5 or ask" prompt engineering is proven in prod.
  */
 
+import { trace } from "@opentelemetry/api";
 import { z } from "zod";
 import type {
+  SkillCallToolsContext,
   SkillDefinition,
   SkillMutationAction,
   SkillsManagerLike,
@@ -21,130 +32,257 @@ import type {
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { tool } from "../utils/tool.js";
+import { isSkillVisibleInScope } from "./skillMatcher.js";
 
-/** Trim a hydrated skill to the fields the model needs. */
-function toToolSkill(skill: SkillDefinition) {
+const NOT_CONFIGURED = {
+  success: false as const,
+  error:
+    "Skills are not available — the skills store failed to initialize. " +
+    "Answer from general knowledge.",
+};
+
+/** Response payload for an activated skill — full instructions, never truncated. */
+function toActivationPayload(skill: SkillDefinition) {
   return {
-    id: skill.id,
     name: skill.name,
     ...(skill.displayName ? { displayName: skill.displayName } : {}),
-    description: skill.description,
-    instructions: skill.instructions,
-    tags: skill.tags ?? [],
-    scope: skill.scope ?? "global",
     version: skill.version ?? 1,
+    instructions: skill.instructions,
+    ...(skill.resources && skill.resources.length > 0
+      ? {
+          resources: skill.resources.map((r) => r.path),
+          resourcesHint:
+            "Auxiliary files — read one with read_skill_resource only when the task needs it.",
+        }
+      : {}),
+    note:
+      "Follow these instructions for the current task. The skill stays loaded " +
+      "for this conversation — do not invoke use_skill for it again.",
   };
 }
 
+/** Build the use_skill description for the call's discovery mode. */
+function useSkillDescription(context: SkillCallToolsContext): string {
+  const base =
+    "Load a team-defined skill (SOP, playbook, workflow) by name to get its full instructions. " +
+    "When the user's task matches a skill, invoke this tool, then follow the loaded instructions exactly. " +
+    "Do NOT invoke it for a skill that is already loaded in this conversation, and do not " +
+    "invoke it at all when no skill matches the task.";
+  if (context.discovery === "tool" && context.listing) {
+    return `${base}\n\nSkills available in this conversation:\n${context.listing}`;
+  }
+  if (context.discovery === "system-prompt") {
+    return `${base} The available skills are listed under "## Available Skills" in your instructions.`;
+  }
+  return `${base} Discover available skills with list_skills.`;
+}
+
 /**
- * Create the built-in skill tools bound to a lazily-resolved manager.
- * Returns Vercel AI SDK tool() objects (description + Zod inputSchema +
- * execute) keyed by tool name.
+ * Per-call skill tools: use_skill + read_skill_resource. Injected into
+ * options.tools for one generate()/stream() call; same-name entries shadow
+ * any registered tool, so the description always reflects this call's
+ * listing and scope.
  */
-export function createSkillTools(
+export function createSkillCallTools(
   resolveManager: () => SkillsManagerLike | null,
-  options?: SkillToolsOptions,
+  context: SkillCallToolsContext,
 ): Record<string, Tool> {
-  const notConfigured = {
-    success: false as const,
-    error:
-      "Skills are not available — the skills store failed to initialize. " +
-      "Answer from general knowledge.",
-    data: { skills: [] },
+  /**
+   * Rebuild activation state from stored history before every dedup
+   * check. use_skill is rare, so one history read per attempt is cheap —
+   * and it keeps dedup truthful across restarts, other instances sharing
+   * the memory backend, and pins whose persistence failed. Fail-open: a
+   * hydration error only risks a duplicate pin, never a lost activation.
+   */
+  const ensureHydrated = async (manager: SkillsManagerLike): Promise<void> => {
+    const { sessionId, getStoredMessages } = context;
+    if (!sessionId) {
+      return;
+    }
+    try {
+      const stored = getStoredMessages
+        ? await getStoredMessages(sessionId)
+        : [];
+      manager.sessions.hydrate(sessionId, stored);
+    } catch (error) {
+      logger.warn("[SkillTools] Session hydration failed — continuing", {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   };
 
-  const tools: Record<string, Tool> = {
-    search_skills: tool({
-      description:
-        "ALWAYS call this at the start of every user request before answering from general knowledge. " +
-        "Searches team-defined skills (SOPs, playbooks, workflows) using an index-first approach — " +
-        "fast, low-cost, and does not load skills that do not match. " +
-        "You MUST provide at least one of: query (keyword from the user message) or tag (domain category). " +
-        "If 1 match is found, follow its instructions exactly. " +
-        "If 2-5 matches are found, use your judgment based on the user message to pick the best one, " +
-        "or ask the user to clarify if the instructions would lead to meaningfully different actions. " +
-        "Only skip this call for purely conversational messages like greetings. " +
-        'Returns `{ skills: [], reason: "no_match" }` when nothing matches — this is expected, NOT an ' +
-        "error. In that case, answer from general knowledge.",
+  return {
+    use_skill: tool({
+      description: useSkillDescription(context),
       inputSchema: z.object({
-        query: z
+        name: z
           .string()
-          .optional()
+          .min(1)
           .describe(
-            "Keyword from the user message, matched against skill name, display name, and description. " +
-              'E.g. "deployment", "refund process", "on-call escalation".',
-          ),
-        tag: z
-          .string()
-          .optional()
-          .describe(
-            'Domain category tag to narrow results (e.g. "payments", "devops"). ' +
-              "Applied on top of the query filter when both are provided.",
-          ),
-        scopeId: z
-          .string()
-          .optional()
-          .describe(
-            "Scope identifier (channel/team/tenant id) to include scoped skills alongside global ones. " +
-              "Usually omit — the host default applies.",
+            'Exact skill name from the available skills listing, e.g. "refund_dispute_escalation".',
           ),
       }),
       execute: async (args) => {
-        if (!args.query && !args.tag) {
-          return {
-            success: false,
-            error:
-              'At least one of "query" or "tag" must be provided to search_skills.',
-            data: { skills: [] },
-          };
-        }
         const manager = resolveManager();
         if (!manager) {
-          return notConfigured;
+          return NOT_CONFIGURED;
         }
         try {
-          const skills = await manager.search(args);
-          if (skills.length === 0) {
+          const skill = await manager.get(args.name);
+          if (!skill || !isSkillVisibleInScope(skill, context.scopeId)) {
             return {
-              success: true,
-              data: {
-                skills: [],
-                reason: "no_match" as const,
-                message: `No skills found${args.query ? ` matching "${args.query}"` : ""}${args.tag ? ` with tag "${args.tag}"` : ""}. Answer from general knowledge.`,
-              },
+              success: false,
+              error:
+                `No skill named "${args.name}" is available. Use the exact name ` +
+                "from the available skills listing (or list_skills).",
             };
           }
-          return {
-            success: true,
-            data: {
-              skills: skills.map(toToolSkill),
-              count: skills.length,
-              ...(skills.length > 1
-                ? {
-                    hint: "Multiple skills matched. Pick the most relevant one for the user message, or ask the user to clarify.",
-                  }
-                : {}),
-            },
-          };
+
+          if (context.sessionId && context.sessionPersistence) {
+            await ensureHydrated(manager);
+            if (
+              manager.sessions.isActive(context.sessionId, skill.id, skill.name)
+            ) {
+              // Report the version the session actually follows — a
+              // mid-session update must not masquerade as loaded.
+              const activation = manager.sessions.getActivation(
+                context.sessionId,
+                skill.id,
+                skill.name,
+              );
+              return {
+                success: true,
+                data: {
+                  status: "already_loaded",
+                  name: skill.name,
+                  version: activation?.version ?? skill.version ?? 1,
+                  message:
+                    "This skill is already loaded in the conversation — follow " +
+                    "the instructions from when it was loaded.",
+                },
+              };
+            }
+            manager.sessions.recordActivation(context.sessionId, skill);
+          }
+
+          const pinned = Boolean(
+            context.sessionId && context.sessionPersistence,
+          );
+          trace.getActiveSpan()?.setAttributes({
+            "skill.name": skill.name,
+            "skill.version": skill.version ?? 1,
+            "skill.instructions_chars": skill.instructions.length,
+            "skill.pinned": pinned,
+          });
+          logger.debug("[SkillTools] Skill activated", {
+            skill: skill.name,
+            version: skill.version ?? 1,
+            sessionId: context.sessionId,
+            pinned,
+          });
+          return { success: true, data: toActivationPayload(skill) };
         } catch (error) {
-          logger.warn("[SkillTools] search_skills failed", {
+          logger.warn("[SkillTools] use_skill failed", {
+            skill: args.name,
             error: error instanceof Error ? error.message : String(error),
           });
           return {
             success: false,
             error: error instanceof Error ? error.message : String(error),
-            data: { skills: [] },
           };
         }
       },
     }),
 
+    read_skill_resource: tool({
+      description:
+        "Read an auxiliary file bundled with a loaded skill (paths appear in the " +
+        "skill's `resources` list or are referenced from its instructions). Load the " +
+        "skill with use_skill first. Only read files the current task actually needs — " +
+        "each resource costs context.",
+      inputSchema: z.object({
+        skill: z.string().min(1).describe("Name of the loaded skill."),
+        path: z
+          .string()
+          .min(1)
+          .describe(
+            'Resource path relative to the skill, e.g. "references/forms.md".',
+          ),
+      }),
+      execute: async (args) => {
+        const manager = resolveManager();
+        if (!manager) {
+          return NOT_CONFIGURED;
+        }
+        try {
+          const skill = await manager.get(args.skill);
+          if (!skill || !isSkillVisibleInScope(skill, context.scopeId)) {
+            return {
+              success: false,
+              error: `No skill named "${args.skill}" is available.`,
+            };
+          }
+          if (context.sessionId && context.sessionPersistence) {
+            await ensureHydrated(manager);
+            if (
+              !manager.sessions.isActive(
+                context.sessionId,
+                skill.id,
+                skill.name,
+              )
+            ) {
+              return {
+                success: false,
+                error: `Skill "${skill.name}" is not loaded — call use_skill first.`,
+              };
+            }
+          }
+          const content = await manager.getResource(skill.id, args.path);
+          if (content === null) {
+            return {
+              success: false,
+              error:
+                `Resource "${args.path}" not found on skill "${skill.name}". ` +
+                "Valid paths are listed in the skill's `resources`.",
+            };
+          }
+          return {
+            success: true,
+            data: { skill: skill.name, path: args.path, content },
+          };
+        } catch (error) {
+          logger.warn("[SkillTools] read_skill_resource failed", {
+            skill: args.skill,
+            path: args.path,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+    }),
+  };
+}
+
+/**
+ * Instance skill tools bound to a lazily-resolved manager: list_skills
+ * plus the gated mutation tools. Returns Vercel AI SDK tool() objects
+ * (description + Zod inputSchema + execute) keyed by tool name.
+ */
+export function createSkillTools(
+  resolveManager: () => SkillsManagerLike | null,
+  options?: SkillToolsOptions,
+): Record<string, Tool> {
+  const tools: Record<string, Tool> = {
     list_skills: tool({
       description:
         "Returns a lightweight list of all available skills — name, display name, description, and " +
         "tags only. No instructions are returned, keeping context cost minimal. " +
         'Use this only when a user explicitly asks "what skills do you have?" or "what can you help ' +
-        'me with?". Do NOT use this for skill lookup before answering — use search_skills instead.',
+        'me with?". To load a skill for a task, use use_skill instead.',
       inputSchema: z.object({
         scopeId: z
           .string()
@@ -156,7 +294,7 @@ export function createSkillTools(
       execute: async (args) => {
         const manager = resolveManager();
         if (!manager) {
-          return notConfigured;
+          return { ...NOT_CONFIGURED, data: { skills: [] } };
         }
         try {
           const items = await manager.list(args.scopeId);
@@ -201,11 +339,7 @@ async function runMutation(
 ) {
   const manager = resolveManager();
   if (!manager) {
-    return {
-      success: false,
-      error:
-        "Skills are not available — the skills store failed to initialize.",
-    };
+    return NOT_CONFIGURED;
   }
   try {
     const result = await manager.requestMutation(action);
@@ -338,8 +472,8 @@ function createSkillMutationTools(
       description:
         "Propose an update to an EXISTING skill. Only the provided fields change; the version is " +
         "bumped. Depending on host configuration the change is applied immediately or queued for " +
-        "human approval. Look the skill up with search_skills or list_skills first to get its id or " +
-        "exact name. Do not paraphrase or expand the user's instructions.",
+        "human approval. Look the skill up with list_skills first to get its exact name. " +
+        "Do not paraphrase or expand the user's instructions.",
       inputSchema: z.object({
         skillId: z
           .string()

--- a/src/lib/skills/skillsManager.ts
+++ b/src/lib/skills/skillsManager.ts
@@ -20,12 +20,19 @@ import type {
   SkillsConfig,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import { filterSkillIndex, formatSkillsPromptIndex } from "./skillMatcher.js";
+import {
+  filterSkillIndex,
+  formatSkillsPromptIndex,
+  renderSkillListing,
+  sortSkillIndex,
+} from "./skillMatcher.js";
+import { SkillSessionTracker } from "./skillSessionTracker.js";
 import { createSkillStore } from "./skillStores.js";
 
 const DEFAULT_MAX_MATCHES = 5;
 const DEFAULT_PROMPT_INDEX_MAX_ITEMS = 50;
 const DEFAULT_INDEX_CACHE_TTL_MS = 30_000;
+const DEFAULT_LISTING_BUDGET_CHARS = 15_000;
 
 export class SkillsManager {
   private readonly store: SkillStore;
@@ -33,12 +40,18 @@ export class SkillsManager {
   private cachedIndexAt = 0;
   /** Serializes writes within this process — see requestMutation(). */
   private mutationQueue: Promise<unknown> = Promise.resolve();
+  /** Per-session activation state (pinned skills). */
+  readonly sessions = new SkillSessionTracker();
 
   constructor(private readonly config: SkillsConfig) {
     this.store = createSkillStore(config.storage);
   }
 
-  /** Cached index read. TTL 0 disables caching. */
+  /**
+   * Cached index read, sorted by name. TTL 0 disables caching. Sorting
+   * here (not per render) keeps every downstream listing byte-stable
+   * regardless of store enumeration order.
+   */
   async getIndex(forceRefresh = false): Promise<SkillIndexItem[]> {
     const ttl = this.config.indexCacheTtlMs ?? DEFAULT_INDEX_CACHE_TTL_MS;
     const fresh =
@@ -48,7 +61,7 @@ export class SkillsManager {
     if (fresh && !forceRefresh && this.cachedIndex) {
       return this.cachedIndex;
     }
-    const index = await this.store.index();
+    const index = sortSkillIndex(await this.store.index());
     this.cachedIndex = index;
     this.cachedIndexAt = Date.now();
     return index;
@@ -117,6 +130,34 @@ export class SkillsManager {
     scopeId?: string;
     tags?: string[];
   }): Promise<string | null> {
+    const items = await this.visibleItems(options);
+    return formatSkillsPromptIndex(
+      items,
+      this.config.promptIndexMaxItems ?? DEFAULT_PROMPT_INDEX_MAX_ITEMS,
+    );
+  }
+
+  /**
+   * Render the `<available_skills>` block for the use_skill tool
+   * description ("tool" discovery mode), or null when nothing is visible.
+   * Bounded by listingBudgetChars; entries are never dropped.
+   */
+  async buildToolListing(options?: {
+    scopeId?: string;
+    tags?: string[];
+  }): Promise<string | null> {
+    const items = await this.visibleItems(options);
+    return renderSkillListing(
+      items,
+      this.config.listingBudgetChars ?? DEFAULT_LISTING_BUDGET_CHARS,
+    );
+  }
+
+  /** Visible (active, scope- and tag-filtered) index entries for one call. */
+  private async visibleItems(options?: {
+    scopeId?: string;
+    tags?: string[];
+  }): Promise<SkillIndexItem[]> {
     let items = await this.list(options?.scopeId);
     if (options?.tags && options.tags.length > 0) {
       const wanted = options.tags.map((t) => t.toLowerCase());
@@ -124,10 +165,35 @@ export class SkillsManager {
         (item.tags ?? []).some((t) => wanted.includes(t.toLowerCase())),
       );
     }
-    return formatSkillsPromptIndex(
-      items,
-      this.config.promptIndexMaxItems ?? DEFAULT_PROMPT_INDEX_MAX_ITEMS,
-    );
+    return items;
+  }
+
+  /**
+   * Read an auxiliary resource file bundled with a skill. Paths are
+   * relative to the skill; traversal segments are rejected. Null when the
+   * skill, the resource, or store resource support is absent.
+   */
+  async getResource(
+    idOrName: string,
+    resourcePath: string,
+  ): Promise<string | null> {
+    const normalized = resourcePath.replace(/\\/g, "/");
+    if (
+      normalized.startsWith("/") ||
+      normalized.split("/").some((segment) => segment === "..")
+    ) {
+      throw new Error(
+        `Invalid resource path "${resourcePath}" — must be relative to the skill directory`,
+      );
+    }
+    if (!this.store.getResource) {
+      return null;
+    }
+    const skill = await this.get(idOrName);
+    if (!skill) {
+      return null;
+    }
+    return this.store.getResource(skill.id, normalized);
   }
 
   /**

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -136,11 +136,11 @@ export type NeurolinkConstructorConfig = {
   classifierRouter?: ClassifierRouterConfig;
   /**
    * Native skills: versioned, discoverable instruction packs (SOPs,
-   * playbooks) with progressive disclosure. When enabled, built-in
-   * search_skills / list_skills tools are registered (plus gated mutation
-   * tools) and a compact skills index is injected into the system prompt
-   * of each generate()/stream() call. Opt-in and fails open on read paths.
-   * See {@link SkillsConfig}.
+   * playbooks) with progressive disclosure. When enabled, each
+   * generate()/stream() call gets a skills discovery listing plus
+   * use_skill / read_skill_resource tools; activated skill instructions
+   * pin to the session so they are loaded once and replayed from history.
+   * Opt-in and fails open on read paths. See {@link SkillsConfig}.
    */
   skills?: SkillsConfig;
 };

--- a/src/lib/types/conversation.ts
+++ b/src/lib/types/conversation.ts
@@ -308,6 +308,23 @@ export type ChatMessageMetadata = {
    * payload from the local artifact store.
    */
   artifactId?: string;
+
+  // --- Skill activation pinning (skills v2) ---
+
+  /**
+   * Marks a pinned skill-activation message: the full instructions of a
+   * skill loaded via use_skill, persisted into session history so later
+   * turns replay it verbatim instead of re-fetching the skill. Pinned
+   * skill messages are protected from sliding-window truncation and are
+   * re-included after memory summarization.
+   */
+  isSkill?: boolean;
+  /** Skill id of a pinned skill-activation message. */
+  skillId?: string;
+  /** Skill name of a pinned skill-activation message. */
+  skillName?: string;
+  /** Skill version captured at activation (sessions pin the activated version). */
+  skillVersion?: number;
 };
 
 /**
@@ -471,6 +488,19 @@ export type StoreConversationTurnOptions = {
   };
   /** Gemini 3 thought signature for reasoning continuity across turns */
   thoughtSignature?: string;
+  /**
+   * Pinned skill-activation messages (skills v2) recorded during this turn.
+   * Inserted between the user and assistant messages so replayed history
+   * mirrors the actual order: ask → skill loaded → answer. Stored verbatim —
+   * skill instructions are never truncated.
+   *
+   * Invariant for history consumers: a skill-bearing turn is a
+   * user → skill(user-role, metadata.isSkill) → assistant triplet, so
+   * stored history is NOT strictly pair-wise alternating. Pair-based
+   * logic must filter `metadata.isSkill` first (see slidingWindowTruncator
+   * for the canonical partition-and-reanchor pattern).
+   */
+  skillMessages?: ChatMessage[];
 };
 
 /**

--- a/src/lib/types/skills.ts
+++ b/src/lib/types/skills.ts
@@ -6,16 +6,31 @@
  *
  * Architecture mirrors the Hippocampus memory subsystem: a `skills` config
  * on the NeuroLink constructor lazily initializes a SkillsManager, which
- * auto-registers built-in tools (search_skills / list_skills, plus gated
- * mutation tools) and optionally injects a compact skills index into the
- * system prompt of each generate()/stream() call.
+ * auto-registers built-in tools (list_skills, plus gated mutation tools)
+ * and augments each generate()/stream() call with the discovery listing
+ * plus per-call use_skill / read_skill_resource tools.
  *
  * Naming: every exported type carries a `Skill` prefix to satisfy the
  * `unique-type-names` ESLint rule.
  */
 
+import type { ChatMessage } from "./conversation.js";
+
 /** Visibility of a skill: available everywhere, or only in specific scopes. */
 export type SkillScopeKind = "global" | "scoped";
+
+/**
+ * Reference to an auxiliary file bundled with a skill (progressive
+ * disclosure level 3). Resources are read into context on demand via the
+ * read_skill_resource tool — a skill's SKILL.md should stay lean and point
+ * to resources for rarely-needed detail.
+ */
+export type SkillResourceRef = {
+  /** Path relative to the skill's directory, e.g. "references/edge-cases.md". */
+  path: string;
+  /** Size in bytes when known (listing hint only). */
+  size?: number;
+};
 
 /** Lifecycle status. Deletes are soft — deprecated skills stay in storage. */
 export type SkillLifecycleStatus = "active" | "deprecated";
@@ -50,6 +65,12 @@ export type SkillDefinition = {
   createdAt?: string;
   /** ISO timestamp of last update. */
   updatedAt?: string;
+  /**
+   * Auxiliary files bundled with the skill, readable on demand through
+   * read_skill_resource. Populated by stores that support resources
+   * (directory-layout filesystem skills, S3, Redis).
+   */
+  resources?: SkillResourceRef[];
   /** Free-form host metadata (audit fields, approval references, …). */
   metadata?: Record<string, unknown>;
 };
@@ -74,6 +95,13 @@ export type SkillStore = {
   index(): Promise<SkillIndexItem[]>;
   /** Optional: drop any internal caches (called after mutations). */
   invalidate?(): void;
+  /**
+   * Optional: fetch an auxiliary resource file bundled with a skill.
+   * `resourcePath` is relative to the skill (e.g. "references/forms.md").
+   * Null when the skill or resource is absent. Stores without resource
+   * support simply omit this method.
+   */
+  getResource?(id: string, resourcePath: string): Promise<string | null>;
 };
 
 /** In-process store, optionally seeded. Good for tests and embedded use. */
@@ -81,6 +109,11 @@ export type SkillMemoryStorageConfig = {
   type: "memory";
   /** Initial skills to seed the store with. */
   skills?: SkillDefinition[];
+  /**
+   * Resource file contents keyed by skill id → relative path.
+   * E.g. `{ "my-skill": { "references/forms.md": "..." } }`.
+   */
+  resources?: Record<string, Record<string, string>>;
 };
 
 /**
@@ -167,6 +200,16 @@ export type SkillS3IndexDocument = {
   skills: SkillIndexItem[];
 };
 
+/** Result of a conditional (ETag) object read. */
+export type SkillS3ConditionalGetResult = {
+  /** Object body; null when the key is absent. */
+  body: string | null;
+  /** ETag of the returned body, for the next conditional read. */
+  etag?: string;
+  /** True when the object is unchanged since the supplied ETag (no body). */
+  notModified?: boolean;
+};
+
 /**
  * Minimal object-storage operations the S3 skill store runs on. The
  * default implementation is created lazily from @aws-sdk/client-s3;
@@ -179,6 +222,15 @@ export type SkillS3ObjectOps = {
   deleteObject(key: string): Promise<void>;
   /** List all object keys under a prefix (paginated internally). */
   listKeys(prefix: string): Promise<string[]>;
+  /**
+   * Optional: ETag-conditional read (If-None-Match). Used for index.json
+   * refreshes so an unchanged index costs a 304 instead of a full download.
+   * Ops without it fall back to plain getObject.
+   */
+  getObjectConditional?(
+    key: string,
+    etag?: string,
+  ): Promise<SkillS3ConditionalGetResult>;
 };
 
 export type SkillsStorageConfig =
@@ -188,7 +240,7 @@ export type SkillsStorageConfig =
   | SkillRedisStorageConfig
   | SkillCustomStorageConfig;
 
-/** Query accepted by SkillsManager.search() and the search_skills tool. */
+/** Query accepted by SkillsManager.search() (programmatic + CLI search). */
 export type SkillSearchQuery = {
   /** Keyword matched (case-insensitive substring) against name, displayName, and description. */
   query?: string;
@@ -255,14 +307,38 @@ export type SkillsConfig = {
   /** Persistence backend. Default: `{ type: "memory" }`. */
   storage?: SkillsStorageConfig;
   /**
-   * Inject a compact skills index (names + descriptions, never instructions)
-   * into the system prompt of each generate()/stream() call. Default: true.
-   * Set false for curator-style pure tool-driven disclosure.
+   * Where the skills listing (names + descriptions, never instructions)
+   * surfaces for model-driven discovery:
+   *  - "tool" (default): an `<available_skills>` block embedded in the
+   *    use_skill tool description — the Claude Code pattern. Keeps the
+   *    host's system prompt untouched and the listing cache-stable.
+   *  - "system-prompt": a "## Available Skills" index appended to the
+   *    system prompt instead.
+   *  - "none": no listing anywhere; discovery only via list_skills.
    */
-  promptIndex?: boolean;
+  discovery?: SkillDiscoveryMode;
+  /**
+   * Character budget for the "tool" discovery listing. When the full
+   * listing exceeds it, every description is shortened uniformly (first
+   * sentence, then a hard cap) so the render stays a pure function of the
+   * index — byte-stable across calls; names are never dropped.
+   * Default: 15000.
+   */
+  listingBudgetChars?: number;
+  /**
+   * Pin activated skill instructions into session history so later turns
+   * replay them verbatim (byte-stable, provider-cacheable) instead of
+   * re-fetching the skill. Requires conversation memory + a sessionId on
+   * the call. Default: true.
+   */
+  sessionPersistence?: boolean;
   /** Maximum skills hydrated (with instructions) per search. Default: 5. */
   maxMatches?: number;
-  /** Maximum entries rendered in the prompt index before truncation. Default: 50. */
+  /**
+   * Maximum entries rendered by the "system-prompt" discovery mode before
+   * truncation. Default: 50. The "tool" mode is bounded by
+   * listingBudgetChars instead and never drops entries.
+   */
   promptIndexMaxItems?: number;
   /** Index cache TTL in milliseconds. Default: 30000. 0 disables caching. */
   indexCacheTtlMs?: number;
@@ -284,6 +360,37 @@ export type SkillsConfig = {
   ) => Promise<SkillMutationDecision>;
 };
 
+/** Where the skills discovery listing surfaces. See SkillsConfig.discovery. */
+export type SkillDiscoveryMode = "tool" | "system-prompt" | "none";
+
+/**
+ * One activated skill in a session: which skill, at which version, when.
+ * Sessions pin the version active at activation time — a mid-session skill
+ * update never mutates instructions the model has already loaded.
+ */
+export type SkillActivationRecord = {
+  skillId: string;
+  name: string;
+  version: number;
+  /** ISO timestamp of activation. */
+  activatedAt: string;
+};
+
+/**
+ * Structural view of the per-session activation tracker consumed by the
+ * skill tools factory.
+ */
+export type SkillSessionStateLike = {
+  isActive: (sessionId: string, skillId: string, name: string) => boolean;
+  getActivation: (
+    sessionId: string,
+    skillId: string,
+    name?: string,
+  ) => SkillActivationRecord | undefined;
+  recordActivation: (sessionId: string, skill: SkillDefinition) => ChatMessage;
+  hydrate: (sessionId: string, storedMessages: ChatMessage[]) => void;
+};
+
 /**
  * Structural view of SkillsManager consumed by the skill tools factory —
  * keeps skillTools.ts decoupled from the concrete manager class.
@@ -291,9 +398,43 @@ export type SkillsConfig = {
 export type SkillsManagerLike = {
   search: (query: SkillSearchQuery) => Promise<SkillDefinition[]>;
   list: (scopeId?: string) => Promise<SkillIndexItem[]>;
+  get: (idOrName: string) => Promise<SkillDefinition | null>;
+  getResource: (
+    idOrName: string,
+    resourcePath: string,
+  ) => Promise<string | null>;
+  sessions: SkillSessionStateLike;
   requestMutation: (
     action: SkillMutationAction,
   ) => Promise<SkillMutationResult>;
+};
+
+/**
+ * Per-call context bound into the use_skill / read_skill_resource tools at
+ * injection time (prepareGenerate/prepareStream). The sessionId is captured
+ * by closure so activation state is tracked without relying on runtime tool
+ * context plumbing.
+ */
+export type SkillCallToolsContext = {
+  /** Session the call belongs to; absent → activation state is per-turn only. */
+  sessionId?: string;
+  /** Scope filter applied when resolving skills for this call. */
+  scopeId?: string;
+  /**
+   * Pin activated instructions into session history after the turn.
+   * Mirrors SkillsConfig.sessionPersistence resolved for this call.
+   */
+  sessionPersistence: boolean;
+  /** Discovery mode resolved for this call — shapes the use_skill description. */
+  discovery: SkillDiscoveryMode;
+  /** Rendered `<available_skills>` block for "tool" discovery; null when empty. */
+  listing?: string | null;
+  /**
+   * Stored session history loader used to hydrate activation state before
+   * every dedup check (restart/multi-instance/failed-persistence safety).
+   * Invoked once per use_skill / read_skill_resource attempt.
+   */
+  getStoredMessages?: (sessionId: string) => Promise<ChatMessage[]>;
 };
 
 /** Options for the createSkillTools factory. */
@@ -308,12 +449,19 @@ export type SkillToolsOptions = {
  * config (same precedence convention as per-call credentials).
  */
 export type SkillsCallOptions = {
-  /** Master toggle for this call (prompt index only — tools stay registered). Default: true. */
+  /** Master toggle for this call (listing + per-call tools). Default: true. */
   enabled?: boolean;
-  /** Per-call override of SkillsConfig.promptIndex. */
-  promptIndex?: boolean;
-  /** Scope filter for the prompt index on this call. Overrides defaultScopeId. */
+  /** Per-call override of SkillsConfig.discovery. */
+  discovery?: SkillDiscoveryMode;
+  /** Scope filter for the listing and skill resolution on this call. Overrides defaultScopeId. */
   scopeId?: string;
-  /** Restrict the prompt index to skills carrying at least one of these tags. */
+  /** Restrict the listing to skills carrying at least one of these tags. */
   tags?: string[];
+  /**
+   * Skill names to activate at the start of this call: their full
+   * instructions are injected up front (and pinned to the session when
+   * sessionPersistence is on), without waiting for the model to invoke
+   * use_skill. Already-active skills are skipped.
+   */
+  preload?: string[];
 };

--- a/src/lib/utils/conversationMemory.ts
+++ b/src/lib/utils/conversationMemory.ts
@@ -312,6 +312,7 @@ export async function storeConversationTurn(
   result: TextGenerationResult,
   startTimeStamp?: Date | undefined,
   requestId?: string,
+  skillMessages?: ChatMessage[],
 ): Promise<void> {
   logger.debug("[conversationMemoryUtils] storeConversationTurn called", {
     requestId,
@@ -486,6 +487,9 @@ export async function storeConversationTurn(
           enableSummarization: originalOptions.enableSummarization,
           requestId,
           events: toolActivityEvents,
+          ...(skillMessages && skillMessages.length > 0
+            ? { skillMessages }
+            : {}),
           tokenUsage: result.usage
             ? {
                 inputTokens: result.usage.input,
@@ -591,6 +595,13 @@ export function buildContextFromPointer(
 
   const messagesAfterPointer = session.messages.slice(pointerIndex + 1);
 
+  // Pinned skill instructions must survive summarization: any skill message
+  // that fell behind the pointer is re-included verbatim after the summary,
+  // so an activated skill keeps its full instructions for the whole session.
+  const pinnedSkillMessages = session.messages
+    .slice(0, pointerIndex + 1)
+    .filter((msg) => msg.metadata?.isSkill);
+
   // Construct context: summary message + recent messages
   const summaryMessage: ChatMessage = {
     id: `summary-${session.summarizedUpToMessageId}`,
@@ -611,7 +622,11 @@ export function buildContextFromPointer(
     summaryLength: session.summarizedMessage.length,
   });
 
-  const contextMessages = [summaryMessage, ...messagesAfterPointer];
+  const contextMessages = [
+    summaryMessage,
+    ...pinnedSkillMessages,
+    ...messagesAfterPointer,
+  ];
 
   // Log context built for LLM with structural metadata
   const totalChars = contextMessages.reduce(

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -5,15 +5,18 @@ import "dotenv/config";
  * Continuous Test Suite: Skills
  *
  * Tests the native skills subsystem end-to-end:
- * - Built-in tool registration (search_skills / list_skills, gated mutation tools)
- * - InMemory + FileSystem stores (JSON, frontmatter .md, <dir>/SKILL.md layouts)
- * - S3 store (hermetic via injected object ops: round-trip, index upsert, self-heal,
- *   fail-open error when @aws-sdk/client-s3 is absent)
+ * - Built-in tool registration (list_skills, gated mutation tools) and the
+ *   per-call use_skill / read_skill_resource injection (discovery listing)
+ * - InMemory + FileSystem stores (JSON, frontmatter .md, <dir>/SKILL.md
+ *   layouts, bundled resources)
+ * - S3 store (hermetic via injected object ops: round-trip, index upsert,
+ *   self-heal, ETag-conditional refresh, resources, fail-open errors)
  * - Redis store (round-trip + SCAN index; SKIPs when Redis is unreachable)
  * - Custom store plug-in
- * - Index-first search semantics (no_match envelope, scope/tag filters, maxMatches)
- * - SkillsManager API via getSkillsManager()
- * - Prompt-index injection (block content, per-call disable, media-mode skip)
+ * - Search semantics on the manager (scope/tag filters, maxMatches)
+ * - Activation + session pinning (already_loaded dedup, pinned history
+ *   messages, summarization/truncation survival, preload, version pinning)
+ * - Listing budget (description shortening, names never dropped, sorted)
  * - Mutation gate (approve / reject / pending / direct apply, soft delete, version bump)
  * - CLI: skills create/list/show/search/delete + --skills-dir flag
  * - Server routes: /api/agent/skills CRUD handlers + 503 when unconfigured
@@ -28,6 +31,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { NeuroLink, RedisSkillStore, S3SkillStore } from "../dist/index.js";
+import { ConversationMemoryManager } from "../dist/lib/core/conversationMemoryManager.js";
+import { buildContextFromPointer } from "../dist/lib/utils/conversationMemory.js";
+import { truncateWithSlidingWindow } from "../dist/lib/context/stages/slidingWindowTruncator.js";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -132,6 +138,9 @@ function makeSkillsInstance(
   overrides: Record<string, unknown> = {},
 ): NeuroLink {
   return new NeuroLink({
+    // Session pinning requires conversation memory (persistence is gated
+    // on it) — enable the in-memory manager for activation/session tests.
+    conversationMemory: { enabled: true },
     skills: {
       enabled: true,
       storage: { type: "memory", skills: SEED_SKILLS },
@@ -146,12 +155,19 @@ function makeSkillsInstance(
 
 async function testToolRegistration(): Promise<void> {
   await runTest(
-    "1. search_skills + list_skills registered when enabled",
+    "1. list_skills registered when enabled; use_skill is per-call only",
     async () => {
       const nl = makeSkillsInstance();
       const tools = nl.getCustomTools();
-      assert(tools.has("search_skills"), "search_skills missing");
       assert(tools.has("list_skills"), "list_skills missing");
+      assert(
+        !tools.has("use_skill"),
+        "use_skill must be injected per call, not registered",
+      );
+      assert(
+        !tools.has("read_skill_resource"),
+        "read_skill_resource must be injected per call, not registered",
+      );
       assert(
         !tools.has("skill_create"),
         "skill_create must be gated off by default",
@@ -170,7 +186,6 @@ async function testToolRegistration(): Promise<void> {
   await runTest("2. No skill tools when skills not configured", async () => {
     const nl = new NeuroLink();
     const tools = nl.getCustomTools();
-    assert(!tools.has("search_skills"), "search_skills must not be registered");
     assert(!tools.has("list_skills"), "list_skills must not be registered");
   });
 
@@ -187,7 +202,7 @@ async function testToolRegistration(): Promise<void> {
 }
 
 // ============================================================
-// TESTS — search semantics through the registered tool
+// TESTS — search semantics (manager) + per-call tool injection
 // ============================================================
 
 type ToolExecute = (params: unknown, ctx?: unknown) => Promise<unknown>;
@@ -198,94 +213,128 @@ function getToolExecute(nl: NeuroLink, name: string): ToolExecute {
   return tool.execute as ToolExecute;
 }
 
-async function testSearchTool(): Promise<void> {
+type CallTool = { description: string; execute: ToolExecute };
+
+/**
+ * Run the exact per-call augmentation generate()/stream() use (private at
+ * the TS level only — dist is plain JS) and return the mutated options.
+ */
+async function applyAugmentation(
+  nl: NeuroLink,
+  options: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const apply = (
+    nl as unknown as {
+      applySkillsAugmentation: (o: Record<string, unknown>) => Promise<void>;
+    }
+  ).applySkillsAugmentation.bind(nl);
+  await apply(options);
+  return options;
+}
+
+function getCallTool(options: Record<string, unknown>, name: string): CallTool {
+  const tools = options.tools as Record<string, CallTool> | undefined;
+  assert(tools && tools[name], `${name} not injected into options.tools`);
+  return tools[name];
+}
+
+function drainSkillMessages(
+  nl: NeuroLink,
+  sessionId: string,
+): Array<{
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}> {
+  return (
+    nl as unknown as {
+      drainPendingSkillMessages: (sid: unknown) => Array<{
+        role: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }>;
+    }
+  ).drainPendingSkillMessages.call(nl, sessionId);
+}
+
+async function testSearch(): Promise<void> {
   await runTest(
-    "4. search_skills returns hydrated match with instructions",
+    "4. manager.search hydrates matches with instructions",
     async () => {
       const nl = makeSkillsInstance();
-      const execute = getToolExecute(nl, "search_skills");
-      const result = (await execute({ query: "refund" })) as {
-        success: boolean;
-        data: { skills: Array<{ name: string; instructions: string }> };
-      };
-      assert(result.success, "expected success");
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const matches = await manager.search({ query: "refund" });
+      assert(matches.length === 1, `expected 1 match, got ${matches.length}`);
       assert(
-        result.data.skills.length === 1,
-        `expected 1 match, got ${result.data.skills.length}`,
-      );
-      assert(
-        result.data.skills[0].name === "refund_dispute_escalation",
+        matches[0].name === "refund_dispute_escalation",
         "wrong skill matched",
       );
       assert(
-        result.data.skills[0].instructions.includes("payments-oncall"),
+        matches[0].instructions.includes("payments-oncall"),
         "instructions not hydrated",
       );
+      const none = await manager.search({ query: "quantum-chromodynamics" });
+      assert(none.length === 0, "no-match must return empty");
     },
   );
 
-  await runTest("5. search_skills no_match is success, not error", async () => {
+  await runTest("5. tag filter applies on top of query", async () => {
     const nl = makeSkillsInstance();
-    const execute = getToolExecute(nl, "search_skills");
-    const result = (await execute({ query: "quantum-chromodynamics" })) as {
-      success: boolean;
-      data: { skills: unknown[]; reason?: string };
-    };
-    assert(result.success, "no_match must be success:true");
-    assert(result.data.reason === "no_match", "expected reason=no_match");
-    assert(result.data.skills.length === 0, "expected empty skills");
-  });
-
-  await runTest("6. search_skills requires query or tag", async () => {
-    const nl = makeSkillsInstance();
-    const execute = getToolExecute(nl, "search_skills");
-    const result = (await execute({})) as { success: boolean; error?: string };
-    assert(!result.success, "parameterless call must fail");
-    assert(
-      (result.error ?? "").includes("query"),
-      "error should mention required params",
-    );
-  });
-
-  await runTest("7. tag filter applies on top of query", async () => {
-    const nl = makeSkillsInstance();
-    const execute = getToolExecute(nl, "search_skills");
-    // "procedure"/"deploy" matches service_deployment; wrong tag excludes it
-    const result = (await execute({ query: "deploy", tag: "payments" })) as {
-      success: boolean;
-      data: { skills: unknown[]; reason?: string };
-    };
-    assert(result.success, "expected success");
-    assert(result.data.reason === "no_match", "wrong tag must exclude match");
+    const manager = nl.getSkillsManager();
+    assert(manager, "manager missing");
+    // "deploy" matches service_deployment; wrong tag excludes it
+    const wrongTag = await manager.search({ query: "deploy", tag: "payments" });
+    assert(wrongTag.length === 0, "wrong tag must exclude match");
+    const rightTag = await manager.search({ query: "deploy", tag: "devops" });
+    assert(rightTag.length === 1, "right tag must include match");
   });
 
   await runTest(
-    "8. scoped skills excluded for other scopes, included for own",
+    "6. scoped skills excluded for other scopes, included for own",
     async () => {
       const nl = makeSkillsInstance();
-      const execute = getToolExecute(nl, "search_skills");
-      const foreign = (await execute({
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const foreign = await manager.search({
         query: "standup",
         scopeId: "team-beta",
-      })) as { data: { skills: unknown[] } };
-      assert(
-        foreign.data.skills.length === 0,
-        "scoped skill leaked into foreign scope",
-      );
-      const own = (await execute({
+      });
+      assert(foreign.length === 0, "scoped skill leaked into foreign scope");
+      const own = await manager.search({
         query: "standup",
         scopeId: "team-alpha",
-      })) as { data: { skills: Array<{ name: string }> } };
+      });
       assert(
-        own.data.skills.length === 1 &&
-          own.data.skills[0].name === "team_alpha_standup",
+        own.length === 1 && own[0].name === "team_alpha_standup",
         "scoped skill missing in own scope",
       );
     },
   );
 
+  await runTest("7. maxMatches caps hydrated results", async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      id: `bulk-${i}`,
+      name: `bulk_skill_${i}`,
+      description: "A bulk generated skill for capping tests.",
+      instructions: `Instructions ${i}`,
+    }));
+    const nl = new NeuroLink({
+      skills: {
+        enabled: true,
+        storage: { type: "memory", skills: many },
+        maxMatches: 3,
+      },
+    });
+    const matches = await nl.getSkillsManager()!.search({ query: "bulk" });
+    assert(
+      matches.length === 3,
+      `expected 3 (maxMatches), got ${matches.length}`,
+    );
+  });
+
   await runTest(
-    "9. list_skills returns index without instructions",
+    "8. list_skills returns index without instructions",
     async () => {
       const nl = makeSkillsInstance();
       const execute = getToolExecute(nl, "list_skills");
@@ -304,30 +353,6 @@ async function testSearchTool(): Promise<void> {
       );
     },
   );
-
-  await runTest("10. maxMatches caps hydrated results", async () => {
-    const many = Array.from({ length: 8 }, (_, i) => ({
-      id: `bulk-${i}`,
-      name: `bulk_skill_${i}`,
-      description: "A bulk generated skill for capping tests.",
-      instructions: `Instructions ${i}`,
-    }));
-    const nl = new NeuroLink({
-      skills: {
-        enabled: true,
-        storage: { type: "memory", skills: many },
-        maxMatches: 3,
-      },
-    });
-    const execute = getToolExecute(nl, "search_skills");
-    const result = (await execute({ query: "bulk" })) as {
-      data: { skills: unknown[] };
-    };
-    assert(
-      result.data.skills.length === 3,
-      `expected 3 (maxMatches), got ${result.data.skills.length}`,
-    );
-  });
 }
 
 // ============================================================
@@ -363,8 +388,10 @@ async function testFilesystemStore(): Promise<void> {
       "2. Hand over the pager.",
     ].join("\n"),
   );
-  // Layout 3: Claude-skills directory
-  fs.mkdirSync(path.join(dir, "release-notes"));
+  // Layout 3: Claude-skills directory (with a bundled resource)
+  fs.mkdirSync(path.join(dir, "release-notes", "references"), {
+    recursive: true,
+  });
   fs.writeFileSync(
     path.join(dir, "release-notes", "SKILL.md"),
     [
@@ -374,6 +401,10 @@ async function testFilesystemStore(): Promise<void> {
       "---",
       "Collect merged PRs and group by feature area.",
     ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(dir, "release-notes", "references", "template.md"),
+    "## Release Notes Template\n- Features\n- Fixes",
   );
 
   await runTest(
@@ -404,6 +435,34 @@ async function testFilesystemStore(): Promise<void> {
         (md?.tags ?? []).includes("oncall"),
         "frontmatter tags must be parsed",
       );
+    },
+  );
+
+  await runTest(
+    "11b. Filesystem store: SKILL.md siblings become readable resources",
+    async () => {
+      const nl = new NeuroLink({
+        skills: { enabled: true, storage: { type: "filesystem", path: dir } },
+      });
+      const manager = nl.getSkillsManager();
+      assert(manager, "manager missing");
+      const skill = await manager.get("release_notes");
+      assert(
+        skill?.resources?.some((r) => r.path === "references/template.md"),
+        "sibling file not listed as a resource",
+      );
+      const content = await manager.getResource(
+        "release_notes",
+        "references/template.md",
+      );
+      assert(
+        content?.includes("Release Notes Template"),
+        "resource content not readable",
+      );
+      const escaped = await manager
+        .getResource("release_notes", "../json-skill.json")
+        .catch(() => null);
+      assert(escaped === null, "path traversal must not escape the skill dir");
     },
   );
 
@@ -499,11 +558,8 @@ async function testCustomStore(): Promise<void> {
           },
         },
       });
-      const execute = getToolExecute(nl, "search_skills");
-      const result = (await execute({ query: "refund" })) as {
-        data: { skills: Array<{ instructions: string }> };
-      };
-      assert(result.data.skills.length === 1, "custom store match failed");
+      const matches = await nl.getSkillsManager()!.search({ query: "refund" });
+      assert(matches.length === 1, "custom store match failed");
       assert(calls.includes("index"), "index() not called");
       assert(
         calls.includes("get:skill-refund"),
@@ -517,97 +573,459 @@ async function testCustomStore(): Promise<void> {
 // TESTS — prompt index
 // ============================================================
 
-async function testPromptIndex(): Promise<void> {
+async function testDiscovery(): Promise<void> {
   await runTest(
-    "15. buildPromptIndex: names+descriptions, no instructions",
+    "15. Default discovery: listing rides the use_skill description, prompt untouched",
     async () => {
       const nl = makeSkillsInstance();
-      const manager = nl.getSkillsManager();
-      assert(manager, "manager missing");
-      const block = await manager.buildPromptIndex();
-      assert(block, "expected a prompt block");
-      assert(block.includes("## Available Skills"), "missing header");
-      assert(block.includes("refund_dispute_escalation"), "missing skill name");
-      assert(block.includes("search_skills"), "missing tool guidance");
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "You are Tara.",
+      });
       assert(
-        !block.includes("payments-oncall"),
-        "instructions leaked into prompt index",
+        options.systemPrompt === "You are Tara.",
+        "tool-mode discovery must not touch the system prompt",
+      );
+      const useSkill = getCallTool(options, "use_skill");
+      getCallTool(options, "read_skill_resource");
+      assert(
+        useSkill.description.includes("<available_skills>"),
+        "listing block missing from use_skill description",
+      );
+      assert(
+        useSkill.description.includes("refund_dispute_escalation"),
+        "skill name missing from listing",
+      );
+      assert(
+        !useSkill.description.includes("payments-oncall"),
+        "instructions leaked into the listing",
+      );
+      // Sorted by name: refund… < service_deployment < team_alpha_standup
+      const listing = useSkill.description;
+      assert(
+        listing.indexOf("refund_dispute_escalation") <
+          listing.indexOf("service_deployment") &&
+          listing.indexOf("service_deployment") <
+            listing.indexOf("team_alpha_standup"),
+        "listing must be name-sorted",
+      );
+      // Deterministic: a second augmentation renders byte-identical listing
+      const again = await applyAugmentation(nl, { systemPrompt: "x" });
+      assert(
+        getCallTool(again, "use_skill").description === useSkill.description,
+        "listing must be byte-stable across calls",
       );
     },
   );
 
   await runTest(
-    "16. applySkillsPromptIndex appends to systemPrompt",
+    "16. Discovery modes: system-prompt appends index; skips honored",
     async () => {
-      const nl = makeSkillsInstance();
-      // Private at the TS level only — dist is plain JS. Reaching in keeps this
-      // a no-API test of the exact injection path generate()/stream() use.
-      const apply = (
-        nl as unknown as {
-          applySkillsPromptIndex: (o: Record<string, unknown>) => Promise<void>;
-        }
-      ).applySkillsPromptIndex.bind(nl);
-
-      const options: Record<string, unknown> = {
+      const spNl = makeSkillsInstance({ discovery: "system-prompt" });
+      const spOptions = await applyAugmentation(spNl, {
         systemPrompt: "You are Tara.",
-      };
-      await apply(options);
-      const prompt = options.systemPrompt as string;
+      });
+      const prompt = spOptions.systemPrompt as string;
       assert(prompt.startsWith("You are Tara."), "base prompt lost");
       assert(prompt.includes("## Available Skills"), "index not appended");
-
-      // Per-call disable
-      const disabled: Record<string, unknown> = {
-        systemPrompt: "base",
-        skills: { enabled: false },
-      };
-      await apply(disabled);
-      assert(disabled.systemPrompt === "base", "per-call disable ignored");
-
-      // promptIndex=false per call
-      const noIndex: Record<string, unknown> = {
-        systemPrompt: "base",
-        skills: { promptIndex: false },
-      };
-      await apply(noIndex);
+      assert(prompt.includes("use_skill"), "index must reference use_skill");
+      const spTool = getCallTool(spOptions, "use_skill");
       assert(
-        noIndex.systemPrompt === "base",
-        "per-call promptIndex=false ignored",
+        !spTool.description.includes("<available_skills>"),
+        "system-prompt mode must not duplicate the listing in the tool",
       );
 
+      const nl = makeSkillsInstance();
+      // Per-call disable
+      const disabled = await applyAugmentation(nl, {
+        systemPrompt: "base",
+        skills: { enabled: false },
+      });
+      assert(disabled.systemPrompt === "base", "per-call disable ignored");
+      assert(!disabled.tools, "disabled call must not receive skill tools");
+
       // Media-only mode skipped
-      const media: Record<string, unknown> = {
+      const media = await applyAugmentation(nl, {
         systemPrompt: "base",
         output: { mode: "video" },
-      };
-      await apply(media);
+      });
       assert(media.systemPrompt === "base", "media mode must skip injection");
+      assert(!media.tools, "media mode must not receive skill tools");
 
-      // Scope filter narrows the block
-      const scoped: Record<string, unknown> = {
+      // Scope filter narrows the listing
+      const scoped = await applyAugmentation(nl, {
         systemPrompt: "",
         skills: { scopeId: "team-beta" },
-      };
-      await apply(scoped);
+      });
       assert(
-        !(scoped.systemPrompt as string).includes("team_alpha_standup"),
-        "foreign-scope skill leaked into prompt index",
+        !getCallTool(scoped, "use_skill").description.includes(
+          "team_alpha_standup",
+        ),
+        "foreign-scope skill leaked into the listing",
       );
     },
   );
 
   await runTest(
-    "17. Instance promptIndex=false disables injection",
+    "17. Listing budget shortens descriptions, never drops names",
     async () => {
-      const nl = makeSkillsInstance({ promptIndex: false });
-      const apply = (
-        nl as unknown as {
-          applySkillsPromptIndex: (o: Record<string, unknown>) => Promise<void>;
-        }
-      ).applySkillsPromptIndex.bind(nl);
-      const options: Record<string, unknown> = { systemPrompt: "base" };
-      await apply(options);
-      assert(options.systemPrompt === "base", "instance-level disable ignored");
+      const longSkills = Array.from({ length: 6 }, (_, i) => ({
+        id: `long-${i}`,
+        name: `long_skill_${i}`,
+        description:
+          `Primary sentence for skill ${i}. ` +
+          "Second sentence with a lot of extra detail that should be the first thing dropped when the listing exceeds its character budget.".repeat(
+            3,
+          ),
+        instructions: "Body.",
+      }));
+      // Tight enough that every description must shrink to its first
+      // sentence (shortening stops as soon as the listing fits).
+      const nl = new NeuroLink({
+        skills: {
+          enabled: true,
+          storage: { type: "memory", skills: longSkills },
+          listingBudgetChars: 400,
+        },
+      });
+      const options = await applyAugmentation(nl, { systemPrompt: "" });
+      const listing = getCallTool(options, "use_skill").description;
+      for (let i = 0; i < 6; i++) {
+        assert(
+          listing.includes(`long_skill_${i}`),
+          `name long_skill_${i} dropped from budgeted listing`,
+        );
+      }
+      assert(
+        !listing.includes("Second sentence"),
+        "descriptions must be shortened under budget pressure",
+      );
+    },
+  );
+}
+
+// ============================================================
+// TESTS — activation + session pinning
+// ============================================================
+
+async function testActivation(): Promise<void> {
+  await runTest(
+    "34. use_skill loads full instructions once, then already_loaded",
+    async () => {
+      const nl = makeSkillsInstance();
+      const sessionId = "sess-activation";
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "",
+        context: { sessionId },
+      });
+      const useSkill = getCallTool(options, "use_skill");
+      const first = (await useSkill.execute({
+        name: "refund_dispute_escalation",
+      })) as {
+        success: boolean;
+        data: { instructions?: string; status?: string };
+      };
+      assert(first.success, "activation failed");
+      assert(
+        first.data.instructions?.includes("payments-oncall"),
+        "full instructions missing from activation",
+      );
+      const second = (await useSkill.execute({
+        name: "refund_dispute_escalation",
+      })) as { data: { status?: string; instructions?: string } };
+      assert(
+        second.data.status === "already_loaded",
+        "second activation must dedupe",
+      );
+      assert(
+        !second.data.instructions,
+        "already_loaded must not resend the body",
+      );
+
+      const unknown = (await useSkill.execute({ name: "nope" })) as {
+        success: boolean;
+        error?: string;
+      };
+      assert(
+        !unknown.success && (unknown.error ?? "").includes("nope"),
+        "unknown skill must return an error envelope",
+      );
+    },
+  );
+
+  await runTest(
+    "35. Activation pins a history message; drain is one-shot",
+    async () => {
+      const nl = makeSkillsInstance();
+      const sessionId = "sess-pin";
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "",
+        context: { sessionId },
+      });
+      await getCallTool(options, "use_skill").execute({
+        name: "service_deployment",
+      });
+      const pinned = drainSkillMessages(nl, sessionId);
+      assert(
+        pinned.length === 1,
+        `expected 1 pinned message, got ${pinned.length}`,
+      );
+      assert(pinned[0].role === "user", "pinned message must be user-role");
+      assert(
+        pinned[0].content.includes("[Skill loaded: service_deployment v1]"),
+        "pinned header missing",
+      );
+      assert(
+        pinned[0].content.includes("pre-deploy checklist"),
+        "pinned body missing",
+      );
+      assert(
+        pinned[0].metadata?.isSkill === true,
+        "metadata.isSkill missing on pinned message",
+      );
+      assert(
+        drainSkillMessages(nl, sessionId).length === 0,
+        "drain must be one-shot",
+      );
+    },
+  );
+
+  await runTest(
+    "36. Memory manager stores pinned skills between ask and answer",
+    async () => {
+      const memory = new ConversationMemoryManager({});
+      await memory.storeConversationTurn({
+        sessionId: "s1",
+        userMessage: "how do I deploy?",
+        aiResponse: "Loaded the SOP and followed it.",
+        skillMessages: [
+          {
+            id: "skill-msg-1",
+            role: "user",
+            content: "[Skill loaded: service_deployment v1]\n\nBody.",
+            metadata: {
+              isSkill: true,
+              skillId: "skill-deploy",
+              skillName: "service_deployment",
+              skillVersion: 1,
+            },
+          },
+        ],
+      });
+      const messages = await memory.getSessionMessages("s1");
+      assert(
+        messages.length === 3,
+        `expected 3 messages, got ${messages.length}`,
+      );
+      assert(
+        messages[0].role === "user" &&
+          messages[1].metadata?.isSkill === true &&
+          messages[2].role === "assistant",
+        "order must be ask → skill → answer",
+      );
+    },
+  );
+
+  await runTest("37. Pinned skills survive summarization replay", async () => {
+    const session = {
+      sessionId: "s2",
+      messages: [
+        { id: "m1", role: "user", content: "old ask" },
+        {
+          id: "m-skill",
+          role: "user",
+          content: "[Skill loaded: x v1]\n\nBody.",
+          metadata: { isSkill: true, skillId: "x", skillName: "x" },
+        },
+        { id: "m2", role: "assistant", content: "old answer" },
+        { id: "m3", role: "user", content: "recent ask" },
+        { id: "m4", role: "assistant", content: "recent answer" },
+      ],
+      createdAt: 0,
+      lastActivity: 0,
+      summarizedUpToMessageId: "m2",
+      summarizedMessage: "Earlier the user asked and got an answer.",
+    };
+    const context = buildContextFromPointer(session as never);
+    assert(context[0]?.metadata?.isSummary === true, "summary must lead");
+    assert(
+      context[1]?.metadata?.isSkill === true,
+      "pinned skill must be re-included right after the summary",
+    );
+    assert(
+      context.some((m: { id: string }) => m.id === "m3"),
+      "recent messages must remain",
+    );
+  });
+
+  await runTest(
+    "38. Pinned skills survive sliding-window truncation",
+    async () => {
+      const filler = (i: number, role: "user" | "assistant") => ({
+        id: `f${i}`,
+        role,
+        content: `filler ${i} `.repeat(50),
+      });
+      const messages = [
+        filler(0, "user"),
+        filler(1, "assistant"),
+        {
+          id: "m-skill",
+          role: "user",
+          content: "[Skill loaded: x v1]\n\nBody.",
+          metadata: { isSkill: true },
+        },
+        ...Array.from({ length: 20 }, (_, i) =>
+          filler(i + 2, i % 2 === 0 ? "user" : "assistant"),
+        ),
+      ];
+      const result = truncateWithSlidingWindow(
+        messages as never,
+        {
+          fraction: 0.9,
+        } as never,
+      );
+      assert(result.truncated, "expected truncation to trigger");
+      assert(
+        result.messages.some((m: { id: string }) => m.id === "m-skill"),
+        "pinned skill dropped by sliding-window truncation",
+      );
+    },
+  );
+
+  await runTest(
+    "39. Resources: listed on activation, gated + path-safe reads",
+    async () => {
+      const nl = new NeuroLink({
+        conversationMemory: { enabled: true },
+        skills: {
+          enabled: true,
+          storage: {
+            type: "memory",
+            skills: [SEED_SKILLS[0]],
+            resources: {
+              "skill-refund": {
+                "references/edge-cases.md": "Edge case: partial refunds.",
+              },
+            },
+          },
+        },
+      });
+      const sessionId = "sess-res";
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "",
+        context: { sessionId },
+      });
+      const readTool = getCallTool(options, "read_skill_resource");
+
+      const early = (await readTool.execute({
+        skill: "refund_dispute_escalation",
+        path: "references/edge-cases.md",
+      })) as { success: boolean; error?: string };
+      assert(
+        !early.success && (early.error ?? "").includes("use_skill"),
+        "resource read must be gated on activation",
+      );
+
+      const activated = (await getCallTool(options, "use_skill").execute({
+        name: "refund_dispute_escalation",
+      })) as { data: { resources?: string[] } };
+      assert(
+        activated.data.resources?.includes("references/edge-cases.md"),
+        "resources not listed on activation",
+      );
+
+      const read = (await readTool.execute({
+        skill: "refund_dispute_escalation",
+        path: "references/edge-cases.md",
+      })) as { success: boolean; data?: { content: string } };
+      assert(
+        read.success && read.data?.content.includes("partial refunds"),
+        "resource content not returned",
+      );
+
+      const traversal = (await readTool.execute({
+        skill: "refund_dispute_escalation",
+        path: "../secrets.txt",
+      })) as { success: boolean };
+      assert(!traversal.success, "traversal path must be rejected");
+    },
+  );
+
+  await runTest(
+    "40. Preload activates up front and never double-pins",
+    async () => {
+      const nl = makeSkillsInstance();
+      const sessionId = "sess-preload";
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "base",
+        context: { sessionId },
+        skills: { preload: ["service_deployment"] },
+      });
+      const prompt = options.systemPrompt as string;
+      assert(
+        prompt.includes("[Skill loaded: service_deployment v1]") &&
+          prompt.includes("pre-deploy checklist"),
+        "preload must inject instructions into the call prompt",
+      );
+      // Second call in the same turn window (pin still pending): must not
+      // re-inject or re-pin.
+      const second = await applyAugmentation(nl, {
+        systemPrompt: "base",
+        context: { sessionId },
+        skills: { preload: ["service_deployment"] },
+      });
+      assert(
+        second.systemPrompt === "base",
+        "already-active preload must not re-inject",
+      );
+      assert(
+        drainSkillMessages(nl, sessionId).length === 1,
+        "exactly one pin must exist across both preloads",
+      );
+      // The pin was drained but never stored (failed persistence): the
+      // tracker derives state from history, so preload self-heals by
+      // re-activating instead of pointing at instructions that exist
+      // nowhere.
+      const third = await applyAugmentation(nl, {
+        systemPrompt: "base",
+        context: { sessionId },
+        skills: { preload: ["service_deployment"] },
+      });
+      assert(
+        (third.systemPrompt as string).includes("pre-deploy checklist"),
+        "unpersisted activation must re-activate, not stay falsely loaded",
+      );
+    },
+  );
+
+  await runTest(
+    "41. Session pins the activated version across updates",
+    async () => {
+      const nl = makeSkillsInstance();
+      const sessionId = "sess-version";
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "",
+        context: { sessionId },
+      });
+      await getCallTool(options, "use_skill").execute({
+        name: "service_deployment",
+      });
+      await nl.getSkillsManager()!.requestMutation({
+        type: "update",
+        skillId: "skill-deploy",
+        patch: { instructions: "Completely new steps." },
+      });
+      const again = (await getCallTool(options, "use_skill").execute({
+        name: "service_deployment",
+      })) as { data: { status?: string; version?: number } };
+      assert(
+        again.data.status === "already_loaded",
+        "updated skill must stay pinned in-session",
+      );
+      assert(
+        again.data.version === 1,
+        `session must keep the activated v1, got v${again.data.version}`,
+      );
     },
   );
 }
@@ -724,14 +1142,8 @@ async function testMutations(): Promise<void> {
         success: boolean;
       };
       assert(result.success, "delete failed");
-      const search = getToolExecute(nl, "search_skills");
-      const after = (await search({ query: "refund" })) as {
-        data: { skills: unknown[]; reason?: string };
-      };
-      assert(
-        after.data.reason === "no_match",
-        "deprecated skill still matches",
-      );
+      const after = await nl.getSkillsManager()!.search({ query: "refund" });
+      assert(after.length === 0, "deprecated skill still matches");
       const list = getToolExecute(nl, "list_skills");
       const listed = (await list({})) as { data: { count: number } };
       assert(listed.data.count === 2, "deprecated skill still listed");
@@ -972,8 +1384,8 @@ async function testS3Store(): Promise<void> {
           storage: { type: "s3", bucket: "no-sdk-installed" },
         },
       });
-      const execute = getToolExecute(nl, "search_skills");
-      const result = (await execute({ query: "anything" })) as {
+      const execute = getToolExecute(nl, "list_skills");
+      const result = (await execute({})) as {
         success: boolean;
         error?: string;
       };
@@ -982,6 +1394,64 @@ async function testS3Store(): Promise<void> {
         (result.error ?? "").length > 0,
         "error message must be surfaced to the model",
       );
+    },
+  );
+
+  await runTest(
+    "27b. S3 store: resources by key + ETag-conditional index refresh",
+    async () => {
+      const stub = makeStubS3({
+        "tara/skills/skill-refund/references/edge-cases.md":
+          "Edge case: partial refunds.",
+      });
+      // Conditional-read seam: serve ETags and count full downloads.
+      let fullReads = 0;
+      let etagVersion = 0;
+      const conditionalOps = {
+        ...stub.ops,
+        async putObject(key: string, body: string) {
+          if (key === "tara/index.json") {
+            etagVersion++;
+          }
+          await stub.ops.putObject(key, body);
+        },
+        async getObjectConditional(key: string, etag?: string) {
+          const current = `"v${etagVersion}"`;
+          if (etag && etag === current) {
+            return { body: null, notModified: true };
+          }
+          fullReads++;
+          return { body: stub.objects.get(key) ?? null, etag: current };
+        },
+      };
+      const store = new S3SkillStore(
+        { type: "s3", bucket: "test-bucket", prefix: "tara/" },
+        conditionalOps,
+      );
+      await store.put(SEED_SKILLS[0]);
+
+      const resource = await store.getResource(
+        "skill-refund",
+        "references/edge-cases.md",
+      );
+      assert(
+        resource === "Edge case: partial refunds.",
+        "resource not readable by key",
+      );
+
+      const baseline = fullReads;
+      await store.index(); // revalidates: post-write etag unknown → 1 full read
+      const afterFirst = fullReads;
+      assert(afterFirst > baseline, "first index read must download");
+      await store.index(); // unchanged → 304, no new download
+      assert(
+        fullReads === afterFirst,
+        "unchanged index must be served from the 304 path",
+      );
+
+      await store.put(SEED_SKILLS[1]); // index rewritten → etag changes
+      const index = await store.index();
+      assert(index.length === 2, "index must reflect the new write");
     },
   );
 }
@@ -1028,7 +1498,7 @@ async function testRedisStore(): Promise<void> {
       "index must strip instructions",
     );
 
-    // Full path through NeuroLink config + built-in tool
+    // Full path through NeuroLink config + manager search
     const nl = new NeuroLink({
       skills: {
         enabled: true,
@@ -1036,13 +1506,10 @@ async function testRedisStore(): Promise<void> {
         indexCacheTtlMs: 0,
       },
     });
-    const execute = getToolExecute(nl, "search_skills");
-    const result = (await execute({ query: "refund" })) as {
-      data: { skills: Array<{ name: string }> };
-    };
+    const matches = await nl.getSkillsManager()!.search({ query: "refund" });
     assert(
-      result.data.skills[0]?.name === "refund_dispute_escalation",
-      "tool search through redis store failed",
+      matches[0]?.name === "refund_dispute_escalation",
+      "search through redis store failed",
     );
 
     await store.delete("skill-refund");
@@ -1364,13 +1831,10 @@ async function testServerRoutes(): Promise<void> {
 // ============================================================
 
 async function testLiveGenerate(): Promise<void> {
+  const LIVE_NAME = "24. Live: model calls use_skill and follows it";
   const liveEnabled = process.env.SKILLS_SUITE_LIVE !== "false";
   if (!liveEnabled) {
-    logTest(
-      "24. Live: model calls search_skills and follows it",
-      "SKIP",
-      "SKILLS_SUITE_LIVE=false",
-    );
+    logTest(LIVE_NAME, "SKIP", "SKILLS_SUITE_LIVE=false");
     return;
   }
 
@@ -1386,30 +1850,37 @@ async function testLiveGenerate(): Promise<void> {
     });
 
     const content = result.content ?? "";
-    const usedTool = JSON.stringify(result.toolExecutions ?? result).includes(
-      "search_skills",
+    const executions = (result.toolExecutions ?? []) as Array<{
+      toolName?: string;
+      tool?: string;
+    }>;
+    const usedTool = executions.some(
+      (execution) =>
+        execution.toolName === "use_skill" || execution.tool === "use_skill",
     );
     const followedSkill =
       content.includes("payments-oncall") ||
       content.toLowerCase().includes("transaction id");
 
-    if (usedTool || followedSkill) {
+    // The tool execution is the hard requirement; instruction phrasing in
+    // the answer is informational (models paraphrase).
+    if (usedTool) {
       logTest(
-        "24. Live: model calls search_skills and follows it",
+        LIVE_NAME,
         "PASS",
-        `toolCalled=${usedTool} followedInstructions=${followedSkill}`,
+        `toolCalled=true followedInstructions=${followedSkill}`,
       );
     } else {
       logTest(
-        "24. Live: model calls search_skills and follows it",
+        LIVE_NAME,
         "FAIL",
-        `Model neither called the tool nor followed instructions. Content: ${content.slice(0, 200)}`,
+        `Model did not invoke use_skill. Content: ${content.slice(0, 200)}`,
       );
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logTest(
-      "24. Live: model calls search_skills and follows it",
+      LIVE_NAME,
       "SKIP",
       `Provider "${TEST_PROVIDER}" unavailable: ${message.slice(0, 160)}`,
     );
@@ -1426,10 +1897,11 @@ async function main(): Promise<void> {
   log("============================================================\n", "cyan");
 
   await testToolRegistration();
-  await testSearchTool();
+  await testSearch();
   await testFilesystemStore();
   await testCustomStore();
-  await testPromptIndex();
+  await testDiscovery();
+  await testActivation();
   await testMutations();
   await testS3Store();
   await testRedisStore();


### PR DESCRIPTION
## Summary

Rewrites the native skills subsystem around the Agent Skills progressive-disclosure architecture (the Claude Code pattern), replacing the v1 "ALWAYS call search_skills" design that forced a blind tool round-trip on every turn.

**Discovery (Level 1)** — a name-sorted, byte-stable `<available_skills>` listing rides inside the `use_skill` tool description (default), the system prompt, or nowhere (`skills.discovery: "tool" | "system-prompt" | "none"`). Budgeted via `listingBudgetChars` with uniform description shortening — names are never dropped, and the render is a pure function of the index so provider prompt caches stay warm.

**Activation (Level 2)** — `use_skill(name)` returns the full instructions, never truncated. With a `sessionId` + conversation memory, the activation is **pinned to the session**: the instructions persist into history (ask → `[Skill loaded: …]` → answer), replay byte-identically on later turns (cached-rate tokens), and re-invocations return a tiny `already_loaded` note. Sessions pin the version they activated. Activation state is derived from stored history on every check, so dedup is truthful across restarts, multi-instance Redis deployments, and failed persistence (self-heals by re-activating).

**Resources (Level 3)** — skills bundle auxiliary files (`references/…`) costing zero tokens until read via `read_skill_resource` (gated on activation, symlink-safe path containment). Supported in filesystem (`<name>/SKILL.md` siblings), S3 (`<prefix>skills/<id>/<path>`), Redis, and memory stores.

Pinned skills survive the whole compaction pipeline: memory summarization replay, compactor Stage-3 LLM summarization (re-seated after the summary), and Stage-4 sliding-window truncation (skills partitioned out of the pair arithmetic and re-anchored, keeping role alternation intact).

Also: `skills.preload` for host-driven activation, per-call scope/tags filtering, S3 index ETag-conditional refresh (unchanged index costs a 304), activation span attributes (`skill.name/version/instructions_chars/pinned`), and caller-supplied per-call tools win over the injected ones.

**Breaking (intentional, subsystem shipped in 9.85.0 with no known adopters):** `search_skills` tool and `promptIndex` config removed; replaced by `use_skill` + `discovery`.

## Review & testing

- Multi-agent adversarial code review (33 agents) — all 8 confirmed correctness findings fixed (Redis userId-scoped hydration, persistence-gated dedup, Stage-3/Stage-4 skill protection, role-alternation-safe truncation, symlink escape, S3 ETag-before-validation, caller-tool clobbering, cache-busting listing shortening)
- `pnpm run test:skills`: 44 passed, 0 failed (activation/pinning/preload/version-pinning/resources/budget/discovery + stores/mutations/CLI/server)
- Memory suite: 21/23 passed, 1 env-dependent flake (upstream Vertex failure mid-suite; model probe passes standalone), 1 skip
- `check`, `lint`, full `build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned native skills with progressive disclosure, session-pinned activation, and selectable discovery modes (tool, system-prompt, or disabled).
  * Added per-call `use_skill` and `read_skill_resource` tools with scoping, optional preload activation, and activation deduping.
  * Added safe skill resource support across backends, including efficient index refresh behavior.

* **Bug Fixes**
  * Preserved pinned skill instructions through summarization and sliding-window truncation.
  * Corrected session turn ordering and statistics to exclude pinned skill messages.

* **Documentation**
  * Updated the native skills guide, configuration/API reference, and examples; fixed related documentation links.

* **Tests**
  * Updated continuous and live skills tests for the new discovery/tool-based flow and resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->