### PR TITLE
fix(utils): pin SSRF downloads to the full validated address set (IPv4 first)

### DIFF
--- a/src/lib/types/safeFetch.ts
+++ b/src/lib/types/safeFetch.ts
@@ -4,6 +4,16 @@
  * Runtime helper lives in `src/lib/utils/safeFetch.ts`.
  */
 
+/**
+ * One validated address the pinned connect layer is allowed to dial.
+ * Produced by `ssrfGuard.ts:validateAndResolveUrl`, consumed by
+ * `safeFetch.ts:buildPinnedAgent`.
+ */
+export type PinnedAddress = {
+  ip: string;
+  family: 4 | 6;
+};
+
 export type SafeDownloadOptions = {
   /** Hard cap on response size in bytes. Pass MAX_VIDEO_BYTES/MAX_AUDIO_BYTES/MAX_IMAGE_BYTES from sizeGuard. */
   maxBytes: number;

--- a/src/lib/utils/safeFetch.ts
+++ b/src/lib/utils/safeFetch.ts
@@ -4,9 +4,9 @@
  * Combines:
  *   - `assertSafeUrl` (validates and rejects blocked IPs)
  *   - undici `Agent` with custom `connect.lookup` so the actual connection
- *     uses the IP we validated (closes the DNS-rebinding window where the
- *     resolver returns a public IP for the guard but a private IP for the
- *     real request).
+ *     only ever dials addresses we validated (closes the DNS-rebinding window
+ *     where the resolver returns a public IP for the guard but a private IP
+ *     for the real request).
  *   - `readBoundedBuffer` for size cap.
  *   - `redirect: "manual"` so a 3xx → private-IP redirect can't bypass
  *     the guard.
@@ -18,18 +18,33 @@
  */
 
 import { Agent, fetch as undiciFetch } from "undici";
-import type { SafeDownloadOptions } from "../types/index.js";
+import type { PinnedAddress, SafeDownloadOptions } from "../types/index.js";
 import { readBoundedBuffer } from "./sizeGuard.js";
 import { validateAndResolveUrl } from "./ssrfGuard.js";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 /**
- * Build a once-off undici Agent whose connect lookup resolves `hostname` to a
- * fixed IP. This pins the actual TCP connection to the IP we validated,
- * removing the DNS-rebinding window.
+ * Build a once-off undici Agent whose connect lookup resolves `hostname` to
+ * the validated address set. The actual TCP connection can only ever go to
+ * an address the SSRF guard cleared, removing the DNS-rebinding window.
+ *
+ * The full set (IPv4 first) matters: pinning a single address turns one
+ * unroutable family into a hard connect timeout. On IPv4-only networks where
+ * the OS resolver prefers AAAA, that broke every safeDownload (Replicate /
+ * Runway / Kling asset fetches) while plain curl of the same URL succeeded —
+ * curl races both families (Happy Eyeballs); a one-address pin cannot.
  */
-function buildPinnedAgent(hostname: string, ip: string, family: 4 | 6): Agent {
+function buildPinnedAgent(
+  hostname: string,
+  addresses: readonly PinnedAddress[],
+): Agent {
+  const primary = addresses[0];
+  if (!primary) {
+    throw new Error(
+      `safeFetch: no validated addresses to pin for "${hostname}"`,
+    );
+  }
   return new Agent({
     connect: {
       lookup: (host, options, callback) => {
@@ -47,15 +62,16 @@ function buildPinnedAgent(hostname: string, ip: string, family: 4 | 6): Agent {
         }
         // Node ≥20 enables autoSelectFamily (Happy Eyeballs) by default, and
         // its lookup contract passes `all: true` expecting an address ARRAY.
-        // Answering with the string form there fails the connection with
-        // "Invalid IP address: undefined" — which broke every safeDownload
-        // (Replicate / Runway / Kling asset fetches) on modern Node while
-        // plain curl of the same URL succeeded.
+        // Hand it every validated address so it can race families and fall
+        // back when one is unroutable.
         if (options?.all) {
-          callback(null, [{ address: ip, family }]);
+          callback(
+            null,
+            addresses.map((a) => ({ address: a.ip, family: a.family })),
+          );
           return;
         }
-        callback(null, ip, family);
+        callback(null, primary.ip, primary.family);
       },
     },
   });
@@ -71,11 +87,11 @@ export async function safeDownload(
   url: string,
   options: SafeDownloadOptions,
 ): Promise<Buffer> {
-  const { url: validatedUrl, ip, family } = await validateAndResolveUrl(url);
+  const { url: validatedUrl, addresses } = await validateAndResolveUrl(url);
   const parsed = new URL(validatedUrl);
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
 
-  const agent = buildPinnedAgent(hostname, ip, family);
+  const agent = buildPinnedAgent(hostname, addresses);
 
   const timeoutCtrl = new AbortController();
   const timeoutId = setTimeout(

--- a/src/lib/utils/ssrfGuard.ts
+++ b/src/lib/utils/ssrfGuard.ts
@@ -27,6 +27,7 @@
 
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import type { PinnedAddress } from "../types/index.js";
 
 /**
  * Blocked IPv4 CIDRs.
@@ -323,6 +324,21 @@ export async function assertSafeUrl(url: string): Promise<void> {
 
   // Hostname — resolve BOTH A and AAAA. Reject if either family yields a
   // blocked address (closes off the "publish AAAA public, A private" attack).
+  await resolveAndValidateHost(url, host);
+}
+
+/**
+ * Resolve `host` (both A and AAAA) and validate every returned address
+ * against the block lists. Returns the full validated set so callers that
+ * pin connections can offer the connect layer more than one address.
+ *
+ * @throws {Error} when resolution fails entirely or any address is blocked
+ *   (all-must-pass — the caller may connect to any address in the set).
+ */
+async function resolveAndValidateHost(
+  url: string,
+  host: string,
+): Promise<{ v4: string[]; v6: string[] }> {
   const [a, aaaa] = await Promise.allSettled([
     lookup(host, { family: 4, all: true }),
     lookup(host, { family: 6, all: true }),
@@ -383,22 +399,33 @@ export async function assertSafeUrl(url: string): Promise<void> {
       );
     }
   }
+
+  return { v4: v4Addresses, v6: v6Addresses };
 }
 
 /**
- * Validate `url` and return the resolved IP that should be used for the
- * actual fetch (companion to `safeFetch.ts:safeDownload`).
+ * Validate `url` and return the resolved address set that should be used for
+ * the actual fetch (companion to `safeFetch.ts:safeDownload`).
  *
- * For IP-literal hosts, returns the normalised IP and family. For hostnames,
- * returns the first acceptable IP from the resolver. Same throw semantics as
- * {@link assertSafeUrl}.
+ * For IP-literal hosts, `addresses` is the normalised IP as a singleton. For
+ * hostnames it is **every** validated address, IPv4 first, so the connect
+ * layer can race families (Happy Eyeballs). Pinning a single OS-preferred
+ * address breaks every download on IPv4-only networks whenever the resolver
+ * prefers AAAA: the pinned connection has no second address to fall back to,
+ * so it times out where plain `curl` (which races both families) succeeds.
+ * `ip`/`family` mirror the first entry for callers that need a single pin.
+ *
+ * Same throw semantics as {@link assertSafeUrl}.
  *
  * This is the canonical entry point for binary downloads where DNS-rebinding
  * pinning matters — see `safeFetch.ts`.
  */
-export async function validateAndResolveUrl(
-  url: string,
-): Promise<{ url: string; ip: string; family: 4 | 6 }> {
+export async function validateAndResolveUrl(url: string): Promise<{
+  url: string;
+  ip: string;
+  family: 4 | 6;
+  addresses: readonly PinnedAddress[];
+}> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -420,7 +447,7 @@ export async function validateAndResolveUrl(
         `URL "${url}" rejected: IPv4 ${host} → ${v4} is in a blocked range`,
       );
     }
-    return { url, ip: v4, family: 4 };
+    return { url, ip: v4, family: 4, addresses: [{ ip: v4, family: 4 }] };
   }
   if (host.includes(":")) {
     const v4FromMapped = extractIPv4FromMapped(host);
@@ -430,7 +457,12 @@ export async function validateAndResolveUrl(
           `URL "${url}" rejected: IPv4-mapped IPv6 ${host} → ${v4FromMapped} is in a blocked range`,
         );
       }
-      return { url, ip: v4FromMapped, family: 4 };
+      return {
+        url,
+        ip: v4FromMapped,
+        family: 4,
+        addresses: [{ ip: v4FromMapped, family: 4 }],
+      };
     }
     const expanded = expandIPv6(host);
     if (!expanded) {
@@ -443,11 +475,28 @@ export async function validateAndResolveUrl(
         `URL "${url}" rejected: IPv6 ${host} is in a blocked range`,
       );
     }
-    return { url, ip: host, family: 6 };
+    return { url, ip: host, family: 6, addresses: [{ ip: host, family: 6 }] };
   }
 
-  // Hostname — resolve and pick a safe address
-  await assertSafeUrl(url);
-  const result = await lookup(host);
-  return { url, ip: result.address, family: result.family as 4 | 6 };
+  // Hostname — resolve once, validate every address, and return the whole
+  // set. Validating the same answer we hand to the connect layer also
+  // removes the rebinding window the previous separate `lookup()` left
+  // between validation and pinning.
+  const { v4: v4Addresses, v6: v6Addresses } = await resolveAndValidateHost(
+    url,
+    host,
+  );
+  const addresses: PinnedAddress[] = [
+    ...v4Addresses.map((ip): PinnedAddress => ({ ip, family: 4 })),
+    ...v6Addresses.map((ip): PinnedAddress => ({ ip, family: 6 })),
+  ];
+  const first = addresses[0];
+  if (!first) {
+    // Both lookups "succeeded" but returned zero addresses — treat exactly
+    // like a resolution failure rather than pinning nothing.
+    throw new Error(
+      `URL "${url}" rejected: hostname ${host} resolved to an empty address set`,
+    );
+  }
+  return { url, ip: first.ip, family: first.family, addresses };
 }

--- a/test/continuous-test-suite-ssrf.ts
+++ b/test/continuous-test-suite-ssrf.ts
@@ -243,6 +243,67 @@ try {
   );
 }
 
+// IP literals carry the validated set as a singleton — the pinned agent
+// consumes `addresses`, so a literal must produce exactly its own IP there.
+try {
+  const result = await validateAndResolveUrl("https://1.1.1.1/");
+  const single = result.addresses.length === 1 ? result.addresses[0] : null;
+  if (single && single.ip === "1.1.1.1" && single.family === 4) {
+    recordTest(
+      "validateAndResolveUrl literal yields singleton addresses[]",
+      true,
+    );
+  } else {
+    recordTest(
+      "validateAndResolveUrl literal yields singleton addresses[]",
+      false,
+      false,
+      `got addresses=${JSON.stringify(result.addresses)}`,
+    );
+  }
+} catch (err) {
+  recordTest(
+    "validateAndResolveUrl literal yields singleton addresses[]",
+    false,
+    false,
+    `unexpectedly rejected: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+// Dual-stack hostname — the returned set must be IPv4-first and `ip`/`family`
+// must mirror its first entry. Regression guard for the single-pin bug: on an
+// IPv4-only network with an AAAA-preferring OS resolver, pinning one IPv6
+// address made every safeDownload connect-timeout (observed live against
+// replicate.delivery) while curl, racing both families, succeeded.
+try {
+  const result = await validateAndResolveUrl("https://one.one.one.one/");
+  const families = result.addresses.map((a) => a.family);
+  const v4First = result.family === 4 && families[0] === 4;
+  const mirrorsFirst =
+    result.ip === result.addresses[0]?.ip &&
+    result.family === result.addresses[0]?.family;
+  const grouped = families.every(
+    (f, i) => i === 0 || f >= (families[i - 1] ?? 0),
+  );
+  if (v4First && mirrorsFirst && grouped) {
+    recordTest("validateAndResolveUrl hostname set is IPv4-first", true);
+  } else {
+    recordTest(
+      "validateAndResolveUrl hostname set is IPv4-first",
+      false,
+      false,
+      `got ip=${result.ip} family=${result.family} addresses=${JSON.stringify(result.addresses)}`,
+    );
+  }
+} catch (err) {
+  recordTest(
+    "validateAndResolveUrl hostname set is IPv4-first",
+    false,
+    false,
+    `unexpectedly rejected: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
 // ───────────────────────────────────────────────────────────────────────
 // Section F — safeDownload propagation (H06)
 // ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem — every `safeDownload` still times out on IPv4-only networks

Follow-up to #1157. That fix made the connect layer's `options.all` contract work, but `validateAndResolveUrl` still pins **one** address chosen by OS resolver preference:

```ts
await assertSafeUrl(url);          // validates EVERY A/AAAA answer…
const result = await lookup(host); // …then discards them and picks ONE by OS preference
```

On a network with broken/absent IPv6 routing but an AAAA-preferring resolver (stock macOS with any IPv6 interface address), that pins a lone IPv6 address. The pinned agent has nothing to fall back to → 10 s connect timeout → the familiar bare `fetch failed`.

## Live evidence (2026-07-15, released 9.87.1)

Real generations succeeded on Replicate; **every download failed**:

```
[0] TypeError: fetch failed
[1] ConnectTimeoutError: Connect Timeout Error (attempted address: replicate.delivery:443, timeout: 10000ms)
```

- `validateAndResolveUrl('https://replicate.delivery/…')` → pinned `2606:4700::6812:1156` (family 6)
- same host, same network: `curl -4` → **200 in 0.39 s**; `curl -6` → timeout. curl survives because Happy Eyeballs races both families — a one-address pin cannot.

## Fix

- `validateAndResolveUrl` hostname path now resolves **once**, validates that exact answer (all-must-pass, unchanged), and returns every cleared address **IPv4 first** as `addresses`; `ip`/`family` mirror the first entry for single-pin callers.
- `buildPinnedAgent` hands the whole set to the connect layer, so `autoSelectFamily` can race families and fall back. Non-`all` callers get the first (now IPv4-preferred) entry.
- The connection can still only ever reach addresses the guard validated — and validating the same answer we pin **removes** the rebinding window the old second `lookup()` left open. Strictly no weaker.

## After (same network, same host)

```
pinned set: [104.18.16.86 v4, 104.18.17.86 v4, 2606:4700::6812:1156 v6, 2606:4700::6812:1056 v6]
OK 4573573 bytes in 1.36s
```

That 4.5 MB file is a kling-v2.1 clip that generated fine but was undownloadable before this patch.

## Tests

`pnpm run test:ssrf`: **42/42** — includes three new cases: literal → singleton `addresses`, dual-stack hostname → IPv4-first ordering, `ip`/`family` mirror `addresses[0]`. Typecheck clean.

## Impact

Unblocks every `safeDownload` consumer (Replicate / Runway / Kling asset fetches) on IPv4-only networks — and the downstream Director draft-tier rollout (juspay/director#98).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened protection against server-side request forgery by validating all resolved IPv4 and IPv6 addresses.
  * Pinned downloads to the complete validated address set, reducing DNS-rebinding risks.
  * Improved handling of dual-stack hosts and connection fallback behavior.

* **Bug Fixes**
  * DNS resolution failures are now rejected instead of being allowed to proceed.

* **Tests**
  * Added coverage for IP literals and dual-stack address ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->