### PR TITLE
fix(image): guard image buffer size to prevent memory exhaustion (#257)

### DIFF
--- a/docs/features/file-processors.md
+++ b/docs/features/file-processors.md
@@ -354,23 +354,15 @@ const result = await neurolink.generate({
 
 Default size limits prevent denial-of-service attacks:
 
-| Category     | Default Limit | Configurable |
-| ------------ | ------------- | ------------ |
-| Documents    | 50 MB         | Yes          |
-| Data files   | 10 MB         | Yes          |
-| Code files   | 5 MB          | Yes          |
-| Config files | 1 MB          | Yes          |
-| Images       | 20 MB         | Yes          |
+| Category     | Default Limit | Configurable     |
+| ------------ | ------------- | ---------------- |
+| Documents    | 50 MB         | Yes              |
+| Data files   | 10 MB         | Yes              |
+| Code files   | 5 MB          | Yes              |
+| Config files | 1 MB          | Yes              |
+| Images       | 10 MB         | No — fixed limit |
 
-```typescript
-import { ProcessorConfig } from "@juspay/neurolink";
-
-// Configure size limits
-ProcessorConfig.setLimits({
-  maxDocumentSize: 100 * 1024 * 1024, // 100 MB
-  maxCodeSize: 10 * 1024 * 1024, // 10 MB
-});
-```
+The **image** limit (`SIZE_LIMITS_BYTES.IMAGE_MAX`, 10 MB) is enforced: an oversized image buffer, file, or download throws a descriptive error before any base64 conversion, so a large image can no longer exhaust process memory. This applies to both entry points — images passed via `generate({ files })` (routed through `FileDetector` → `ImageProcessor`) and via `generate({ images })` (routed through the message builder). The internal image helpers that convert buffers/files/URLs accept an optional size override, but it is not exposed through `generate()` or any other public API — the 10 MB limit is fixed for SDK callers.
 
 ## Error Handling
 

--- a/src/lib/utils/errorHandling.ts
+++ b/src/lib/utils/errorHandling.ts
@@ -54,6 +54,7 @@ export const ERROR_CODES = {
   IMAGE_TOO_LARGE: "IMAGE_TOO_LARGE",
   IMAGE_TOO_SMALL: "IMAGE_TOO_SMALL",
   INVALID_IMAGE_FORMAT: "INVALID_IMAGE_FORMAT",
+  INVALID_IMAGE_SIZE: "INVALID_IMAGE_SIZE",
 
   // PDF validation errors
   PDF_PAGE_LIMIT_EXCEEDED: "PDF_PAGE_LIMIT_EXCEEDED",
@@ -668,6 +669,27 @@ export class ErrorFactory {
           "Use a lower quality JPEG compression",
           "Reduce image dimensions",
         ],
+      },
+    });
+  }
+
+  /**
+   * Create an invalid image size error (NaN/Infinity/negative byte length).
+   * Distinct from `imageTooLarge` — this rejects a malformed size value
+   * before it reaches the max-size comparison, since `NaN > maxSize` and
+   * `-1 > maxSize` both evaluate to `false` and would otherwise let a
+   * corrupted stat/header value silently skip the guard.
+   */
+  static invalidImageSize(size: number): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.INVALID_IMAGE_SIZE,
+      message: `Invalid image size: ${size} (must be a finite, non-negative number)`,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: {
+        field: "input.images",
+        size,
       },
     });
   }

--- a/src/lib/utils/imageProcessor.ts
+++ b/src/lib/utils/imageProcessor.ts
@@ -7,7 +7,9 @@ import { logger } from "./logger.js";
 import { urlDownloadRateLimiter } from "./rateLimiter.js";
 import { withRetry } from "./retryHandler.js";
 import { SYSTEM_LIMITS } from "../core/constants.js";
+import { SIZE_LIMITS_BYTES } from "../processors/config/sizeLimits.js";
 import { getImageCache } from "./imageCache.js";
+import { ErrorFactory, NeuroLinkError } from "./errorHandling.js";
 import type { ProcessedImage, FileProcessingResult } from "../types/index.js";
 
 /**
@@ -95,7 +97,10 @@ export class ImageProcessor {
     }
 
     const mediaType = this.detectImageType(content);
-    const base64 = content.toString("base64");
+    const base64 = ImageProcessor.safeBase64Convert(
+      content,
+      "image processing",
+    );
     const dataUri = `data:${mediaType};base64,${base64}`;
 
     // Validate output before returning
@@ -171,9 +176,17 @@ export class ImageProcessor {
       }
 
       // Handle Buffer - convert to data URI
-      const base64 = image.toString("base64");
+      const base64 = ImageProcessor.safeBase64Convert(
+        image,
+        "OpenAI image input",
+      );
       return `data:image/jpeg;base64,${base64}`;
     } catch (error) {
+      // Preserve typed errors (e.g. IMAGE_TOO_LARGE) as-is — don't flatten
+      // them into a generic Error and lose the error `code` for callers.
+      if (error instanceof NeuroLinkError) {
+        throw error;
+      }
       logger.error("Failed to process image for OpenAI:", error);
       throw new Error(
         `Image processing failed for OpenAI: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -207,7 +220,10 @@ export class ImageProcessor {
           base64Data = image;
         }
       } else {
-        base64Data = image.toString("base64");
+        base64Data = ImageProcessor.safeBase64Convert(
+          image,
+          "provider image input",
+        );
       }
 
       return {
@@ -215,6 +231,11 @@ export class ImageProcessor {
         data: base64Data, // Google wants base64 WITHOUT data URI prefix
       };
     } catch (error) {
+      // Preserve typed errors (e.g. IMAGE_TOO_LARGE) as-is — don't flatten
+      // them into a generic Error and lose the error `code` for callers.
+      if (error instanceof NeuroLinkError) {
+        throw error;
+      }
       logger.error("Failed to process image for Google AI:", error);
       throw new Error(
         `Image processing failed for Google AI: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -248,7 +269,10 @@ export class ImageProcessor {
           base64Data = image;
         }
       } else {
-        base64Data = image.toString("base64");
+        base64Data = ImageProcessor.safeBase64Convert(
+          image,
+          "provider image input",
+        );
       }
 
       return {
@@ -256,6 +280,11 @@ export class ImageProcessor {
         data: base64Data, // Anthropic wants base64 WITHOUT data URI prefix
       };
     } catch (error) {
+      // Preserve typed errors (e.g. IMAGE_TOO_LARGE) as-is — don't flatten
+      // them into a generic Error and lose the error `code` for callers.
+      if (error instanceof NeuroLinkError) {
+        throw error;
+      }
       logger.error("Failed to process image for Anthropic:", error);
       throw new Error(
         `Image processing failed for Anthropic: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -284,6 +313,11 @@ export class ImageProcessor {
         return ImageProcessor.processImageForGoogle(image);
       }
     } catch (error) {
+      // Preserve typed errors bubbling up from processImageForGoogle/
+      // processImageForAnthropic (e.g. IMAGE_TOO_LARGE) as-is.
+      if (error instanceof NeuroLinkError) {
+        throw error;
+      }
       logger.error("Failed to process image for Vertex AI:", error);
       throw new Error(
         `Image processing failed for Vertex AI: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -385,22 +419,81 @@ export class ImageProcessor {
   }
 
   /**
-   * Validate image size (default 10MB limit)
+   * Throwing size guard for a raw byte length. Prevents memory exhaustion by
+   * rejecting an oversized input BEFORE an unbounded read/allocation happens
+   * (#257) — callers that can get a size cheaply (e.g. `fs.stat`) should
+   * validate it before ever reading the bytes into memory. Default limit is
+   * the canonical `SIZE_LIMITS_BYTES.IMAGE_MAX` (10 MB); there is no public
+   * way to raise it — `maxSize` is an internal-only override for advanced
+   * callers (e.g. video image inputs use a higher limit).
+   *
+   * @param size - Byte length to validate
+   * @param context - Short label identifying the source (unused in the
+   *   thrown message today, kept for call-site readability and future use)
+   * @param maxSize - Max allowed size in bytes
+   * @throws NeuroLinkError (`INVALID_IMAGE_SIZE`) if `size` is not a finite,
+   *   non-negative number
+   * @throws NeuroLinkError (`IMAGE_TOO_LARGE`) if `size` exceeds `maxSize`
    */
-  static validateImageSize(
-    data: Buffer | string,
-    maxSize: number = 10 * 1024 * 1024,
-  ): boolean {
-    try {
-      const size =
-        typeof data === "string"
-          ? Buffer.byteLength(data, "base64")
-          : data.length;
-      return size <= maxSize;
-    } catch (error) {
-      logger.warn("Failed to validate image size:", error);
-      return false;
+  static validateSize(
+    size: number,
+    context: string,
+    maxSize: number = SIZE_LIMITS_BYTES.IMAGE_MAX,
+  ): void {
+    // Reject a malformed maxSize before it's ever compared: `size > NaN` and
+    // `size > Infinity` (for a negative maxSize) can both evaluate `false`,
+    // which would let a corrupted/negative limit bypass the guard entirely.
+    if (!Number.isFinite(maxSize) || maxSize < 0) {
+      throw ErrorFactory.invalidConfiguration(
+        "maxSize",
+        "must be a finite, non-negative byte count",
+        { maxSize, context },
+      );
     }
+    // Fail closed on malformed sizes first: `NaN > maxSize` and
+    // `-1 > maxSize` both evaluate to `false`, which would otherwise let a
+    // corrupted stat/header value silently skip the guard below.
+    if (!Number.isFinite(size) || size < 0) {
+      throw ErrorFactory.invalidImageSize(size);
+    }
+    if (size > maxSize) {
+      const mb = (size / (1024 * 1024)).toFixed(1);
+      const maxMb = (maxSize / (1024 * 1024)).toFixed(0);
+      throw ErrorFactory.imageTooLarge(mb, maxMb);
+    }
+  }
+
+  /**
+   * Throwing size guard for image buffers. Prevents memory exhaustion by
+   * rejecting oversized buffers with a descriptive error BEFORE an unbounded
+   * `Buffer.toString("base64")` allocation (#257). Delegates to
+   * `validateSize` so buffer-based and pre-read (stat-based) callers share
+   * one implementation.
+   *
+   * @param buffer - Image buffer to validate
+   * @param context - Short label identifying the source (see `validateSize`)
+   * @param maxSize - Max allowed size in bytes
+   * @throws NeuroLinkError (`IMAGE_TOO_LARGE`) if the buffer exceeds `maxSize`
+   */
+  static validateBufferSize(
+    buffer: Buffer,
+    context: string,
+    maxSize: number = SIZE_LIMITS_BYTES.IMAGE_MAX,
+  ): void {
+    ImageProcessor.validateSize(buffer.length, context, maxSize);
+  }
+
+  /**
+   * Size-guarded Buffer → base64. Use in place of `buffer.toString("base64")`
+   * on any path that converts a caller-supplied image buffer (#257).
+   */
+  static safeBase64Convert(
+    buffer: Buffer,
+    context: string,
+    maxSize: number = SIZE_LIMITS_BYTES.IMAGE_MAX,
+  ): string {
+    ImageProcessor.validateBufferSize(buffer, context, maxSize);
+    return buffer.toString("base64");
   }
 
   /**
@@ -564,7 +657,7 @@ export class ImageProcessor {
               ? image.split(",")[1] || image
               : image;
           } else {
-            data = image.toString("base64");
+            data = ImageProcessor.safeBase64Convert(image, "image input");
           }
           format = "base64";
       }
@@ -576,6 +669,11 @@ export class ImageProcessor {
         format,
       };
     } catch (error) {
+      // Preserve typed errors (e.g. IMAGE_TOO_LARGE) bubbling up from the
+      // provider-specific branches above as-is.
+      if (error instanceof NeuroLinkError) {
+        throw error;
+      }
       logger.error(`Failed to process image for ${provider}:`, error);
       throw new Error(
         `Image processing failed: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -708,10 +806,23 @@ export const imageUtils = {
   },
 
   /**
-   * Convert Buffer to base64 string
+   * Convert Buffer to base64 string. Guarded by the same #257 size limit as
+   * every other conversion site (default `SIZE_LIMITS_BYTES.IMAGE_MAX`);
+   * pass `maxBytes` to override for a caller with a legitimate need for a
+   * different ceiling rather than silently accepting an unbounded buffer.
+   * `imageUtils`/`ImageProcessor` are internal-only — not re-exported from
+   * `src/lib/index.ts` or the package's public `exports` map — so this
+   * default does not change behavior for any external SDK consumer.
    */
-  bufferToBase64: (buffer: Buffer): string => {
-    return buffer.toString("base64");
+  bufferToBase64: (
+    buffer: Buffer,
+    maxBytes: number = SIZE_LIMITS_BYTES.IMAGE_MAX,
+  ): string => {
+    return ImageProcessor.safeBase64Convert(
+      buffer,
+      "buffer-to-base64",
+      maxBytes,
+    );
   },
 
   /**

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, statSync } from "fs";
+import { readFile as readFileAsync, stat as statAsync } from "fs/promises";
 import { getGlobalDispatcher, interceptors, request } from "undici";
 import {
   MultimodalLogger,
@@ -28,8 +29,10 @@ import type {
   TextGenerationOptions,
 } from "../types/index.js";
 import { tracers, ATTR, withSpan } from "../telemetry/index.js";
+import { NeuroLinkError } from "./errorHandling.js";
 import { FileDetector } from "./fileDetector.js";
 import { getImageCache } from "./imageCache.js";
+import { ImageProcessor } from "./imageProcessor.js";
 import { logger } from "./logger.js";
 import { PDFImageConverter, PDFProcessor } from "./pdfProcessor.js";
 import { urlDownloadRateLimiter } from "./rateLimiter.js";
@@ -1800,14 +1803,42 @@ function detectMimeTypeFromBuffer(buffer: Buffer): string | undefined {
 /**
  * Convert file path to raw base64 string.
  * Returns raw base64 (not a data: URI) to avoid SSRF validation in AI SDK v6.
+ * Uses async fs so a large/slow-filesystem image never blocks the event loop
+ * while the size guard (below) or the read itself is in flight.
  */
-function convertFilePathToBase64(filePath: string): string {
-  if (!existsSync(filePath)) {
-    throw new Error(`Image file not found: ${filePath}`);
+async function convertFilePathToBase64(filePath: string): Promise<string> {
+  let stats;
+  try {
+    stats = await statAsync(filePath);
+  } catch (error) {
+    // Only ENOENT means "not found" — EACCES/ELOOP/etc. are real access or
+    // filesystem problems that must not be misreported as a missing file.
+    const code =
+      error instanceof Error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined;
+    if (code === "ENOENT") {
+      throw new Error(`Image file not found: ${filePath}`, { cause: error });
+    }
+    throw new Error(
+      `Cannot access image file ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Image path is not a file: ${filePath}`);
   }
 
-  const buffer = readFileSync(filePath);
-  return buffer.toString("base64");
+  // #257: check the file size via stat BEFORE reading it into memory, so a
+  // huge image path never triggers an unbounded read + base64 allocation.
+  // Delegates to ImageProcessor's shared guard (no local reimplementation).
+  const context = `image file "${filePath}"`;
+  ImageProcessor.validateSize(stats.size, context);
+  const buffer = await readFileAsync(filePath);
+  // TOCTOU: the file can grow, or a symlink can be swapped, between the stat
+  // above and this read completing. Re-validate the bytes actually read
+  // (not just the pre-read stat) before the base64 allocation.
+  return ImageProcessor.safeBase64Convert(buffer, context);
 }
 
 /**
@@ -1819,10 +1850,10 @@ function convertFilePathToBase64(filePath: string): string {
  * Passing raw base64 avoids this because `new URL(base64string)` throws and
  * the SDK treats the string as inline base64 data instead.
  */
-function processImageToBase64(
+async function processImageToBase64(
   image: Buffer | string,
   index: number,
-): { imageData: string; mimeType: string } {
+): Promise<{ imageData: string; mimeType: string }> {
   let imageData: string;
   let mimeType = "image/jpeg"; // Default mime type
 
@@ -1855,13 +1886,18 @@ function processImageToBase64(
     } else {
       // File path string - convert to raw base64
       try {
-        imageData = convertFilePathToBase64(image);
+        imageData = await convertFilePathToBase64(image);
         mimeType = getMimeTypeFromExtension(image);
       } catch (error) {
         MultimodalLogger.logError("FILE_PATH_CONVERSION", error as Error, {
           index,
           filePath: image,
         });
+        // Preserve typed errors (e.g. IMAGE_TOO_LARGE) as-is — don't flatten
+        // them into a generic Error and lose the error `code` for callers.
+        if (error instanceof NeuroLinkError) {
+          throw error;
+        }
         throw new Error(
           `Failed to convert file path to base64: ${image}. ${error}`,
           { cause: error },
@@ -1874,6 +1910,9 @@ function processImageToBase64(
     if (detectedMimeType) {
       mimeType = detectedMimeType;
     }
+    // #257: guard the buffer size before the unbounded base64 conversion.
+    // Delegates to ImageProcessor's shared guard (no local reimplementation).
+    ImageProcessor.validateBufferSize(image, `image input at index ${index}`);
     imageData = image.toString("base64");
   }
 
@@ -1957,11 +1996,13 @@ async function convertSimpleImagesToProviderFormat(
     { type: "text", text: enhancedText },
   ];
 
-  // Process all images (including downloaded URLs) for Vercel AI SDK
-  actualImages.forEach(({ data: image }, index) => {
+  // Process all images (including downloaded URLs) for Vercel AI SDK.
+  // Sequential for...of (not Promise.all) to preserve image ordering and
+  // keep the original forEach's one-at-a-time error semantics.
+  for (const [index, { data: image }] of actualImages.entries()) {
     try {
       // Use helper function to process image and reduce nesting depth
-      const { imageData, mimeType } = processImageToBase64(image, index);
+      const { imageData, mimeType } = await processImageToBase64(image, index);
 
       content.push({
         type: "image" as const,
@@ -1975,7 +2016,7 @@ async function convertSimpleImagesToProviderFormat(
       });
       throw error;
     }
-  });
+  }
 
   return content;
 }

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -35,10 +35,14 @@ import type { CSVLoaderOptions } from "../src/lib/types/index.js";
 import iconv from "iconv-lite";
 import { Readable, Transform } from "node:stream";
 import { PDFProcessor } from "../src/lib/utils/pdfProcessor.js";
+import { SIZE_LIMITS_BYTES } from "../src/lib/processors/config/sizeLimits.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
 import { isMultimodalInput } from "../src/lib/types/index.js";
 import { FileDetector } from "../src/lib/utils/fileDetector.js";
+import { ImageProcessor, imageUtils } from "../src/lib/utils/imageProcessor.js";
+import { ERROR_CODES } from "../src/lib/utils/errorHandling.js";
 import {
+  chmodSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -4789,6 +4793,266 @@ exit 127
       }
     },
   },
+  // ---------- #257: image buffer size guard (memory exhaustion) ----------
+  {
+    name: "FileDetector #257: oversized image rejected before base64; at-limit passes",
+    category: "image-processor",
+    fn: async () => {
+      const IMAGE_MAX = SIZE_LIMITS_BYTES.IMAGE_MAX;
+      const pngHeader = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+      const mk = (size: number): Buffer => {
+        const b = Buffer.alloc(size);
+        pngHeader.forEach((byte, i) => (b[i] = byte));
+        return b;
+      };
+      // 11 MB image (the files→FileDetector→ImageProcessor path) must throw a
+      // descriptive size error instead of an unbounded base64 allocation.
+      let rejected = false;
+      try {
+        await FileDetector.detectAndProcess(mk(IMAGE_MAX + 1024 * 1024), {
+          allowedTypes: ["image", "unknown"],
+        });
+      } catch (e) {
+        rejected =
+          e instanceof Error && /too large|exceeds|limit/i.test(e.message);
+      }
+      if (!rejected) {
+        return false;
+      }
+      // An image exactly at the limit must still succeed (no false rejection).
+      const ok = await FileDetector.detectAndProcess(mk(IMAGE_MAX), {
+        allowedTypes: ["image", "unknown"],
+      });
+      return ok.type === "image";
+    },
+  },
+  {
+    name: "buildMultimodalMessagesArray #257: oversized image Buffer rejected (images path)",
+    category: "message-builder",
+    fn: async () => {
+      // The generate({ images: [...] }) path — distinct from files→FileDetector.
+      const oversized = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX + 1024 * 1024);
+      // Full 8-byte PNG signature so MIME detection succeeds
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(
+        oversized,
+      );
+      try {
+        await buildMultimodalMessagesArray(
+          {
+            input: { text: "hi", images: [oversized] },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai",
+          "gpt-4o",
+        );
+        return false; // should have thrown
+      } catch (e) {
+        return e instanceof Error && /too large|exceeds|limit/i.test(e.message);
+      }
+    },
+  },
+  // ---------- #257 round 2: NaN/negative size rejection, typed-error preservation ----------
+  {
+    name: "ImageProcessor.validateSize rejects NaN/Infinity/negative sizes with typed INVALID_IMAGE_SIZE (fail closed)",
+    category: "image-processor",
+    fn: async () => {
+      // NaN > maxSize and -1 > maxSize both evaluate to false, so a naive
+      // comparison-only guard silently lets malformed sizes through.
+      for (const size of [NaN, Infinity, -Infinity, -1]) {
+        try {
+          ImageProcessor.validateSize(size, "test");
+          return false; // must throw for every malformed size
+        } catch (e) {
+          if (
+            !(e instanceof NeuroLinkError) ||
+            e.code !== ERROR_CODES.INVALID_IMAGE_SIZE
+          ) {
+            return false;
+          }
+        }
+      }
+      // A valid in-range size must not throw.
+      try {
+        ImageProcessor.validateSize(1024, "test");
+      } catch {
+        return false;
+      }
+      // A valid but oversized number must still hit the pre-existing
+      // IMAGE_TOO_LARGE guard, not the new malformed-size guard.
+      try {
+        ImageProcessor.validateSize(SIZE_LIMITS_BYTES.IMAGE_MAX + 1, "test");
+        return false;
+      } catch (e) {
+        return (
+          e instanceof NeuroLinkError && e.code === ERROR_CODES.IMAGE_TOO_LARGE
+        );
+      }
+    },
+  },
+  {
+    name: "ImageProcessor.validateSize rejects malformed maxSize (NaN/Infinity/negative) instead of silently letting size through (fail closed)",
+    category: "image-processor",
+    fn: async () => {
+      // `size > NaN` and `size > -1` both evaluate to false, so a malformed
+      // maxSize previously bypassed the guard entirely — any size, however
+      // large, would compare as "not over the limit".
+      for (const maxSize of [NaN, Infinity, -1, -Infinity]) {
+        try {
+          ImageProcessor.validateSize(1024, "test", maxSize);
+          return false; // must throw for every malformed maxSize
+        } catch (e) {
+          if (
+            !(e instanceof NeuroLinkError) ||
+            e.code !== ERROR_CODES.INVALID_CONFIGURATION
+          ) {
+            return false;
+          }
+        }
+      }
+      // A valid maxSize must still behave exactly as before: in-range passes,
+      // over-range throws IMAGE_TOO_LARGE.
+      try {
+        ImageProcessor.validateSize(1024, "test", 2048);
+      } catch {
+        return false;
+      }
+      try {
+        ImageProcessor.validateSize(4096, "test", 2048);
+        return false;
+      } catch (e) {
+        return (
+          e instanceof NeuroLinkError && e.code === ERROR_CODES.IMAGE_TOO_LARGE
+        );
+      }
+    },
+  },
+  {
+    name: "ImageProcessor provider wrappers preserve typed IMAGE_TOO_LARGE error through every catch (not flattened to plain Error)",
+    category: "image-processor",
+    fn: async () => {
+      const oversized = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX + 1024);
+      const throwsTyped = (thrower: () => unknown): boolean => {
+        try {
+          thrower();
+          return false;
+        } catch (e) {
+          return (
+            e instanceof NeuroLinkError &&
+            e.code === ERROR_CODES.IMAGE_TOO_LARGE
+          );
+        }
+      };
+      return (
+        throwsTyped(() => ImageProcessor.processImageForOpenAI(oversized)) &&
+        throwsTyped(() => ImageProcessor.processImageForGoogle(oversized)) &&
+        throwsTyped(() => ImageProcessor.processImageForAnthropic(oversized)) &&
+        // Routes through processImageForGoogle, exercising its own
+        // enclosing catch on top of the one already exercised above.
+        throwsTyped(() =>
+          ImageProcessor.processImageForVertex(oversized, "gemini-pro"),
+        ) &&
+        // Default branch of processImage() — exercises the outermost catch.
+        throwsTyped(() =>
+          ImageProcessor.processImage(oversized, "some-other-provider"),
+        )
+      );
+    },
+  },
+  {
+    name: "ImageProcessor.safeBase64Convert revalidates actual buffer bytes independent of any prior size claim (TOCTOU guard)",
+    category: "image-processor",
+    fn: async () => {
+      // convertFilePathToBase64 must not trust the pre-read fs.stat size
+      // alone (a file can grow, or a symlink can be swapped, between stat
+      // and read) — it now re-runs this exact guard against the bytes
+      // actually read. Prove the guard is a real, independent check on the
+      // buffer itself, not a rubber stamp on a caller-supplied number.
+      const actuallyOversized = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX + 1);
+      try {
+        ImageProcessor.safeBase64Convert(actuallyOversized, "toctou-recheck");
+        return false;
+      } catch (e) {
+        return (
+          e instanceof NeuroLinkError && e.code === ERROR_CODES.IMAGE_TOO_LARGE
+        );
+      }
+    },
+  },
+  {
+    name: "imageUtils.bufferToBase64: default stays guarded at 10MB; explicit maxBytes override is opt-in (no silent break for internal callers)",
+    category: "image-processor",
+    fn: async () => {
+      const oversized = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX + 1024);
+      let defaultThrew = false;
+      try {
+        imageUtils.bufferToBase64(oversized);
+      } catch (e) {
+        defaultThrew =
+          e instanceof NeuroLinkError && e.code === ERROR_CODES.IMAGE_TOO_LARGE;
+      }
+      if (!defaultThrew) {
+        return false;
+      }
+      // A caller with a legitimate need for a higher ceiling can opt in
+      // explicitly instead of being silently capped.
+      const base64 = imageUtils.bufferToBase64(
+        oversized,
+        SIZE_LIMITS_BYTES.IMAGE_MAX * 2,
+      );
+      return typeof base64 === "string" && base64.length > 0;
+    },
+  },
+  {
+    name: "convertFilePathToBase64 (via buildMultimodalMessagesArray): oversized file path rejected pre-read; at-limit file path succeeds",
+    category: "message-builder",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-img-file-"));
+      const pngHeader = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+      try {
+        // Oversized file path — must be rejected by the stat-based guard
+        // BEFORE the file is read into memory, with the typed error intact.
+        const bigPath = pathJoin(dir, "big.png");
+        const big = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX + 1024 * 1024);
+        pngHeader.copy(big);
+        writeFileSync(bigPath, big);
+        try {
+          await buildMultimodalMessagesArray(
+            {
+              input: { text: "hi", images: [bigPath] },
+            } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+            "openai",
+            "gpt-4o",
+          );
+          return false; // should have thrown
+        } catch (e) {
+          if (
+            !(e instanceof NeuroLinkError) ||
+            e.code !== ERROR_CODES.IMAGE_TOO_LARGE
+          ) {
+            return false;
+          }
+        }
+
+        // At-limit file path must still succeed (no false rejection from
+        // the new post-read revalidation).
+        const okPath = pathJoin(dir, "ok.png");
+        const ok = Buffer.alloc(SIZE_LIMITS_BYTES.IMAGE_MAX);
+        pngHeader.copy(ok);
+        writeFileSync(okPath, ok);
+        const messages = await buildMultimodalMessagesArray(
+          {
+            input: { text: "hi", images: [okPath] },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai",
+          "gpt-4o",
+        );
+        return Array.isArray(messages) && messages.length > 0;
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
   // ---------- round-3 review: skipLines must reach csv-parser itself, not just the manual data-event counter ----------
   {
     name: "CSVProcessor.parseCSVFile: skipLines is passed to csv-parser so the sep= line never becomes the header",
@@ -4901,6 +5165,81 @@ exit 127
           fileRows[1].amount === "200"
         );
       } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "convertFilePathToBase64: ENOENT reports 'not found', EACCES/other stat errors are NOT misreported as 'not found'",
+    category: "message-builder",
+    fn: async () => {
+      // Permission bits are meaningless for root — chmod 000 does not deny
+      // access, so the EACCES half of this test cannot run under root. The
+      // ENOENT half is platform-independent and must still run under root,
+      // so this only skips the EACCES assertion below, not the whole test.
+      const isRoot =
+        typeof process.getuid === "function" && process.getuid() === 0;
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-img-access-"));
+      const filePath = pathJoin(dir, "photo.png");
+      try {
+        writeFileSync(
+          filePath,
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        );
+
+        // ENOENT: a path that genuinely does not exist.
+        let enoentMessage = "";
+        try {
+          await buildMultimodalMessagesArray(
+            {
+              input: {
+                text: "hi",
+                images: [pathJoin(dir, "does-not-exist.png")],
+              },
+            } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+            "openai",
+            "gpt-4o",
+          );
+          return false;
+        } catch (e) {
+          enoentMessage = e instanceof Error ? e.message : String(e);
+        }
+        if (!/not found/i.test(enoentMessage)) {
+          return false;
+        }
+        if (isRoot) {
+          return null;
+        }
+
+        // EACCES: stat() itself fails (no execute permission to traverse
+        // into `dir`) — a real access error, not a missing file. The old
+        // `statAsync(...).catch(() => null)` regressed this to "not found".
+        chmodSync(dir, 0o000);
+        let eaccesMessage = "";
+        try {
+          await buildMultimodalMessagesArray(
+            {
+              input: { text: "hi", images: [filePath] },
+            } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+            "openai",
+            "gpt-4o",
+          );
+          return false;
+        } catch (e) {
+          eaccesMessage = e instanceof Error ? e.message : String(e);
+        } finally {
+          chmodSync(dir, 0o700); // restore so cleanup can remove the dir
+        }
+        return (
+          !/not found/i.test(eaccesMessage) &&
+          /cannot access/i.test(eaccesMessage)
+        );
+      } finally {
+        try {
+          chmodSync(dir, 0o700);
+        } catch {
+          /* already restored */
+        }
         rmSync(dir, { recursive: true, force: true });
       }
     },


### PR DESCRIPTION
## What & why

Fixes #257 (IMG-001) — **memory exhaustion on large images**. Several `Buffer.toString("base64")` sites converted caller-supplied image buffers with **no size check**, so a large image could exhaust process memory (base64 allocates ~1.33× the buffer).

## Fix

`ImageProcessor` gains two helpers:
- `validateBufferSize(buffer, context, maxSize?)` — throws a descriptive error above the limit.
- `safeBase64Convert(buffer, context, maxSize?)` — validates, then converts.

Default limit is the canonical `SIZE_LIMITS_BYTES.IMAGE_MAX` (**10 MB**), overridable via `maxSize`. The **6 previously-unguarded sites** now route through it: `process()`, the OpenAI/Google/Anthropic Buffer branches, the `processImage()` default case, and `imageUtils.bufferToBase64`. (`fileToBase64DataUri` / `urlToBase64DataUri` were already guarded — left as-is.)

## Enhancement gap → closed

The **sibling** `generate({ images })` path (`messageBuilder`, hit by the CLI `--image` flag) had the *identical* unguarded conversion — fixing only `imageProcessor` would leave it exploitable. So:
- `convertFilePathToBase64` now **stats the file size before reading it into memory**.
- the Buffer branch of `processImageToBase64` guards before converting.

Both entry points a user hits are now covered.

## Docs gap → closed

`docs/features/file-processors.md`'s "File Size Limits" table claimed **Images: 20 MB** and showed a `ProcessorConfig.setLimits({...})` snippet **that doesn't exist in the codebase**. Corrected to the real enforced **10 MB** and replaced the fictional API with an accurate description of the enforcement + override.

## Testing / proof

New bugfixes-suite tests (deterministic, no API keys):
- `FileDetector.detectAndProcess(<11 MB image>)` throws a size error; an image **exactly at 10 MB still succeeds** (no false rejection).
- `buildMultimodalMessagesArray({ images: [<11 MB Buffer>] })` throws — covering the sibling `images` path.

`pnpm run check` ✅ (0 errors) · `pnpm run lint` ✅ (0 errors) · `pnpm run build` ✅ · `prettier --check` ✅.

## Risk
Low — the guard only rejects previously-uncaught oversized buffers (a hard crash today) with a clean error; in-range images behave identically. `maxSize` remains an escape hatch for hi-res power users. No new constant (reuses `SIZE_LIMITS_BYTES.IMAGE_MAX`).

Fixes #257.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enforced a fixed 10 MB image limit across file, buffer, URL, and image inputs.
  - Added validation for malformed image-size values with a dedicated, non-retriable error.
- **Bug Fixes**
  - Oversized images now fail fast with descriptive errors before base64 conversion/allocation.
  - Preserved image ordering during multi-image conversions by processing sequentially.
  - Improved error classification for missing files vs other filesystem issues, while keeping typed errors intact.
- **Documentation**
  - Updated image size-limit guidance to reflect the fixed 10 MB behavior.
- **Tests**
  - Expanded regression coverage for image-size enforcement, TOCTOU revalidation, and error-path correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->