### PR TITLE
fix(csv): quote-aware delimiter detection + quality-weighted confidence

### DIFF
--- a/src/lib/utils/csvProcessor.ts
+++ b/src/lib/utils/csvProcessor.ts
@@ -431,6 +431,21 @@ function calculateDataQualityScore(
 /**
  * Analyze all columns in parsed CSV data
  */
+/**
+ * Confidence for a CSV processing result, weighted by data quality.
+ *
+ * The result used to report a static `confidence: 100` regardless of how clean
+ * the data was. This ties confidence to `dataQualityScore` so it actually
+ * varies with quality factors (ragged rows, high null rate, type
+ * inconsistency): a cleanly-parsed CSV stays at 100, a messy one is pulled
+ * halfway toward its quality score. It never drops below 50 for a CSV that
+ * parsed — the *format* is certain, only the *data* is imperfect.
+ */
+function csvResultConfidence(dataQualityScore: number): number {
+  const clamped = Math.max(0, Math.min(100, dataQualityScore));
+  return Math.round((100 + clamped) / 2);
+}
+
 function analyzeColumns(rows: unknown[]): {
   columnMetadata: CSVColumnMetadata[];
   dataQualityWarnings: CSVDataQualityWarning[];
@@ -744,7 +759,7 @@ export class CSVProcessor {
         content: limitedCSV,
         mimeType: "text/csv",
         metadata: {
-          confidence: 100,
+          confidence: csvResultConfidence(dataQualityScore),
           size: content.length,
           rowCount,
           totalLines: limitedLines.length,
@@ -851,7 +866,7 @@ export class CSVProcessor {
       content: formatted,
       mimeType: "text/csv",
       metadata: {
-        confidence: 100,
+        confidence: csvResultConfidence(dataQualityScore),
         size: content.length,
         rowCount,
         columnCount,

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -2753,13 +2753,43 @@ class ContentHeuristicStrategy implements DetectionStrategy {
       return hasReasonableLengths && noBinaryChars && hasUniformLengths;
     }
 
-    // Count delimiters per line and check consistency
-    const delimRegex = delimiter === "|" ? /\|/g : new RegExp(delimiter, "g");
-    const counts = lines.map((line) => (line.match(delimRegex) || []).length);
+    // Count delimiters per line and check consistency. Delimiters inside a
+    // double-quoted field are field content, not column separators (RFC 4180) —
+    // a naive count inflates rows with quoted delimiters (e.g. `"Smith, John"`),
+    // which used to make consistency collapse and reject a valid CSV.
+    const counts = lines.map((line) =>
+      ContentHeuristicStrategy.countDelimitersOutsideQuotes(line, delimiter),
+    );
     const firstCount = counts[0];
     const consistentLines = counts.filter((c) => c === firstCount).length;
 
     return consistentLines / lines.length >= 0.8;
+  }
+
+  /**
+   * Count occurrences of `delimiter` in `line` that fall OUTSIDE double-quoted
+   * fields, honoring RFC-4180 escaped quotes (`""`). Used by CSV detection so a
+   * delimiter embedded in a quoted value is not mistaken for a column break.
+   */
+  private static countDelimitersOutsideQuotes(
+    line: string,
+    delimiter: string,
+  ): number {
+    let count = 0;
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          i++; // escaped quote inside a quoted field — skip the pair
+          continue;
+        }
+        inQuotes = !inQuotes;
+      } else if (ch === delimiter && !inQuotes) {
+        count++;
+      }
+    }
+    return count;
   }
 
   private looksLikeJSON(text: string): boolean {

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -475,6 +475,45 @@ const tests: TestFunction[] = [
       return true;
     },
   },
+  // ---------- CSV detection: quoted delimiters (issue #299) ----------
+  {
+    name: "FileDetector: quoted commas do not break CSV detection (RFC 4180)",
+    category: "csv-processor",
+    fn: async () => {
+      // Each data row has a comma inside a quoted field plus one real column
+      // break. A quote-unaware delimiter count sees 2 delimiters on data rows
+      // vs 1 on the header, collapses consistency below 0.8, and rejects a
+      // valid CSV. The quote-aware count sees 1 delimiter on every row.
+      const csv =
+        'name,note\n"Smith, John",hello\n"Doe, Jane",world\n"Roe, Max",foo\n';
+      const result = await FileDetector.detectAndProcess(Buffer.from(csv));
+      return result.type === "csv";
+    },
+  },
+  // ---------- CSV metadata confidence varies with quality (issue #386) ----------
+  {
+    name: "CSVProcessor: metadata.confidence reflects data quality, not a static 100",
+    category: "csv-processor",
+    fn: async () => {
+      const clean = "id,name,age\n1,Alice,30\n2,Bob,25\n3,Cara,41\n4,Dan,38\n";
+      const messy =
+        "id,name,age,city,score\n1,Alice,,,\n2,,,,\n3,,,foo,\n4,,,,\n5,,,,\n";
+      const rc = await CSVProcessor.process(Buffer.from(clean), {
+        maxRows: 100,
+      });
+      const rm = await CSVProcessor.process(Buffer.from(messy), {
+        maxRows: 100,
+      });
+      const cleanConf = rc.metadata?.confidence;
+      const messyConf = rm.metadata?.confidence;
+      return (
+        cleanConf === 100 &&
+        typeof messyConf === "number" &&
+        messyConf < 100 &&
+        messyConf >= 50
+      );
+    },
+  },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------
   {
     name: "resolveVertexLocation: gemini-* forced to global regardless of configured location",


### PR DESCRIPTION
## What
Two CSV gaps from the open-issue audit.

- **#299:** `looksLikeCSV()` counted delimiters with a naive regex, so commas inside quoted fields (e.g. `"Smith, John"`) inflated the per-row count, collapsed the consistency ratio below 0.8, and **rejected a valid CSV**.
- **#386:** CSV results reported a static `metadata.confidence` of `100` regardless of data quality.

## Fix
- **#299:** count delimiters **outside** double-quoted fields (RFC 4180, escaped-quote aware).
- **#386:** weight `confidence` by `dataQualityScore` (`csvResultConfidence`): a clean CSV stays at 100, a messy one is pulled halfway toward its quality score, never below 50. This is the processing-result confidence, **separate from the detection-strategy selection path**, so strategy ranking is unaffected.

## Proof
Quoted-comma CSV now detects as `csv`; clean CSV → confidence 100, messy CSV → 65 (quality 30). 2 new regression tests → **bugfixes suite 91/91**. The 11 pre-existing `context` suite failures (section 6.x provider-streaming NoOutput, live network/quota) are **identical on `release`** and unrelated.

Fixes #299, #386.
