### PR TITLE
fix(utils): safeFetch pinned-agent lookup honors options.all (autoSelectFamily)

### DIFF
--- a/src/lib/utils/safeFetch.ts
+++ b/src/lib/utils/safeFetch.ts
@@ -32,7 +32,7 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 function buildPinnedAgent(hostname: string, ip: string, family: 4 | 6): Agent {
   return new Agent({
     connect: {
-      lookup: (host, _options, callback) => {
+      lookup: (host, options, callback) => {
         if (host.toLowerCase() !== hostname.toLowerCase()) {
           // The host the connect layer asks for differs from the URL host —
           // this happens for absolute Host headers etc. Reject defensively.
@@ -43,6 +43,16 @@ function buildPinnedAgent(hostname: string, ip: string, family: 4 | 6): Agent {
             "",
             0,
           );
+          return;
+        }
+        // Node ≥20 enables autoSelectFamily (Happy Eyeballs) by default, and
+        // its lookup contract passes `all: true` expecting an address ARRAY.
+        // Answering with the string form there fails the connection with
+        // "Invalid IP address: undefined" — which broke every safeDownload
+        // (Replicate / Runway / Kling asset fetches) on modern Node while
+        // plain curl of the same URL succeeded.
+        if (options?.all) {
+          callback(null, [{ address: ip, family }]);
           return;
         }
         callback(null, ip, family);


### PR DESCRIPTION
## Problem

Every `safeDownload` of a provider asset (Replicate prediction outputs, Runway/Kling media) fails with a bare `fetch failed` on modern Node — while `curl` of the same URL succeeds. Observed live twice today: Replicate predictions **completed** (billed, output URL valid) but `downloadPredictionOutput` failed on the `replicate.delivery` URL both times.

## Root cause

Node ≥20 enables `autoSelectFamily` (Happy Eyeballs) by default; its `net` lookup contract passes `all: true` and expects an **array of `{address, family}`**. `buildPinnedAgent`'s lookup always answers in string form → undici fails the connect with `Invalid IP address: undefined`.

## Minimal repro (Node 24, undici, against replicate.delivery)

```
string-form callback → FETCH FAILED: Invalid IP address: undefined
all-aware callback   → HTTP 200
```

(Agent with `connect.lookup` pinning a resolved IP; identical setup, only the callback shape differs.)

## Fix

The `options.all` branch returns `[{ address: ip, family }]`; the legacy branch is byte-for-byte unchanged. SSRF pinning semantics are identical — both forms hand the connection exactly the validated IP.

## Relation to other PRs

Third in today's series from wiring juspay/director's draft-tier b-roll through NeuroLink: #1147 (js-yaml runtime dep), #1150 (Replicate `imageInputKey`), and this one. With #1150 locally mirrored plus this fix, `minimax/hailuo-2.3-fast` and `kwaivgi/kling-v2.1` (inline data-URI `start_image`) generate and download end-to-end on Replicate.

`pnpm run typecheck` clean; pre-commit hook suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability when connecting to pinned IP addresses.
  * Prevented connection failures caused by updated network lookup behavior.
  * Continued enforcing download timeouts, redirect rejection, and response size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->