### PR TITLE
feat(video): imageInputKey option for Replicate image-to-video models

### DIFF
--- a/src/lib/adapters/video/replicateVideoHandler.ts
+++ b/src/lib/adapters/video/replicateVideoHandler.ts
@@ -76,27 +76,38 @@ export class ReplicateVideoHandler implements VideoHandler {
     const model = options.model ?? DEFAULT_MODEL;
     const dataUri = `data:image/${this.detectImageType(image)};base64,${image.toString("base64")}`;
 
-    // Wan-Alpha + most image-to-video models accept this shape; specific
-    // models may require provider-specific extras passed through
-    // VideoOutputOptions.[unknown key].
+    // Replicate image-to-video models do not share an input schema. The
+    // legacy shape below (`image` + `num_frames`/`fps`/`aspect_ratio`) fits
+    // Wan-Alpha-era models; current models (minimax/hailuo-2.3-*,
+    // wan-video/wan-2.7-i2v) key the image as `first_frame_image` /
+    // `first_frame` and take `duration` instead of frame counts — a missing
+    // required image key fails the prediction on submit. `imageInputKey`
+    // selects the image key AND the modern `duration`/`resolution` shape;
+    // omitting it preserves the legacy payload exactly.
     //
-    // `resolution` is forwarded as the `resolution` input parameter.
-    // Wan-Alpha and several other Replicate image-to-video models accept it
-    // (e.g. "720p", "1080p"). Models that do not recognise it will silently
-    // ignore the field — the Replicate API does not reject unknown input keys.
     // `calculateDimensions` still populates the metadata `dimensions` field
     // so downstream consumers always receive correct width/height regardless
     // of whether the model honoured the resolution hint.
-    const inputPayload: Record<string, unknown> = {
-      image: dataUri,
-      prompt,
-      num_frames: (options.length ?? 4) * 24, // Assume 24 fps
-      fps: 24,
-      aspect_ratio: options.aspectRatio,
-      ...(options.resolution !== undefined
-        ? { resolution: options.resolution }
-        : {}),
-    };
+    const inputPayload: Record<string, unknown> =
+      options.imageInputKey !== undefined
+        ? {
+            [options.imageInputKey]: dataUri,
+            prompt,
+            duration: options.length ?? 4,
+            ...(options.resolution !== undefined
+              ? { resolution: options.resolution }
+              : {}),
+          }
+        : {
+            image: dataUri,
+            prompt,
+            num_frames: (options.length ?? 4) * 24, // Assume 24 fps
+            fps: 24,
+            aspect_ratio: options.aspectRatio,
+            ...(options.resolution !== undefined
+              ? { resolution: options.resolution }
+              : {}),
+          };
 
     let prediction: Awaited<ReturnType<typeof predict>>;
     try {

--- a/src/lib/types/multimodal.ts
+++ b/src/lib/types/multimodal.ts
@@ -217,6 +217,18 @@ export type VideoOutputOptions = {
    */
   imageUrl?: string;
   /**
+   * Replicate only: the input-schema key the model expects the image under.
+   * Replicate image-to-video models disagree on this — e.g.
+   * `minimax/hailuo-2.3-fast` requires `first_frame_image`,
+   * `wan-video/wan-2.7-i2v` requires `first_frame` — and a model whose
+   * required image key is missing fails the prediction on submit. Setting
+   * this also switches the payload to the modern `duration`/`resolution`
+   * field shape those models expect (instead of the legacy
+   * `num_frames`/`fps`/`aspect_ratio` shape). Omit for models that accept
+   * the default `image` key.
+   */
+  imageInputKey?: string;
+  /**
    * Per-call provider credentials. Takes precedence over instance-level
    * credentials set at construction time, which in turn override env vars.
    */


### PR DESCRIPTION
## Problem

`ReplicateVideoHandler` hardcodes the input image under the `image` key with a legacy `num_frames`/`fps`/`aspect_ratio` payload. Current Replicate i2v models define different schemas and **fail the prediction on submit** when their required image key is missing:

| Model | Required image key | Observed failure |
|---|---|---|
| `minimax/hailuo-2.3-fast` | `first_frame_image` (required) | 422 on submit |
| `wan-video/wan-2.7-i2v` | `first_frame` / `first_clip` | `ValueError: At least one of 'first_frame' or 'first_clip' must be provided.` |

Schemas verified against the live Replicate models API (`GET /v1/models/...` → `latest_version.openapi_schema`, 2026-07-12). Both models also take `duration` (seconds) — `num_frames`/`fps` are not schema fields for either. Found while wiring these models as draft-tier b-roll generators in juspay/director (a NeuroLink-based pipeline).

## Change

- `VideoOutputOptions.imageInputKey?: string` — the key the model expects the image data URI under. Setting it also switches the payload to the modern `duration`/`resolution` shape those models expect.
- **Backward compatible:** when omitted, the payload is byte-for-byte the legacy shape — existing callers unaffected. `options.output.video` extras already reach the handler verbatim, so callers can adopt this with no extra plumbing.

Example: `output.video = { provider: 'replicate', model: 'minimax/hailuo-2.3-fast', imageInputKey: 'first_frame_image', length: 4, resolution: '720p' }`

## Side observation (deliberately not changed here)

The handler's default model `atonamy/wan-alpha` is text-to-video only — its schema has no image field, so the `image` key it is sent is silently ignored. Worth revisiting the default separately; left untouched to keep this PR surgical.

`pnpm run typecheck` clean; pre-commit check/format/lint suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an optional image input key for image-to-video model integrations.
  * Improved compatibility with modern image-to-video models by using duration-based payloads (with optional resolution).
  * Preserved legacy video generation behavior when the image input key is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->