### PR TITLE
fix(proxy): harden updater fallback and terminal errors

### DIFF
--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -144,7 +144,7 @@ neurolink proxy setup --no-service
 
 ### `neurolink proxy guard` (hidden)
 
-Internal fail-open guard process. Spawned only by a foreground `proxy start`; launchd-managed proxies leave restart ownership entirely to launchd. The guard reverts stale Claude Code settings only after its parent is confirmed dead and never restarts or signals a live proxy.
+Internal fail-open guard process. Spawned only by a foreground `proxy start`; launchd-managed proxies leave restart ownership entirely to launchd. The guard reverts stale Claude Code settings only after its parent is confirmed dead and never restarts or signals a live proxy. A launchd installation uses a separate updater-only worker which never changes client settings.
 
 | Flag                  | Type      | Default      | Description                                                  |
 | --------------------- | --------- | ------------ | ------------------------------------------------------------ |
@@ -553,16 +553,19 @@ routing.
 
 ## 3. Environment Variables
 
-| Variable                      | Purpose                                                                                                                                                              | Used By                                          |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `ANTHROPIC_API_KEY`           | Anthropic API key. Used as a fallback credential when no OAuth accounts are found.                                                                                   | Proxy routes, Anthropic provider                 |
-| `ANTHROPIC_OAUTH_TOKEN`       | OAuth access token for Anthropic (alternative to stored tokens).                                                                                                     | Anthropic provider, providerConfig               |
-| `CLAUDE_OAUTH_TOKEN`          | Alias for `ANTHROPIC_OAUTH_TOKEN`. Checked as a fallback.                                                                                                            | Anthropic provider, providerConfig               |
-| `NEUROLINK_SKIP_MCP`          | Set to `"true"` to skip MCP server initialization. Automatically set by `proxy start` (tools come from Claude Code, not local MCP servers).                          | `NeuroLink` constructor                          |
-| `NEUROLINK_LOG_LEVEL`         | Log level for the NeuroLink logger. Values: `error`, `warn`, `info`, `debug`.                                                                                        | Logger utility                                   |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP HTTP endpoint for proxy telemetry export. Written automatically to `~/.neurolink/.env` by `neurolink proxy telemetry setup`. Example: `http://localhost:14318`. | Proxy OTEL init (`initializeProxyOpenTelemetry`) |
-| `NEUROLINK_ENV_FILE`          | Path to a `.env` file the proxy should load at startup. Overrides the default `~/.neurolink/.env` auto-load.                                                         | `proxyEnv.ts` (`resolveProxyEnvFile`)            |
-| `NEUROLINK_PROXY_AUTO_UPDATE` | Enables the legacy guard updater only for `1`, `on`, or `true`. Disabled by default. launchd-managed proxies do not spawn a guard.                                   | Foreground fail-open guard                       |
+| Variable                         | Purpose                                                                                                                                                                                                                                 | Used By                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `ANTHROPIC_API_KEY`              | Anthropic API key. Used as a fallback credential when no OAuth accounts are found.                                                                                                                                                      | Proxy routes, Anthropic provider                 |
+| `ANTHROPIC_OAUTH_TOKEN`          | OAuth access token for Anthropic (alternative to stored tokens).                                                                                                                                                                        | Anthropic provider, providerConfig               |
+| `CLAUDE_OAUTH_TOKEN`             | Alias for `ANTHROPIC_OAUTH_TOKEN`. Checked as a fallback.                                                                                                                                                                               | Anthropic provider, providerConfig               |
+| `NEUROLINK_SKIP_MCP`             | Set to `"true"` to skip MCP server initialization. Automatically set by `proxy start` (tools come from Claude Code, not local MCP servers).                                                                                             | `NeuroLink` constructor                          |
+| `NEUROLINK_LOG_LEVEL`            | Log level for the NeuroLink logger. Values: `error`, `warn`, `info`, `debug`.                                                                                                                                                           | Logger utility                                   |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`    | OTLP HTTP endpoint for proxy telemetry export. Written automatically to `~/.neurolink/.env` by `neurolink proxy telemetry setup`. Example: `http://localhost:14318`.                                                                    | Proxy OTEL init (`initializeProxyOpenTelemetry`) |
+| `NEUROLINK_ENV_FILE`             | Path to a `.env` file the proxy should load at startup. Overrides the default `~/.neurolink/.env` auto-load.                                                                                                                            | `proxyEnv.ts` (`resolveProxyEnvFile`)            |
+| `NEUROLINK_PROXY_AUTO_UPDATE`    | Automatic package updates for launchd installations. Enabled by default; set to `0`, `off`, or `false` to disable. Updates use the package manager owning the running install and restart only after all requests and streams are idle. | Dedicated launchd updater worker                 |
+| `NEUROLINK_PACKAGE_MANAGER_PATH` | Optional absolute path to the npm or pnpm executable used by the updater. The candidate is still rejected unless its writable global root owns the running NeuroLink installation.                                                      | Dedicated launchd updater worker                 |
+| `NEUROLINK_PACKAGE_MANAGER`      | Optional `npm` or `pnpm` type for `NEUROLINK_PACKAGE_MANAGER_PATH`. When omitted, the updater infers the type from the executable name.                                                                                                 | Dedicated launchd updater worker                 |
+| `NEUROLINK_PNPM_PATH`            | Legacy pnpm-specific updater override. Prefer `NEUROLINK_PACKAGE_MANAGER_PATH` for new installations.                                                                                                                                   | Dedicated launchd updater worker                 |
 
 ### Proxy Env File Resolution Order
 
@@ -607,7 +610,7 @@ When the proxy starts, it automatically writes to `~/.claude/settings.json`:
 
 - **On `proxy start`** -- Both keys are written (or merged into existing settings).
 - **On `proxy stop` (Ctrl+C / SIGTERM)** -- Both keys are removed. Other env keys in the settings file are preserved.
-- **Fail-open guard** -- A foreground proxy's detached guard removes stale settings only after confirming its parent died and no replacement is healthy. launchd-managed proxies do not spawn this guard.
+- **Fail-open guard** -- A foreground proxy's detached guard removes stale settings only after confirming its parent died and no replacement is healthy. launchd-managed proxies do not spawn this cleanup guard; they use a separate updater-only worker.
 - **Safety** -- If the `ANTHROPIC_BASE_URL` has been changed to a different value (e.g., another proxy), the cleanup will not overwrite it.
 
 After starting the proxy, restart Claude Code for the new settings to take effect.

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -544,7 +544,7 @@ The proxy persists its running state to `~/.neurolink/proxy-state.json` so that 
 
 ### Fail-open guard
 
-A foreground proxy spawns one detached `neurolink proxy guard` that removes stale Claude Code settings after confirming its parent process has died. A launchd-managed proxy does not spawn a guard: launchd is the sole restart supervisor, preventing stale guards from restarting or terminating healthy replacement processes. Runtime package updates are opt-in through `NEUROLINK_PROXY_AUTO_UPDATE=1` (also accepts `on` or `true`).
+A foreground proxy spawns one detached `neurolink proxy guard` that removes stale Claude Code settings after confirming its parent process has died. A launchd-managed proxy keeps restart ownership in launchd and starts a separate updater-only worker. Automatic package updates are enabled by default and can be disabled with `NEUROLINK_PROXY_AUTO_UPDATE=off` (also accepts `0` or `false`). The worker validates the global package root and executable directory, requires the package manager that owns the running installation, and waits for every request and stream to finish plus a two-minute idle window before asking launchd to restart. Updater diagnostics are written to `~/.neurolink/logs/proxy-updater.log` and exposed in `neurolink proxy status`.
 
 ## Architecture
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -43,6 +43,8 @@ import type {
   ProxyStatusPrimaryAccount,
   ProxyTelemetryAction,
   ProxyTelemetryArgs,
+  ProxyRuntimeActivity,
+  RuntimeRequestMetadata,
   StatusStats,
 } from "../../lib/types/index.js";
 import type { ModelRouter } from "../../lib/proxy/modelRouter.js";
@@ -56,6 +58,16 @@ import {
   normalizeAnthropicAccountKey,
   shouldLoadFallbackCredential,
 } from "../../lib/proxy/accountSelection.js";
+import {
+  beginProxyRequest,
+  getProxyActivitySnapshot,
+  trackProxyResponse,
+} from "../../lib/proxy/proxyActivity.js";
+import {
+  describeInstallFailure,
+  getGlobalInstallArgs,
+  resolveGlobalInstaller,
+} from "../../lib/proxy/globalInstaller.js";
 import {
   loadProxyEnvFile,
   resolveProxyEnvFile,
@@ -216,7 +228,7 @@ function isLaunchdManagedProcess(): boolean {
 function isProxyAutoUpdateEnabled(
   value = process.env.NEUROLINK_PROXY_AUTO_UPDATE,
 ): boolean {
-  return ["1", "on", "true"].includes((value ?? "").trim().toLowerCase());
+  return !["0", "off", "false"].includes((value ?? "").trim().toLowerCase());
 }
 
 /** Keys we manage in Claude Code's settings.env */
@@ -457,6 +469,55 @@ async function isProxyHealthy(
   }
 }
 
+async function getProxyRuntimeActivity(
+  host: string,
+  port: number,
+  timeoutMs: number = 3_000,
+): Promise<ProxyRuntimeActivity | null> {
+  try {
+    const response = await fetch(`http://${host}:${port}/status`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const payload = (await response.json()) as {
+      activity?: Partial<ProxyRuntimeActivity>;
+    };
+    const activeRequests = Number(payload.activity?.activeRequests);
+    if (!Number.isFinite(activeRequests) || activeRequests < 0) {
+      return null;
+    }
+    return {
+      activeRequests,
+      lastActivityAt:
+        typeof payload.activity?.lastActivityAt === "string"
+          ? payload.activity.lastActivityAt
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isSafeUpdateWindow(
+  activity: ProxyRuntimeActivity,
+  quietThresholdMs: number,
+  nowMs: number = Date.now(),
+): boolean {
+  if (activity.activeRequests > 0) {
+    return false;
+  }
+  if (!activity.lastActivityAt) {
+    return true;
+  }
+  const lastActivityMs = Date.parse(activity.lastActivityAt);
+  return (
+    Number.isFinite(lastActivityMs) &&
+    nowMs - lastActivityMs >= quietThresholdMs
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Stable entrypoint for launchd
 // ---------------------------------------------------------------------------
@@ -566,136 +627,6 @@ exit 127
   chmodSync(TRAMPOLINE_PATH, 0o755);
 }
 
-/**
- * Check whether a pnpm binary can install into the global store.
- *
- * Multiple pnpm major versions can coexist (e.g., standalone v8 + nvm v10).
- * They use different store layouts (`store/v10` vs `store/v10/v3`), so a
- * pnpm that passes `--version` may still fail `pnpm add -g` with
- * ERR_PNPM_UNEXPECTED_STORE. We detect this by running `pnpm root -g` and
- * checking whether the resolved global root directory actually exists on disk.
- */
-function canInstallGlobally(pnpmPath: string): boolean {
-  try {
-    const { execFileSync } = _require(
-      "node:child_process",
-    ) as typeof import("node:child_process");
-    const { existsSync } = _require("fs") as typeof import("fs");
-    const globalRoot = execFileSync(pnpmPath, ["root", "-g"], {
-      encoding: "utf8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    // If the global root exists, this pnpm version is compatible with
-    // the current store layout and can install packages there.
-    return !!globalRoot && existsSync(globalRoot);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Resolve the `pnpm` binary defensively.
- *
- * Tries multiple candidates in order of preference. Each candidate must:
- * 1. Respond to `pnpm --version` (binary works)
- * 2. Have a compatible global store (`pnpm root -g` points to an existing dir)
- *
- * This defends against environments with multiple pnpm major versions
- * (e.g., standalone v8 + nvm v10) where the wrong one would fail with
- * ERR_PNPM_UNEXPECTED_STORE on `pnpm add -g`.
- *
- * Honors `NEUROLINK_PNPM_PATH` as an escape hatch.
- */
-function resolveFullPnpmPath(): {
-  bin: string;
-  resolved: boolean;
-  version?: string;
-  tried: Array<{
-    path: string;
-    version?: string;
-    working: boolean;
-    globalStoreOk?: boolean;
-  }>;
-} {
-  const candidates: string[] = [];
-
-  // 1. User override
-  if (process.env.NEUROLINK_PNPM_PATH) {
-    candidates.push(process.env.NEUROLINK_PNPM_PATH);
-  }
-
-  // 2. PNPM_HOME (pnpm's own env variable)
-  if (process.env.PNPM_HOME) {
-    candidates.push(join(process.env.PNPM_HOME, "pnpm"));
-  }
-
-  // 3. `which pnpm` — whatever is on PATH
-  try {
-    const { execFileSync } = _require(
-      "node:child_process",
-    ) as typeof import("node:child_process");
-    const whichOut = execFileSync("which", ["pnpm"], {
-      encoding: "utf8",
-      timeout: 5_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    if (whichOut) {
-      candidates.push(whichOut);
-    }
-  } catch {
-    // ignore
-  }
-
-  // 4. Common standalone installer locations
-  candidates.push(join(homedir(), ".local", "share", "pnpm", "pnpm"));
-  candidates.push(join(homedir(), "Library", "pnpm", "pnpm"));
-
-  // Dedupe while preserving order
-  const seen = new Set<string>();
-  const unique = candidates.filter((p) => {
-    if (!p || seen.has(p)) {
-      return false;
-    }
-    seen.add(p);
-    return true;
-  });
-
-  // Probe each candidate: must pass --version AND have a compatible global store
-  const tried = unique.map((path) => {
-    const version = probeBinVersion(path);
-    const working = version !== undefined;
-    const globalStoreOk = working ? canInstallGlobally(path) : false;
-    return { path, version, working, globalStoreOk };
-  });
-
-  // Prefer a candidate that can actually install globally
-  const fullyWorking = tried.find((r) => r.working && r.globalStoreOk);
-  if (fullyWorking) {
-    return {
-      bin: fullyWorking.path,
-      resolved: true,
-      version: fullyWorking.version,
-      tried,
-    };
-  }
-
-  // Fall back to any candidate that at least responds to --version
-  // (better than nothing — the install may still fail, but will be
-  // caught and suppressed by the caller)
-  const anyWorking = tried.find((r) => r.working);
-  if (anyWorking) {
-    return {
-      bin: anyWorking.path,
-      resolved: true,
-      version: anyWorking.version,
-      tried,
-    };
-  }
-
-  return { bin: "pnpm", resolved: false, tried };
-}
-
 function spawnFailOpenGuard(
   host: string,
   port: number,
@@ -748,6 +679,62 @@ function spawnFailOpenGuard(
     return undefined;
   } finally {
     closeSync(logFd); // parent closes its copy; child keeps the fd
+  }
+}
+
+function spawnProxyUpdater(
+  host: string,
+  port: number,
+  parentPid: number,
+): number | undefined {
+  if (!isProxyAutoUpdateEnabled()) {
+    logger.always("[proxy] automatic updates disabled by environment");
+    return undefined;
+  }
+
+  const entryScript = process.argv[1];
+  if (!entryScript) {
+    logger.always("[proxy] updater disabled: CLI entry script is unavailable");
+    return undefined;
+  }
+
+  const args = [
+    entryScript,
+    "proxy",
+    "guard",
+    "--host",
+    host,
+    "--port",
+    String(port),
+    "--parent-pid",
+    String(parentPid),
+    "--updater-only",
+    "--quiet",
+  ];
+  const { openSync, closeSync, mkdirSync, existsSync } = _require(
+    "fs",
+  ) as typeof import("fs");
+  const logsDir = join(homedir(), ".neurolink", "logs");
+  if (!existsSync(logsDir)) {
+    mkdirSync(logsDir, { recursive: true });
+  }
+  const logFd = openSync(join(logsDir, "proxy-updater.log"), "a");
+
+  try {
+    const child = spawn(process.execPath, args, {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env: process.env,
+    });
+    child.unref();
+    return child.pid;
+  } catch (error) {
+    logger.always(
+      `[proxy] updater failed to start: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  } finally {
+    closeSync(logFd);
   }
 }
 
@@ -1092,7 +1079,7 @@ async function resolveBootPrimaryAccountKey(
   return key;
 }
 
-async function createProxyStartApp(params: {
+export async function createProxyStartApp(params: {
   neurolink: ProxyNeurolinkRuntime["neurolink"];
   modelRouter: ModelRouter | undefined;
   strategy: ProxyStartStrategy;
@@ -1107,26 +1094,117 @@ async function createProxyStartApp(params: {
     await import("../../lib/server/routes/claudeProxyRoutes.js");
   const { createOpenAIProxyRoutes } =
     await import("../../lib/server/routes/openaiProxyRoutes.js");
+  const { logBodyCapture, logRequest } =
+    await import("../../lib/proxy/requestLogger.js");
+  const { recordFinalError } = await import("../../lib/proxy/usageStats.js");
   const { Hono } = await import("hono");
 
   const app = new Hono();
   const readiness = createProxyReadinessState();
-  app.onError((err, c) => {
+  const requestMetadata = new WeakMap<Request, RuntimeRequestMetadata>();
+
+  const recordRuntimeError = async (
+    metadata: RuntimeRequestMetadata,
+    status: number,
+    errorType: string,
+    errorMessage: string,
+    clientMessage: string = errorMessage,
+    clientErrorType: string = errorType,
+  ): Promise<void> => {
+    recordFinalError(status);
+    await Promise.all([
+      logRequest({
+        timestamp: new Date().toISOString(),
+        requestId: metadata.requestId,
+        method: metadata.method,
+        path: metadata.path,
+        model: metadata.model,
+        stream: metadata.stream,
+        toolCount: metadata.toolCount,
+        account: "",
+        accountType: "proxy-runtime",
+        responseStatus: status,
+        responseTimeMs: Date.now() - metadata.startedAt,
+        errorType,
+        errorMessage,
+      }),
+      logBodyCapture({
+        timestamp: new Date().toISOString(),
+        requestId: metadata.requestId,
+        model: metadata.model,
+        stream: metadata.stream,
+        phase: "client_response",
+        headers: { "content-type": "application/json" },
+        body: {
+          type: "error",
+          error: { type: clientErrorType, message: clientMessage },
+        },
+        contentType: "application/json",
+        responseStatus: status,
+        durationMs: Date.now() - metadata.startedAt,
+      }),
+    ]);
+  };
+
+  app.onError(async (err, c) => {
     const errMsg = err instanceof Error ? err.message : String(err);
     logger.always(`[proxy] unhandled error: ${errMsg}`);
     if (err instanceof Error && err.stack) {
-      logger.debug(`[proxy] stack: ${err.stack}`);
+      logger.always(`[proxy] unhandled stack: ${err.stack}`);
     }
+    const metadata = requestMetadata.get(c.req.raw) ?? {
+      requestId: crypto.randomUUID(),
+      method: c.req.method,
+      path: c.req.path,
+      startedAt: Date.now(),
+      model: "-",
+      stream: false,
+      toolCount: 0,
+    };
+    await recordRuntimeError(
+      metadata,
+      502,
+      "unhandled_proxy_error",
+      errMsg,
+      "Proxy internal error",
+      "api_error",
+    );
+    requestMetadata.delete(c.req.raw);
     return c.json(
       {
         type: "error",
         error: {
           type: "api_error",
-          message: `Proxy internal error: ${errMsg}`,
+          message: "Proxy internal error",
         },
       },
       502,
     );
+  });
+
+  app.use("/v1/*", async (c, next) => {
+    const metadata: RuntimeRequestMetadata = {
+      requestId: crypto.randomUUID(),
+      method: c.req.method,
+      path: c.req.path,
+      startedAt: Date.now(),
+      model: "-",
+      stream: false,
+      toolCount: 0,
+    };
+    requestMetadata.set(c.req.raw, metadata);
+    const finishActivity = beginProxyRequest();
+    const finish = () => {
+      finishActivity();
+      requestMetadata.delete(c.req.raw);
+    };
+    try {
+      await next();
+      c.res = trackProxyResponse(c.res, finish);
+    } catch (error) {
+      finishActivity();
+      throw error;
+    }
   });
 
   const routeGroup = createClaudeProxyRoutes(
@@ -1156,6 +1234,15 @@ async function createProxyStartApp(params: {
         try {
           body = rawBody ? JSON.parse(rawBody) : emptyBody;
         } catch {
+          const metadata = requestMetadata.get(c.req.raw);
+          if (metadata) {
+            await recordRuntimeError(
+              metadata,
+              400,
+              "invalid_request_error",
+              "Request body must be valid JSON",
+            );
+          }
           return c.json(
             {
               type: "error",
@@ -1177,12 +1264,18 @@ async function createProxyStartApp(params: {
       const toolCount = Array.isArray(bodyRec?.tools)
         ? (bodyRec.tools as unknown[]).length
         : 0;
+      const metadata = requestMetadata.get(c.req.raw);
+      if (metadata) {
+        metadata.model = String(model);
+        metadata.stream = stream === "stream";
+        metadata.toolCount = toolCount;
+      }
       logger.always(
         `[proxy] ${c.req.method} ${c.req.path} → model=${model} ${stream} tools=${toolCount}`,
       );
 
       const ctx = {
-        requestId: crypto.randomUUID(),
+        requestId: metadata?.requestId ?? crypto.randomUUID(),
         method: c.req.method,
         path: c.req.path,
         headers: Object.fromEntries(c.req.raw.headers.entries()),
@@ -1297,6 +1390,7 @@ async function createProxyStartApp(params: {
     const { loadAccountCooldowns } =
       await import("../../lib/proxy/accountCooldown.js");
     const stats = getStats();
+    const runtimeState = loadProxyState();
     const cooldowns = await loadAccountCooldowns();
     const storedAccountKeys = new Set<string>();
     try {
@@ -1359,6 +1453,20 @@ async function createProxyStartApp(params: {
           };
         }),
         primaryAccount,
+      },
+      activity: (() => {
+        const activity = getProxyActivitySnapshot();
+        return {
+          activeRequests: activity.activeRequests,
+          lastActivityAt: activity.lastActivityAt?.toISOString() ?? null,
+        };
+      })(),
+      autoUpdate: {
+        enabled: isProxyAutoUpdateEnabled(),
+        updaterPid: runtimeState?.updaterPid ?? null,
+        updaterRunning: runtimeState?.updaterPid
+          ? isProcessRunning(runtimeState.updaterPid)
+          : false,
       },
       config: params.proxyConfig
         ? {
@@ -1785,6 +1893,10 @@ async function startProxyRuntime(params: {
     port: params.port,
   });
   markProxyReady(params.readiness);
+  const updaterPid =
+    managedByLaunchd && !params.argv.dev
+      ? spawnProxyUpdater(readinessHost, params.port, process.pid)
+      : undefined;
   const fallbackChain: FallbackInfo[] | undefined =
     params.proxyConfig?.routing?.fallbackChain?.map((entry) => ({
       provider: entry.provider as string,
@@ -1809,6 +1921,7 @@ async function startProxyRuntime(params: {
       ? [...params.accountAllowlist]
       : undefined,
     guardPid,
+    updaterPid,
     managedBy: managedByLaunchd ? "launchd" : "manual",
     passthrough: params.passthrough,
   });
@@ -2157,6 +2270,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         envFile: null as string | null,
         fallbackChain: null as FallbackInfo[] | null,
         accountAllowlist: null as string[] | null,
+        autoUpdateEnabled: isProxyAutoUpdateEnabled(),
+        updaterPid: null as number | null,
+        updaterRunning: false,
       };
 
       if (state && isProcessRunning(state.pid)) {
@@ -2172,6 +2288,10 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         status.envFile = state.envFile ?? null;
         status.fallbackChain = state.fallbackChain ?? null;
         status.accountAllowlist = state.accountAllowlist ?? null;
+        status.updaterPid = state.updaterPid ?? null;
+        status.updaterRunning = state.updaterPid
+          ? isProcessRunning(state.updaterPid)
+          : false;
       }
 
       // Fetch live stats before rendering (JSON or text)
@@ -2223,6 +2343,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         );
         logger.always(
           `  ${chalk.bold("Uptime:")}     ${chalk.cyan(formatUptime(status.uptime ?? 0))}`,
+        );
+        logger.always(
+          `  ${chalk.bold("Auto-update:")} ${status.autoUpdateEnabled ? chalk.green(status.updaterRunning ? `enabled (PID ${status.updaterPid})` : "enabled (worker unavailable)") : chalk.yellow("disabled")}`,
         );
         if (status.envFile) {
           logger.always(
@@ -2433,6 +2556,11 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         alias: "pollIntervalMs",
         default: 1_000,
       })
+      .option("updater-only", {
+        type: "boolean",
+        alias: "updaterOnly",
+        default: false,
+      })
       .option("quiet", {
         type: "boolean",
         default: true,
@@ -2449,13 +2577,14 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         : 0;
     const failureThreshold = Math.max(1, Number(argv.failureThreshold ?? 5));
     const pollIntervalMs = Math.max(250, Number(argv.pollIntervalMs ?? 1_000));
+    const updaterOnly = argv.updaterOnly === true;
 
     if (!Number.isFinite(parentPid) || parentPid <= 0) {
       return;
     }
 
-    // Automatic package mutation is disabled by default. Operators must opt in
-    // explicitly, and launchd-managed proxy processes do not spawn this guard.
+    // Package mutation belongs to the dedicated launchd updater worker. The
+    // foreground fail-open guard remains cleanup-only.
     const UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2 hours
     const QUIET_THRESHOLD_MS = 120 * 1000; // 2 minutes of silence
     const UPDATE_TIMEOUT_MS = 30 * 1000; // 30 seconds to come healthy
@@ -2475,6 +2604,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     // Auto-update only works on macOS with launchd. On other platforms,
     // there's no restart mechanism, so skip the update loop entirely.
     const canAutoUpdate =
+      updaterOnly &&
       isProxyAutoUpdateEnabled() &&
       process.platform === "darwin" &&
       (await isLaunchdManaging());
@@ -2504,8 +2634,6 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         // Lazy-load update modules so they're only imported at check time
         const { checkForUpdate } =
           await import("../../lib/proxy/updateChecker.js");
-        const { checkTrafficQuiet } =
-          await import("../../lib/proxy/quietDetector.js");
         const {
           recordCheck,
           isVersionSuppressed,
@@ -2528,43 +2656,31 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         }
 
         logger.always(
-          `[guard] update available: ${runningVersion} → ${result.latestVersion}`,
+          `[updater] update available: ${runningVersion} → ${result.latestVersion}`,
         );
 
-        // 2. Best-effort quiet wait — try for a brief window, but proceed
-        //    regardless. The install (pnpm add -g) is non-disruptive; only the
-        //    restart causes a ~1-3s blip. Blocking updates for hours/days because
-        //    traffic never goes silent is worse than a brief interruption.
-        const maxQuietWaitMs = 5 * 60 * 1000; // 5 minutes max, then proceed
+        // 2. Wait for an exact runtime-idle window. Never force an update while
+        // a request or stream is active; the next worker cycle can try again.
         const quietPollMs = 10_000; // check every 10s
-        const quietStart = Date.now();
-
-        while (Date.now() - quietStart < maxQuietWaitMs) {
+        while (!guardStopping) {
           if (getProcessStatus(parentPid) === "not_running") {
             logger.always(
-              `[guard] parent process died during quiet-wait, aborting update`,
+              `[updater] parent process died while waiting for idle traffic`,
             );
             return;
           }
-          const quietStatus = checkTrafficQuiet(QUIET_THRESHOLD_MS);
-          if (quietStatus.isQuiet) {
-            logger.always(`[guard] traffic quiet, proceeding with update`);
+          const activity = await getProxyRuntimeActivity(host, port);
+          if (activity && isSafeUpdateWindow(activity, QUIET_THRESHOLD_MS)) {
+            logger.always(`[updater] traffic idle, proceeding with update`);
             break;
           }
           logger.debug(
-            `[guard] traffic active (last activity ${Math.round(quietStatus.silenceDurationMs / 1000)}s ago), waiting...`,
+            `[updater] waiting for idle traffic (${activity?.activeRequests ?? "unknown"} active requests)`,
           );
           await new Promise((r) => setTimeout(r, quietPollMs));
         }
-
-        // Proceed with install regardless — don't block updates indefinitely.
-        // The install itself (pnpm add -g) doesn't affect the running process.
-        // Only the restart afterwards causes a brief interruption.
-        const finalQuiet = checkTrafficQuiet(QUIET_THRESHOLD_MS);
-        if (!finalQuiet.isQuiet) {
-          logger.always(
-            `[guard] traffic still active after ${Math.round(maxQuietWaitMs / 1000)}s wait, proceeding with update anyway (restart will briefly interrupt in-flight requests)`,
-          );
+        if (guardStopping) {
+          return;
         }
 
         // 3. Install update (validate version string before passing to shell)
@@ -2575,27 +2691,26 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           return;
         }
 
-        // Resolve pnpm to a deterministic path, validating that it actually
-        // runs (some environments have broken shims on PATH).
-        const pnpmResolution = resolveFullPnpmPath();
-        // Log the full candidate list so operators can see why a particular
-        // pnpm was chosen (or why none worked).
+        const installerResolution = resolveGlobalInstaller({
+          entryScript: process.argv[1],
+        });
         logger.always(
-          `[guard] pnpm candidates: ${pnpmResolution.tried
-            .map((c) => `${c.path}(${c.working ? `v${c.version}` : "BROKEN"})`)
+          `[updater] package-manager candidates: ${installerResolution.tried
+            .map(
+              (candidate) =>
+                `${candidate.kind}:${candidate.bin}(${candidate.installable ? `v${candidate.version}` : (candidate.reason ?? "unusable")})`,
+            )
             .join(", ")}`,
         );
-        if (!pnpmResolution.resolved) {
-          // Environmental problem, not version-specific — skip this cycle
-          // without suppressing the version (so we retry on the next tick
-          // once the user fixes pnpm).
+        const installer = installerResolution.installer;
+        if (!installer) {
           logger.always(
-            `[guard] WARNING: no working pnpm found; skipping update cycle. Install pnpm or set NEUROLINK_PNPM_PATH.`,
+            `[updater] WARNING: no package manager has a writable global root and executable directory; skipping this cycle`,
           );
           return;
         }
         logger.always(
-          `[guard] traffic quiet, installing @juspay/neurolink@${result.latestVersion} via ${pnpmResolution.bin} (pnpm v${pnpmResolution.version})...`,
+          `[updater] installing @juspay/neurolink@${result.latestVersion} via ${installer.kind} ${installer.bin} (v${installer.version})`,
         );
         if (guardStopping || getProcessStatus(parentPid) === "not_running") {
           return;
@@ -2603,48 +2718,25 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         const { execFileSync } = await import("node:child_process");
         try {
           execFileSync(
-            pnpmResolution.bin,
-            ["add", "-g", `@juspay/neurolink@${result.latestVersion}`],
+            installer.bin,
+            getGlobalInstallArgs(
+              installer.kind,
+              `@juspay/neurolink@${result.latestVersion}`,
+            ),
             {
               timeout: 120_000,
               stdio: "pipe",
             },
           );
         } catch (installErr) {
-          // Capture stderr for actionable diagnostics
-          const stderr =
-            installErr &&
-            typeof installErr === "object" &&
-            "stderr" in installErr
-              ? String((installErr as { stderr: unknown }).stderr).slice(0, 500)
-              : "";
-          const msg =
-            installErr instanceof Error
-              ? installErr.message
-              : String(installErr);
-          logger.always(
-            `[guard] WARNING: pnpm install failed: ${msg}${stderr ? `\n  stderr: ${stderr}` : ""}`,
-          );
-          suppressVersion(
-            result.latestVersion,
-            `install_failed: ${msg.slice(0, 200)}${stderr ? ` | stderr: ${stderr.slice(0, 200)}` : ""}`,
-          );
+          const detail = describeInstallFailure(installErr);
+          logger.always(`[updater] WARNING: global install failed:\n${detail}`);
           return;
         }
 
-        // 4. Rewrite the launchd plist so it picks up the (possibly new)
-        //    stable bin path, then restart via launchctl.
+        // 4. Refresh and validate the stable trampoline. The plist already
+        // points at this path, so it must not be unloaded or rewritten here.
         try {
-          const {
-            writeFileSync,
-            existsSync: fsExists,
-            mkdirSync: fsMkdir,
-          } = await import("fs");
-          if (!fsExists(PLIST_DIR)) {
-            fsMkdir(PLIST_DIR, { recursive: true });
-          }
-          // Rewrite the trampoline and plist so the restarted service
-          // resolves the newly installed binary via PATH.
           writeTrampoline();
 
           // Validate the trampoline actually resolves to the NEW version
@@ -2653,7 +2745,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           const probed = probeBinVersion(TRAMPOLINE_PATH);
           if (!probed) {
             logger.always(
-              `[guard] WARNING: trampoline does not resolve to a working neurolink after install; skipping restart.`,
+              `[updater] WARNING: trampoline does not resolve to a working neurolink after install; skipping restart`,
             );
             suppressVersion(
               result.latestVersion,
@@ -2662,90 +2754,76 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
             return;
           }
           if (probed !== result.latestVersion) {
-            // The trampoline resolves to a DIFFERENT version than what we
-            // just installed. This means `pnpm add -g` installed into a
-            // store that PATH doesn't reach (store mismatch), or PATH still
-            // shadows with an older shim. Restarting would run the wrong
-            // version — abort.
             logger.always(
-              `[guard] ABORT: trampoline resolves to v${probed} but installed v${result.latestVersion}.`,
+              `[updater] ABORT: trampoline resolves to v${probed} but installed v${result.latestVersion}`,
             );
             logger.always(
-              `[guard]   pnpm used: ${pnpmResolution.bin} (v${pnpmResolution.version})`,
-            );
-            logger.always(
-              `[guard]   This usually means pnpm's global store doesn't match the PATH-visible neurolink.`,
-            );
-            logger.always(
-              `[guard]   Fix: run 'pnpm add -g @juspay/neurolink' with the SAME pnpm whose bin dir is on PATH.`,
+              `[updater] installer used: ${installer.kind} ${installer.bin} (v${installer.version})`,
             );
             suppressVersion(
               result.latestVersion,
-              `version_mismatch: trampoline=${probed} expected=${result.latestVersion} pnpm=${pnpmResolution.bin}(v${pnpmResolution.version})`,
+              `version_mismatch: trampoline=${probed} expected=${result.latestVersion} installer=${installer.kind}:${installer.bin}(v${installer.version})`,
             );
             return;
           }
 
-          const existingArgs = parseExistingPlistArgs();
-          const updatedPlist = buildPlist(
-            port,
-            host,
-            existingArgs.envFile,
-            existingArgs.configFile,
-          );
-          writeFileSync(PLIST_PATH, updatedPlist, "utf-8");
+          logger.always(`[updater] trampoline validated at v${probed}`);
+        } catch (trampolineError) {
           logger.always(
-            `[guard] trampoline (resolves to v${probed}) + plist rewritten at ${PLIST_PATH}`,
-          );
-        } catch (plistErr) {
-          logger.always(
-            `[guard] WARNING: failed to rewrite plist (restart may use stale path): ${
-              plistErr instanceof Error ? plistErr.message : String(plistErr)
+            `[updater] WARNING: failed to refresh trampoline; refusing restart: ${
+              trampolineError instanceof Error
+                ? trampolineError.message
+                : String(trampolineError)
             }`,
           );
-          // Continue with restart anyway — the stable bin symlink may still be correct
+          return;
         }
 
         if (guardStopping || getProcessStatus(parentPid) === "not_running") {
           return;
         }
 
+        // Installation can overlap new traffic. Re-establish a full idle window
+        // before restart so no accepted request or long stream is interrupted.
+        while (!guardStopping) {
+          if (getProcessStatus(parentPid) === "not_running") {
+            return;
+          }
+          const activity = await getProxyRuntimeActivity(host, port);
+          if (activity && isSafeUpdateWindow(activity, QUIET_THRESHOLD_MS)) {
+            break;
+          }
+          logger.debug(
+            `[updater] update installed; deferring restart (${activity?.activeRequests ?? "unknown"} active requests)`,
+          );
+          await sleep(10_000);
+        }
+        if (guardStopping) {
+          return;
+        }
+
         // Signal the health loop to not exit when it detects
         // the parent PID is gone — we're intentionally restarting.
         updateRestartInProgress = true;
-        logger.always(
-          `[guard] restarting proxy via launchctl bootout/bootstrap...`,
-        );
+        logger.always(`[updater] restarting proxy via launchctl kickstart`);
         const uid = process.getuid?.() ?? 501;
         try {
-          // bootout unloads the in-memory job definition. This is required
-          // because a forced kickstart reuses the cached plist and ignores any
-          // on-disk changes (like the trampoline rewrite above).
-          try {
-            execFileSync(
-              "launchctl",
-              ["bootout", `gui/${uid}/${PLIST_LABEL}`],
-              { timeout: 10_000, stdio: "pipe" },
-            );
-          } catch {
-            // Job may not be loaded (first install, or already unloaded)
-          }
-          // bootstrap loads the plist fresh from disk, picking up the
-          // new trampoline-based ProgramArguments.
-          execFileSync("launchctl", ["bootstrap", `gui/${uid}`, PLIST_PATH], {
-            timeout: 10_000,
-            stdio: "pipe",
-          });
+          execFileSync(
+            "launchctl",
+            ["kickstart", "-k", `gui/${uid}/${PLIST_LABEL}`],
+            {
+              timeout: 10_000,
+              stdio: "pipe",
+            },
+          );
         } catch (restartErr) {
           updateRestartInProgress = false;
           const msg =
             restartErr instanceof Error
               ? restartErr.message
               : String(restartErr);
-          logger.always(`[guard] WARNING: launchctl bootstrap failed: ${msg}`);
-          suppressVersion(
-            result.latestVersion,
-            `restart_failed: ${msg.slice(0, 200)}`,
+          logger.always(
+            `[updater] WARNING: launchctl kickstart failed: ${msg}`,
           );
           return;
         }
@@ -2773,21 +2851,21 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
 
         if (healthy) {
           logger.always(
-            `[guard] update successful: now running ${result.latestVersion}`,
+            `[updater] update successful: now running ${result.latestVersion}`,
           );
           recordSuccessfulUpdate(result.latestVersion);
-          // The new proxy will spawn its own guard. Exit this one.
+          // The replacement proxy starts a worker running the new version.
           process.exit(0);
         } else {
           logger.always(
-            `[guard] WARNING: proxy unhealthy after update to ${result.latestVersion}`,
+            `[updater] WARNING: proxy unhealthy after update to ${result.latestVersion}`,
           );
           suppressVersion(result.latestVersion, "unhealthy_after_restart");
           updateRestartInProgress = false;
         }
       } catch (err) {
         logger.always(
-          `[guard] update check error: ${err instanceof Error ? err.message : String(err)}`,
+          `[updater] update check error: ${err instanceof Error ? err.message : String(err)}`,
         );
       } finally {
         updateInProgress = false;
@@ -2827,7 +2905,11 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         break;
       }
 
-      if (!healthy && consecutiveUnhealthy >= failureThreshold) {
+      if (
+        !updateRestartInProgress &&
+        !healthy &&
+        consecutiveUnhealthy >= failureThreshold
+      ) {
         // A detached guard cannot safely decide that a live process should be
         // replaced. Leave recovery to the foreground operator or launchd.
         if (!argv.quiet) {
@@ -2849,6 +2931,10 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     }
 
     stopUpdateChecks();
+
+    if (updaterOnly) {
+      return;
+    }
 
     const guardHost = host === "0.0.0.0" ? "localhost" : host;
     const expectedBaseUrl = `http://${guardHost}:${port}`;
@@ -3092,46 +3178,6 @@ function buildLaunchdPath(): string {
   }
 
   return [...segments].join(":");
-}
-
-/**
- * Parse the existing launchd plist to extract --env-file and --config values.
- * Used by the auto-updater to rewrite the plist with the same configuration.
- */
-function parseExistingPlistArgs(): {
-  envFile?: string;
-  configFile?: string;
-} {
-  try {
-    const { readFileSync, existsSync: fsExists } = _require(
-      "fs",
-    ) as typeof import("fs");
-    if (!fsExists(PLIST_PATH)) {
-      return {};
-    }
-    const xml = readFileSync(PLIST_PATH, "utf-8");
-    // Extract --env-file value: <string>--env-file</string>\n    <string>VALUE</string>
-    const envMatch = xml.match(
-      /<string>--env-file<\/string>\s*<string>([^<]+)<\/string>/,
-    );
-    const configMatch = xml.match(
-      /<string>--config<\/string>\s*<string>([^<]+)<\/string>/,
-    );
-    // Unescape XML entities so buildPlist() doesn't double-escape them.
-    const unescapeXml = (value?: string) =>
-      value
-        ?.replace(/&apos;/g, "'")
-        .replace(/&quot;/g, '"')
-        .replace(/&gt;/g, ">")
-        .replace(/&lt;/g, "<")
-        .replace(/&amp;/g, "&");
-    return {
-      envFile: unescapeXml(envMatch?.[1]),
-      configFile: unescapeXml(configMatch?.[1]),
-    };
-  } catch {
-    return {};
-  }
 }
 
 function buildPlist(

--- a/src/lib/proxy/globalInstaller.ts
+++ b/src/lib/proxy/globalInstaller.ts
@@ -1,0 +1,203 @@
+import { execFileSync as nodeExecFileSync } from "node:child_process";
+import { accessSync, constants, existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import type {
+  GlobalInstallerExecFile,
+  GlobalInstallerKind,
+  GlobalInstallerProbe,
+  GlobalInstallerResolution,
+  ResolveGlobalInstallerOptions,
+} from "../types/index.js";
+
+function runText(
+  execFileSync: GlobalInstallerExecFile,
+  bin: string,
+  args: string[],
+): string {
+  return String(
+    execFileSync(bin, args, {
+      encoding: "utf8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  ).trim();
+}
+
+function writableDirectory(path: string): boolean {
+  try {
+    if (!existsSync(path)) {
+      return false;
+    }
+    accessSync(path, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPathInside(path: string | undefined, parent: string): boolean {
+  if (!path) {
+    return false;
+  }
+  try {
+    const candidate = realpathSync(path);
+    const root = realpathSync(parent);
+    return candidate === root || candidate.startsWith(`${root}/`);
+  } catch {
+    const candidate = resolve(path);
+    const root = resolve(parent);
+    return candidate === root || candidate.startsWith(`${root}/`);
+  }
+}
+
+function probeInstaller(
+  kind: GlobalInstallerKind,
+  bin: string,
+  entryScript: string | undefined,
+  execFileSync: GlobalInstallerExecFile,
+): GlobalInstallerProbe {
+  const base: GlobalInstallerProbe = {
+    kind,
+    bin,
+    working: false,
+    installable: false,
+    matchesCurrentInstall: false,
+  };
+
+  try {
+    base.version = runText(execFileSync, bin, ["--version"]);
+    base.working = base.version.length > 0;
+    base.globalRoot = runText(execFileSync, bin, ["root", "-g"]);
+    base.globalBinDir =
+      kind === "pnpm"
+        ? runText(execFileSync, bin, ["bin", "-g"])
+        : join(runText(execFileSync, bin, ["prefix", "-g"]), "bin");
+
+    if (!base.globalRoot || !writableDirectory(base.globalRoot)) {
+      base.reason = "global package root is missing or not writable";
+      return base;
+    }
+    if (!base.globalBinDir || !writableDirectory(base.globalBinDir)) {
+      base.reason = "global executable directory is missing or not writable";
+      return base;
+    }
+
+    base.installable = true;
+    base.matchesCurrentInstall = isPathInside(entryScript, base.globalRoot);
+    return base;
+  } catch (error) {
+    base.reason = error instanceof Error ? error.message : String(error);
+    return base;
+  }
+}
+
+function resolveFromPath(
+  command: string,
+  execFileSync: GlobalInstallerExecFile,
+): string | undefined {
+  try {
+    const result = runText(execFileSync, "which", [command]);
+    return result || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve a package manager that can update the installation currently running. */
+export function resolveGlobalInstaller(
+  options: ResolveGlobalInstallerOptions = {},
+): GlobalInstallerResolution {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? homedir();
+  const entryScript = options.entryScript ?? process.argv[1];
+  const execFileSync = options.execFileSync ?? nodeExecFileSync;
+  const candidates: Array<{ kind: GlobalInstallerKind; bin: string }> = [];
+
+  if (env.NEUROLINK_PACKAGE_MANAGER_PATH) {
+    const configuredKind = env.NEUROLINK_PACKAGE_MANAGER?.toLowerCase();
+    const inferredName = basename(env.NEUROLINK_PACKAGE_MANAGER_PATH);
+    const kind: GlobalInstallerKind =
+      configuredKind === "npm" || configuredKind === "pnpm"
+        ? configuredKind
+        : inferredName.startsWith("npm")
+          ? "npm"
+          : "pnpm";
+    candidates.push({ kind, bin: env.NEUROLINK_PACKAGE_MANAGER_PATH });
+  }
+  if (env.NEUROLINK_PNPM_PATH) {
+    candidates.push({ kind: "pnpm", bin: env.NEUROLINK_PNPM_PATH });
+  }
+  if (env.PNPM_HOME) {
+    candidates.push({ kind: "pnpm", bin: join(env.PNPM_HOME, "pnpm") });
+  }
+
+  const nodeBinDir = dirname(process.execPath);
+  candidates.push({ kind: "npm", bin: join(nodeBinDir, "npm") });
+  const pathPnpm = resolveFromPath("pnpm", execFileSync);
+  const pathNpm = resolveFromPath("npm", execFileSync);
+  if (pathPnpm) {
+    candidates.push({ kind: "pnpm", bin: pathPnpm });
+  }
+  if (pathNpm) {
+    candidates.push({ kind: "npm", bin: pathNpm });
+  }
+  candidates.push(
+    { kind: "pnpm", bin: join(homeDir, ".local", "share", "pnpm", "pnpm") },
+    { kind: "pnpm", bin: join(homeDir, "Library", "pnpm", "pnpm") },
+    { kind: "npm", bin: "/opt/homebrew/bin/npm" },
+    { kind: "npm", bin: "/usr/local/bin/npm" },
+  );
+
+  const seen = new Set<string>();
+  const tried = candidates
+    .filter(({ kind, bin }) => {
+      const key = `${kind}:${bin}`;
+      if (!bin || seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .map(({ kind, bin }) =>
+      probeInstaller(kind, bin, entryScript, execFileSync),
+    );
+
+  const matchingInstaller = tried.find(
+    (probe) => probe.installable && probe.matchesCurrentInstall,
+  );
+  // When the running entry script is known, installing into a different
+  // global root cannot update that process and may shadow another install.
+  const installer = entryScript
+    ? matchingInstaller
+    : (matchingInstaller ?? tried.find((probe) => probe.installable));
+  return { installer, tried };
+}
+
+export function getGlobalInstallArgs(
+  kind: GlobalInstallerKind,
+  packageSpec: string,
+): string[] {
+  return kind === "pnpm"
+    ? ["add", "-g", packageSpec]
+    : ["install", "--global", "--no-audit", "--no-fund", packageSpec];
+}
+
+function capturedOutput(error: unknown, key: "stdout" | "stderr"): string {
+  if (!error || typeof error !== "object" || !(key in error)) {
+    return "";
+  }
+  const raw = (error as Record<string, unknown>)[key];
+  return String(raw ?? "")
+    .trim()
+    .slice(0, 1_000);
+}
+
+export function describeInstallFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const stdout = capturedOutput(error, "stdout");
+  const stderr = capturedOutput(error, "stderr");
+  return [message, stdout && `stdout: ${stdout}`, stderr && `stderr: ${stderr}`]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/src/lib/proxy/openaiFormat.ts
+++ b/src/lib/proxy/openaiFormat.ts
@@ -775,6 +775,7 @@ export function convertClaudeToOpenAIResponse(
  */
 export function createClaudeToOpenAIStreamTransform(
   requestModel: string,
+  options: { onError?: (message: string) => void } = {},
 ): TransformStream<Uint8Array, Uint8Array> {
   const serializer = new OpenAIStreamSerializer(requestModel);
   const encoder = new TextEncoder();
@@ -815,6 +816,9 @@ export function createClaudeToOpenAIStreamTransform(
     try {
       data = JSON.parse(dataStr) as Record<string, unknown>;
     } catch {
+      return;
+    }
+    if (finished) {
       return;
     }
 
@@ -916,8 +920,20 @@ export function createClaudeToOpenAIStreamTransform(
         return;
       }
 
+      case "error": {
+        const error = (data.error ?? {}) as { message?: unknown };
+        const message =
+          typeof error.message === "string"
+            ? error.message
+            : "Anthropic stream failed";
+        finished = true;
+        options.onError?.(message);
+        emit(controller, serializer.emitError(message));
+        return;
+      }
+
       default:
-        // ping, error, and unknown events are ignored.
+        // ping and unknown events are ignored.
         return;
     }
   };
@@ -963,10 +979,12 @@ export function createClaudeToOpenAIStreamTransform(
       buffer += decoder.decode();
       drainBufferedEvents(controller);
 
-      // If the upstream closed without a message_stop, still finalize.
+      // Closing without message_stop is an interrupted stream, not success.
       if (!finished) {
         finished = true;
-        emit(controller, serializer.finish(stopReason, usage));
+        const message = "Anthropic stream ended before message_stop";
+        options.onError?.(message);
+        emit(controller, serializer.emitError(message));
       }
     },
   });

--- a/src/lib/proxy/proxyActivity.ts
+++ b/src/lib/proxy/proxyActivity.ts
@@ -1,0 +1,93 @@
+import type { ProxyActivitySnapshot } from "../types/index.js";
+
+let activeRequests = 0;
+let lastActivityAtMs: number | null = null;
+
+function touchActivity(): void {
+  lastActivityAtMs = Date.now();
+}
+
+/** Track one client-facing proxy request until its response body settles. */
+export function beginProxyRequest(): () => void {
+  activeRequests += 1;
+  touchActivity();
+  let finished = false;
+
+  return () => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    activeRequests = Math.max(0, activeRequests - 1);
+    touchActivity();
+  };
+}
+
+export function getProxyActivitySnapshot(): ProxyActivitySnapshot {
+  return {
+    activeRequests,
+    lastActivityAt:
+      lastActivityAtMs === null ? null : new Date(lastActivityAtMs),
+  };
+}
+
+export function isProxyActivityQuiet(
+  snapshot: ProxyActivitySnapshot,
+  quietThresholdMs: number,
+  nowMs: number = Date.now(),
+): boolean {
+  if (snapshot.activeRequests > 0) {
+    return false;
+  }
+  if (snapshot.lastActivityAt === null) {
+    return true;
+  }
+  return nowMs - snapshot.lastActivityAt.getTime() >= quietThresholdMs;
+}
+
+/** Keep activity open until the response body completes, errors, or is cancelled. */
+export function trackProxyResponse(
+  response: Response,
+  finishRequest: () => void,
+): Response {
+  if (!response.body) {
+    finishRequest();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const trackedBody = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { value, done } = await reader.read();
+        if (done) {
+          finishRequest();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        finishRequest();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        finishRequest();
+      }
+    },
+  });
+
+  return new Response(trackedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+export function resetProxyActivityForTests(): void {
+  activeRequests = 0;
+  lastActivityAtMs = null;
+}

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -117,10 +117,12 @@ import type {
   RouteGroup,
   RuntimeAccountState,
   ServerContext,
+  StreamResult,
   StreamTerminalOutcome,
   TransientRateLimitRetryBudget,
 } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { withTimeout } from "../../utils/async/withTimeout.js";
 import { ProviderHealthChecker } from "../../utils/providerHealth.js";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -155,6 +157,8 @@ let configuredAccountAllowlist: AccountAllowlist | undefined;
 const MAX_AUTH_RETRIES = 5;
 const MAX_TRANSIENT_SAME_ACCOUNT_RETRIES = 2;
 const TRANSIENT_SAME_ACCOUNT_RETRY_DELAYS_MS = [250, 1_000] as const;
+const MAX_FALLBACK_NETWORK_RETRIES = 1;
+const FALLBACK_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 
 /** Maximum upstream 429 attempts per account before rotating — for a TRANSIENT
  *  burst 429 only (window still "allowed", short retry-after). An exhaustion 429
@@ -2400,28 +2404,65 @@ async function executeClaudeFallbackTranslation(args: {
     options,
     providerLabel,
   } = args;
+  const fallbackAbortController = new AbortController();
+  let streamResult: StreamResult;
+  try {
+    streamResult = await withTimeout(
+      ctx.neurolink.stream({
+        ...options,
+        abortSignal: fallbackAbortController.signal,
+      }),
+      FALLBACK_STREAM_IDLE_TIMEOUT_MS,
+      `Fallback ${providerLabel} initialization timed out after ${FALLBACK_STREAM_IDLE_TIMEOUT_MS}ms`,
+    );
+  } catch (error) {
+    fallbackAbortController.abort(error);
+    throw error;
+  }
+  const consumeFallbackStream = async (
+    onText?: (text: string) => void,
+  ): Promise<string> => {
+    const iterator = streamResult.stream[Symbol.asyncIterator]();
+    let collectedText = "";
+    try {
+      while (true) {
+        const { value: chunk, done } = await withTimeout(
+          iterator.next(),
+          FALLBACK_STREAM_IDLE_TIMEOUT_MS,
+          `Fallback ${providerLabel} stream timed out after ${FALLBACK_STREAM_IDLE_TIMEOUT_MS}ms of inactivity`,
+        );
+        if (done) {
+          return collectedText;
+        }
+        const text = extractText(chunk);
+        if (text) {
+          collectedText += text;
+          onText?.(text);
+        }
+      }
+    } catch (error) {
+      fallbackAbortController.abort(error);
+      void iterator.return?.().catch(() => {
+        // Timeout/error already determines the request outcome.
+      });
+      throw error;
+    }
+  };
+
   if (body.stream) {
-    const streamResult = await ctx.neurolink.stream(options);
     const serializer = new ClaudeStreamSerializer(body.model, 0);
 
     // Eagerly consume stream so errors fire synchronously and the
     // fallback loop in tryConfiguredClaudeFallbackChain can catch them.
     const frames: string[] = [];
-    let collectedText = "";
-
     for (const frame of serializer.start()) {
       frames.push(frame);
     }
-
-    for await (const chunk of streamResult.stream) {
-      const text = extractText(chunk);
-      if (text) {
-        collectedText += text;
-        for (const frame of serializer.pushDelta(text)) {
-          frames.push(frame);
-        }
+    const collectedText = await consumeFallbackStream((text) => {
+      for (const frame of serializer.pushDelta(text)) {
+        frames.push(frame);
       }
-    }
+    });
 
     const toolCalls = streamResult.toolCalls ?? [];
 
@@ -2481,14 +2522,7 @@ async function executeClaudeFallbackTranslation(args: {
     return sseGenerator();
   }
 
-  const streamResult = await ctx.neurolink.stream(options);
-  let collectedText = "";
-  for await (const chunk of streamResult.stream) {
-    const text = extractText(chunk);
-    if (text) {
-      collectedText += text;
-    }
-  }
+  const collectedText = await consumeFallbackStream();
   if (!hasTranslatedOutput(collectedText, streamResult.toolCalls)) {
     throw new Error(
       `Translated provider ${providerLabel} returned no content or tool calls`,
@@ -2525,6 +2559,31 @@ async function executeClaudeFallbackTranslation(args: {
   return clientResponse;
 }
 
+async function executeClaudeFallbackWithRetry(
+  args: Parameters<typeof executeClaudeFallbackTranslation>[0],
+): Promise<unknown> {
+  let lastError: unknown;
+  for (let retry = 0; retry <= MAX_FALLBACK_NETWORK_RETRIES; retry += 1) {
+    try {
+      return await executeClaudeFallbackTranslation(args);
+    } catch (error) {
+      lastError = error;
+      if (
+        !isRetryableNetworkError(error) ||
+        retry === MAX_FALLBACK_NETWORK_RETRIES
+      ) {
+        throw error;
+      }
+      const delayMs = TRANSIENT_SAME_ACCOUNT_RETRY_DELAYS_MS[retry] ?? 250;
+      logger.always(
+        `[proxy] retrying fallback=${args.providerLabel} after transient network error (${retry + 1}/${MAX_FALLBACK_NETWORK_RETRIES}) in ${delayMs}ms: ${describeTransportError(error)}`,
+      );
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 async function tryConfiguredClaudeFallbackChain(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
@@ -2546,7 +2605,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
       cacheReadTokens?: number;
     },
   ) => void;
-}): Promise<{ response: unknown | null }> {
+}): Promise<{ response: unknown | null; lastErrorMessage?: string }> {
   const {
     ctx,
     body,
@@ -2578,6 +2637,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
     attemptCount: fallbackPlan.attempts.slice(1).length,
     reason: "all_anthropic_accounts_exhausted",
   });
+  let lastFallbackError: string | undefined;
 
   for (const fallback of fallbackPlan.attempts.slice(1)) {
     if (!fallback.provider || !fallback.model) {
@@ -2604,7 +2664,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
         provider: fallback.provider,
         model: fallback.model,
       });
-      const response = await executeClaudeFallbackTranslation({
+      const response = await executeClaudeFallbackWithRetry({
         ctx,
         body,
         tracer,
@@ -2661,7 +2721,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
       }
 
       logger.always(
-        `[proxy] fallback ${fallback.provider}/${fallback.model} failed [${errorClass}]: ${errMsg}`,
+        `[proxy] fallback ${fallback.provider}/${fallback.model} failed [${errorClass}]: ${describeTransportError(fallbackErr)}`,
       );
       recordFallbackAttempt({
         provider: fallback.provider,
@@ -2670,10 +2730,11 @@ async function tryConfiguredClaudeFallbackChain(args: {
         errorMessage: `[${errorClass}] ${errMsg}`,
         durationMs: Date.now() - fallbackStart,
       });
+      lastFallbackError = `[${fallback.provider}/${fallback.model}] ${describeTransportError(fallbackErr)}`;
     }
   }
 
-  return { response: null };
+  return { response: null, lastErrorMessage: lastFallbackError };
 }
 
 async function tryAutoClaudeFallback(args: {
@@ -2695,9 +2756,10 @@ async function tryAutoClaudeFallback(args: {
       cacheReadTokens?: number;
     },
   ) => void;
-}): Promise<unknown | null> {
+}): Promise<{ response: unknown | null; lastErrorMessage?: string }> {
   const { ctx, body, tracer, requestStartTime, logProxyBody, logFinalRequest } =
     args;
+  const fallbackStart = Date.now();
   try {
     const parsed = parseClaudeRequest(body);
     const plan = buildProxyTranslationPlan(
@@ -2711,11 +2773,11 @@ async function tryAutoClaudeFallback(args: {
       (attempt) => attempt.label === "auto-provider",
     );
     if (!autoAttempt) {
-      return null;
+      return { response: null };
     }
     logger.always("[proxy] fallback → auto-provider");
     const options = buildProxyFallbackOptions(parsed);
-    return await executeClaudeFallbackTranslation({
+    const response = await executeClaudeFallbackWithRetry({
       ctx,
       body,
       tracer,
@@ -2725,13 +2787,38 @@ async function tryAutoClaudeFallback(args: {
       options: options as Parameters<ServerContext["neurolink"]["stream"]>[0],
       providerLabel: "auto-provider",
     });
+    recordFallbackAttempt({
+      provider: "auto-provider",
+      model: body.model,
+      status: "success",
+      durationMs: Date.now() - fallbackStart,
+    });
+    tracer?.setFallbackInfo({
+      triggered: true,
+      provider: "auto-provider",
+      model: body.model,
+      attemptCount: 1,
+      reason: "fallback_success",
+    });
+    return { response };
   } catch (fallbackErr) {
-    logger.debug(
-      `[proxy] fallback auto-provider failed: ${
-        fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-      }`,
-    );
-    return null;
+    const errorMessage = describeTransportError(fallbackErr);
+    logger.always(`[proxy] fallback auto-provider failed: ${errorMessage}`);
+    recordFallbackAttempt({
+      provider: "auto-provider",
+      model: body.model,
+      status: "failure",
+      errorMessage,
+      durationMs: Date.now() - fallbackStart,
+    });
+    tracer?.setFallbackInfo({
+      triggered: true,
+      provider: "auto-provider",
+      model: body.model,
+      attemptCount: 1,
+      reason: "fallback_failure",
+    });
+    return { response: null, lastErrorMessage: errorMessage };
   }
 }
 
@@ -2749,6 +2836,7 @@ function buildClaudeAnthropicFailureResponse(args: {
   sawTransientFailure: boolean;
   sawRateLimit: boolean;
   lastError: unknown;
+  fallbackFailureMessage?: string;
   orderedAccounts: ProxyPassthroughAccount[];
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
   logProxyBody: ProxyBodyCaptureLogger;
@@ -2776,6 +2864,7 @@ function buildClaudeAnthropicFailureResponse(args: {
     sawTransientFailure,
     sawRateLimit,
     lastError,
+    fallbackFailureMessage,
     orderedAccounts,
     buildLoggedClaudeError,
     logProxyBody,
@@ -2836,25 +2925,39 @@ function buildClaudeAnthropicFailureResponse(args: {
   }
 
   if ((sawNetworkError || sawTransientFailure) && !sawRateLimit) {
+    const fallbackSuffix = fallbackFailureMessage
+      ? ` Fallback also failed: ${fallbackFailureMessage}`
+      : "";
     const msg = `All Anthropic accounts failed due to transient upstream/network errors. Last error: ${
       lastError instanceof Error
         ? lastError.message
         : String(lastError ?? "unknown")
-    }`;
+    }.${fallbackSuffix}`;
     tracer?.setError("transient_error", msg.slice(0, 500));
     tracer?.end(502, Date.now() - requestStartTime);
-    return buildLoggedClaudeError(502, msg);
+    return buildLoggedClaudeError(
+      502,
+      msg,
+      fallbackFailureMessage ? "fallback_exhausted" : "transient_error",
+    );
   }
 
   if (!sawRateLimit) {
+    const fallbackSuffix = fallbackFailureMessage
+      ? ` Fallback also failed: ${fallbackFailureMessage}`
+      : "";
     const msg = `All Anthropic accounts failed. Last error: ${
       lastError instanceof Error
         ? lastError.message
         : String(lastError ?? "unknown")
-    }`;
+    }.${fallbackSuffix}`;
     tracer?.setError("all_accounts_failed", msg.slice(0, 500));
     tracer?.end(502, Date.now() - requestStartTime);
-    return buildLoggedClaudeError(502, msg);
+    return buildLoggedClaudeError(
+      502,
+      msg,
+      fallbackFailureMessage ? "fallback_exhausted" : "all_accounts_failed",
+    );
   }
 
   const now = Date.now();
@@ -5702,6 +5805,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
   // repaired by changing providers. Preserve the authoritative Anthropic 400
   // rather than delaying it or returning unrelated fallback output.
   if (shouldAttemptClaudeFallback(loopState)) {
+    let fallbackFailureMessage: string | undefined;
     const configuredFallbackResult = await tryConfiguredClaudeFallbackChain({
       ctx,
       body,
@@ -5715,11 +5819,12 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     if (configuredFallbackResult.response) {
       return configuredFallbackResult.response;
     }
+    fallbackFailureMessage = configuredFallbackResult.lastErrorMessage;
 
     // Try auto-provider fallback when the configured chain didn't produce a
     // response (either no chain configured, or all entries failed/deduped).
     if (!loopState.sawRateLimit) {
-      const autoFallbackResponse = await tryAutoClaudeFallback({
+      const autoFallbackResult = await tryAutoClaudeFallback({
         ctx,
         body,
         tracer,
@@ -5727,10 +5832,14 @@ async function handleAnthropicRoutedClaudeRequest(args: {
         logProxyBody,
         logFinalRequest,
       });
-      if (autoFallbackResponse) {
-        return autoFallbackResponse;
+      if (autoFallbackResult.response) {
+        return autoFallbackResult.response;
       }
+      fallbackFailureMessage =
+        autoFallbackResult.lastErrorMessage ?? fallbackFailureMessage;
     }
+
+    loopState.fallbackFailureMessage = fallbackFailureMessage;
   }
 
   return buildClaudeAnthropicFailureResponse({
@@ -5743,6 +5852,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     sawTransientFailure: loopState.sawTransientFailure,
     sawRateLimit: loopState.sawRateLimit,
     lastError: loopState.lastError,
+    fallbackFailureMessage: loopState.fallbackFailureMessage,
     orderedAccounts,
     buildLoggedClaudeError,
     logProxyBody,
@@ -6184,6 +6294,7 @@ function isRetryableNetworkError(error: unknown): boolean {
     normalized.includes("econnrefused") ||
     normalized.includes("econnreset") ||
     normalized.includes("etimedout") ||
+    normalized.includes("timed out") ||
     normalized.includes("connection error") ||
     normalized.includes("connect error") ||
     normalized.includes("fetch failed") ||
@@ -6376,4 +6487,6 @@ export const __testHooks = {
   waitForTransientAccountAvailability,
   describeTransportError,
   shouldAttemptClaudeFallback,
+  executeClaudeFallbackWithRetry,
+  buildClaudeAnthropicFailureResponse,
 };

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -232,14 +232,66 @@ async function handleOpenAIToAnthropicBridge(args: {
         "Anthropic loopback returned empty stream body",
       );
     }
-    // Streaming success: log now since the response body is consumed by the
-    // client. Token counts are not visible at this layer (the inner /v1/messages
-    // handler accounts them), so we omit them here.
-    await writeLifecycle(200);
+    let terminalStreamError: string | undefined;
     const transformed = upstream.body.pipeThrough(
-      createClaudeToOpenAIStreamTransform(body.model),
+      createClaudeToOpenAIStreamTransform(body.model, {
+        onError: (message) => {
+          terminalStreamError = sanitizeForLog(message);
+        },
+      }),
     );
-    return new Response(transformed, {
+    const reader = transformed.getReader();
+    let lifecycleWritten = false;
+    const finishLifecycle = async (
+      status: number,
+      errorType?: string,
+      errorMessage?: string,
+    ): Promise<void> => {
+      if (lifecycleWritten) {
+        return;
+      }
+      lifecycleWritten = true;
+      await writeLifecycle(status, { errorType, errorMessage });
+    };
+    const trackedStream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { value, done } = await reader.read();
+          if (done) {
+            if (terminalStreamError) {
+              await finishLifecycle(
+                502,
+                "loopback_stream_error",
+                terminalStreamError,
+              );
+            } else {
+              await finishLifecycle(200);
+            }
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+        } catch (error) {
+          const message = sanitizeForLog(
+            error instanceof Error ? error.message : String(error),
+          );
+          await finishLifecycle(502, "loopback_stream_error", message);
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          await finishLifecycle(
+            499,
+            "client_cancelled",
+            "Client cancelled the OpenAI-compatible stream",
+          );
+        }
+      },
+    });
+    return new Response(trackedStream, {
       status: 200,
       headers: {
         "content-type": "text/event-stream",

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -929,6 +929,8 @@ export type ProxyGuardArgs = {
   failureThreshold?: number;
   pollIntervalMs?: number;
   quiet?: boolean;
+  /** Run update checks only; never mutate client settings. */
+  updaterOnly?: boolean;
 };
 
 /** Arguments accepted by `neurolink proxy telemetry <subcommand>` */
@@ -958,6 +960,8 @@ export type ProxyState = {
   accountAllowlist?: string[];
   /** Optional fail-open guard PID that reverts Claude settings if proxy dies */
   guardPid?: number;
+  /** Dedicated updater PID for launchd-managed proxy installations. */
+  updaterPid?: number;
   /** How the proxy was launched — "launchd" if installed as service, "manual" otherwise */
   managedBy?: "launchd" | "manual";
   /** Whether the proxy is running in transparent passthrough mode */

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -617,6 +617,7 @@ export type AnthropicLoopState = {
   } | null;
   authFailureMessage: string | null;
   authCooldownMessage: string | null;
+  fallbackFailureMessage?: string;
   attemptNumber: number;
 };
 
@@ -1110,6 +1111,29 @@ export type QuietStatus = {
   silenceDurationMs: number;
 };
 
+/** In-process proxy request activity used to protect streaming restarts. */
+export type ProxyActivitySnapshot = {
+  activeRequests: number;
+  lastActivityAt: Date | null;
+};
+
+/** Activity payload exposed by the running proxy status endpoint. */
+export type ProxyRuntimeActivity = {
+  activeRequests: number;
+  lastActivityAt: string | null;
+};
+
+/** Request metadata retained by the HTTP adapter for terminal error logging. */
+export type RuntimeRequestMetadata = {
+  requestId: string;
+  method: string;
+  path: string;
+  startedAt: number;
+  model: string;
+  stream: boolean;
+  toolCount: number;
+};
+
 // =============================================================================
 // RAW STREAM CAPTURE (from proxy/rawStreamCapture.ts)
 // =============================================================================
@@ -1291,6 +1315,40 @@ export type UpdateState = {
   suppressedVersions: Record<string, SuppressedVersion>;
   lastUpdateAt: string | null;
   lastUpdateVersion: string | null;
+};
+
+/** Supported global package managers for proxy self-updates. */
+export type GlobalInstallerKind = "npm" | "pnpm";
+
+/** Result of probing one global package-manager executable. */
+export type GlobalInstallerProbe = {
+  kind: GlobalInstallerKind;
+  bin: string;
+  version?: string;
+  globalRoot?: string;
+  globalBinDir?: string;
+  working: boolean;
+  installable: boolean;
+  matchesCurrentInstall: boolean;
+  reason?: string;
+};
+
+/** Selected package manager plus all candidates considered. */
+export type GlobalInstallerResolution = {
+  installer?: GlobalInstallerProbe;
+  tried: GlobalInstallerProbe[];
+};
+
+/** Injectable command runner used by global-installer tests. */
+export type GlobalInstallerExecFile =
+  typeof import("node:child_process").execFileSync;
+
+/** Overrides used while resolving the global package manager. */
+export type ResolveGlobalInstallerOptions = {
+  entryScript?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  execFileSync?: GlobalInstallerExecFile;
 };
 
 // =============================================================================

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -848,7 +848,7 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "launchd: auto-updater rewrites trampoline + plist before kickstart",
+    name: "launchd: auto-updater refreshes trampoline before atomic kickstart",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -857,14 +857,19 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
         "utf-8",
       );
-      // The guard's update section must rewrite trampoline before kickstart
+      // The updater refreshes the stable trampoline, then asks launchd for an
+      // atomic restart. Rewriting or unloading the plist here can strand the
+      // daemon if the updater is killed with its parent process.
       const guardSection = src.slice(
-        src.indexOf("[guard] traffic quiet, installing"),
-        src.indexOf("[guard] restarting proxy via launchctl"),
+        src.indexOf("[updater] package-manager candidates"),
+        src.indexOf("// 5. Wait for healthy restart"),
       );
       return (
         guardSection.includes("writeTrampoline()") &&
-        guardSection.includes("writeFileSync(PLIST_PATH")
+        guardSection.includes('["kickstart", "-k"') &&
+        !guardSection.includes("writeFileSync(PLIST_PATH") &&
+        !guardSection.includes('["bootout"') &&
+        !guardSection.includes('["bootstrap"')
       );
     },
   },
@@ -912,7 +917,7 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "updater: uses resolveFullPnpmPath, not bare 'pnpm'",
+    name: "updater: resolves the package manager that owns the running install",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -921,14 +926,19 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
         "utf-8",
       );
+      const installer = readFileSync(
+        pathJoin(process.cwd(), "src/lib/proxy/globalInstaller.ts"),
+        "utf-8",
+      );
       return (
-        src.includes("resolveFullPnpmPath()") &&
-        src.includes("pnpmResolution.bin")
+        src.includes("resolveGlobalInstaller") &&
+        src.includes("getGlobalInstallArgs") &&
+        installer.includes("matchesCurrentInstall")
       );
     },
   },
   {
-    name: "updater: suppressVersion includes error detail, not just 'install_failed'",
+    name: "updater: environmental install failures are retried, not suppressed",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -937,12 +947,12 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
         "utf-8",
       );
-      // Old: suppressVersion(v, "install_failed")
-      // New: suppressVersion(v, `install_failed: ${msg}...`)
+      const section = src.slice(
+        src.indexOf("global install failed"),
+        src.indexOf("global install failed") + 400,
+      );
       return (
-        !src.includes(
-          'suppressVersion(result.latestVersion, "install_failed")',
-        ) && src.includes("install_failed:")
+        section.includes("return;") && !section.includes("suppressVersion")
       );
     },
   },
@@ -1043,12 +1053,14 @@ const tests: TestFunction[] = [
       );
       // Auto-updater must probe trampoline after writing, before kickstart.
       const guardSection = src.slice(
-        src.indexOf("[guard] pnpm candidates"),
-        src.indexOf("[guard] restarting proxy via launchctl"),
+        src.indexOf("[updater] package-manager candidates"),
+        src.indexOf("// 5. Wait for healthy restart"),
       );
       return (
         guardSection.includes("probeBinVersion(TRAMPOLINE_PATH)") &&
-        guardSection.includes("trampoline_broken_after_install")
+        guardSection.includes("trampoline_broken_after_install") &&
+        guardSection.indexOf("probeBinVersion(TRAMPOLINE_PATH)") <
+          guardSection.indexOf('["kickstart", "-k"')
       );
     },
   },
@@ -1078,32 +1090,27 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "pnpm: resolver tries NEUROLINK_PNPM_PATH, PNPM_HOME, which, common paths",
+    name: "installer: resolver probes pnpm and npm global roots and bin paths",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
       const { join: pathJoin } = await import("path");
       const src = readFileSync(
-        pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
+        pathJoin(process.cwd(), "src/lib/proxy/globalInstaller.ts"),
         "utf-8",
       );
-      // Find function body — from declaration to next top-level `}`
-      const fnStart = src.indexOf("function resolveFullPnpmPath(");
-      const fnEnd = src.indexOf("\n}\n", fnStart);
-      const fn = src.slice(fnStart, fnEnd);
       return (
-        fn.includes("NEUROLINK_PNPM_PATH") &&
-        fn.includes("PNPM_HOME") &&
-        fn.includes('"which"') &&
-        // common install locations are built via join(homedir(), ...)
-        fn.includes('".local"') &&
-        fn.includes('"Library"') &&
-        fn.includes("probeBinVersion")
+        src.includes("NEUROLINK_PNPM_PATH") &&
+        src.includes("PNPM_HOME") &&
+        src.includes('resolveFromPath("pnpm"') &&
+        src.includes('resolveFromPath("npm"') &&
+        src.includes('["bin", "-g"]') &&
+        src.includes('["prefix", "-g"]')
       );
     },
   },
   {
-    name: "pnpm: updater logs all candidates with their versions",
+    name: "installer: updater logs every package-manager candidate",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -1113,13 +1120,13 @@ const tests: TestFunction[] = [
         "utf-8",
       );
       return (
-        src.includes("[guard] pnpm candidates:") &&
-        src.includes("pnpmResolution.tried")
+        src.includes("[updater] package-manager candidates:") &&
+        src.includes("installerResolution.tried")
       );
     },
   },
   {
-    name: "pnpm: updater skips cycle (no suppression) when no working pnpm found",
+    name: "installer: updater skips without suppression when no manager is usable",
     category: "launchd-regression",
     fn: async () => {
       const { readFileSync } = await import("fs");
@@ -1128,12 +1135,12 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
         "utf-8",
       );
-      // When no pnpm is resolved, we should NOT suppressVersion (that's
+      // When no installer is resolved, we should NOT suppressVersion (that's
       // version-keyed and inappropriate for an environmental failure).
       // We should just log and return.
       const section = src.slice(
-        src.indexOf("no working pnpm found"),
-        src.indexOf("no working pnpm found") + 500,
+        src.indexOf("no package manager has a writable global root"),
+        src.indexOf("no package manager has a writable global root") + 500,
       );
       return (
         section.includes("return;") && !section.includes("suppressVersion")

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -1092,7 +1092,7 @@ describe("stream terminal outcomes", () => {
 });
 
 describe("launchd lifecycle source invariants", () => {
-  it("leaves restart ownership with launchd and keeps auto-update opt-in", async () => {
+  it("leaves restart ownership with launchd and isolates automatic updates", async () => {
     const source = await readFile(
       new URL("../src/cli/commands/proxy.ts", import.meta.url),
       "utf8",
@@ -1101,11 +1101,21 @@ describe("launchd lifecycle source invariants", () => {
       new URL("../src/lib/proxy/updateState.ts", import.meta.url),
       "utf8",
     );
+    const installer = await readFile(
+      new URL("../src/lib/proxy/globalInstaller.ts", import.meta.url),
+      "utf8",
+    );
 
     expect(source).not.toContain("tryLaunchdRestart");
     expect(source).toContain("params.argv.dev || managedByLaunchd");
     expect(source).toContain("NEUROLINK_PROXY_AUTO_UPDATE");
-    expect(source).toContain('["1", "on", "true"]');
+    expect(source).toContain('["0", "off", "false"]');
+    expect(source).toContain("spawnProxyUpdater");
+    expect(source).toContain("updaterOnly &&");
+    expect(source).toContain("getProxyRuntimeActivity");
+    expect(source).not.toContain("proceeding with update anyway");
+    expect(source).toContain('["kickstart", "-k"');
+    expect(source).not.toContain('["bootout", `gui/${uid}/${PLIST_LABEL}`]');
     expect(source).toContain("stopUpdateChecks()");
     expect(source).toContain('from "../../../package.json" with');
     expect(source).toContain("<key>ExitTimeOut</key>");
@@ -1122,6 +1132,10 @@ describe("launchd lifecycle source invariants", () => {
     expect(source).toContain("Timed out draining the proxy server");
     expect(updateState).toContain("randomUUID()");
     expect(updateState).not.toContain("const tempPath = `${filePath}.tmp`");
+    expect(installer).toContain('["bin", "-g"]');
+    expect(installer).toContain('["prefix", "-g"]');
+    expect(installer).toContain("stdout:");
+    expect(installer).toContain("stderr:");
   });
 
   it("keeps dev-mode cooldown state outside the live state directory", () => {

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -1,0 +1,370 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  describeInstallFailure,
+  getGlobalInstallArgs,
+  resolveGlobalInstaller,
+} from "../src/lib/proxy/globalInstaller.js";
+import {
+  beginProxyRequest,
+  getProxyActivitySnapshot,
+  isProxyActivityQuiet,
+  resetProxyActivityForTests,
+  trackProxyResponse,
+} from "../src/lib/proxy/proxyActivity.js";
+import { createClaudeToOpenAIStreamTransform } from "../src/lib/proxy/openaiFormat.js";
+import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
+import { createProxyStartApp } from "../src/cli/commands/proxy.js";
+import { getStats, resetStats } from "../src/lib/proxy/usageStats.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  resetProxyActivityForTests();
+  resetStats();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("proxy runtime activity", () => {
+  it("never reports quiet while a request is active", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T00:00:00Z"));
+    const finish = beginProxyRequest();
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    expect(isProxyActivityQuiet(getProxyActivitySnapshot(), 120_000)).toBe(
+      false,
+    );
+
+    finish();
+    expect(getProxyActivitySnapshot().activeRequests).toBe(0);
+    expect(isProxyActivityQuiet(getProxyActivitySnapshot(), 120_000)).toBe(
+      false,
+    );
+    vi.advanceTimersByTime(120_000);
+    expect(isProxyActivityQuiet(getProxyActivitySnapshot(), 120_000)).toBe(
+      true,
+    );
+  });
+
+  it("holds activity until the response body has settled", async () => {
+    const finish = beginProxyRequest();
+    const response = trackProxyResponse(new Response("complete"), finish);
+
+    expect(getProxyActivitySnapshot().activeRequests).toBe(1);
+    await expect(response.text()).resolves.toBe("complete");
+    expect(getProxyActivitySnapshot().activeRequests).toBe(0);
+  });
+});
+
+describe("proxy runtime error finalization", () => {
+  const createApp = async (getToolRegistry: () => unknown) =>
+    createProxyStartApp({
+      neurolink: { getToolRegistry } as never,
+      modelRouter: undefined,
+      strategy: "fill-first",
+      passthrough: false,
+      port: 55123,
+      host: "127.0.0.1",
+      proxyConfig: null,
+      primaryAccountKey: undefined,
+      accountAllowlist: undefined,
+    });
+
+  it("records invalid JSON as one completed error", async () => {
+    const { app } = await createApp(() => ({}));
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not-json",
+    });
+
+    expect(response.status).toBe(400);
+    await response.text();
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getProxyActivitySnapshot().activeRequests).toBe(0);
+  });
+
+  it("records uncaught adapter failures and returns a generic 502", async () => {
+    const { app } = await createApp(() => {
+      throw new Error("adapter exploded at /private/internal/path");
+    });
+    const response = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-5",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      type: "error",
+      error: { type: "api_error", message: "Proxy internal error" },
+    });
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getProxyActivitySnapshot().activeRequests).toBe(0);
+  });
+});
+
+describe("global installer resolution", () => {
+  it("rejects pnpm without a global bin and selects npm owning the running install", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neurolink-installer-"));
+    tempDirs.push(root);
+    const npmPrefix = join(root, "npm-prefix");
+    const npmRoot = join(npmPrefix, "lib", "node_modules");
+    await mkdir(npmRoot, { recursive: true });
+    await mkdir(join(npmPrefix, "bin"), { recursive: true });
+    const pnpmRoot = join(root, "pnpm-root");
+    await mkdir(pnpmRoot, { recursive: true });
+
+    const fakeExec = vi.fn((bin: string, args: string[]) => {
+      const key = `${bin} ${args.join(" ")}`;
+      const outputs: Record<string, string> = {
+        "which pnpm": "/fake/pnpm",
+        "which npm": "/fake/npm",
+        "/fake/pnpm --version": "10.0.0",
+        "/fake/pnpm root -g": pnpmRoot,
+        "/fake/pnpm bin -g": "",
+        "/fake/npm --version": "11.0.0",
+        "/fake/npm root -g": npmRoot,
+        "/fake/npm prefix -g": npmPrefix,
+      };
+      if (!(key in outputs)) {
+        throw new Error(`unavailable: ${key}`);
+      }
+      return outputs[key];
+    });
+
+    const result = resolveGlobalInstaller({
+      entryScript: join(npmRoot, "@juspay", "neurolink", "dist", "cli.js"),
+      env: {},
+      homeDir: root,
+      execFileSync: fakeExec as never,
+    });
+
+    expect(result.installer).toMatchObject({
+      kind: "npm",
+      bin: "/fake/npm",
+      installable: true,
+      matchesCurrentInstall: true,
+    });
+    expect(
+      result.tried.find((candidate) => candidate.bin === "/fake/pnpm"),
+    ).toMatchObject({ installable: false });
+    expect(getGlobalInstallArgs("npm", "@juspay/neurolink@9.87.3")).toEqual([
+      "install",
+      "--global",
+      "--no-audit",
+      "--no-fund",
+      "@juspay/neurolink@9.87.3",
+    ]);
+
+    const unrelated = resolveGlobalInstaller({
+      entryScript: join(root, "another-install", "dist", "cli.js"),
+      env: {},
+      homeDir: root,
+      execFileSync: fakeExec as never,
+    });
+    expect(unrelated.installer).toBeUndefined();
+    expect(unrelated.tried.some((candidate) => candidate.installable)).toBe(
+      true,
+    );
+  });
+
+  it("includes stdout and stderr in install failures", () => {
+    const error = Object.assign(new Error("command failed"), {
+      stdout: "ERR_PNPM_NO_GLOBAL_BIN_DIR",
+      stderr: "secondary detail",
+    });
+    expect(describeInstallFailure(error)).toContain(
+      "stdout: ERR_PNPM_NO_GLOBAL_BIN_DIR",
+    );
+    expect(describeInstallFailure(error)).toContain("stderr: secondary detail");
+  });
+});
+
+describe("fallback transport handling", () => {
+  it("retries a fallback fetch failure before succeeding", async () => {
+    vi.useFakeTimers();
+    const stream = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new TypeError("fetch failed"), {
+          cause: { code: "UND_ERR_CONNECT_TIMEOUT" },
+        }),
+      )
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield { content: "fallback response" };
+        })(),
+        toolCalls: [],
+        finishReason: "end_turn",
+        model: "fallback-model",
+        usage: { input: 1, output: 2, total: 3 },
+      });
+    const promise = __testHooks.executeClaudeFallbackWithRetry({
+      ctx: { neurolink: { stream } } as never,
+      body: {
+        model: "claude-sonnet-5",
+        messages: [],
+        stream: false,
+      },
+      requestStartTime: Date.now(),
+      logProxyBody: vi.fn(),
+      logFinalRequest: vi.fn(),
+      options: {} as never,
+      providerLabel: "auto-provider",
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toMatchObject({
+      type: "message",
+      model: "fallback-model",
+    });
+    expect(stream).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves fallback exhaustion in the terminal structured error", () => {
+    const buildLoggedClaudeError = vi.fn(
+      (status: number, message: string, errorType?: string) => ({
+        status,
+        message,
+        errorType,
+      }),
+    );
+    const result = __testHooks.buildClaudeAnthropicFailureResponse({
+      requestStartTime: Date.now(),
+      authFailureMessage: null,
+      authCooldownMessage: null,
+      invalidRequestFailure: null,
+      sawNetworkError: true,
+      sawTransientFailure: false,
+      sawRateLimit: false,
+      lastError: new Error("Anthropic connect timeout"),
+      fallbackFailureMessage: "[openai/gpt] fetch failed",
+      orderedAccounts: [],
+      buildLoggedClaudeError,
+      logProxyBody: vi.fn(),
+      logFinalRequest: vi.fn(),
+    });
+
+    expect(result).toMatchObject({
+      status: 502,
+      errorType: "fallback_exhausted",
+    });
+    expect(result.message).toContain(
+      "Fallback also failed: [openai/gpt] fetch failed",
+    );
+  });
+
+  it("times out and retries a fallback stream that never yields", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const abortSignals: AbortSignal[] = [];
+    const stream = vi.fn().mockImplementation((options) => {
+      abortSignals.push(options.abortSignal);
+      return Promise.resolve({
+        stream: {
+          [Symbol.asyncIterator]: () => ({
+            next: () => new Promise(() => undefined),
+            return: cancel,
+          }),
+        },
+        toolCalls: [],
+        model: "fallback-model",
+      });
+    });
+    const promise = __testHooks.executeClaudeFallbackWithRetry({
+      ctx: { neurolink: { stream } } as never,
+      body: {
+        model: "claude-sonnet-5",
+        messages: [],
+        stream: false,
+      },
+      requestStartTime: Date.now(),
+      logProxyBody: vi.fn(),
+      logFinalRequest: vi.fn(),
+      options: {} as never,
+      providerLabel: "auto-provider",
+    });
+    const rejection = expect(promise).rejects.toThrow(
+      "Fallback auto-provider stream timed out",
+    );
+
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(stream).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledTimes(2);
+    expect(abortSignals).toHaveLength(2);
+    expect(abortSignals.every((signal) => signal.aborted)).toBe(true);
+  });
+});
+
+describe("Anthropic to OpenAI stream bridge", () => {
+  const transform = async (
+    input: string,
+    onError = vi.fn(),
+  ): Promise<{ output: string; onError: ReturnType<typeof vi.fn> }> => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(input));
+        controller.close();
+      },
+    });
+    const output = await new Response(
+      source.pipeThrough(
+        createClaudeToOpenAIStreamTransform("claude-sonnet-5", { onError }),
+      ),
+    ).text();
+    return { output, onError };
+  };
+
+  it("propagates Anthropic SSE errors instead of emitting success", async () => {
+    const message = "Upstream stream interrupted: terminated";
+    const result = await transform(
+      `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message } })}\n\n`,
+    );
+
+    expect(result.onError).toHaveBeenCalledWith(message);
+    expect(result.output).toContain('"type":"server_error"');
+    expect(result.output).toContain(message);
+    expect(result.output).not.toContain("[DONE]");
+  });
+
+  it("treats a close without message_stop as an interruption", async () => {
+    const result = await transform(
+      `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: {} })}\n\n`,
+    );
+
+    expect(result.onError).toHaveBeenCalledWith(
+      "Anthropic stream ended before message_stop",
+    );
+    expect(result.output).toContain('"type":"server_error"');
+    expect(result.output).not.toContain("[DONE]");
+  });
+
+  it("ignores frames received after a terminal Anthropic error", async () => {
+    const result = await transform(
+      [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: {} })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text" } })}\n\n`,
+        `event: error\ndata: ${JSON.stringify({ type: "error", error: { message: "stream failed" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "late output" } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+      ].join(""),
+    );
+
+    expect(result.onError).toHaveBeenCalledTimes(1);
+    expect(result.output).toContain('"type":"server_error"');
+    expect(result.output).not.toContain("late output");
+    expect(result.output).not.toContain("[DONE]");
+  });
+});


### PR DESCRIPTION
## Description

Hardens the Claude proxy updater, fallback execution, stream termination, and adapter-level error telemetry based on the recent live failure analysis.

## Root Causes Addressed

- launchd-managed proxies did not spawn the guard that contained the updater, so auto-update could never run
- package-manager detection could select a working pnpm from an unrelated global root instead of the npm installation actually running NeuroLink
- restart safety inferred quiet traffic from debug-log timestamps and could interrupt active streams
- configured and auto-provider fallback failures were discarded, fallback streams could hang indefinitely, and transient fallback transport failures had no bounded retry
- Anthropic SSE error/early-close events could be converted into an OpenAI-compatible success terminator
- uncaught adapter errors such as `fetch failed` bypassed structured request/error statistics

## Changes

- add a dedicated launchd updater worker; automatic updates are enabled by default and can be disabled with `NEUROLINK_PROXY_AUTO_UPDATE=off|false|0`
- resolve only a writable npm/pnpm global root that owns the running entry script; log all candidates plus captured install stdout/stderr
- track active requests through response-body completion and require zero active requests plus a two-minute idle window before install and again before restart
- replace `bootout`/`bootstrap` with atomic `launchctl kickstart -k`; never rewrite or unload the stable plist during an update
- add bounded fallback initialization/stream idle timeouts, one retry for transient network failures, upstream abort on timeout, and preserved terminal fallback diagnostics
- propagate Anthropic SSE errors and incomplete streams as OpenAI `server_error` events without fake `[DONE]` success
- record invalid JSON and uncaught adapter failures in request logs, body capture, and usage stats while returning a generic client-safe 502
- expose request activity and updater worker state through `/status` and `neurolink proxy status`

## Testing

- [x] `pnpm run build` including package/declaration build, browser build, CLI build, and publint
- [x] CLI TypeScript check
- [x] focused proxy reliability tests: 48/48
- [x] production bugfix regression suite: 89/89
- [x] OpenAI proxy format suite: 10/10
- [x] remaining unit stages after model-pool: 58/58
- [x] isolated packaged proxy smoke on port 55789: health/status, invalid JSON 400, structured 1 request/1 error/0 rate limits, active request count returned to zero
- [x] real machine read-only installer probe selected NVM npm 11.12.1 owning the installed package and rejected the unrelated pnpm root

`pnpm run test:unit` has one pre-existing failure: `test/modelPool.test.ts` times out at its fixed 5-second limit. It reproduces unchanged in the untouched original checkout; all 18 other tests in that file pass.

## Deployment Notes

The currently installed older proxy cannot gain the new updater worker by itself. Upgrade once to the release containing this PR and restart through the normal operator workflow; subsequent launchd-managed releases auto-update by default. Set `NEUROLINK_PROXY_AUTO_UPDATE=off` before that restart to opt out. Updater diagnostics are written to `~/.neurolink/logs/proxy-updater.log`.

The live proxy was not restarted, upgraded, reconfigured, or used for test traffic while developing this change. No dependencies were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy auto-updates are enabled by default, with clearer behavior for launchd-managed vs foreground runs.
  * Added runtime activity introspection (active requests, idle detection) and “Auto-update” status visibility, plus updater diagnostics output.
* **Bug Fixes**
  * Hardened streaming and cancellation handling with more accurate SSE/OpenAI-compatible error frames.
  * Improved fallback translation reliability with retries, timeouts, and clearer “fallback also failed” messaging.
* **Documentation**
  * Updated proxy guard, environment variables (including package-manager selection), and cleanup/updater guidance.
* **Tests**
  * Added coverage for activity tracking, installer selection, updater fallback, and stream/interruption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->