### PR TITLE
docs(mcp): replace unsubstantiated '58+ servers supported' claims with honest framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for await (const chunk of result.stream) {
 
 Extracted from production systems at Juspay, NeuroLink provides a practical, TypeScript-first way to integrate AI into any application. Whether you're building with OpenAI, Anthropic, Google, AWS Bedrock, Azure, or any of our 30+ supported providers, NeuroLink gives you a single, consistent interface that works everywhere.
 
-**Why NeuroLink?** Switch providers with a single parameter change, leverage 64+ built-in tools and MCP servers, deploy with confidence using enterprise features like Redis memory and multi-provider failover, and optimize costs automatically with intelligent routing. Use it via our professional CLI or TypeScript SDK—whichever fits your workflow.
+**Why NeuroLink?** Switch providers with a single parameter change, leverage built-in tools plus any MCP-compliant tool server, deploy with confidence using enterprise features like Redis memory and multi-provider failover, and optimize costs automatically with intelligent routing. Use it via our professional CLI or TypeScript SDK—whichever fits your workflow.
 
 **Where we're headed:** We're building for the future of AI—edge-first execution and continuous streaming architectures that make AI practically free and universally available. **[Read our vision →](docs/about/vision.md)**
 
@@ -489,7 +489,7 @@ NeuroLink is a comprehensive AI development platform. Every feature below is shi
 | `calculateMath`      | Mathematical operations  | ✅                      | [Tool Reference](docs/sdk/custom-tools.md) |
 | `websearchGrounding` | Google Vertex web search | ⚠️ Requires credentials | [Tool Reference](docs/sdk/custom-tools.md) |
 
-**58+ External MCP Servers** supported (GitHub, PostgreSQL, Google Drive, Slack, and more):
+**External MCP servers** — connect any MCP-compliant server via `neurolink mcp add`; 11 popular servers (GitHub, PostgreSQL, Google Drive, Slack, and more) ship with ready-made configs:
 
 ```typescript
 // stdio transport - local MCP servers via command execution
@@ -993,7 +993,7 @@ Full command and API breakdown lives in [`docs/cli/commands.md`](docs/cli/comman
 
 - [Enterprise HITL Guide](docs/features/enterprise-hitl.md) - Approval workflows for high-stakes operations
 - [Interactive CLI Guide](docs/features/interactive-cli.md) - AI development environment
-- [MCP Tools Showcase](docs/features/mcp-tools-showcase.md) - 58+ external tools & 6 built-in tools
+- [MCP Tools Showcase](docs/features/mcp-tools-showcase.md) - 6 built-in tools & connecting external MCP servers
 
 **Provider Intelligence:**
 

--- a/docs/about/vision.md
+++ b/docs/about/vision.md
@@ -143,7 +143,7 @@ await stream.send("Compare to last week");
 - ✅ Enterprise features (proxy, Redis, failover, telemetry)
 - ✅ SDK + CLI for any workflow
 - ✅ Real-time streaming with tool support
-- ✅ 6 built-in tools + 58+ MCP servers
+- ✅ 6 built-in tools + any MCP-compliant server
 - ✅ Production deployment at scale (15M+ requests/month)
 
 **You can use this today.**

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -18,7 +18,7 @@ NeuroLink goes beyond simple API wrappers to provide a comprehensive AI developm
 
 ## 🚀 Feature Overview
 
-- **[MCP Integration](mcp-integration.md)** — Model Context Protocol support with 6 built-in tools and 58+ discoverable external servers.
+- **[MCP Integration](mcp-integration.md)** — Model Context Protocol support: 6 built-in tools, plus connect any MCP-compliant external server.
 - **[Analytics & Evaluation](analytics.md)** — Built-in usage tracking, cost monitoring, performance metrics, and AI response quality evaluation.
 - **[Factory Patterns](factory-patterns.md)** — Unified provider architecture using the Factory Pattern for consistent interfaces and easy extensibility.
 - **[Dynamic Models](dynamic-models.md)** — Self-updating model configurations, automatic cost optimization, and smart model resolution.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -58,7 +58,7 @@ Comprehensive guides for all NeuroLink features organized by category. Each guid
 | **[Image Generation](../image-generation-streaming.md)** | Generate images from text prompts using Gemini models via Vertex AI or Google AI Studio.           |
 | **[Enterprise HITL](enterprise-hitl.md)**                | Production-ready HITL with approval workflows, confidence thresholds, and enterprise patterns.     |
 | **[Interactive CLI](interactive-cli.md)**                | AI development environment with loop mode, session variables, and conversation memory.             |
-| **[MCP Tools Showcase](mcp-tools-showcase.md)**          | Complete guide to 6 built-in tools and 58+ external MCP servers across 6 categories.               |
+| **[MCP Tools Showcase](mcp-tools-showcase.md)**          | Complete guide to 6 built-in tools and connecting external MCP servers across 6 categories.        |
 | **[Human-in-the-Loop (HITL)](hitl.md)**                  | Pause AI tool execution for user approval before risky operations like file deletion or API calls. |
 | **[Guardrails Middleware](guardrails.md)**               | Content filtering, PII detection, and safety checks for AI outputs with zero configuration.        |
 | **[Redis Conversation Export](conversation-history.md)** | Export complete session history as JSON for analytics, debugging, and compliance auditing.         |
@@ -253,7 +253,7 @@ NeuroLink includes **5 production-ready MCP servers** for enterprise agent deplo
 - **Tool Standards**: Full MCP specification compliance
 - **Context Passing**: Rich context with sessionId, userId, permissions (15+ fields)
 
-#### 58+ External MCP Servers
+#### External MCP Servers
 
 Supported for extended functionality:
 
@@ -283,7 +283,7 @@ const result = await neurolink.generate({
 ```
 
 **[MCP Integration Guide](../advanced/mcp-integration.md)** - Setup and usage
-**[MCP Server Catalog](../guides/mcp/server-catalog.md)** - Complete server list (58+)
+**[MCP Server Catalog](../guides/mcp/server-catalog.md)** - Directory of 58+ community servers you can connect
 
 ---
 

--- a/docs/features/interactive-cli.md
+++ b/docs/features/interactive-cli.md
@@ -79,7 +79,7 @@ $ npx @juspay/neurolink loop --enable-conversation-memory
 
 ╔══════════════════════════════════════════════════════════╗
 ║         NeuroLink Interactive Loop Mode v8.26.1          ║
-║  Universal AI Platform - 13 Providers | 58+ MCP Tools    ║
+║  Universal AI Platform - Multi-Provider | MCP Tools      ║
 ╚══════════════════════════════════════════════════════════╝
 
 💬 Conversation Memory: Enabled (Redis)
@@ -108,7 +108,7 @@ I'm an AI assistant powered by Google Gemini 3 Flash through NeuroLink. I have a
 
 1. **Text Generation**: Complex reasoning, creative writing, coding
 2. **Vision**: Image analysis and description
-3. **Tool Usage**: 58+ MCP tools including:
+3. **Tool Usage**: built-in + connected MCP tools including:
    - Filesystem operations (read, write, list files)
    - Web search and browsing
    - GitHub integration

--- a/docs/features/mcp-tools-showcase.md
+++ b/docs/features/mcp-tools-showcase.md
@@ -1,16 +1,16 @@
 ---
-title: MCP Tools Ecosystem - 58+ Integrations
+title: MCP Tools Ecosystem - Built-in Tools + Any MCP Server
 description: Complete showcase of Model Context Protocol tools - built-in core tools and external MCP server ecosystem
 keywords: mcp, model context protocol, tools, integrations, ecosystem, servers
 ---
 
-# MCP Tools Ecosystem: 58+ Integrations
+# MCP Tools Ecosystem: Built-in Tools + Any MCP Server
 
 > **Since**: v7.0.0 | **Status**: Production Ready | **MCP Version**: 2024-11-05
 
 ## Overview
 
-NeuroLink's Model Context Protocol (MCP) integration provides a **universal plugin system** that transforms the SDK from a simple AI interface into a complete AI development platform. With 6 built-in core tools and access to 58+ community MCP servers, you can extend AI capabilities to interact with filesystems, databases, APIs, cloud services, and custom enterprise systems.
+NeuroLink's Model Context Protocol (MCP) integration provides a **universal plugin system** that transforms the SDK from a simple AI interface into a complete AI development platform. With 6 built-in core tools and the ability to connect any community MCP server (58+ cataloged in the [server directory](../guides/mcp/server-catalog.md)), you can extend AI capabilities to interact with filesystems, databases, APIs, cloud services, and custom enterprise systems.
 
 ### What is MCP?
 
@@ -22,13 +22,13 @@ The Model Context Protocol is an **open standard** (like USB-C for AI) that enab
 
 ### Why MCP Matters
 
-| Traditional Approach                    | MCP Approach                   | Benefit                 |
-| --------------------------------------- | ------------------------------ | ----------------------- |
-| Custom tool integrations per provider   | One MCP tool works everywhere  | 10x faster integration  |
-| Manual tool discovery and configuration | Automatic tool registry        | Zero-config tool usage  |
-| Provider-specific tool formats          | Universal JSON-RPC protocol    | Provider portability    |
-| Limited to SDK-defined tools            | 58+ community servers + custom | Unlimited extensibility |
-| Static tool set                         | Dynamic runtime addition       | Adapt to changing needs |
+| Traditional Approach                    | MCP Approach                      | Benefit                 |
+| --------------------------------------- | --------------------------------- | ----------------------- |
+| Custom tool integrations per provider   | One MCP tool works everywhere     | 10x faster integration  |
+| Manual tool discovery and configuration | Automatic tool registry           | Zero-config tool usage  |
+| Provider-specific tool formats          | Universal JSON-RPC protocol       | Provider portability    |
+| Limited to SDK-defined tools            | any community MCP server + custom | Unlimited extensibility |
+| Static tool set                         | Dynamic runtime addition          | Adapt to changing needs |
 
 ### NeuroLink's Deep MCP Integration
 
@@ -356,9 +356,9 @@ const result = await neurolink.generate({
 
 ---
 
-## External MCP Servers (58+)
+## External MCP Servers
 
-NeuroLink integrates with the growing MCP ecosystem of 58+ external servers across 6 major categories.
+NeuroLink connects to the growing MCP ecosystem — any MCP-compliant server works; the [server catalog](../guides/mcp/server-catalog.md) lists 58+ across 6 major categories.
 
 ### Quick Integration Example
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@juspay/neurolink",
   "version": "9.88.12",
   "packageManager": "pnpm@10.15.1",
-  "description": "TypeScript AI SDK with 24+ LLM providers behind one consistent API. MCP-native (58+ servers), voice TTS/STT/realtime, RAG, agents, memory, context compaction. OpenAI · Anthropic · Gemini · Bedrock · Azure · Ollama · DeepSeek · NVIDIA NIM and more.",
+  "description": "TypeScript AI SDK with 24+ LLM providers behind one consistent API. MCP-native (connect any MCP server), voice TTS/STT/realtime, RAG, agents, memory, context compaction. OpenAI · Anthropic · Gemini · Bedrock · Azure · Ollama · DeepSeek · NVIDIA NIM and more.",
   "author": {
     "name": "Juspay Technologies",
     "email": "support@juspay.in",

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -386,7 +386,7 @@ const isNonRetryableProviderError = sharedIsNonRetryableProviderError;
  *
  * Main SDK class providing unified access to 14+ AI providers with enterprise features:
  * - Multi-provider support (OpenAI, Anthropic, Google AI Studio, Google Vertex, AWS Bedrock, etc.)
- * - MCP (Model Context Protocol) tool integration with 58+ external servers
+ * - MCP (Model Context Protocol) tool integration — connect any MCP-compliant server
  * - Human-in-the-Loop (HITL) security workflows for regulated industries
  * - Redis-based conversation memory and persistence
  * - Enterprise middleware system for monitoring and control


### PR DESCRIPTION
## What

Removes every user-facing claim that NeuroLink *supports/integrates/ships* "58+ MCP servers" (and the "64+ built-in tools and MCP servers" aggregate), replacing it with the code-verified truth:

- NeuroLink is an **MCP host/client** — **any** MCP-compliant server connects via `neurolink mcp add` (4 transports).
- **11 unique popular servers** ship with ready-made configs across the two curated in-code catalogs (`src/cli/commands/mcp.ts` `POPULAR_MCP_SERVERS` + config catalog).
- The docs' [server-catalog page](docs/guides/mcp/server-catalog.md) genuinely **lists 58+ community servers** — kept, but framed as a *directory of what you can connect*, never as shipped integrations.

## Why

No code path substantiates "58+ supported" (verified in the capability audit): the only catalogs in the codebase total 11 unique servers. The claim originated from a doc comment on the `NeuroLink` class and spread to README + 5 docs pages. Landing-page copies were already fixed in #1149; this cleans up README, docs, and the source doc comment. Also fixes a stale interactive-CLI banner claiming "13 Providers | 58+ MCP Tools" (the real CLI prints no such banner; 13 contradicts our current provider count too).

## Files

- `README.md` — hero "Why NeuroLink?" line, MCP section header, docs index link
- `docs/about/vision.md`, `docs/advanced/index.md`, `docs/features/index.md`, `docs/features/interactive-cli.md`, `docs/features/mcp-tools-showcase.md` (title/h1/overview/table/section)
- `src/lib/neurolink.ts` — class doc comment

Docs + one comment only; no behavior change. Prettier-clean (tables realigned by format:staged).