### PR TITLE
feat(examples): degit-able starter templates — chat, mcp-client, proxy-failover

### DIFF
--- a/examples/starters/README.md
+++ b/examples/starters/README.md
@@ -1,0 +1,17 @@
+# Starters
+
+Self-contained templates you can copy out and run in under a minute. Each has its own
+`package.json` — no monorepo setup needed:
+
+```bash
+npx degit juspay/neurolink/examples/starters/<name> my-app
+cd my-app && npm install
+```
+
+| Starter          | Shows                                                                    |
+| ---------------- | ------------------------------------------------------------------------ |
+| `chat`           | Streaming terminal chat with automatic provider selection                |
+| `mcp-client`     | Registering an MCP server (filesystem) and letting the model use it      |
+| `proxy-failover` | Running the Claude Code proxy with account pooling + a status health CLI |
+
+Each starter's README lists the exact env vars it needs.

--- a/examples/starters/chat/.env.example
+++ b/examples/starters/chat/.env.example
@@ -1,0 +1,6 @@
+# Set exactly one of these depending on the provider you want NeuroLink to
+# auto-select. NeuroLink picks the first available provider automatically —
+# no provider name needs to be passed in code.
+OPENAI_API_KEY=your-openai-api-key-here
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here
+# GOOGLE_AI_API_KEY=your-google-ai-studio-api-key-here

--- a/examples/starters/chat/README.md
+++ b/examples/starters/chat/README.md
@@ -1,0 +1,32 @@
+# NeuroLink Chat Starter
+
+A minimal terminal chat loop built on NeuroLink's streaming API. It reads a line from
+stdin, streams the model's reply token-by-token to stdout, and repeats — NeuroLink
+auto-selects whichever provider matches the API key you set, no provider code required.
+
+## Quickstart
+
+```bash
+npx degit juspay/neurolink/examples/starters/chat my-app
+cd my-app && npm install
+cp .env.example .env   # then set one provider API key
+npm start
+```
+
+## What it does
+
+- `src/index.ts` runs a `readline/promises` loop, sending each line you type to
+  `neurolink.stream({ input: { text } })` and writing chunks to stdout as they arrive.
+- Type `/exit` (or Ctrl+C) to quit.
+- To pin a specific provider/model instead of auto-selection, see the commented
+  example in `src/index.ts`.
+
+## Configuration
+
+Copy `.env.example` to `.env` and set exactly one provider key (e.g. `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, or `GOOGLE_AI_API_KEY`). NeuroLink picks the first available one.
+
+## Scripts
+
+- `npm start` — run the chat loop.
+- `npm run typecheck` — type-check without emitting.

--- a/examples/starters/chat/package.json
+++ b/examples/starters/chat/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "neurolink-starter-chat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal terminal chat starter using NeuroLink streaming generation",
+  "engines": {
+    "node": ">=20.18.1"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@juspay/neurolink": "^9.88.12"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/starters/chat/src/index.ts
+++ b/examples/starters/chat/src/index.ts
@@ -1,0 +1,69 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { NeuroLink } from "@juspay/neurolink";
+
+// Auto-selects the first provider with a matching API key in the
+// environment (see .env.example) — no provider name required here.
+const neurolink = new NeuroLink();
+
+// To pin a specific provider/model instead of auto-selection, pass it on
+// each stream() call below, e.g.:
+// const result = await neurolink.stream({ input: { text }, provider: "anthropic", model: "claude-sonnet-4-5" });
+
+const rl = createInterface({ input: stdin, output: stdout });
+
+const printWelcome = (): void => {
+  console.log("NeuroLink terminal chat. Type a message and press Enter.");
+  console.log("Type /exit or press Ctrl+C to quit.\n");
+};
+
+const isTextChunk = (chunk: unknown): chunk is { content: string } =>
+  typeof chunk === "object" &&
+  chunk !== null &&
+  "content" in chunk &&
+  typeof (chunk as { content: unknown }).content === "string";
+
+const streamReply = async (text: string): Promise<void> => {
+  // stream() returns a StreamResult whose `.stream` is an AsyncIterable of
+  // text/reasoning/audio/image chunk events — plain-text chunks carry a
+  // `content` string field (src/lib/types/stream.ts:664-672).
+  const result = await neurolink.stream({ input: { text } });
+
+  for await (const chunk of result.stream) {
+    if (isTextChunk(chunk) && chunk.content.length > 0) {
+      stdout.write(chunk.content);
+    }
+  }
+  stdout.write("\n\n");
+};
+
+const main = async (): Promise<void> => {
+  printWelcome();
+
+  for (;;) {
+    const line = await rl.question("you> ");
+    const text = line.trim();
+
+    if (text.length === 0) {
+      continue;
+    }
+    if (text === "/exit") {
+      break;
+    }
+
+    stdout.write("ai>  ");
+    try {
+      await streamReply(text);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`\n[error] ${message}\n`);
+    }
+  }
+
+  rl.close();
+};
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/examples/starters/chat/tsconfig.json
+++ b/examples/starters/chat/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/examples/starters/mcp-client/.env.example
+++ b/examples/starters/mcp-client/.env.example
@@ -1,0 +1,6 @@
+# Set exactly one of these depending on the provider you want NeuroLink to
+# auto-select. NeuroLink picks the first available provider automatically —
+# no provider name needs to be passed in code.
+OPENAI_API_KEY=your-openai-api-key-here
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here
+# GOOGLE_AI_API_KEY=your-google-ai-studio-api-key-here

--- a/examples/starters/mcp-client/.mcp-config.json
+++ b/examples/starters/mcp-client/.mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "name": "filesystem",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "transport": "stdio",
+      "description": "Read-only access to files in this starter's directory"
+    }
+  }
+}

--- a/examples/starters/mcp-client/README.md
+++ b/examples/starters/mcp-client/README.md
@@ -1,0 +1,57 @@
+# mcp-client
+
+Shows NeuroLink wiring up an external MCP (Model Context Protocol) server —
+the reference `@modelcontextprotocol/server-filesystem` — and letting the
+model call it during a single `generate()` to read a local file.
+
+## Quickstart
+
+```bash
+npx degit juspay/neurolink/examples/starters/mcp-client my-app
+cd my-app && npm install
+cp .env.example .env   # then edit .env and set one provider key
+npm start
+```
+
+## How the MCP server gets registered
+
+NeuroLink auto-loads `.mcp-config.json` from the current working directory
+during MCP initialization (see `src/lib/mcp/externalServerManager.ts`,
+`loadMCPConfiguration`, default path `.mcp-config.json` in `cwd`). This
+starter ships one that spawns the filesystem server scoped to `.` (this
+directory), so it can only read files here — including `sample.txt`.
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "name": "filesystem",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+The NeuroLink CLI's `mcp add` / `mcp install` commands write to the same
+file and shape. Adding this server by hand would look like:
+
+```bash
+neurolink mcp add filesystem npx --args "-y,@modelcontextprotocol/server-filesystem,." --transport stdio
+# or, for the popular-servers shortcut:
+neurolink mcp install filesystem
+```
+
+`src/index.ts` calls `neurolink.getMCPStatus()` and `neurolink.listMCPServers()`
+to confirm the server connected, then runs one `generate()` call asking the
+model to read `sample.txt` — tool use is enabled by default, so no extra flag
+is needed. The printed `toolsUsed` list confirms whether the filesystem tool
+actually ran.
+
+## Requirements
+
+- Node.js >= 20.18.1
+- `npx` available (used to launch `@modelcontextprotocol/server-filesystem`
+  on demand — nothing is installed globally)
+- One provider API key (OpenAI, Anthropic, or Google AI Studio) in `.env`

--- a/examples/starters/mcp-client/package.json
+++ b/examples/starters/mcp-client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "neurolink-starter-mcp-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Registers the filesystem MCP server with NeuroLink and lets the model use it to read a local file",
+  "engines": {
+    "node": ">=20.18.1"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@juspay/neurolink": "^9.88.12"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/starters/mcp-client/sample.txt
+++ b/examples/starters/mcp-client/sample.txt
@@ -1,0 +1,4 @@
+This file is a fixture for the mcp-client starter.
+
+If a model can read this sentence back to you, the filesystem MCP server
+is wired up correctly and NeuroLink handed the tool call through to it.

--- a/examples/starters/mcp-client/src/index.ts
+++ b/examples/starters/mcp-client/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Registers the filesystem MCP server (via `.mcp-config.json`, loaded
+ * automatically from the current working directory) and runs one
+ * generation where the model uses that server's tools to read sample.txt.
+ *
+ * Config-file auto-loading and status/tool APIs verified against:
+ *   src/lib/neurolink.ts:2798  (loadMCPConfigurationInternal, called during MCP init)
+ *   src/lib/mcp/externalServerManager.ts:355 (defaults to .mcp-config.json in cwd)
+ *   src/lib/neurolink.ts:13711 (getMCPStatus — call before listMCPServers, per its own doc comment)
+ *   src/lib/neurolink.ts:13781 (listMCPServers)
+ *   src/lib/types/generate.ts:1128 (disableTools — tools stay enabled by default, so no flag needed)
+ *   src/lib/types/generate.ts:1443 (toolsUsed on the generate() result)
+ */
+
+import { NeuroLink } from "@juspay/neurolink";
+
+const PROVIDER_ENV_VARS = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_AI_API_KEY",
+] as const;
+
+function hasProviderKey(): boolean {
+  return PROVIDER_ENV_VARS.some((name) => Boolean(process.env[name]));
+}
+
+async function main(): Promise<void> {
+  if (!hasProviderKey()) {
+    console.error(
+      "No provider API key found. Set one of: " +
+        PROVIDER_ENV_VARS.join(", ") +
+        " (see .env.example).",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const neurolink = new NeuroLink();
+
+  try {
+    // getMCPStatus() triggers MCP initialization (which loads .mcp-config.json
+    // from cwd) and must be awaited before listMCPServers() is meaningful.
+    const status = await neurolink.getMCPStatus();
+    console.log(
+      `MCP status: ${status.availableServers}/${status.totalServers} server(s) available, ${status.totalTools} tool(s) discovered.`,
+    );
+
+    const servers = await neurolink.listMCPServers();
+    const filesystem = servers.find((server) => server.name === "filesystem");
+    if (!filesystem) {
+      console.error(
+        "The filesystem MCP server from .mcp-config.json was not registered. " +
+          "Check that npx can reach @modelcontextprotocol/server-filesystem.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log(
+      `filesystem server: ${filesystem.status} (${filesystem.tools.length} tool(s): ${filesystem.tools
+        .map((tool) => tool.name)
+        .join(", ")})`,
+    );
+
+    const result = await neurolink.generate({
+      input: {
+        text: "Use your file tools to read sample.txt in the current directory, then quote its second paragraph back to me exactly.",
+      },
+    });
+
+    console.log("\nModel response:\n" + result.content);
+    if (result.toolsUsed?.length) {
+      console.log("\nTools used: " + result.toolsUsed.join(", "));
+    } else {
+      console.log(
+        "\nNo tools were used — the model answered without reading the file.",
+      );
+    }
+  } finally {
+    await neurolink.shutdown();
+  }
+}
+
+await main();

--- a/examples/starters/mcp-client/tsconfig.json
+++ b/examples/starters/mcp-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/examples/starters/proxy-failover/.env.example
+++ b/examples/starters/proxy-failover/.env.example
@@ -1,0 +1,4 @@
+# Host/port the NeuroLink Claude proxy is listening on.
+# These are the proxy's defaults (see `neurolink proxy start --help`).
+PROXY_HOST=127.0.0.1
+PROXY_PORT=55669

--- a/examples/starters/proxy-failover/README.md
+++ b/examples/starters/proxy-failover/README.md
@@ -1,0 +1,58 @@
+# proxy-failover
+
+Shows how to run Claude Code through the NeuroLink Claude proxy, which pools multiple
+Anthropic accounts and fails over between them on rate limits. `src/index.ts` is a small
+CLI that queries the proxy's local `/status` endpoint and prints a health/account summary.
+
+## Quickstart
+
+```bash
+npx degit juspay/neurolink/examples/starters/proxy-failover my-app
+cd my-app && npm install
+cp .env.example .env   # defaults match the proxy's defaults, edit only if you changed them
+npm start
+```
+
+## Set up the proxy itself
+
+This starter does not start the proxy — it only checks on one that's already running.
+To set one up:
+
+```bash
+# Install the CLI if you haven't already
+npm install -g @juspay/neurolink
+
+# One-command setup: authenticates via OAuth, installs the proxy as a background
+# service, and points Claude Code at it (sets ANTHROPIC_BASE_URL)
+neurolink proxy setup
+
+# Add more Anthropic accounts to the pool for higher aggregate throughput
+neurolink auth login anthropic --method oauth --add --label work
+neurolink auth login anthropic --method oauth --add --label personal
+
+# Restart Claude Code to pick up the new ANTHROPIC_BASE_URL, then verify:
+neurolink proxy status
+```
+
+The proxy listens on `http://127.0.0.1:55669` by default. When a pooled account hits a
+429, the proxy rotates to the next account automatically; when all accounts are
+exhausted it can fall back to other providers configured in NeuroLink.
+
+## What `npm start` does
+
+Fetches `GET /status` from the running proxy and prints:
+
+- process id, address, routing strategy, uptime
+- total requests / successes / errors / rate-limits
+- per-account request and error counts
+
+If the proxy isn't running, it prints a clear message (not a stack trace) telling you
+to run `neurolink proxy start` or `neurolink proxy setup`.
+
+This starter makes no calls to Anthropic — it only talks to the local proxy process.
+
+## Reference
+
+- `neurolink proxy setup` / `neurolink proxy start` / `neurolink proxy status` — see
+  `docs/features/claude-proxy.md` and `docs/features/claude-proxy-config-reference.md`
+  in the main NeuroLink repo.

--- a/examples/starters/proxy-failover/package.json
+++ b/examples/starters/proxy-failover/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "proxy-failover",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Status checker for the NeuroLink Claude proxy (multi-account pooling, rate-limit failover) used with Claude Code",
+  "engines": {
+    "node": ">=20.18.1"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@juspay/neurolink": "^9.88.12"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/starters/proxy-failover/src/index.ts
+++ b/examples/starters/proxy-failover/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Status checker for the NeuroLink Claude proxy.
+ *
+ * The proxy (started with `neurolink proxy start` / `neurolink proxy setup`) exposes
+ * a `/status` endpoint on http://127.0.0.1:55669 by default. This script queries it
+ * and prints a human-readable summary: whether the proxy is up, which accounts are
+ * pooled, and basic request/error counters. It makes no calls to Anthropic itself.
+ *
+ * Endpoint, default port, and response shape verified against:
+ *   src/cli/commands/proxy.ts:1410 (app.get("/status", ...))
+ *   src/cli/commands/proxy.ts:2135 (const port = argv.port ?? 55669)
+ */
+
+interface AccountStat {
+  readonly label: string;
+  readonly type: string;
+  readonly requests?: number;
+  readonly errors?: number;
+  readonly rateLimits?: number;
+}
+
+interface ProxyStatusResponse {
+  readonly status: string;
+  readonly ready: boolean;
+  readonly pid: number;
+  readonly port: number;
+  readonly host: string;
+  readonly strategy: string;
+  readonly uptime: number;
+  readonly version: string;
+  readonly stats: {
+    readonly totalRequests: number;
+    readonly totalSuccess: number;
+    readonly totalErrors: number;
+    readonly totalRateLimits: number;
+    readonly accounts: readonly AccountStat[];
+  };
+}
+
+function isProxyStatusResponse(value: unknown): value is ProxyStatusResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.status === "string" &&
+    typeof candidate.pid === "number" &&
+    typeof candidate.stats === "object" &&
+    candidate.stats !== null
+  );
+}
+
+function formatUptime(seconds: number): string {
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  return `${hours}h ${minutes}m ${secs}s`;
+}
+
+function printStatus(status: ProxyStatusResponse): void {
+  console.log("NeuroLink Claude proxy: running");
+  console.log(`  pid:       ${status.pid}`);
+  console.log(`  address:   http://${status.host}:${status.port}`);
+  console.log(`  strategy:  ${status.strategy}`);
+  console.log(`  version:   ${status.version}`);
+  console.log(`  uptime:    ${formatUptime(status.uptime)}`);
+  console.log(
+    `  requests:  ${status.stats.totalRequests} total, ${status.stats.totalSuccess} ok, ` +
+      `${status.stats.totalErrors} errors, ${status.stats.totalRateLimits} rate-limited`,
+  );
+
+  if (status.stats.accounts.length === 0) {
+    console.log(
+      "  accounts:  (none pooled yet — run `neurolink auth login anthropic --method oauth`)",
+    );
+    return;
+  }
+
+  console.log("  accounts:");
+  for (const account of status.stats.accounts) {
+    const requests = account.requests ?? 0;
+    const errors = account.errors ?? 0;
+    const rateLimits = account.rateLimits ?? 0;
+    console.log(
+      `    - ${account.label} (${account.type}): ${requests} requests, ${errors} errors, ${rateLimits} rate-limits`,
+    );
+  }
+}
+
+async function checkProxyStatus(host: string, port: number): Promise<void> {
+  const url = `http://${host}:${port}/status`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: AbortSignal.timeout(3000) });
+  } catch {
+    console.error(`Could not reach the NeuroLink proxy at ${url}.`);
+    console.error("Is it running? Start it with:");
+    console.error("  neurolink proxy start");
+    console.error("or set it up for the first time with:");
+    console.error("  neurolink proxy setup");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!response.ok) {
+    console.error(
+      `Proxy responded with HTTP ${response.status} ${response.statusText} at ${url}.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const body: unknown = await response.json();
+  if (!isProxyStatusResponse(body)) {
+    console.error(
+      `Unexpected response shape from ${url}. Is this a NeuroLink proxy?`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  printStatus(body);
+}
+
+const host = process.env.PROXY_HOST ?? "127.0.0.1";
+const port = Number.parseInt(process.env.PROXY_PORT ?? "55669", 10);
+
+await checkProxyStatus(host, port);

--- a/examples/starters/proxy-failover/tsconfig.json
+++ b/examples/starters/proxy-failover/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Three self-contained starter templates under `examples/starters/` + an index README. Each is copy-out-and-run:

```bash
npx degit juspay/neurolink/examples/starters/<name> my-app
cd my-app && npm install && npm start
```

| Starter | Shows |
|---|---|
| `chat` | Streaming terminal chat via `neurolink.stream()`, automatic provider selection, one-line provider pinning |
| `mcp-client` | `.mcp-config.json` auto-load registering the filesystem MCP server; a `generate()` call where the model reads a shipped `sample.txt`; the `neurolink mcp add` CLI equivalent |
| `proxy-failover` | `neurolink proxy setup` + account-pooling walkthrough, plus a status health CLI against the local `/status` endpoint with a clean not-running message |

## Verification (all three)

- Real `npm install` against the registry succeeded
- `tsc --noEmit` clean under `strict` — no `any` anywhere (only guarded narrowing)
- prettier-clean per repo config
- README steps checked against the shipped files; degit paths match the repo layout
- Every SDK/CLI API verified against source before use (e.g., stream chunk shape `src/lib/types/stream.ts:664-672`, `.mcp-config.json` auto-load `src/lib/mcp/externalServerManager.ts:355`, proxy status port `src/cli/commands/proxy.ts:2135`)
- `.env.example` files contain placeholder names only; no lockfiles or `node_modules` shipped

## Why

Growth playbook play #7 (marketing repo `docs/growth-exec/growth-playbook.md`): the template/starter gallery is the single biggest owned discovery+retention asset for Vercel AI SDK and Mastra in this exact category — this is NeuroLink's first step there, timed for the July 22 launch traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three ready-to-use starter templates: terminal chat, MCP client, and proxy failover.
  * Added provider configuration examples and setup instructions for each starter.
  * Added an MCP example that reads a local file through a filesystem tool.
  * Added a proxy status example showing health, uptime, request metrics, and account failover details.

* **Documentation**
  * Added a central guide explaining how to copy, configure, install, and run the starter templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->