### PR TITLE
fix(message-builder): image input download + data-URI safety

### DIFF
--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1609,7 +1609,10 @@ async function convertContentToProviderFormat(
  * Check if a string is an internet URL
  */
 function isInternetUrl(input: string): boolean {
-  return input.startsWith("http://") || input.startsWith("https://");
+  // Scheme is case-insensitive (RFC 3986) — "HTTPS://..." must still be a URL,
+  // not fall through to the file-path branch and produce a confusing error.
+  const lower = input.toLowerCase();
+  return lower.startsWith("http://") || lower.startsWith("https://");
 }
 
 /**
@@ -1656,20 +1659,23 @@ async function downloadImageFromUrl(url: string): Promise<string> {
       );
     }
 
-    // Read the response body
+    // Read the response body, enforcing the size cap INCREMENTALLY: a
+    // misbehaving/malicious server on a user-supplied URL must not be able to
+    // force unbounded memory growth by streaming gigabytes before we ever
+    // check the total (the previous code concat'd everything first).
+    const maxSize = 10 * 1024 * 1024; // 10MB
     const chunks: Buffer[] = [];
+    let totalSize = 0;
     for await (const chunk of response.body) {
+      totalSize += chunk.length;
+      if (totalSize > maxSize) {
+        throw new Error(
+          `Image too large: exceeds ${maxSize} bytes while downloading from ${url}`,
+        );
+      }
       chunks.push(chunk);
     }
     const buffer = Buffer.concat(chunks);
-
-    // Check file size (limit to 10MB)
-    const maxSize = 10 * 1024 * 1024; // 10MB
-    if (buffer.length > maxSize) {
-      throw new Error(
-        `Image too large: ${buffer.length} bytes (max: ${maxSize} bytes)`,
-      );
-    }
 
     // Convert to base64 data URI
     const base64 = buffer.toString("base64");
@@ -1825,10 +1831,23 @@ function processImageToBase64(
       // Data URI (including downloaded URLs) - extract mime type and raw base64
       const match = image.match(/^data:([^;]+);base64,(.+)$/);
       if (match) {
-        mimeType = match[1];
+        const declaredMime = match[1];
+        // #348: only accept image/* data URIs; reject a non-image MIME before
+        // it reaches a provider API rather than passing it through unchecked.
+        if (!declaredMime.startsWith("image/")) {
+          throw new Error(
+            `Unsupported data URI MIME type for image input at index ${index}: "${declaredMime}" (expected image/*)`,
+          );
+        }
+        mimeType = declaredMime;
         imageData = match[2]; // Raw base64 only — NOT the full data: URI
       } else {
-        imageData = image;
+        // #270: a malformed data: URI must fail loudly, not silently pass the
+        // raw string through as if it were valid base64 (which corrupts the
+        // request and surfaces as an opaque provider error later).
+        throw new Error(
+          `Malformed image data URI at index ${index} (expected "data:<image/...>;base64,<data>")`,
+        );
       }
     } else if (isInternetUrl(image)) {
       // This should not happen as URLs are processed separately

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -16,7 +16,10 @@ import {
   parseRetryAfterMs,
 } from "../src/lib/proxy/routingPolicy.js";
 
-import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
+import {
+  convertToModelMessages,
+  buildMultimodalMessagesArray,
+} from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
 import { PDFProcessor } from "../src/lib/utils/pdfProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
@@ -546,6 +549,55 @@ const tests: TestFunction[] = [
       return (
         Object.keys(qr[0] ?? {}).join(",") === "name,note" && qr.length === 2
       );
+    },
+  },
+  // ---------- Image data-URI validation (issues #270, #348) ----------
+  {
+    name: "buildMultimodalMessagesArray rejects malformed / non-image data URIs",
+    category: "message-builder",
+    fn: async () => {
+      const build = (images: string[]) =>
+        buildMultimodalMessagesArray(
+          {
+            input: { text: "hi", images },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai",
+          "gpt-4o",
+        );
+      const throwsWith = async (
+        images: string[],
+        re: RegExp,
+      ): Promise<boolean> => {
+        try {
+          await build(images);
+          return false;
+        } catch (e) {
+          return e instanceof Error && re.test(e.message);
+        }
+      };
+      // #270: a malformed data URI must fail loudly, not pass through silently.
+      if (
+        !(await throwsWith(
+          ["data:image/png;NOTBASE64whoops"],
+          /Malformed image data URI/,
+        ))
+      ) {
+        return false;
+      }
+      // #348: a non-image MIME data URI must be rejected.
+      if (
+        !(await throwsWith(
+          ["data:text/plain;base64,aGVsbG8="],
+          /Unsupported data URI MIME/,
+        ))
+      ) {
+        return false;
+      }
+      // A valid image data URI must still build.
+      const png =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const msgs = await build([`data:image/png;base64,${png}`]);
+      return Array.isArray(msgs);
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
Fixes #334 #270 #348 #330. Incremental 10MB cap while streaming (was after Buffer.concat → unbounded memory); reject malformed data URIs loudly; validate image/* MIME; case-insensitive URL scheme. Regression test; bugfixes 90/90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image URLs regardless of letter casing.
  * Prevented oversized remote images over 10 MB from being downloaded.
  * Added clearer validation and error messages for malformed or unsupported image data.
  * Ensured only valid image data URIs are accepted during message preparation.

* **Tests**
  * Added coverage for valid, malformed, and unsupported image data URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->