### PR TITLE
fix(proxy): make updater and stats self-consistent

### DIFF
--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -75,16 +75,31 @@ neurolink proxy status --format json
   "startTime": "2025-03-22T10:00:00.000Z",
   "uptime": 3600000,
   "url": "http://127.0.0.1:55669",
+  "autoUpdateEnabled": true,
+  "updaterPid": 12346,
+  "updaterRunning": true,
+  "latestVersion": "9.88.9",
+  "pendingRestartVersion": null,
+  "lastUpdateFailure": null,
   "fallbackChain": [{ "provider": "google-ai", "model": "gemini-2.5-pro" }],
   "stats": {
     "totalAttempts": 42,
+    "totalAttemptErrors": 5,
     "totalRequests": 31,
     "totalSuccess": 29,
     "totalErrors": 2,
-    "totalRateLimits": 5
+    "totalRateLimits": 3,
+    "totalTransientRateLimits": 2,
+    "totalQuotaRateLimits": 1
   }
 }
 ```
+
+`totalRequests`, `totalSuccess`, and `totalErrors` are final request outcomes.
+`totalAttempts`, `totalAttemptErrors`, and the rate-limit counters describe
+upstream attempts, including retries that later recovered. Per-account
+`requests`, `success`, and `errors` use the same final-outcome semantics;
+`attemptErrors` and the rate-limit fields remain attempt-level diagnostics.
 
 ### `neurolink proxy telemetry <action>`
 

--- a/docs/features/claude-proxy-observability.md
+++ b/docs/features/claude-proxy-observability.md
@@ -109,7 +109,7 @@ Do not point dashboard panels at the stale log stream `neurolink_proxy_logs` unl
 ### Local Log Families And Query Rules
 
 - `~/.neurolink/logs/proxy-YYYY-MM-DD.jsonl` holds final request summaries. These are the rows the dashboard is built around.
-- `~/.neurolink/logs/proxy-attempts-YYYY-MM-DD.jsonl` holds per-upstream-attempt diagnostics. Use it when retries or account rotation need debugging.
+- `~/.neurolink/logs/proxy-attempts-YYYY-MM-DD.jsonl` holds per-upstream-attempt diagnostics. Rate-limited attempts include `retryable`, `rateLimitKind`, and `cooldownReason` so transient admission throttles are distinguishable from exhausted quota windows. Use this file when retries or account rotation need debugging.
 - `~/.neurolink/logs/proxy-debug-YYYY-MM-DD.jsonl` is the redacted index for captured request and response bodies.
 - `~/.neurolink/logs/bodies/YYYY-MM-DD/<request-id>/*.json.gz` stores the corresponding redacted body artifacts.
 - In OpenObserve, body captures arrive in the same `neurolink_proxy` log stream with `event.name=proxy.body_capture`, so request panels must filter to request-summary rows, for example `http_method IS NOT NULL`.

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -544,7 +544,7 @@ The proxy persists its running state to `~/.neurolink/proxy-state.json` so that 
 
 ### Fail-open guard
 
-A foreground proxy spawns one detached `neurolink proxy guard` that removes stale Claude Code settings after confirming its parent process has died. A launchd-managed proxy keeps restart ownership in launchd and starts a separate updater-only worker. Automatic package updates are enabled by default and can be disabled with `NEUROLINK_PROXY_AUTO_UPDATE=off` (also accepts `0` or `false`). The worker validates the global package root and executable directory, requires the package manager that owns the running installation, and waits for every request and stream to finish plus a two-minute idle window before asking launchd to restart. Updater diagnostics are written to `~/.neurolink/logs/proxy-updater.log` and exposed in `neurolink proxy status`.
+A foreground proxy spawns one detached `neurolink proxy guard` that removes stale Claude Code settings after confirming its parent process has died. A launchd-managed proxy keeps restart ownership in launchd and starts a separate updater-only worker. Automatic package updates are enabled by default and can be disabled with `NEUROLINK_PROXY_AUTO_UPDATE=off` (also accepts `0` or `false`). The worker validates the global package root and executable directory, requires the package manager that owns the running installation, and waits for every request and stream to finish plus a two-minute idle window before asking launchd to restart. Post-install executable validation uses bounded retries, and the proxy supervises and replaces an updater worker that exits unexpectedly. Installed-but-not-running versions and stage-specific update failures remain persisted in `~/.neurolink/update-state.json`. Updater diagnostics are written to `~/.neurolink/logs/proxy-updater.log` and exposed in `neurolink proxy status`.
 
 ## Architecture
 
@@ -639,11 +639,13 @@ This prevents unbounded log growth without requiring external cron jobs.
 
 In-memory per-account statistics track:
 
-- Upstream attempt count, success count, error count, rate-limit count
-- Current backoff level and cooling state
-- Last attempt and last error timestamps
+- Final completed, successful, and failed request counts
+- Upstream attempts and failed attempts, including authentication retries,
+  network failures, and retries that later recovered
+- Transient-throttle and exhausted-quota attempt counts
+- Current account cooling state
 
-Proxy-wide status also tracks total upstream attempts separately from completed requests. Statistics reset on proxy restart. Access them via the `/status` endpoint or `neurolink proxy status`.
+Final request counters add up across accounts and match proxy-wide completed, success, and error totals. Attempt counters are intentionally separate because one final request can make several attempts or rotate accounts. Statistics reset on proxy restart. Access them via the `/status` endpoint or `neurolink proxy status`.
 
 ## Comparison with CLIProxyAPI
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -67,7 +67,19 @@ import {
   describeInstallFailure,
   getGlobalInstallArgs,
   resolveGlobalInstaller,
+  validateInstalledVersion,
 } from "../../lib/proxy/globalInstaller.js";
+import { startUpdaterWorkerSupervisor } from "../../lib/proxy/updaterSupervisor.js";
+import {
+  abandonPendingUpdate,
+  isVersionSuppressed,
+  loadUpdateState,
+  recordCheck,
+  recordSuccessfulUpdate,
+  recordUpdateFailure,
+  recordUpdateInstalled,
+  suppressVersion,
+} from "../../lib/proxy/updateState.js";
 import {
   loadProxyEnvFile,
   resolveProxyEnvFile,
@@ -725,6 +737,16 @@ function spawnProxyUpdater(
       detached: true,
       stdio: ["ignore", logFd, logFd],
       env: process.env,
+    });
+    child.once("error", (error) => {
+      logger.always(
+        `[proxy] updater worker error pid=${child.pid ?? "unknown"}: ${error.message}`,
+      );
+    });
+    child.once("exit", (code, signal) => {
+      logger.always(
+        `[proxy] updater worker exited pid=${child.pid ?? "unknown"} code=${code ?? "none"} signal=${signal ?? "none"}`,
+      );
     });
     child.unref();
     return child.pid;
@@ -1391,6 +1413,7 @@ export async function createProxyStartApp(params: {
       await import("../../lib/proxy/accountCooldown.js");
     const stats = getStats();
     const runtimeState = loadProxyState();
+    const updateState = loadUpdateState();
     const cooldowns = await loadAccountCooldowns();
     const storedAccountKeys = new Set<string>();
     try {
@@ -1428,10 +1451,13 @@ export async function createProxyStartApp(params: {
       health,
       stats: {
         totalAttempts: stats.totalAttempts,
+        totalAttemptErrors: stats.totalAttemptErrors,
         totalRequests: stats.totalRequests,
         totalSuccess: stats.totalSuccess,
         totalErrors: stats.totalErrors,
         totalRateLimits: stats.totalRateLimits,
+        totalTransientRateLimits: stats.totalTransientRateLimits,
+        totalQuotaRateLimits: stats.totalQuotaRateLimits,
         accounts: Object.values(stats.accounts).map((account) => {
           const normalizedKey = normalizeAnthropicAccountKey(account.label);
           const accountKey = storedAccountKeys.has(normalizedKey)
@@ -1445,10 +1471,13 @@ export async function createProxyStartApp(params: {
             label: account.label,
             type: account.type,
             attempts: account.attemptCount,
-            requests: account.attemptCount,
+            requests: account.successCount + account.errorCount,
             success: account.successCount,
             errors: account.errorCount,
+            attemptErrors: account.attemptErrorCount,
             rateLimits: account.rateLimitCount,
+            transientRateLimits: account.transientRateLimitCount,
+            quotaRateLimits: account.quotaRateLimitCount,
             cooling: (cooldowns[accountKey]?.coolingUntil ?? 0) > now,
           };
         }),
@@ -1467,6 +1496,19 @@ export async function createProxyStartApp(params: {
         updaterRunning: runtimeState?.updaterPid
           ? isProcessRunning(runtimeState.updaterPid)
           : false,
+        liveVersion: PROXY_VERSION,
+        latestVersion: updateState?.lastCheckVersion || null,
+        pendingRestartVersion: updateState?.pendingRestartVersion ?? null,
+        lastCheckAt: updateState?.lastCheckAt ?? null,
+        lastUpdateAt: updateState?.lastUpdateAt ?? null,
+        lastUpdateVersion: updateState?.lastUpdateVersion ?? null,
+        lastFailure: updateState?.lastFailure
+          ? {
+              at: updateState.lastFailure.at,
+              version: updateState.lastFailure.version,
+              stage: updateState.lastFailure.stage,
+            }
+          : null,
       },
       config: params.proxyConfig
         ? {
@@ -1751,6 +1793,7 @@ function registerProxyShutdownHandlers(params: {
   isDev?: boolean;
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
+  updaterSupervisor?: { stop: () => void };
 }): void {
   let shutdownStarted = false;
 
@@ -1793,6 +1836,7 @@ function registerProxyShutdownHandlers(params: {
     shutdownStarted = true;
     clearInterval(params.refreshInterval);
     clearInterval(params.logCleanupInterval);
+    params.updaterSupervisor?.stop();
     logger.always(`\nShutting down proxy (${signal})...`);
     let exitCode = signal === "SIGINT" ? 0 : 1;
 
@@ -1893,10 +1937,39 @@ async function startProxyRuntime(params: {
     port: params.port,
   });
   markProxyReady(params.readiness);
-  const updaterPid =
+  try {
+    const { reconcileRunningUpdate } =
+      await import("../../lib/proxy/updateState.js");
+    if (reconcileRunningUpdate(PROXY_VERSION)) {
+      logger.always(
+        `[proxy] confirmed pending update is now running at v${PROXY_VERSION}`,
+      );
+    }
+  } catch (error) {
+    logger.always(
+      `[proxy] WARNING: failed to reconcile update state: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  /** Mirror the supervised worker PID into the proxy state used by status. */
+  const updatePersistedUpdaterPid = (updaterPid: number | undefined): void => {
+    const state = loadProxyState();
+    if (!state || state.pid !== process.pid) {
+      return;
+    }
+    saveProxyState({ ...state, updaterPid });
+  };
+  const updaterSupervisor =
     managedByLaunchd && !params.argv.dev
-      ? spawnProxyUpdater(readinessHost, params.port, process.pid)
+      ? startUpdaterWorkerSupervisor({
+          spawnWorker: () =>
+            spawnProxyUpdater(readinessHost, params.port, process.pid),
+          isProcessRunning,
+          stopWorker: (pid) => process.kill(pid, "SIGTERM"),
+          onPidChange: updatePersistedUpdaterPid,
+          log: (message) => logger.always(message),
+        })
       : undefined;
+  const updaterPid = updaterSupervisor?.currentPid();
   const fallbackChain: FallbackInfo[] | undefined =
     params.proxyConfig?.routing?.fallbackChain?.map((entry) => ({
       provider: entry.provider as string,
@@ -2001,6 +2074,7 @@ async function startProxyRuntime(params: {
     host: params.host,
     port: params.port,
     isDev,
+    updaterSupervisor,
     ...maintenance,
   });
 }
@@ -2208,19 +2282,62 @@ function printStatusStats(stats: StatusStats): void {
   console.info(
     `    Completed:   ${stats.totalRequests} total, ${stats.totalSuccess} success, ${stats.totalErrors} errors`,
   );
-  console.info(`    Rate limits: ${stats.totalRateLimits}`);
+  if (stats.totalAttemptErrors !== undefined) {
+    console.info(`    Failed attempts: ${stats.totalAttemptErrors}`);
+  }
+  console.info(
+    `    Rate-limited attempts: ${stats.totalRateLimits}` +
+      (stats.totalTransientRateLimits !== undefined &&
+      stats.totalQuotaRateLimits !== undefined
+        ? ` (${stats.totalTransientRateLimits} transient, ${stats.totalQuotaRateLimits} quota)`
+        : ""),
+  );
   if (stats.accounts?.length) {
     console.info(`\n  Accounts:`);
-    for (const a of stats.accounts) {
-      const acctStatus = a.cooling
-        ? chalk.red("cooling")
-        : chalk.green("active");
-      const attempts = a.attempts ?? a.requests ?? 0;
-      const success = a.success ?? 0;
-      const errors = a.errors ?? 0;
-      const rateLimits = a.rateLimits ?? 0;
+    const headers = [
+      "ACCOUNT",
+      "AUTH",
+      "ATTEMPTS",
+      "SUCCESS",
+      "ERRORS",
+      "RL",
+      "STATUS",
+    ];
+    const rows = stats.accounts.map((account) => [
+      account.label,
+      account.type,
+      String(account.attempts ?? account.requests ?? 0),
+      String(account.success ?? 0),
+      String(account.errors ?? 0),
+      String(account.rateLimits ?? 0),
+      account.cooling ? "cooling" : "active",
+    ]);
+    const widths = headers.map((header, index) =>
+      Math.max(header.length, ...rows.map((row) => row[index].length)),
+    );
+    const numericColumns = new Set([2, 3, 4, 5]);
+    /** Align text columns left and numeric account counters right. */
+    const formatRow = (cells: string[]): string =>
+      cells
+        .map((cell, index) =>
+          numericColumns.has(index)
+            ? cell.padStart(widths[index])
+            : cell.padEnd(widths[index]),
+        )
+        .join("  ");
+
+    console.info(`    ${chalk.gray(formatRow(headers))}`);
+    console.info(
+      `    ${chalk.gray(widths.map((width) => "-".repeat(width)).join("  "))}`,
+    );
+    for (const row of rows) {
+      const status = row[6];
+      const formatted = formatRow(row);
+      const statusStart = formatted.length - widths[6];
+      const prefix = formatted.slice(0, statusStart);
+      const paddedStatus = formatted.slice(statusStart);
       console.info(
-        `    ${a.label.padEnd(20)} ${a.type.padEnd(8)} ${String(attempts).padEnd(6)} attempts  ${String(success).padEnd(6)} success  ${String(errors).padEnd(6)} errors  ${String(rateLimits).padEnd(6)} rl  ${acctStatus}`,
+        `    ${chalk.cyan(prefix.slice(0, widths[0]))}${prefix.slice(widths[0])}${status === "cooling" ? chalk.red(paddedStatus) : chalk.green(paddedStatus)}`,
       );
     }
   }
@@ -2256,6 +2373,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
   handler: async (argv) => {
     try {
       const state = loadProxyState();
+      const updateState = loadUpdateState();
 
       const status = {
         running: false,
@@ -2273,6 +2391,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         autoUpdateEnabled: isProxyAutoUpdateEnabled(),
         updaterPid: null as number | null,
         updaterRunning: false,
+        latestVersion: updateState?.lastCheckVersion || null,
+        pendingRestartVersion: updateState?.pendingRestartVersion ?? null,
+        lastUpdateFailure: updateState?.lastFailure ?? null,
       };
 
       if (state && isProcessRunning(state.pid)) {
@@ -2347,6 +2468,21 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         logger.always(
           `  ${chalk.bold("Auto-update:")} ${status.autoUpdateEnabled ? chalk.green(status.updaterRunning ? `enabled (PID ${status.updaterPid})` : "enabled (worker unavailable)") : chalk.yellow("disabled")}`,
         );
+        if (status.pendingRestartVersion) {
+          logger.always(
+            `  ${chalk.bold("Pending:")}    ${chalk.yellow(`v${status.pendingRestartVersion} installed; restart pending`)}`,
+          );
+        }
+        if (status.latestVersion) {
+          logger.always(
+            `  ${chalk.bold("Latest:")}     ${chalk.cyan(`v${status.latestVersion}`)}`,
+          );
+        }
+        if (status.lastUpdateFailure) {
+          logger.always(
+            `  ${chalk.bold("Update error:")} ${chalk.red(`${status.lastUpdateFailure.stage}: ${status.lastUpdateFailure.message}`)}`,
+          );
+        }
         if (status.envFile) {
           logger.always(
             `  ${chalk.bold("Env File:")}   ${chalk.cyan(status.envFile)}`,
@@ -2403,10 +2539,13 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
             const statusData = (await statusResp.json()) as {
               stats?: {
                 totalAttempts?: number;
+                totalAttemptErrors?: number;
                 totalRequests: number;
                 totalSuccess: number;
                 totalErrors: number;
                 totalRateLimits: number;
+                totalTransientRateLimits?: number;
+                totalQuotaRateLimits?: number;
                 accounts?: {
                   label: string;
                   type: string;
@@ -2414,7 +2553,10 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
                   requests?: number;
                   success?: number;
                   errors?: number;
+                  attemptErrors?: number;
                   rateLimits?: number;
+                  transientRateLimits?: number;
+                  quotaRateLimits?: number;
                   cooling: boolean;
                 }[];
               };
@@ -2623,6 +2765,19 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         updateCheckInterval = undefined;
       }
     };
+    /** Keep state-write failures observable without terminating the updater. */
+    const persistUpdaterState = (
+      operation: string,
+      action: () => void,
+    ): void => {
+      try {
+        action();
+      } catch (error) {
+        logger.always(
+          `[updater] WARNING: failed to ${operation}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    };
     let updateInProgress = false;
     let updateRestartInProgress = false;
     const runUpdateCheck = async () => {
@@ -2630,25 +2785,25 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         return;
       }
       updateInProgress = true;
+      let updateVersion = runningVersion;
       try {
         // Lazy-load update modules so they're only imported at check time
         const { checkForUpdate } =
           await import("../../lib/proxy/updateChecker.js");
-        const {
-          recordCheck,
-          isVersionSuppressed,
-          suppressVersion,
-          recordSuccessfulUpdate,
-        } = await import("../../lib/proxy/updateState.js");
 
         // 1. Check for update
         const result = await checkForUpdate(runningVersion);
-        recordCheck(result.latestVersion);
+        updateVersion = result.latestVersion;
+        persistUpdaterState("record update check", () =>
+          recordCheck(result.latestVersion),
+        );
 
         if (!result.updateAvailable) {
           return;
         }
-        if (isVersionSuppressed(result.latestVersion)) {
+        const pendingRestart =
+          loadUpdateState()?.pendingRestartVersion === result.latestVersion;
+        if (isVersionSuppressed(result.latestVersion) && !pendingRestart) {
           logger.debug(
             `[guard] version ${result.latestVersion} is suppressed, skipping`,
           );
@@ -2685,53 +2840,71 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
 
         // 3. Install update (validate version string before passing to shell)
         if (!/^\d+\.\d+\.\d+$/.test(result.latestVersion)) {
+          const message = `invalid version format: ${result.latestVersion}`;
           logger.always(
             `[guard] WARNING: invalid version format "${result.latestVersion}", skipping`,
+          );
+          persistUpdaterState("record update failure", () =>
+            recordUpdateFailure(result.latestVersion, "check", message),
           );
           return;
         }
 
-        const installerResolution = resolveGlobalInstaller({
-          entryScript: process.argv[1],
-        });
-        logger.always(
-          `[updater] package-manager candidates: ${installerResolution.tried
-            .map(
-              (candidate) =>
-                `${candidate.kind}:${candidate.bin}(${candidate.installable ? `v${candidate.version}` : (candidate.reason ?? "unusable")})`,
-            )
-            .join(", ")}`,
-        );
-        const installer = installerResolution.installer;
-        if (!installer) {
-          logger.always(
-            `[updater] WARNING: no package manager has a writable global root and executable directory; skipping this cycle`,
-          );
-          return;
-        }
-        logger.always(
-          `[updater] installing @juspay/neurolink@${result.latestVersion} via ${installer.kind} ${installer.bin} (v${installer.version})`,
-        );
-        if (guardStopping || getProcessStatus(parentPid) === "not_running") {
-          return;
-        }
         const { execFileSync } = await import("node:child_process");
-        try {
-          execFileSync(
-            installer.bin,
-            getGlobalInstallArgs(
-              installer.kind,
-              `@juspay/neurolink@${result.latestVersion}`,
-            ),
-            {
-              timeout: 120_000,
-              stdio: "pipe",
-            },
+        if (!pendingRestart) {
+          const installerResolution = resolveGlobalInstaller({
+            entryScript: process.argv[1],
+          });
+          logger.always(
+            `[updater] package-manager candidates: ${installerResolution.tried
+              .map(
+                (candidate) =>
+                  `${candidate.kind}:${candidate.bin}(${candidate.installable ? `v${candidate.version}` : (candidate.reason ?? "unusable")})`,
+              )
+              .join(", ")}`,
           );
-        } catch (installErr) {
-          const detail = describeInstallFailure(installErr);
-          logger.always(`[updater] WARNING: global install failed:\n${detail}`);
-          return;
+          const installer = installerResolution.installer;
+          if (!installer) {
+            const message =
+              "no package manager has a writable global root and executable directory";
+            logger.always(`[updater] WARNING: ${message}; skipping this cycle`);
+            persistUpdaterState("record update failure", () =>
+              recordUpdateFailure(result.latestVersion, "install", message),
+            );
+            return;
+          }
+          logger.always(
+            `[updater] installing @juspay/neurolink@${result.latestVersion} via ${installer.kind} ${installer.bin} (v${installer.version})`,
+          );
+          if (guardStopping || getProcessStatus(parentPid) === "not_running") {
+            return;
+          }
+          try {
+            execFileSync(
+              installer.bin,
+              getGlobalInstallArgs(
+                installer.kind,
+                `@juspay/neurolink@${result.latestVersion}`,
+              ),
+              {
+                timeout: 120_000,
+                stdio: "pipe",
+              },
+            );
+          } catch (installErr) {
+            const detail = describeInstallFailure(installErr);
+            logger.always(
+              `[updater] WARNING: global install failed:\n${detail}`,
+            );
+            persistUpdaterState("record update failure", () =>
+              recordUpdateFailure(result.latestVersion, "install", detail),
+            );
+            return;
+          }
+        } else {
+          logger.always(
+            `[updater] resuming pending restart for already-installed v${result.latestVersion}`,
+          );
         }
 
         // 4. Refresh and validate the stable trampoline. The plist already
@@ -2739,42 +2912,41 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         try {
           writeTrampoline();
 
-          // Validate the trampoline actually resolves to the NEW version
-          // before asking launchd to restart. If the install somehow left
-          // PATH still pointing at the old version, don't kickstart.
-          const probed = probeBinVersion(TRAMPOLINE_PATH);
-          if (!probed) {
-            logger.always(
-              `[updater] WARNING: trampoline does not resolve to a working neurolink after install; skipping restart`,
+          const validation = await validateInstalledVersion({
+            binPath: TRAMPOLINE_PATH,
+            expectedVersion: result.latestVersion,
+          });
+          if (validation.version !== result.latestVersion) {
+            const message = `trampoline validation failed after ${validation.attempts} attempts: ${validation.failure ?? "unknown failure"}`;
+            logger.always(`[updater] WARNING: ${message}; restart deferred`);
+            persistUpdaterState("record update failure", () =>
+              recordUpdateFailure(result.latestVersion, "validation", message),
             );
-            suppressVersion(
-              result.latestVersion,
-              `trampoline_broken_after_install: ${TRAMPOLINE_PATH} --version failed`,
-            );
-            return;
-          }
-          if (probed !== result.latestVersion) {
-            logger.always(
-              `[updater] ABORT: trampoline resolves to v${probed} but installed v${result.latestVersion}`,
-            );
-            logger.always(
-              `[updater] installer used: ${installer.kind} ${installer.bin} (v${installer.version})`,
-            );
-            suppressVersion(
-              result.latestVersion,
-              `version_mismatch: trampoline=${probed} expected=${result.latestVersion} installer=${installer.kind}:${installer.bin}(v${installer.version})`,
+            persistUpdaterState("abandon invalid pending update", () =>
+              abandonPendingUpdate(result.latestVersion),
             );
             return;
           }
 
-          logger.always(`[updater] trampoline validated at v${probed}`);
-        } catch (trampolineError) {
+          persistUpdaterState("record installed update", () =>
+            recordUpdateInstalled(result.latestVersion),
+          );
           logger.always(
-            `[updater] WARNING: failed to refresh trampoline; refusing restart: ${
-              trampolineError instanceof Error
-                ? trampolineError.message
-                : String(trampolineError)
-            }`,
+            `[updater] trampoline validated at v${validation.version} after ${validation.attempts} attempt(s)`,
+          );
+        } catch (trampolineError) {
+          const message =
+            trampolineError instanceof Error
+              ? trampolineError.message
+              : String(trampolineError);
+          logger.always(
+            `[updater] WARNING: failed to refresh trampoline; refusing restart: ${message}`,
+          );
+          persistUpdaterState("record update failure", () =>
+            recordUpdateFailure(result.latestVersion, "validation", message),
+          );
+          persistUpdaterState("abandon invalid pending update", () =>
+            abandonPendingUpdate(result.latestVersion),
           );
           return;
         }
@@ -2825,6 +2997,9 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           logger.always(
             `[updater] WARNING: launchctl kickstart failed: ${msg}`,
           );
+          persistUpdaterState("record update failure", () =>
+            recordUpdateFailure(result.latestVersion, "restart", msg),
+          );
           return;
         }
 
@@ -2853,19 +3028,35 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           logger.always(
             `[updater] update successful: now running ${result.latestVersion}`,
           );
-          recordSuccessfulUpdate(result.latestVersion);
+          persistUpdaterState("record successful update", () =>
+            recordSuccessfulUpdate(result.latestVersion),
+          );
           // The replacement proxy starts a worker running the new version.
           process.exit(0);
         } else {
           logger.always(
             `[updater] WARNING: proxy unhealthy after update to ${result.latestVersion}`,
           );
-          suppressVersion(result.latestVersion, "unhealthy_after_restart");
+          persistUpdaterState("record update failure", () =>
+            recordUpdateFailure(
+              result.latestVersion,
+              "health",
+              `proxy did not report v${result.latestVersion} healthy within ${UPDATE_TIMEOUT_MS}ms`,
+            ),
+          );
+          persistUpdaterState("abandon unhealthy pending update", () =>
+            abandonPendingUpdate(result.latestVersion),
+          );
+          persistUpdaterState("suppress unhealthy update", () =>
+            suppressVersion(result.latestVersion, "unhealthy_after_restart"),
+          );
           updateRestartInProgress = false;
         }
       } catch (err) {
-        logger.always(
-          `[updater] update check error: ${err instanceof Error ? err.message : String(err)}`,
+        const message = err instanceof Error ? err.message : String(err);
+        logger.always(`[updater] update check error: ${message}`);
+        persistUpdaterState("record update failure", () =>
+          recordUpdateFailure(updateVersion, "check", message),
         );
       } finally {
         updateInProgress = false;
@@ -2890,12 +3081,27 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
       const healthy = await isProxyHealthy(host, port, 1_500);
 
       if (healthy) {
+        if (updaterOnly && consecutiveUnhealthy >= failureThreshold) {
+          logger.always(
+            `[updater] proxy health recovered after ${consecutiveUnhealthy} failed checks`,
+          );
+        }
         consecutiveUnhealthy = 0;
       } else {
         consecutiveUnhealthy += 1;
+        if (updaterOnly && consecutiveUnhealthy === failureThreshold) {
+          logger.always(
+            `[updater] proxy health unavailable after ${consecutiveUnhealthy} checks; worker remains active`,
+          );
+        }
       }
 
       if (parentStatus === "not_running" && !updateRestartInProgress) {
+        if (updaterOnly) {
+          logger.always(
+            `[updater] parent pid=${parentPid} exited; updater worker stopping`,
+          );
+        }
         // Parent is gone (and we're not mid-update-restart).
         // If endpoint is still healthy, another proxy took over.
         if (healthy) {
@@ -2906,6 +3112,7 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
       }
 
       if (
+        !updaterOnly &&
         !updateRestartInProgress &&
         !healthy &&
         consecutiveUnhealthy >= failureThreshold

--- a/src/lib/proxy/globalInstaller.ts
+++ b/src/lib/proxy/globalInstaller.ts
@@ -1,13 +1,15 @@
 import { execFileSync as nodeExecFileSync } from "node:child_process";
 import { accessSync, constants, existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import type {
   GlobalInstallerExecFile,
   GlobalInstallerKind,
   GlobalInstallerProbe,
   GlobalInstallerResolution,
+  InstalledVersionValidation,
   ResolveGlobalInstallerOptions,
+  ValidateInstalledVersionOptions,
 } from "../types/index.js";
 
 function runText(
@@ -181,6 +183,62 @@ export function getGlobalInstallArgs(
   return kind === "pnpm"
     ? ["add", "-g", packageSpec]
     : ["install", "--global", "--no-audit", "--no-fund", packageSpec];
+}
+
+/**
+ * Validate a freshly installed CLI with retries. Global package replacement
+ * can leave executable shims briefly unavailable while filesystem metadata and
+ * cold module loading settle, so a single short probe is not authoritative.
+ */
+export async function validateInstalledVersion(
+  options: ValidateInstalledVersionOptions,
+): Promise<InstalledVersionValidation> {
+  if (!isAbsolute(options.binPath)) {
+    return {
+      attempts: 0,
+      failure: `binPath must be absolute: ${options.binPath}`,
+    };
+  }
+  const execFileSync = options.execFileSync ?? nodeExecFileSync;
+  const sleepFn =
+    options.sleep ??
+    ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 5);
+  const delayMs = Math.max(0, options.delayMs ?? 2_000);
+  const timeoutMs = Math.max(1_000, options.timeoutMs ?? 10_000);
+  let lastVersion: string | undefined;
+  let lastFailure: string | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const output = String(
+        execFileSync(options.binPath, ["--version"], {
+          encoding: "utf8",
+          timeout: timeoutMs,
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).trim();
+      lastVersion = output || undefined;
+      if (lastVersion === options.expectedVersion) {
+        return { version: lastVersion, attempts: attempt };
+      }
+      lastFailure = lastVersion
+        ? `resolved to v${lastVersion}; expected v${options.expectedVersion}`
+        : "version command returned empty output";
+    } catch (error) {
+      lastFailure = describeInstallFailure(error);
+    }
+
+    if (attempt < maxAttempts) {
+      await sleepFn(delayMs);
+    }
+  }
+
+  return {
+    version: lastVersion,
+    attempts: maxAttempts,
+    failure: lastFailure ?? "version validation failed",
+  };
 }
 
 function capturedOutput(error: unknown, key: "stdout" | "stderr"): string {

--- a/src/lib/proxy/updateState.ts
+++ b/src/lib/proxy/updateState.ts
@@ -19,6 +19,13 @@ import type { UpdateState } from "../types/index.js";
 
 const STATE_FILENAME = "update-state.json";
 const SUPPRESSION_TTL_MS = 86_400_000; // 24 hours
+const UPDATE_FAILURE_STAGES = new Set([
+  "check",
+  "install",
+  "validation",
+  "restart",
+  "health",
+]);
 
 // ============================================
 // Internal Helpers
@@ -45,6 +52,23 @@ function ensureParentDir(filePath: string): void {
   }
 }
 
+/** Reject malformed persisted failure metadata before it reaches status output. */
+function isValidLastFailure(
+  value: unknown,
+): value is NonNullable<UpdateState["lastFailure"]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.at === "string" &&
+    typeof candidate.version === "string" &&
+    typeof candidate.stage === "string" &&
+    UPDATE_FAILURE_STAGES.has(candidate.stage) &&
+    typeof candidate.message === "string"
+  );
+}
+
 // ============================================
 // Exported Functions
 // ============================================
@@ -59,6 +83,8 @@ export function getDefaultUpdateState(): UpdateState {
     suppressedVersions: {},
     lastUpdateAt: null,
     lastUpdateVersion: null,
+    pendingRestartVersion: null,
+    lastFailure: null,
   };
 }
 
@@ -89,7 +115,19 @@ export function loadUpdateState(stateFilePath?: string): UpdateState | null {
     ) {
       return getDefaultUpdateState();
     }
-    return parsed as UpdateState;
+    const candidate = parsed as Partial<UpdateState>;
+    return {
+      ...getDefaultUpdateState(),
+      ...candidate,
+      suppressedVersions: candidate.suppressedVersions ?? {},
+      pendingRestartVersion:
+        typeof candidate.pendingRestartVersion === "string"
+          ? candidate.pendingRestartVersion
+          : null,
+      lastFailure: isValidLastFailure(candidate.lastFailure)
+        ? candidate.lastFailure
+        : null,
+    };
   } catch {
     // Corrupt or unreadable JSON — return default state
     return getDefaultUpdateState();
@@ -178,7 +216,65 @@ export function recordSuccessfulUpdate(
   const state = loadUpdateState(stateFilePath) ?? getDefaultUpdateState();
   state.lastUpdateAt = new Date().toISOString();
   state.lastUpdateVersion = version;
+  state.pendingRestartVersion = null;
+  state.lastFailure = null;
+  delete state.suppressedVersions[version];
   saveUpdateState(state, stateFilePath);
+}
+
+/** Record that package installation completed but the live restart is pending. */
+export function recordUpdateInstalled(
+  version: string,
+  stateFilePath?: string,
+): void {
+  const state = loadUpdateState(stateFilePath) ?? getDefaultUpdateState();
+  state.pendingRestartVersion = version;
+  state.lastFailure = null;
+  saveUpdateState(state, stateFilePath);
+}
+
+/** Abandon a matching installed version so the next cycle may reinstall it. */
+export function abandonPendingUpdate(
+  version: string,
+  stateFilePath?: string,
+): boolean {
+  const state = loadUpdateState(stateFilePath);
+  if (!state || state.pendingRestartVersion !== version) {
+    return false;
+  }
+  state.pendingRestartVersion = null;
+  saveUpdateState(state, stateFilePath);
+  return true;
+}
+
+/** Persist a stage-specific updater failure so status remains actionable. */
+export function recordUpdateFailure(
+  version: string,
+  stage: NonNullable<UpdateState["lastFailure"]>["stage"],
+  message: string,
+  stateFilePath?: string,
+): void {
+  const state = loadUpdateState(stateFilePath) ?? getDefaultUpdateState();
+  state.lastFailure = {
+    at: new Date().toISOString(),
+    version,
+    stage,
+    message: message.trim().slice(0, 1_000),
+  };
+  saveUpdateState(state, stateFilePath);
+}
+
+/** Complete an updater-managed install after a manual or automatic restart. */
+export function reconcileRunningUpdate(
+  runningVersion: string,
+  stateFilePath?: string,
+): boolean {
+  const state = loadUpdateState(stateFilePath);
+  if (!state || state.pendingRestartVersion !== runningVersion) {
+    return false;
+  }
+  recordSuccessfulUpdate(runningVersion, stateFilePath);
+  return true;
 }
 
 /**

--- a/src/lib/proxy/updaterSupervisor.ts
+++ b/src/lib/proxy/updaterSupervisor.ts
@@ -1,0 +1,71 @@
+import type {
+  UpdaterWorkerSupervisor,
+  UpdaterWorkerSupervisorOptions,
+} from "../types/index.js";
+
+/** Keep the launchd updater worker alive while its owning proxy is running. */
+export function startUpdaterWorkerSupervisor(
+  options: UpdaterWorkerSupervisorOptions,
+): UpdaterWorkerSupervisor {
+  let stopped = false;
+  let pid: number | undefined;
+
+  /** Return the healthy worker PID or replace an unavailable worker. */
+  const checkNow = (): number | undefined => {
+    if (stopped) {
+      return pid;
+    }
+    if (pid !== undefined && options.isProcessRunning(pid)) {
+      return pid;
+    }
+
+    const previousPid = pid;
+    try {
+      pid = options.spawnWorker();
+    } catch (error) {
+      pid = undefined;
+      options.log?.(
+        `[proxy] updater worker spawn failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    options.onPidChange?.(pid);
+    if (pid !== undefined) {
+      options.log?.(
+        previousPid === undefined
+          ? `[proxy] updater worker started pid=${pid}`
+          : `[proxy] updater worker restarted oldPid=${previousPid} newPid=${pid}`,
+      );
+    } else {
+      options.log?.("[proxy] updater worker unavailable; retrying later");
+    }
+    return pid;
+  };
+
+  checkNow();
+  const interval = setInterval(checkNow, options.intervalMs ?? 30_000);
+  interval.unref?.();
+
+  return {
+    currentPid: () => pid,
+    checkNow,
+    stop: () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      clearInterval(interval);
+      const activePid = pid;
+      if (activePid !== undefined && options.isProcessRunning(activePid)) {
+        try {
+          options.stopWorker(activePid);
+        } catch (error) {
+          options.log?.(
+            `[proxy] updater worker stop failed pid=${activePid}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      pid = undefined;
+      options.onPidChange?.(undefined);
+    },
+  };
+}

--- a/src/lib/proxy/usageStats.ts
+++ b/src/lib/proxy/usageStats.ts
@@ -9,10 +9,13 @@ import type { AccountStats, ProxyStats } from "../types/index.js";
 const stats: ProxyStats = {
   startedAt: Date.now(),
   totalAttempts: 0,
+  totalAttemptErrors: 0,
   totalRequests: 0,
   totalSuccess: 0,
   totalErrors: 0,
   totalRateLimits: 0,
+  totalTransientRateLimits: 0,
+  totalQuotaRateLimits: 0,
   accounts: {},
 };
 
@@ -39,13 +42,22 @@ export function recordAttemptError(
   accountLabel: string,
   accountType: string,
   status: number,
+  rateLimitKind?: "transient" | "quota",
 ): void {
   const acct = ensureAccount(accountLabel, accountType);
-  acct.errorCount++;
+  stats.totalAttemptErrors++;
+  acct.attemptErrorCount++;
   acct.lastErrorAt = Date.now();
   if (status === 429) {
     stats.totalRateLimits++;
     acct.rateLimitCount++;
+    if (rateLimitKind === "transient") {
+      stats.totalTransientRateLimits++;
+      acct.transientRateLimitCount++;
+    } else if (rateLimitKind === "quota") {
+      stats.totalQuotaRateLimits++;
+      acct.quotaRateLimitCount++;
+    }
   }
 }
 
@@ -79,10 +91,13 @@ export function getAccountStats(label: string): AccountStats | undefined {
 export function resetStats(): void {
   stats.startedAt = Date.now();
   stats.totalAttempts = 0;
+  stats.totalAttemptErrors = 0;
   stats.totalRequests = 0;
   stats.totalSuccess = 0;
   stats.totalErrors = 0;
   stats.totalRateLimits = 0;
+  stats.totalTransientRateLimits = 0;
+  stats.totalQuotaRateLimits = 0;
   stats.accounts = {};
 }
 
@@ -92,9 +107,12 @@ function ensureAccount(label: string, type: string): AccountStats {
       label,
       type,
       attemptCount: 0,
+      attemptErrorCount: 0,
       successCount: 0,
       errorCount: 0,
       rateLimitCount: 0,
+      transientRateLimitCount: 0,
+      quotaRateLimitCount: 0,
       lastAttemptAt: 0,
     };
   }

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -4010,24 +4010,11 @@ async function handleAnthropicAuthRetry(args: {
   buildUpstreamBody: (token: string) => { bodyStr: string; sessionId?: string };
   enabledAccounts: ProxyPassthroughAccount[];
   orderedAccounts: ProxyPassthroughAccount[];
-  response: Response;
   tracer?: ProxyTracer;
   requestStartTime: number;
-  fetchStartMs: number;
-  attemptNumber: number;
-  finalBodyStr: string;
+  allocateAttemptNumber: () => number;
   upstreamSpan?: import("@opentelemetry/api").Span;
-  logAttempt: (
-    status: number,
-    errorType?: string,
-    errorMessage?: string,
-    extra?: {
-      inputTokens?: number;
-      outputTokens?: number;
-      cacheCreationTokens?: number;
-      cacheReadTokens?: number;
-    },
-  ) => void;
+  logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: (
     status: number,
@@ -4057,12 +4044,9 @@ async function handleAnthropicAuthRetry(args: {
     buildUpstreamBody,
     enabledAccounts,
     orderedAccounts,
-    response: _response,
     tracer,
     requestStartTime,
-    fetchStartMs,
-    attemptNumber,
-    finalBodyStr,
+    allocateAttemptNumber,
     upstreamSpan,
     logAttempt,
     logProxyBody,
@@ -4074,6 +4058,9 @@ async function handleAnthropicAuthRetry(args: {
     sawNetworkError,
   } = args;
   recordAttemptError(account.label, account.type, 401);
+  logAttempt(401, "authentication_error", "received 401 from Anthropic", {
+    retryable: true,
+  });
   let currentLastError = lastError;
   let currentAuthFailureMessage = authFailureMessage;
   let currentSawRateLimit = sawRateLimit;
@@ -4119,6 +4106,30 @@ async function handleAnthropicAuthRetry(args: {
     }
     await clearAuthCooldownAfterRefresh(account, accountState);
     headers.authorization = `Bearer ${account.token}`;
+    const retryAttemptNumber = allocateAttemptNumber();
+    recordAttempt(account.label, account.type);
+    const retryLogAttempt: AnthropicAttemptLogger = (
+      status,
+      errorType,
+      errorMessage,
+      extra,
+    ) =>
+      logAttempt(status, errorType, errorMessage, {
+        ...extra,
+        attempt: retryAttemptNumber,
+      });
+    const retryBodyStr = buildUpstreamBody(account.token).bodyStr;
+    const retryFetchStartMs = Date.now();
+    logProxyBody({
+      phase: "upstream_request",
+      headers,
+      body: retryBodyStr,
+      bodySize: Buffer.byteLength(retryBodyStr, "utf8"),
+      contentType: headers["content-type"] ?? "application/json",
+      account: account.label,
+      accountType: account.type,
+      attempt: retryAttemptNumber,
+    });
 
     try {
       const retryResp = await fetch(
@@ -4126,7 +4137,7 @@ async function handleAnthropicAuthRetry(args: {
         {
           method: "POST",
           headers,
-          body: buildUpstreamBody(account.token).bodyStr,
+          body: retryBodyStr,
           signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
         },
       );
@@ -4144,9 +4155,9 @@ async function handleAnthropicAuthRetry(args: {
           retryResp,
           tracer,
           requestStartTime,
-          fetchStartMs,
-          attemptNumber,
-          finalBodyStr,
+          fetchStartMs: retryFetchStartMs,
+          attemptNumber: retryAttemptNumber,
+          finalBodyStr: retryBodyStr,
           upstreamSpan: currentUpstreamSpan,
           logProxyBody,
           logFinalRequest,
@@ -4188,9 +4199,9 @@ async function handleAnthropicAuthRetry(args: {
         contentType: retryRespHeaders["content-type"] ?? "application/json",
         account: account.label,
         accountType: account.type,
-        attempt: attemptNumber,
+        attempt: retryAttemptNumber,
         responseStatus: retryStatus,
-        durationMs: Date.now() - fetchStartMs,
+        durationMs: Date.now() - retryFetchStartMs,
       });
       authRetryError = `retry ${authRetry + 1}/${MAX_AUTH_RETRIES} failed with status ${retryStatus}`;
       currentLastError = retryBody;
@@ -4205,7 +4216,7 @@ async function handleAnthropicAuthRetry(args: {
         logger.always(
           `[proxy] ← 429 account=${account.label} anti-abuse/construction rejection after OAuth refresh — returning non-retryable request error`,
         );
-        logAttempt(429, "construction_rejection", retryBody);
+        retryLogAttempt(429, "construction_rejection", retryBody);
         tracer?.setError("construction_rejection", retryBody.slice(0, 500));
         currentUpstreamSpan?.end();
         return {
@@ -4214,7 +4225,7 @@ async function handleAnthropicAuthRetry(args: {
             account,
             tracer,
             requestStartTime,
-            attemptNumber,
+            attemptNumber: retryAttemptNumber,
             logProxyBody,
             logFinalRequest,
           }),
@@ -4227,8 +4238,6 @@ async function handleAnthropicAuthRetry(args: {
           upstreamSpan: undefined,
         };
       }
-
-      recordAttemptError(account.label, account.type, retryStatus);
 
       // Construction rejections return through the terminal 400 path above.
       // Every 429 reaching this branch is a genuine rate limit and must cool
@@ -4248,6 +4257,19 @@ async function handleAnthropicAuthRetry(args: {
           nowRetry,
           getUnifiedRateLimitStatus(retryRespHeaders),
         );
+        const rateLimitKind =
+          retryPlan.reason === "transient" ? "transient" : "quota";
+        recordAttemptError(
+          account.label,
+          account.type,
+          retryStatus,
+          rateLimitKind,
+        );
+        retryLogAttempt(429, "rate_limit_error", retryBody, {
+          retryable: true,
+          rateLimitKind,
+          cooldownReason: retryPlan.reason,
+        });
         if (
           !accountState.coolingUntil ||
           retryPlan.coolingUntil > accountState.coolingUntil
@@ -4276,6 +4298,13 @@ async function handleAnthropicAuthRetry(args: {
       }
 
       if (retryStatus === 401 || retryStatus === 402 || retryStatus === 403) {
+        recordAttemptError(account.label, account.type, retryStatus);
+        retryLogAttempt(
+          retryStatus,
+          "authentication_error",
+          summarizeErrorMessage(retryBody),
+          { retryable: true },
+        );
         if (authRetry < MAX_AUTH_RETRIES - 1) {
           await sleep(1000);
         }
@@ -4283,11 +4312,22 @@ async function handleAnthropicAuthRetry(args: {
       }
 
       if (isTransientHttpFailure(retryStatus, retryBody)) {
+        recordAttemptError(account.label, account.type, retryStatus);
+        retryLogAttempt(
+          retryStatus,
+          "api_error",
+          summarizeErrorMessage(retryBody),
+          { retryable: true },
+        );
         currentSawTransientFailure = true;
         break;
       }
 
-      logAttempt(retryStatus, "api_error", summarizeErrorMessage(retryBody));
+      retryLogAttempt(
+        retryStatus,
+        "api_error",
+        summarizeErrorMessage(retryBody),
+      );
       recordFinalError(retryStatus, account.label, account.type);
       try {
         logFinalRequest(
@@ -4335,6 +4375,7 @@ async function handleAnthropicAuthRetry(args: {
           : String(retryFetchErr);
       authRetryError = `network error on retry ${authRetry + 1}: ${message}`;
       currentLastError = authRetryError;
+      retryLogAttempt(502, "network_error", message, { retryable: true });
       logger.debug(`[proxy] ${authRetryError}`);
       break;
     }
@@ -4346,7 +4387,6 @@ async function handleAnthropicAuthRetry(args: {
     logger.always(
       `[proxy] ⚠ account=${account.label} auth retries exhausted, rotating to next account`,
     );
-    logAttempt(401, "authentication_error", authRetryError);
     tracer?.setError("authentication_error", authRetryError);
     tracer?.recordRetry(account.label, "auth_exhausted");
     currentUpstreamSpan?.end();
@@ -4496,17 +4536,7 @@ async function handleAnthropicNonOkResponse(args: {
   requestStartTime: number;
   fetchStartMs: number;
   attemptNumber: number;
-  logAttempt: (
-    status: number,
-    errorType?: string,
-    errorMessage?: string,
-    extra?: {
-      inputTokens?: number;
-      outputTokens?: number;
-      cacheCreationTokens?: number;
-      cacheReadTokens?: number;
-    },
-  ) => void;
+  logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: (
     status: number,
@@ -4702,13 +4732,29 @@ async function handleAnthropicNonOkResponse(args: {
   }
 
   if (isTransientHttpFailure(response.status, errBody)) {
-    recordAttemptError(account.label, account.type, response.status);
+    recordAttemptError(
+      account.label,
+      account.type,
+      response.status,
+      response.status === 429 ? "transient" : undefined,
+    );
     currentSawTransientFailure = true;
     logger.always(
       `[proxy] ← ${response.status} account=${account.label} (transient)`,
     );
     currentLastError = errBody;
-    logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
+    logAttempt(
+      response.status,
+      "api_error",
+      summarizeErrorMessage(errBody),
+      response.status === 429
+        ? {
+            retryable: true,
+            rateLimitKind: "transient",
+            cooldownReason: "transient",
+          }
+        : undefined,
+    );
     tracer?.setError("transient_error", summarizeErrorMessage(errBody));
     tracer?.recordRetry(account.label, "transient");
     return {
@@ -4906,7 +4952,7 @@ function createAnthropicAttemptLogger(args: {
     logRequestAttempt({
       timestamp: new Date().toISOString(),
       requestId: ctx.requestId,
-      attempt: attemptNumber,
+      attempt: extra?.attempt ?? attemptNumber,
       method: ctx.method,
       path: ctx.path,
       model: body.model,
@@ -4929,6 +4975,11 @@ function createAnthropicAttemptLogger(args: {
         : {}),
       ...(extra?.cacheReadTokens !== undefined
         ? { cacheReadTokens: extra.cacheReadTokens }
+        : {}),
+      ...(extra?.retryable !== undefined ? { retryable: extra.retryable } : {}),
+      ...(extra?.rateLimitKind ? { rateLimitKind: extra.rateLimitKind } : {}),
+      ...(extra?.cooldownReason
+        ? { cooldownReason: extra.cooldownReason }
         : {}),
       ...(traceCtx
         ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
@@ -5319,7 +5370,6 @@ async function fetchAnthropicAccountResponse(args: {
       };
     }
     sawRateLimit = true;
-    recordAttemptError(account.label, account.type, 429);
     // Parse the unified-window quota headers (present on real rate-limit 429s)
     // and derive a reset-aware cooldown plan. This is the fix for "kept
     // hammering the 5h/7d-exhausted account instead of switching": on an
@@ -5334,6 +5384,9 @@ async function fetchAnthropicAccountResponse(args: {
       now,
       unifiedStatus,
     );
+    const rateLimitKind =
+      cooldownPlan.reason === "transient" ? "transient" : "quota";
+    recordAttemptError(account.label, account.type, 429, rateLimitKind);
     logger.always(
       `[proxy] ← 429 account=${account.label} reason=${cooldownPlan.reason} ` +
         `retry-after=${retryAfterMs}ms 5h-status=${errRespHeaders["anthropic-ratelimit-unified-5h-status"] ?? "unknown"} ` +
@@ -5341,7 +5394,11 @@ async function fetchAnthropicAccountResponse(args: {
         `unified-status=${unifiedStatus ?? "unknown"} ` +
         `→ ${cooldownPlan.rotateImmediately ? `rotate now, cool ${minutesUntil(cooldownPlan.coolingUntil, now)}m` : "retry same account (transient)"}`,
     );
-    logAttempt(429, "rate_limit_error", String(lastError));
+    logAttempt(429, "rate_limit_error", String(lastError), {
+      retryable: true,
+      rateLimitKind,
+      cooldownReason: cooldownPlan.reason,
+    });
     tracer?.setError("rate_limit_error", String(lastError).slice(0, 500));
     tracer?.recordRetry(account.label, "rate_limit");
     currentUpstreamSpan?.end();
@@ -5677,12 +5734,12 @@ async function handleAnthropicRoutedClaudeRequest(args: {
           buildUpstreamBody: preparedAttempt.buildUpstreamBody,
           enabledAccounts,
           orderedAccounts,
-          response,
           tracer,
           requestStartTime,
-          fetchStartMs: preparedAttempt.fetchStartMs,
-          attemptNumber: loopState.attemptNumber,
-          finalBodyStr: preparedAttempt.finalBodyStr,
+          allocateAttemptNumber: () => {
+            loopState.attemptNumber += 1;
+            return loopState.attemptNumber;
+          },
           upstreamSpan,
           logAttempt,
           logProxyBody,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -534,6 +534,12 @@ export type RequestAttemptLogEntry = {
   responseTimeMs: number;
   errorType?: string;
   errorMessage?: string;
+  /** Whether this failed attempt may be retried without changing the request. */
+  retryable?: boolean;
+  /** Distinguishes short-lived admission throttles from exhausted quota windows. */
+  rateLimitKind?: "transient" | "quota";
+  /** Reset-aware cooldown reason selected for a rate-limited attempt. */
+  cooldownReason?: "transient" | "session" | "weekly" | "unified";
   inputTokens?: number;
   outputTokens?: number;
   cacheCreationTokens?: number;
@@ -602,6 +608,11 @@ export type AnthropicAttemptLogger = (
     outputTokens?: number;
     cacheCreationTokens?: number;
     cacheReadTokens?: number;
+    retryable?: boolean;
+    rateLimitKind?: "transient" | "quota";
+    cooldownReason?: "transient" | "session" | "weekly" | "unified";
+    /** Override used when one account selection performs an OAuth retry fetch. */
+    attempt?: number;
   },
 ) => void;
 
@@ -685,8 +696,10 @@ export type PreparedAnthropicAccountAttempt = {
 
 /** How to cool an account after a genuine (non-anti-abuse) 429, derived from
  *  the response's quota headers + retry-after. */
+export type RateLimitCoolingReason = Exclude<AccountCoolingReason, "auth">;
+
 export type AccountCooldownPlan = {
-  reason: AccountCoolingReason;
+  reason: RateLimitCoolingReason;
   /** Epoch-ms until which the account should not be used. */
   coolingUntil: number;
   /** When true (unified/5h/7d rejected), rotate immediately — retrying the
@@ -733,9 +746,16 @@ export type AccountStats = {
   label: string;
   type: string;
   attemptCount: number;
+  /** Failed upstream attempts, including retries that later recovered. */
+  attemptErrorCount: number;
+  /** Final requests successfully completed by this account. */
   successCount: number;
+  /** Final requests that terminated as errors on this account. */
   errorCount: number;
+  /** All upstream attempts that returned 429. */
   rateLimitCount: number;
+  transientRateLimitCount: number;
+  quotaRateLimitCount: number;
   lastAttemptAt: number;
   lastErrorAt?: number;
 };
@@ -743,10 +763,13 @@ export type AccountStats = {
 export type ProxyStats = {
   startedAt: number;
   totalAttempts: number;
+  totalAttemptErrors: number;
   totalRequests: number;
   totalSuccess: number;
   totalErrors: number;
   totalRateLimits: number;
+  totalTransientRateLimits: number;
+  totalQuotaRateLimits: number;
   accounts: Record<string, AccountStats>;
 };
 
@@ -1315,6 +1338,22 @@ export type UpdateState = {
   suppressedVersions: Record<string, SuppressedVersion>;
   lastUpdateAt: string | null;
   lastUpdateVersion: string | null;
+  /** Installed by the updater but not yet confirmed as the running version. */
+  pendingRestartVersion: string | null;
+  /** Last updater failure, retained until a successful update or replacement. */
+  lastFailure: {
+    at: string;
+    version: string;
+    stage: "check" | "install" | "validation" | "restart" | "health";
+    message: string;
+  } | null;
+};
+
+/** Result of validating a newly installed CLI through the stable trampoline. */
+export type InstalledVersionValidation = {
+  version?: string;
+  attempts: number;
+  failure?: string;
 };
 
 /** Supported global package managers for proxy self-updates. */
@@ -1349,6 +1388,34 @@ export type ResolveGlobalInstallerOptions = {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
   execFileSync?: GlobalInstallerExecFile;
+};
+
+/** Options for validating a newly installed CLI through its stable executable. */
+export type ValidateInstalledVersionOptions = {
+  binPath: string;
+  expectedVersion: string;
+  maxAttempts?: number;
+  delayMs?: number;
+  timeoutMs?: number;
+  execFileSync?: GlobalInstallerExecFile;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/** Dependencies and callbacks used to supervise the updater worker process. */
+export type UpdaterWorkerSupervisorOptions = {
+  spawnWorker: () => number | undefined;
+  isProcessRunning: (pid: number) => boolean;
+  stopWorker: (pid: number) => void;
+  onPidChange?: (pid: number | undefined) => void;
+  log?: (message: string) => void;
+  intervalMs?: number;
+};
+
+/** Handle used by the proxy process to inspect and stop updater supervision. */
+export type UpdaterWorkerSupervisor = {
+  currentPid: () => number | undefined;
+  checkNow: () => number | undefined;
+  stop: () => void;
 };
 
 // =============================================================================
@@ -1456,10 +1523,13 @@ export type ProxyStartApp = {
 /** Stats shape consumed by the proxy status printer. */
 export type StatusStats = {
   totalAttempts?: number;
+  totalAttemptErrors?: number;
   totalRequests: number;
   totalSuccess: number;
   totalErrors: number;
   totalRateLimits: number;
+  totalTransientRateLimits?: number;
+  totalQuotaRateLimits?: number;
   accounts?: {
     label: string;
     type: string;
@@ -1467,7 +1537,10 @@ export type StatusStats = {
     requests?: number;
     success?: number;
     errors?: number;
+    attemptErrors?: number;
     rateLimits?: number;
+    transientRateLimits?: number;
+    quotaRateLimits?: number;
     cooling: boolean;
   }[];
 };

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -36,7 +36,11 @@ import {
   createStreamTerminalOutcomeTracker,
   mergeStreamTerminalOutcome,
 } from "../src/lib/proxy/streamOutcome.js";
-import { getStats, resetStats } from "../src/lib/proxy/usageStats.js";
+import {
+  getStats,
+  recordAttempt,
+  resetStats,
+} from "../src/lib/proxy/usageStats.js";
 import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
@@ -297,6 +301,8 @@ describe("429 classification and retry amplification", () => {
       end: vi.fn(),
     };
     const upstreamSpan = { end: vi.fn() };
+    const allocateAttemptNumber = vi.fn().mockReturnValue(3);
+    recordAttempt(account.label, account.type);
 
     const result = await __testHooks.handleAnthropicAuthRetry({
       ctx: {} as never,
@@ -310,12 +316,9 @@ describe("429 classification and retry amplification", () => {
       buildUpstreamBody: () => ({ bodyStr: "{}" }),
       enabledAccounts: [account],
       orderedAccounts: [account],
-      response: new Response(upstreamBody, { status: 401 }),
       tracer: tracer as never,
       requestStartTime: Date.now(),
-      fetchStartMs: Date.now(),
-      attemptNumber: 2,
-      finalBodyStr: "{}",
+      allocateAttemptNumber,
       upstreamSpan: upstreamSpan as never,
       logAttempt,
       logProxyBody,
@@ -339,11 +342,21 @@ describe("429 classification and retry amplification", () => {
         },
       },
     });
-    expect(logAttempt).toHaveBeenCalledTimes(1);
-    expect(logAttempt).toHaveBeenCalledWith(
+    expect(allocateAttemptNumber).toHaveBeenCalledOnce();
+    expect(logAttempt).toHaveBeenCalledTimes(2);
+    expect(logAttempt).toHaveBeenNthCalledWith(
+      1,
+      401,
+      "authentication_error",
+      "received 401 from Anthropic",
+      { retryable: true },
+    );
+    expect(logAttempt).toHaveBeenNthCalledWith(
+      2,
       429,
       "construction_rejection",
       upstreamBody,
+      { attempt: 3 },
     );
     expect(logFinalRequest).toHaveBeenCalledTimes(1);
     expect(logFinalRequest).toHaveBeenCalledWith(
@@ -356,7 +369,24 @@ describe("429 classification and retry amplification", () => {
     expect(tracer.end).toHaveBeenCalledTimes(1);
     expect(upstreamSpan.end).toHaveBeenCalledTimes(1);
     expect(getStats().totalRateLimits).toBe(0);
-    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getStats()).toMatchObject({
+      totalAttempts: 2,
+      totalAttemptErrors: 1,
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(
+      logProxyBody.mock.calls.map(([capture]) => ({
+        phase: capture.phase,
+        attempt: capture.attempt,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        { phase: "upstream_request", attempt: 3 },
+        { phase: "upstream_response", attempt: 3 },
+        { phase: "client_response", attempt: 3 },
+      ]),
+    );
   });
 
   it("still counts and plans cooldown for a genuine transient 429", async () => {
@@ -379,8 +409,9 @@ describe("429 classification and retry amplification", () => {
       ),
     );
 
+    const logAttempt = vi.fn();
     const result = await __testHooks.fetchAnthropicAccountResponse(
-      fetchArgs(vi.fn(), vi.fn()),
+      fetchArgs(logAttempt, vi.fn()),
     );
 
     expect(result).toMatchObject({
@@ -389,7 +420,22 @@ describe("429 classification and retry amplification", () => {
       sawRateLimit: true,
       cooldownPlan: { reason: "transient", rotateImmediately: false },
     });
-    expect(getStats().totalRateLimits).toBe(1);
+    expect(getStats()).toMatchObject({
+      totalAttemptErrors: 1,
+      totalRateLimits: 1,
+      totalTransientRateLimits: 1,
+      totalQuotaRateLimits: 0,
+    });
+    expect(logAttempt).toHaveBeenCalledWith(
+      429,
+      "rate_limit_error",
+      expect.any(String),
+      {
+        retryable: true,
+        rateLimitKind: "transient",
+        cooldownReason: "transient",
+      },
+    );
   });
 
   it("shares two transient retries across an entire concurrent account window", () => {
@@ -1111,12 +1157,16 @@ describe("launchd lifecycle source invariants", () => {
     expect(source).toContain("NEUROLINK_PROXY_AUTO_UPDATE");
     expect(source).toContain('["0", "off", "false"]');
     expect(source).toContain("spawnProxyUpdater");
+    expect(source).toContain("startUpdaterWorkerSupervisor");
     expect(source).toContain("updaterOnly &&");
+    expect(source).toContain("!updaterOnly &&");
     expect(source).toContain("getProxyRuntimeActivity");
     expect(source).not.toContain("proceeding with update anyway");
     expect(source).toContain('["kickstart", "-k"');
     expect(source).not.toContain('["bootout", `gui/${uid}/${PLIST_LABEL}`]');
     expect(source).toContain("stopUpdateChecks()");
+    expect(source).toContain("validateInstalledVersion");
+    expect(source).not.toContain("trampoline_broken_after_install");
     expect(source).toContain('from "../../../package.json" with');
     expect(source).toContain("<key>ExitTimeOut</key>");
     expect(source).toContain("backgroundRefreshInProgress");

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +6,7 @@ import {
   describeInstallFailure,
   getGlobalInstallArgs,
   resolveGlobalInstaller,
+  validateInstalledVersion,
 } from "../src/lib/proxy/globalInstaller.js";
 import {
   beginProxyRequest,
@@ -15,15 +16,31 @@ import {
   trackProxyResponse,
 } from "../src/lib/proxy/proxyActivity.js";
 import { createClaudeToOpenAIStreamTransform } from "../src/lib/proxy/openaiFormat.js";
+import { startUpdaterWorkerSupervisor } from "../src/lib/proxy/updaterSupervisor.js";
+import {
+  abandonPendingUpdate,
+  loadUpdateState,
+  recordUpdateFailure,
+  recordUpdateInstalled,
+  reconcileRunningUpdate,
+} from "../src/lib/proxy/updateState.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 import { createProxyStartApp } from "../src/cli/commands/proxy.js";
-import { getStats, resetStats } from "../src/lib/proxy/usageStats.js";
+import {
+  getStats,
+  recordAttempt,
+  recordAttemptError,
+  recordFinalError,
+  recordFinalSuccess,
+  resetStats,
+} from "../src/lib/proxy/usageStats.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   resetProxyActivityForTests();
   resetStats();
   await Promise.all(
@@ -112,6 +129,80 @@ describe("proxy runtime error finalization", () => {
     expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
     expect(getProxyActivitySnapshot().activeRequests).toBe(0);
   });
+
+  it("reports final account outcomes separately from failed attempts", async () => {
+    const { app } = await createApp(() => ({}));
+    recordAttempt("primary@example.com", "oauth");
+    recordAttemptError("primary@example.com", "oauth", 429, "transient");
+    recordAttempt("fallback@example.com", "oauth");
+    recordFinalSuccess("fallback@example.com", "oauth");
+    recordAttempt("primary@example.com", "oauth");
+    recordFinalError(502, "primary@example.com", "oauth");
+
+    const response = await app.request("/status");
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.stats).toMatchObject({
+      totalAttempts: 3,
+      totalAttemptErrors: 1,
+      totalRequests: 2,
+      totalSuccess: 1,
+      totalErrors: 1,
+      totalRateLimits: 1,
+      totalTransientRateLimits: 1,
+      totalQuotaRateLimits: 0,
+    });
+    expect(body.stats.accounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "primary@example.com",
+          attempts: 2,
+          requests: 1,
+          success: 0,
+          errors: 1,
+          attemptErrors: 1,
+          rateLimits: 1,
+          transientRateLimits: 1,
+          quotaRateLimits: 0,
+        }),
+        expect.objectContaining({
+          label: "fallback@example.com",
+          attempts: 1,
+          requests: 1,
+          success: 1,
+          errors: 0,
+          attemptErrors: 0,
+        }),
+      ]),
+    );
+  });
+
+  it("omits raw updater failure diagnostics from the status endpoint", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neurolink-status-home-"));
+    tempDirs.push(root);
+    const stateDir = join(root, ".neurolink");
+    const statePath = join(stateDir, "update-state.json");
+    await mkdir(stateDir, { recursive: true });
+    recordUpdateFailure(
+      "9.88.9",
+      "install",
+      "registry failed at /private/internal/path",
+      statePath,
+    );
+    vi.stubEnv("HOME", root);
+
+    const { app } = await createApp(() => ({}));
+    const response = await app.request("/status");
+    const body = await response.json();
+
+    expect(body.autoUpdate.lastFailure).toEqual({
+      at: expect.any(String),
+      version: "9.88.9",
+      stage: "install",
+    });
+    expect(JSON.stringify(body.autoUpdate)).not.toContain("/private/internal");
+  });
 });
 
 describe("global installer resolution", () => {
@@ -188,6 +279,223 @@ describe("global installer resolution", () => {
       "stdout: ERR_PNPM_NO_GLOBAL_BIN_DIR",
     );
     expect(describeInstallFailure(error)).toContain("stderr: secondary detail");
+  });
+
+  it("retries transient post-install trampoline failures", async () => {
+    const execFileSync = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error("probe timed out"), {
+          stderr: "cold start exceeded timeout",
+        });
+      })
+      .mockReturnValue("9.88.9\n");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      validateInstalledVersion({
+        binPath: "/fake/neurolink-proxy",
+        expectedVersion: "9.88.9",
+        maxAttempts: 5,
+        delayMs: 10,
+        execFileSync: execFileSync as never,
+        sleep,
+      }),
+    ).resolves.toEqual({ version: "9.88.9", attempts: 2 });
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it("reports a persistent installed-version mismatch after bounded retries", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const result = await validateInstalledVersion({
+      binPath: "/fake/neurolink-proxy",
+      expectedVersion: "9.88.9",
+      maxAttempts: 3,
+      delayMs: 10,
+      execFileSync: vi.fn().mockReturnValue("9.88.0\n") as never,
+      sleep,
+    });
+
+    expect(result).toEqual({
+      version: "9.88.0",
+      attempts: 3,
+      failure: "resolved to v9.88.0; expected v9.88.9",
+    });
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects relative executable paths without invoking them", async () => {
+    const execFileSync = vi.fn();
+
+    await expect(
+      validateInstalledVersion({
+        binPath: "neurolink-proxy",
+        expectedVersion: "9.88.9",
+        execFileSync: execFileSync as never,
+      }),
+    ).resolves.toEqual({
+      attempts: 0,
+      failure: "binPath must be absolute: neurolink-proxy",
+    });
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("updater worker recovery", () => {
+  it("replaces a dead worker and publishes the new pid", async () => {
+    vi.useFakeTimers();
+    const running = new Set<number>();
+    const spawned = [101, 202];
+    const onPidChange = vi.fn();
+    const stopWorker = vi.fn((pid: number) => running.delete(pid));
+    const supervisor = startUpdaterWorkerSupervisor({
+      spawnWorker: () => {
+        const pid = spawned.shift();
+        if (pid !== undefined) {
+          running.add(pid);
+        }
+        return pid;
+      },
+      isProcessRunning: (pid) => running.has(pid),
+      stopWorker,
+      onPidChange,
+      intervalMs: 30_000,
+    });
+
+    expect(supervisor.currentPid()).toBe(101);
+    running.delete(101);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(supervisor.currentPid()).toBe(202);
+    expect(onPidChange).toHaveBeenNthCalledWith(1, 101);
+    expect(onPidChange).toHaveBeenNthCalledWith(2, 202);
+    supervisor.stop();
+    expect(stopWorker).toHaveBeenCalledWith(202);
+    expect(onPidChange).toHaveBeenLastCalledWith(undefined);
+    expect(supervisor.currentPid()).toBeUndefined();
+  });
+
+  it("contains worker spawn exceptions and retries on the next interval", async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const spawnWorker = vi
+      .fn<() => number>()
+      .mockImplementationOnce(() => {
+        throw new Error("spawn unavailable");
+      })
+      .mockReturnValue(303);
+    const supervisor = startUpdaterWorkerSupervisor({
+      spawnWorker,
+      isProcessRunning: (pid) => pid === 303,
+      stopWorker: vi.fn(),
+      log,
+      intervalMs: 30_000,
+    });
+
+    expect(supervisor.currentPid()).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      "[proxy] updater worker spawn failed: spawn unavailable",
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(supervisor.currentPid()).toBe(303);
+    supervisor.stop();
+  });
+
+  it("persists pending installs and reconciles them after restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neurolink-update-state-"));
+    tempDirs.push(root);
+    const statePath = join(root, "update-state.json");
+
+    recordUpdateInstalled("9.88.9", statePath);
+    recordUpdateFailure(
+      "9.88.9",
+      "validation",
+      "temporary probe failure",
+      statePath,
+    );
+    expect(loadUpdateState(statePath)).toMatchObject({
+      pendingRestartVersion: "9.88.9",
+      lastFailure: { stage: "validation" },
+    });
+
+    expect(reconcileRunningUpdate("9.88.9", statePath)).toBe(true);
+    expect(loadUpdateState(statePath)).toMatchObject({
+      pendingRestartVersion: null,
+      lastUpdateVersion: "9.88.9",
+      lastFailure: null,
+    });
+  });
+
+  it("abandons invalid pending installs without dropping failure details", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neurolink-update-state-"));
+    tempDirs.push(root);
+    const statePath = join(root, "update-state.json");
+
+    recordUpdateInstalled("9.88.9", statePath);
+    recordUpdateFailure("9.88.9", "validation", "wrong version", statePath);
+    expect(abandonPendingUpdate("9.88.9", statePath)).toBe(true);
+    expect(loadUpdateState(statePath)).toMatchObject({
+      pendingRestartVersion: null,
+      lastFailure: { stage: "validation", message: "wrong version" },
+    });
+    expect(reconcileRunningUpdate("9.88.9", statePath)).toBe(false);
+  });
+
+  it("discards malformed persisted updater failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neurolink-update-state-"));
+    tempDirs.push(root);
+    const statePath = join(root, "update-state.json");
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        lastCheckAt: new Date().toISOString(),
+        suppressedVersions: {},
+        lastFailure: { stage: "unknown" },
+      }),
+    );
+
+    expect(loadUpdateState(statePath)?.lastFailure).toBeNull();
+  });
+});
+
+describe("request and attempt accounting", () => {
+  it("keeps recovered attempt failures out of final account errors", () => {
+    recordAttempt("hello@neurolink.ink", "oauth");
+    recordAttemptError("hello@neurolink.ink", "oauth", 429, "transient");
+    recordAttempt("hello@neurolink.ink", "oauth");
+    recordAttemptError("hello@neurolink.ink", "oauth", 429, "transient");
+    recordAttempt("fallback@example.com", "oauth");
+    recordFinalSuccess("fallback@example.com", "oauth");
+    recordAttempt("hello@neurolink.ink", "oauth");
+    recordFinalError(502, "hello@neurolink.ink", "oauth");
+
+    expect(getStats()).toMatchObject({
+      totalAttempts: 4,
+      totalAttemptErrors: 2,
+      totalRequests: 2,
+      totalSuccess: 1,
+      totalErrors: 1,
+      totalRateLimits: 2,
+      totalTransientRateLimits: 2,
+      totalQuotaRateLimits: 0,
+      accounts: {
+        "hello@neurolink.ink": {
+          attemptCount: 3,
+          attemptErrorCount: 2,
+          successCount: 0,
+          errorCount: 1,
+          rateLimitCount: 2,
+          transientRateLimitCount: 2,
+          quotaRateLimitCount: 0,
+        },
+        "fallback@example.com": {
+          attemptCount: 1,
+          attemptErrorCount: 0,
+          successCount: 1,
+          errorCount: 0,
+        },
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- supervise and respawn the auto-updater worker while the proxy parent is alive
- retry installed CLI validation and reconcile an installed-but-not-yet-running version without suppressing a valid release
- separate upstream attempt failures from final request failures in global and per-account stats
- classify 429 attempts as transient admission throttles or account quota exhaustion
- preserve strict terminal failure reporting for genuinely incomplete SSE streams

## Root causes

The updater could exit silently and was never respawned. A single transient executable probe after installation also marked the installed version as broken and suppressed it for 24 hours, even though the same trampoline worked moments later.

The status mismatch came from comparing different units: global errors represented final user-request outcomes, while account errors included every failed upstream attempt. One request that received three transient 429s and then succeeded on another account therefore appeared as one global success but three account errors.

The investigated final failure was not a fake rate limit or proxy crash. The upstream socket closed after 131 seconds during thinking, before content_block_stop, message_delta, or message_stop, so the response was genuinely incomplete and must remain a failure.

## Verification

- `pnpm check`
- `pnpm lint` (0 errors; existing warning baseline only)
- repository pre-commit validation, security checks, production/package builds, and `publint`
- `pnpm exec vitest run test/proxyUpdaterFallback.test.ts test/proxyReliabilityHardening.test.ts` (54/54 passing)

No live proxy restart, deployment, or synthetic live API request was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded proxy `/status` and `proxy status --format json` with detailed auto-update state, pending restart info, and structured update failure details.
  * Improved usage statistics by separating final outcomes from attempt-level errors, including transient vs quota rate-limit breakdowns and new attempt error counters.
  * Enhanced attempt telemetry for retries and rate-limit classifications (retryable, cooldown reason, transient vs quota).
  * Added supervised updater worker recovery and more robust post-install global CLI version validation.
* **Documentation**
  * Updated proxy documentation and observability examples to reflect the richer auto-update/status fields and the clarified attempt vs final-outcome semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->