### PR TITLE
fix(cli): play mp3 TTS on Linux via real decoders, not paplay (#1138)

### DIFF
--- a/docs/features/tts.md
+++ b/docs/features/tts.md
@@ -309,11 +309,15 @@ tts: {
 - Auto-converts to WAV when `play: true` on Windows
 - Use MP3 for file output, WAV for immediate playback
 
-**macOS/Linux:**
+**macOS:**
 
-- All formats supported
-- `afplay` (macOS) and `ffplay` (Linux) handle all formats
-- Use MP3 for general purpose
+- `afplay` (built-in) decodes every format — no setup needed.
+
+**Linux:**
+
+- **WAV** requires ALSA (`aplay`) or PulseAudio (`paplay`), but no compressed-format decoder.
+- **Compressed formats (mp3/ogg/opus)** need a real decoder — NeuroLink tries `ffplay` (ffmpeg), then `mpv`, `mpg123` (mp3), then `cvlc` (VLC), in that order. Install any one of them.
+- `paplay`/`aplay` **cannot** decode mp3, so with none of the above installed a default `--tts-play` (which defaults to mp3) will report a clear error naming the decoders — or use `--tts-format wav` when `aplay` or `paplay` is available.
 
 ---
 

--- a/src/cli/utils/audioPlayer.ts
+++ b/src/cli/utils/audioPlayer.ts
@@ -8,14 +8,33 @@
  */
 
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import type { AudioFormat } from "../../lib/types/index.js";
+import type {
+  TTSAudioFormat,
+  CliAudioPlayerCommand,
+} from "../../lib/types/index.js";
 
 const execFileAsync = promisify(execFile);
+
+/** Wall-clock cap on a single player invocation; a hung decoder must not block the CLI forever. */
+const PLAYER_TIMEOUT_MS = 30_000;
+
+/**
+ * Single source of truth for format -> temp-file-extension. Formats outside this
+ * playback-supported set (m4a, flac, webm, mp4, mpeg, mpga, pcm16) fall back to
+ * "mp3" — `playAudio` only ever receives the four formats below in practice.
+ */
+const AUDIO_EXTENSIONS: Partial<Record<TTSAudioFormat, string>> = {
+  mp3: "mp3",
+  wav: "wav",
+  ogg: "ogg",
+  opus: "opus",
+};
 
 /**
  * Get the file extension for an audio format
@@ -23,85 +42,165 @@ const execFileAsync = promisify(execFile);
  * @param format - Audio format
  * @returns File extension string (e.g., "mp3", "wav")
  */
-export function getAudioExtension(format: AudioFormat): string {
-  switch (format) {
-    case "mp3":
-      return "mp3";
-    case "wav":
-      return "wav";
-    case "ogg":
-      return "ogg";
-    case "opus":
-      return "opus";
-    default:
-      return "mp3";
-  }
+export function getAudioExtension(format: TTSAudioFormat): string {
+  return AUDIO_EXTENSIONS[format] ?? "mp3";
+}
+
+/** ffmpeg's ffplay decodes every format we emit; quiet + auto-exit for CLI use. */
+function ffplayCommand(filePath: string): CliAudioPlayerCommand {
+  return {
+    command: "ffplay",
+    args: ["-nodisp", "-autoexit", "-loglevel", "quiet", filePath],
+  };
 }
 
 /**
- * Get the platform-specific audio player command and arguments
+ * Escape a value for interpolation inside a single-quoted PowerShell string.
+ * PowerShell's single-quoted strings only treat `''` as a literal `'` — unlike
+ * shell/execFile argv, this string is parsed by powershell.exe itself, so an
+ * unescaped quote (e.g. a Windows username like `O'Brien` under `%TEMP%`)
+ * would break out of the string and let the remainder run as PS code.
+ */
+export function escapePowerShellSingleQuoted(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Build the ordered list of player commands to try for a file.
+ *
+ * The list is tried in order until one succeeds; a missing binary (ENOENT) or a
+ * decode failure simply advances to the next candidate.
+ *
+ * The Linux ordering is the crux of the mp3-playback fix (#1138): `paplay`
+ * (PulseAudio) and `aplay` (ALSA) only decode libsndfile/PCM formats and
+ * **cannot** decode mp3/AAC. Since `--tts-format` defaults to mp3, compressed
+ * formats must lead with real decoders (ffplay/mpv/mpg123/cvlc); paplay/aplay
+ * remain only as last-resort fallbacks (and still work for wav/ogg).
  *
  * @param filePath - Path to the audio file
  * @param format - Audio format
- * @returns Object with command and args for execFile
+ * @param platform - Platform id (defaults to `process.platform`; injectable for tests)
+ * @returns Ordered player commands; empty for unsupported platforms
  */
-function getPlayerCommand(
+export function getPlayerCandidates(
   filePath: string,
-  format: AudioFormat,
-): { command: string; args: string[] } {
-  const platform = process.platform;
+  format: TTSAudioFormat,
+  platform: NodeJS.Platform = process.platform,
+): CliAudioPlayerCommand[] {
+  const isWav = format === "wav";
 
   switch (platform) {
     case "darwin":
-      return { command: "afplay", args: [filePath] };
+      // afplay decodes mp3/wav/aac/flac natively.
+      return [{ command: "afplay", args: [filePath] }];
 
     case "linux":
-      if (format === "wav") {
-        return { command: "aplay", args: [filePath] };
+      if (isWav) {
+        // WAV/PCM: ALSA and PulseAudio both decode it; ffplay as a backstop.
+        return [
+          { command: "aplay", args: [filePath] },
+          { command: "paplay", args: [filePath] },
+          ffplayCommand(filePath),
+        ];
       }
-      return { command: "paplay", args: [filePath] };
+      // Compressed formats (mp3/ogg/opus): lead with decoders that actually
+      // handle them, then fall back to paplay/aplay (which work for some
+      // formats but never mp3).
+      return [
+        ffplayCommand(filePath),
+        {
+          command: "mpv",
+          args: ["--no-video", "--really-quiet", filePath],
+        },
+        ...(format === "mp3"
+          ? [{ command: "mpg123", args: ["-q", filePath] }]
+          : []),
+        {
+          command: "cvlc",
+          args: ["--play-and-exit", "--no-loop", "--intf", "dummy", filePath],
+        },
+        { command: "paplay", args: [filePath] },
+        { command: "aplay", args: [filePath] },
+      ];
 
-    case "win32":
-      if (format === "wav") {
-        return {
+    case "win32": {
+      // filePath is embedded inside a single-quoted PS string below, so it must
+      // be escaped — a Windows username with an apostrophe (e.g. `O'Brien`,
+      // present in `%TEMP%`) would otherwise break out of the string.
+      const psPath = escapePowerShellSingleQuoted(filePath);
+      if (isWav) {
+        return [
+          {
+            command: "powershell",
+            args: [
+              "-NoProfile",
+              "-Command",
+              `(New-Object System.Media.SoundPlayer '${psPath}').PlaySync()`,
+            ],
+          },
+        ];
+      }
+      return [
+        {
           command: "powershell",
           args: [
             "-NoProfile",
             "-Command",
-            `(New-Object System.Media.SoundPlayer '${filePath}').PlaySync()`,
+            `$player = New-Object -ComObject WMPlayer.OCX; $player.URL = '${psPath}'; $player.controls.play(); Start-Sleep -Seconds 1; while ($player.playState -eq 3) { Start-Sleep -Milliseconds 100 }; $player.close()`,
           ],
-        };
-      }
-      return {
-        command: "powershell",
-        args: [
-          "-NoProfile",
-          "-Command",
-          `$player = New-Object -ComObject WMPlayer.OCX; $player.URL = '${filePath}'; $player.controls.play(); Start-Sleep -Seconds 1; while ($player.playState -eq 3) { Start-Sleep -Milliseconds 100 }; $player.close()`,
-        ],
-      };
+        },
+      ];
+    }
 
     default:
-      throw new Error(
-        `Unsupported platform: ${platform}. Audio playback is supported on macOS, Linux, and Windows.`,
-      );
+      return [];
   }
+}
+
+/**
+ * Build a helpful, format-aware error message when no player could decode the file.
+ *
+ * Exported for testing: the message a user sees when Linux mp3 playback finds no
+ * decoder must name the real fix (ffmpeg/mpv/mpg123/VLC or `--tts-format wav`),
+ * not the misleading "install PulseAudio" that paplay-only routing produced (#1138).
+ */
+export function buildPlaybackErrorMessage(
+  platform: NodeJS.Platform,
+  format: TTSAudioFormat,
+  attempts: string[],
+): string {
+  const tried = attempts.length ? ` (tried: ${attempts.join("; ")})` : "";
+
+  if (platform === "linux") {
+    if (format === "wav") {
+      return `Could not play wav audio${tried}. Install ALSA (aplay) or PulseAudio (paplay).`;
+    }
+    // mpg123 only decodes mp3 (see getPlayerCandidates) — recommending it for
+    // ogg/opus failures would send users chasing a decoder that can't help.
+    if (format === "mp3") {
+      return `Could not play mp3 audio${tried}. paplay/aplay cannot decode mp3; install one of: ffmpeg (ffplay), mpv, mpg123, or VLC (cvlc) — or use --tts-format wav.`;
+    }
+    return `Could not play ${format} audio${tried}. Install ffmpeg (ffplay), mpv, or VLC (cvlc) — or use --tts-format wav.`;
+  }
+
+  return `Could not play ${format} audio${tried}. Ensure a system audio player is installed and available in PATH.`;
 }
 
 /**
  * Play audio from a buffer using platform-specific CLI tools
  *
- * Writes the buffer to a temporary file, plays it using the appropriate
- * system audio player, and cleans up the temp file afterward.
+ * Writes the buffer to a temporary file, plays it using the first available
+ * system audio player that can decode the format, and cleans up the temp file.
  *
  * Supported platforms:
- * - macOS: uses `afplay` (built-in, supports mp3/wav/aac/flac)
- * - Linux: uses `paplay` for non-wav, `aplay` for wav
- * - Windows: uses PowerShell SoundPlayer (wav) or WMPlayer.OCX (mp3)
+ * - macOS: `afplay` (built-in; decodes mp3/wav/aac/flac)
+ * - Linux: real decoders (ffplay/mpv/mpg123/cvlc) for compressed formats,
+ *   aplay/paplay for wav — falling through the list until one works
+ * - Windows: PowerShell SoundPlayer (wav) or WMPlayer.OCX (compressed)
  *
  * @param buffer - Audio data buffer
  * @param format - Audio format (mp3, wav, ogg, opus)
- * @throws Error if playback fails or platform is unsupported
+ * @throws Error if no available player can play the audio, or platform is unsupported
  *
  * @example
  * ```typescript
@@ -110,49 +209,59 @@ function getPlayerCommand(
  */
 export async function playAudio(
   buffer: Buffer,
-  format: AudioFormat,
+  format: TTSAudioFormat,
 ): Promise<void> {
   const ext = getAudioExtension(format);
-  const tempFile = path.join(os.tmpdir(), `nl-tts-${Date.now()}.${ext}`);
+  // randomUUID (not just Date.now()) avoids two concurrent calls in the same
+  // millisecond racing on the same temp path.
+  const tempFile = path.join(os.tmpdir(), `nl-tts-${randomUUID()}.${ext}`);
 
   try {
     // Write audio buffer to temp file
     await fs.promises.writeFile(tempFile, buffer);
 
-    const { command, args } = getPlayerCommand(tempFile, format);
+    const candidates = getPlayerCandidates(tempFile, format);
 
-    try {
-      await execFileAsync(command, args);
-    } catch (execError) {
-      const err = execError as NodeJS.ErrnoException;
-
-      // Handle binary not found
-      if (err.code === "ENOENT") {
-        if (process.platform === "linux" && command === "paplay") {
-          // Fallback to aplay on Linux
-          try {
-            await execFileAsync("aplay", [tempFile]);
-            return;
-          } catch (fallbackError) {
-            const fbErr = fallbackError as NodeJS.ErrnoException;
-            if (fbErr.code === "ENOENT") {
-              throw new Error(
-                "Neither paplay nor aplay found. Install PulseAudio (paplay) or ALSA (aplay) for audio playback.",
-                { cause: fallbackError },
-              );
-            }
-            throw fallbackError;
-          }
-        }
-
-        throw new Error(
-          `Audio player '${command}' not found. Ensure it is installed and available in PATH.`,
-          { cause: execError },
-        );
-      }
-
-      throw execError;
+    if (candidates.length === 0) {
+      throw new Error(
+        `Unsupported platform: ${process.platform}. Audio playback is supported on macOS, Linux, and Windows.`,
+      );
     }
+
+    const attempts: string[] = [];
+
+    for (const { command, args } of candidates) {
+      try {
+        // `timeout` guards against a hung decoder (e.g. blocked on the audio
+        // device) so playback can't stall the CLI forever; SIGTERM lets the
+        // player shut down cleanly before Node force-kills it.
+        await execFileAsync(command, args, {
+          timeout: PLAYER_TIMEOUT_MS,
+          killSignal: "SIGTERM",
+        });
+        return; // Played successfully.
+      } catch (execError) {
+        const err = execError as NodeJS.ErrnoException & { killed?: boolean };
+        // Every failure (missing binary, decode error, or timeout) is
+        // recorded and surfaced in the final error below — none are lost.
+        // We still advance to the next candidate rather than aborting on the
+        // first non-ENOENT failure: `command` existing but failing on this
+        // particular file (e.g. a corrupt stream, or one decoder lacking
+        // codec support) doesn't mean the *next* candidate will fail too,
+        // and failing fast here would defeat the multi-decoder fallback
+        // that #1138 exists to provide.
+        const detail = err.killed
+          ? `timed out after ${PLAYER_TIMEOUT_MS}ms`
+          : err.code === "ENOENT"
+            ? "not installed"
+            : (err.message ?? "failed");
+        attempts.push(`${command}: ${detail}`);
+      }
+    }
+
+    throw new Error(
+      buildPlaybackErrorMessage(process.platform, format, attempts),
+    );
   } finally {
     // Always clean up temp file
     try {

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -1944,3 +1944,13 @@ export type CliNetworkCommandArgs = BaseCommandArgs & {
   /** Show detailed information */
   detailed?: boolean;
 };
+
+/**
+ * A single audio-player invocation for CLI TTS playback: a binary plus its
+ * arguments for `execFile`. The player list is tried in order until one
+ * succeeds (see `src/cli/utils/audioPlayer.ts`).
+ */
+export type CliAudioPlayerCommand = {
+  command: string;
+  args: string[];
+};

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -25,7 +25,13 @@ import { PDFProcessor } from "../src/lib/utils/pdfProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
 import { isMultimodalInput } from "../src/lib/types/index.js";
 import { FileDetector } from "../src/lib/utils/fileDetector.js";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 import AdmZip from "adm-zip";
@@ -44,6 +50,12 @@ import {
 import { OpenAICompatibleProvider } from "../src/lib/providers/openaiCompatible.js";
 import { LiteLLMProvider } from "../src/lib/providers/litellm.js";
 import { ModelAccessDeniedError } from "../src/lib/types/index.js";
+
+import {
+  getPlayerCandidates,
+  buildPlaybackErrorMessage,
+  escapePowerShellSingleQuoted,
+} from "../src/cli/utils/audioPlayer.js";
 
 import type {
   ParsedClaudeRequest,
@@ -3849,6 +3861,169 @@ exit 127
           return captured?.finishReason === "tool-calls";
         },
       ),
+  },
+  // ---------- #1138: Linux mp3 TTS playback (paplay can't decode mp3) ----------
+  {
+    name: "audioPlayer #1138: Linux mp3 leads with real decoders, not paplay/aplay",
+    category: "cli-tts",
+    fn: async () => {
+      const file = "/tmp/nl-tts-test.mp3";
+      const linuxMp3 = getPlayerCandidates(file, "mp3", "linux");
+      const commands = linuxMp3.map((c) => c.command);
+
+      // paplay/aplay cannot decode mp3, so they must not be tried first.
+      if (commands[0] === "paplay" || commands[0] === "aplay") {
+        return false;
+      }
+      // The intended priority is ffplay first (most reliable decoder).
+      if (commands[0] !== "ffplay") {
+        return false;
+      }
+      // A real mp3-capable decoder must be present and ordered ahead of paplay.
+      const decoders = ["ffplay", "mpv", "mpg123", "cvlc"];
+      const firstDecoderIdx = commands.findIndex((c) => decoders.includes(c));
+      const paplayIdx = commands.indexOf("paplay");
+      if (firstDecoderIdx === -1) {
+        return false;
+      }
+      if (paplayIdx !== -1 && firstDecoderIdx > paplayIdx) {
+        return false;
+      }
+      // mpg123 (mp3-only) should be offered for mp3 but not for opus.
+      if (!commands.includes("mpg123")) {
+        return false;
+      }
+      const linuxOpus = getPlayerCandidates(file, "opus", "linux").map(
+        (c) => c.command,
+      );
+      if (linuxOpus.includes("mpg123")) {
+        return false;
+      }
+
+      // wav still routes to aplay first on Linux; macOS uses afplay.
+      const linuxWav = getPlayerCandidates(file, "wav", "linux");
+      if (linuxWav[0]?.command !== "aplay") {
+        return false;
+      }
+      const macMp3 = getPlayerCandidates(file, "mp3", "darwin");
+      if (macMp3[0]?.command !== "afplay") {
+        return false;
+      }
+
+      return true;
+    },
+  },
+  {
+    name: "audioPlayer #1138: Linux mp3 playback error is format-aware, not misleading",
+    category: "cli-tts",
+    fn: async () => {
+      // The exact message a user sees when no decoder is installed.
+      const mp3Err = buildPlaybackErrorMessage("linux", "mp3", [
+        "ffplay: not installed",
+        "mpv: not installed",
+      ]);
+      // Must name the real decoders + the wav fallback, and explain the
+      // paplay/aplay limitation — NOT the old "Install PulseAudio" (which was
+      // misleading, since PulseAudio simply cannot decode mp3).
+      const namesDecoders =
+        mp3Err.includes("ffmpeg") &&
+        mp3Err.includes("mpv") &&
+        mp3Err.includes("mpg123") &&
+        mp3Err.includes("--tts-format wav");
+      const explainsLimitation = /paplay\/aplay cannot decode mp3/.test(mp3Err);
+      const surfacesAttempts = mp3Err.includes("ffplay: not installed");
+      if (!namesDecoders || !explainsLimitation || !surfacesAttempts) {
+        return false;
+      }
+      // The wav path keeps the simple ALSA/PulseAudio guidance.
+      const wavErr = buildPlaybackErrorMessage("linux", "wav", []);
+      if (!(wavErr.includes("aplay") && wavErr.includes("paplay"))) {
+        return false;
+      }
+      return true;
+    },
+  },
+  {
+    name: "audioPlayer #1180: ogg/opus playback error does not recommend mp3-only mpg123",
+    category: "cli-tts",
+    fn: async () => {
+      // mpg123 (see getPlayerCandidates) is only ever offered for mp3, so the
+      // error message must not send ogg/opus users chasing an mp3-only decoder,
+      // nor claim the categorical "paplay/aplay cannot decode" framing that
+      // only applies to mp3.
+      const oggErr = buildPlaybackErrorMessage("linux", "ogg", [
+        "ffplay: not installed",
+      ]);
+      const opusErr = buildPlaybackErrorMessage("linux", "opus", [
+        "ffplay: not installed",
+      ]);
+      for (const err of [oggErr, opusErr]) {
+        if (err.includes("mpg123")) {
+          return false;
+        }
+        if (/cannot decode/.test(err)) {
+          return false;
+        }
+        if (!(err.includes("ffmpeg") && err.includes("--tts-format wav"))) {
+          return false;
+        }
+      }
+      // mp3 keeps recommending mpg123 — only the ogg/opus branch changed.
+      const mp3Err = buildPlaybackErrorMessage("linux", "mp3", []);
+      if (!mp3Err.includes("mpg123")) {
+        return false;
+      }
+      return true;
+    },
+  },
+  {
+    name: "audioPlayer #1180: PowerShell single-quote escaping prevents command injection",
+    category: "cli-tts",
+    fn: async () => {
+      // A Windows username with an apostrophe (e.g. O'Brien) lands in %TEMP%,
+      // so filePath can legitimately contain a single quote. Unescaped, it
+      // would break out of the PS single-quoted string and let the remainder
+      // run as arbitrary PowerShell.
+      const maliciousPath =
+        "C:\\Users\\O'Brien\\nl-tts-1.mp3'; Remove-Item -Recurse -Force C:\\; '";
+      if (escapePowerShellSingleQuoted("O'Brien") !== "O''Brien") {
+        return false;
+      }
+
+      const wavCandidates = getPlayerCandidates(maliciousPath, "wav", "win32");
+      const mp3Candidates = getPlayerCandidates(maliciousPath, "mp3", "win32");
+      for (const candidates of [wavCandidates, mp3Candidates]) {
+        const psCommand = candidates[0]?.args[2] ?? "";
+        // The escaped path (quotes doubled) must appear intact...
+        if (!psCommand.includes(maliciousPath.replace(/'/g, "''"))) {
+          return false;
+        }
+        // ...and the raw, unescaped malicious path must NOT appear verbatim
+        // (that would mean it broke out of the single-quoted string).
+        if (psCommand.includes(`'${maliciousPath}'`)) {
+          return false;
+        }
+      }
+      return true;
+    },
+  },
+  {
+    name: "audioPlayer #1180: execFileAsync is invoked with a player timeout",
+    category: "cli-tts",
+    fn: async () => {
+      // Static check without spawning a real process: confirm the timeout
+      // option is wired into the execFileAsync call that plays candidates,
+      // so a hung decoder can't block the CLI forever.
+      const modulePath = pathJoin(
+        process.cwd(),
+        "src/cli/utils/audioPlayer.ts",
+      );
+      const source = readFileSync(modulePath, "utf8");
+      return (
+        /execFileAsync\(command, args, \{\s*timeout:/.test(source) &&
+        source.includes("killSignal")
+      );
+    },
   },
 ];
 


### PR DESCRIPTION
## What & why

Fixes #1138 — `--tts-play` mp3 playback is broken on Linux.

`src/cli/utils/audioPlayer.ts` routed all non-wav audio to `paplay`, but PulseAudio's `paplay` (and ALSA's `aplay`) only decode **libsndfile/PCM** formats (WAV/FLAC/Ogg/AIFF) — they **cannot decode mp3/AAC**. Since `--tts-format` defaults to **mp3**, the default `neurolink generate "..." --tts --tts-play` fails playback on Linux, with a misleading *"Install PulseAudio (paplay) or ALSA (aplay)"* message (PulseAudio is present; the format is simply undecodable).

## Fix

- `playAudio` now builds an **ordered candidate list** per platform + format and tries each until one succeeds (a missing binary or a decode failure advances to the next).
- **Linux, compressed formats (mp3/ogg/opus):** lead with real decoders — `ffplay` (ffmpeg) → `mpv` → `mpg123` (mp3 only) → `cvlc` (VLC) — then `paplay`/`aplay` as last-resort fallbacks (which still handle wav).
- **Linux wav:** unchanged — `aplay` first, then `paplay`, then `ffplay`.
- **macOS / Windows:** unchanged (`afplay` decodes everything; PowerShell paths preserved).
- Error message is now **format-aware**: points at ffmpeg/mpv/mpg123/VLC or `--tts-format wav`, and lists what was tried.

## Testing / proof

- `getPlayerCandidates(file, format, platform)` is exported and **platform-injectable**, so the behavior is deterministically testable off-Linux.
- New bugfixes-suite test asserts: Linux mp3 leads with a real decoder (never `paplay`/`aplay`); `mpg123` is offered for mp3 but **not** opus; Linux wav still routes to `aplay` first; macOS uses `afplay`.
- `pnpm run check` ✅ · `pnpm run lint` ✅ (0 errors) · bugfixes suite **90/90 PASS** · `pnpm run build:cli` ✅.

## Notes

- CLI-only change; no SDK API surface touched. The helper type moved to `src/lib/types/cli.ts` as `CliAudioPlayerCommand` to satisfy the types-location lint rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux TTS playback for MP3, OGG, and Opus audio by trying compatible decoders in sequence.
  * Added clearer playback errors that identify attempted players and explain when required decoders are unavailable.
  * Preserved reliable WAV playback through standard Linux audio systems.

* **Documentation**
  * Added platform-specific TTS playback guidance for macOS and Linux.
  * Clarified decoder requirements and recommended WAV as a zero-dependency Linux fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->