### PR TITLE
fix(security): harden isMultimodalInput guard + remove hardcoded AWS account ID

### DIFF
--- a/neurolink-demo/server.ts
+++ b/neurolink-demo/server.ts
@@ -51,7 +51,7 @@ const ALL_PROVIDERS = [
 const DEFAULT_MODELS: Record<string, string> = {
   openai: "gpt-4o",
   bedrock:
-    "arn:aws:bedrock:us-east-2:225681119357:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "arn:aws:bedrock:us-east-2:123456789012:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
   vertex: "gemini-2.5-pro",
   "google-ai": "gemini-2.5-pro",
   anthropic: "claude-3-5-sonnet-20241022",

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -56,7 +56,7 @@ const ConfigSchema: z.ZodType<CliNeuroLinkConfig> = z.object({
           model: z
             .string()
             .default(
-              "arn:aws:bedrock:us-east-2:225681119357:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+              "arn:aws:bedrock:us-east-2:123456789012:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
             ),
         })
         .optional(),
@@ -629,7 +629,7 @@ export class ConfigManager {
         name: "model",
         message: "Model ARN:",
         default:
-          "arn:aws:bedrock:us-east-2:225681119357:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "arn:aws:bedrock:us-east-2:123456789012:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       },
     ]);
 

--- a/src/lib/types/multimodal.ts
+++ b/src/lib/types/multimodal.ts
@@ -659,18 +659,26 @@ function isDirectorSegment(segment: unknown): segment is DirectorSegment {
 }
 
 export function isMultimodalInput(input: unknown): input is MultimodalInput {
-  const maybeInput = input as MultimodalInput;
+  if (typeof input !== "object" || input === null) {
+    return false;
+  }
+  const m = input as MultimodalInput;
+  // Each field must be a NON-EMPTY ARRAY. Checking `.length` alone is unsafe:
+  // a string value (e.g. `{ images: "oops" }`) has a truthy `.length`, so the
+  // old guard would claim a malformed input is multimodal and then crash
+  // downstream when the field is iterated as an array.
+  const hasItems = (v: unknown): boolean => Array.isArray(v) && v.length > 0;
   return !!(
-    maybeInput?.images?.length ||
-    maybeInput?.csvFiles?.length ||
-    maybeInput?.pdfFiles?.length ||
-    maybeInput?.files?.length ||
-    maybeInput?.content?.length ||
-    maybeInput?.audioFiles?.length ||
-    maybeInput?.videoFiles?.length ||
-    (maybeInput?.segments?.length &&
-      Array.isArray(maybeInput.segments) &&
-      maybeInput.segments.every(isDirectorSegment))
+    hasItems(m.images) ||
+    hasItems(m.csvFiles) ||
+    hasItems(m.pdfFiles) ||
+    hasItems(m.files) ||
+    hasItems(m.content) ||
+    hasItems(m.audioFiles) ||
+    hasItems(m.videoFiles) ||
+    (Array.isArray(m.segments) &&
+      m.segments.length > 0 &&
+      m.segments.every(isDirectorSegment))
   );
 }
 

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -19,6 +19,7 @@ import {
 import { convertToModelMessages } from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
+import { isMultimodalInput } from "../src/lib/types/index.js";
 
 import {
   GoogleVertexProvider,
@@ -226,6 +227,23 @@ const tests: TestFunction[] = [
       // A path inside cwd must still be allowed.
       const ok = await rf.execute({ path: "package.json" });
       return ok.success === true;
+    },
+  },
+  // ---------- isMultimodalInput guards against non-array fields (issue #278) ----------
+  {
+    name: "isMultimodalInput returns false for non-array fields (no unsafe .length)",
+    category: "type-guard",
+    fn: async () => {
+      const cases: Array<[unknown, boolean]> = [
+        [{ images: "not-an-array" }, false], // string .length was truthy
+        [{ csvFiles: 42 }, false],
+        [null, false],
+        ["hello", false],
+        [{}, false],
+        [{ images: [Buffer.from("x")] }, true],
+        [{ files: [{ buffer: Buffer.from("x"), filename: "a.pdf" }] }, true],
+      ];
+      return cases.every(([inp, want]) => isMultimodalInput(inp) === want);
     },
   },
   // ---------- Bug 1: Vertex location routing via resolveVertexLocation ----------


### PR DESCRIPTION
Fixes #278 #1012. isMultimodalInput required non-empty ARRAY per field (a string .length was truthy → false-positive + downstream crash); replaced hardcoded AWS account ID 225681119357 with placeholder 123456789012 (config.ts x2 + demo). Regression test; bugfixes 90/90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for multimodal inputs, rejecting malformed or empty fields and accepting only correctly structured content.
  * Updated Amazon Bedrock default model configuration to use the current inference profile.

* **Tests**
  * Added coverage for valid and invalid multimodal input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->