### PR TITLE
fix(json): unwrap single-element array wrapper for object schemas

### DIFF
--- a/src/lib/utils/json/coerce.ts
+++ b/src/lib/utils/json/coerce.ts
@@ -260,6 +260,24 @@ export function coerceJsonToSchema(
           repaired: true,
           truncated: candidate.truncated,
         });
+      } else if (
+        // Single-element array wrapper: for an OBJECT schema, models sometimes
+        // return `[{...}]` instead of `{...}` (seen on the native Anthropic
+        // path under escaping stress). Unwrap a lone object element and
+        // re-validate — the safeParse gate rejects an incorrect unwrap, so an
+        // array schema (which validates the array directly above) is untouched.
+        Array.isArray(outcome.value) &&
+        outcome.value.length === 1 &&
+        outcome.value[0] !== null &&
+        typeof outcome.value[0] === "object" &&
+        !Array.isArray(outcome.value[0]) &&
+        safeParseable.safeParse(outcome.value[0]).success
+      ) {
+        schemaValid.push({
+          value: outcome.value[0],
+          repaired: true,
+          truncated: candidate.truncated,
+        });
       }
     }
   }

--- a/test/continuous-test-suite-coerce-nested-unwrap.ts
+++ b/test/continuous-test-suite-coerce-nested-unwrap.ts
@@ -142,4 +142,52 @@ await test("no schema → nested string is left untouched (first parseable wins)
   );
 });
 
+await test("unwraps a single-element array wrapping the object (native-Anthropic [{...}] case)", () => {
+  // Models on the native Anthropic path sometimes return `[{...}]` for an
+  // object schema under escaping stress. The lone object element must be
+  // unwrapped and validated, not returned as an array. Refs #635.
+  const inner = {
+    summary: "wrapped in an array",
+    attachment: null,
+  };
+  const r = coerceJsonToSchema(JSON.stringify([inner]), schema);
+  assertEqual(
+    Array.isArray(r?.structuredData),
+    false,
+    "result is the object, not an array",
+  );
+  assertEqual(
+    obj(r).summary,
+    "wrapped in an array",
+    "object content recovered",
+  );
+});
+
+await test("array schema still receives the array directly (no over-unwrap)", () => {
+  const arrSchema = z.array(z.object({ id: z.number() }));
+  const r = coerceJsonToSchema('[{"id":1}]', arrSchema);
+  assertEqual(
+    Array.isArray(r?.structuredData),
+    true,
+    "array-typed schema keeps the array",
+  );
+});
+
+await test("multi-element array is NOT force-unwrapped for an object schema", () => {
+  // Only a lone element is a safe unwrap; a 2+ element array is genuinely not
+  // the object the schema wants, so it must fall through unchanged.
+  const r = coerceJsonToSchema(
+    JSON.stringify([
+      { summary: "a", attachment: null },
+      { summary: "b", attachment: null },
+    ]),
+    schema,
+  );
+  assertEqual(
+    Array.isArray(r?.structuredData),
+    true,
+    "multi-element array not silently reduced to its first element",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## What
On the native-Anthropic structured-output path under escaping stress, models sometimes return `[{...}]` instead of `{...}` for an **object** schema. Because a JS array is `typeof "object"`, `coerceJsonToSchema` accepted it as `firstValid` and returned an **array** as `structuredData`, failing the caller's object-shaped schema. Caught adversarially during the audit's live `test:json-e2e` run (#635).

## Fix
When a candidate array does not itself satisfy the schema, and it holds exactly one non-array object element that **does** satisfy it, unwrap to that element. Gated by `safeParse`, mirroring the existing nested-string unwrap:
- array-typed schemas keep their array (no over-unwrap)
- multi-element arrays are left untouched (never silently reduced to their first element)

## Proof
`coerce-nested-unwrap` **9/9** (3 new tests), `structured-coerce` **7/7**, `json` **21/21** — no regressions.

Refs #635 (feature already shipped; this hardens the fallback edge case).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured data handling when valid object data is wrapped in a single-element array.
  * Preserved array results when the schema expects an array or when multiple elements are present.

* **Tests**
  * Added coverage for single-element arrays, array schemas, and multi-element arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->