### PR TITLE
fix(pptx): extract speaker notes into PptxProcessor output

### DIFF
--- a/src/lib/processors/document/PptxProcessor.ts
+++ b/src/lib/processors/document/PptxProcessor.ts
@@ -42,6 +42,16 @@ const TEXT_ELEMENT_REGEX = /<a:t[^>]*>([\s\S]*?)<\/a:t>/g;
 const SLIDE_ENTRY_REGEX = /^ppt\/slides\/slide(\d+)\.xml$/;
 
 /**
+ * A slide's per-slide relationships file, e.g.
+ * "ppt/slides/_rels/slide1.xml.rels", which links the slide to its speaker
+ * notes part (among other relationships).
+ */
+const SLIDE_RELS_NAME = (n: number) => `ppt/slides/_rels/slide${n}.xml.rels`;
+
+/** Matches a single `<Relationship .../>` tag inside a .rels document. */
+const RELATIONSHIP_TAG_REGEX = /<Relationship\b[^>]*\/?>/g;
+
+/**
  * Static utility class for extracting text from PPTX files.
  *
  * Designed as a static class (not extending BaseFileProcessor) because
@@ -84,15 +94,77 @@ export class PptxProcessor {
 
     for (const slide of slides) {
       const texts = PptxProcessor.extractTextFromXml(slide.xml);
-      if (texts.length > 0) {
+      const notes = PptxProcessor.extractNotesForSlide(zip, slide.slideNumber);
+      // Emit a slide section when it has either body text or speaker notes.
+      if (texts.length > 0 || notes) {
         parts.push(`### Slide ${slide.slideNumber}`);
-        parts.push(texts.join("\n"));
+        if (texts.length > 0) {
+          parts.push(texts.join("\n"));
+        }
+        if (notes) {
+          parts.push(`**Speaker notes:** ${notes}`);
+        }
         parts.push(""); // blank line between slides
       }
     }
 
     const result = parts.join("\n").trim();
     return result || null;
+  }
+
+  /**
+   * Extract the speaker notes for one slide.
+   *
+   * Speaker notes live in a separate `ppt/notesSlides/notesSlideN.xml` part
+   * whose number is NOT tied to the slide number — the link is declared in the
+   * slide's own relationships file (`ppt/slides/_rels/slideN.xml.rels`) via a
+   * relationship of type `.../notesSlide`. We resolve that target, then pull the
+   * `<a:t>` runs from the notes part. Returns null when the slide has no notes.
+   *
+   * @param zip - The opened PPTX archive
+   * @param slideNumber - 1-indexed slide number
+   * @returns The notes text (runs joined by a space), or null when absent
+   */
+  private static extractNotesForSlide(
+    zip: AdmZip,
+    slideNumber: number,
+  ): string | null {
+    const relsEntry = zip.getEntry(SLIDE_RELS_NAME(slideNumber));
+    if (!relsEntry) {
+      return null;
+    }
+    const relsXml = relsEntry.getData().toString("utf-8");
+
+    let notesTarget: string | null = null;
+    RELATIONSHIP_TAG_REGEX.lastIndex = 0;
+    for (
+      let match = RELATIONSHIP_TAG_REGEX.exec(relsXml);
+      match !== null;
+      match = RELATIONSHIP_TAG_REGEX.exec(relsXml)
+    ) {
+      const tag = match[0];
+      if (/Type="[^"]*\/notesSlide"/.test(tag)) {
+        notesTarget = tag.match(/Target="([^"]+)"/)?.[1] ?? null;
+        break;
+      }
+    }
+    if (!notesTarget) {
+      return null;
+    }
+
+    // Targets are relative to the slide's folder (ppt/slides/), e.g.
+    // "../notesSlides/notesSlide1.xml" → "ppt/notesSlides/notesSlide1.xml".
+    const normalized = notesTarget
+      .replace(/^\.\.\//, "ppt/")
+      .replace(/^\/+/, "");
+    const notesEntry = zip.getEntry(normalized);
+    if (!notesEntry) {
+      return null;
+    }
+    const notes = PptxProcessor.extractTextFromXml(
+      notesEntry.getData().toString("utf-8"),
+    ).join(" ");
+    return notes.trim() || null;
   }
 
   /**

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -24,6 +24,8 @@ import { FileDetector } from "../src/lib/utils/fileDetector.js";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
+import AdmZip from "adm-zip";
+import { PptxProcessor } from "../src/lib/processors/document/PptxProcessor.js";
 
 import {
   GoogleVertexProvider,
@@ -393,6 +395,51 @@ const tests: TestFunction[] = [
         }
       }
       return true;
+    },
+  },
+  // ---------- PPTX speaker-notes extraction (issue #441) ----------
+  {
+    name: "PptxProcessor.extractText includes speaker notes resolved via slide rels",
+    category: "pptx-processor",
+    fn: async () => {
+      const at = (s: string) => `<a:t>${s}</a:t>`;
+      const slideXml = `<?xml version="1.0"?><p:sld xmlns:a="x"><p:cSld><p:spTree>${at(
+        "Quarterly Results",
+      )}</p:spTree></p:cSld></p:sld>`;
+      const notesXml = `<?xml version="1.0"?><p:notes xmlns:a="x"><p:cSld><p:spTree>${at(
+        "Mention the RTO improvement.",
+      )}</p:spTree></p:cSld></p:notes>`;
+      // notesSlide number (3) deliberately differs from slide number (1): the
+      // link must be resolved through the rels file, not by matching numbers.
+      const relsXml = `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" Target="../notesSlides/notesSlide3.xml"/></Relationships>`;
+
+      const zip = new AdmZip();
+      zip.addFile("ppt/slides/slide1.xml", Buffer.from(slideXml));
+      zip.addFile("ppt/slides/_rels/slide1.xml.rels", Buffer.from(relsXml));
+      zip.addFile("ppt/notesSlides/notesSlide3.xml", Buffer.from(notesXml));
+
+      const out = await PptxProcessor.extractText(zip.toBuffer());
+      return (
+        typeof out === "string" &&
+        out.includes("Quarterly Results") &&
+        out.includes("Speaker notes:") &&
+        out.includes("Mention the RTO improvement.")
+      );
+    },
+  },
+  {
+    name: "PptxProcessor.extractText omits the notes line for a slide without notes",
+    category: "pptx-processor",
+    fn: async () => {
+      const slideXml = `<?xml version="1.0"?><p:sld xmlns:a="x"><p:cSld><p:spTree><a:t>Only a title</a:t></p:spTree></p:cSld></p:sld>`;
+      const zip = new AdmZip();
+      zip.addFile("ppt/slides/slide1.xml", Buffer.from(slideXml));
+      const out = await PptxProcessor.extractText(zip.toBuffer());
+      return (
+        typeof out === "string" &&
+        out.includes("Only a title") &&
+        !out.includes("Speaker notes:")
+      );
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
## What
PPTX speaker notes were silently dropped — only slide body `<a:t>` runs were extracted.

## Fix
Speaker notes live in a separate `ppt/notesSlides/notesSlideN.xml` part whose number is **not** tied to the slide number; the link is declared in the slide's own `ppt/slides/_rels/slideN.xml.rels` via a `.../notesSlide` relationship. Resolve each slide's notes part through its rels, extract the notes text, and append it under the slide as `**Speaker notes:** …`. Slides without notes are unchanged.

## Proof
2 new regression tests (notes number deliberately ≠ slide number, resolved via rels; and a no-notes slide) → **bugfixes suite 91/91**.

Fixes #441.
