### PR TITLE
fix(tools): sandbox built-in file tools to the working directory

### DIFF
--- a/src/lib/agent/directTools.ts
+++ b/src/lib/agent/directTools.ts
@@ -26,6 +26,31 @@ function truncateOutput(output: string): string {
   return output;
 }
 
+/**
+ * Contain a built-in file tool to the process working directory.
+ *
+ * Returns the resolved absolute path when it lies inside `process.cwd()`, or an
+ * `error` string otherwise. This is the sandbox for the default-enabled
+ * `readFile` / `writeFile` / `listDirectory` / `analyzeCSV` tools: without it an
+ * agent can pass an absolute path (`/etc/passwd`) or `../` traversal and reach
+ * arbitrary files. The previous guard (`!resolvedPath.startsWith(cwd) &&
+ * !path.isAbsolute(filePath)`) was always false for absolute paths, so it never
+ * fired. The `cwd + path.sep` suffix prevents a sibling-prefix bypass
+ * (`/home/app` vs `/home/app-evil`).
+ */
+function resolveWithinCwd(
+  filePath: string,
+): { path: string } | { error: string } {
+  const resolvedPath = path.resolve(filePath);
+  const cwd = path.resolve(process.cwd());
+  if (resolvedPath !== cwd && !resolvedPath.startsWith(cwd + path.sep)) {
+    return {
+      error: `Access denied: "${filePath}" resolves outside the working directory`,
+    };
+  }
+  return { path: resolvedPath };
+}
+
 // Runtime Google Search tool creation - bypasses TypeScript strict typing
 function createGoogleSearchTools() {
   const searchTool = {};
@@ -85,16 +110,13 @@ export const directAgentTools = {
     }),
     execute: async ({ path: filePath }) => {
       try {
-        // Security check - prevent reading outside current directory for relative paths
-        const resolvedPath = path.resolve(filePath);
-        const cwd = process.cwd();
-
-        if (!resolvedPath.startsWith(cwd) && !path.isAbsolute(filePath)) {
-          return {
-            success: false,
-            error: `Access denied: Cannot read files outside current directory`,
-          };
+        // Sandbox: contain reads to the working directory (blocks absolute-path
+        // escape and ../ traversal).
+        const guard = resolveWithinCwd(filePath);
+        if ("error" in guard) {
+          return { success: false, error: guard.error };
         }
+        const resolvedPath = guard.path;
 
         const content = fs.readFileSync(resolvedPath, "utf-8");
         const stats = fs.statSync(resolvedPath);
@@ -130,7 +152,12 @@ export const directAgentTools = {
     }),
     execute: async ({ path: dirPath, includeHidden }) => {
       try {
-        const resolvedPath = path.resolve(dirPath);
+        // Sandbox: contain directory listing to the working directory.
+        const guard = resolveWithinCwd(dirPath);
+        if ("error" in guard) {
+          return { success: false, error: guard.error };
+        }
+        const resolvedPath = guard.path;
         const items = fs.readdirSync(resolvedPath);
 
         const filteredItems = includeHidden
@@ -267,16 +294,13 @@ export const directAgentTools = {
     }),
     execute: async ({ path: filePath, content, mode }) => {
       try {
-        const resolvedPath = path.resolve(filePath);
-        const cwd = process.cwd();
-
-        // Security check
-        if (!resolvedPath.startsWith(cwd) && !path.isAbsolute(filePath)) {
-          return {
-            success: false,
-            error: `Access denied: Cannot write files outside current directory`,
-          };
+        // Sandbox: contain writes to the working directory (blocks absolute-path
+        // escape and ../ traversal).
+        const guard = resolveWithinCwd(filePath);
+        if ("error" in guard) {
+          return { success: false, error: guard.error };
         }
+        const resolvedPath = guard.path;
 
         // Check if file exists for create mode
         if (mode === "create" && fs.existsSync(resolvedPath)) {
@@ -386,12 +410,13 @@ export const directAgentTools = {
       try {
         // Resolve file path
         logger.debug(`[analyzeCSV] Resolving file: ${filePath}`);
-        const path = await import("path");
 
-        // Resolve path (support both relative and absolute)
-        const resolvedPath = path.isAbsolute(filePath)
-          ? filePath
-          : path.resolve(process.cwd(), filePath);
+        // Sandbox: contain CSV reads to the working directory.
+        const guard = resolveWithinCwd(filePath);
+        if ("error" in guard) {
+          return { success: false, error: guard.error };
+        }
+        const resolvedPath = guard.path;
 
         logger.debug(`[analyzeCSV] Resolved path: ${resolvedPath}`);
 

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -18,6 +18,7 @@ import {
 
 import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
+import { directAgentTools } from "../src/lib/agent/directTools.js";
 
 import {
   GoogleVertexProvider,
@@ -193,6 +194,38 @@ const tests: TestFunction[] = [
         typeof raw.content === "string" &&
         raw.content.includes('"line1\rline2"')
       );
+    },
+  },
+  // ---------- Built-in file tools are sandboxed to cwd (issue #1004) ----------
+  {
+    name: "directAgentTools: readFile/writeFile/listDirectory deny paths outside cwd",
+    category: "tool-sandbox",
+    fn: async () => {
+      type Exec = {
+        execute: (a: unknown) => Promise<{ success: boolean; error?: string }>;
+      };
+      const rf = directAgentTools.readFile as unknown as Exec;
+      const wf = directAgentTools.writeFile as unknown as Exec;
+      const ld = directAgentTools.listDirectory as unknown as Exec;
+      const denied = (r: { success: boolean; error?: string }) =>
+        r.success === false && /Access denied/.test(r.error ?? "");
+      // Absolute-path escape and ../ traversal must be denied on all three.
+      const results = await Promise.all([
+        rf.execute({ path: "/etc/passwd" }),
+        rf.execute({ path: "../../../../../../etc/passwd" }),
+        ld.execute({ path: "/etc" }),
+        wf.execute({
+          path: "/tmp/neurolink-sandbox-escape.txt",
+          content: "x",
+          mode: "overwrite",
+        }),
+      ]);
+      if (!results.every(denied)) {
+        return false;
+      }
+      // A path inside cwd must still be allowed.
+      const ok = await rf.execute({ path: "package.json" });
+      return ok.success === true;
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
Fixes #1004. readFile/writeFile guard (`!startsWith(cwd) && !isAbsolute`) was always false for absolute paths — arbitrary FS read/write; listDirectory/analyzeCSV had no guard. Added resolveWithinCwd() containment (blocks absolute escape + ../ traversal, sibling-prefix-safe) to all four. Regression test; bugfixes 90/90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem protection by blocking attempts to access files outside the working directory.
  * Prevented absolute-path and parent-directory traversal access through file tools and CSV analysis.
  * Preserved access to permitted files within the working directory.

* **Tests**
  * Added regression coverage for blocked and permitted filesystem access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->