### PR TITLE
fix(generate): stop treating ai@6 raw-text output echo as parsed schema output

### DIFF
--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -859,6 +859,17 @@ export class GenerationHandler {
       }
       try {
         const scalar: unknown = JSON.parse(strippedText);
+        if (scalar === "") {
+          // A JSON-encoded empty string is an EMPTY completion, not a
+          // recovered scalar — normalize to a true empty ('' content, no
+          // structuredData) so callers' empty-response handling fires
+          // instead of a literal '""' reaching the user.
+          logger.warn(
+            "[GenerationHandler] schema requested but the model returned an empty JSON string; normalizing to empty content",
+            { provider: this.providerName, model: this.modelName },
+          );
+          return "";
+        }
         if (scalar !== null && scalar !== undefined) {
           structuredData = scalar;
           return strippedText;
@@ -875,7 +886,18 @@ export class GenerationHandler {
     if (useStructuredOutput) {
       try {
         const experimentalOutput = generateResult.experimental_output;
-        if (experimentalOutput !== undefined) {
+        // ai@6 generateText resolves `output ?? text()` internally, so a
+        // result produced WITHOUT an output spec — the structured-output
+        // fallback retry, or the tools↔schema exclusion path — no longer
+        // throws here: `experimental_output` echoes the RAW MODEL TEXT.
+        // Treating that echo as parsed schema output double-encodes the
+        // content (JSON.stringify of a string) and, for an empty
+        // completion, turns '' into the literal '""'. Detect the echo
+        // (a string identical to the step text) and coerce it instead.
+        const rawTextEcho =
+          typeof experimentalOutput === "string" &&
+          experimentalOutput === (generateResult.text ?? "");
+        if (experimentalOutput !== undefined && !rawTextEcho) {
           // AI-SDK already parsed + schema-validated the object. Expose it
           // directly and serialise canonically — no hand-parsing needed.
           structuredData = experimentalOutput;

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5184,7 +5184,17 @@ Current user's request: ${currentInput}`;
       } else {
         try {
           const scalar: unknown = JSON.parse(textResult.content);
-          if (scalar !== null && scalar !== undefined) {
+          if (scalar === "") {
+            // A JSON-encoded empty string is an EMPTY completion, not a
+            // recovered scalar — normalize to a true empty so callers'
+            // empty-response handling fires instead of a literal '""'
+            // reaching the user. `structuredData` stays undefined.
+            textResult.content = "";
+            logger.warn(
+              "[NeuroLink] schema requested but the model returned an empty JSON string; normalizing to empty content",
+              { provider: textResult.provider, model: textResult.model },
+            );
+          } else if (scalar !== null && scalar !== undefined) {
             textResult.structuredData = scalar;
           }
         } catch {

--- a/test/continuous-test-suite-schema-empty-normalization.ts
+++ b/test/continuous-test-suite-schema-empty-normalization.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: schema-mode empty/echo normalization (pure, no API).
+ *
+ * ai@6 resolves `output ?? text()` inside generateText, so a result produced
+ * WITHOUT an output spec (structured-output fallback retry, tools↔schema
+ * exclusion path) no longer throws from `experimental_output` — it echoes the
+ * raw model text as a string. formatEnhancedResult must treat that echo as
+ * text to coerce, never as parsed schema output; and a JSON-encoded empty
+ * string (`""`) must normalize to a TRUE empty so callers' empty-response
+ * handling fires instead of a literal '""' reaching the user.
+ *
+ * Run: npx tsx test/continuous-test-suite-schema-empty-normalization.ts
+ */
+import { defineSuite, assertEqual } from "./helpers/harness.js";
+import { GenerationHandler } from "../src/lib/core/modules/GenerationHandler.js";
+import type { TextGenerationOptions } from "../src/lib/types/index.js";
+
+const { test, runSuite } = defineSuite("Schema-mode empty/echo normalization");
+
+const handler = new GenerationHandler(
+  "anthropic",
+  "claude-sonnet-4-6",
+  () => true,
+  () => undefined,
+  async () => undefined,
+  () => undefined,
+);
+
+// Any object with a string `summary` validates (mirrors the coerce suite).
+const schema = {
+  safeParse: (v: unknown) => ({
+    success:
+      !!v &&
+      typeof v === "object" &&
+      typeof (v as { summary?: unknown }).summary === "string",
+  }),
+} as unknown as NonNullable<TextGenerationOptions["schema"]>;
+
+const options = {
+  input: { text: "irrelevant" },
+  schema,
+} as unknown as TextGenerationOptions;
+
+const format = (generateResult: Record<string, unknown>) =>
+  handler.formatEnhancedResult(
+    generateResult as Parameters<GenerationHandler["formatEnhancedResult"]>[0],
+    {},
+    [],
+    [],
+    options,
+  );
+
+await test("EMPTY completion via raw-text echo (fallback result) → true empty", () => {
+  // Fallback retry result: no output spec, ai@6 text() default echoes ''.
+  const r = format({ text: "", experimental_output: "", finishReason: "stop" });
+  assertEqual(r.content, "", "content must be '' — never the literal '\"\"'");
+  assertEqual(
+    r.structuredData === undefined,
+    true,
+    "structuredData must stay unset on an empty completion",
+  );
+});
+
+await test("literal '\"\"' completion (no experimental_output) → true empty", () => {
+  // Provider-native shape: model emits a JSON empty string as its whole text.
+  const r = format({ text: '""', finishReason: "stop" });
+  assertEqual(r.content, "", "JSON-encoded empty string normalizes to ''");
+  assertEqual(
+    r.structuredData === undefined,
+    true,
+    "'' scalar is an empty completion, not recovered structured data",
+  );
+});
+
+await test("NON-EMPTY raw-text echo coerces to the schema object (no double-encode)", () => {
+  const json = '{"summary":"recovered json"}';
+  const r = format({
+    text: json,
+    experimental_output: json,
+    finishReason: "stop",
+  });
+  assertEqual(r.content, json, "content stays single-encoded JSON text");
+  assertEqual(
+    (r.structuredData as { summary?: string } | undefined)?.summary,
+    "recovered json",
+    "echoed JSON text parses into structuredData",
+  );
+});
+
+await test("genuine Output.object result (object) is preserved untouched", () => {
+  const obj = { summary: "native structured output" };
+  const r = format({
+    text: '{"summary":"native structured output"}',
+    experimental_output: obj,
+    finishReason: "stop",
+  });
+  assertEqual(
+    (r.structuredData as { summary?: string }).summary,
+    "native structured output",
+    "parsed object exposed directly",
+  );
+  assertEqual(
+    r.content,
+    JSON.stringify(obj),
+    "content is the canonical serialisation",
+  );
+});
+
+await test("parsed STRING that differs from raw text stays structured (z.string() schema)", () => {
+  // Output.object with a string schema: text '"hello"' parses to 'hello' —
+  // NOT the raw-text echo, so it must remain structured output.
+  const r = format({
+    text: '"hello"',
+    experimental_output: "hello",
+    finishReason: "stop",
+  });
+  assertEqual(r.structuredData, "hello", "parsed scalar string preserved");
+  assertEqual(r.content, '"hello"', "canonical JSON serialisation");
+});
+
+await runSuite();


### PR DESCRIPTION
## Problem

Since ai@6 resolves `output ?? text()` **inside** `generateText`, a result produced *without* an output spec no longer throws from the `experimental_output` getter — it **echoes the raw model text as a string**. Two NeuroLink paths produce such results while a schema is active:

1. the structured-output **fallback retry** (after `NoObjectGeneratedError` / tools↔schema conflict / schema-complexity errors), and
2. the **tools↔schema exclusion** path (Gemini, native Anthropic surface).

`formatEnhancedResult` treats any defined `experimental_output` as the AI-SDK's parsed+validated object, so on those paths it:

- sets `structuredData` to the raw **text string**, and
- `JSON.stringify`s it into `content` — double-encoding every response.

For a **non-empty** response the facade's JSON-string-literal unwrap accidentally repairs the damage downstream. For an **EMPTY completion** it survives to the caller as content `'""'` (the literal two characters) with `structuredData ''` — so consumers' empty-response handling never fires and users see a literal `""`. This was found in production-style E2E testing of curator's empty-response retry (its retry predicate never fired on the schema path).

## Fix (3 changes)

| Site | Change |
|---|---|
| `GenerationHandler.formatEnhancedResult` | Detect the raw-text **echo** (`typeof experimental_output === 'string' && === generateResult.text`) and route it through text-mode coercion instead of serialising it as schema output |
| `GenerationHandler` `coerceTextMode` scalar path | A JSON-encoded empty string (`'""'`) is an **empty completion**, not a recovered scalar — normalize to `''` content, no `structuredData`, + WARN |
| `neurolink.ts` facade scalar path | Same guard for provider-native `generate()` overrides (Vertex / Google AI / Anthropic native) |

Genuine `Output.object` results are unaffected: their `experimental_output` is a parsed object (or a parsed string ≠ raw text), never the raw-text echo.

## Verification (stubbed Anthropic API, wire-level)

| Case | Before | After |
|---|---|---|
| Empty completion + schema (fallback path) | content `'""'`, structuredData `''` | content `''`, structuredData unset ✅ |
| Non-JSON first attempt → fallback returns valid JSON | repaired only by accidental facade unwrap | parsed object + single-encoded content at the formatter ✅ |
| Model literally emits `""` as its completion | content `'""'`, structuredData `''` | content `''`, structuredData unset ✅ |
| Empty completion, no schema | `''` | `''` (no regression) ✅ |

- `tsc --noEmit` clean
- `continuous-test-suite-structured-coerce` / `coerce-nested-unwrap` / `json` — all PASS
- prettier clean; eslint: 0 errors (7 pre-existing max-lines warnings on untouched functions)

🤖 Investigated & authored with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured-output handling for empty responses.
  * Prevented echoed model text from being incorrectly treated as parsed structured data.
  * Avoided unwanted JSON-stringified content in generated results.
  * Added warnings when empty or invalid structured-output recovery occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->