### PR TITLE
fix(proxy): harden Anthropic request and retry handling

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -65,7 +65,6 @@ import {
   logBodyCapture,
   logRequest,
   logRequestAttempt,
-  logStreamError,
 } from "../../proxy/requestLogger.js";
 import { createSSEInterceptor } from "../../proxy/sseInterceptor.js";
 import {
@@ -119,6 +118,7 @@ import type {
   RuntimeAccountState,
   ServerContext,
   StreamTerminalOutcome,
+  TransientRateLimitRetryBudget,
 } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
 import { ProviderHealthChecker } from "../../utils/providerHealth.js";
@@ -188,6 +188,21 @@ const UPSTREAM_FETCH_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
 const accountRuntimeState = new Map<string, RuntimeAccountState>();
 
+/** Shared across requests so a concurrent burst gets at most two retries for
+ *  the account/window, rather than every request starting its own retry chain. */
+const transientRateLimitRetryBudgets = new Map<
+  string,
+  TransientRateLimitRetryBudget
+>();
+
+/** Pace requests that arrive while the last usable account has a short
+ * transient cooldown. This converts a local 429/retry storm into a bounded
+ * queue and avoids releasing every waiting request at the same millisecond. */
+const transientCooldownAdmissionSchedules = new Map<
+  string,
+  { coolingUntil: number; nextAdmissionAt: number }
+>();
+
 /** Track whether we've run the one-time startup prune. */
 let startupPruneDone = false;
 
@@ -195,6 +210,10 @@ let startupPruneDone = false;
  *  provide a retry-after header. Short enough to recover quickly, long
  *  enough to avoid immediately hammering the same account. */
 const DEFAULT_COOLING_PERIOD_MS = 60_000;
+const MAX_TRANSIENT_QUEUE_WAIT_MS = 90_000;
+const MAX_TRANSIENT_TOTAL_QUEUE_WAIT_MS = 120_000;
+const TRANSIENT_ADMISSION_SPACING_MS = 250;
+const MAX_TRANSIENT_ADMISSION_SPREAD_MS = 15_000;
 
 /** Advance the primary account index when the current primary is exhausted
  *  (429 retries exhausted or auth failure). This is what makes fill-first work:
@@ -272,6 +291,108 @@ function maybeResetPrimaryToHome(
 function isAccountCooling(accountKey: string): boolean {
   const state = accountRuntimeState.get(accountKey);
   return !!state?.coolingUntil && Date.now() < state.coolingUntil;
+}
+
+function claimTransientRateLimitRetry(
+  accountKey: string,
+  coolingUntil: number,
+  now: number = Date.now(),
+): number | undefined {
+  let budget = transientRateLimitRetryBudgets.get(accountKey);
+  if (!budget || now >= budget.coolingUntil) {
+    budget = { coolingUntil, retriesClaimed: 0 };
+    transientRateLimitRetryBudgets.set(accountKey, budget);
+  } else if (coolingUntil > budget.coolingUntil) {
+    budget.coolingUntil = coolingUntil;
+  }
+
+  if (budget.retriesClaimed >= MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES) {
+    return undefined;
+  }
+  budget.retriesClaimed += 1;
+  return budget.retriesClaimed;
+}
+
+function claimTransientCooldownAdmission(
+  accountKey: string,
+  coolingUntil: number,
+  now: number = Date.now(),
+): number | undefined {
+  if (coolingUntil <= now) {
+    return 0;
+  }
+  if (coolingUntil - now > MAX_TRANSIENT_QUEUE_WAIT_MS) {
+    return undefined;
+  }
+
+  let schedule = transientCooldownAdmissionSchedules.get(accountKey);
+  if (!schedule || now >= schedule.coolingUntil) {
+    schedule = { coolingUntil, nextAdmissionAt: coolingUntil };
+    transientCooldownAdmissionSchedules.set(accountKey, schedule);
+  } else if (coolingUntil > schedule.coolingUntil) {
+    schedule.coolingUntil = coolingUntil;
+    schedule.nextAdmissionAt = Math.max(schedule.nextAdmissionAt, coolingUntil);
+  }
+
+  const admissionAt = Math.max(
+    now,
+    schedule.coolingUntil,
+    schedule.nextAdmissionAt,
+  );
+  if (admissionAt - schedule.coolingUntil > MAX_TRANSIENT_ADMISSION_SPREAD_MS) {
+    return undefined;
+  }
+  schedule.nextAdmissionAt = admissionAt + TRANSIENT_ADMISSION_SPACING_MS;
+  return admissionAt - now;
+}
+
+async function waitForTransientAccountAvailability(
+  orderedAccounts: ProxyPassthroughAccount[],
+): Promise<ProxyPassthroughAccount[]> {
+  const deadline = Date.now() + MAX_TRANSIENT_TOTAL_QUEUE_WAIT_MS;
+  while (Date.now() < deadline) {
+    const available = orderedAccounts.filter(
+      (account) => !isAccountCooling(account.key),
+    );
+    if (available.length > 0) {
+      return available;
+    }
+
+    const now = Date.now();
+    const transientCandidate = orderedAccounts
+      .map((account) => ({
+        account,
+        state: getOrCreateRuntimeState(account.key),
+      }))
+      .filter(
+        ({ state }) =>
+          state.coolingReason === "transient" &&
+          state.coolingUntil !== undefined &&
+          state.coolingUntil > now,
+      )
+      .sort(
+        (a, b) =>
+          (a.state.coolingUntil ?? Number.POSITIVE_INFINITY) -
+          (b.state.coolingUntil ?? Number.POSITIVE_INFINITY),
+      )[0];
+    if (!transientCandidate?.state.coolingUntil) {
+      return [];
+    }
+
+    const waitMs = claimTransientCooldownAdmission(
+      transientCandidate.account.key,
+      transientCandidate.state.coolingUntil,
+      now,
+    );
+    if (waitMs === undefined || now + waitMs > deadline) {
+      return [];
+    }
+    logger.always(
+      `[proxy] all usable accounts are transiently cooling; queueing request for account=${transientCandidate.account.label} in ${waitMs}ms`,
+    );
+    await sleep(waitMs);
+  }
+  return [];
 }
 
 // ---------------------------------------------------------------------------
@@ -892,15 +1013,14 @@ function polyfillOAuthBody(
   bodyStr: string,
   accountToken: string,
   snapshot: ClaudeSnapshot | null,
+  isClaudeClientRequest: boolean,
   preferredSessionId?: string,
 ): { bodyStr: string; sessionId?: string } {
   try {
     const parsed = JSON.parse(bodyStr);
 
-    // Billing header block (required by Anthropic for OAuth)
-    // NOTE: This block MUST be deterministic (no random values) to preserve
-    // Anthropic's prompt caching prefix chain. We keep the real Claude Code
-    // version/entrypoint shape when present, but stabilize the volatile cch.
+    // Billing header block synthesized for clients that do not already provide
+    // the genuine Claude Code identity shape.
     const agentBlock = {
       type: "text",
       text:
@@ -912,11 +1032,11 @@ function polyfillOAuthBody(
     //
     // The subscription/OAuth path only accepts a `system` it recognises as the
     // genuine Claude Code prompt. A real CC client sends its own billing + agent
-    // identity blocks alongside the canonical prompt — we keep those in place and
-    // just stabilise the volatile billing `cch`. A custom client (Curator) sends
-    // its own arbitrary system prompt with NO agent block; left in `system` it is
-    // rejected as `rate_limit_error: "Error"`, so we relocate it into the message
-    // stream and send only the recognised billing + agent blocks as `system`.
+    // identity blocks alongside the canonical prompt, which must pass through
+    // unchanged. A custom client (Curator) sends its own arbitrary system prompt
+    // with NO agent block; left in `system` it is rejected as
+    // `rate_limit_error: "Error"`, so we relocate it into the message stream and
+    // send only the recognised billing + agent blocks as `system`.
     if (parsed.system) {
       if (typeof parsed.system === "string") {
         parsed.system = [{ type: "text", text: parsed.system }];
@@ -939,29 +1059,28 @@ function polyfillOAuthBody(
           ),
         };
 
-        // A genuine Claude Code client supplies its own agent-identity block;
-        // a custom client (Curator) does not.
-        const isClaudeCodeClient = agentIdx >= 0;
-
-        // Strip billing/agent from their positions (reverse order so indices
-        // stay valid). What remains is the client's "extra" system content.
-        const indicesToRemove = [billingIdx, agentIdx]
-          .filter((i) => i >= 0)
-          .sort((a, b) => b - a);
-        for (const idx of indicesToRemove) {
-          parsed.system.splice(idx, 1);
-        }
-
-        if (!isClaudeCodeClient && parsed.system.length > 0) {
-          // Non-CC client: relocate its system into the message stream so the
-          // subscription/OAuth path accepts the request, then send only the
-          // recognised billing + agent blocks as `system`.
-          relocateClientSystemIntoMessages(parsed, parsed.system);
-          parsed.system = [billingBlock, agentBlock];
+        const hasClaudeCodeSystemIdentity =
+          isClaudeClientRequest && agentIdx >= 0;
+        if (hasClaudeCodeSystemIdentity) {
+          // Claude Code's subagent billing marker, block order, and cache
+          // controls are part of the accepted request shape. Preserve every
+          // supplied block exactly; only synthesize a billing block if absent.
+          if (billingIdx < 0) {
+            parsed.system.unshift(billingBlock);
+          }
         } else {
-          // Genuine Claude Code (or no extra blocks): keep the recognised system
-          // and append the deterministic billing + agent blocks at the end.
-          parsed.system = [...parsed.system, billingBlock, agentBlock];
+          // Strip generated identity blocks before relocating a custom
+          // client's actual system instructions into the message stream.
+          const indicesToRemove = [billingIdx, agentIdx]
+            .filter((i) => i >= 0)
+            .sort((a, b) => b - a);
+          for (const idx of indicesToRemove) {
+            parsed.system.splice(idx, 1);
+          }
+          if (parsed.system.length > 0) {
+            relocateClientSystemIntoMessages(parsed, parsed.system);
+          }
+          parsed.system = [billingBlock, agentBlock];
         }
       }
     } else {
@@ -2850,8 +2969,6 @@ async function handleAnthropicStreamingSuccessResponse(args: {
   ) => void;
 }): Promise<AnthropicSuccessResult> {
   const {
-    ctx,
-    body,
     account,
     accountState: _accountState,
     response,
@@ -2955,20 +3072,11 @@ async function handleAnthropicStreamingSuccessResponse(args: {
         }
         controller.enqueue(value);
       } catch (streamErr) {
-        const errMsg =
-          streamErr instanceof Error ? streamErr.message : String(streamErr);
+        const errMsg = describeTransportError(streamErr);
         logger.always(
           `[proxy] mid-stream error account=${account.label}: ${errMsg}`,
         );
         streamOutcomeTracker.fail(errMsg);
-        logStreamError({
-          timestamp: new Date().toISOString(),
-          requestId: ctx.requestId,
-          account: account.label,
-          model: body.model,
-          errorMessage: errMsg,
-          durationMs: Date.now() - fetchStartMs,
-        });
         if (!mainStreamClosed) {
           mainStreamClosed = true;
           const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
@@ -3548,7 +3656,6 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
   ) => void;
 }): Promise<Response | unknown> {
   const {
-    ctx,
     body,
     account,
     accountState,
@@ -3608,20 +3715,11 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
           }
           controller.enqueue(value);
         } catch (streamErr) {
-          const errMsg =
-            streamErr instanceof Error ? streamErr.message : String(streamErr);
+          const errMsg = describeTransportError(streamErr);
           logger.always(
             `[proxy] mid-stream error (auth-retry) account=${account.label}: ${errMsg}`,
           );
           streamOutcomeTracker.fail(errMsg);
-          logStreamError({
-            timestamp: new Date().toISOString(),
-            requestId: ctx.requestId,
-            account: account.label,
-            model: body.model,
-            errorMessage: errMsg,
-            durationMs: Date.now() - fetchStartMs,
-          });
           if (!retryStreamClosed) {
             retryStreamClosed = true;
             const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
@@ -3920,18 +4018,43 @@ async function handleAnthropicAuthRetry(args: {
       logger.debug(
         `[proxy] retry ${authRetry + 1} failed: ${retryStatus} ${retryBody.substring(0, 120)}`,
       );
-      recordAttemptError(account.label, account.type, retryStatus);
 
-      // A real rate-limit 429 rotates accounts. But an anti-abuse / construction
-      // 429 (no rate-limit headers, body "Error") is NOT a real rate limit:
-      // advancing the primary or rotating cannot help and only burns quota. Skip
-      // the rotate path for it so it falls through to the terminal error return
-      // below, surfacing the truthful upstream error — mirroring the initial
-      // fetch path's fast-fail (isAntiAbuseConstruction429).
       if (
         retryStatus === 429 &&
-        !isAntiAbuseConstruction429(retryRespHeaders, retryBody)
+        isAntiAbuseConstruction429(retryRespHeaders, retryBody)
       ) {
+        logger.always(
+          `[proxy] ← 429 account=${account.label} anti-abuse/construction rejection after OAuth refresh — returning non-retryable request error`,
+        );
+        logAttempt(429, "construction_rejection", retryBody);
+        tracer?.setError("construction_rejection", retryBody.slice(0, 500));
+        currentUpstreamSpan?.end();
+        return {
+          response: finalizeAnthropicTerminalFetchError({
+            terminalError: buildAnthropicConstructionRejectionTerminalError(),
+            account,
+            tracer,
+            requestStartTime,
+            attemptNumber,
+            logProxyBody,
+            logFinalRequest,
+          }),
+          continueLoop: false,
+          lastError: retryBody,
+          authFailureMessage: currentAuthFailureMessage,
+          sawRateLimit: currentSawRateLimit,
+          sawTransientFailure: currentSawTransientFailure,
+          sawNetworkError: currentSawNetworkError,
+          upstreamSpan: undefined,
+        };
+      }
+
+      recordAttemptError(account.label, account.type, retryStatus);
+
+      // Construction rejections return through the terminal 400 path above.
+      // Every 429 reaching this branch is a genuine rate limit and must cool
+      // the account according to its reset window before rotating.
+      if (retryStatus === 429) {
         currentSawRateLimit = true;
         // Cool the account per its real reset window before rotating, so a
         // session/weekly-exhausted account isn't re-selected next request.
@@ -4088,7 +4211,7 @@ function buildAnthropicTerminalErrorResponse(args: {
       cacheReadTokens?: number;
     },
   ) => void;
-  errorType: "not_found_error" | "api_error";
+  errorType: "not_found_error" | "api_error" | "construction_rejection";
 }): Response | unknown {
   const {
     responseStatus,
@@ -4149,6 +4272,39 @@ function buildAnthropicTerminalErrorResponse(args: {
     });
     return clientError;
   }
+}
+
+function finalizeAnthropicTerminalFetchError(args: {
+  terminalError: NonNullable<AnthropicUpstreamFetchResult["terminalError"]>;
+  account: ProxyPassthroughAccount;
+  tracer?: ProxyTracer;
+  requestStartTime: number;
+  attemptNumber: number;
+  logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
+}): Response | unknown {
+  const {
+    terminalError,
+    account,
+    tracer,
+    requestStartTime,
+    attemptNumber,
+    logProxyBody,
+    logFinalRequest,
+  } = args;
+  recordFinalError(terminalError.status, account.label, account.type);
+  tracer?.end(terminalError.status, Date.now() - requestStartTime);
+  return buildAnthropicTerminalErrorResponse({
+    responseStatus: terminalError.status,
+    account,
+    errBody: terminalError.body,
+    errRespHeaders: terminalError.headers,
+    requestStartTime,
+    attemptNumber,
+    logProxyBody,
+    logFinalRequest,
+    errorType: terminalError.errorType,
+  });
 }
 
 async function handleAnthropicNonOkResponse(args: {
@@ -4757,6 +4913,7 @@ async function prepareAnthropicAccountAttempt(args: {
           bodyStr,
           token,
           snapshot,
+          isClaudeClientRequest,
           headers["x-claude-code-session-id"],
         )
       : { bodyStr };
@@ -4817,7 +4974,7 @@ async function prepareAnthropicAccountAttempt(args: {
  * "Error" and which carries NONE of the real rate-limit headers (no retry-after,
  * no anthropic-ratelimit-*). This is NOT a capacity limit — retrying or rotating
  * accounts cannot fix it and only burns quota, so the caller must fail fast and
- * surface the truthful upstream error instead of "all accounts rate-limited".
+ * return a non-retryable request error instead of "all accounts rate-limited".
  */
 function isAntiAbuseConstruction429(
   headers: Record<string, string>,
@@ -4833,6 +4990,23 @@ function isAntiAbuseConstruction429(
   return (
     body.includes("rate_limit_error") && /"message"\s*:\s*"Error"/.test(body)
   );
+}
+
+function buildAnthropicConstructionRejectionTerminalError(): NonNullable<
+  AnthropicUpstreamFetchResult["terminalError"]
+> {
+  return {
+    status: 400,
+    body: JSON.stringify(
+      buildClaudeError(
+        400,
+        "Anthropic rejected the OAuth request shape. This is not an account rate limit.",
+        "invalid_request_error",
+      ),
+    ),
+    headers: { "content-type": "application/json" },
+    errorType: "construction_rejection",
+  };
 }
 
 async function fetchAnthropicAccountResponse(args: {
@@ -4912,9 +5086,7 @@ async function fetchAnthropicAccountResponse(args: {
   }
 
   if (response.status === 429) {
-    sawRateLimit = true;
     const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
-    recordAttemptError(account.label, account.type, 429);
     // Capture full response headers and body for diagnostics (parity with
     // handleAnthropicNonOkResponse which does this for all other error statuses).
     const errRespHeaders: Record<string, string> = {};
@@ -4946,11 +5118,11 @@ async function fetchAnthropicAccountResponse(args: {
     });
     // Anti-abuse / request-construction 429 (no rate-limit headers, body
     // "Error"): rotating accounts cannot help and only burns quota. Fail fast
-    // and surface the truthful upstream error instead of the misleading
-    // "all accounts rate-limited" after 44 wasted attempts.
+    // and return a non-retryable request error instead of prompting the client
+    // to repeat the same malformed request as a genuine rate limit.
     if (isAntiAbuseConstruction429(errRespHeaders, String(lastError))) {
       logger.always(
-        `[proxy] ← 429 account=${account.label} anti-abuse/construction rejection (no ratelimit headers, body="Error") — NOT a real rate limit; returning upstream error without rotating`,
+        `[proxy] ← 429 account=${account.label} anti-abuse/construction rejection (no ratelimit headers, body="Error") — NOT a real rate limit; returning non-retryable request error`,
       );
       logAttempt(429, "construction_rejection", String(lastError));
       tracer?.setError(
@@ -4958,21 +5130,17 @@ async function fetchAnthropicAccountResponse(args: {
         String(lastError).slice(0, 500),
       );
       currentUpstreamSpan?.end();
-      const passthrough = new Response(String(lastError), {
-        status: 429,
-        headers: {
-          "content-type": errRespHeaders["content-type"] ?? "application/json",
-        },
-      });
       return {
         continueLoop: false,
-        response: passthrough,
+        terminalError: buildAnthropicConstructionRejectionTerminalError(),
         lastError,
         sawRateLimit,
         sawNetworkError,
         upstreamSpan: undefined,
       };
     }
+    sawRateLimit = true;
+    recordAttemptError(account.label, account.type, 429);
     // Parse the unified-window quota headers (present on real rate-limit 429s)
     // and derive a reset-aware cooldown plan. This is the fix for "kept
     // hammering the 5h/7d-exhausted account instead of switching": on an
@@ -5019,6 +5187,10 @@ async function fetchAnthropicAccountResponse(args: {
     sawNetworkError,
     upstreamSpan: currentUpstreamSpan,
   };
+}
+
+function shouldAttemptClaudeFallback(loopState: AnthropicLoopState): boolean {
+  return loopState.invalidRequestFailure === null;
 }
 
 async function handleAnthropicRoutedClaudeRequest(args: {
@@ -5096,7 +5268,17 @@ async function handleAnthropicRoutedClaudeRequest(args: {
   const nonCoolingAccounts = orderedAccounts.filter(
     (a) => !isAccountCooling(a.key),
   );
-  const effectiveAccounts = nonCoolingAccounts;
+  let effectiveAccounts = nonCoolingAccounts;
+
+  // If every usable account is cooling and the soonest recovery is a short
+  // transient burst cooldown, hold this request and pace its admission instead
+  // of returning a proxy-local 429 that makes the client retry in a herd. The
+  // helper rechecks because an in-flight retry can extend the cooldown while
+  // this request is waiting.
+  if (effectiveAccounts.length === 0) {
+    effectiveAccounts =
+      await waitForTransientAccountAvailability(orderedAccounts);
+  }
   if (effectiveAccounts.length === 0 && orderedAccounts.length > 0) {
     const coolingStates = orderedAccounts.map((account) =>
       getOrCreateRuntimeState(account.key),
@@ -5193,6 +5375,17 @@ async function handleAnthropicRoutedClaudeRequest(args: {
       loopState.lastError = fetchResult.lastError;
       loopState.sawRateLimit = fetchResult.sawRateLimit;
       loopState.sawNetworkError = fetchResult.sawNetworkError;
+      if (fetchResult.terminalError) {
+        return finalizeAnthropicTerminalFetchError({
+          terminalError: fetchResult.terminalError,
+          account,
+          tracer,
+          requestStartTime,
+          attemptNumber: loopState.attemptNumber,
+          logProxyBody,
+          logFinalRequest,
+        });
+      }
       if (fetchResult.continueLoop || !fetchResult.response) {
         // Genuine 429 (carries a cooldown plan derived from quota headers).
         if (fetchResult.cooldownPlan) {
@@ -5204,48 +5397,58 @@ async function handleAnthropicRoutedClaudeRequest(args: {
               // Non-fatal: routing already has the in-memory snapshot.
             });
           }
-          // Transient burst (window still allowed): a couple of jittered
-          // same-account retries before giving up. Exhaustion plans set
-          // rotateImmediately, so retrySameAccount is false and we skip this.
-          if (
-            fetchResult.retrySameAccount &&
-            fetchResult.retryAfterMs !== undefined &&
-            rateLimitSameAccountRetries < MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES
-          ) {
-            rateLimitSameAccountRetries += 1;
-            const base = Math.min(
-              fetchResult.retryAfterMs || 1_000,
-              MAX_RATE_LIMIT_RETRY_DELAY_MS,
-            );
-            // Cap AFTER jitter so the final sleep never exceeds the cap.
-            const delayMs = Math.min(
-              MAX_RATE_LIMIT_RETRY_DELAY_MS,
-              jitteredDelay(base),
-            );
-            logger.always(
-              `[proxy] retrying same account=${account.label} after transient 429 (${rateLimitSameAccountRetries}/${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
-            );
-            await sleep(delayMs);
-            continue;
-          }
-          // Exhaustion, or transient retries used up: park the account until
-          // its ACTUAL reset (5h/7d) — no 60s hardcap — and rotate. Extend-only
-          // so a concurrent short transient plan can't shorten a longer weekly
-          // cooldown already set by another in-flight request.
+          // Publish the cooldown before retrying so requests arriving behind
+          // this one skip the throttled account instead of joining the burst.
+          let cooldownExtended = false;
           if (
             !accountState.coolingUntil ||
             plan.coolingUntil > accountState.coolingUntil
           ) {
             accountState.coolingUntil = plan.coolingUntil;
             accountState.coolingReason = plan.reason;
+            cooldownExtended = true;
           }
-          await saveAccountCooldown(
-            account.key,
-            accountState.coolingUntil ?? plan.coolingUntil,
-            accountState.coolingReason ?? plan.reason,
-          ).catch(() => {
-            // Non-fatal: routing already has the in-memory cooldown.
-          });
+          if (cooldownExtended) {
+            await saveAccountCooldown(
+              account.key,
+              accountState.coolingUntil,
+              accountState.coolingReason ?? plan.reason,
+            ).catch(() => {
+              // Non-fatal: routing already has the in-memory cooldown.
+            });
+          }
+
+          // Transient retries are budgeted across all concurrent requests for
+          // this account/window. Exhaustion plans rotate immediately and never
+          // claim this budget.
+          const sharedRetrySlot = fetchResult.retrySameAccount
+            ? claimTransientRateLimitRetry(account.key, plan.coolingUntil)
+            : undefined;
+          if (
+            fetchResult.retrySameAccount &&
+            fetchResult.retryAfterMs !== undefined &&
+            rateLimitSameAccountRetries < MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES &&
+            sharedRetrySlot !== undefined
+          ) {
+            rateLimitSameAccountRetries += 1;
+            const base = Math.min(
+              fetchResult.retryAfterMs || 1_000,
+              MAX_RATE_LIMIT_RETRY_DELAY_MS,
+            );
+            // Stagger the two shared slots, then cap after jitter so the final
+            // sleep never exceeds the configured maximum.
+            const delayMs = Math.min(
+              MAX_RATE_LIMIT_RETRY_DELAY_MS,
+              jitteredDelay(base * sharedRetrySlot),
+            );
+            logger.always(
+              `[proxy] retrying same account=${account.label} after transient 429 (shared slot ${sharedRetrySlot}/${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
+            );
+            await sleep(delayMs);
+            continue;
+          }
+          // Exhaustion, or the shared transient retry budget being used up:
+          // rotate while the already-published cooldown remains active.
           advancePrimaryIfCurrent(
             account.key,
             enabledAccounts.length,
@@ -5419,33 +5622,38 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     acctSelectionSpan?.end();
   }
 
-  const configuredFallbackResult = await tryConfiguredClaudeFallbackChain({
-    ctx,
-    body,
-    parsedFallbackRequest: parsedRequest,
-    modelRouter,
-    tracer,
-    requestStartTime,
-    logProxyBody,
-    logFinalRequest,
-  });
-  if (configuredFallbackResult.response) {
-    return configuredFallbackResult.response;
-  }
-
-  // Try auto-provider fallback when the configured chain didn't produce a
-  // response (either no chain configured, or all entries failed/deduped).
-  if (!loopState.sawRateLimit) {
-    const autoFallbackResponse = await tryAutoClaudeFallback({
+  // Deterministic invalid requests (for example, prompt-too-long) cannot be
+  // repaired by changing providers. Preserve the authoritative Anthropic 400
+  // rather than delaying it or returning unrelated fallback output.
+  if (shouldAttemptClaudeFallback(loopState)) {
+    const configuredFallbackResult = await tryConfiguredClaudeFallbackChain({
       ctx,
       body,
+      parsedFallbackRequest: parsedRequest,
+      modelRouter,
       tracer,
       requestStartTime,
       logProxyBody,
       logFinalRequest,
     });
-    if (autoFallbackResponse) {
-      return autoFallbackResponse;
+    if (configuredFallbackResult.response) {
+      return configuredFallbackResult.response;
+    }
+
+    // Try auto-provider fallback when the configured chain didn't produce a
+    // response (either no chain configured, or all entries failed/deduped).
+    if (!loopState.sawRateLimit) {
+      const autoFallbackResponse = await tryAutoClaudeFallback({
+        ctx,
+        body,
+        tracer,
+        requestStartTime,
+        logProxyBody,
+        logFinalRequest,
+      });
+      if (autoFallbackResponse) {
+        return autoFallbackResponse;
+      }
     }
   }
 
@@ -5836,6 +6044,28 @@ function getErrorCode(error: unknown): string | undefined {
   return typeof causeCode === "string" ? causeCode : undefined;
 }
 
+function describeTransportError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!error || typeof error !== "object") {
+    return message;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  const causeMessage =
+    cause instanceof Error
+      ? cause.message
+      : cause && typeof cause === "object"
+        ? String((cause as { message?: unknown }).message ?? "")
+        : "";
+  const code = getErrorCode(error);
+  const detail = [
+    code,
+    causeMessage && causeMessage !== message && causeMessage,
+  ]
+    .filter(Boolean)
+    .join(": ");
+  return detail ? `${message} (${detail})` : message;
+}
+
 /**
  * Determine whether a thrown fetch error is a transient connectivity issue.
  */
@@ -6043,9 +6273,31 @@ export const __testHooks = {
   },
   resetAllRuntimeState: (): void => {
     accountRuntimeState.clear();
+    transientRateLimitRetryBudgets.clear();
+    transientCooldownAdmissionSchedules.clear();
     primaryAccountIndex = 0;
     lastKnownAccountCount = 0;
     configuredPrimaryAccountKey = undefined;
     configuredAccountAllowlist = undefined;
   },
+  polyfillOAuthBody: (
+    bodyStr: string,
+    isClaudeClientRequest: boolean,
+  ): { bodyStr: string; sessionId?: string } =>
+    polyfillOAuthBody(
+      bodyStr,
+      "test-account-token",
+      null,
+      isClaudeClientRequest,
+    ),
+  isAntiAbuseConstruction429,
+  fetchAnthropicAccountResponse,
+  finalizeAnthropicTerminalFetchError,
+  handleAnthropicAuthRetry,
+  handleAnthropicStreamingSuccessResponse,
+  claimTransientRateLimitRetry,
+  claimTransientCooldownAdmission,
+  waitForTransientAccountAvailability,
+  describeTransportError,
+  shouldAttemptClaudeFallback,
 };

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -694,6 +694,11 @@ export type AccountCooldownPlan = {
   rotateImmediately: boolean;
 };
 
+export type TransientRateLimitRetryBudget = {
+  coolingUntil: number;
+  retriesClaimed: number;
+};
+
 export type AnthropicUpstreamFetchResult = {
   continueLoop: boolean;
   retrySameAccount?: boolean;
@@ -703,6 +708,15 @@ export type AnthropicUpstreamFetchResult = {
   cooldownPlan?: AccountCooldownPlan;
   /** Quota snapshot parsed from the response headers (429 or success), if present. */
   quota?: AccountQuota;
+  /** A terminal upstream rejection already captured and classified by the
+   *  fetch layer. The route must finalize it directly instead of feeding it
+   *  through the generic non-OK handler a second time. */
+  terminalError?: {
+    status: number;
+    body: string;
+    headers: Record<string, string>;
+    errorType: "construction_rejection";
+  };
   response?: Response;
   lastError: unknown;
   sawRateLimit: boolean;

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -787,7 +787,7 @@ const tests: TestFunction[] = [
           "Anthropic accounts are cooling after upstream rate limits",
         ) &&
         src.includes("Earliest retry at") &&
-        src.includes("const effectiveAccounts = nonCoolingAccounts;")
+        src.includes("let effectiveAccounts = nonCoolingAccounts;")
       );
     },
   },

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -36,18 +36,498 @@ import {
   createStreamTerminalOutcomeTracker,
   mergeStreamTerminalOutcome,
 } from "../src/lib/proxy/streamOutcome.js";
+import { getStats, resetStats } from "../src/lib/proxy/usageStats.js";
 import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   clearRefreshStateForTests();
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
   );
   __testHooks.resetAllRuntimeState();
+  resetStats();
+});
+
+describe("OAuth request-shape preservation", () => {
+  it("preserves the exact genuine Claude Code subagent system shape", () => {
+    const agentCache = { type: "ephemeral" };
+    const instructionsCache = { type: "ephemeral" };
+    const request = {
+      model: "claude-sonnet-5",
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.207.fa5; cc_entrypoint=cli; cc_is_subagent=true;",
+        },
+        {
+          type: "text",
+          text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+          cache_control: agentCache,
+        },
+        {
+          type: "text",
+          text: "Keep this canonical Claude Code instruction block in place.",
+          cache_control: instructionsCache,
+        },
+      ],
+      messages: [{ role: "user", content: "hello" }],
+      metadata: {
+        user_id: JSON.stringify({
+          device_id: "a".repeat(64),
+          account_uuid: "11111111-1111-4111-8111-111111111111",
+          session_id: "22222222-2222-4222-8222-222222222222",
+        }),
+      },
+    };
+
+    const result = JSON.parse(
+      __testHooks.polyfillOAuthBody(JSON.stringify(request), true).bodyStr,
+    );
+
+    expect(result).toEqual(request);
+  });
+
+  it("continues relocating billing-only custom-client instructions out of OAuth system", () => {
+    const result = JSON.parse(
+      __testHooks.polyfillOAuthBody(
+        JSON.stringify({
+          model: "claude-sonnet-5",
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.201; cc_entrypoint=cli; cch=random;",
+            },
+            {
+              type: "text",
+              text: "Custom application instructions",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+          messages: [{ role: "user", content: "hello" }],
+        }),
+        true,
+      ).bodyStr,
+    );
+
+    expect(result.system).toHaveLength(2);
+    expect(result.system[0].text).toContain("x-anthropic-billing-header");
+    expect(result.system[1].text).toContain("Claude Agent SDK");
+    expect(result.messages[0].content[0]).toMatchObject({
+      type: "text",
+      text: "<system_instructions>\nCustom application instructions\n</system_instructions>",
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("prepends synthesized billing before an existing Claude Code agent block", () => {
+    const result = JSON.parse(
+      __testHooks.polyfillOAuthBody(
+        JSON.stringify({
+          model: "claude-sonnet-5",
+          system: [
+            {
+              type: "text",
+              text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+              cache_control: { type: "ephemeral" },
+            },
+            { type: "text", text: "Canonical Claude Code instructions" },
+          ],
+          messages: [{ role: "user", content: "hello" }],
+        }),
+        true,
+      ).bodyStr,
+    );
+
+    expect(result.system.map((block: { text: string }) => block.text)).toEqual([
+      expect.stringContaining("x-anthropic-billing-header"),
+      "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+      "Canonical Claude Code instructions",
+    ]);
+  });
+});
+
+describe("429 classification and retry amplification", () => {
+  const fetchArgs = (
+    logAttempt: ReturnType<typeof vi.fn>,
+    logProxyBody: ReturnType<typeof vi.fn>,
+  ) => ({
+    url: "https://api.anthropic.com/v1/messages",
+    headers: { "content-type": "application/json" },
+    finalBodyStr: "{}",
+    account: {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    },
+    accountState: {
+      consecutiveRefreshFailures: 0,
+      permanentlyDisabled: false,
+    },
+    enabledAccounts: [],
+    orderedAccounts: [],
+    logAttempt,
+    logProxyBody,
+    fetchStartMs: Date.now(),
+    attemptNumber: 1,
+    currentLastError: undefined,
+    currentSawRateLimit: false,
+    currentSawNetworkError: false,
+  });
+
+  it("returns a construction rejection once without counting it as a rate limit", async () => {
+    const body = JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Error" },
+    });
+    const clientBody = JSON.stringify({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Anthropic rejected the OAuth request shape. This is not an account rate limit.",
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(body, {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "x-should-retry": "true",
+        },
+      }),
+    );
+    const logAttempt = vi.fn();
+    const logProxyBody = vi.fn();
+    const logFinalRequest = vi.fn();
+    const args = fetchArgs(logAttempt, logProxyBody);
+
+    const result = await __testHooks.fetchAnthropicAccountResponse(args);
+
+    expect(result).toMatchObject({
+      continueLoop: false,
+      sawRateLimit: false,
+      terminalError: {
+        status: 400,
+        body: clientBody,
+        errorType: "construction_rejection",
+      },
+    });
+    expect(result.response).toBeUndefined();
+    expect(logAttempt).toHaveBeenCalledTimes(1);
+    expect(logAttempt).toHaveBeenCalledWith(
+      429,
+      "construction_rejection",
+      body,
+    );
+    if (!result.terminalError) {
+      throw new Error("expected a terminal construction rejection");
+    }
+    expect(
+      __testHooks.finalizeAnthropicTerminalFetchError({
+        terminalError: result.terminalError,
+        account: args.account,
+        requestStartTime: args.fetchStartMs,
+        attemptNumber: args.attemptNumber,
+        logProxyBody,
+        logFinalRequest,
+      }),
+    ).toEqual(JSON.parse(clientBody));
+    expect(logProxyBody).toHaveBeenCalledTimes(2);
+    expect(logFinalRequest).toHaveBeenCalledTimes(1);
+    expect(logFinalRequest).toHaveBeenCalledWith(
+      400,
+      "primary@example.com",
+      "oauth",
+      "construction_rejection",
+      clientBody,
+    );
+    expect(getStats().totalRateLimits).toBe(0);
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getStats().accounts["primary@example.com"]).toMatchObject({
+      errorCount: 1,
+      rateLimitCount: 0,
+    });
+  });
+
+  it("finalizes a construction rejection after OAuth refresh as one 400", async () => {
+    const upstreamBody = JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Error" },
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: "refreshed-access",
+            refresh_token: "refreshed-refresh",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(upstreamBody, {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "x-should-retry": "true",
+          },
+        }),
+      );
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "expired-access",
+      refreshToken: "valid-refresh",
+      type: "oauth" as const,
+    };
+    const logAttempt = vi.fn();
+    const logProxyBody = vi.fn();
+    const logFinalRequest = vi.fn();
+    const tracer = {
+      logUpstreamResponseHeaders: vi.fn(),
+      logUpstreamResponseBody: vi.fn(),
+      setError: vi.fn(),
+      end: vi.fn(),
+    };
+    const upstreamSpan = { end: vi.fn() };
+
+    const result = await __testHooks.handleAnthropicAuthRetry({
+      ctx: {} as never,
+      body: { model: "claude-sonnet-5", messages: [], stream: true },
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      headers: { "content-type": "application/json" },
+      buildUpstreamBody: () => ({ bodyStr: "{}" }),
+      enabledAccounts: [account],
+      orderedAccounts: [account],
+      response: new Response(upstreamBody, { status: 401 }),
+      tracer: tracer as never,
+      requestStartTime: Date.now(),
+      fetchStartMs: Date.now(),
+      attemptNumber: 2,
+      finalBodyStr: "{}",
+      upstreamSpan: upstreamSpan as never,
+      logAttempt,
+      logProxyBody,
+      logFinalRequest,
+      lastError: undefined,
+      authFailureMessage: null,
+      sawRateLimit: false,
+      sawTransientFailure: false,
+      sawNetworkError: false,
+    });
+
+    expect(result).toMatchObject({
+      continueLoop: false,
+      sawRateLimit: false,
+      response: {
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Anthropic rejected the OAuth request shape. This is not an account rate limit.",
+        },
+      },
+    });
+    expect(logAttempt).toHaveBeenCalledTimes(1);
+    expect(logAttempt).toHaveBeenCalledWith(
+      429,
+      "construction_rejection",
+      upstreamBody,
+    );
+    expect(logFinalRequest).toHaveBeenCalledTimes(1);
+    expect(logFinalRequest).toHaveBeenCalledWith(
+      400,
+      account.label,
+      account.type,
+      "construction_rejection",
+      expect.stringContaining("not an account rate limit"),
+    );
+    expect(tracer.end).toHaveBeenCalledTimes(1);
+    expect(upstreamSpan.end).toHaveBeenCalledTimes(1);
+    expect(getStats().totalRateLimits).toBe(0);
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+  });
+
+  it("still counts and plans cooldown for a genuine transient 429", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "Rate limited" },
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "1",
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-status": "allowed",
+            "anthropic-ratelimit-unified-7d-status": "allowed",
+          },
+        },
+      ),
+    );
+
+    const result = await __testHooks.fetchAnthropicAccountResponse(
+      fetchArgs(vi.fn(), vi.fn()),
+    );
+
+    expect(result).toMatchObject({
+      continueLoop: true,
+      retrySameAccount: true,
+      sawRateLimit: true,
+      cooldownPlan: { reason: "transient", rotateImmediately: false },
+    });
+    expect(getStats().totalRateLimits).toBe(1);
+  });
+
+  it("shares two transient retries across an entire concurrent account window", () => {
+    const now = 1_800_000_000_000;
+    const coolingUntil = now + 60_000;
+    const claims = Array.from({ length: 8 }, () =>
+      __testHooks.claimTransientRateLimitRetry(
+        "anthropic:primary@example.com",
+        coolingUntil,
+        now,
+      ),
+    );
+
+    expect(claims).toEqual([
+      1,
+      2,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(
+      __testHooks.claimTransientRateLimitRetry(
+        "anthropic:primary@example.com",
+        coolingUntil + 120_000,
+        coolingUntil + 1,
+      ),
+    ).toBe(1);
+  });
+
+  it("paces a bounded queue through a short transient cooldown", () => {
+    const now = 1_800_000_000_000;
+    const coolingUntil = now + 60_000;
+    const firstThree = Array.from({ length: 3 }, () =>
+      __testHooks.claimTransientCooldownAdmission(
+        "anthropic:primary@example.com",
+        coolingUntil,
+        now,
+      ),
+    );
+
+    expect(firstThree).toEqual([60_000, 60_250, 60_500]);
+    const remainingClaims = Array.from({ length: 59 }, () =>
+      __testHooks.claimTransientCooldownAdmission(
+        "anthropic:primary@example.com",
+        coolingUntil,
+        now,
+      ),
+    );
+    expect(remainingClaims.at(-2)).toBe(75_000);
+    expect(remainingClaims.at(-1)).toBeUndefined();
+    expect(
+      __testHooks.claimTransientCooldownAdmission(
+        "anthropic:other@example.com",
+        now + 120_000,
+        now,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("waits for transient recovery and spaces concurrent admissions", async () => {
+    vi.useFakeTimers();
+    const now = 1_800_000_000_000;
+    vi.setSystemTime(now);
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    };
+    __testHooks.setAccountRuntimeState(account.key, {
+      coolingUntil: now + 60_000,
+      coolingReason: "transient",
+    });
+
+    const firstAdmission = __testHooks.waitForTransientAccountAvailability([
+      account,
+    ]);
+    const secondAdmission = __testHooks.waitForTransientAccountAvailability([
+      account,
+    ]);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(firstAdmission).resolves.toEqual([account]);
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(secondAdmission).resolves.toEqual([account]);
+  });
+
+  it("never queues through a hard quota cooldown", async () => {
+    const now = Date.now();
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    };
+    __testHooks.setAccountRuntimeState(account.key, {
+      coolingUntil: now + 5 * 60 * 60 * 1000,
+      coolingReason: "five_hour",
+    });
+
+    await expect(
+      __testHooks.waitForTransientAccountAvailability([account]),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not run provider fallback for a deterministic invalid request", () => {
+    const loopState = {
+      lastError: undefined,
+      sawRateLimit: false,
+      sawNetworkError: false,
+      sawTransientFailure: false,
+      invalidRequestFailure: null,
+      authFailureMessage: null,
+      authCooldownMessage: null,
+      attemptNumber: 1,
+    };
+
+    expect(__testHooks.shouldAttemptClaudeFallback(loopState)).toBe(true);
+    expect(
+      __testHooks.shouldAttemptClaudeFallback({
+        ...loopState,
+        invalidRequestFailure: {
+          status: 400,
+          body: JSON.stringify({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message: "prompt is too long",
+            },
+          }),
+          contentType: "application/json",
+        },
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("authoritative unified rate-limit handling", () => {
@@ -520,6 +1000,95 @@ describe("stream terminal outcomes", () => {
       __testHooks.getStreamFailureDetails({ kind: "client_cancelled" }),
     ).toMatchObject({ status: 499, errorType: "client_cancelled" });
   });
+
+  it("retains the nested transport cause for terminated streams", () => {
+    const cause = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const error = new Error("terminated", { cause });
+
+    expect(__testHooks.describeTransportError(error)).toBe(
+      "terminated (UND_ERR_SOCKET: other side closed)",
+    );
+  });
+
+  it("settles failed-stream telemetry exactly once", async () => {
+    const encoder = new TextEncoder();
+    const transportCause = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const upstreamStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+          ),
+        );
+      },
+      pull() {
+        throw new Error("terminated", { cause: transportCause });
+      },
+    });
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    };
+    const logFinalRequest = vi.fn();
+    const logProxyBody = vi.fn();
+    const upstreamSpan = { end: vi.fn() };
+    const tracer = {
+      setUsage: vi.fn(),
+      logStreamEvents: vi.fn(),
+      setResponseInfo: vi.fn(),
+      logUpstreamResponseBody: vi.fn(),
+      recordMetrics: vi.fn(),
+      recordBodySizes: vi.fn(),
+      setError: vi.fn(),
+      end: vi.fn(),
+    };
+
+    const result = await __testHooks.handleAnthropicStreamingSuccessResponse({
+      ctx: {} as never,
+      body: { model: "claude-opus-4-8", messages: [], stream: true },
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      response: new Response(upstreamStream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+      responseHeaders: { "content-type": "text/event-stream" },
+      tracer: tracer as never,
+      requestStartTime: Date.now(),
+      fetchStartMs: Date.now(),
+      attemptNumber: 1,
+      finalBodyStr: "{}",
+      upstreamSpan: upstreamSpan as never,
+      logProxyBody,
+      logFinalRequest,
+    });
+
+    expect(result).not.toHaveProperty("retryNextAccount");
+    await (result.response as Response).text();
+    await vi.waitFor(() => expect(logFinalRequest).toHaveBeenCalledTimes(1));
+
+    expect(logFinalRequest).toHaveBeenCalledWith(
+      502,
+      account.label,
+      account.type,
+      "stream_error",
+      "terminated (UND_ERR_SOCKET: other side closed)",
+      expect.any(Object),
+    );
+    expect(tracer.setError).toHaveBeenCalledTimes(1);
+    expect(tracer.end).toHaveBeenCalledTimes(1);
+    expect(upstreamSpan.end).toHaveBeenCalledTimes(1);
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+  });
 });
 
 describe("launchd lifecycle source invariants", () => {
@@ -567,7 +1136,7 @@ describe("launchd lifecycle source invariants", () => {
       new URL("../src/lib/server/routes/claudeProxyRoutes.ts", import.meta.url),
       "utf8",
     );
-    expect(source).toContain("const effectiveAccounts = nonCoolingAccounts;");
+    expect(source).toContain("let effectiveAccounts = nonCoolingAccounts;");
     expect(source).toContain("eligible credentials reloaded");
     expect(source).toContain("authCooldownMessage");
     expect(source).not.toContain("credentials changed, re-enabling");


### PR DESCRIPTION
## Summary

- preserve genuine Claude Code OAuth request bodies instead of reordering system identity blocks or relocating their instructions
- classify Anthropic construction rejections separately from genuine rate limits and finalize them exactly once
- publish transient cooldowns before retrying, share retry budgets across concurrent requests, and pace requests waiting for short cooldown recovery
- keep authoritative quota cooldowns reset-aware, skip fallback for deterministic invalid requests, and improve stream transport diagnostics without duplicate terminal telemetry

## Evidence

A direct A/B replay used the same captured request, account, endpoint, and headers:

- original Claude Code body: HTTP 200, with 5h and 7d quota explicitly allowed
- proxy-mutated body: HTTP 429 with rate_limit_error: Error and no genuine rate-limit headers
- patched transformation is byte-identical to the accepted original body

A later incident reproduced the same result with a different captured request.

## Validation

- 210/210 Vitest tests
- 118/118 environment guard checks
- 89/89 production bugfix checks
- pnpm typecheck
- pnpm build:cli
- full pre-commit check, lint, validation, security scan, package build, browser build, and publint

The live proxy was not modified or restarted during development or verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved temporary rate-limit handling by coordinating retries and smoothing recovery when accounts are cooling down.
  - More consistent streaming error reporting that preserves underlying transport details.
  - Certain “construction rejection” 429 responses are now treated as non-retryable terminal errors (mapped to a terminal failure instead of rate limiting).
  - Preserved genuine Claude Code identity blocks while keeping custom instructions formatted consistently.
  - Prevented deterministic invalid requests from triggering unnecessary provider fallback.
- **Tests**
  - Expanded reliability and OAuth/streaming error coverage for rate-limit coordination, cooldown pacing, terminal error handling, and fallback gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->