### PR TITLE
fix(pdf): validate render scale in convertToImages

### DIFF
--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -240,6 +240,9 @@ export const PDF_LIMITS = {
   MAX_SIZE_MB: 20,
   // Default maximum pages for image conversion
   DEFAULT_MAX_PAGES: 20,
+  // Upper bound for the render scale factor. Above this, a single page can
+  // allocate hundreds of MB; scale <= 0 produces a degenerate viewport.
+  MAX_SCALE: 10,
 };
 
 // Performance and System Limits

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -329,6 +329,15 @@ export class PDFProcessor {
       );
     }
 
+    // 0b. Validate the render scale. A non-finite or non-positive scale yields a
+    // degenerate viewport (blank/zero-dimension render), and an excessive scale
+    // can allocate hundreds of MB per page — reject both with a clear message.
+    if (!Number.isFinite(scale) || scale <= 0 || scale > PDF_LIMITS.MAX_SCALE) {
+      throw new Error(
+        `Invalid scale: ${scale}. Scale must be a finite number greater than 0 and at most ${PDF_LIMITS.MAX_SCALE}.`,
+      );
+    }
+
     // 1. Validate buffer is not empty or too small
     if (!pdfBuffer || pdfBuffer.length < 5) {
       throw new Error(

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -18,6 +18,7 @@ import {
 
 import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
+import { PDFProcessor } from "../src/lib/utils/pdfProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
 import { isMultimodalInput } from "../src/lib/types/index.js";
 import { FileDetector } from "../src/lib/utils/fileDetector.js";
@@ -440,6 +441,38 @@ const tests: TestFunction[] = [
         out.includes("Only a title") &&
         !out.includes("Speaker notes:")
       );
+    },
+  },
+  // ---------- PDF scale validation (issue #340) ----------
+  {
+    name: "PDFProcessor.convertToImages rejects out-of-range scale with a clear error",
+    category: "pdf-processor",
+    fn: async () => {
+      const pdf = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(20)]);
+      const rejects = async (scale: number): Promise<boolean> => {
+        try {
+          await PDFProcessor.convertToImages(pdf, { scale });
+          return false;
+        } catch (e) {
+          return e instanceof Error && /Invalid scale/.test(e.message);
+        }
+      };
+      // 0, negative, non-finite, and above the max must all be rejected on scale.
+      for (const bad of [0, -1, Number.NaN, 11]) {
+        if (!(await rejects(bad))) {
+          return false;
+        }
+      }
+      // A valid scale must pass the scale gate (it may fail later on the fake
+      // PDF body, but NOT with an "Invalid scale" message).
+      try {
+        await PDFProcessor.convertToImages(pdf, { scale: 2 });
+      } catch (e) {
+        if (e instanceof Error && /Invalid scale/.test(e.message)) {
+          return false;
+        }
+      }
+      return true;
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
## What
`PDFProcessor.convertToImages` accepted any `scale`, so `scale <= 0` produced a degenerate viewport (blank/zero-dimension render) and an unbounded scale could allocate hundreds of MB per page.

## Fix
Add an explicit guard rejecting non-finite, non-positive, or above-max scale factors with a clear message, alongside the existing format/buffer/size validation. Adds `PDF_LIMITS.MAX_SCALE` (10).

## Proof
`scale ∈ {0, -1, NaN, 11}` all rejected with `Invalid scale`; a valid scale passes the gate. New regression test → **bugfixes suite 90/90**.

Fixes #340.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF-to-image conversion now validates rendering scale values.
  * Invalid, non-positive, non-finite, or excessively large scale settings are rejected with a clear error instead of producing blank renders or excessive resource usage.

* **Tests**
  * Added regression coverage for invalid and valid rendering scale values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->