### PR TITLE
fix(proxy): seed persisted quota and probe unknown accounts

### DIFF
--- a/src/lib/proxy/accountQuota.ts
+++ b/src/lib/proxy/accountQuota.ts
@@ -205,13 +205,20 @@ export async function loadAccountQuota(
  * Update quota for a single account.
  * Updates in-memory cache immediately (non-blocking),
  * then debounces the disk write to every 5 seconds.
+ *
+ * Loads the persisted file into the cache before the first write so a save
+ * after a process restart merges with existing entries instead of rewriting
+ * the file with only the accounts used since boot (which silently erased
+ * other accounts' snapshots and blinded quota-aware routing to them).
  */
 export async function saveAccountQuota(
   accountKey: string,
   quota: AccountQuota,
 ): Promise<void> {
+  if (!cacheLoaded) {
+    await loadAccountQuotas();
+  }
   memoryCache[accountKey] = quota;
-  cacheLoaded = true;
   dirty = true;
   scheduleFlush();
 }

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -21,6 +21,7 @@ import {
   parseClaudeCodeUserId,
 } from "../../auth/anthropicOAuth.js";
 import {
+  loadAccountQuotas,
   parseQuotaHeaders,
   saveAccountQuota,
 } from "../../proxy/accountQuota.js";
@@ -363,6 +364,32 @@ function maybeCoolFromQuota(
   }
 }
 
+/**
+ * Seed each account's runtime quota from the persisted snapshots in
+ * ~/.neurolink/account-quotas.json (keyed by label). Runtime state is
+ * in-memory only, so without this the quota-aware ordering is blind after a
+ * proxy restart: all accounts tie, selection falls back to token-store
+ * enumeration order, and the first account served becomes self-reinforcing
+ * (it alone has data) — starving the others regardless of their resets.
+ * Never overwrites fresher in-memory quota; stale disk snapshots degrade
+ * gracefully because past reset timestamps are ignored by resetEpochToMs.
+ */
+async function seedRuntimeQuotasFromDisk(
+  accounts: ProxyPassthroughAccount[],
+): Promise<void> {
+  try {
+    const persisted = await loadAccountQuotas();
+    for (const account of accounts) {
+      const state = getOrCreateRuntimeState(account.key);
+      if (!state.quota && persisted[account.label]) {
+        state.quota = persisted[account.label];
+      }
+    }
+  } catch {
+    // Non-fatal: seeding is best-effort; ordering falls back to probe-first.
+  }
+}
+
 /** Quota-aware selection is on by default; disable with
  *  NEUROLINK_PROXY_QUOTA_ROUTING=off|false|0. Only affects the fill-first
  *  strategy (round-robin keeps strict rotation). */
@@ -384,6 +411,7 @@ function accountSortMetrics(accountKey: string, now: number) {
     q?.sessionStatus === "rejected" && sessionReset !== undefined;
   return {
     usable: !coolingActive && !weeklyRejected && !sessionRejected,
+    hasQuota: !!q,
     coolingUntil: st?.coolingUntil ?? 0,
     weeklyReset: weeklyReset ?? Number.POSITIVE_INFINITY,
     sessionReset: sessionReset ?? Number.POSITIVE_INFINITY,
@@ -397,17 +425,21 @@ function accountSortMetrics(accountKey: string, now: number) {
  * allowance isn't wasted, then move to accounts with longer-dated resets.
  *
  * Priority among usable accounts:
- *   1. soonest WEEKLY (7d) reset  — the scarce, use-it-or-lose-it ceiling
- *   2. soonest SESSION (5h) reset
- *   3. highest weekly utilization — finish off the one closest to done
- * Accounts with no quota data yet keep insertion order (stable sort) and sit
- * after those with a known soonest reset. Cooling/rejected accounts sort last,
- * soonest-back-to-service first, as last resort.
+ *   1. no quota data yet — probe first: one request reveals its windows and
+ *      self-corrects the ordering. (Ranking unknowns last would starve them
+ *      forever: never picked → never observed → never comparable.)
+ *   2. soonest WEEKLY (7d) reset  — the scarce, use-it-or-lose-it ceiling
+ *   3. soonest SESSION (5h) reset
+ *   4. highest weekly utilization — finish off the one closest to done
+ *   5. configured primary account, then insertion order
+ * Cooling/rejected accounts sort last, soonest-back-to-service first, as
+ * last resort.
  */
 function orderAccountsByQuota(
   accounts: ProxyPassthroughAccount[],
   now: number,
 ): ProxyPassthroughAccount[] {
+  const primaryKey = configuredPrimaryAccountKey;
   return [...accounts].sort((a, b) => {
     const ma = accountSortMetrics(a.key, now);
     const mb = accountSortMetrics(b.key, now);
@@ -419,13 +451,22 @@ function orderAccountsByQuota(
       const bu = mb.coolingUntil || Number.POSITIVE_INFINITY;
       return au - bu;
     }
+    if (ma.hasQuota !== mb.hasQuota) {
+      return ma.hasQuota ? 1 : -1;
+    }
     if (ma.weeklyReset !== mb.weeklyReset) {
       return ma.weeklyReset - mb.weeklyReset;
     }
     if (ma.sessionReset !== mb.sessionReset) {
       return ma.sessionReset - mb.sessionReset;
     }
-    return mb.weeklyUsed - ma.weeklyUsed;
+    if (ma.weeklyUsed !== mb.weeklyUsed) {
+      return mb.weeklyUsed - ma.weeklyUsed;
+    }
+    if (primaryKey && (a.key === primaryKey) !== (b.key === primaryKey)) {
+      return a.key === primaryKey ? -1 : 1;
+    }
+    return 0;
   });
 }
 
@@ -1726,6 +1767,8 @@ async function loadClaudeProxyAccounts(args: {
     state.lastToken = account.token;
     state.lastRefreshToken = account.refreshToken;
   }
+
+  await seedRuntimeQuotasFromDisk(accounts);
 
   const enabledAccounts = accounts.filter((account) => {
     return !getOrCreateRuntimeState(account.key).permanentlyDisabled;
@@ -5401,6 +5444,11 @@ export const __testHooks = {
   planCooldownFor429,
   orderAccountsByQuota,
   resetEpochToMs,
+  seedRuntimeQuotasFromDisk,
+  getAccountRuntimeState: (key: string): RuntimeAccountState | undefined => {
+    const state = accountRuntimeState.get(key);
+    return state ? { ...state } : undefined;
+  },
   setConfiguredPrimaryAccountKey: (key: string | undefined): void => {
     configuredPrimaryAccountKey = key;
   },

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1689,9 +1689,150 @@ async function testOrderAccountsByQuota(): Promise<boolean | null> {
     return false;
   }
 
+  // Probe-first: an account with NO quota data must sort before known
+  // accounts (one request reveals its windows). Ranking it last would starve
+  // it forever: never picked → never observed → never comparable.
+  const d: Acct = { key: "anthropic:d", label: "d", token: "t", type: "oauth" };
+  const probeOrdered = __testHooks
+    .orderAccountsByQuota([a, b, d] as never, now)
+    .map((x: { label: string }) => x.label);
+  if (probeOrdered.join(",") !== "d,b,a") {
+    log(
+      `orderAccountsByQuota: expected d,b,a (unknown probed first), got ${probeOrdered.join(",")}`,
+      "red",
+    );
+    __testHooks.resetAllRuntimeState();
+    return false;
+  }
+
+  // Primary tie-break: with equal knowledge (both unknown), the configured
+  // primary wins over insertion order.
+  const e: Acct = { key: "anthropic:e", label: "e", token: "t", type: "oauth" };
+  __testHooks.setConfiguredPrimaryAccountKey("anthropic:e");
+  const tieOrdered = __testHooks
+    .orderAccountsByQuota([d, e] as never, now)
+    .map((x: { label: string }) => x.label);
+  __testHooks.setConfiguredPrimaryAccountKey(undefined);
+  if (tieOrdered.join(",") !== "e,d") {
+    log(
+      `orderAccountsByQuota: expected e,d (primary tie-break), got ${tieOrdered.join(",")}`,
+      "red",
+    );
+    __testHooks.resetAllRuntimeState();
+    return false;
+  }
+
   __testHooks.resetAllRuntimeState();
-  log("orderAccountsByQuota: soonest-reset-first ordering passed", "green");
+  log(
+    "orderAccountsByQuota: soonest-reset-first + probe-first + primary tie-break passed",
+    "green",
+  );
   return true;
+}
+
+// ============================================================================
+// Tests: quota persistence merges across restarts (no clobber)
+// ============================================================================
+
+async function testSaveAccountQuotaMerges(): Promise<boolean | null> {
+  const { initAccountQuota, saveAccountQuota, loadAccountQuotas } =
+    await import("../src/lib/proxy/accountQuota.js");
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nl-quota-test-"));
+  const quotaPath = path.join(tmpDir, "account-quotas.json");
+  try {
+    // Simulate a pre-restart file holding account A's snapshot.
+    const existing = makeQuota({ weeklyResetAt: 1_900_000_000 });
+    fs.writeFileSync(quotaPath, JSON.stringify({ "a@test": existing }));
+
+    // Fresh process state pointing at that file (initAccountQuota resets the
+    // module cache, mimicking a restart), then the first save is for B.
+    initAccountQuota(quotaPath);
+    await saveAccountQuota("b@test", makeQuota({}) as never);
+
+    const all = await loadAccountQuotas();
+    if (!all["a@test"] || !all["b@test"]) {
+      log(
+        `saveAccountQuota: first save after restart must merge with disk, got keys=${Object.keys(all).join(",")}`,
+        "red",
+      );
+      return false;
+    }
+    log(
+      "saveAccountQuota: merges with persisted entries after restart",
+      "green",
+    );
+    return true;
+  } finally {
+    // Point the module back at a throwaway path so the debounced flush from
+    // this test can't touch the real ~/.neurolink file.
+    initAccountQuota(path.join(tmpDir, "discard.json"));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ============================================================================
+// Tests: runtime quota seeding from persisted snapshots at boot
+// ============================================================================
+
+async function testSeedRuntimeQuotasFromDisk(): Promise<boolean | null> {
+  const { __testHooks } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  const { initAccountQuota } = await import("../src/lib/proxy/accountQuota.js");
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nl-seed-test-"));
+  const quotaPath = path.join(tmpDir, "account-quotas.json");
+  try {
+    __testHooks.resetAllRuntimeState();
+    const diskQuota = makeQuota({ weeklyResetAt: 1_900_000_000 });
+    fs.writeFileSync(quotaPath, JSON.stringify({ "a@test": diskQuota }));
+    initAccountQuota(quotaPath);
+
+    type Acct = { key: string; label: string; token: string; type: "oauth" };
+    const accts: Acct[] = [
+      { key: "anthropic:a@test", label: "a@test", token: "t", type: "oauth" },
+      { key: "anthropic:b@test", label: "b@test", token: "t", type: "oauth" },
+    ];
+    // b has fresher in-memory quota that seeding must NOT overwrite.
+    const inMemory = makeQuota({ weeklyResetAt: 1_950_000_000 });
+    __testHooks.setAccountRuntimeState("anthropic:b@test", {
+      quota: inMemory as never,
+    });
+
+    await __testHooks.seedRuntimeQuotasFromDisk(accts as never);
+
+    const stateA = __testHooks.getAccountRuntimeState("anthropic:a@test");
+    const stateB = __testHooks.getAccountRuntimeState("anthropic:b@test");
+    if (
+      (stateA?.quota as { weeklyResetAt?: number } | undefined)
+        ?.weeklyResetAt !== 1_900_000_000
+    ) {
+      log(
+        `seedRuntimeQuotasFromDisk: account A should be seeded from disk, got ${JSON.stringify(stateA?.quota)}`,
+        "red",
+      );
+      return false;
+    }
+    if (
+      (stateB?.quota as { weeklyResetAt?: number } | undefined)
+        ?.weeklyResetAt !== 1_950_000_000
+    ) {
+      log(
+        "seedRuntimeQuotasFromDisk: fresher in-memory quota must not be overwritten",
+        "red",
+      );
+      return false;
+    }
+    log(
+      "seedRuntimeQuotasFromDisk: seeds from disk, preserves in-memory",
+      "green",
+    );
+    return true;
+  } finally {
+    __testHooks.resetAllRuntimeState();
+    initAccountQuota(path.join(tmpDir, "discard.json"));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 }
 
 // ============================================================================
@@ -2044,6 +2185,16 @@ const tests: TestFunction[] = [
   {
     name: "Quota: orderAccountsByQuota (soonest-reset-first)",
     fn: testOrderAccountsByQuota,
+    category: "proxy-primary",
+  },
+  {
+    name: "Quota: saveAccountQuota merges across restarts",
+    fn: testSaveAccountQuotaMerges,
+    category: "proxy-primary",
+  },
+  {
+    name: "Quota: seedRuntimeQuotasFromDisk at boot",
+    fn: testSeedRuntimeQuotasFromDisk,
     category: "proxy-primary",
   },
   {


### PR DESCRIPTION
## Description

Follow-up to #1143 (quota-aware account switching, shipped in 9.85.1). Field-observed on a live 2-account deployment: after a proxy restart, **all traffic locked onto the non-primary account** and never moved. Three root causes, confirmed from the deployed instance's logs, `/status`, and `~/.neurolink/account-quotas.json`:

1. **Quota file clobbered on restart** — `saveAccountQuota` marked its cache loaded without reading disk first, so the first save after boot rewrote `account-quotas.json` with only the accounts used since boot, erasing the other accounts' snapshots.
2. **Ordering blind at boot** — quota-aware ordering reads only in-memory runtime state, which a restart wipes; nothing seeded it from the persisted snapshots. All accounts tied, and selection fell back to token-store enumeration order (not the configured primary).
3. **Unknown-quota starvation** — the comparator treated missing quota as `Infinity` ("resets last"), so the first account to serve became self-reinforcing: it alone had data, always sorted first, and the other account never got a request to reveal its windows.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `accountQuota.ts`: `saveAccountQuota` loads the persisted file into the cache before its first write, merging instead of clobbering across restarts.
- `claudeProxyRoutes.ts`: new `seedRuntimeQuotasFromDisk` hydrates each account's runtime quota from the persisted snapshots (label→key) during account loading; never overwrites fresher in-memory data; stale resets degrade gracefully (past timestamps are ignored).
- `orderAccountsByQuota`: usable accounts with **no quota data are probed first** (one request reveals their windows and self-corrects the ordering), and equal-knowledge ties break by the **configured primary**, then insertion order.

## Testing

- [x] `tsc --strict`, prettier, ESLint gates, `validate:all`, and full build pass (pre-commit hook).
- [x] New no-API regression tests: `testSaveAccountQuotaMerges` (merge across restart), `testSeedRuntimeQuotasFromDisk` (seeds from disk, preserves in-memory), extended `testOrderAccountsByQuota` (probe-first + primary tie-break).
- [x] Runtime-verified the exact field scenario: after restart with seeded disk data, the account whose weekly window resets sooner is selected regardless of token-store enumeration order.

## Breaking Changes

- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved account quota data across proxy restarts by reusing existing persisted quota entries instead of overwriting them.
  * Improved quota restoration on startup/reconfiguration, merging newly saved quota with existing on-disk data.
  * Enhanced account selection by prioritizing accounts with known quota, “probing” accounts without quota information, and using the configured primary account to break ordering ties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->