### PR TITLE
fix(file-detector): path-traversal sandbox, TOCTOU-safe read, clearer errors

### DIFF
--- a/scripts/build-browser.mjs
+++ b/scripts/build-browser.mjs
@@ -119,6 +119,8 @@ export const unlink = noopAsync;
 export const access = noopAsync;
 export const rename = noopAsync;
 export const rm = noopAsync;
+export const open = async () => ({ stat: noopAsync, readFile: noopAsync, close: noopAsync, read: noopAsync, write: noopAsync });
+export const realpath = async (p) => p;
 export const spawn = () => ({on:noop,stdout:{on:noop},stderr:{on:noop},kill:noop});
 export const exec = (c,cb) => cb?.(null,'','');
 export const execSync = () => '';

--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -350,6 +350,16 @@ export type FileDetectorOptions = {
   maxSize?: number;
   timeout?: number;
   allowedTypes?: FileType[];
+  /**
+   * When set, local file paths must resolve inside this base directory;
+   * anything that escapes it (absolute path, `../` traversal, or a symlink
+   * pointing outside) is rejected. Containment is enforced on the real,
+   * symlink-resolved path of both the base dir and the target, so a symlink
+   * inside the base cannot be used to reach a file outside it. Servers that
+   * accept file paths from untrusted callers should set this to sandbox
+   * filesystem access; SDK callers loading their own files can omit it.
+   */
+  allowedBaseDir?: string;
   audioOptions?: AudioProcessorOptions;
   csvOptions?: CSVProcessorOptions;
   officeOptions?: OfficeProcessorOptions;

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -4,7 +4,13 @@
  * Uses multi-strategy approach for reliable type identification
  */
 
-import { readFile, stat } from "fs/promises";
+import { open, readFile, realpath } from "fs/promises";
+import {
+  isAbsolute as isAbsolutePath,
+  relative as relativePath,
+  resolve as resolvePath,
+  sep,
+} from "path";
 import { getGlobalDispatcher, interceptors, request } from "undici";
 // Lazy-loaded processor singletons — avoids loading heavy media deps
 // (mediabunny, fluent-ffmpeg, music-metadata, adm-zip) on every generate() call.
@@ -779,8 +785,10 @@ export class FileDetector {
       }
     }
 
-    logger.warn(
-      `[FileDetector] Low confidence: ${best?.type ?? "unknown"} (${best?.metadata.confidence ?? 0}%)`,
+    // Below-threshold detection is the common case for any file under the
+    // ContentHeuristic ceiling — a debug detail, not a warning-worthy anomaly.
+    logger.debug(
+      `[FileDetector] Best-effort type below threshold: ${best?.type ?? "unknown"} (${best?.metadata.confidence ?? 0}%, threshold ${confidenceThreshold}%)`,
     );
     return best as FileDetectionResult;
   }
@@ -1806,7 +1814,7 @@ export class FileDetector {
         });
 
         if (response.statusCode !== 200) {
-          throw new Error(`HTTP ${response.statusCode}`);
+          throw new Error(`HTTP ${response.statusCode} fetching ${url}`);
         }
 
         const chunks: Buffer[] = [];
@@ -1832,23 +1840,58 @@ export class FileDetector {
    * Load file from filesystem path
    */
   private static async loadFromPath(
-    path: string,
+    filePath: string,
     options?: FileDetectorOptions,
   ): Promise<Buffer> {
     const maxSize = options?.maxSize || 200 * 1024 * 1024; // 200MB default (matches Curator memory-safety cap)
-    const statInfo = await stat(path);
 
-    if (!statInfo.isFile()) {
-      throw new Error("Not a file");
+    // Reject NUL-byte injection outright (a classic path-truncation vector).
+    if (filePath.includes("\0")) {
+      throw new Error("Invalid file path: contains a null byte");
     }
 
-    if (statInfo.size > maxSize) {
-      throw new Error(
-        `File too large: ${formatFileSize(statInfo.size)} (max: ${formatFileSize(maxSize)})`,
-      );
+    // Optional sandbox: when a base dir is configured (servers accepting paths
+    // from untrusted callers), reject anything that resolves outside it. Real
+    // paths are resolved (symlinks followed) on BOTH sides so a symlink inside
+    // the base dir pointing outside cannot bypass containment. The
+    // path.relative check (not a string prefix) correctly handles the root dir
+    // ("/") and sibling-prefix ("/app" vs "/app-evil") edge cases.
+    if (options?.allowedBaseDir) {
+      let base: string;
+      let real: string;
+      try {
+        base = await realpath(resolvePath(options.allowedBaseDir));
+        real = await realpath(filePath);
+      } catch {
+        throw new Error(
+          `Access denied: "${filePath}" could not be resolved within the allowed base directory`,
+        );
+      }
+      const rel = relativePath(base, real);
+      if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolutePath(rel)) {
+        throw new Error(
+          `Access denied: "${filePath}" resolves outside the allowed base directory`,
+        );
+      }
     }
 
-    return await readFile(path);
+    // Open a handle and stat/read through the SAME descriptor so a symlink
+    // swap between the size check and the read cannot occur (TOCTOU).
+    const handle = await open(filePath, "r");
+    try {
+      const statInfo = await handle.stat();
+      if (!statInfo.isFile()) {
+        throw new Error(`Not a file: ${filePath}`);
+      }
+      if (statInfo.size > maxSize) {
+        throw new Error(
+          `File too large: ${filePath} is ${formatFileSize(statInfo.size)} (max: ${formatFileSize(maxSize)})`,
+        );
+      }
+      return await handle.readFile();
+    } finally {
+      await handle.close();
+    }
   }
 
   /**
@@ -1857,7 +1900,9 @@ export class FileDetector {
   private static loadFromDataURI(dataUri: string): Buffer {
     const match = dataUri.match(/^data:([^;]+);base64,(.+)$/);
     if (!match) {
-      throw new Error("Invalid data URI format");
+      throw new Error(
+        `Invalid data URI format (expected "data:<mime>;base64,<data>"): "${dataUri.slice(0, 32)}…"`,
+      );
     }
     return Buffer.from(match[2], "base64");
   }

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -20,6 +20,10 @@ import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
 import { isMultimodalInput } from "../src/lib/types/index.js";
+import { FileDetector } from "../src/lib/utils/fileDetector.js";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 
 import {
   GoogleVertexProvider,
@@ -244,6 +248,92 @@ const tests: TestFunction[] = [
         [{ files: [{ buffer: Buffer.from("x"), filename: "a.pdf" }] }, true],
       ];
       return cases.every(([inp, want]) => isMultimodalInput(inp) === want);
+    },
+  },
+  // ---------- FileDetector path hardening (issues #279, #272) ----------
+  {
+    name: "FileDetector.loadFromPath rejects null bytes and enforces allowedBaseDir",
+    category: "file-detector",
+    fn: async () => {
+      const load = (
+        FileDetector as unknown as {
+          loadFromPath: (
+            p: string,
+            o?: { allowedBaseDir?: string },
+          ) => Promise<Buffer>;
+        }
+      ).loadFromPath;
+      const throwsWith = async (
+        p: string,
+        o: { allowedBaseDir?: string } | undefined,
+        re: RegExp,
+      ): Promise<boolean> => {
+        try {
+          await load(p, o);
+          return false;
+        } catch (e) {
+          return e instanceof Error && re.test(e.message);
+        }
+      };
+      // null-byte injection is always rejected
+      if (!(await throwsWith("foo\0.txt", undefined, /null byte/))) {
+        return false;
+      }
+      // with a base dir, an absolute escape is denied
+      if (
+        !(await throwsWith(
+          "/etc/passwd",
+          { allowedBaseDir: process.cwd() },
+          /outside the allowed base/,
+        ))
+      ) {
+        return false;
+      }
+      // a path inside the base dir still loads
+      try {
+        const buf = await load("package.json", {
+          allowedBaseDir: process.cwd(),
+        });
+        return Buffer.isBuffer(buf) && buf.length > 0;
+      } catch {
+        return false;
+      }
+    },
+  },
+  {
+    name: "FileDetector.loadFromPath: a symlink inside allowedBaseDir pointing outside is denied",
+    category: "file-detector",
+    fn: async () => {
+      const load = (
+        FileDetector as unknown as {
+          loadFromPath: (
+            p: string,
+            o?: { allowedBaseDir?: string },
+          ) => Promise<Buffer>;
+        }
+      ).loadFromPath;
+      const base = mkdtempSync(pathJoin(tmpdir(), "nl-sandbox-"));
+      const outside = mkdtempSync(pathJoin(tmpdir(), "nl-secret-"));
+      const secret = pathJoin(outside, "secret.txt");
+      const linkInside = pathJoin(base, "escape.txt");
+      try {
+        writeFileSync(secret, "top secret");
+        // A symlink that lives inside the sandbox but resolves outside it.
+        symlinkSync(secret, linkInside);
+        // Path-resolution alone would see linkInside under `base` and allow it;
+        // real-path (symlink-followed) containment must deny it.
+        try {
+          await load(linkInside, { allowedBaseDir: base });
+          return false; // reached the file — containment bypassed
+        } catch (e) {
+          return (
+            e instanceof Error && /outside the allowed base/.test(e.message)
+          );
+        }
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+        rmSync(outside, { recursive: true, force: true });
+      }
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
Fixes #279 #272 #360 #389 #397. null-byte rejection + opt-in allowedBaseDir sandbox; single-FileHandle stat+read (no symlink-swap window); error context; extension query-strip; below-threshold log warn→debug. Regression test; bugfixes 90/90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional base-directory restrictions for local file loading.
  - Local paths now prevent directory traversal, absolute-path escapes, symlink escapes, and NUL-byte injection.

- **Bug Fixes**
  - Improved errors for failed HTTP requests and malformed data URIs.
  - File access now uses safer, more consistent filesystem handling.

- **Diagnostics**
  - Low-confidence detections are logged less prominently and include confidence and threshold details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->