### PR TITLE
fix(proxy): harden account routing and process reliability

### DIFF
--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -144,7 +144,7 @@ neurolink proxy setup --no-service
 
 ### `neurolink proxy guard` (hidden)
 
-Internal fail-open guard process. Spawned automatically by `proxy start` as a detached child. Monitors the proxy health endpoint and reverts Claude Code settings if the proxy dies unexpectedly.
+Internal fail-open guard process. Spawned only by a foreground `proxy start`; launchd-managed proxies leave restart ownership entirely to launchd. The guard reverts stale Claude Code settings only after its parent is confirmed dead and never restarts or signals a live proxy.
 
 | Flag                  | Type      | Default      | Description                                                  |
 | --------------------- | --------- | ------------ | ------------------------------------------------------------ |
@@ -399,6 +399,13 @@ routing:
   #   neurolink auth clear-primary
   primary-account: "alice@example.com"
 
+  # Optional hard boundary for Anthropic credential discovery. Entries may be
+  # labels/emails or full anthropic:<label> keys. An empty list denies all.
+  # Hidden legacy/env credentials require explicit legacy-default/env entries.
+  # Accepts: account-allowlist (kebab) or accountAllowlist (camel).
+  account-allowlist:
+    - "alice@example.com"
+
   # Model mappings: remap incoming model names to different provider/model pairs
   # Accepts: model-mappings (kebab) or modelMappings (camel)
   model-mappings:
@@ -495,6 +502,7 @@ cloaking:
 | ------------------------------------------ | ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `strategy`                                 | `"round-robin" \| "fill-first"` | _(none)_ | No       | Account selection strategy. `round-robin` rotates across accounts. `fill-first` uses one account until exhausted.                                                                                                                                                              |
 | `primary-account` / `primaryAccount`       | `string`                        | _(none)_ | No       | Email/label of the Anthropic account to treat as primary (home). Resolved per-request to `anthropic:<email>`; falls back to insertion-order index 0 when absent or when the configured account isn't currently authenticated. Manage via `neurolink auth set-primary <email>`. |
+| `account-allowlist` / `accountAllowlist`   | `string[]`                      | _(none)_ | No       | Allowed Anthropic account labels/keys. When present, unlisted TokenStore, legacy, and environment credentials are excluded before loading or refresh. Empty denies all; absent is unrestricted. Special fallback labels are `legacy-default` and `env`.                        |
 | `model-mappings` / `modelMappings`         | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                                                                                                                                                                                       |
 | `fallback-chain` / `fallbackChain`         | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                                                                                                                                                                              |
 | `passthrough-models` / `passthroughModels` | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                                                                                                                                                                                    |
@@ -534,7 +542,12 @@ The config loader validates the following:
 - Each provider key in `accounts` must map to an array.
 - Each account must have a non-empty string `apiKey`.
 - If `version` is present, it must be a number.
+- `routing.account-allowlist` must be an array of non-empty strings when present.
 - Plaintext API keys (not using `${ENV_VAR}` references) trigger a warning.
+
+An absent default config is optional. An existing config that cannot be read or
+validated fails proxy startup; it is never ignored in favor of unrestricted
+routing.
 
 ---
 
@@ -549,6 +562,7 @@ The config loader validates the following:
 | `NEUROLINK_LOG_LEVEL`         | Log level for the NeuroLink logger. Values: `error`, `warn`, `info`, `debug`.                                                                                        | Logger utility                                   |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint for proxy telemetry export. Written automatically to `~/.neurolink/.env` by `neurolink proxy telemetry setup`. Example: `http://localhost:14318`. | Proxy OTEL init (`initializeProxyOpenTelemetry`) |
 | `NEUROLINK_ENV_FILE`          | Path to a `.env` file the proxy should load at startup. Overrides the default `~/.neurolink/.env` auto-load.                                                         | `proxyEnv.ts` (`resolveProxyEnvFile`)            |
+| `NEUROLINK_PROXY_AUTO_UPDATE` | Enables the legacy guard updater only for `1`, `on`, or `true`. Disabled by default. launchd-managed proxies do not spawn a guard.                                   | Foreground fail-open guard                       |
 
 ### Proxy Env File Resolution Order
 
@@ -565,7 +579,9 @@ The `--env-file` flag is baked into the launchd plist by `proxy install`, so the
 
 1. **TokenStore compound keys** -- `anthropic:<label>` entries in `~/.neurolink/tokens.json`.
 2. **Legacy credentials file** -- `~/.neurolink/anthropic-credentials.json` (only if no compound keys exist).
-3. **`ANTHROPIC_API_KEY` env var** -- Only if no OAuth accounts are found at all.
+3. **`ANTHROPIC_API_KEY` env var** -- Only if no Anthropic TokenStore entries or legacy credential are present.
+
+`routing.account-allowlist` filters these sources before loading or refresh. Legacy and environment fallbacks are never activated merely because existing TokenStore accounts are disabled, cooling, or unavailable.
 
 ---
 
@@ -591,7 +607,7 @@ When the proxy starts, it automatically writes to `~/.claude/settings.json`:
 
 - **On `proxy start`** -- Both keys are written (or merged into existing settings).
 - **On `proxy stop` (Ctrl+C / SIGTERM)** -- Both keys are removed. Other env keys in the settings file are preserved.
-- **Fail-open guard** -- If the proxy crashes without a clean shutdown, the detached guard process detects the unhealthy endpoint and removes the stale settings automatically.
+- **Fail-open guard** -- A foreground proxy's detached guard removes stale settings only after confirming its parent died and no replacement is healthy. launchd-managed proxies do not spawn this guard.
 - **Safety** -- If the `ANTHROPIC_BASE_URL` has been changed to a different value (e.g., another proxy), the cleanup will not overwrite it.
 
 After starting the proxy, restart Claude Code for the new settings to take effect.
@@ -608,12 +624,13 @@ All NeuroLink proxy files are stored under `~/.neurolink/` (with `0o700` directo
 | `~/.neurolink/anthropic-credentials.json`                    | `0o600`      | **Legacy credentials** -- Single-account OAuth tokens. Used as a fallback when no compound keys exist in `tokens.json`. Updated on token refresh (pre-request or on-401).                                                                                                                                              |
 | `~/.neurolink/proxy-config.yaml`                             | user default | **Proxy config** -- YAML/JSON configuration file. Loaded by `proxy start` (default path, overridable with `--config`).                                                                                                                                                                                                 |
 | `~/.neurolink/.env`                                          | `0o600`      | **Proxy env file** — Auto-loaded by the proxy on startup. Created with mode `0o600` by `neurolink proxy telemetry setup` with `OTEL_EXPORTER_OTLP_ENDPOINT`. Add any provider API keys or proxy env vars here to avoid exporting them in every shell session. Override path with `--env-file` or `NEUROLINK_ENV_FILE`. |
-| `~/.neurolink/proxy-state.json`                              | user default | **Proxy state** -- Runtime state persisted by the running proxy (PID, port, host, strategy, start time, fallback chain, guard PID). Used by `proxy status` and the fail-open guard.                                                                                                                                    |
+| `~/.neurolink/proxy-state.json`                              | user default | **Proxy state** -- Runtime state persisted by the running proxy (PID, port, host, strategy, start time, fallback chain, account allowlist, foreground guard PID). Used by `proxy status` and the fail-open guard.                                                                                                      |
 | `~/.neurolink/logs/proxy-YYYY-MM-DD.jsonl`                   | `0o600`      | **Request summary logs** -- One JSONL entry per completed proxied request. Includes requestId, method, path, model, status, account label, response time, token usage, and trace correlation fields.                                                                                                                   |
 | `~/.neurolink/logs/proxy-attempts-YYYY-MM-DD.jsonl`          | `0o600`      | **Attempt logs** -- One JSONL entry per upstream attempt. Useful for retry, failover, and cooldown debugging without inflating request totals.                                                                                                                                                                         |
 | `~/.neurolink/logs/proxy-debug-YYYY-MM-DD.jsonl`             | `0o600`      | **Debug index logs** -- Redacted body-capture index rows with phase, headers, status, duration, and the stored body artifact path.                                                                                                                                                                                     |
 | `~/.neurolink/logs/bodies/YYYY-MM-DD/<request-id>/*.json.gz` | `0o600`      | **Body artifacts** -- Compressed redacted request and response bodies captured for debugging.                                                                                                                                                                                                                          |
 | `~/.neurolink/account-quotas.json`                           | user default | **Account quotas** -- Cached quota/utilization data from Anthropic's `unified-5h` and `unified-7d` rate-limit headers. Flushed to disk every 5 seconds.                                                                                                                                                                |
+| `~/.neurolink/account-cooldowns.json`                        | `0o600`      | **Account cooldowns** -- Extend-only rate-limit and transient-auth recovery timestamps. Persisted atomically so a proxy restart cannot immediately retry a known-exhausted account.                                                                                                                                    |
 | `~/.claude/settings.json`                                    | user default | **Claude Code settings** -- Auto-configured with `ANTHROPIC_BASE_URL` and `ENABLE_TOOL_SEARCH` when the proxy starts. Cleaned up on shutdown.                                                                                                                                                                          |
 
 ### TokenStore Details
@@ -878,7 +895,10 @@ These headers are parsed by `parseQuotaHeaders()` in `accountQuota.ts` and cache
 
 ## Token Refresh
 
-The proxy uses a reactive (not background) refresh strategy. There is no background timer polling for token expiry. Instead, tokens are refreshed on demand:
+The proxy coordinates background, pre-request, and on-401 refresh paths:
 
-1. **Pre-request check** — Before each request, if the token's `expiresAt <= now + 1 hour`, the proxy refreshes it inline via `POST https://api.anthropic.com/v1/oauth/token` (fallback: `https://console.anthropic.com/v1/oauth/token`). On success, the credential file is updated atomically (write to `.tmp`, then rename).
-2. **On-401 retry** — If Anthropic returns a 401 despite the pre-request check, the proxy refreshes the token and retries the request up to 5 times before failing over to the next account.
+1. **Background check** — One non-overlapping cycle runs every 30 seconds and considers only allowed, enabled accounts within 5 minutes of expiry.
+2. **Pre-request check** — Before each request, if `expiresAt <= now + 5 minutes`, refresh inline via `POST https://api.anthropic.com/v1/oauth/token` (fallback: `https://console.anthropic.com/v1/oauth/token`).
+3. **On-401 retry** — If Anthropic returns a 401, refresh and retry within the bounded account retry budget before rotating.
+
+Concurrent callers sharing a rotating refresh token reuse one in-flight result. `400`, `401`, `403`, and `404` refresh responses are credential rejections and disable the account until explicit login. Network failures, refresh `429`s, and `5xx` responses are transient and receive a bounded auth cooldown. Automatic token persistence preserves manual disable metadata.

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -102,22 +102,27 @@ If the caller sends W3C trace headers (`traceparent`, `tracestate`) or NeuroLink
 
 ### Token Management
 
-The proxy uses a reactive two-layer token refresh strategy to ensure requests never fail due to expired tokens:
+The proxy uses three coordinated token refresh paths:
 
-1. **Pre-request check** -- Before each request, the proxy checks if the OAuth token expires within the next 1 hour. If so, it refreshes the token before sending the request.
-2. **401 retry** -- If Anthropic returns a 401 despite the above check, the proxy refreshes the token and retries the request up to 5 times per account. If all retries fail, the account enters a 5-minute cooldown and the proxy tries the next account. After 15 consecutive refresh failures across requests, the account is permanently disabled until re-authentication.
+1. **Background check** -- Every 30 seconds, one non-overlapping maintenance cycle checks allowed, enabled accounts.
+2. **Pre-request check** -- A request refreshes an OAuth token when it is within 5 minutes of expiry.
+3. **401 retry** -- An unexpected Anthropic 401 triggers refresh and bounded retry before account rotation.
 
-Refreshed tokens are persisted to `~/.neurolink/anthropic-credentials.json` using atomic writes (write to `.tmp`, then rename) with `0o600` permissions.
+Refresh calls sharing the same rotating refresh token are serialized and reuse the winning result. Credential rejection responses (`400`, `401`, `403`, or `404`) disable the account until explicit login; network errors, refresh-endpoint `429`s, and `5xx` responses apply a bounded 30-second to 5-minute auth cooldown instead. Automatic token saves preserve an operator-disabled account's metadata.
+
+Refreshed TokenStore and legacy credentials are persisted with `0o600` permissions using serialized atomic snapshot writes.
 
 ### Multi-Account Routing
 
 When multiple accounts are available, the proxy uses **fill-first** routing:
 
 1. Use the first non-cooling account for every request.
-2. On a 429, apply exponential backoff to that account and try the next one.
+2. On a 429, classify the authoritative quota window, persist its cooldown, and try the next account.
 3. Continue until a request succeeds or all accounts are exhausted.
 4. If all accounts are exhausted, walk the fallback chain (alternative providers).
 5. If all fallbacks fail, return a 429 with a `Retry-After` header indicating the earliest account recovery time.
+
+If every account has a known future cooldown, the proxy does not call any of them again. Cooldowns survive restarts in `~/.neurolink/account-cooldowns.json`.
 
 Account sources are checked in priority order:
 
@@ -136,6 +141,19 @@ curl http://127.0.0.1:55669/status   # stats.primaryAccount.label = alice@exampl
 ```
 
 After a 429 cools off, traffic returns to the configured primary (not literal index 0). When the configured account is missing or disabled, the proxy logs a warning at startup and falls back to insertion-order index 0. See the [config reference](./claude-proxy-config-reference.md#neurolink-auth-set-primary) for the full CLI surface (`set-primary` / `get-primary` / `clear-primary`).
+
+#### Restricting eligible accounts
+
+`primary-account` controls ordering; it is not a security or isolation boundary. To ensure the proxy can use only an explicit set of Anthropic credentials, configure `routing.account-allowlist`:
+
+```yaml
+routing:
+  primary-account: primary@example.com
+  account-allowlist:
+    - primary@example.com
+```
+
+Entries accept an email/label or a full `anthropic:<email-or-label>` key and are matched case-insensitively. When the field is present, unlisted TokenStore accounts are excluded before token loading or refresh. The legacy credential and `ANTHROPIC_API_KEY` fallback are also denied unless explicitly listed as `legacy-default` or `env`, and neither hidden fallback is considered while any Anthropic TokenStore entry exists. An empty list denies all Anthropic credentials; an absent field preserves unrestricted account discovery.
 
 ### Fallback Chain
 
@@ -175,6 +193,9 @@ accounts:
 # Routing configuration
 routing:
   strategy: fill-first # or round-robin
+  primary-account: primary@example.com
+  account-allowlist:
+    - primary@example.com
 
   # Model mappings: remap incoming model names to different providers
   model-mappings:
@@ -433,23 +454,23 @@ The proxy discovers accounts in this order:
 2. Legacy credentials file (if no compound keys exist)
 3. `ANTHROPIC_API_KEY` environment variable (if no other accounts exist)
 
+When `routing.account-allowlist` is configured, this discovery happens only within the allowed set. A disabled or unavailable TokenStore account does not cause the proxy to activate a legacy file or environment key while TokenStore entries still exist.
+
 Within the account pool, the proxy uses **fill-first** routing: it always tries the first non-cooling account and only switches on failure. This avoids unnecessary identity switches that could confuse Claude Code's session state.
 
 ### Cooldown and backoff
 
 When an account encounters an error, it enters a cooldown period based on the error type:
 
-| Status Code   | Cooldown Duration                  | Behavior                 |
-| ------------- | ---------------------------------- | ------------------------ |
-| 429           | Exponential backoff (1s to 10 min) | Try next account         |
-| 401/402/403   | 5 minutes                          | Try next account         |
-| 404           | No cooldown                        | Return error immediately |
-| 5xx/transient | No cooldown                        | Rotate immediately       |
-| Network error | No cooldown                        | Rotate immediately       |
+| Failure                                                | Cooldown                                          | Behavior                                         |
+| ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------ |
+| Authoritative unified, 5-hour, or 7-day rejection      | Upstream reset or `Retry-After`, capped at 8 days | Persist cooldown and rotate immediately          |
+| Transient burst 429                                    | Upstream delay, capped at 15 minutes              | At most 2 same-account retries, then rotate      |
+| Refresh credential rejection (`400`/`401`/`403`/`404`) | Disabled until explicit login                     | Rotate without retrying an invalid refresh token |
+| Refresh network, `429`, or `5xx`                       | 30 seconds to 5 minutes                           | Persist auth cooldown and rotate                 |
+| Upstream `5xx` or network error                        | Bounded same-account retries                      | Rotate after retry budget                        |
 
-**Exponential backoff on 429:**
-
-The proxy respects the `Retry-After` header from Anthropic when present. For repeated 429s on the same account, the cooldown is calculated as `baseCooldown * 2^level` where `baseCooldown` is the `Retry-After` value (or 1 second if absent) and `level` increments on each consecutive 429. This produces a sequence like 1s, 2s, 4s, 8s, 16s, ... up to a 10-minute cap. The backoff level resets to zero on a successful request.
+Cooldown updates are extend-only: a late concurrent response cannot shorten a longer known reset window.
 
 ## Error Handling
 
@@ -457,17 +478,16 @@ The proxy classifies upstream errors and applies different strategies:
 
 ### 429 Rate Limit
 
-- Parse `Retry-After` header (seconds or HTTP date format)
-- Apply exponential backoff with level tracking
-- Put the account into cooling state
-- Immediately try the next account
-- Log: `[proxy] <- 429 account=work backoff-level=2 cooldown=4s`
+- Treat top-level `anthropic-ratelimit-unified-status: rejected` as authoritative, even if sub-windows still say `allowed`.
+- Prefer the rejected 5-hour or 7-day reset and otherwise use `Retry-After`.
+- Persist the cooldown and rotate immediately for authoritative exhaustion.
+- Return the earliest recovery timestamp without another upstream request when all accounts are cooling.
 
 ### 401/402/403 Authentication Errors
 
-- **OAuth accounts with refresh token:** Refresh the token and retry the request up to 5 times per account. If all retries fail, apply a 5-minute cooldown and try the next account. After 15 consecutive refresh failures across requests, the account is permanently disabled until re-authentication via `neurolink auth login`.
-- **OAuth accounts without refresh token:** Apply a 5-minute cooldown, try the next account.
-- **API key accounts:** Apply a 5-minute cooldown, try the next account.
+- **OAuth accounts with refresh token:** Serialize refresh, persist the new rotating token, and retry. A rejected refresh credential disables the account until re-authentication; transient refresh infrastructure errors cool and rotate.
+- **OAuth accounts without refresh token:** Disable until re-authentication and rotate.
+- **API key accounts:** Rotate after authentication failure.
 
 ### 400/422 Request Shape Error
 
@@ -485,7 +505,7 @@ The proxy classifies upstream errors and applies different strategies:
 
 - Transient errors (408, 500, 502, 503, 504, and Cloudflare 520-526/529).
 - Also matches `400` responses with `api_error` or `overloaded_error` types that wrap transient HTML content (e.g., Cloudflare error pages).
-- No cooldown applied -- immediate rotation to the next account.
+- Apply bounded same-account retries, then rotate to the next account.
 
 ### All Accounts Exhausted
 
@@ -520,11 +540,11 @@ When the proxy stops (Ctrl+C or SIGTERM), it removes these entries from the sett
 
 ### Proxy state file
 
-The proxy persists its running state to `~/.neurolink/proxy-state.json` so that `neurolink proxy status` can report on it and `neurolink proxy start` can detect an already-running instance. The state includes PID, port, host, strategy, start time, fallback chain, and the optional fail-open guard PID.
+The proxy persists its running state to `~/.neurolink/proxy-state.json` so that `neurolink proxy status` can report on it and `neurolink proxy start` can detect an already-running instance. The state includes PID, port, host, strategy, start time, fallback chain, enforced account allowlist, and the optional foreground fail-open guard PID.
 
 ### Fail-open guard
 
-On startup, the proxy spawns a detached background process (`neurolink proxy guard`) that monitors the proxy's health endpoint. If the proxy process exits unexpectedly without cleaning up `~/.claude/settings.json`, the guard removes the stale `ANTHROPIC_BASE_URL` entry so that Claude Code falls back to direct Anthropic access rather than failing against a dead proxy.
+A foreground proxy spawns one detached `neurolink proxy guard` that removes stale Claude Code settings after confirming its parent process has died. A launchd-managed proxy does not spawn a guard: launchd is the sole restart supervisor, preventing stale guards from restarting or terminating healthy replacement processes. Runtime package updates are opt-in through `NEUROLINK_PROXY_AUTO_UPDATE=1` (also accepts `on` or `true`).
 
 ## Architecture
 
@@ -542,9 +562,9 @@ On startup, the proxy spawns a detached background process (`neurolink proxy gua
 
 When the target provider is `anthropic` (the default for any `claude-*` model), the proxy operates in passthrough mode:
 
-1. Load all available accounts (TokenStore, legacy file, env var). Expired accounts are given one refresh attempt at startup; if that fails, they are disabled.
+1. Load allowed, enabled TokenStore accounts. Consider legacy or environment credentials only when no Anthropic TokenStore entries exist and the source is allowed.
 2. Select the first non-cooling account according to the active routing strategy. With the default `fill-first` strategy, this is always the current primary account until it cools down.
-3. Auto-refresh the token if expiring within 1 hour.
+3. Auto-refresh the token if expiring within 5 minutes, sharing one in-flight refresh for concurrent requests.
 4. Forward the raw request body via plain `fetch()` to `https://api.anthropic.com/v1/messages?beta=true`.
 5. Set authentication headers (`Authorization: Bearer` for OAuth, `x-api-key` for API keys).
 6. Forward client headers as-is, preserving Claude Code's own request shape, then merge in required OAuth betas and trace headers when absent. The proxy extracts incoming `traceparent` and `x-neurolink-*` headers and injects outbound trace context plus `x-claude-code-session-id` when needed.

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -2109,6 +2109,10 @@ async function saveAccountToPool(
     return;
   }
 
+  // Login is an explicit operator action and is the only token-save path that
+  // should make a previously disabled account eligible again.
+  await defaultTokenStore.markEnabled(compoundKey);
+
   logger.always(chalk.green(`\nAccount added: ${compoundKey}\n`));
 }
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -29,6 +29,7 @@ import {
   StateFileManager,
 } from "../utils/serverUtils.js";
 import type {
+  AccountAllowlist,
   FallbackInfo,
   LoadedProxyConfig,
   ProxyGuardArgs,
@@ -47,16 +48,24 @@ import type {
 import type { ModelRouter } from "../../lib/proxy/modelRouter.js";
 import { configureProxyKeepAliveDispatcher } from "../../lib/proxy/proxyDispatcher.js";
 import {
+  anthropicAccountKeysEqual,
+  createAccountAllowlist,
+  ENV_ANTHROPIC_ACCOUNT_KEY,
+  isAccountAllowed,
+  LEGACY_ANTHROPIC_ACCOUNT_KEY,
+  normalizeAnthropicAccountKey,
+  shouldLoadFallbackCredential,
+} from "../../lib/proxy/accountSelection.js";
+import {
   loadProxyEnvFile,
   resolveProxyEnvFile,
 } from "../../lib/proxy/proxyEnv.js";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import packageJson from "../../../package.json" with { type: "json" };
 
 const _require = createRequire(import.meta.url);
-const { version: PROXY_VERSION } = _require("../../../package.json") as {
-  version: string;
-};
+const PROXY_VERSION = packageJson.version;
 
 const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
   new URL(
@@ -128,6 +137,9 @@ async function resolveStatusPrimaryAccount(
   proxyConfig: LoadedProxyConfig | null,
 ): Promise<ProxyStatusPrimaryAccount> {
   const configured = proxyConfig?.routing?.primaryAccount?.trim() || null;
+  const accountAllowlist = createAccountAllowlist(
+    proxyConfig?.routing?.accountAllowlist,
+  );
   let enabledAnthropicKeys: string[] = [];
   try {
     const { tokenStore } = await import("../../lib/auth/tokenStore.js");
@@ -135,7 +147,7 @@ async function resolveStatusPrimaryAccount(
     const filtered: string[] = [];
     for (const key of all) {
       const disabled = await tokenStore.isDisabled(key);
-      if (!disabled) {
+      if (!disabled && isAccountAllowed(key, accountAllowlist)) {
         filtered.push(key);
       }
     }
@@ -149,11 +161,14 @@ async function resolveStatusPrimaryAccount(
   }
 
   if (configured) {
-    const configuredKey = `anthropic:${configured}`;
-    if (enabledAnthropicKeys.includes(configuredKey)) {
+    const configuredKey = normalizeAnthropicAccountKey(configured);
+    const matchedKey = enabledAnthropicKeys.find((key) =>
+      anthropicAccountKeysEqual(key, configuredKey),
+    );
+    if (matchedKey) {
       return {
         configured,
-        key: configuredKey,
+        key: matchedKey,
         label: configured,
         source: "configured",
       };
@@ -194,49 +209,14 @@ async function isLaunchdManaging(): Promise<boolean> {
   }
 }
 
-/**
- * Attempt to restart the proxy via launchd kickstart.
- * Returns true if the proxy comes back healthy within timeoutMs.
- */
-async function tryLaunchdRestart(
-  host: string,
-  port: number,
-  timeoutMs: number = 15_000,
-): Promise<boolean> {
-  if (process.platform !== "darwin") {
-    return false;
-  }
+function isLaunchdManagedProcess(): boolean {
+  return process.platform === "darwin" && process.ppid === 1;
+}
 
-  try {
-    const { existsSync } = await import("fs");
-    if (!existsSync(PLIST_PATH)) {
-      return false;
-    }
-  } catch {
-    return false;
-  }
-
-  try {
-    const { execFileSync } = await import("node:child_process");
-    const uid = process.getuid?.() ?? 501;
-    execFileSync(
-      "launchctl",
-      ["kickstart", "-k", `gui/${uid}/${PLIST_LABEL}`],
-      { stdio: "ignore", timeout: 5_000 },
-    );
-  } catch {
-    return false;
-  }
-
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await sleep(1_000);
-    if (await isProxyHealthy(host, port, 2_000)) {
-      return true;
-    }
-  }
-
-  return false;
+function isProxyAutoUpdateEnabled(
+  value = process.env.NEUROLINK_PROXY_AUTO_UPDATE,
+): boolean {
+  return ["1", "on", "true"].includes((value ?? "").trim().toLowerCase());
 }
 
 /** Keys we manage in Claude Code's settings.env */
@@ -972,6 +952,7 @@ async function loadProxyStartConfiguration(
   modelRouter: ModelRouter | undefined;
   passthrough: boolean;
   primaryAccountKey: string | undefined;
+  accountAllowlist: AccountAllowlist | undefined;
 }> {
   const configPath =
     argv.config ?? join(homedir(), ".neurolink", "proxy-config.yaml");
@@ -984,20 +965,15 @@ async function loadProxyStartConfiguration(
       spinner.text = `Loaded proxy config from ${configPath}`;
     }
   } catch (configError) {
-    if (argv.config) {
-      if (spinner) {
-        spinner.fail(chalk.red(`Failed to load proxy config: ${configPath}`));
-      }
-      process.exit(1);
-    }
     const isNotFound =
       configError instanceof Error &&
       "code" in configError &&
       (configError as NodeJS.ErrnoException).code === "ENOENT";
-    if (!isNotFound) {
-      logger.warn(
-        `[proxy] Ignoring default config ${configPath}: ${configError instanceof Error ? configError.message : String(configError)}`,
-      );
+    if (argv.config || !isNotFound) {
+      if (spinner) {
+        spinner.fail(chalk.red(`Failed to load proxy config: ${configPath}`));
+      }
+      throw configError;
     }
   }
 
@@ -1019,6 +995,17 @@ async function loadProxyStartConfiguration(
   const primaryAccountKey = await resolveBootPrimaryAccountKey(
     proxyConfig?.routing?.primaryAccount,
   );
+  const accountAllowlist = await resolveBootAccountAllowlist(
+    proxyConfig?.routing?.accountAllowlist,
+  );
+  if (
+    primaryAccountKey &&
+    !isAccountAllowed(primaryAccountKey, accountAllowlist)
+  ) {
+    throw new Error(
+      `Configured routing.primaryAccount=${proxyConfig?.routing?.primaryAccount} is excluded by routing.accountAllowlist`,
+    );
+  }
 
   return {
     configPath,
@@ -1027,7 +1014,48 @@ async function loadProxyStartConfiguration(
     modelRouter,
     passthrough: argv.passthrough ?? false,
     primaryAccountKey,
+    accountAllowlist,
   };
+}
+
+async function resolveBootAccountAllowlist(
+  configuredAccounts: string[] | undefined,
+): Promise<AccountAllowlist | undefined> {
+  const allowlist = createAccountAllowlist(configuredAccounts);
+  if (allowlist === undefined) {
+    return undefined;
+  }
+  if (allowlist.size === 0) {
+    logger.warn(
+      "[proxy] routing.accountAllowlist is empty; all stored Anthropic credentials are denied",
+    );
+    return allowlist;
+  }
+
+  try {
+    const { tokenStore } = await import("../../lib/auth/tokenStore.js");
+    const known = new Set(
+      (await tokenStore.listByPrefix("anthropic:")).map(
+        normalizeAnthropicAccountKey,
+      ),
+    );
+    known.add(LEGACY_ANTHROPIC_ACCOUNT_KEY);
+    known.add(ENV_ANTHROPIC_ACCOUNT_KEY);
+    for (const key of allowlist) {
+      if (!known.has(key)) {
+        logger.warn(
+          `[proxy] WARN: routing.accountAllowlist entry ${key} is allowed but not currently authenticated`,
+        );
+      }
+    }
+  } catch (err) {
+    logger.debug(
+      `[proxy] could not validate account allowlist against token store: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return allowlist;
 }
 
 /** Resolve the operator's configured primary email to a stable token-store
@@ -1042,11 +1070,11 @@ async function resolveBootPrimaryAccountKey(
   if (!trimmed) {
     return undefined;
   }
-  const key = `anthropic:${trimmed}`;
+  const key = normalizeAnthropicAccountKey(trimmed);
   try {
     const { tokenStore } = await import("../../lib/auth/tokenStore.js");
     const known = await tokenStore.listByPrefix("anthropic:");
-    if (!known.includes(key)) {
+    if (!known.some((knownKey) => anthropicAccountKeysEqual(knownKey, key))) {
       logger.warn(
         `[proxy] WARN: configured routing.primaryAccount=${trimmed} not ` +
           `found in token store; falling back to first enabled account. ` +
@@ -1073,6 +1101,7 @@ async function createProxyStartApp(params: {
   host: string;
   proxyConfig: LoadedProxyConfig | null;
   primaryAccountKey: string | undefined;
+  accountAllowlist: AccountAllowlist | undefined;
 }) {
   const { createClaudeProxyRoutes } =
     await import("../../lib/server/routes/claudeProxyRoutes.js");
@@ -1106,6 +1135,7 @@ async function createProxyStartApp(params: {
     params.strategy,
     params.passthrough,
     params.primaryAccountKey,
+    params.accountAllowlist,
   );
 
   const openaiRouteGroup = createOpenAIProxyRoutes(
@@ -1264,7 +1294,24 @@ async function createProxyStartApp(params: {
 
   app.get("/status", async (c) => {
     const { getStats } = await import("../../lib/proxy/usageStats.js");
+    const { loadAccountCooldowns } =
+      await import("../../lib/proxy/accountCooldown.js");
     const stats = getStats();
+    const cooldowns = await loadAccountCooldowns();
+    const storedAccountKeys = new Set<string>();
+    try {
+      const { tokenStore } = await import("../../lib/auth/tokenStore.js");
+      for (const key of await tokenStore.listByPrefix("anthropic:")) {
+        storedAccountKeys.add(normalizeAnthropicAccountKey(key));
+      }
+    } catch (err) {
+      logger.debug(
+        `[proxy] /status: failed to resolve account cooldown labels: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    const now = Date.now();
     const health = buildProxyHealthResponse(readiness, {
       strategy: params.strategy,
       passthrough: params.passthrough,
@@ -1291,20 +1338,35 @@ async function createProxyStartApp(params: {
         totalSuccess: stats.totalSuccess,
         totalErrors: stats.totalErrors,
         totalRateLimits: stats.totalRateLimits,
-        accounts: Object.values(stats.accounts).map((account) => ({
-          label: account.label,
-          type: account.type,
-          attempts: account.attemptCount,
-          requests: account.attemptCount,
-          success: account.successCount,
-          errors: account.errorCount,
-          rateLimits: account.rateLimitCount,
-          cooling: false, // No persistent cooldown — always active
-        })),
+        accounts: Object.values(stats.accounts).map((account) => {
+          const normalizedKey = normalizeAnthropicAccountKey(account.label);
+          const accountKey = storedAccountKeys.has(normalizedKey)
+            ? normalizedKey
+            : account.label === "env"
+              ? ENV_ANTHROPIC_ACCOUNT_KEY
+              : account.type === "oauth"
+                ? LEGACY_ANTHROPIC_ACCOUNT_KEY
+                : normalizedKey;
+          return {
+            label: account.label,
+            type: account.type,
+            attempts: account.attemptCount,
+            requests: account.attemptCount,
+            success: account.successCount,
+            errors: account.errorCount,
+            rateLimits: account.rateLimitCount,
+            cooling: (cooldowns[accountKey]?.coolingUntil ?? 0) > now,
+          };
+        }),
         primaryAccount,
       },
       config: params.proxyConfig
-        ? { hasRouting: !!params.proxyConfig.routing }
+        ? {
+            hasRouting: !!params.proxyConfig.routing,
+            accountAllowlist: params.accountAllowlist
+              ? [...params.accountAllowlist]
+              : null,
+          }
         : null,
     });
   });
@@ -1373,16 +1435,68 @@ async function initializeProxyOpenTelemetry(): Promise<void> {
   }
 }
 
-async function refreshProxyTokensInBackground(): Promise<void> {
-  const { needsRefresh, refreshToken, persistTokens } =
-    await import("../../lib/proxy/tokenRefresh.js");
+const BACKGROUND_REFRESH_BASE_COOLDOWN_MS = 30_000;
+const BACKGROUND_REFRESH_MAX_COOLDOWN_MS = 5 * 60 * 1000;
+const backgroundRefreshFailures = new Map<
+  string,
+  { consecutiveFailures: number; coolingUntil: number }
+>();
+const backgroundRejectedRefreshTokens = new Map<string, string>();
+let backgroundRefreshInProgress = false;
+
+function canAttemptBackgroundRefresh(
+  key: string,
+  refreshToken?: string,
+): boolean {
+  const rejectedToken = backgroundRejectedRefreshTokens.get(key);
+  if (rejectedToken !== undefined) {
+    if (rejectedToken === refreshToken) {
+      return false;
+    }
+    backgroundRejectedRefreshTokens.delete(key);
+  }
+  const state = backgroundRefreshFailures.get(key);
+  return !state || Date.now() >= state.coolingUntil;
+}
+
+function recordBackgroundRefreshFailure(key: string): void {
+  const consecutiveFailures =
+    (backgroundRefreshFailures.get(key)?.consecutiveFailures ?? 0) + 1;
+  const delayMs = Math.min(
+    BACKGROUND_REFRESH_MAX_COOLDOWN_MS,
+    BACKGROUND_REFRESH_BASE_COOLDOWN_MS *
+      2 ** Math.min(consecutiveFailures - 1, 4),
+  );
+  backgroundRefreshFailures.set(key, {
+    consecutiveFailures,
+    coolingUntil: Date.now() + delayMs,
+  });
+}
+
+async function refreshProxyTokensInBackground(
+  accountAllowlist?: AccountAllowlist,
+): Promise<void> {
+  const {
+    needsRefresh,
+    refreshToken,
+    persistTokens,
+    isPermanentRefreshFailure,
+  } = await import("../../lib/proxy/tokenRefresh.js");
   const { tokenStore } = await import("../../lib/auth/tokenStore.js");
 
+  let storedAnthropicAccountCount: number | undefined;
   try {
     const allKeys = await tokenStore.listProviders();
     const anthropicKeys = allKeys.filter((key) => key.startsWith("anthropic:"));
+    storedAnthropicAccountCount = anthropicKeys.length;
     for (const key of anthropicKeys) {
       try {
+        if (
+          !isAccountAllowed(key, accountAllowlist) ||
+          (await tokenStore.isDisabled(key))
+        ) {
+          continue;
+        }
         const tokens = await tokenStore.loadTokens(key);
         if (!tokens) {
           continue;
@@ -1393,14 +1507,29 @@ async function refreshProxyTokensInBackground(): Promise<void> {
           refreshToken: tokens.refreshToken,
           expiresAt: tokens.expiresAt,
         };
-        if (needsRefresh(account)) {
-          const result = await refreshToken(account);
-          if (result.success) {
-            await persistTokens({ providerKey: key }, account);
-            logger.debug(
-              `[proxy] background token refresh succeeded for ${key}`,
-            );
-          }
+        if (!needsRefresh(account)) {
+          backgroundRefreshFailures.delete(key);
+          continue;
+        }
+        if (!canAttemptBackgroundRefresh(key, tokens.refreshToken)) {
+          continue;
+        }
+        const result = await refreshToken(account);
+        if (result.success) {
+          await persistTokens({ providerKey: key }, account);
+          backgroundRefreshFailures.delete(key);
+          logger.debug(`[proxy] background token refresh succeeded for ${key}`);
+        } else if (isPermanentRefreshFailure(result)) {
+          await tokenStore.markDisabled(key, "refresh_invalid");
+          backgroundRefreshFailures.delete(key);
+          logger.warn(
+            `[proxy] background refresh credential rejected for ${key}; disabled until explicit login`,
+          );
+        } else {
+          recordBackgroundRefreshFailure(key);
+          logger.debug(`[proxy] background token refresh deferred for ${key}`, {
+            status: result.status,
+          });
         }
       } catch {
         // non-fatal per-account
@@ -1411,6 +1540,16 @@ async function refreshProxyTokensInBackground(): Promise<void> {
   }
 
   try {
+    if (
+      storedAnthropicAccountCount === undefined ||
+      !shouldLoadFallbackCredential(
+        storedAnthropicAccountCount,
+        LEGACY_ANTHROPIC_ACCOUNT_KEY,
+        accountAllowlist,
+      )
+    ) {
+      return;
+    }
     const credPath = join(
       homedir(),
       ".neurolink",
@@ -1427,11 +1566,32 @@ async function refreshProxyTokensInBackground(): Promise<void> {
       refreshToken: creds.oauth.refreshToken,
       expiresAt: creds.oauth.expiresAt,
     };
-    if (needsRefresh(account)) {
+    const legacyKey = LEGACY_ANTHROPIC_ACCOUNT_KEY;
+    if (!needsRefresh(account)) {
+      backgroundRefreshFailures.delete(legacyKey);
+      return;
+    }
+    if (canAttemptBackgroundRefresh(legacyKey, account.refreshToken)) {
       const result = await refreshToken(account);
       if (result.success) {
         await persistTokens(credPath, account);
+        backgroundRefreshFailures.delete(legacyKey);
+        backgroundRejectedRefreshTokens.delete(legacyKey);
         logger.debug("[proxy] background token refresh succeeded");
+      } else if (isPermanentRefreshFailure(result)) {
+        backgroundRefreshFailures.delete(legacyKey);
+        backgroundRejectedRefreshTokens.set(
+          legacyKey,
+          account.refreshToken ?? "",
+        );
+        logger.warn(
+          "[proxy] background legacy refresh credential rejected; waiting for explicit login",
+        );
+      } else {
+        recordBackgroundRefreshFailure(legacyKey);
+        logger.debug("[proxy] background legacy token refresh deferred", {
+          status: result.status,
+        });
       }
     }
   } catch {
@@ -1441,16 +1601,35 @@ async function refreshProxyTokensInBackground(): Promise<void> {
 
 function startProxyBackgroundMaintenance(
   cleanupLogs: (days: number, maxMb: number) => void,
+  accountAllowlist?: AccountAllowlist,
 ): {
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
 } {
   const refreshInterval = setInterval(() => {
-    void refreshProxyTokensInBackground();
+    if (backgroundRefreshInProgress) {
+      return;
+    }
+    backgroundRefreshInProgress = true;
+    void refreshProxyTokensInBackground(accountAllowlist)
+      .catch((error) => {
+        logger.debug(
+          `[proxy] background token refresh cycle failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      })
+      .finally(() => {
+        backgroundRefreshInProgress = false;
+      });
   }, 30_000);
   const logCleanupInterval = setInterval(
     () => {
-      cleanupLogs(7, 500);
+      try {
+        cleanupLogs(7, 500);
+      } catch (error) {
+        logger.debug(
+          `[proxy] background log cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     },
     60 * 60 * 1000,
   );
@@ -1458,17 +1637,65 @@ function startProxyBackgroundMaintenance(
 }
 
 function registerProxyShutdownHandlers(params: {
-  server: { close?: () => void };
+  server: { close?: (callback?: (error?: Error) => void) => void };
   host: string;
   port: number;
   isDev?: boolean;
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
 }): void {
+  let shutdownStarted = false;
+
+  const closeServer = async (): Promise<void> => {
+    const close = params.server.close?.bind(params.server);
+    if (!close) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+      const timeout = setTimeout(
+        () => finish(new Error("Timed out draining the proxy server")),
+        30_000,
+      );
+      timeout.unref?.();
+      try {
+        close((error) => finish(error));
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  };
+
   const shutdown = async (signal: string) => {
+    if (shutdownStarted) {
+      return;
+    }
+    shutdownStarted = true;
     clearInterval(params.refreshInterval);
     clearInterval(params.logCleanupInterval);
     logger.always(`\nShutting down proxy (${signal})...`);
+    let exitCode = signal === "SIGINT" ? 0 : 1;
+
+    try {
+      await closeServer();
+    } catch (error) {
+      exitCode = 1;
+      logger.error(
+        `[proxy] failed to drain server during shutdown: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
 
     try {
       const { flushOpenTelemetry, shutdownOpenTelemetry } =
@@ -1499,19 +1726,28 @@ function registerProxyShutdownHandlers(params: {
     }
 
     try {
-      params.server.close?.();
-    } catch {
-      // Best-effort close
+      clearProxyState();
+    } catch (error) {
+      exitCode = 1;
+      logger.error(
+        `[proxy] failed to clear runtime state during shutdown: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
-    clearProxyState();
-    process.exit(signal === "SIGINT" ? 0 : 1);
+    process.exit(exitCode);
+  };
+
+  const forceExitAfterShutdownFailure = (error: unknown): never => {
+    logger.error(
+      `[proxy] unexpected shutdown failure: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
   };
 
   process.on("SIGTERM", () => {
-    void shutdown("SIGTERM");
+    void shutdown("SIGTERM").catch(forceExitAfterShutdownFailure);
   });
   process.on("SIGINT", () => {
-    void shutdown("SIGINT");
+    void shutdown("SIGINT").catch(forceExitAfterShutdownFailure);
   });
 }
 
@@ -1524,6 +1760,7 @@ async function startProxyRuntime(params: {
   port: number;
   strategy: ProxyStartStrategy;
   proxyConfig: LoadedProxyConfig | null;
+  accountAllowlist: AccountAllowlist | undefined;
   loadedEnvFile: string | undefined;
   passthrough: boolean;
   cleanupLogs: ProxyNeurolinkRuntime["cleanupLogs"];
@@ -1534,11 +1771,14 @@ async function startProxyRuntime(params: {
     port: params.port,
     hostname: params.host,
   });
-  // Skip the fail-open guard in dev mode — it monitors the proxy and clears
-  // global Claude settings on exit, which is exactly what we want to avoid.
-  const guardPid = params.argv.dev
-    ? undefined
-    : spawnFailOpenGuard(params.host, params.port, process.pid);
+  const managedByLaunchd = isLaunchdManagedProcess();
+  // launchd already owns restart supervision. A second detached supervisor can
+  // outlive its parent and terminate a healthy replacement, so the guard is
+  // reserved for foreground mode where it only cleans stale client settings.
+  const guardPid =
+    params.argv.dev || managedByLaunchd
+      ? undefined
+      : spawnFailOpenGuard(params.host, params.port, process.pid);
   const readinessHost = params.host === "0.0.0.0" ? "127.0.0.1" : params.host;
   await waitForProxyReadiness({
     host: readinessHost,
@@ -1565,11 +1805,11 @@ async function startProxyRuntime(params: {
     statusPath: "/status",
     envFile: params.loadedEnvFile,
     fallbackChain,
+    accountAllowlist: params.accountAllowlist
+      ? [...params.accountAllowlist]
+      : undefined,
     guardPid,
-    managedBy:
-      process.platform === "darwin" && process.ppid === 1
-        ? "launchd"
-        : "manual",
+    managedBy: managedByLaunchd ? "launchd" : "manual",
     passthrough: params.passthrough,
   });
 
@@ -1639,7 +1879,10 @@ async function startProxyRuntime(params: {
     );
   }
 
-  const maintenance = startProxyBackgroundMaintenance(params.cleanupLogs);
+  const maintenance = startProxyBackgroundMaintenance(
+    params.cleanupLogs,
+    params.accountAllowlist,
+  );
   registerProxyShutdownHandlers({
     server,
     host: params.host,
@@ -1665,6 +1908,9 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       const { initAccountQuota } =
         await import("../../lib/proxy/accountQuota.js");
       initAccountQuota(devPaths.quotaFile);
+      const { initAccountCooldown } =
+        await import("../../lib/proxy/accountCooldown.js");
+      initAccountCooldown(devPaths.cooldownFile);
 
       // Ensure the dev state directory exists
       const { mkdirSync, existsSync } = await import("fs");
@@ -1692,6 +1938,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       modelRouter,
       passthrough,
       primaryAccountKey,
+      accountAllowlist,
     } = await loadProxyStartConfiguration(argv, spinner);
 
     if (spinner) {
@@ -1709,6 +1956,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       host,
       proxyConfig,
       primaryAccountKey,
+      accountAllowlist,
     });
 
     await initializeProxyOpenTelemetry();
@@ -1726,6 +1974,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       port,
       strategy,
       proxyConfig,
+      accountAllowlist,
       loadedEnvFile,
       passthrough,
       cleanupLogs,
@@ -1907,6 +2156,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         url: null as string | null,
         envFile: null as string | null,
         fallbackChain: null as FallbackInfo[] | null,
+        accountAllowlist: null as string[] | null,
       };
 
       if (state && isProcessRunning(state.pid)) {
@@ -1921,6 +2171,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         status.url = `http://${state.host === "0.0.0.0" ? "localhost" : state.host}:${state.port}`;
         status.envFile = state.envFile ?? null;
         status.fallbackChain = state.fallbackChain ?? null;
+        status.accountAllowlist = state.accountAllowlist ?? null;
       }
 
       // Fetch live stats before rendering (JSON or text)
@@ -1977,6 +2228,13 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
           logger.always(
             `  ${chalk.bold("Env File:")}   ${chalk.cyan(status.envFile)}`,
           );
+        }
+        if (status.accountAllowlist) {
+          const scope =
+            status.accountAllowlist.length > 0
+              ? status.accountAllowlist.join(", ")
+              : "none (deny all)";
+          logger.always(`  ${chalk.bold("Accounts:")}   ${chalk.cyan(scope)}`);
         }
 
         // Display fallback chain if configured
@@ -2196,10 +2454,8 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
       return;
     }
 
-    // ---------------------------------------------------------------
-    // Auto-update loop (runs concurrently with the health monitor)
-    // Always on — no flags needed. Hardcoded sensible defaults.
-    // ---------------------------------------------------------------
+    // Automatic package mutation is disabled by default. Operators must opt in
+    // explicitly, and launchd-managed proxy processes do not spawn this guard.
     const UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2 hours
     const QUIET_THRESHOLD_MS = 120 * 1000; // 2 minutes of silence
     const UPDATE_TIMEOUT_MS = 30 * 1000; // 30 seconds to come healthy
@@ -2219,12 +2475,28 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     // Auto-update only works on macOS with launchd. On other platforms,
     // there's no restart mechanism, so skip the update loop entirely.
     const canAutoUpdate =
-      process.platform === "darwin" && (await isLaunchdManaging());
+      isProxyAutoUpdateEnabled() &&
+      process.platform === "darwin" &&
+      (await isLaunchdManaging());
 
+    let guardStopping = false;
+    let updateCheckTimeout: NodeJS.Timeout | undefined;
+    let updateCheckInterval: NodeJS.Timeout | undefined;
+    const stopUpdateChecks = (): void => {
+      guardStopping = true;
+      if (updateCheckTimeout) {
+        clearTimeout(updateCheckTimeout);
+        updateCheckTimeout = undefined;
+      }
+      if (updateCheckInterval) {
+        clearInterval(updateCheckInterval);
+        updateCheckInterval = undefined;
+      }
+    };
     let updateInProgress = false;
     let updateRestartInProgress = false;
     const runUpdateCheck = async () => {
-      if (updateInProgress) {
+      if (guardStopping || updateInProgress) {
         return;
       }
       updateInProgress = true;
@@ -2325,6 +2597,9 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         logger.always(
           `[guard] traffic quiet, installing @juspay/neurolink@${result.latestVersion} via ${pnpmResolution.bin} (pnpm v${pnpmResolution.version})...`,
         );
+        if (guardStopping || getProcessStatus(parentPid) === "not_running") {
+          return;
+        }
         const { execFileSync } = await import("node:child_process");
         try {
           execFileSync(
@@ -2431,6 +2706,10 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           // Continue with restart anyway — the stable bin symlink may still be correct
         }
 
+        if (guardStopping || getProcessStatus(parentPid) === "not_running") {
+          return;
+        }
+
         // Signal the health loop to not exit when it detects
         // the parent PID is gone — we're intentionally restarting.
         updateRestartInProgress = true;
@@ -2440,7 +2719,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         const uid = process.getuid?.() ?? 501;
         try {
           // bootout unloads the in-memory job definition. This is required
-          // because `kickstart -k` reuses the cached plist and ignores any
+          // because a forced kickstart reuses the cached plist and ignores any
           // on-disk changes (like the trampoline rewrite above).
           try {
             execFileSync(
@@ -2517,8 +2796,11 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
 
     // Run first check after a short delay, then on interval
     if (canAutoUpdate) {
-      setTimeout(runUpdateCheck, 30_000);
-      setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
+      updateCheckTimeout = setTimeout(runUpdateCheck, 30_000);
+      updateCheckInterval = setInterval(
+        runUpdateCheck,
+        UPDATE_CHECK_INTERVAL_MS,
+      );
     }
 
     const startedAt = Date.now();
@@ -2539,17 +2821,26 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         // Parent is gone (and we're not mid-update-restart).
         // If endpoint is still healthy, another proxy took over.
         if (healthy) {
+          stopUpdateChecks();
           return;
         }
         break;
       }
 
       if (!healthy && consecutiveUnhealthy >= failureThreshold) {
-        // Parent still exists but endpoint is repeatedly unhealthy.
-        break;
+        // A detached guard cannot safely decide that a live process should be
+        // replaced. Leave recovery to the foreground operator or launchd.
+        if (!argv.quiet) {
+          logger.always(
+            `[proxy] fail-open guard observed an unhealthy live parent; leaving process supervision unchanged`,
+          );
+        }
+        stopUpdateChecks();
+        return;
       }
 
       if (maxWaitMs > 0 && Date.now() - startedAt >= maxWaitMs) {
+        stopUpdateChecks();
         return;
       }
 
@@ -2557,19 +2848,13 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
       parentStatus = getProcessStatus(parentPid);
     }
 
+    stopUpdateChecks();
+
     const guardHost = host === "0.0.0.0" ? "localhost" : host;
     const expectedBaseUrl = `http://${guardHost}:${port}`;
 
-    // Attempt restart via launchd before falling back to cleanup
-    const restarted = await tryLaunchdRestart(guardHost, port);
-    if (restarted) {
-      if (!argv.quiet) {
-        logger.always(`[proxy] fail-open guard restarted proxy via launchd`);
-      }
-      return;
-    }
-
-    // Restart failed or launchd not installed — clean up Claude settings
+    // The parent is confirmed gone and no replacement is healthy. Foreground
+    // guards are cleanup-only; they never restart or signal proxy processes.
     const cleared = await clearClaudeProxySettings(expectedBaseUrl);
     try {
       await clearOpenCodeProxySettings(`${expectedBaseUrl}/v1`);
@@ -2904,6 +3189,9 @@ ${configArgs}
 
   <key>ThrottleInterval</key>
   <integer>5</integer>
+
+  <key>ExitTimeOut</key>
+  <integer>45</integer>
 
   <key>StandardOutPath</key>
   <string>${join(homedir(), ".neurolink", "logs", "proxy-launchd-stdout.log")}</string>

--- a/src/lib/auth/tokenStore.ts
+++ b/src/lib/auth/tokenStore.ts
@@ -182,13 +182,23 @@ export class TokenStore {
       }
     }
 
-    // Update provider tokens
+    const existingProvider = storageData.providers[provider];
+    const now = Date.now();
+    // Token rotation must not silently clear an operator-disabled account.
+    // Explicit login calls markEnabled() after saving fresh credentials.
     storageData.providers[provider] = {
       tokens,
-      createdAt: Date.now(),
-      lastAccessed: Date.now(),
+      createdAt: existingProvider?.createdAt ?? now,
+      lastAccessed: now,
+      ...(existingProvider?.disabled === true
+        ? {
+            disabled: true,
+            disabledAt: existingProvider.disabledAt,
+            disabledReason: existingProvider.disabledReason,
+          }
+        : {}),
     };
-    storageData.lastModified = Date.now();
+    storageData.lastModified = now;
 
     try {
       const content = this.encryptionEnabled
@@ -594,6 +604,10 @@ export class TokenStore {
    * round-trips. The state survives proxy restarts because it is stored
    * alongside the tokens in the JSON file.
    *
+   * This operation and saveTokens() share the instance mutex. A concurrent
+   * save cannot erase a disable: a later disable wins, while a later save
+   * preserves the existing disabled metadata.
+   *
    * @param provider - The provider key (e.g., "anthropic:user@example.com")
    * @param reason - Optional human-readable reason (e.g., "refresh_failed")
    */
@@ -694,6 +708,24 @@ export class TokenStore {
       } catch (error) {
         if (error instanceof TokenStoreError && error.code === "NOT_FOUND") {
           return false;
+        }
+        throw error;
+      }
+    });
+  }
+
+  /** Return the persisted disable reason, if the provider is disabled. */
+  async getDisabledReason(provider: string): Promise<string | undefined> {
+    return this._mutex.runExclusive(async () => {
+      try {
+        const storageData = await this.loadStorageData();
+        const providerData = storageData.providers[provider];
+        return providerData?.disabled === true
+          ? providerData.disabledReason
+          : undefined;
+      } catch (error) {
+        if (error instanceof TokenStoreError && error.code === "NOT_FOUND") {
+          return undefined;
         }
         throw error;
       }

--- a/src/lib/proxy/accountCooldown.ts
+++ b/src/lib/proxy/accountCooldown.ts
@@ -1,0 +1,126 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  AccountCoolingReason,
+  PersistedAccountCooldown,
+} from "../types/index.js";
+import { AsyncMutex } from "../utils/asyncMutex.js";
+import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
+
+const COOLDOWN_FILE = "account-cooldowns.json";
+const VALID_REASONS = new Set<AccountCoolingReason>([
+  "weekly",
+  "session",
+  "unified",
+  "transient",
+  "auth",
+]);
+
+let customCooldownFilePath: string | null = null;
+let cacheLoaded = false;
+let cacheLoadPromise: Promise<void> | null = null;
+let memoryCache: Record<string, PersistedAccountCooldown> = {};
+const mutationMutex = new AsyncMutex();
+
+export function initAccountCooldown(cooldownFilePath: string): void {
+  customCooldownFilePath = cooldownFilePath;
+  cacheLoaded = false;
+  cacheLoadPromise = null;
+  memoryCache = {};
+}
+
+function getCooldownFilePath(): string {
+  return customCooldownFilePath ?? join(homedir(), ".neurolink", COOLDOWN_FILE);
+}
+
+function isPersistedCooldown(
+  value: unknown,
+): value is PersistedAccountCooldown {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PersistedAccountCooldown>;
+  return (
+    typeof candidate.coolingUntil === "number" &&
+    Number.isFinite(candidate.coolingUntil) &&
+    typeof candidate.updatedAt === "number" &&
+    Number.isFinite(candidate.updatedAt) &&
+    typeof candidate.reason === "string" &&
+    VALID_REASONS.has(candidate.reason as AccountCoolingReason)
+  );
+}
+
+async function ensureAccountCooldownsLoaded(): Promise<void> {
+  if (!cacheLoaded) {
+    if (!cacheLoadPromise) {
+      cacheLoadPromise = (async () => {
+        try {
+          const parsed = JSON.parse(
+            await readFile(getCooldownFilePath(), "utf8"),
+          ) as Record<string, unknown>;
+          memoryCache = Object.fromEntries(
+            Object.entries(parsed).filter(
+              (entry): entry is [string, PersistedAccountCooldown] =>
+                isPersistedCooldown(entry[1]),
+            ),
+          );
+        } catch {
+          memoryCache = {};
+        }
+        cacheLoaded = true;
+      })().finally(() => {
+        cacheLoadPromise = null;
+      });
+    }
+    await cacheLoadPromise;
+  }
+}
+
+export async function loadAccountCooldowns(): Promise<
+  Record<string, PersistedAccountCooldown>
+> {
+  await ensureAccountCooldownsLoaded();
+  return mutationMutex.runExclusive(async () => ({ ...memoryCache }));
+}
+
+export async function saveAccountCooldown(
+  accountKey: string,
+  coolingUntil: number,
+  reason: AccountCoolingReason,
+): Promise<void> {
+  await mutationMutex.runExclusive(async () => {
+    await ensureAccountCooldownsLoaded();
+    const current = memoryCache[accountKey];
+    if (current && current.coolingUntil > coolingUntil) {
+      return;
+    }
+    memoryCache[accountKey] = {
+      coolingUntil,
+      reason,
+      updatedAt: Date.now(),
+    };
+    await writeJsonSnapshotAtomically(getCooldownFilePath(), memoryCache);
+  });
+}
+
+export async function clearAccountCooldown(
+  accountKey: string,
+  expectedCoolingUntil?: number,
+): Promise<void> {
+  await mutationMutex.runExclusive(async () => {
+    await ensureAccountCooldownsLoaded();
+    const current = memoryCache[accountKey];
+    if (!current) {
+      return;
+    }
+    if (
+      expectedCoolingUntil !== undefined &&
+      current.coolingUntil !== expectedCoolingUntil
+    ) {
+      return;
+    }
+    delete memoryCache[accountKey];
+    await writeJsonSnapshotAtomically(getCooldownFilePath(), memoryCache);
+  });
+}

--- a/src/lib/proxy/accountQuota.ts
+++ b/src/lib/proxy/accountQuota.ts
@@ -10,10 +10,12 @@
  * path is never blocked by file I/O.
  */
 
-import { dirname, join } from "path";
+import { join } from "path";
 import { homedir } from "os";
 import { promises as fs } from "fs";
 import type { AccountQuota } from "../types/index.js";
+import { AsyncMutex } from "../utils/asyncMutex.js";
+import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
 
 // ---------------------------------------------------------------------------
 // Header parsing (pure CPU — no I/O, safe for hot path)
@@ -37,6 +39,15 @@ function getHeader(
     }
   }
   return undefined;
+}
+
+/** Read and normalize Anthropic's authoritative top-level unified status. */
+export function getUnifiedRateLimitStatus(
+  headers: Headers | Record<string, string>,
+): string | undefined {
+  const value = getHeader(headers, "anthropic-ratelimit-unified-status");
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
 }
 
 /**
@@ -68,6 +79,7 @@ export function parseQuotaHeaders(
   const fallbackRaw = getHeader(headers, `${P}unified-fallback-percentage`);
 
   return {
+    unifiedStatus: getUnifiedRateLimitStatus(headers),
     sessionUsed,
     sessionStatus: getHeader(headers, `${P}unified-5h-status`) ?? "unknown",
     sessionResetAt: sessionResetRaw ? parseInt(sessionResetRaw, 10) || 0 : 0,
@@ -90,8 +102,12 @@ const FLUSH_INTERVAL_MS = 5_000; // write to disk at most every 5 seconds
 
 let memoryCache: Record<string, AccountQuota> = {};
 let cacheLoaded = false;
+let cacheLoadPromise: Promise<void> | null = null;
 let dirty = false;
+let cacheVersion = 0;
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
+const stateMutex = new AsyncMutex();
+const flushMutex = new AsyncMutex();
 
 /** Custom quota file path set via initAccountQuota(). */
 let customQuotaFilePath: string | null = null;
@@ -112,43 +128,48 @@ export function initAccountQuota(quotaFilePath: string): void {
   // Reset cache so the new path is picked up on next load
   memoryCache = {};
   cacheLoaded = false;
+  cacheLoadPromise = null;
   dirty = false;
+  cacheVersion = 0;
 }
 
 function getQuotaFilePath(): string {
   return customQuotaFilePath ?? join(homedir(), ".neurolink", QUOTA_FILE);
 }
 
-async function ensureDir(): Promise<void> {
-  const filePath = getQuotaFilePath();
-  const dir = dirname(filePath);
-  await fs.mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => {
-    // Non-fatal: directory may already exist
-  });
-}
-
 /** Flush the in-memory cache to disk (async, non-blocking). */
 async function flushToDisk(): Promise<void> {
-  if (!dirty) {
-    return;
-  }
-  try {
-    // Snapshot before async I/O so we only clear dirty if nothing changed
-    const snapshot = JSON.stringify(memoryCache, null, 2);
-    await ensureDir();
-    const filePath = getQuotaFilePath();
-    const tmpPath = `${filePath}.tmp`;
-    await fs.writeFile(tmpPath, snapshot, {
-      mode: 0o600,
+  await flushMutex.runExclusive(async () => {
+    let snapshot: Record<string, AccountQuota> | undefined;
+    let snapshotVersion = 0;
+    let filePath = "";
+
+    await stateMutex.runExclusive(async () => {
+      if (!dirty) {
+        return;
+      }
+      snapshot = Object.fromEntries(
+        Object.entries(memoryCache).map(([key, quota]) => [key, { ...quota }]),
+      );
+      snapshotVersion = cacheVersion;
+      filePath = getQuotaFilePath();
     });
-    await fs.rename(tmpPath, filePath);
-    // Only clear dirty if the cache hasn't changed during the write
-    if (JSON.stringify(memoryCache, null, 2) === snapshot) {
-      dirty = false;
+
+    if (!snapshot) {
+      return;
     }
-  } catch {
-    // Non-fatal — quota is best-effort telemetry
-  }
+
+    try {
+      await writeJsonSnapshotAtomically(filePath, snapshot, 0o600);
+      await stateMutex.runExclusive(async () => {
+        if (cacheVersion === snapshotVersion) {
+          dirty = false;
+        }
+      });
+    } catch {
+      // Non-fatal — quota is best-effort telemetry
+    }
+  });
 }
 
 function scheduleFlush(): void {
@@ -175,20 +196,30 @@ function scheduleFlush(): void {
  * Load all persisted account quotas.
  * First call reads from disk; subsequent calls return the in-memory cache.
  */
+async function ensureAccountQuotasLoaded(): Promise<void> {
+  if (!cacheLoaded) {
+    if (!cacheLoadPromise) {
+      cacheLoadPromise = (async () => {
+        try {
+          const raw = await fs.readFile(getQuotaFilePath(), "utf-8");
+          memoryCache = JSON.parse(raw) as Record<string, AccountQuota>;
+        } catch {
+          memoryCache = {};
+        }
+        cacheLoaded = true;
+      })().finally(() => {
+        cacheLoadPromise = null;
+      });
+    }
+    await cacheLoadPromise;
+  }
+}
+
 export async function loadAccountQuotas(): Promise<
   Record<string, AccountQuota>
 > {
-  if (cacheLoaded) {
-    return { ...memoryCache };
-  }
-  try {
-    const raw = await fs.readFile(getQuotaFilePath(), "utf-8");
-    memoryCache = JSON.parse(raw) as Record<string, AccountQuota>;
-  } catch {
-    memoryCache = {};
-  }
-  cacheLoaded = true;
-  return { ...memoryCache };
+  await ensureAccountQuotasLoaded();
+  return stateMutex.runExclusive(async () => ({ ...memoryCache }));
 }
 
 /**
@@ -215,10 +246,19 @@ export async function saveAccountQuota(
   accountKey: string,
   quota: AccountQuota,
 ): Promise<void> {
-  if (!cacheLoaded) {
-    await loadAccountQuotas();
-  }
-  memoryCache[accountKey] = quota;
-  dirty = true;
+  await stateMutex.runExclusive(async () => {
+    await ensureAccountQuotasLoaded();
+    memoryCache[accountKey] = { ...quota };
+    dirty = true;
+    cacheVersion += 1;
+  });
   scheduleFlush();
+}
+
+export async function flushAccountQuotaStateForTests(): Promise<void> {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  await flushToDisk();
 }

--- a/src/lib/proxy/accountSelection.ts
+++ b/src/lib/proxy/accountSelection.ts
@@ -1,0 +1,52 @@
+import type { AccountAllowlist } from "../types/index.js";
+
+export const LEGACY_ANTHROPIC_ACCOUNT_KEY = "anthropic:legacy-default";
+export const ENV_ANTHROPIC_ACCOUNT_KEY = "anthropic:env";
+
+export function normalizeAnthropicAccountKey(value: string): string {
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.startsWith("anthropic:") ? trimmed : `anthropic:${trimmed}`;
+}
+
+export function anthropicAccountKeysEqual(
+  left: string,
+  right: string,
+): boolean {
+  return (
+    normalizeAnthropicAccountKey(left) === normalizeAnthropicAccountKey(right)
+  );
+}
+
+export function createAccountAllowlist(
+  values?: readonly string[],
+): AccountAllowlist | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  return new Set(
+    values
+      .map(normalizeAnthropicAccountKey)
+      .filter((value) => value !== "anthropic:"),
+  );
+}
+
+export function isAccountAllowed(
+  accountKey: string,
+  allowlist?: AccountAllowlist,
+): boolean {
+  return (
+    allowlist === undefined ||
+    allowlist.has(normalizeAnthropicAccountKey(accountKey))
+  );
+}
+
+export function shouldLoadFallbackCredential(
+  storedAnthropicAccountCount: number,
+  fallbackAccountKey: string,
+  allowlist?: AccountAllowlist,
+): boolean {
+  return (
+    storedAnthropicAccountCount === 0 &&
+    isAccountAllowed(fallbackAccountKey, allowlist)
+  );
+}

--- a/src/lib/proxy/proxyConfig.ts
+++ b/src/lib/proxy/proxyConfig.ts
@@ -270,6 +270,27 @@ export function validateProxyConfig(config: unknown): string[] {
     return errors;
   }
 
+  if (hasRouting) {
+    const routing = cfg.routing as Record<string, unknown>;
+    const rawAccountAllowlist =
+      routing["account-allowlist"] ?? routing.accountAllowlist;
+    if (rawAccountAllowlist !== undefined) {
+      if (!Array.isArray(rawAccountAllowlist)) {
+        errors.push(
+          "routing.account-allowlist must be an array of non-empty strings",
+        );
+      } else {
+        rawAccountAllowlist.forEach((entry, index) => {
+          if (typeof entry !== "string" || entry.trim() === "") {
+            errors.push(
+              `routing.account-allowlist[${index}] must be a non-empty string`,
+            );
+          }
+        });
+      }
+    }
+  }
+
   if (!hasAccounts && !hasRouting) {
     errors.push('Config must contain at least one of "accounts" or "routing"');
     return errors;
@@ -358,6 +379,7 @@ function warnPlaintextApiKeys(
  * - `model-mappings` / `modelMappings` — array of {from, to, provider}
  * - `fallback-chain` / `fallbackChain` — array of {provider, model}
  * - `passthroughModels` / `passthrough-models` — array of model IDs
+ * - `account-allowlist` / `accountAllowlist` — allowed Anthropic account IDs
  *
  * Accepts both camelCase and kebab-case keys for YAML-friendliness.
  */
@@ -451,6 +473,14 @@ function parseRoutingConfig(
           `string, got ${typeof rawPrimary}`,
       );
     }
+  }
+
+  const rawAccountAllowlist = (raw["account-allowlist"] ??
+    raw.accountAllowlist) as unknown;
+  if (Array.isArray(rawAccountAllowlist)) {
+    result.accountAllowlist = [
+      ...new Set(rawAccountAllowlist.map((entry) => String(entry).trim())),
+    ];
   }
 
   return result;

--- a/src/lib/proxy/proxyPaths.ts
+++ b/src/lib/proxy/proxyPaths.ts
@@ -24,6 +24,7 @@ export function resolveProxyPaths(dev: boolean): ProxyPaths {
       stateDir: base,
       logsDir: join(base, "logs"),
       quotaFile: join(base, "account-quotas.json"),
+      cooldownFile: join(base, "account-cooldowns.json"),
       isDev: true,
     };
   }
@@ -32,6 +33,7 @@ export function resolveProxyPaths(dev: boolean): ProxyPaths {
     stateDir: base,
     logsDir: join(base, "logs"),
     quotaFile: join(base, "account-quotas.json"),
+    cooldownFile: join(base, "account-cooldowns.json"),
     isDev: false,
   };
 }

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -759,6 +759,8 @@ export async function logStreamError(entry: {
   const logEntry: Record<string, unknown> = {
     ...entry,
     responseStatus: 200,
+    terminalStatus: 502,
+    terminalOutcome: "stream_error",
     errorType: "stream_error",
     note: "mid-stream failure after initial 200",
   };

--- a/src/lib/proxy/snapshotPersistence.ts
+++ b/src/lib/proxy/snapshotPersistence.ts
@@ -11,7 +11,7 @@ async function writeSnapshotFile(
 ): Promise<void> {
   const dir = dirname(targetPath);
   const baseName = basename(targetPath);
-  await mkdir(dir, { recursive: true });
+  await mkdir(dir, { recursive: true, mode: 0o700 });
   const tempPath = join(dir, `.${baseName}.${process.pid}.${randomUUID()}.tmp`);
 
   try {

--- a/src/lib/proxy/sseInterceptor.ts
+++ b/src/lib/proxy/sseInterceptor.ts
@@ -230,6 +230,9 @@ function finalize(acc: TelemetryAccumulator): SSETelemetry {
     streamDurationMs: Date.now() - acc.startTime,
     totalBytesReceived: acc.totalBytesReceived,
     events: acc.events,
+    ...(acc.streamErrorMessage
+      ? { streamErrorMessage: acc.streamErrorMessage }
+      : {}),
     ...(acc.rawTextChunks ? { rawText: acc.rawTextChunks.join("") } : {}),
   };
 }
@@ -407,6 +410,22 @@ function processEvent(
   } catch {
     // Malformed JSON — skip silently, bytes already forwarded to client
     return;
+  }
+
+  if (event.event === "error") {
+    const payload =
+      parsed && typeof parsed === "object"
+        ? (parsed as Record<string, unknown>)
+        : {};
+    const nestedError =
+      payload.error && typeof payload.error === "object"
+        ? (payload.error as Record<string, unknown>)
+        : undefined;
+    const message = nestedError?.message ?? payload.message;
+    acc.streamErrorMessage =
+      typeof message === "string" && message.trim()
+        ? message.trim()
+        : truncateString(event.data, MAX_EVENT_DATA_BYTES);
   }
 
   switch (event.event) {

--- a/src/lib/proxy/streamOutcome.ts
+++ b/src/lib/proxy/streamOutcome.ts
@@ -1,0 +1,37 @@
+import type {
+  StreamTerminalOutcome,
+  StreamTerminalOutcomeTracker,
+} from "../types/index.js";
+
+export function createStreamTerminalOutcomeTracker(): StreamTerminalOutcomeTracker {
+  let settled = false;
+  let resolveOutcome!: (outcome: StreamTerminalOutcome) => void;
+  const outcome = new Promise<StreamTerminalOutcome>((resolve) => {
+    resolveOutcome = resolve;
+  });
+
+  const settle = (value: StreamTerminalOutcome): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    resolveOutcome(value);
+  };
+
+  return {
+    outcome,
+    complete: () => settle({ kind: "completed" }),
+    fail: (message) => settle({ kind: "upstream_error", message }),
+    cancel: () => settle({ kind: "client_cancelled" }),
+  };
+}
+
+export function mergeStreamTerminalOutcome(
+  outcome: StreamTerminalOutcome,
+  sseErrorMessage?: string,
+): StreamTerminalOutcome {
+  if (outcome.kind === "completed" && sseErrorMessage) {
+    return { kind: "upstream_error", message: sseErrorMessage };
+  }
+  return outcome;
+}

--- a/src/lib/proxy/tokenRefresh.ts
+++ b/src/lib/proxy/tokenRefresh.ts
@@ -1,8 +1,10 @@
 import { logger } from "../utils/logger.js";
 import { tokenStore } from "../auth/tokenStore.js";
+import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
 import type {
   RefreshableAccount,
   RefreshResult,
+  SharedRefreshResult,
   StoredOAuthTokens,
   TokenPersistTarget,
 } from "../types/index.js";
@@ -10,8 +12,11 @@ import type {
 const REFRESH_URL = "https://api.anthropic.com/v1/oauth/token";
 const REFRESH_URL_FALLBACK = "https://console.anthropic.com/v1/oauth/token";
 const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
-const BUFFER_MS = 60 * 60 * 1000;
+const BUFFER_MS = 5 * 60 * 1000;
+const SUCCESS_CACHE_MS = 60_000;
 const USER_AGENT = "claude-cli/2.1.80 (external, cli)";
+
+const refreshesInFlight = new Map<string, Promise<SharedRefreshResult>>();
 
 export function needsRefresh(account: RefreshableAccount): boolean {
   return !!(
@@ -21,7 +26,15 @@ export function needsRefresh(account: RefreshableAccount): boolean {
   );
 }
 
-export async function refreshToken(
+function isRefreshCredentialRejection(status: number | undefined): boolean {
+  return status === 400 || status === 401 || status === 403 || status === 404;
+}
+
+export function isPermanentRefreshFailure(result: RefreshResult): boolean {
+  return isRefreshCredentialRejection(result.status);
+}
+
+async function performTokenRefresh(
   account: RefreshableAccount,
 ): Promise<RefreshResult> {
   if (!account.refreshToken) {
@@ -40,6 +53,7 @@ export async function refreshToken(
   };
 
   const urls = [REFRESH_URL, REFRESH_URL_FALLBACK];
+  let terminalFailure: RefreshResult | undefined;
 
   for (const url of urls) {
     try {
@@ -56,11 +70,19 @@ export async function refreshToken(
           status: resp.status,
           error: errorBody.slice(0, 500),
         });
-        // If primary URL returned a non-ok status, try fallback
+        const failure = {
+          success: false,
+          error: errorBody,
+          status: resp.status,
+        } satisfies RefreshResult;
+        if (isRefreshCredentialRejection(resp.status)) {
+          terminalFailure = failure;
+        }
+        // If primary URL returned a non-ok status, try fallback.
         if (url === REFRESH_URL) {
           continue;
         }
-        return { success: false, error: errorBody, status: resp.status };
+        return terminalFailure ?? failure;
       }
 
       const data = (await resp.json()) as {
@@ -68,14 +90,11 @@ export async function refreshToken(
         refresh_token?: string;
         expires_in?: number;
       };
-      const previousExpiresAt = account.expiresAt;
       account.token = data.access_token;
       account.expiresAt =
         data.expires_in !== undefined
           ? Date.now() + data.expires_in * 1000
-          : previousExpiresAt && previousExpiresAt > Date.now()
-            ? previousExpiresAt
-            : Date.now() + 55 * 60 * 1000;
+          : Date.now() + 55 * 60 * 1000;
       if (data.refresh_token) {
         account.refreshToken = data.refresh_token;
       }
@@ -89,12 +108,90 @@ export async function refreshToken(
       if (url === REFRESH_URL) {
         continue;
       }
-      return { success: false, error: String(e) };
+      return terminalFailure ?? { success: false, error: String(e) };
     }
   }
 
   // Should not reach here, but guard against empty urls array
-  return { success: false, error: "No refresh URLs available" };
+  return (
+    terminalFailure ?? {
+      success: false,
+      error: "No refresh URLs available",
+    }
+  );
+}
+
+/**
+ * Serialize refreshes by refresh-token value. OAuth refresh tokens may rotate,
+ * so concurrent refreshes with the same old token can make all but the first
+ * request fail with invalid_grant. A short success cache covers callers that
+ * loaded either the old token or the newly rotated token around persistence.
+ */
+export async function refreshToken(
+  account: RefreshableAccount,
+): Promise<RefreshResult> {
+  if (!account.refreshToken) {
+    return { success: false, error: "No refresh token available" };
+  }
+
+  const lockKey = account.refreshToken;
+  let sharedPromise = refreshesInFlight.get(lockKey);
+  if (!sharedPromise) {
+    const refreshAccount: RefreshableAccount = { ...account };
+    const createdPromise = performTokenRefresh(refreshAccount).then(
+      (result) => {
+        const shared = {
+          result,
+          token: refreshAccount.token,
+          refreshToken: refreshAccount.refreshToken,
+          expiresAt: refreshAccount.expiresAt,
+        };
+        if (result.success) {
+          const cachedKeys = new Set([lockKey]);
+          const rotatedKey = refreshAccount.refreshToken;
+          if (
+            rotatedKey &&
+            rotatedKey !== lockKey &&
+            !refreshesInFlight.has(rotatedKey)
+          ) {
+            refreshesInFlight.set(rotatedKey, createdPromise);
+            cachedKeys.add(rotatedKey);
+          }
+          const timer = setTimeout(() => {
+            for (const key of cachedKeys) {
+              if (refreshesInFlight.get(key) === createdPromise) {
+                refreshesInFlight.delete(key);
+              }
+            }
+          }, SUCCESS_CACHE_MS);
+          timer.unref?.();
+        } else if (refreshesInFlight.get(lockKey) === createdPromise) {
+          refreshesInFlight.delete(lockKey);
+        }
+        return shared;
+      },
+      (error) => {
+        if (refreshesInFlight.get(lockKey) === createdPromise) {
+          refreshesInFlight.delete(lockKey);
+        }
+        throw error;
+      },
+    );
+    refreshesInFlight.set(lockKey, createdPromise);
+    sharedPromise = createdPromise;
+  }
+
+  const shared = await sharedPromise;
+  if (shared.result.success) {
+    account.token = shared.token;
+    account.refreshToken = shared.refreshToken;
+    account.expiresAt = shared.expiresAt;
+  }
+  return shared.result;
+}
+
+export function clearRefreshStateForTests(): void {
+  refreshesInFlight.clear();
 }
 
 export async function persistTokens(
@@ -124,11 +221,7 @@ async function persistLegacyCredentials(
       refreshToken: account.refreshToken,
     };
     existing.updatedAt = Date.now();
-    const tmpPath = credPath + ".tmp";
-    await fs.writeFile(tmpPath, JSON.stringify(existing, null, 2), {
-      mode: 0o600,
-    });
-    await fs.rename(tmpPath, credPath);
+    await writeJsonSnapshotAtomically(credPath, existing, 0o600);
   } catch (err) {
     logger.warn("[token-refresh] Failed to persist legacy credentials", {
       error: err instanceof Error ? err.message : String(err),

--- a/src/lib/proxy/updateState.ts
+++ b/src/lib/proxy/updateState.ts
@@ -10,6 +10,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { randomUUID } from "node:crypto";
 import type { UpdateState } from "../types/index.js";
 
 // ============================================
@@ -107,10 +108,20 @@ export function saveUpdateState(
 ): void {
   const filePath = resolveStatePath(stateFilePath);
   ensureParentDir(filePath);
-  // Atomic write: write to temp file then rename to prevent corruption on crash
-  const tmpPath = filePath + ".tmp";
-  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
-  fs.renameSync(tmpPath, filePath);
+  // A process-unique temp path prevents concurrent update checks from renaming
+  // each other's file. The guard is single-owner now, but this also keeps
+  // explicit update commands safe when they overlap.
+  const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+    fs.renameSync(tmpPath, filePath);
+  } finally {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // Best-effort cleanup after a successful rename or interrupted write.
+    }
+  }
 }
 
 /**

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -21,6 +21,19 @@ import {
   parseClaudeCodeUserId,
 } from "../../auth/anthropicOAuth.js";
 import {
+  clearAccountCooldown,
+  loadAccountCooldowns,
+  saveAccountCooldown,
+} from "../../proxy/accountCooldown.js";
+import {
+  anthropicAccountKeysEqual,
+  ENV_ANTHROPIC_ACCOUNT_KEY,
+  isAccountAllowed,
+  LEGACY_ANTHROPIC_ACCOUNT_KEY,
+  shouldLoadFallbackCredential,
+} from "../../proxy/accountSelection.js";
+import {
+  getUnifiedRateLimitStatus,
   loadAccountQuotas,
   parseQuotaHeaders,
   saveAccountQuota,
@@ -56,6 +69,11 @@ import {
 } from "../../proxy/requestLogger.js";
 import { createSSEInterceptor } from "../../proxy/sseInterceptor.js";
 import {
+  createStreamTerminalOutcomeTracker,
+  mergeStreamTerminalOutcome,
+} from "../../proxy/streamOutcome.js";
+import {
+  isPermanentRefreshFailure,
   needsRefresh,
   persistTokens,
   refreshToken,
@@ -73,6 +91,7 @@ import {
   recordFinalSuccess,
 } from "../../proxy/usageStats.js";
 import type {
+  AccountAllowlist,
   AccountCooldownPlan,
   AccountQuota,
   AnthropicAttemptLogger,
@@ -99,6 +118,7 @@ import type {
   RouteGroup,
   RuntimeAccountState,
   ServerContext,
+  StreamTerminalOutcome,
 } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
 import { ProviderHealthChecker } from "../../utils/providerHealth.js";
@@ -130,9 +150,9 @@ let lastKnownAccountCount = 0;
  *  When undefined, home semantics fall back to enabledAccounts[0] (insertion
  *  order) — preserves pre-existing behavior. */
 let configuredPrimaryAccountKey: string | undefined;
+let configuredAccountAllowlist: AccountAllowlist | undefined;
 
 const MAX_AUTH_RETRIES = 5;
-const MAX_CONSECUTIVE_REFRESH_FAILURES = 15;
 const MAX_TRANSIENT_SAME_ACCOUNT_RETRIES = 2;
 const TRANSIENT_SAME_ACCOUNT_RETRY_DELAYS_MS = [250, 1_000] as const;
 
@@ -156,6 +176,11 @@ const MIN_COOLDOWN_MS = 5_000;
  *  we should return to the account soon rather than parking it for the full
  *  reset window. */
 const TRANSIENT_MAX_COOLDOWN_MS = 15 * 60 * 1000; // 15 minutes
+/** Fallback for authoritative rejected states that do not provide a usable
+ * reset or retry-after. These are not transient burst limits. */
+const DEFAULT_HARD_COOLDOWN_MS = 15 * 60 * 1000; // 15 minutes
+const AUTH_REFRESH_BASE_COOLDOWN_MS = 30_000;
+const AUTH_REFRESH_MAX_COOLDOWN_MS = 5 * 60 * 1000;
 /** Timeout for upstream requests to Anthropic. Must be generous enough
  *  to cover the full lifecycle of streaming responses, including extended
  *  thinking from Opus models (which can exceed 5 minutes for large contexts). */
@@ -196,11 +221,12 @@ function advancePrimaryIfCurrent(
  *  removed). The resolution is per-request because enabledAccounts membership
  *  can shift between requests. */
 function resolveHomeIndex(enabledAccounts: ProxyPassthroughAccount[]): number {
-  if (!configuredPrimaryAccountKey) {
+  const primaryAccountKey = configuredPrimaryAccountKey;
+  if (!primaryAccountKey) {
     return 0;
   }
-  const idx = enabledAccounts.findIndex(
-    (a) => a.key === configuredPrimaryAccountKey,
+  const idx = enabledAccounts.findIndex((a) =>
+    anthropicAccountKeysEqual(a.key, primaryAccountKey),
   );
   return idx >= 0 ? idx : 0;
 }
@@ -229,7 +255,12 @@ function maybeResetPrimaryToHome(
     // Home account is no longer cooling — reset to it
     primaryAccountIndex = homeIndex;
     if (homeState?.coolingUntil) {
+      const expiredCooldown = homeState.coolingUntil;
       homeState.coolingUntil = undefined;
+      homeState.coolingReason = undefined;
+      clearAccountCooldown(homeAccount.key, expiredCooldown).catch(() => {
+        // Best-effort cleanup; an expired entry is ignored on the next boot.
+      });
       logger.always(
         `[proxy] home primary account=${homeAccount.label} cooling expired, resetting primaryAccountIndex to ${homeIndex}`,
       );
@@ -290,6 +321,7 @@ function planCooldownFor429(
   quota: AccountQuota | null,
   retryAfterMs: number,
   now: number,
+  unifiedStatus: string | undefined = quota?.unifiedStatus,
 ): AccountCooldownPlan {
   // Weekly exhaustion takes precedence — it's the longest, hardest ceiling.
   if (quota && quota.weeklyStatus === "rejected") {
@@ -308,6 +340,18 @@ function planCooldownFor429(
       (retryAfterMs > 0 ? now + retryAfterMs : now + DEFAULT_COOLING_PERIOD_MS);
     return {
       reason: "session",
+      coolingUntil: clampCooldownUntil(reset, now),
+      rotateImmediately: true,
+    };
+  }
+  // Anthropic may reject the authoritative top-level unified limit while both
+  // 5h and 7d sub-window statuses still say "allowed". Treating this as a
+  // transient burst retries a known-exhausted account and delays failover.
+  if (unifiedStatus?.trim().toLowerCase() === "rejected") {
+    const reset =
+      retryAfterMs > 0 ? now + retryAfterMs : now + DEFAULT_HARD_COOLDOWN_MS;
+    return {
+      reason: "unified",
       coolingUntil: clampCooldownUntil(reset, now),
       rotateImmediately: true,
     };
@@ -341,7 +385,7 @@ function maybeCoolFromQuota(
   state: RuntimeAccountState,
   quota: AccountQuota,
   now: number,
-): void {
+): boolean {
   let until: number | undefined;
   let reason: RuntimeAccountState["coolingReason"];
   if (quota.weeklyStatus === "rejected") {
@@ -350,9 +394,12 @@ function maybeCoolFromQuota(
   } else if (quota.sessionStatus === "rejected") {
     until = resetEpochToMs(quota.sessionResetAt, now);
     reason = "session";
+  } else if (quota.unifiedStatus === "rejected") {
+    until = now + DEFAULT_HARD_COOLDOWN_MS;
+    reason = "unified";
   }
   if (until === undefined) {
-    return;
+    return false;
   }
   const clamped = clampCooldownUntil(until, now);
   if (!state.coolingUntil || clamped > state.coolingUntil) {
@@ -361,7 +408,9 @@ function maybeCoolFromQuota(
     logger.always(
       `[proxy] proactively cooling account (${reason}) ~${minutesUntil(clamped, now)}m from success-response quota (status rejected)`,
     );
+    return true;
   }
+  return false;
 }
 
 /**
@@ -378,11 +427,24 @@ async function seedRuntimeQuotasFromDisk(
   accounts: ProxyPassthroughAccount[],
 ): Promise<void> {
   try {
-    const persisted = await loadAccountQuotas();
+    const [persistedQuotas, persistedCooldowns] = await Promise.all([
+      loadAccountQuotas(),
+      loadAccountCooldowns(),
+    ]);
+    const now = Date.now();
     for (const account of accounts) {
       const state = getOrCreateRuntimeState(account.key);
-      if (!state.quota && persisted[account.label]) {
-        state.quota = persisted[account.label];
+      if (!state.quota && persistedQuotas[account.label]) {
+        state.quota = persistedQuotas[account.label];
+      }
+      const persistedCooldown = persistedCooldowns[account.key];
+      if (
+        persistedCooldown?.coolingUntil > now &&
+        (!state.coolingUntil ||
+          persistedCooldown.coolingUntil > state.coolingUntil)
+      ) {
+        state.coolingUntil = persistedCooldown.coolingUntil;
+        state.coolingReason = persistedCooldown.reason;
       }
     }
   } catch {
@@ -937,6 +999,7 @@ function polyfillOAuthBody(
 
 async function tryLoadLegacyAccount(
   creds: {
+    email?: string;
     oauth?: { accessToken?: string; refreshToken?: string; expiresAt?: number };
   },
   legacyCredPath: string,
@@ -948,23 +1011,52 @@ async function tryLoadLegacyAccount(
   let legacyToken = creds.oauth.accessToken;
   let legacyRefresh = creds.oauth.refreshToken;
   let legacyExpiry = creds.oauth.expiresAt;
+  const legacyLabel = creds.email?.trim() || "legacy-default";
   const legacyExpired = legacyExpiry ? legacyExpiry < Date.now() : false;
+  const legacyAccount = (): ProxyPassthroughAccount => ({
+    key: LEGACY_ANTHROPIC_ACCOUNT_KEY,
+    label: legacyLabel,
+    token: legacyToken,
+    refreshToken: legacyRefresh,
+    expiresAt: legacyExpiry,
+    type: "oauth",
+    persistTarget: { credPath: legacyCredPath },
+  });
 
   if (!legacyExpired) {
-    return {
-      key: "anthropic:legacy-default",
-      label: "default",
-      token: legacyToken,
-      refreshToken: legacyRefresh,
-      expiresAt: legacyExpiry,
-      type: "oauth",
-      persistTarget: { credPath: legacyCredPath },
-    };
+    return legacyAccount();
+  }
+
+  const state = getOrCreateRuntimeState(LEGACY_ANTHROPIC_ACCOUNT_KEY);
+  if (state.permanentlyDisabled) {
+    return undefined;
+  }
+  const persistedCooldown = (await loadAccountCooldowns())[
+    LEGACY_ANTHROPIC_ACCOUNT_KEY
+  ];
+  if (
+    persistedCooldown?.coolingUntil > Date.now() &&
+    (!state.coolingUntil || persistedCooldown.coolingUntil > state.coolingUntil)
+  ) {
+    state.coolingUntil = persistedCooldown.coolingUntil;
+    state.coolingReason = persistedCooldown.reason;
+  }
+  if (
+    state.coolingReason === "auth" &&
+    state.coolingUntil &&
+    state.coolingUntil > Date.now()
+  ) {
+    return legacyAccount();
   }
 
   if (!legacyRefresh) {
     logger.always(
       "[proxy] skipping legacy account (expired, no refresh token)",
+    );
+    await disableAccountUntilReauth(
+      legacyAccount(),
+      state,
+      "missing_refresh_token",
     );
     return undefined;
   }
@@ -973,31 +1065,36 @@ async function tryLoadLegacyAccount(
     token: legacyToken,
     refreshToken: legacyRefresh,
     expiresAt: legacyExpiry,
-    label: "default",
+    label: legacyLabel,
   };
   const ok = await refreshToken(tmp);
   if (!ok.success) {
-    logger.always(
-      `[proxy] skipping legacy account (expired, refresh failed: ${ok.error?.slice(0, 200) ?? "unknown"})`,
+    if (isPermanentRefreshFailure(ok)) {
+      await disableAccountUntilReauth(
+        legacyAccount(),
+        state,
+        "refresh_invalid",
+      );
+      return undefined;
+    }
+    const coolingUntil = await coolAccountAfterTransientRefreshFailure(
+      legacyAccount(),
+      state,
     );
-    return undefined;
+    logger.always(
+      `[proxy] legacy refresh temporarily unavailable (${ok.status ?? "network"}); cooling until ${new Date(coolingUntil).toISOString()}`,
+    );
+    return legacyAccount();
   }
 
   legacyToken = tmp.token;
   legacyRefresh = tmp.refreshToken;
   legacyExpiry = tmp.expiresAt;
   await persistTokens(legacyCredPath, tmp);
+  await clearAuthCooldownAfterRefresh(legacyAccount(), state);
   logger.always("[proxy] refreshed legacy account at startup");
 
-  return {
-    key: "anthropic:legacy-default",
-    label: "default",
-    token: legacyToken,
-    refreshToken: legacyRefresh,
-    expiresAt: legacyExpiry,
-    type: "oauth",
-    persistTarget: { credPath: legacyCredPath },
-  };
+  return legacyAccount();
 }
 
 async function handleTranslatedClaudeRequest(args: {
@@ -1242,6 +1339,46 @@ async function handleClaudePassthroughRequest(args: {
   });
 }
 
+function trackUpstreamReadableStream(source: ReadableStream<Uint8Array>): {
+  stream: ReadableStream<Uint8Array>;
+  outcome: Promise<StreamTerminalOutcome>;
+} {
+  const reader = source.getReader();
+  const tracker = createStreamTerminalOutcomeTracker();
+  let closed = false;
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (closed) {
+        return;
+      }
+      try {
+        const { done, value } = await reader.read();
+        if (closed) {
+          return;
+        }
+        if (done) {
+          closed = true;
+          tracker.complete();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        closed = true;
+        const message = error instanceof Error ? error.message : String(error);
+        tracker.fail(message);
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      closed = true;
+      tracker.cancel();
+      return reader.cancel(reason);
+    },
+  });
+  return { stream, outcome: tracker.outcome };
+}
+
 async function handleClaudePassthroughStreamResponse(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
@@ -1273,7 +1410,8 @@ async function handleClaudePassthroughStreamResponse(args: {
   if (!responseBody) {
     throw new Error("Expected passthrough stream response body");
   }
-  let streamSource: ReadableStream<Uint8Array> = responseBody;
+  const trackedStream = trackUpstreamReadableStream(responseBody);
+  let streamSource: ReadableStream<Uint8Array> = trackedStream.stream;
 
   if (tracer) {
     try {
@@ -1286,8 +1424,13 @@ async function handleClaudePassthroughStreamResponse(args: {
       const capturedResponse = response;
       const capturedRequestBytes = bodyStr.length;
 
-      Promise.all([telemetry, clientCapture])
-        .then(([data, clientBody]) => {
+      Promise.all([telemetry, clientCapture, trackedStream.outcome])
+        .then(([data, clientBody, rawOutcome]) => {
+          const terminalOutcome = mergeStreamTerminalOutcome(
+            rawOutcome,
+            data.streamErrorMessage,
+          );
+          const failure = getStreamFailureDetails(terminalOutcome);
           capturedTracer.setUsage({
             inputTokens: data.usage.inputTokens,
             outputTokens: data.usage.outputTokens,
@@ -1330,7 +1473,13 @@ async function handleClaudePassthroughStreamResponse(args: {
             data.totalBytesReceived,
           );
           capturedUpstreamSpan?.end();
-          capturedTracer.end(200, Date.now() - requestStartTime);
+          if (failure) {
+            capturedTracer.setError(failure.errorType, failure.message);
+          }
+          capturedTracer.end(
+            failure?.status ?? response.status,
+            Date.now() - requestStartTime,
+          );
 
           const traceCtx = capturedTracer.getTraceContext();
           logRequest({
@@ -1343,7 +1492,7 @@ async function handleClaudePassthroughStreamResponse(args: {
             toolCount,
             account: "passthrough",
             accountType: "passthrough",
-            responseStatus: 200,
+            responseStatus: failure?.status ?? response.status,
             responseTimeMs: Date.now() - requestStartTime,
             inputTokens: data.usage.inputTokens,
             outputTokens: data.usage.outputTokens,
@@ -1351,6 +1500,12 @@ async function handleClaudePassthroughStreamResponse(args: {
             cacheReadTokens: data.usage.cacheReadInputTokens,
             traceId: traceCtx.traceId,
             spanId: traceCtx.spanId,
+            ...(failure
+              ? {
+                  errorType: failure.errorType,
+                  errorMessage: failure.message,
+                }
+              : {}),
           });
           logProxyBody({
             phase: "upstream_response",
@@ -1406,39 +1561,145 @@ async function handleClaudePassthroughStreamResponse(args: {
           });
         });
     } catch {
-      // Streaming capture is best-effort.
+      trackedStream.outcome.then((outcome) => {
+        const failure = getStreamFailureDetails(outcome);
+        upstreamSpan?.end();
+        if (failure) {
+          tracer.setError(failure.errorType, failure.message);
+        }
+        tracer.end(
+          failure?.status ?? response.status,
+          Date.now() - requestStartTime,
+        );
+        const traceCtx = tracer.getTraceContext();
+        logRequest({
+          timestamp: new Date().toISOString(),
+          requestId: ctx.requestId,
+          method: ctx.method,
+          path: ctx.path,
+          model: body.model,
+          stream: true,
+          toolCount,
+          account: "passthrough",
+          accountType: "passthrough",
+          responseStatus: failure?.status ?? response.status,
+          responseTimeMs: Date.now() - requestStartTime,
+          traceId: traceCtx.traceId,
+          spanId: traceCtx.spanId,
+          ...(failure
+            ? {
+                errorType: failure.errorType,
+                errorMessage: failure.message,
+              }
+            : {}),
+        });
+      });
     }
   } else {
-    clientCapture
-      .then((clientBody) => {
-        logProxyBody({
-          phase: "upstream_response",
-          headers: responseHeaders,
-          body: clientBody.text,
-          bodySize: clientBody.totalBytes,
-          contentType: responseHeaders["content-type"] ?? "text/event-stream",
-          account: "passthrough",
-          accountType: "passthrough",
-          attempt: 1,
-          responseStatus: 200,
-          durationMs: Date.now() - requestStartTime,
-        });
-        logProxyBody({
-          phase: "client_response",
-          headers: responseHeaders,
-          body: clientBody.text,
-          bodySize: clientBody.totalBytes,
-          contentType: responseHeaders["content-type"] ?? "text/event-stream",
-          account: "passthrough",
-          accountType: "passthrough",
-          attempt: 1,
-          responseStatus: 200,
-          durationMs: Date.now() - requestStartTime,
-        });
-      })
-      .catch(() => {
-        // Non-fatal
+    try {
+      const { stream: interceptor, telemetry } = createSSEInterceptor({
+        captureRawText: true,
       });
+      streamSource = streamSource.pipeThrough(interceptor);
+      Promise.all([telemetry, clientCapture, trackedStream.outcome])
+        .then(([data, clientBody, rawOutcome]) => {
+          const terminalOutcome = mergeStreamTerminalOutcome(
+            rawOutcome,
+            data.streamErrorMessage,
+          );
+          const failure = getStreamFailureDetails(terminalOutcome);
+          logRequest({
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            method: ctx.method,
+            path: ctx.path,
+            model: body.model,
+            stream: true,
+            toolCount,
+            account: "passthrough",
+            accountType: "passthrough",
+            responseStatus: failure?.status ?? response.status,
+            responseTimeMs: Date.now() - requestStartTime,
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+            ...(failure
+              ? {
+                  errorType: failure.errorType,
+                  errorMessage: failure.message,
+                }
+              : {}),
+          });
+          logProxyBody({
+            phase: "upstream_response",
+            headers: responseHeaders,
+            body: data.rawText ?? "",
+            bodySize: data.totalBytesReceived,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: "passthrough",
+            accountType: "passthrough",
+            attempt: 1,
+            responseStatus: response.status,
+            durationMs: Date.now() - requestStartTime,
+          });
+          logProxyBody({
+            phase: "client_response",
+            headers: responseHeaders,
+            body: clientBody.text,
+            bodySize: clientBody.totalBytes,
+            contentType: responseHeaders["content-type"] ?? "text/event-stream",
+            account: "passthrough",
+            accountType: "passthrough",
+            attempt: 1,
+            responseStatus: response.status,
+            durationMs: Date.now() - requestStartTime,
+          });
+        })
+        .catch((error) => {
+          logRequest({
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            method: ctx.method,
+            path: ctx.path,
+            model: body.model,
+            stream: true,
+            toolCount,
+            account: "passthrough",
+            accountType: "passthrough",
+            responseStatus: 500,
+            responseTimeMs: Date.now() - requestStartTime,
+            errorType: "stream_telemetry_error",
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+          });
+        });
+    } catch {
+      // Streaming capture is best-effort; the tracked source still propagates
+      // the transport failure to the client.
+      trackedStream.outcome.then((outcome) => {
+        const failure = getStreamFailureDetails(outcome);
+        logRequest({
+          timestamp: new Date().toISOString(),
+          requestId: ctx.requestId,
+          method: ctx.method,
+          path: ctx.path,
+          model: body.model,
+          stream: true,
+          toolCount,
+          account: "passthrough",
+          accountType: "passthrough",
+          responseStatus: failure?.status ?? response.status,
+          responseTimeMs: Date.now() - requestStartTime,
+          ...(failure
+            ? {
+                errorType: failure.errorType,
+                errorMessage: failure.message,
+              }
+            : {}),
+        });
+      });
+    }
   }
 
   const clientStream = streamSource.pipeThrough(clientCaptureStream);
@@ -1605,6 +1866,7 @@ async function loadClaudeProxyAccounts(args: {
   const accounts: ProxyPassthroughAccount[] = [];
   const legacyCredPath = `${(os as typeof import("os")).homedir()}/.neurolink/anthropic-credentials.json`;
   const { tokenStore } = await import("../../auth/tokenStore.js");
+  const persistedCooldowns = await loadAccountCooldowns();
 
   if (!startupPruneDone) {
     await tokenStore.pruneExpired();
@@ -1613,20 +1875,23 @@ async function loadClaudeProxyAccounts(args: {
 
   const compoundKeys = await tokenStore.listByPrefix("anthropic:");
   for (const key of compoundKeys) {
+    if (!isAccountAllowed(key, configuredAccountAllowlist)) {
+      logger.debug(
+        `[proxy] skipping account=${key} (not in account allowlist)`,
+      );
+      continue;
+    }
     if (await tokenStore.isDisabled(key)) {
       const existingState = getOrCreateRuntimeState(key);
-      const tokens = await tokenStore.loadTokens(key);
-      const hasTrackedTokens =
-        existingState.lastToken !== undefined && existingState.lastToken !== "";
-      const tokenChanged =
-        tokens &&
-        hasTrackedTokens &&
-        (existingState.lastToken !== tokens.accessToken ||
-          existingState.lastRefreshToken !== tokens.refreshToken);
-      if (tokenChanged) {
+      const disabledReason = await tokenStore.getDisabledReason(key);
+      // Older releases permanently disabled accounts after any refresh error,
+      // including timeouts, 429s and 5xx responses. Re-evaluate those legacy
+      // entries once under the terminal/transient classifier below.
+      const legacyTransientDisable = disabledReason === "refresh_failed";
+      if (legacyTransientDisable) {
         await tokenStore.markEnabled(key);
         logger.always(
-          `[proxy] account=${key.split(":")[1] ?? key} re-enabled (credentials changed)`,
+          `[proxy] account=${key.split(":")[1] ?? key} re-enabled for legacy refresh failure recheck`,
         );
         existingState.permanentlyDisabled = false;
         existingState.consecutiveRefreshFailures = 0;
@@ -1647,12 +1912,44 @@ async function loadClaudeProxyAccounts(args: {
     let accessToken = tokens.accessToken;
     let refreshTok = tokens.refreshToken;
     let expiresAt = tokens.expiresAt;
+    const label = key.split(":")[1] ?? key;
+    const accountType: "oauth" | "api_key" =
+      tokens.tokenType === "Bearer" ? "oauth" : "api_key";
+    const existingState = getOrCreateRuntimeState(key);
+    const persistedCooldown = persistedCooldowns[key];
+    if (
+      persistedCooldown?.coolingUntil > Date.now() &&
+      (!existingState.coolingUntil ||
+        persistedCooldown.coolingUntil > existingState.coolingUntil)
+    ) {
+      existingState.coolingUntil = persistedCooldown.coolingUntil;
+      existingState.coolingReason = persistedCooldown.reason;
+    }
+
+    const addAccount = (): void => {
+      accounts.push({
+        key,
+        label,
+        token: accessToken,
+        refreshToken: refreshTok,
+        expiresAt,
+        type: accountType,
+        persistTarget: { providerKey: key },
+      });
+    };
     const isExpired = expiresAt ? expiresAt < Date.now() : false;
 
     if (isExpired) {
-      const label = key.split(":")[1] ?? key;
-      const existingState = getOrCreateRuntimeState(key);
       if (existingState.permanentlyDisabled) {
+        continue;
+      }
+
+      if (
+        existingState.coolingReason === "auth" &&
+        existingState.coolingUntil &&
+        existingState.coolingUntil > Date.now()
+      ) {
+        addAccount();
         continue;
       }
 
@@ -1663,6 +1960,7 @@ async function loadClaudeProxyAccounts(args: {
         await disableAccountUntilReauth(
           { key, label, token: accessToken, type: "oauth" },
           existingState,
+          "missing_refresh_token",
         );
         continue;
       }
@@ -1675,13 +1973,31 @@ async function loadClaudeProxyAccounts(args: {
       };
       const refreshed = await refreshToken(tempAccount);
       if (!refreshed.success) {
-        logger.always(
-          `[proxy] skipping account=${label} (expired, refresh failed: ${refreshed.error?.slice(0, 200) ?? "unknown"})`,
-        );
-        await disableAccountUntilReauth(
-          { key, label, token: accessToken, type: "oauth" },
-          existingState,
-        );
+        const account = {
+          key,
+          label,
+          token: accessToken,
+          type: "oauth",
+        } as const;
+        if (isPermanentRefreshFailure(refreshed)) {
+          logger.always(
+            `[proxy] skipping account=${label} (refresh token rejected: ${refreshed.error?.slice(0, 200) ?? "unknown"})`,
+          );
+          await disableAccountUntilReauth(
+            account,
+            existingState,
+            "refresh_invalid",
+          );
+        } else {
+          const coolingUntil = await coolAccountAfterTransientRefreshFailure(
+            account,
+            existingState,
+          );
+          logger.always(
+            `[proxy] account=${label} refresh temporarily unavailable (${refreshed.status ?? "network"}); cooling until ${new Date(coolingUntil).toISOString()} and rotating`,
+          );
+          addAccount();
+        }
         continue;
       }
 
@@ -1697,27 +2013,25 @@ async function loadClaudeProxyAccounts(args: {
       logger.always(
         `[proxy] refreshed expired account=${key.split(":")[1] ?? key} at startup`,
       );
+      await clearAuthCooldownAfterRefresh({ key }, existingState);
     }
 
-    const accountType: "oauth" | "api_key" =
-      tokens.tokenType === "Bearer" ? "oauth" : "api_key";
-
-    accounts.push({
-      key,
-      label: key.split(":")[1] ?? key,
-      token: accessToken,
-      refreshToken: refreshTok,
-      expiresAt,
-      type: accountType,
-      persistTarget: { providerKey: key },
-    });
+    addAccount();
   }
 
-  if (accounts.length === 0) {
+  if (
+    accounts.length === 0 &&
+    shouldLoadFallbackCredential(
+      compoundKeys.length,
+      LEGACY_ANTHROPIC_ACCOUNT_KEY,
+      configuredAccountAllowlist,
+    )
+  ) {
     try {
       const creds = JSON.parse(
         (fs as typeof import("fs")).readFileSync(legacyCredPath, "utf8"),
       ) as {
+        email?: string;
         oauth?: {
           accessToken?: string;
           refreshToken?: string;
@@ -1733,9 +2047,17 @@ async function loadClaudeProxyAccounts(args: {
     }
   }
 
-  if (process.env.ANTHROPIC_API_KEY && accounts.length === 0) {
+  if (
+    process.env.ANTHROPIC_API_KEY &&
+    accounts.length === 0 &&
+    shouldLoadFallbackCredential(
+      compoundKeys.length,
+      ENV_ANTHROPIC_ACCOUNT_KEY,
+      configuredAccountAllowlist,
+    )
+  ) {
     accounts.push({
-      key: "anthropic:env",
+      key: ENV_ANTHROPIC_ACCOUNT_KEY,
       label: "env",
       token: process.env.ANTHROPIC_API_KEY,
       type: "api_key",
@@ -1743,10 +2065,15 @@ async function loadClaudeProxyAccounts(args: {
   }
 
   if (accounts.length === 0) {
-    tracer?.setError("authentication_error", "No Anthropic credentials found");
+    const noCredentialsMessage = configuredAccountAllowlist
+      ? "No allowed Anthropic credentials are currently available"
+      : compoundKeys.length > 0
+        ? "Configured Anthropic accounts are disabled or unavailable"
+        : "No Anthropic credentials found";
+    tracer?.setError("authentication_error", noCredentialsMessage);
     tracer?.end(401, Date.now() - requestStartTime);
     return {
-      response: buildLoggedClaudeError(401, "No Anthropic credentials found"),
+      response: buildLoggedClaudeError(401, noCredentialsMessage),
     };
   }
 
@@ -1758,9 +2085,11 @@ async function loadClaudeProxyAccounts(args: {
     if (tokenChanged) {
       if (state.permanentlyDisabled) {
         logger.always(
-          `[proxy] account=${account.label} credentials changed, re-enabling`,
+          `[proxy] account=${account.label} eligible credentials reloaded; clearing stale runtime auth-disable state`,
         );
       }
+      // Eligibility was already resolved while loading accounts. This only
+      // clears stale in-process auth state after an explicit credential reload.
       state.consecutiveRefreshFailures = 0;
       state.permanentlyDisabled = false;
     }
@@ -2215,6 +2544,7 @@ function buildClaudeAnthropicFailureResponse(args: {
   tracer?: ProxyTracer;
   requestStartTime: number;
   authFailureMessage: string | null;
+  authCooldownMessage: string | null;
   invalidRequestFailure: {
     status: number;
     body: string;
@@ -2245,6 +2575,7 @@ function buildClaudeAnthropicFailureResponse(args: {
     tracer,
     requestStartTime,
     authFailureMessage,
+    authCooldownMessage,
     invalidRequestFailure,
     sawNetworkError,
     sawTransientFailure,
@@ -2259,6 +2590,16 @@ function buildClaudeAnthropicFailureResponse(args: {
     tracer?.setError("authentication_error", authFailureMessage);
     tracer?.end(401, Date.now() - requestStartTime);
     return buildLoggedClaudeError(401, authFailureMessage);
+  }
+
+  if (authCooldownMessage && !sawRateLimit) {
+    tracer?.setError("token_refresh_unavailable", authCooldownMessage);
+    tracer?.end(503, Date.now() - requestStartTime);
+    return buildLoggedClaudeError(
+      503,
+      authCooldownMessage,
+      "token_refresh_unavailable",
+    );
   }
 
   if (invalidRequestFailure) {
@@ -2321,10 +2662,29 @@ function buildClaudeAnthropicFailureResponse(args: {
     return buildLoggedClaudeError(502, msg);
   }
 
-  // All accounts returned 429 after exhausting per-account retries.
-  // Return 1s retry-after — the proxy already waited for each upstream retry-after inline.
-  const retryAfterSec = 1;
-  const errorMessage = `All ${orderedAccounts.length} accounts rate-limited after ${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES + 1} attempts each (1 initial + ${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES} retries).`;
+  const now = Date.now();
+  const activeRateLimitCooldowns = orderedAccounts
+    .map((account) => getOrCreateRuntimeState(account.key))
+    .filter(
+      (state) =>
+        state.coolingUntil &&
+        state.coolingUntil > now &&
+        state.coolingReason !== "auth",
+    );
+  const earliestRetryAt = Math.min(
+    ...activeRateLimitCooldowns.map(
+      (state) => state.coolingUntil ?? Number.POSITIVE_INFINITY,
+    ),
+  );
+  const allAccountsCooling =
+    orderedAccounts.length > 0 &&
+    activeRateLimitCooldowns.length === orderedAccounts.length;
+  const retryAfterSec = allAccountsCooling
+    ? Math.max(1, Math.ceil((earliestRetryAt - now) / 1000))
+    : 1;
+  const errorMessage = allAccountsCooling
+    ? `All ${orderedAccounts.length} Anthropic accounts are cooling after upstream rate limits. Earliest retry at ${new Date(earliestRetryAt).toISOString()}.`
+    : `All ${orderedAccounts.length} accounts rate-limited after per-account retries.`;
   logger.always(
     `[proxy] all accounts rate-limited, retry in ${retryAfterSec}s`,
   );
@@ -2406,7 +2766,16 @@ async function handleAnthropicSuccessfulResponse(args: {
     // account whose window resets soonest (max-utilization) and proactively
     // skip any whose window is already rejected — without eating a 429 first.
     accountState.quota = quota;
-    maybeCoolFromQuota(accountState, quota, Date.now());
+    if (maybeCoolFromQuota(accountState, quota, Date.now())) {
+      const { coolingUntil, coolingReason } = accountState;
+      if (coolingUntil !== undefined && coolingReason !== undefined) {
+        saveAccountCooldown(account.key, coolingUntil, coolingReason).catch(
+          () => {
+            // Non-fatal: cooldown is already active in memory.
+          },
+        );
+      }
+    }
     saveAccountQuota(account.label, quota).catch(() => {
       // Non-fatal: quota persistence is best-effort
     });
@@ -2526,9 +2895,35 @@ async function handleAnthropicStreamingSuccessResponse(args: {
   }
 
   const reader = response.body.getReader();
-  const firstChunk = await reader.read();
+  let firstChunk: ReadableStreamReadResult<Uint8Array>;
+  try {
+    firstChunk = await reader.read();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.always(
+      `[proxy] stream failed before first chunk account=${account.label}: ${message}; trying next account`,
+    );
+    recordAttemptError(account.label, account.type, 502);
+    tracer?.recordRetry(account.label, "stream_before_first_chunk");
+    upstreamSpan?.end();
+    logProxyBody({
+      phase: "upstream_response",
+      headers: responseHeaders,
+      body: message,
+      bodySize: Buffer.byteLength(message, "utf8"),
+      contentType: responseHeaders["content-type"] ?? "text/event-stream",
+      account: account.label,
+      accountType: account.type,
+      attempt: attemptNumber,
+      responseStatus: 502,
+      durationMs: Date.now() - fetchStartMs,
+    });
+    return { retryNextAccount: true };
+  }
   if (firstChunk.done || !firstChunk.value || firstChunk.value.length === 0) {
-    reader.cancel();
+    await reader.cancel().catch(() => {
+      // Best-effort release before rotating to another account.
+    });
     logger.always(
       `[proxy] ← empty stream from account=${account.label}, trying next`,
     );
@@ -2537,6 +2932,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     return { retryNextAccount: true };
   }
 
+  const streamOutcomeTracker = createStreamTerminalOutcomeTracker();
   let mainStreamClosed = false;
   const remainingStream = new ReadableStream({
     start(controller) {
@@ -2553,6 +2949,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
         }
         if (done) {
           mainStreamClosed = true;
+          streamOutcomeTracker.complete();
           controller.close();
           return;
         }
@@ -2563,6 +2960,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
         logger.always(
           `[proxy] mid-stream error account=${account.label}: ${errMsg}`,
         );
+        streamOutcomeTracker.fail(errMsg);
         logStreamError({
           timestamp: new Date().toISOString(),
           requestId: ctx.requestId,
@@ -2581,7 +2979,8 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     },
     cancel() {
       mainStreamClosed = true;
-      reader.cancel();
+      streamOutcomeTracker.cancel();
+      return reader.cancel();
     },
   });
 
@@ -2590,6 +2989,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     response,
     responseHeaders,
     remainingStream,
+    streamOutcome: streamOutcomeTracker.outcome,
     tracer,
     requestStartTime,
     attemptNumber,
@@ -2601,11 +3001,32 @@ async function handleAnthropicStreamingSuccessResponse(args: {
   return { response: result };
 }
 
+function getStreamFailureDetails(
+  outcome: StreamTerminalOutcome,
+): { status: number; errorType: string; message: string } | undefined {
+  if (outcome.kind === "upstream_error") {
+    return {
+      status: 502,
+      errorType: "stream_error",
+      message: outcome.message,
+    };
+  }
+  if (outcome.kind === "client_cancelled") {
+    return {
+      status: 499,
+      errorType: "client_cancelled",
+      message: "Client cancelled the streaming response",
+    };
+  }
+  return undefined;
+}
+
 function attachAnthropicSuccessStreamTelemetry(args: {
   account: ProxyPassthroughAccount;
   response: Response;
   responseHeaders: Record<string, string>;
   remainingStream: ReadableStream<Uint8Array>;
+  streamOutcome: Promise<StreamTerminalOutcome>;
   tracer?: ProxyTracer;
   requestStartTime: number;
   attemptNumber: number;
@@ -2631,6 +3052,7 @@ function attachAnthropicSuccessStreamTelemetry(args: {
     response,
     responseHeaders,
     remainingStream,
+    streamOutcome,
     tracer,
     requestStartTime,
     attemptNumber,
@@ -2655,8 +3077,12 @@ function attachAnthropicSuccessStreamTelemetry(args: {
       const capturedRequestBytes = finalBodyStr.length;
       const capturedAccountLabel = account.label;
 
-      Promise.all([telemetry, clientCapture])
-        .then(([data, clientBody]) => {
+      Promise.all([telemetry, clientCapture, streamOutcome])
+        .then(([data, clientBody, rawOutcome]) => {
+          const terminalOutcome = mergeStreamTerminalOutcome(
+            rawOutcome,
+            data.streamErrorMessage,
+          );
           capturedTracer.setUsage({
             inputTokens: data.usage.inputTokens,
             outputTokens: data.usage.outputTokens,
@@ -2698,21 +3124,41 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             data.totalBytesReceived,
           );
           capturedUpstreamSpan?.end();
-          capturedTracer.end(200, Date.now() - requestStartTime);
-          recordFinalSuccess(capturedAccountLabel, account.type);
-          logFinalRequest(
-            200,
-            capturedAccountLabel,
-            account.type,
-            undefined,
-            undefined,
-            {
-              inputTokens: data.usage.inputTokens,
-              outputTokens: data.usage.outputTokens,
-              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-              cacheReadTokens: data.usage.cacheReadInputTokens,
-            },
-          );
+          const failure = getStreamFailureDetails(terminalOutcome);
+          const usage = {
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          };
+          if (failure) {
+            capturedTracer.setError(failure.errorType, failure.message);
+            capturedTracer.end(failure.status, Date.now() - requestStartTime);
+            recordFinalError(
+              failure.status,
+              capturedAccountLabel,
+              account.type,
+            );
+            logFinalRequest(
+              failure.status,
+              capturedAccountLabel,
+              account.type,
+              failure.errorType,
+              failure.message,
+              usage,
+            );
+          } else {
+            capturedTracer.end(200, Date.now() - requestStartTime);
+            recordFinalSuccess(capturedAccountLabel, account.type);
+            logFinalRequest(
+              200,
+              capturedAccountLabel,
+              account.type,
+              undefined,
+              undefined,
+              usage,
+            );
+          }
           logProxyBody({
             phase: "upstream_response",
             headers: responseHeaders,
@@ -2755,7 +3201,28 @@ function attachAnthropicSuccessStreamTelemetry(args: {
           );
         });
     } catch {
-      // Interceptor attachment failed after stream setup; response handling continues.
+      // Interceptor attachment failed after stream setup. Preserve delivery but
+      // still settle the request from the actual stream terminal outcome.
+      streamOutcome.then((outcome) => {
+        const failure = getStreamFailureDetails(outcome);
+        upstreamSpan?.end();
+        if (failure) {
+          tracer.setError(failure.errorType, failure.message);
+          tracer.end(failure.status, Date.now() - requestStartTime);
+          recordFinalError(failure.status, account.label, account.type);
+          logFinalRequest(
+            failure.status,
+            account.label,
+            account.type,
+            failure.errorType,
+            failure.message,
+          );
+        } else {
+          tracer.end(response.status, Date.now() - requestStartTime);
+          recordFinalSuccess(account.label, account.type);
+          logFinalRequest(response.status, account.label, account.type);
+        }
+      });
     }
   } else {
     upstreamSpan?.end();
@@ -2766,22 +3233,44 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         });
       streamSource = streamSource.pipeThrough(noTracerInterceptor);
       const capturedAccountLabel = account.label;
-      Promise.all([noTracerTelemetry, clientCapture])
-        .then(([data, clientBody]) => {
-          recordFinalSuccess(capturedAccountLabel, account.type);
-          logFinalRequest(
-            200,
-            capturedAccountLabel,
-            account.type,
-            undefined,
-            undefined,
-            {
-              inputTokens: data.usage.inputTokens,
-              outputTokens: data.usage.outputTokens,
-              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-              cacheReadTokens: data.usage.cacheReadInputTokens,
-            },
+      Promise.all([noTracerTelemetry, clientCapture, streamOutcome])
+        .then(([data, clientBody, rawOutcome]) => {
+          const terminalOutcome = mergeStreamTerminalOutcome(
+            rawOutcome,
+            data.streamErrorMessage,
           );
+          const failure = getStreamFailureDetails(terminalOutcome);
+          const usage = {
+            inputTokens: data.usage.inputTokens,
+            outputTokens: data.usage.outputTokens,
+            cacheCreationTokens: data.usage.cacheCreationInputTokens,
+            cacheReadTokens: data.usage.cacheReadInputTokens,
+          };
+          if (failure) {
+            recordFinalError(
+              failure.status,
+              capturedAccountLabel,
+              account.type,
+            );
+            logFinalRequest(
+              failure.status,
+              capturedAccountLabel,
+              account.type,
+              failure.errorType,
+              failure.message,
+              usage,
+            );
+          } else {
+            recordFinalSuccess(capturedAccountLabel, account.type);
+            logFinalRequest(
+              200,
+              capturedAccountLabel,
+              account.type,
+              undefined,
+              undefined,
+              usage,
+            );
+          }
           logProxyBody({
             phase: "upstream_response",
             headers: responseHeaders,
@@ -2807,9 +3296,17 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             durationMs: Date.now() - requestStartTime,
           });
         })
-        .catch(() => {
-          recordFinalSuccess(account.label, account.type);
-          logFinalRequest(response.status, account.label, account.type);
+        .catch((error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          recordFinalError(500, account.label, account.type);
+          logFinalRequest(
+            500,
+            account.label,
+            account.type,
+            "stream_telemetry_error",
+            message,
+          );
         });
     } catch {
       clientCapture
@@ -2830,8 +3327,22 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         .catch(() => {
           // Non-fatal
         });
-      recordFinalSuccess(account.label, account.type);
-      logFinalRequest(response.status, account.label, account.type);
+      streamOutcome.then((outcome) => {
+        const failure = getStreamFailureDetails(outcome);
+        if (failure) {
+          recordFinalError(failure.status, account.label, account.type);
+          logFinalRequest(
+            failure.status,
+            account.label,
+            account.type,
+            failure.errorType,
+            failure.message,
+          );
+        } else {
+          recordFinalSuccess(account.label, account.type);
+          logFinalRequest(response.status, account.label, account.type);
+        }
+      });
     }
   }
 
@@ -3057,7 +3568,16 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
     // stash quota for proactive selection and proactively cool if this
     // response reveals the window flipped to "rejected".
     accountState.quota = retryQuota;
-    maybeCoolFromQuota(accountState, retryQuota, Date.now());
+    if (maybeCoolFromQuota(accountState, retryQuota, Date.now())) {
+      const { coolingUntil, coolingReason } = accountState;
+      if (coolingUntil !== undefined && coolingReason !== undefined) {
+        saveAccountCooldown(account.key, coolingUntil, coolingReason).catch(
+          () => {
+            // Non-fatal: cooldown is already active in memory.
+          },
+        );
+      }
+    }
     saveAccountQuota(account.label, retryQuota).catch((error) => {
       logger.debug("[proxy] Failed to persist account quota after auth retry", {
         account: account.label,
@@ -3068,6 +3588,7 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
 
   if (body.stream && retryResp.body) {
     const retryReader = retryResp.body.getReader();
+    const streamOutcomeTracker = createStreamTerminalOutcomeTracker();
     let retryStreamClosed = false;
     const retryStream = new ReadableStream({
       async pull(controller) {
@@ -3081,6 +3602,7 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
           }
           if (done) {
             retryStreamClosed = true;
+            streamOutcomeTracker.complete();
             controller.close();
             return;
           }
@@ -3091,6 +3613,7 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
           logger.always(
             `[proxy] mid-stream error (auth-retry) account=${account.label}: ${errMsg}`,
           );
+          streamOutcomeTracker.fail(errMsg);
           logStreamError({
             timestamp: new Date().toISOString(),
             requestId: ctx.requestId,
@@ -3109,97 +3632,24 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
       },
       cancel() {
         retryStreamClosed = true;
-        retryReader.cancel();
+        streamOutcomeTracker.cancel();
+        return retryReader.cancel();
       },
     });
 
-    let retryClientStream: ReadableStream<Uint8Array> = retryStream;
-    if (tracer) {
-      try {
-        const { stream: retryInterceptor, telemetry: retryTelemetry } =
-          createSSEInterceptor();
-        retryClientStream = retryStream.pipeThrough(retryInterceptor);
-        const capturedTracer = tracer;
-        const capturedUpstreamSpan = upstreamSpan;
-        const capturedRetryResp = retryResp;
-        const capturedRetryRequestBytes = finalBodyStr.length;
-        const capturedAccountLabel = account.label;
-        retryTelemetry
-          .then((data) => {
-            capturedTracer.setUsage({
-              inputTokens: data.usage.inputTokens,
-              outputTokens: data.usage.outputTokens,
-              cacheCreationTokens: data.usage.cacheCreationInputTokens,
-              cacheReadTokens: data.usage.cacheReadInputTokens,
-            });
-            capturedTracer.logStreamEvents(data.events);
-            capturedTracer.setResponseInfo(responseInfoFromStream(data));
-            capturedTracer.logUpstreamResponseHeaders(
-              Object.fromEntries([...capturedRetryResp.headers.entries()]),
-            );
-            capturedTracer.recordMetrics();
-            capturedTracer.recordBodySizes(
-              capturedRetryRequestBytes,
-              data.totalBytesReceived,
-            );
-            capturedUpstreamSpan?.end();
-            capturedTracer.end(200, Date.now() - requestStartTime);
-            recordFinalSuccess(capturedAccountLabel, account.type);
-            logFinalRequest(
-              200,
-              capturedAccountLabel,
-              account.type,
-              undefined,
-              undefined,
-              {
-                inputTokens: data.usage.inputTokens,
-                outputTokens: data.usage.outputTokens,
-                cacheCreationTokens: data.usage.cacheCreationInputTokens,
-                cacheReadTokens: data.usage.cacheReadInputTokens,
-              },
-            );
-          })
-          .catch((error) => {
-            capturedTracer.setError(
-              "stream_error",
-              error instanceof Error ? error.message : String(error),
-            );
-            capturedUpstreamSpan?.end();
-            capturedTracer.end(500, Date.now() - requestStartTime);
-            recordFinalError(500, capturedAccountLabel, account.type);
-            logFinalRequest(
-              500,
-              capturedAccountLabel,
-              account.type,
-              "stream_error",
-              error instanceof Error ? error.message : String(error),
-            );
-          });
-      } catch {
-        retryClientStream = retryStream;
-      }
-    }
-
-    const responseHeaders: Record<string, string> = {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache",
-      connection: "keep-alive",
-    };
-    for (const headerName of [
-      "retry-after",
-      "anthropic-ratelimit-requests-remaining",
-      "anthropic-ratelimit-requests-limit",
-      "anthropic-ratelimit-tokens-remaining",
-      "anthropic-ratelimit-tokens-limit",
-    ]) {
-      const value = retryResp.headers.get(headerName);
-      if (value) {
-        responseHeaders[headerName] = value;
-      }
-    }
-    return new Response(retryClientStream, {
-      status: retryResp.status,
-      headers: responseHeaders,
+    return attachAnthropicSuccessStreamTelemetry({
+      account,
+      response: retryResp,
+      responseHeaders: Object.fromEntries([...retryResp.headers.entries()]),
+      remainingStream: retryStream,
+      streamOutcome: streamOutcomeTracker.outcome,
+      tracer,
+      requestStartTime,
+      attemptNumber,
+      finalBodyStr,
+      upstreamSpan,
+      logProxyBody,
+      logFinalRequest,
     });
   }
 
@@ -3362,29 +3812,35 @@ async function handleAnthropicAuthRetry(args: {
     );
     const refreshSucceeded = await refreshToken(account);
     if (!refreshSucceeded.success) {
-      accountState.consecutiveRefreshFailures += 1;
       authRetryError = `refresh failed for account=${account.label} attempt ${authRetry + 1}/${MAX_AUTH_RETRIES}: ${refreshSucceeded.error?.slice(0, 200) ?? "unknown"}`;
       currentLastError = authRetryError;
-      logger.always(
-        `[proxy] ⚠ account=${account.label} refresh failed on attempt ${authRetry + 1}`,
-      );
-      if (
-        accountState.consecutiveRefreshFailures >=
-        MAX_CONSECUTIVE_REFRESH_FAILURES
-      ) {
-        await disableAccountUntilReauth(account, accountState);
+      if (isPermanentRefreshFailure(refreshSucceeded)) {
+        await disableAccountUntilReauth(
+          account,
+          accountState,
+          "refresh_invalid",
+        );
         currentAuthFailureMessage = formatReauthMessage(account.label);
-        break;
+        logger.always(
+          `[proxy] account=${account.label} refresh token rejected; disabled until re-authentication`,
+        );
+      } else {
+        const coolingUntil = await coolAccountAfterTransientRefreshFailure(
+          account,
+          accountState,
+        );
+        currentSawTransientFailure = true;
+        logger.always(
+          `[proxy] account=${account.label} refresh temporarily unavailable (${refreshSucceeded.status ?? "network"}); cooling until ${new Date(coolingUntil).toISOString()} and rotating`,
+        );
       }
-      if (authRetry < MAX_AUTH_RETRIES - 1) {
-        await sleep(2000);
-      }
-      continue;
+      break;
     }
 
     if (account.persistTarget) {
       await persistTokens(account.persistTarget, account);
     }
+    await clearAuthCooldownAfterRefresh(account, accountState);
     headers.authorization = `Bearer ${account.token}`;
 
     try {
@@ -3488,6 +3944,7 @@ async function handleAnthropicAuthRetry(args: {
           retryQuota429,
           parseRetryAfterMs(retryRespHeaders["retry-after"] ?? null),
           nowRetry,
+          getUnifiedRateLimitStatus(retryRespHeaders),
         );
         if (
           !accountState.coolingUntil ||
@@ -3496,6 +3953,18 @@ async function handleAnthropicAuthRetry(args: {
           accountState.coolingUntil = retryPlan.coolingUntil;
           accountState.coolingReason = retryPlan.reason;
         }
+        if (retryQuota429) {
+          saveAccountQuota(account.label, retryQuota429).catch(() => {
+            // Non-fatal: routing already has the in-memory snapshot.
+          });
+        }
+        await saveAccountCooldown(
+          account.key,
+          accountState.coolingUntil ?? retryPlan.coolingUntil,
+          accountState.coolingReason ?? retryPlan.reason,
+        ).catch(() => {
+          // Non-fatal: routing already has the in-memory cooldown.
+        });
         advancePrimaryIfCurrent(
           account.key,
           enabledAccounts.length,
@@ -3725,7 +4194,6 @@ async function handleAnthropicNonOkResponse(args: {
     body: string;
     contentType?: string;
   } | null;
-  maxConsecutiveRefreshFailures: number;
 }): Promise<AnthropicNonOkResult> {
   const {
     response,
@@ -3744,7 +4212,6 @@ async function handleAnthropicNonOkResponse(args: {
     authFailureMessage,
     sawTransientFailure,
     invalidRequestFailure,
-    maxConsecutiveRefreshFailures,
   } = args;
   let currentLastError = lastError;
   let currentAuthFailureMessage = authFailureMessage;
@@ -3805,12 +4272,11 @@ async function handleAnthropicNonOkResponse(args: {
     !account.refreshToken
   ) {
     recordAttemptError(account.label, account.type, response.status);
-    accountState.consecutiveRefreshFailures += 1;
-    if (
-      accountState.consecutiveRefreshFailures >= maxConsecutiveRefreshFailures
-    ) {
-      await disableAccountUntilReauth(account, accountState);
-    }
+    await disableAccountUntilReauth(
+      account,
+      accountState,
+      "missing_refresh_token",
+    );
     currentAuthFailureMessage = formatReauthMessage(account.label);
     logger.always(
       `[proxy] ← ${response.status} account=${account.label} (auth failure, no refresh token)`,
@@ -4173,26 +4639,31 @@ async function prepareAnthropicAccountAttempt(args: {
       if (account.persistTarget) {
         await persistTokens(account.persistTarget, account);
       }
-      accountState.consecutiveRefreshFailures = 0;
+      await clearAuthCooldownAfterRefresh(account, accountState);
     } else {
-      accountState.consecutiveRefreshFailures += 1;
       lastError = `token refresh failed for account=${account.label}: ${refreshed.error?.slice(0, 200) ?? "unknown"}`;
-      logger.debug(
-        `[proxy] preflight refresh failed account=${account.label} failures=${accountState.consecutiveRefreshFailures}`,
-      );
-      if (
-        accountState.consecutiveRefreshFailures >=
-        MAX_CONSECUTIVE_REFRESH_FAILURES
-      ) {
-        await disableAccountUntilReauth(account, accountState);
+      if (isPermanentRefreshFailure(refreshed)) {
+        await disableAccountUntilReauth(
+          account,
+          accountState,
+          "refresh_invalid",
+        );
         authFailureMessage = formatReauthMessage(account.label);
-        logAttempt(401, "authentication_error", String(lastError));
-        return {
-          continueLoop: true,
-          lastError,
-          authFailureMessage,
-        };
+      } else {
+        await coolAccountAfterTransientRefreshFailure(account, accountState);
       }
+      logAttempt(
+        isPermanentRefreshFailure(refreshed) ? 401 : 503,
+        isPermanentRefreshFailure(refreshed)
+          ? "authentication_error"
+          : "token_refresh_unavailable",
+        String(lastError),
+      );
+      return {
+        continueLoop: true,
+        lastError,
+        authFailureMessage,
+      };
     }
   }
 
@@ -4509,11 +4980,18 @@ async function fetchAnthropicAccountResponse(args: {
     // ACTUAL reset, not a 60s hardcap.
     const now = Date.now();
     const quota = parseQuotaHeaders(errRespHeaders);
-    const cooldownPlan = planCooldownFor429(quota, retryAfterMs, now);
+    const unifiedStatus = getUnifiedRateLimitStatus(errRespHeaders);
+    const cooldownPlan = planCooldownFor429(
+      quota,
+      retryAfterMs,
+      now,
+      unifiedStatus,
+    );
     logger.always(
       `[proxy] ← 429 account=${account.label} reason=${cooldownPlan.reason} ` +
         `retry-after=${retryAfterMs}ms 5h-status=${errRespHeaders["anthropic-ratelimit-unified-5h-status"] ?? "unknown"} ` +
         `7d-status=${errRespHeaders["anthropic-ratelimit-unified-7d-status"] ?? "unknown"} ` +
+        `unified-status=${unifiedStatus ?? "unknown"} ` +
         `→ ${cooldownPlan.rotateImmediately ? `rotate now, cool ${minutesUntil(cooldownPlan.coolingUntil, now)}m` : "retry same account (transient)"}`,
     );
     logAttempt(429, "rate_limit_error", String(lastError));
@@ -4596,6 +5074,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     sawTransientFailure: false,
     invalidRequestFailure: null,
     authFailureMessage: null,
+    authCooldownMessage: null,
     attemptNumber: 0,
   };
   const acctSelectionSpan = tracer?.startAccountSelection();
@@ -4611,13 +5090,34 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     maybeResetPrimaryToHome(enabledAccounts);
   }
 
-  // Skip accounts that are still cooling from a recent 429-exhaustion,
-  // but keep them as last-resort if ALL accounts are cooling.
+  // Never re-hammer accounts with a known active cooldown. When every account
+  // is cooling, report the earliest persisted retry time without an upstream
+  // call; restarting the proxy must not erase or bypass this quarantine.
   const nonCoolingAccounts = orderedAccounts.filter(
     (a) => !isAccountCooling(a.key),
   );
-  const effectiveAccounts =
-    nonCoolingAccounts.length > 0 ? nonCoolingAccounts : orderedAccounts;
+  const effectiveAccounts = nonCoolingAccounts;
+  if (effectiveAccounts.length === 0 && orderedAccounts.length > 0) {
+    const coolingStates = orderedAccounts.map((account) =>
+      getOrCreateRuntimeState(account.key),
+    );
+    const hasRateLimitCooldown = coolingStates.some(
+      (state) => state.coolingReason !== "auth",
+    );
+    loopState.sawRateLimit = hasRateLimitCooldown;
+    loopState.sawTransientFailure = !hasRateLimitCooldown;
+    loopState.lastError = hasRateLimitCooldown
+      ? "All Anthropic accounts have active rate-limit cooldowns"
+      : "All Anthropic accounts have active authentication cooldowns";
+    if (!hasRateLimitCooldown) {
+      const earliestRetryAt = Math.min(
+        ...coolingStates.map(
+          (state) => state.coolingUntil ?? Number.POSITIVE_INFINITY,
+        ),
+      );
+      loopState.authCooldownMessage = `All ${orderedAccounts.length} Anthropic accounts are temporarily unavailable while OAuth refresh is cooling. Earliest retry at ${new Date(earliestRetryAt).toISOString()}.`;
+    }
+  }
 
   accountLoop: for (const account of effectiveAccounts) {
     const accountState = getOrCreateRuntimeState(account.key);
@@ -4700,6 +5200,9 @@ async function handleAnthropicRoutedClaudeRequest(args: {
           // Refresh the account's quota snapshot for proactive selection.
           if (fetchResult.quota) {
             accountState.quota = fetchResult.quota;
+            saveAccountQuota(account.label, fetchResult.quota).catch(() => {
+              // Non-fatal: routing already has the in-memory snapshot.
+            });
           }
           // Transient burst (window still allowed): a couple of jittered
           // same-account retries before giving up. Exhaustion plans set
@@ -4736,6 +5239,13 @@ async function handleAnthropicRoutedClaudeRequest(args: {
             accountState.coolingUntil = plan.coolingUntil;
             accountState.coolingReason = plan.reason;
           }
+          await saveAccountCooldown(
+            account.key,
+            accountState.coolingUntil ?? plan.coolingUntil,
+            accountState.coolingReason ?? plan.reason,
+          ).catch(() => {
+            // Non-fatal: routing already has the in-memory cooldown.
+          });
           advancePrimaryIfCurrent(
             account.key,
             enabledAccounts.length,
@@ -4833,7 +5343,6 @@ async function handleAnthropicRoutedClaudeRequest(args: {
           authFailureMessage: loopState.authFailureMessage,
           sawTransientFailure: loopState.sawTransientFailure,
           invalidRequestFailure: loopState.invalidRequestFailure,
-          maxConsecutiveRefreshFailures: MAX_CONSECUTIVE_REFRESH_FAILURES,
         });
         loopState.lastError = nonOkResult.lastError;
         loopState.authFailureMessage = nonOkResult.authFailureMessage;
@@ -4876,8 +5385,12 @@ async function handleAnthropicRoutedClaudeRequest(args: {
         accountState.coolingUntil &&
         Date.now() >= accountState.coolingUntil
       ) {
+        const expiredCooldown = accountState.coolingUntil;
         accountState.coolingUntil = undefined;
         accountState.coolingReason = undefined;
+        clearAccountCooldown(account.key, expiredCooldown).catch(() => {
+          // Best-effort cleanup; expired entries are ignored during seeding.
+        });
       }
 
       const successResult = await handleAnthropicSuccessfulResponse({
@@ -4940,6 +5453,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     tracer,
     requestStartTime,
     authFailureMessage: loopState.authFailureMessage,
+    authCooldownMessage: loopState.authCooldownMessage,
     invalidRequestFailure: loopState.invalidRequestFailure,
     sawNetworkError: loopState.sawNetworkError,
     sawTransientFailure: loopState.sawTransientFailure,
@@ -4972,8 +5486,12 @@ export function createClaudeProxyRoutes(
   accountStrategy: "round-robin" | "fill-first" = "fill-first",
   passthroughMode: boolean = false,
   primaryAccountKey?: string,
+  accountAllowlist?: AccountAllowlist,
 ): RouteGroup {
   configuredPrimaryAccountKey = primaryAccountKey;
+  configuredAccountAllowlist = accountAllowlist
+    ? new Set(accountAllowlist)
+    : undefined;
   return {
     prefix: `${basePath}/v1`,
     routes: [
@@ -5198,13 +5716,14 @@ function getOrCreateRuntimeState(accountKey: string): RuntimeAccountState {
 async function disableAccountUntilReauth(
   account: ProxyPassthroughAccount,
   state: RuntimeAccountState,
+  reason: "missing_refresh_token" | "refresh_invalid",
 ): Promise<void> {
   state.permanentlyDisabled = true;
 
   // Decision 7 (usage): Persist disabled state to disk so it survives restarts
   try {
     const { tokenStore } = await import("../../auth/tokenStore.js");
-    await tokenStore.markDisabled(account.key, "refresh_failed");
+    await tokenStore.markDisabled(account.key, reason);
   } catch (e) {
     logger.debug(
       `[proxy] failed to persist disabled state for ${account.label}: ${e instanceof Error ? e.message : String(e)}`,
@@ -5214,6 +5733,51 @@ async function disableAccountUntilReauth(
   logger.always(
     `[proxy] account=${account.label} disabled until re-authentication. Run: neurolink auth login anthropic --method oauth`,
   );
+}
+
+async function coolAccountAfterTransientRefreshFailure(
+  account: Pick<ProxyPassthroughAccount, "key" | "label">,
+  state: RuntimeAccountState,
+): Promise<number> {
+  state.consecutiveRefreshFailures += 1;
+  const exponent = Math.min(state.consecutiveRefreshFailures - 1, 4);
+  const delayMs = Math.min(
+    AUTH_REFRESH_MAX_COOLDOWN_MS,
+    AUTH_REFRESH_BASE_COOLDOWN_MS * 2 ** exponent,
+  );
+  const coolingUntil = Date.now() + delayMs;
+  if (!state.coolingUntil || coolingUntil > state.coolingUntil) {
+    state.coolingUntil = coolingUntil;
+    state.coolingReason = "auth";
+  }
+  const effectiveCoolingUntil = state.coolingUntil ?? coolingUntil;
+  const effectiveReason = state.coolingReason ?? "auth";
+  state.coolingUntil = effectiveCoolingUntil;
+  state.coolingReason = effectiveReason;
+  await saveAccountCooldown(
+    account.key,
+    effectiveCoolingUntil,
+    effectiveReason,
+  ).catch(() => {
+    // Non-fatal: the in-memory cooldown still prevents immediate re-hammering.
+  });
+  return effectiveCoolingUntil;
+}
+
+async function clearAuthCooldownAfterRefresh(
+  account: Pick<ProxyPassthroughAccount, "key">,
+  state: RuntimeAccountState,
+): Promise<void> {
+  state.consecutiveRefreshFailures = 0;
+  if (state.coolingReason !== "auth" || !state.coolingUntil) {
+    return;
+  }
+  const previousCoolingUntil = state.coolingUntil;
+  state.coolingUntil = undefined;
+  state.coolingReason = undefined;
+  await clearAccountCooldown(account.key, previousCoolingUntil).catch(() => {
+    // Best-effort cleanup; an expired auth cooldown is harmless on next boot.
+  });
 }
 
 function formatReauthMessage(labels: string | string[]): string {
@@ -5442,6 +6006,9 @@ export const __testHooks = {
   resolveHomeIndex,
   maybeResetPrimaryToHome,
   planCooldownFor429,
+  isPermanentRefreshFailure,
+  getStreamFailureDetails,
+  trackUpstreamReadableStream,
   orderAccountsByQuota,
   resetEpochToMs,
   seedRuntimeQuotasFromDisk,
@@ -5454,6 +6021,13 @@ export const __testHooks = {
   },
   getConfiguredPrimaryAccountKey: (): string | undefined =>
     configuredPrimaryAccountKey,
+  setConfiguredAccountAllowlist: (
+    allowlist: AccountAllowlist | undefined,
+  ): void => {
+    configuredAccountAllowlist = allowlist ? new Set(allowlist) : undefined;
+  },
+  getConfiguredAccountAllowlist: (): string[] | undefined =>
+    configuredAccountAllowlist ? [...configuredAccountAllowlist] : undefined,
   setPrimaryAccountIndex: (index: number): void => {
     primaryAccountIndex = index;
   },
@@ -5472,5 +6046,6 @@ export const __testHooks = {
     primaryAccountIndex = 0;
     lastKnownAccountCount = 0;
     configuredPrimaryAccountKey = undefined;
+    configuredAccountAllowlist = undefined;
   },
 };

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -84,7 +84,7 @@ export type StoredProviderTokens = {
   disabled?: boolean;
   /** When the tokens were disabled (Unix ms) */
   disabledAt?: number;
-  /** Reason the tokens were disabled (e.g., "refresh_failed") */
+  /** Reason the tokens were disabled (e.g., "refresh_invalid") */
   disabledReason?: string;
 };
 

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -954,6 +954,8 @@ export type ProxyState = {
   envFile?: string;
   /** Fallback chain from proxy config (persisted at start time) */
   fallbackChain?: FallbackInfo[];
+  /** Normalized Anthropic account keys allowed for this proxy process. */
+  accountAllowlist?: string[];
   /** Optional fail-open guard PID that reverts Claude settings if proxy dies */
   guardPid?: number;
   /** How the proxy was launched — "launchd" if installed as service, "manual" otherwise */

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -616,6 +616,7 @@ export type AnthropicLoopState = {
     contentType?: string;
   } | null;
   authFailureMessage: string | null;
+  authCooldownMessage: string | null;
   attemptNumber: number;
 };
 
@@ -687,9 +688,9 @@ export type AccountCooldownPlan = {
   reason: AccountCoolingReason;
   /** Epoch-ms until which the account should not be used. */
   coolingUntil: number;
-  /** When true (5h/7d window rejected), rotate immediately — retrying the same
-   *  account is futile until its window resets. When false (transient burst),
-   *  a small number of jittered same-account retries is allowed first. */
+  /** When true (unified/5h/7d rejected), rotate immediately — retrying the
+   *  same account is futile until its window resets. When false (transient
+   *  burst), a small number of jittered same-account retries is allowed first. */
   rotateImmediately: boolean;
 };
 
@@ -751,6 +752,14 @@ export type RefreshResult = {
   status?: number;
 };
 
+/** Result shared by callers waiting on the same rotating refresh token. */
+export type SharedRefreshResult = {
+  result: RefreshResult;
+  token: string;
+  refreshToken?: string;
+  expiresAt?: number;
+};
+
 export type TokenPersistTarget =
   | string
   | { credPath: string }
@@ -761,6 +770,9 @@ export type TokenPersistTarget =
 // =============================================================================
 
 export type AccountQuota = {
+  /** Top-level unified status. A rejected value can be authoritative even
+   *  while both 5h and 7d sub-window statuses still report allowed. */
+  unifiedStatus?: string;
   /** 0.0-1.0  (from unified-5h-utilization) */
   sessionUsed: number;
   /** "allowed" | "throttled" | "rejected" */
@@ -788,9 +800,25 @@ export type AccountQuota = {
 /** Why an account is currently cooling. Drives cooldown duration and logging.
  *  - "weekly"    : 7d unified limit rejected — cool until the weekly reset.
  *  - "session"   : 5h unified limit rejected — cool until the session reset.
+ *  - "unified"   : top-level unified limit rejected — cool for retry-after.
  *  - "transient" : short per-minute/burst 429 — cool for retry-after only.
- *  - "auth"      : auth/refresh failures (reserved; currently rotate-only). */
-export type AccountCoolingReason = "weekly" | "session" | "transient" | "auth";
+ *  - "auth"      : transient refresh failure with bounded backoff. */
+export type AccountCoolingReason =
+  | "weekly"
+  | "session"
+  | "unified"
+  | "transient"
+  | "auth";
+
+/** Restart-safe cooldown snapshot for one account. */
+export type PersistedAccountCooldown = {
+  coolingUntil: number;
+  reason: AccountCoolingReason;
+  updatedAt: number;
+};
+
+/** Normalized Anthropic account keys eligible for proxy routing. */
+export type AccountAllowlist = ReadonlySet<string>;
 
 /** Runtime state for a proxy account. */
 export type RuntimeAccountState = {
@@ -799,9 +827,9 @@ export type RuntimeAccountState = {
   lastToken?: string;
   lastRefreshToken?: string;
   /** Epoch-ms timestamp until which the account should not be used for new
-   *  requests. Set from the ACTUAL Anthropic reset window (5h/7d) on an
-   *  exhaustion 429, or from retry-after on a transient burst. Other requests
-   *  arriving during this window skip the account rather than hammering it. */
+   *  requests. Set from the actual Anthropic reset/retry window or from
+   *  bounded refresh backoff. Other requests arriving during this window skip
+   *  the account rather than hammering it. */
   coolingUntil?: number;
   /** Why the account is cooling (set alongside coolingUntil). */
   coolingReason?: AccountCoolingReason;
@@ -931,6 +959,8 @@ export type ProxyPaths = {
   logsDir: string;
   /** account-quotas.json — per-account rate limit state */
   quotaFile: string;
+  /** account-cooldowns.json — restart-safe account cooldown state */
+  cooldownFile: string;
   /** Whether this is a dev-mode isolated instance */
   isDev: boolean;
 };
@@ -1163,7 +1193,23 @@ export type SSETelemetry = {
   streamDurationMs: number;
   totalBytesReceived: number;
   events: Array<{ type: string; timestamp: number; data: string }>;
+  /** Error carried as a terminal SSE `event: error`, if one was observed. */
+  streamErrorMessage?: string;
   rawText?: string;
+};
+
+/** Terminal outcome of a response body after the HTTP headers were sent. */
+export type StreamTerminalOutcome =
+  | { kind: "completed" }
+  | { kind: "upstream_error"; message: string }
+  | { kind: "client_cancelled" };
+
+/** First-writer-wins tracker for an upstream streaming response. */
+export type StreamTerminalOutcomeTracker = {
+  outcome: Promise<StreamTerminalOutcome>;
+  complete: () => void;
+  fail: (message: string) => void;
+  cancel: () => void;
 };
 
 /** Mutable accumulator the SSE interceptor uses internally. */
@@ -1186,6 +1232,7 @@ export type TelemetryAccumulator = {
   rawTextBytes: number;
   rawTextTruncated: boolean;
   eventLogTruncated: boolean;
+  streamErrorMessage?: string;
 };
 
 /** Result of createSSEInterceptor: the pass-through stream and a telemetry promise. */

--- a/src/lib/types/subscription.ts
+++ b/src/lib/types/subscription.ts
@@ -1122,6 +1122,11 @@ export type ProxyRoutingConfig = {
    *  Resolved per-request to a stable key (anthropic:<email>); does not
    *  encode an index. */
   primaryAccount?: string;
+  /** Anthropic account emails/labels that may be loaded by the proxy. When
+   *  present, every token-store, legacy, and environment credential outside
+   *  this set is excluded before refresh or routing. An empty list denies all
+   *  stored credentials. */
+  accountAllowlist?: string[];
 };
 
 /** Cloaking plugin config */

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -771,7 +771,7 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "429 regression: synthesized 429 message references retry count",
+    name: "429 regression: synthesized 429 reports active cooldown recovery",
     category: "429-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -780,11 +780,14 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/lib/server/routes/claudeProxyRoutes.ts"),
         "utf-8",
       );
-      // The final 429 message should mention attempts/retries per account,
-      // not the old cooldown-based "Earliest recovery in Ns" phrasing.
+      // Known-cooling accounts must not be re-hammered. The final response
+      // should expose the earliest persisted retry timestamp instead.
       return (
-        (src.includes("retries each") || src.includes("attempts each")) &&
-        !src.includes("Earliest recovery in")
+        src.includes(
+          "Anthropic accounts are cooling after upstream rate limits",
+        ) &&
+        src.includes("Earliest retry at") &&
+        src.includes("const effectiveAccounts = nonCoolingAccounts;")
       );
     },
   },

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -1,0 +1,578 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TokenStore } from "../src/lib/auth/tokenStore.js";
+import {
+  anthropicAccountKeysEqual,
+  createAccountAllowlist,
+  ENV_ANTHROPIC_ACCOUNT_KEY,
+  isAccountAllowed,
+  LEGACY_ANTHROPIC_ACCOUNT_KEY,
+  shouldLoadFallbackCredential,
+} from "../src/lib/proxy/accountSelection.js";
+import {
+  clearAccountCooldown,
+  initAccountCooldown,
+  loadAccountCooldowns,
+  saveAccountCooldown,
+} from "../src/lib/proxy/accountCooldown.js";
+import {
+  flushAccountQuotaStateForTests,
+  getUnifiedRateLimitStatus,
+  initAccountQuota,
+  loadAccountQuotas,
+  parseQuotaHeaders,
+  saveAccountQuota,
+} from "../src/lib/proxy/accountQuota.js";
+import { resolveProxyPaths } from "../src/lib/proxy/proxyPaths.js";
+import { createSSEInterceptor } from "../src/lib/proxy/sseInterceptor.js";
+import {
+  clearRefreshStateForTests,
+  needsRefresh,
+  refreshToken,
+} from "../src/lib/proxy/tokenRefresh.js";
+import {
+  createStreamTerminalOutcomeTracker,
+  mergeStreamTerminalOutcome,
+} from "../src/lib/proxy/streamOutcome.js";
+import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
+import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  clearRefreshStateForTests();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+  __testHooks.resetAllRuntimeState();
+});
+
+describe("authoritative unified rate-limit handling", () => {
+  it("rotates immediately when unified is rejected but 5h and 7d are allowed", () => {
+    const now = 1_800_000_000_000;
+    const retryAfterMs = 12 * 60 * 60 * 1000;
+    const headers = new Headers({
+      "anthropic-ratelimit-unified-status": "rejected",
+      "anthropic-ratelimit-unified-5h-status": "allowed",
+      "anthropic-ratelimit-unified-5h-utilization": "0.42",
+      "anthropic-ratelimit-unified-5h-reset": String(now / 1000 + 3600),
+      "anthropic-ratelimit-unified-7d-status": "allowed",
+      "anthropic-ratelimit-unified-7d-utilization": "0.63",
+      "anthropic-ratelimit-unified-7d-reset": String(now / 1000 + 86400),
+    });
+
+    const quota = parseQuotaHeaders(headers);
+    expect(quota?.unifiedStatus).toBe("rejected");
+    expect(getUnifiedRateLimitStatus(headers)).toBe("rejected");
+    expect(
+      __testHooks.planCooldownFor429(
+        quota,
+        retryAfterMs,
+        now,
+        getUnifiedRateLimitStatus(headers),
+      ),
+    ).toEqual({
+      reason: "unified",
+      coolingUntil: now + retryAfterMs,
+      rotateImmediately: true,
+    });
+  });
+
+  it("does not classify a normal allowed response as unified exhaustion", () => {
+    const headers = {
+      "Anthropic-RateLimit-Unified-Status": " allowed ",
+    };
+    expect(getUnifiedRateLimitStatus(headers)).toBe("allowed");
+  });
+});
+
+describe("cooldown persistence", () => {
+  it("restores a cooldown after module state is reset and clears it conditionally", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-cooldown-"));
+    tempDirs.push(dir);
+    const file = join(dir, "account-cooldowns.json");
+    const coolingUntil = Date.now() + 60_000;
+
+    initAccountCooldown(file);
+    initAccountQuota(join(dir, "account-quotas.json"));
+    await saveAccountCooldown("anthropic:a", coolingUntil, "unified");
+
+    initAccountCooldown(file);
+    expect(await loadAccountCooldowns()).toMatchObject({
+      "anthropic:a": { coolingUntil, reason: "unified" },
+    });
+    await __testHooks.seedRuntimeQuotasFromDisk([
+      {
+        key: "anthropic:a",
+        label: "a",
+        token: "test-token",
+        type: "oauth",
+      },
+    ]);
+    expect(__testHooks.getAccountRuntimeState("anthropic:a")).toMatchObject({
+      coolingUntil,
+      coolingReason: "unified",
+    });
+
+    await clearAccountCooldown("anthropic:a", coolingUntil + 1);
+    expect(await loadAccountCooldowns()).toHaveProperty("anthropic:a");
+    await clearAccountCooldown("anthropic:a", coolingUntil);
+    expect(await loadAccountCooldowns()).not.toHaveProperty("anthropic:a");
+  });
+
+  it("preserves concurrent first writes while the persisted cache loads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-cooldown-race-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "account-cooldowns.json"));
+    const now = Date.now();
+
+    await Promise.all([
+      saveAccountCooldown("anthropic:a", now + 60_000, "session"),
+      saveAccountCooldown("anthropic:b", now + 120_000, "weekly"),
+    ]);
+
+    expect(await loadAccountCooldowns()).toMatchObject({
+      "anthropic:a": { coolingUntil: now + 60_000 },
+      "anthropic:b": { coolingUntil: now + 120_000 },
+    });
+  });
+
+  it("serializes cooldown extensions and conditional clears on disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-cooldown-order-"));
+    tempDirs.push(dir);
+    const file = join(dir, "account-cooldowns.json");
+    initAccountCooldown(file);
+    const initialCoolingUntil = Date.now() + 60_000;
+    const extendedCoolingUntil = initialCoolingUntil + 120_000;
+
+    await saveAccountCooldown("anthropic:a", initialCoolingUntil, "session");
+    await Promise.all([
+      saveAccountCooldown("anthropic:a", extendedCoolingUntil, "weekly"),
+      clearAccountCooldown("anthropic:a", initialCoolingUntil),
+      saveAccountCooldown("anthropic:a", initialCoolingUntil + 30_000, "auth"),
+    ]);
+
+    const persisted = JSON.parse(await readFile(file, "utf8"));
+    expect(persisted["anthropic:a"]).toMatchObject({
+      coolingUntil: extendedCoolingUntil,
+      reason: "weekly",
+    });
+  });
+
+  it("preserves concurrent first quota updates while the cache loads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-quota-race-"));
+    tempDirs.push(dir);
+    initAccountQuota(join(dir, "account-quotas.json"));
+    const quota = {
+      sessionUsed: 0.1,
+      sessionStatus: "allowed",
+      sessionResetAt: 0,
+      weeklyUsed: 0.2,
+      weeklyStatus: "allowed",
+      weeklyResetAt: 0,
+      fallbackPercentage: 0,
+      overageStatus: "unknown",
+      lastUpdated: Date.now(),
+    };
+
+    await Promise.all([
+      saveAccountQuota("anthropic:a", quota),
+      saveAccountQuota("anthropic:b", { ...quota, sessionUsed: 0.3 }),
+    ]);
+
+    expect(await loadAccountQuotas()).toMatchObject({
+      "anthropic:a": { sessionUsed: 0.1 },
+      "anthropic:b": { sessionUsed: 0.3 },
+    });
+    await flushAccountQuotaStateForTests();
+    const persisted = JSON.parse(
+      await readFile(join(dir, "account-quotas.json"), "utf8"),
+    );
+    expect(persisted).toMatchObject({
+      "anthropic:a": { sessionUsed: 0.1 },
+      "anthropic:b": { sessionUsed: 0.3 },
+    });
+  });
+});
+
+describe("refresh failure classification", () => {
+  it("uses the shared five-minute expiry buffer", () => {
+    expect(
+      needsRefresh({
+        token: "token",
+        refreshToken: "refresh",
+        expiresAt: Date.now() + 6 * 60 * 1000,
+        label: "account",
+      }),
+    ).toBe(false);
+    expect(
+      needsRefresh({
+        token: "token",
+        refreshToken: "refresh",
+        expiresAt: Date.now() + 4 * 60 * 1000,
+        label: "account",
+      }),
+    ).toBe(true);
+  });
+
+  it("only treats rejected refresh credentials as permanent", () => {
+    expect(
+      __testHooks.isPermanentRefreshFailure({ success: false, status: 400 }),
+    ).toBe(true);
+    expect(
+      __testHooks.isPermanentRefreshFailure({ success: false, status: 401 }),
+    ).toBe(true);
+    expect(
+      __testHooks.isPermanentRefreshFailure({ success: false, status: 404 }),
+    ).toBe(true);
+    expect(
+      __testHooks.isPermanentRefreshFailure({ success: false, status: 429 }),
+    ).toBe(false);
+    expect(
+      __testHooks.isPermanentRefreshFailure({ success: false, status: 503 }),
+    ).toBe(false);
+    expect(__testHooks.isPermanentRefreshFailure({ success: false })).toBe(
+      false,
+    );
+  });
+
+  it("preserves a stale-token 404 when the fallback endpoint is down", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
+      .mockRejectedValueOnce(new Error("fallback endpoint unavailable"));
+
+    const result = await refreshToken({
+      token: "expired",
+      refreshToken: "invalid",
+      label: "account-a",
+    });
+    expect(result).toMatchObject({ success: false, status: 404 });
+    expect(__testHooks.isPermanentRefreshFailure(result)).toBe(true);
+  });
+
+  it("keeps refresh endpoint 429 and 5xx failures transient", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("limited", { status: 429 }))
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+
+    const result = await refreshToken({
+      token: "expired",
+      refreshToken: "still-valid",
+      label: "account-b",
+    });
+    expect(result).toMatchObject({ success: false, status: 503 });
+    expect(__testHooks.isPermanentRefreshFailure(result)).toBe(false);
+  });
+
+  it("serializes concurrent rotating-token refreshes", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const first = {
+      token: "old-access-a",
+      refreshToken: "shared-old-refresh",
+      label: "account-a",
+    };
+    const second = {
+      token: "old-access-b",
+      refreshToken: "shared-old-refresh",
+      label: "account-b",
+    };
+
+    const results = await Promise.all([
+      refreshToken(first),
+      refreshToken(second),
+    ]);
+
+    expect(results).toEqual([{ success: true }, { success: true }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    });
+    expect(second).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    });
+
+    const rotatedTokenCaller = {
+      token: "stale-access",
+      refreshToken: "new-refresh",
+      label: "account-a-reloaded",
+    };
+    expect(await refreshToken(rotatedTokenCaller)).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(rotatedTokenCaller).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    });
+  });
+});
+
+describe("account restriction", () => {
+  it("normalizes an explicit allowlist and denies every unlisted source", () => {
+    const allowlist = createAccountAllowlist([
+      " primary@example.com ",
+      "anthropic:PRIMARY@example.com",
+    ]);
+
+    expect([...allowlist!]).toEqual(["anthropic:primary@example.com"]);
+    expect(isAccountAllowed("primary@example.com", allowlist)).toBe(true);
+    expect(isAccountAllowed("anthropic:other@example.com", allowlist)).toBe(
+      false,
+    );
+    expect(isAccountAllowed(LEGACY_ANTHROPIC_ACCOUNT_KEY, allowlist)).toBe(
+      false,
+    );
+    expect(isAccountAllowed(ENV_ANTHROPIC_ACCOUNT_KEY, allowlist)).toBe(false);
+    expect(
+      anthropicAccountKeysEqual(
+        "anthropic:PRIMARY@example.com",
+        "primary@example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("distinguishes an absent allowlist from an explicit deny-all list", () => {
+    expect(isAccountAllowed("anthropic:any", undefined)).toBe(true);
+    expect(isAccountAllowed("anthropic:any", createAccountAllowlist([]))).toBe(
+      false,
+    );
+  });
+
+  it("never activates hidden fallback credentials while token-store accounts exist", () => {
+    expect(
+      shouldLoadFallbackCredential(1, LEGACY_ANTHROPIC_ACCOUNT_KEY, undefined),
+    ).toBe(false);
+    expect(
+      shouldLoadFallbackCredential(
+        1,
+        LEGACY_ANTHROPIC_ACCOUNT_KEY,
+        createAccountAllowlist(["legacy-default"]),
+      ),
+    ).toBe(false);
+    expect(
+      shouldLoadFallbackCredential(
+        0,
+        LEGACY_ANTHROPIC_ACCOUNT_KEY,
+        createAccountAllowlist(["primary@example.com"]),
+      ),
+    ).toBe(false);
+    expect(
+      shouldLoadFallbackCredential(
+        0,
+        LEGACY_ANTHROPIC_ACCOUNT_KEY,
+        createAccountAllowlist(["legacy-default"]),
+      ),
+    ).toBe(true);
+  });
+
+  it("parses and validates account-allowlist without failing open", async () => {
+    const config = await parseProxyConfigString(
+      JSON.stringify({
+        routing: {
+          "account-allowlist": [" primary@example.com ", "anthropic:other"],
+        },
+      }),
+    );
+    expect(config.routing?.accountAllowlist).toEqual([
+      "primary@example.com",
+      "anthropic:other",
+    ]);
+
+    await expect(
+      parseProxyConfigString(
+        JSON.stringify({ routing: { "account-allowlist": "hello" } }),
+      ),
+    ).rejects.toThrow("account-allowlist must be an array");
+  });
+
+  it("preserves manual disable metadata across automatic token saves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-token-store-"));
+    tempDirs.push(dir);
+    const store = new TokenStore({
+      encryptionEnabled: false,
+      customStoragePath: join(dir, "tokens.json"),
+    });
+    const key = "anthropic:disabled@example.com";
+    await store.saveTokens(key, {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+    await store.markDisabled(key, "manual_single_account_routing");
+    await store.saveTokens(key, {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: Date.now() + 120_000,
+      tokenType: "Bearer",
+    });
+
+    expect(await store.isDisabled(key)).toBe(true);
+    expect(await store.getDisabledReason(key)).toBe(
+      "manual_single_account_routing",
+    );
+    expect(await store.loadTokens(key)).toMatchObject({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+    });
+
+    await store.markEnabled(key);
+    await Promise.all([
+      store.saveTokens(key, {
+        accessToken: "concurrent-access",
+        refreshToken: "concurrent-refresh",
+        expiresAt: Date.now() + 180_000,
+        tokenType: "Bearer",
+      }),
+      store.markDisabled(key, "concurrent_operator_disable"),
+    ]);
+    expect(await store.isDisabled(key)).toBe(true);
+    expect(await store.getDisabledReason(key)).toBe(
+      "concurrent_operator_disable",
+    );
+  });
+});
+
+describe("stream terminal outcomes", () => {
+  it("preserves the first terminal outcome", async () => {
+    const tracker = createStreamTerminalOutcomeTracker();
+    tracker.fail("socket reset");
+    tracker.complete();
+    expect(await tracker.outcome).toEqual({
+      kind: "upstream_error",
+      message: "socket reset",
+    });
+  });
+
+  it("captures a passthrough source failure while preserving stream failure", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        controller.error(new Error("upstream socket reset"));
+      },
+    });
+    const tracked = __testHooks.trackUpstreamReadableStream(source);
+    await expect(new Response(tracked.stream).text()).rejects.toBeInstanceOf(
+      Error,
+    );
+    expect(await tracked.outcome).toEqual({
+      kind: "upstream_error",
+      message: "upstream socket reset",
+    });
+  });
+
+  it("records client cancellation as a distinct terminal outcome", async () => {
+    let sourceCancelled = false;
+    const source = new ReadableStream<Uint8Array>({
+      cancel() {
+        sourceCancelled = true;
+      },
+    });
+    const tracked = __testHooks.trackUpstreamReadableStream(source);
+
+    await tracked.stream.cancel("client disconnected");
+
+    expect(sourceCancelled).toBe(true);
+    expect(await tracked.outcome).toEqual({ kind: "client_cancelled" });
+  });
+
+  it("promotes a terminal SSE error instead of reporting success", async () => {
+    const { stream, telemetry } = createSSEInterceptor();
+    const source = new Response(
+      'event: error\ndata: {"type":"error","error":{"message":"quota stream interrupted"}}\n\n',
+    ).body!;
+    await new Response(source.pipeThrough(stream)).text();
+    const data = await telemetry;
+
+    expect(data.streamErrorMessage).toBe("quota stream interrupted");
+    expect(
+      mergeStreamTerminalOutcome(
+        { kind: "completed" },
+        data.streamErrorMessage,
+      ),
+    ).toEqual({
+      kind: "upstream_error",
+      message: "quota stream interrupted",
+    });
+    expect(
+      __testHooks.getStreamFailureDetails({
+        kind: "upstream_error",
+        message: "quota stream interrupted",
+      }),
+    ).toEqual({
+      status: 502,
+      errorType: "stream_error",
+      message: "quota stream interrupted",
+    });
+    expect(
+      __testHooks.getStreamFailureDetails({ kind: "client_cancelled" }),
+    ).toMatchObject({ status: 499, errorType: "client_cancelled" });
+  });
+});
+
+describe("launchd lifecycle source invariants", () => {
+  it("leaves restart ownership with launchd and keeps auto-update opt-in", async () => {
+    const source = await readFile(
+      new URL("../src/cli/commands/proxy.ts", import.meta.url),
+      "utf8",
+    );
+    const updateState = await readFile(
+      new URL("../src/lib/proxy/updateState.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("tryLaunchdRestart");
+    expect(source).toContain("params.argv.dev || managedByLaunchd");
+    expect(source).toContain("NEUROLINK_PROXY_AUTO_UPDATE");
+    expect(source).toContain('["1", "on", "true"]');
+    expect(source).toContain("stopUpdateChecks()");
+    expect(source).toContain('from "../../../package.json" with');
+    expect(source).toContain("<key>ExitTimeOut</key>");
+    expect(source).toContain("backgroundRefreshInProgress");
+    expect(source).toContain("await tokenStore.isDisabled(key)");
+    expect(source).toContain(
+      'await tokenStore.markDisabled(key, "refresh_invalid")',
+    );
+    expect(source).not.toContain("tokenChanged || legacyTransientDisable");
+    expect(source).toContain("initAccountCooldown(devPaths.cooldownFile)");
+    expect(source).not.toContain("Ignoring default config");
+    expect(source).not.toContain("cooling: false");
+    expect(source).toContain("catch(forceExitAfterShutdownFailure)");
+    expect(source).toContain("Timed out draining the proxy server");
+    expect(updateState).toContain("randomUUID()");
+    expect(updateState).not.toContain("const tempPath = `${filePath}.tmp`");
+  });
+
+  it("keeps dev-mode cooldown state outside the live state directory", () => {
+    const paths = resolveProxyPaths(true);
+    expect(paths.cooldownFile).toBe(
+      join(process.cwd(), ".neurolink-dev", "account-cooldowns.json"),
+    );
+  });
+
+  it("does not fall back to known-cooling accounts", async () => {
+    const source = await readFile(
+      new URL("../src/lib/server/routes/claudeProxyRoutes.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("const effectiveAccounts = nonCoolingAccounts;");
+    expect(source).toContain("eligible credentials reloaded");
+    expect(source).toContain("authCooldownMessage");
+    expect(source).not.toContain("credentials changed, re-enabling");
+    expect(source).not.toContain(
+      "nonCoolingAccounts.length > 0 ? nonCoolingAccounts : orderedAccounts",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Make launchd the sole restart supervisor for launchd-managed proxies; make the foreground guard cleanup-only and runtime auto-update opt-in.
- Persist account cooldowns across restarts, honor authoritative unified quota rejection, and never retry accounts with active cooldowns.
- Serialize cooldown/quota persistence and rotating OAuth refreshes, including callers that observe the newly rotated refresh token.
- Distinguish terminal credential rejection from transient endpoint failures and preserve manual disable metadata.
- Add `routing.account-allowlist` as a fail-closed boundary across TokenStore, legacy-file, and environment credentials.
- Prevent hidden legacy/environment credentials from activating while any Anthropic TokenStore entry exists.
- Record upstream stream errors and client cancellation as terminal outcomes instead of successful HTTP 200 completions.
- Drain and exit deterministically on shutdown, surfacing close failures without leaving rejected signal handlers.

## Account isolation

`primary-account` remains an ordering preference. The new allowlist is the eligibility boundary and is applied before token loading or refresh. Empty means deny all; absent preserves existing unrestricted behavior. Legacy and environment fallbacks require explicit `legacy-default` or `env` entries.

Automatic token rotation no longer clears an operator-disabled account. Only explicit login re-enables current disable metadata; legacy `refresh_failed` records from older releases receive one migration recheck.

## Verification

- `pnpm run typecheck`: pass.
- `pnpm exec vitest run test/proxyReliabilityHardening.test.ts`: 23/23 pass.
- `pnpm test:bugfixes`: 89/89 pass.
- Changed-file ESLint: 0 errors and no new warnings.
- `pnpm run build:cli`: pass.
- Full pre-commit pipeline will run again on the amended commit.

## Rollout safety

Development and tests did not start, stop, signal, reconfigure, or install over the live proxy. The existing process-level proxy suite was intentionally not run because it manages global proxy state and processes. Release rollout should use an isolated state directory first, then a controlled launchd replacement with health and restart-count verification.
