### PR TITLE
fix(proxy): prioritize expiring session windows in account routing

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -581,40 +581,104 @@ function isQuotaRoutingEnabled(): boolean {
   return v !== "off" && v !== "false" && v !== "0";
 }
 
-/** Derive the ordering signals for an account from its latest runtime quota. */
-function accountSortMetrics(accountKey: string, now: number) {
+/** Session-utilization soft limit above which an account is demoted below
+ *  accounts with headroom (never made unusable). The utilization snapshot is
+ *  always at least one response stale and requests land in concurrent bursts,
+ *  so a small buffer under 100% turns the window-exhaustion handoff proactive
+ *  (scheduled between requests) instead of reactive (a burst of 429s).
+ *  Override with NEUROLINK_PROXY_SESSION_SOFT_LIMIT (0 < x <= 1; 1 disables). */
+function getSessionSoftLimit(): number {
+  // Number() rejects partially numeric values ("0.5oops") that parseFloat
+  // would silently truncate.
+  const raw = Number(process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT ?? "");
+  return Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : 0.97;
+}
+
+/** Width of the bucket within which two session resets count as "the same
+ *  time", letting the weekly reset decide. Exact epoch equality never occurs,
+ *  and bucketing (unlike pairwise closeness) keeps the comparator transitive.
+ *  Override with NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS. */
+function getSessionResetToleranceMs(): number {
+  // Number() + isInteger rejects partially numeric values ("900000oops")
+  // that parseInt would silently truncate.
+  const raw = Number(
+    process.env.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS ?? "",
+  );
+  return Number.isInteger(raw) && raw > 0 ? raw : 15 * 60 * 1000;
+}
+
+/**
+ * Derive the ordering signals for an account from its latest runtime quota.
+ *
+ * Reset freshening: a window whose reset epoch has already passed is treated
+ * as FRESH (0 used, "allowed", reset unknown) at read time — stale snapshot
+ * numbers from before the reset can never saturate or reject an account whose
+ * window Anthropic has since renewed. The snapshot itself is refreshed from
+ * live response headers the next time the account serves a request.
+ */
+function accountSortMetrics(
+  accountKey: string,
+  now: number,
+  sessionSoftLimit: number,
+  sessionResetToleranceMs: number,
+) {
   const st = accountRuntimeState.get(accountKey);
   const q = st?.quota;
   const coolingActive = !!st?.coolingUntil && now < st.coolingUntil;
+  // resetEpochToMs returns undefined for absent OR passed resets, so a
+  // ticking window is exactly "reset !== undefined".
   const weeklyReset = resetEpochToMs(q?.weeklyResetAt, now);
   const sessionReset = resetEpochToMs(q?.sessionResetAt, now);
-  const weeklyRejected =
-    q?.weeklyStatus === "rejected" && weeklyReset !== undefined;
-  const sessionRejected =
-    q?.sessionStatus === "rejected" && sessionReset !== undefined;
+  const sessionTicking = sessionReset !== undefined;
+  const weeklyTicking = weeklyReset !== undefined;
+  const sessionUsed = sessionTicking ? (q?.sessionUsed ?? 0) : 0;
+  const weeklyUsed = weeklyTicking ? (q?.weeklyUsed ?? -1) : q ? 0 : -1;
+  const sessionStatus = sessionTicking
+    ? (q?.sessionStatus ?? "unknown")
+    : "allowed";
+  const weeklyStatus = weeklyTicking
+    ? (q?.weeklyStatus ?? "unknown")
+    : "allowed";
+  const saturated =
+    sessionStatus === "throttled" ||
+    (sessionTicking && sessionUsed >= sessionSoftLimit);
   return {
-    usable: !coolingActive && !weeklyRejected && !sessionRejected,
+    usable:
+      !coolingActive &&
+      weeklyStatus !== "rejected" &&
+      sessionStatus !== "rejected",
+    saturated,
     hasQuota: !!q,
     coolingUntil: st?.coolingUntil ?? 0,
-    weeklyReset: weeklyReset ?? Number.POSITIVE_INFINITY,
+    sessionResetBucket: sessionTicking
+      ? Math.floor(sessionReset / sessionResetToleranceMs)
+      : Number.POSITIVE_INFINITY,
     sessionReset: sessionReset ?? Number.POSITIVE_INFINITY,
-    weeklyUsed: q?.weeklyUsed ?? -1,
+    weeklyReset: weeklyReset ?? Number.POSITIVE_INFINITY,
+    weeklyUsed,
   };
 }
 
 /**
  * Order accounts to MAXIMIZE quota utilization (fill-first, smart order):
- * spend the account whose window refreshes SOONEST first, so its about-to-reset
+ * spend the window that expires SOONEST first, so its about-to-reset
  * allowance isn't wasted, then move to accounts with longer-dated resets.
  *
  * Priority among usable accounts:
  *   1. no quota data yet — probe first: one request reveals its windows and
  *      self-corrects the ordering. (Ranking unknowns last would starve them
  *      forever: never picked → never observed → never comparable.)
- *   2. soonest WEEKLY (7d) reset  — the scarce, use-it-or-lose-it ceiling
- *   3. soonest SESSION (5h) reset
- *   4. highest weekly utilization — finish off the one closest to done
- *   5. configured primary account, then insertion order
+ *   2. session headroom before session-saturated (>= soft limit or
+ *      "throttled") — saturated accounts then follow the same bucketed
+ *      session ordering below: soonest back in service first, weekly
+ *      deciding same-bucket ties.
+ *   3. soonest SESSION (5h) reset — the capacity expiring soonest; compared
+ *      in tolerance buckets so near-simultaneous resets count as equal.
+ *   4. soonest WEEKLY (7d) reset — decides between same-bucket sessions.
+ *   5. highest weekly utilization — finish off the one closest to done
+ *   6. configured primary account, then insertion order
+ * An account with NO ticking session window (fresh, not yet started) has
+ * nothing expiring and sorts after ticking windows in step 3.
  * Cooling/rejected accounts sort last, soonest-back-to-service first, as
  * last resort.
  */
@@ -623,9 +687,15 @@ function orderAccountsByQuota(
   now: number,
 ): ProxyPassthroughAccount[] {
   const primaryKey = configuredPrimaryAccountKey;
+  // Read the env-tunable thresholds once per sort: cheaper than per-compare,
+  // and a mid-sort env change can never make the comparator intransitive.
+  const sessionSoftLimit = getSessionSoftLimit();
+  const sessionResetToleranceMs = getSessionResetToleranceMs();
+  const metrics = (key: string) =>
+    accountSortMetrics(key, now, sessionSoftLimit, sessionResetToleranceMs);
   return [...accounts].sort((a, b) => {
-    const ma = accountSortMetrics(a.key, now);
-    const mb = accountSortMetrics(b.key, now);
+    const ma = metrics(a.key);
+    const mb = metrics(b.key);
     if (ma.usable !== mb.usable) {
       return ma.usable ? -1 : 1;
     }
@@ -637,11 +707,17 @@ function orderAccountsByQuota(
     if (ma.hasQuota !== mb.hasQuota) {
       return ma.hasQuota ? 1 : -1;
     }
+    if (ma.saturated !== mb.saturated) {
+      return ma.saturated ? 1 : -1;
+    }
+    // Saturated pairs fall through to the same bucketed session ordering:
+    // soonest-back-in-service at bucket granularity, weekly deciding ties —
+    // honoring the configured tolerance instead of exact-epoch comparison.
+    if (ma.sessionResetBucket !== mb.sessionResetBucket) {
+      return ma.sessionResetBucket - mb.sessionResetBucket;
+    }
     if (ma.weeklyReset !== mb.weeklyReset) {
       return ma.weeklyReset - mb.weeklyReset;
-    }
-    if (ma.sessionReset !== mb.sessionReset) {
-      return ma.sessionReset - mb.sessionReset;
     }
     if (ma.weeklyUsed !== mb.weeklyUsed) {
       return mb.weeklyUsed - ma.weeklyUsed;

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1731,6 +1731,189 @@ async function testOrderAccountsByQuota(): Promise<boolean | null> {
 }
 
 // ============================================================================
+// Tests: session-first ordering, soft limit, and reset freshening
+// ============================================================================
+
+async function testSessionFirstOrdering(): Promise<boolean | null> {
+  const { __testHooks } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  // Isolate the quota env knobs: earlier cases assume the defaults, and a
+  // configured shell must neither fail them nor be mutated by this test.
+  const savedSoftLimit = process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT;
+  const savedTolerance = process.env.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS;
+  delete process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT;
+  delete process.env.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS;
+  try {
+    return await runSessionFirstOrderingCases(__testHooks);
+  } finally {
+    if (savedSoftLimit !== undefined) {
+      process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT = savedSoftLimit;
+    } else {
+      delete process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT;
+    }
+    if (savedTolerance !== undefined) {
+      process.env.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS = savedTolerance;
+    } else {
+      delete process.env.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS;
+    }
+  }
+}
+
+async function runSessionFirstOrderingCases(
+  __testHooks: (typeof import("../src/lib/server/routes/claudeProxyRoutes.js"))["__testHooks"],
+): Promise<boolean | null> {
+  const now = 1_800_000_000_000;
+  const nowSec = Math.floor(now / 1000);
+  // Bucket-aligned base so same-bucket cases are deterministic regardless of
+  // the tolerance value in effect (default 15 min = 900s).
+  const bucketSec = 900;
+  const baseSec = (Math.floor(nowSec / bucketSec) + 2) * bucketSec;
+
+  type Acct = { key: string; label: string; token: string; type: "oauth" };
+  const acct = (l: string): Acct => ({
+    key: `anthropic:${l}`,
+    label: l,
+    token: "t",
+    type: "oauth",
+  });
+  const order = (list: Acct[]): string =>
+    __testHooks
+      .orderAccountsByQuota(list as never, now)
+      .map((x: { label: string }) => x.label)
+      .join(",");
+  const setQuota = (l: string, over: Record<string, number | string>): void =>
+    __testHooks.setAccountRuntimeState(`anthropic:${l}`, {
+      quota: makeQuota(over) as never,
+    });
+  const fail = (msg: string): false => {
+    log(msg, "red");
+    __testHooks.resetAllRuntimeState();
+    return false;
+  };
+
+  // 1. Session-first: x's session resets in 1h, y's in 3h. y's WEEKLY resets
+  //    far sooner — but the expiring session window must win.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", {
+    sessionResetAt: nowSec + 3600,
+    weeklyResetAt: nowSec + 5 * 24 * 3600,
+  });
+  setQuota("y", {
+    sessionResetAt: nowSec + 3 * 3600,
+    weeklyResetAt: nowSec + 6 * 3600,
+  });
+  let got = order([acct("x"), acct("y")]);
+  if (got !== "x,y") {
+    return fail(`session-first: expected x,y (1h session wins), got ${got}`);
+  }
+
+  // 2. Same session bucket → weekly decides.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", {
+    sessionResetAt: baseSec + 60,
+    weeklyResetAt: nowSec + 5 * 24 * 3600,
+  });
+  setQuota("y", {
+    sessionResetAt: baseSec + 120,
+    weeklyResetAt: nowSec + 6 * 3600,
+  });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "y,x") {
+    return fail(`same-bucket: expected y,x (weekly tie-break), got ${got}`);
+  }
+
+  // 3. Soft limit (default 0.97): a saturated session demotes below headroom
+  //    even when its session reset is soonest.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", { sessionResetAt: nowSec + 3600, sessionUsed: 0.98 });
+  setQuota("y", { sessionResetAt: nowSec + 3 * 3600, sessionUsed: 0.5 });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "y,x") {
+    return fail(`soft-limit: expected y,x (0.98 saturated), got ${got}`);
+  }
+
+  // 4. Just under the limit is NOT saturated.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", { sessionResetAt: nowSec + 3600, sessionUsed: 0.96 });
+  setQuota("y", { sessionResetAt: nowSec + 3 * 3600, sessionUsed: 0.5 });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "x,y") {
+    return fail(`under-limit: expected x,y (0.96 has headroom), got ${got}`);
+  }
+
+  // 5. "throttled" status demotes regardless of utilization.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", { sessionResetAt: nowSec + 3600, sessionStatus: "throttled" });
+  setQuota("y", { sessionResetAt: nowSec + 3 * 3600 });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "y,x") {
+    return fail(`throttled: expected y,x (throttled demoted), got ${got}`);
+  }
+
+  // 6. Reset freshening: a PASSED session reset means a fresh window — high
+  //    stale utilization must not saturate it. It has nothing expiring, so it
+  //    sorts after ticking windows but ahead of saturated ones.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", { sessionResetAt: nowSec - 60, sessionUsed: 0.99 });
+  setQuota("y", { sessionResetAt: nowSec + 2 * 3600, sessionUsed: 0.5 });
+  setQuota("z", { sessionResetAt: nowSec + 1800, sessionUsed: 0.99 });
+  got = order([acct("x"), acct("y"), acct("z")]);
+  if (got !== "y,x,z") {
+    return fail(
+      `freshening: expected y,x,z (ticking first, fresh window not saturated, saturated last), got ${got}`,
+    );
+  }
+
+  // 7. Both saturated, different buckets → soonest session reset first
+  //    (returns to service first).
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", { sessionResetAt: nowSec + 3600, sessionUsed: 0.99 });
+  setQuota("y", { sessionResetAt: nowSec + 1800, sessionUsed: 0.99 });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "y,x") {
+    return fail(`both-saturated: expected y,x (soonest reset), got ${got}`);
+  }
+
+  // 8. Both saturated, SAME bucket → tolerance still applies and weekly
+  //    decides, exactly like the unsaturated path.
+  __testHooks.resetAllRuntimeState();
+  setQuota("x", {
+    sessionResetAt: baseSec + 60,
+    sessionUsed: 0.99,
+    weeklyResetAt: nowSec + 5 * 24 * 3600,
+  });
+  setQuota("y", {
+    sessionResetAt: baseSec + 120,
+    sessionUsed: 0.99,
+    weeklyResetAt: nowSec + 6 * 3600,
+  });
+  got = order([acct("x"), acct("y")]);
+  if (got !== "y,x") {
+    return fail(
+      `both-saturated-same-bucket: expected y,x (weekly tie-break), got ${got}`,
+    );
+  }
+
+  // 9. Soft limit is configurable via env (outer finally restores it).
+  __testHooks.resetAllRuntimeState();
+  process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT = "0.5";
+  setQuota("x", { sessionResetAt: nowSec + 3600, sessionUsed: 0.6 });
+  setQuota("y", { sessionResetAt: nowSec + 3 * 3600, sessionUsed: 0.1 });
+  got = order([acct("x"), acct("y")]);
+  delete process.env.NEUROLINK_PROXY_SESSION_SOFT_LIMIT;
+  if (got !== "y,x") {
+    return fail(`env-limit: expected y,x (0.6 >= 0.5 saturated), got ${got}`);
+  }
+
+  __testHooks.resetAllRuntimeState();
+  log(
+    "sessionFirstOrdering: 9 cases passed (session-first, bucket tie-break, 0.97 soft limit, throttle, freshening)",
+    "green",
+  );
+  return true;
+}
+
+// ============================================================================
 // Tests: quota persistence merges across restarts (no clobber)
 // ============================================================================
 
@@ -2185,6 +2368,11 @@ const tests: TestFunction[] = [
   {
     name: "Quota: orderAccountsByQuota (soonest-reset-first)",
     fn: testOrderAccountsByQuota,
+    category: "proxy-primary",
+  },
+  {
+    name: "Quota: session-first ordering + soft limit + freshening",
+    fn: testSessionFirstOrdering,
     category: "proxy-primary",
   },
   {


### PR DESCRIPTION
## Description

Refines the quota-aware account ordering introduced in #1143/#1144. The previous comparator ranked accounts by soonest **weekly (7d)** reset, which ignores the window that actually expires first: the rolling **5h session**. With two accounts whose sessions reset at different times, the session window closing soonest is the capacity that is about to be lost — it should be consumed first, regardless of the weekly schedule. The old ordering also considered session state only at hard exhaustion ("rejected"), so window handoffs happened reactively via 429s, and stale snapshots could misrepresent an account whose window had already reset.

## Type of Change

- [x] Bug fix / behavior refinement (non-breaking)

## Changes Made

- **Session-first ordering:** usable accounts now rank by soonest 5h session reset. Session resets are compared in tolerance buckets (default 15 min, `NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS`) so near-simultaneous resets count as equal and the soonest **weekly** reset breaks the tie; bucketing keeps the comparator transitive. Accounts with no ticking session window (fresh, not yet started) have nothing expiring and sort after ticking windows.
- **Session soft limit (default 0.97, `NEUROLINK_PROXY_SESSION_SOFT_LIMIT`):** an account whose session utilization reaches the limit — or whose status is `throttled` — is demoted below accounts with headroom (never made unusable; still serves as fallback). The utilization snapshot is at least one response stale and requests arrive in concurrent bursts, so the small buffer makes the exhaustion handoff proactive and error-free instead of a burst of 429s at every window boundary. Saturated accounts order by soonest session reset (first back in service). Setting the limit to `1` disables demotion.
- **Reset freshening at read time:** a window whose reset epoch has passed is treated as fresh (0 used, `allowed`, reset unknown) in every routing decision, so stale pre-reset numbers can never saturate or reject an account whose window Anthropic has since renewed. The snapshot then self-corrects from live response headers on the account's next request.
- Probe-first for never-observed accounts and the configured-primary tie-break are unchanged.

## Testing

- [x] New no-API suite test `testSessionFirstOrdering` (8 cases): session-first vs weekly, same-bucket weekly tie-break, 0.97 boundary (0.96 stays, 0.97/0.98 demote), throttled demotion, passed-reset freshening for both windows, both-saturated recovery order, env-configurable limit.
- [x] Runtime-verified 13 scenarios including all regressions from the prior ordering tests (weekly-first fallback when no session is ticking, probe-first, primary tie-break) — all pass.
- [x] `pnpm exec vitest run test/proxyReliabilityHardening.test.ts` — 36/36 pass (adjacent cooldown/quota persistence unaffected).
- [x] `tsc --strict`, ESLint gates, prettier, `validate:all`, and full build pass via the pre-commit hook.

## Breaking Changes

- [x] No breaking changes. Existing env toggle `NEUROLINK_PROXY_QUOTA_ROUTING` still gates the whole feature; round-robin strategy is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota-based account ordering by using session utilization limits and reset timing to prioritize more usable accounts.
  * Added more accurate handling for near/expired reset epochs so completed resets don’t incorrectly demote accounts.
  * Updated ordering rules to better account for soft-limit saturation, throttled status, and bucketed reset windows.
* **Tests**
  * Added a continuous in-process test covering session-first ordering, throttling, soft-limit behavior, reset precedence, and tie-breaking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->