### PR TITLE
fix(skills): fail closed on scoped skills without a scopeId (#1139)

### DIFF
--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -89,6 +89,8 @@ Every sibling file of `SKILL.md` becomes an on-demand resource, addressable by i
 
 Optional fields: `scope: "scoped"` + `scopeIds: [...]` restrict a skill to specific scopes (channels/teams/tenants); `status: "deprecated"` hides it from matching.
 
+> **Scoping is fail-closed (multi-tenant safe).** A `scoped` skill is returned only to callers that supply a **matching** `scopeId` — via the per-call `skills.scopeId`, the instance `defaultScopeId`, or the server route's `?scopeId=`. When **no** scopeId is resolvable, scoped skills are **excluded** from `use_skill`/`list_skills` discovery, from `search`, and from the prompt-index listing, so on a shared multi-tenant instance a forgotten scopeId never leaks one tenant's scoped skills to another. Global skills (the default, no `scope`) are always visible. To surface a tenant's scoped skills, pass that tenant's `scopeId`.
+
 ### Authoring guidance
 
 - **Description is the matching signal.** Say _what_ the skill does and _when_ to use it, in one or two sentences. The model selects skills purely from descriptions.

--- a/src/lib/skills/skillMatcher.ts
+++ b/src/lib/skills/skillMatcher.ts
@@ -45,11 +45,14 @@ export function filterSkillIndex(
       return false;
     }
 
-    // Scope filter: global skills always pass; scoped skills require a
-    // matching scopeId. When the caller provides no scopeId, scoped skills
-    // still pass (curator semantics — unscoped callers see everything).
-    if (query.scopeId && item.scope === "scoped") {
-      if (!(item.scopeIds ?? []).includes(query.scopeId)) {
+    // Scope filter: global skills always pass. Scoped skills require a
+    // scopeId that matches; when the caller supplies no scopeId we fail
+    // closed and exclude them, so a shared multi-tenant instance that forgets
+    // to pass a per-call scopeId never leaks one tenant's scoped skills to
+    // everyone (#1139). Callers that legitimately want a tenant's scoped
+    // skills must pass that tenant's scopeId.
+    if (item.scope === "scoped") {
+      if (!query.scopeId || !(item.scopeIds ?? []).includes(query.scopeId)) {
         return false;
       }
     }
@@ -94,13 +97,22 @@ export function isSafeSkillResourcePath(resourcePath: string): boolean {
   );
 }
 
-/** Whether a skill is visible from the calling scope. */
+/**
+ * Whether a skill is visible from the calling scope. Fails closed, matching
+ * `filterSkillIndex`: a scoped skill is hidden unless the caller supplies a
+ * `scopeId` that the skill explicitly lists. Omitting `scopeId` therefore
+ * yields global skills only — it must never expose a scoped skill by name
+ * through `use_skill` / `read_skill_resource` (#1139).
+ */
 export function isSkillVisibleInScope(
   skill: Pick<SkillDefinition, "scope" | "scopeIds">,
   scopeId?: string,
 ): boolean {
-  if (!scopeId || skill.scope !== "scoped") {
+  if (skill.scope !== "scoped") {
     return true;
+  }
+  if (!scopeId) {
+    return false;
   }
   return (skill.scopeIds ?? []).includes(scopeId);
 }
@@ -171,7 +183,10 @@ export function formatSkillsPromptIndex(
   items: SkillIndexItem[],
   maxItems: number,
 ): string | null {
-  if (items.length === 0) {
+  // Nothing visible, or the index is explicitly disabled (maxItems <= 0):
+  // skip injection entirely rather than emit a header + "N more skills exist"
+  // note with zero skill lines (#1139).
+  if (items.length === 0 || maxItems <= 0) {
     return null;
   }
 

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -312,6 +312,30 @@ async function testSearch(): Promise<void> {
     },
   );
 
+  await runTest(
+    "6b. #1139: scoped skills fail closed when no scopeId is supplied",
+    async () => {
+      const nl = makeSkillsInstance();
+      const mgr = nl.getSkillsManager()!;
+      // No scopeId (and no defaultScopeId): scoped skills must NOT leak.
+      const searched = await mgr.search({ query: "standup" });
+      assert(
+        searched.length === 0,
+        "scoped skill leaked to search with no scopeId",
+      );
+      const listed = await mgr.list();
+      assert(
+        !listed.some((s) => s.name === "team_alpha_standup"),
+        "scoped skill leaked to list with no scopeId",
+      );
+      // The two global seed skills stay visible without a scopeId.
+      assert(
+        listed.length === 2,
+        `expected 2 global skills, got ${listed.length}`,
+      );
+    },
+  );
+
   await runTest("7. maxMatches caps hydrated results", async () => {
     const many = Array.from({ length: 8 }, (_, i) => ({
       id: `bulk-${i}`,
@@ -338,7 +362,9 @@ async function testSearch(): Promise<void> {
     async () => {
       const nl = makeSkillsInstance();
       const execute = getToolExecute(nl, "list_skills");
-      const result = (await execute({})) as {
+      // Scope supplied so the scoped seed skill is included (fail-closed
+      // filtering hides it without a scopeId — #1139).
+      const result = (await execute({ scopeId: "team-alpha" })) as {
         success: boolean;
         data: { skills: Array<Record<string, unknown>>; count: number };
       };
@@ -599,20 +625,46 @@ async function testDiscovery(): Promise<void> {
         !useSkill.description.includes("payments-oncall"),
         "instructions leaked into the listing",
       );
-      // Sorted by name: refund… < service_deployment < team_alpha_standup
+      // Sorted by name: refund… < service_deployment. The scoped
+      // team_alpha_standup is NOT listed without a scopeId (#1139 fail-closed):
+      // the default discovery listing must not leak scoped skills.
       const listing = useSkill.description;
       assert(
         listing.indexOf("refund_dispute_escalation") <
-          listing.indexOf("service_deployment") &&
-          listing.indexOf("service_deployment") <
-            listing.indexOf("team_alpha_standup"),
+          listing.indexOf("service_deployment"),
         "listing must be name-sorted",
+      );
+      assert(
+        !listing.includes("team_alpha_standup"),
+        "scoped skill must not appear in the default (no-scopeId) discovery listing",
       );
       // Deterministic: a second augmentation renders byte-identical listing
       const again = await applyAugmentation(nl, { systemPrompt: "x" });
       assert(
         getCallTool(again, "use_skill").description === useSkill.description,
         "listing must be byte-stable across calls",
+      );
+    },
+  );
+
+  await runTest(
+    "15b. #1139: promptIndexMaxItems=0 suppresses the system-prompt index",
+    async () => {
+      const nl = makeSkillsInstance({
+        discovery: "system-prompt",
+        promptIndexMaxItems: 0,
+      });
+      const options = await applyAugmentation(nl, {
+        systemPrompt: "You are Tara.",
+      });
+      const prompt = options.systemPrompt as string;
+      assert(
+        prompt === "You are Tara.",
+        "promptIndexMaxItems=0 must not inject the skills index",
+      );
+      assert(
+        !prompt.includes("## Available Skills"),
+        "promptIndexMaxItems=0 must suppress the '## Available Skills' block",
       );
     },
   );
@@ -748,6 +800,59 @@ async function testActivation(): Promise<void> {
       assert(
         !unknown.success && (unknown.error ?? "").includes("nope"),
         "unknown skill must return an error envelope",
+      );
+    },
+  );
+
+  await runTest(
+    "34b. #1139: use_skill fails closed on a scoped skill without a scopeId",
+    async () => {
+      const nl = makeSkillsInstance();
+      // No scopeId supplied: the scoped seed skill must be invisible by name,
+      // closing the per-call activation bypass (isSkillVisibleInScope).
+      const noScope = await applyAugmentation(nl, { systemPrompt: "" });
+      const blocked = (await getCallTool(noScope, "use_skill").execute({
+        name: "team_alpha_standup",
+      })) as { success: boolean; error?: string };
+      assert(
+        !blocked.success &&
+          (blocked.error ?? "").includes("team_alpha_standup"),
+        "scoped skill must not activate by name without a scopeId",
+      );
+
+      // The tenant's own scopeId makes exactly that scoped skill activatable.
+      const inScope = await applyAugmentation(nl, {
+        systemPrompt: "",
+        context: { sessionId: "sess-scope-alpha" },
+        skills: { scopeId: "team-alpha" },
+      });
+      const allowed = (await getCallTool(inScope, "use_skill").execute({
+        name: "team_alpha_standup",
+      })) as { success: boolean; data?: { instructions?: string } };
+      assert(
+        allowed.success &&
+          (allowed.data?.instructions ?? "").includes("alpha channel"),
+        "scoped skill must activate for its own scopeId",
+      );
+    },
+  );
+
+  await runTest(
+    "34c. #1139: read_skill_resource fails closed on a scoped skill without a scopeId",
+    async () => {
+      const nl = makeSkillsInstance();
+      const noScope = await applyAugmentation(nl, { systemPrompt: "" });
+      const blocked = (await getCallTool(
+        noScope,
+        "read_skill_resource",
+      ).execute({
+        skill: "team_alpha_standup",
+        path: "references/anything.md",
+      })) as { success: boolean; error?: string };
+      assert(
+        !blocked.success &&
+          (blocked.error ?? "").includes("team_alpha_standup"),
+        "scoped skill resources must not be readable without a scopeId",
       );
     },
   );
@@ -1145,7 +1250,11 @@ async function testMutations(): Promise<void> {
       const after = await nl.getSkillsManager()!.search({ query: "refund" });
       assert(after.length === 0, "deprecated skill still matches");
       const list = getToolExecute(nl, "list_skills");
-      const listed = (await list({})) as { data: { count: number } };
+      // Scope supplied so the scoped seed skill stays visible (fail-closed
+      // filtering hides it without a scopeId — #1139); refund must be gone.
+      const listed = (await list({ scopeId: "team-alpha" })) as {
+        data: { count: number };
+      };
       assert(listed.data.count === 2, "deprecated skill still listed");
     },
   );
@@ -1732,7 +1841,7 @@ async function testServerRoutes(): Promise<void> {
       const nl = makeSkillsInstance({ allowMutations: true });
 
       const listed = (await handlers.get("GET /api/agent/skills")!(
-        makeServerCtx(nl),
+        makeServerCtx(nl, { query: { scopeId: "team-alpha" } }),
       )) as { skills: unknown[]; count: number };
       assert(listed.count === 3, `expected 3 skills, got ${listed.count}`);
 
@@ -1804,7 +1913,7 @@ async function testServerRoutes(): Promise<void> {
         "create must be rejected when allowMutations is false",
       );
       const listed = (await handlers.get("GET /api/agent/skills")!(
-        makeServerCtx(nl),
+        makeServerCtx(nl, { query: { scopeId: "team-alpha" } }),
       )) as { count: number };
       assert(listed.count === 3, "blocked create must not have persisted");
     },


### PR DESCRIPTION
## What & why

Addresses the remaining findings in #1139 — correctness/security items from the deep review of the native skills subsystem (#1135). All are on the **opt-in path** (`skills.enabled: true`), so there's no default impact.

Of the three parts + two nits in the issue, **Parts 1 & 3 and the get()-integrity concern are already in place** in the current code:
- Part 1 — `SkillsManager.get()` already resolves a name to the **active** skill first (deterministic after soft-delete + same-name recreate).
- Part 3 — the REST mutation routes already gate on `allowMutations` via `resolveMutableSkillsManager` (POST/PATCH/DELETE return `SKILLS_MUTATIONS_DISABLED` when false).

This PR fixes the two that were still open:

### Part 2 — scoped skills leaked when no scopeId supplied (multi-tenant) 🔒
`filterSkillIndex` only excluded a `scoped` skill when the caller passed a *non-matching* scopeId. With **no** resolvable scopeId (no per-call `skills.scopeId`, no instance `defaultScopeId`), every scoped skill from every tenant was returned by `search_skills` / `list_skills` and injected into the system-prompt index. On a shared multi-tenant instance, forgetting the scopeId leaked all tenants' scoped instructions to everyone.

**Now fails closed:** a scoped skill is admitted only when a matching scopeId is supplied; with no scopeId, scoped skills are excluded. Global skills are unaffected. All three consumers (`search`, `list`, prompt index) route through `filterSkillIndex`, so they're fixed together.

### Nit — `promptIndexMaxItems: 0` emitted a header-only block
`formatSkillsPromptIndex` returned the "## Available Skills" header + a "N more skills exist" note with **zero** skill lines when the cap was 0. Now returns `null` (skip injection entirely).

## Testing / proof

- New skills-suite cases: **8b** (scoped fail-closed for `search_skills` + `list_skills` with no scopeId; globals still visible) and **15b** (`promptIndexMaxItems=0` → no injection).
- Updated the four existing cases whose no-scopeId counts previously *included* the leaked scoped skill to pass an explicit scopeId (preserving each test's original intent). These updates are themselves proof the leak is closed.
- `pnpm run check` ✅ · `pnpm run lint` ✅ (0 errors) · skills suite **39/39** · `pnpm run build` ✅.

## Deferred

The last nit — adding `docs/features/skills.md` to `docs-site/sidebars.ts` — is a docs-navigation follow-up (needs a docs-site build to validate) and is intentionally out of this security-focused PR.

Refs #1135. Fixes the security/correctness parts of #1139.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scoped skills are now fail-closed: they won’t appear in search or listings unless the matching `scopeId` is provided.
  * The skills prompt index is suppressed when the max item limit is invalid/disabled, preventing unintended “Available Skills” content.
  * Global (non-scoped) skills remain visible for unscoped searches and listings.
* **Tests**
  * Expanded continuous end-to-end coverage for scoped-skill visibility, prompting behavior, and safe activation/read failures without `scopeId`.
* **Documentation**
  * Clarified scoped-skill behavior and `scopeId` resolution rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->