### PR TITLE
fix(cli): validate file inputs + wire multimodal flags into batch (#288, #291)

### DIFF
--- a/docs/features/multimodal.md
+++ b/docs/features/multimodal.md
@@ -424,6 +424,25 @@ for await (const chunk of stream) {
 }
 ```
 
+### Batch with Multimodal (CLI)
+
+The `batch` command supports `--image`, `--csv`, `--pdf`, and `--video`. The file(s) are attached **identically to every prompt** in the batch (a one-line notice is printed to **stderr**, unconditionally — it is not suppressed by `--quiet`, so it never corrupts `--format json` output written to stdout):
+
+```bash
+neurolink batch questions.txt --csv sales.csv --format json
+```
+
+> `--file` (auto-detect) is **not** available in `batch`, because it collides with the `<file>` positional (the prompts-list path). Use the explicit `--image` / `--csv` / `--pdf` / `--video` flags instead.
+
+### File validation & troubleshooting (CLI)
+
+Before any provider call, the CLI validates local file inputs across `generate`, `stream`, and `batch`:
+
+- A path that points at a **directory**, doesn't exist, or can't be read (e.g. a permissions error) is rejected up front with a clear error and troubleshooting hints — no cryptic `EISDIR`/`EACCES` deep in processing. This also applies to the `batch` `<file>` prompts-list positional itself.
+- A **large** file (images > 10 MB, CSV/PDF > 50 MB) prints a non-blocking warning to **stderr**. Like the batch attachment notice, this is unconditional — visible without `--debug` and regardless of `--quiet` — and never mixes into stdout, so `--format json` output stays valid JSON even when large-file warnings fire.
+
+This runs even under `--dry-run` and without API keys configured.
+
 ---
 
 ## Configuration & Fine-tuning

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -50,6 +50,7 @@ import { resolveFilePaths } from "../utils/pathResolver.js";
 import {
   validateCliInputFiles,
   validateCsvMaxRows,
+  validatePromptsFilePath,
 } from "../utils/inputValidation.js";
 import { animatedWrite } from "../utils/typewriter.js";
 import { createStreamAbortHandler } from "../utils/abortHandler.js";
@@ -845,12 +846,31 @@ export class CLICommandFactory {
     },
   };
 
-  // Helper method to build options for commands
-  private static buildOptions(yargs: Argv, additionalOptions = {}) {
+  // Helper method to build options for commands. `excludeOptions` drops
+  // common flags from registration entirely (not just from validation) —
+  // #1191 round-5: batch uses this to omit `commonOptions.file` so `--file`
+  // isn't a recognized flag at all, since it would collide with the
+  // `<file>` positional (the prompts list).
+  private static buildOptions(
+    yargs: Argv,
+    additionalOptions = {},
+    excludeOptions: Array<keyof typeof CLICommandFactory.commonOptions> = [],
+  ) {
+    const baseOptions =
+      excludeOptions.length === 0
+        ? CLICommandFactory.commonOptions
+        : (Object.fromEntries(
+            Object.entries(CLICommandFactory.commonOptions).filter(
+              ([key]) =>
+                !excludeOptions.includes(
+                  key as keyof typeof CLICommandFactory.commonOptions,
+                ),
+            ),
+          ) as typeof CLICommandFactory.commonOptions);
     return (
       yargs
         .options({
-          ...CLICommandFactory.commonOptions,
+          ...baseOptions,
           ...additionalOptions,
         })
         // NEW9: implies relationships so users who pass --stt-provider or
@@ -2003,12 +2023,20 @@ export class CLICommandFactory {
    */
   static createBatchCommand(): CommandModule {
     return {
-      command: "batch <file>",
+      // #1191 round-5: the positional is named `promptsFile`, not `file` —
+      // yargs implicitly accepts `--<positionalName>` as a flag alias for
+      // any positional regardless of whether it's separately registered via
+      // `.options()`, so a positional literally named `file` would let
+      // `--file` silently pass strictOptions() even after removing
+      // `commonOptions.file` below. Renaming the key (invocation syntax is
+      // unaffected — it's still just `neurolink batch prompts.txt`) is what
+      // actually makes `--file` an unknown argument.
+      command: "batch <promptsFile>",
       describe: "Process multiple prompts from a file",
       builder: (yargs) => {
         return CLICommandFactory.buildOptions(
           yargs
-            .positional("file", {
+            .positional("promptsFile", {
               type: "string" as const,
               description: "File with prompts (one per line)",
               demandOption: true,
@@ -2026,6 +2054,11 @@ export class CLICommandFactory {
               "$0 batch batch.txt --output results.json",
               "Save results to file",
             ),
+          {},
+          // `--file` is not a batch flag — the positional above is the
+          // prompts-list path. Omit it from registration so it's rejected
+          // as unknown rather than silently accepted then ignored.
+          ["file"],
         );
       },
       handler: async (argv) =>
@@ -4616,15 +4649,41 @@ export class CLICommandFactory {
     const spinner = options.quiet ? null : ora().start();
 
     try {
-      if (!argv.file) {
+      if (!argv.promptsFile) {
         throw new Error("No file specified");
       }
 
-      if (!fs.existsSync(argv.file)) {
-        throw new Error(`File not found: ${argv.file}`);
-      }
+      // #291/round-4 #1191: validate multimodal flags and resolve their
+      // paths *before* the prompts file is read/parsed below, mirroring
+      // generate/stream (which validate all inputs before any processing).
+      // Previously this ran after `fs.readFileSync(resolvedPromptsPath)`,
+      // so a large prompts file paired with an invalid --image path paid
+      // the read/parse cost before the flag error ever surfaced. `--file`
+      // (the common auto-detect flag) isn't registered on batch at all —
+      // see createBatchCommand — so `argv.file` can never be set here; no
+      // exclusion needed to protect the (differently-named) positional.
+      validateCliInputFiles(argv as unknown as Record<string, unknown>);
+      const batchImages = CLICommandFactory.processCliImages(
+        argv.image as string | string[] | undefined,
+      );
+      const batchCsvFiles = CLICommandFactory.processCliCSVFiles(
+        argv.csv as string | string[] | undefined,
+      );
+      const batchPdfFiles = CLICommandFactory.processCliPDFFiles(
+        argv.pdf as string | string[] | undefined,
+      );
+      const batchVideoFiles = CLICommandFactory.processCliVideoFiles(
+        argv.video as string | string[] | undefined,
+      );
 
-      const buffer = fs.readFileSync(argv.file);
+      // #291: route the prompts-list positional through the same friendly
+      // aggregated-error path as the multimodal flags above (not found /
+      // unreadable / directory / malformed file:// URL), instead of a raw
+      // existsSync+readFileSync that throws an unfriendly EISDIR when
+      // pointed at a directory.
+      const resolvedPromptsPath = validatePromptsFilePath(argv.promptsFile);
+
+      const buffer = fs.readFileSync(resolvedPromptsPath);
       const prompts = buffer
         .toString("utf8")
         .split("\n")
@@ -4680,6 +4739,26 @@ export class CLICommandFactory {
       const enhancedOptions = { ...options, ...sessionVariables };
       const sessionId = globalSession.getCurrentSessionId();
 
+      // batchImages/batchCsvFiles/batchPdfFiles/batchVideoFiles were already
+      // validated and resolved above, before the prompts file was read.
+      if (
+        batchImages?.length ||
+        batchCsvFiles?.length ||
+        batchPdfFiles?.length ||
+        batchVideoFiles?.length
+      ) {
+        // Pause the spinner so the notice isn't swallowed by its re-renders.
+        // Safety-relevant, so always visible (not gated behind --quiet) and
+        // written to stderr so `--format json` output on stdout stays parseable.
+        spinner?.stop();
+        logger.alwaysStderr(
+          chalk.yellow(
+            "⚠️  Multimodal files (--image/--csv/--pdf/--video) are attached to ALL prompts in this batch.",
+          ),
+        );
+        spinner?.start();
+      }
+
       for (let i = 0; i < prompts.length; i++) {
         if (spinner) {
           spinner.text = `Processing ${i + 1}/${prompts.length}: ${prompts[i].substring(0, 30)}...`;
@@ -4729,7 +4808,37 @@ export class CLICommandFactory {
 
           const runBatchGenerate = () =>
             sdk.generate({
-              input: { text: inputText },
+              input: {
+                text: inputText,
+                ...(batchImages?.length && { images: batchImages }),
+                ...(batchCsvFiles?.length && { csvFiles: batchCsvFiles }),
+                ...(batchPdfFiles?.length && { pdfFiles: batchPdfFiles }),
+                ...(batchVideoFiles?.length && {
+                  videoFiles: batchVideoFiles,
+                }),
+              },
+              // Only construct these when the corresponding files are
+              // actually attached — batch has no CSV/video mode to opt into,
+              // unlike generate/stream, so an empty options object here is
+              // pure noise on every prompt of every batch run.
+              ...(batchCsvFiles?.length && {
+                csvOptions: {
+                  maxRows: argv.csvMaxRows as number | undefined,
+                  formatStyle: argv.csvFormat as
+                    | "raw"
+                    | "markdown"
+                    | "json"
+                    | undefined,
+                },
+              }),
+              ...(batchVideoFiles?.length && {
+                videoOptions: {
+                  frames: argv.videoFrames as number | undefined,
+                  quality: argv.videoQuality as number | undefined,
+                  format: argv.videoFormat as "jpeg" | "png" | undefined,
+                  transcribeAudio: argv.transcribeAudio as boolean | undefined,
+                },
+              }),
               provider: enhancedOptions.provider,
               model: enhancedOptions.model,
               temperature: enhancedOptions.temperature,

--- a/src/cli/utils/inputValidation.ts
+++ b/src/cli/utils/inputValidation.ts
@@ -1,18 +1,22 @@
 /**
  * CLI Input Validation Utilities
  *
- * Validates multimodal file flags (--image/--csv/--pdf/--video/--file) and
- * --csv-max-rows before a generate/stream/batch run starts, so bad input
- * fails fast with a clear message instead of surfacing deep inside provider
- * calls. Exported as standalone functions (rather than private statics on
- * CLICommandFactory) so callers — including tests — can import and invoke
- * them directly, without reaching into the class via an `unknown` cast.
+ * Validates multimodal file flags (--image/--csv/--pdf/--video/--file), the
+ * batch `<promptsFile>` positional, and --csv-max-rows before a
+ * generate/stream/batch run starts, so bad input fails fast with a clear
+ * message instead of surfacing deep inside provider calls. Exported as
+ * standalone functions (rather than private statics on CLICommandFactory)
+ * so callers — including tests — can import and invoke them directly,
+ * without reaching into the class via an `unknown` cast.
  */
 
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { logger } from "../../lib/utils/logger.js";
-import { resolveFilePaths } from "./pathResolver.js";
+import { redactUrlForError } from "../../lib/utils/logSanitize.js";
+import type { CliValidatedFileOption } from "../../lib/types/index.js";
+import { resolveFilePath } from "./pathResolver.js";
 
 /**
  * Soft (warn-only) size thresholds for CLI multimodal flags. Intentionally
@@ -29,25 +33,157 @@ export const CLI_SOFT_LIMITS_MB = {
   VIDEO_MAX_MB: 500,
 } as const;
 
+// `file://` is intentionally excluded here: it addresses a local path, so it
+// must still go through directory/missing-path validation below (via
+// tryResolveFileUrl in validateSingleLocalPath). Only genuine remote/inline
+// references (http(s), data URIs) skip validation entirely (#319).
 function isNonLocalFileReference(filePath: string): boolean {
   const lower = filePath.toLowerCase();
   return (
     lower.startsWith("http://") ||
     lower.startsWith("https://") ||
-    lower.startsWith("file://") ||
     lower.startsWith("data:")
   );
 }
 
+// #291: a `file://` URL still points at something on disk, so validation
+// needs the real filesystem path. Returns undefined (instead of throwing)
+// for a malformed URL so the caller can report a friendly error.
+function tryResolveFileUrl(filePath: string): string | undefined {
+  if (!filePath.toLowerCase().startsWith("file://")) {
+    return filePath;
+  }
+  try {
+    return fileURLToPath(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Shared aggregated-error format for any invalid local file path (missing,
+ * unreadable, a directory, or a malformed `file://` URL). Used by both the
+ * flag-based loop in `validateCliInputFiles` and the batch `<promptsFile>`
+ * positional check in `validatePromptsFilePath`, so every caller gets the
+ * same clear error + troubleshooting hints instead of a raw exception.
+ */
+function buildInvalidFileError(errors: string[]): Error {
+  return new Error(
+    "❌ One or more input files are invalid:\n" +
+      `${errors.join("\n")}\n` +
+      "💡 Troubleshooting:\n" +
+      "  • Check the path is correct and relative to your current directory, or pass an absolute path / URL.\n" +
+      `  • Check your working directory (${process.cwd()}).\n` +
+      "  • For remote resources, prefix the value with http:// or https://.\n" +
+      "  • If you pointed at a folder, point at the file inside it instead.",
+  );
+}
+
+/**
+ * Validate a single raw path/URL value for `option`, pushing a friendly
+ * message onto `errors` instead of letting fs calls throw a raw exception
+ * (ENOENT, EACCES/EPERM TOCTOU, a directory, or a malformed `file://` URL).
+ * Returns the resolved local filesystem path on success (or the original
+ * value unchanged for a skipped http(s)/data: reference), and `undefined`
+ * when an error was pushed.
+ *
+ * `rawPath` is redacted via `redactUrlForError` before ever being
+ * interpolated into a message — a `file://` value can carry a sensitive
+ * query string, fragment, or embedded `user:pass@` credentials that must
+ * never be echoed back verbatim. This is a no-op for ordinary filesystem
+ * paths (they aren't parseable as a URL, so the redaction fallback simply
+ * returns them unchanged).
+ */
+function validateSingleLocalPath(
+  option: string,
+  rawPath: string,
+  errors: string[],
+  warnAtMB?: number,
+): string | undefined {
+  const resolvedPath = resolveFilePath(rawPath);
+  if (isNonLocalFileReference(resolvedPath)) {
+    // URLs / data: refs skip both existence and size checks (#319).
+    return resolvedPath;
+  }
+
+  const safeRawPath = redactUrlForError(rawPath);
+
+  // #291: `file://` URLs are local paths in disguise — validate the decoded
+  // filesystem path so a directory or missing path is still caught here
+  // instead of failing cryptically deep in processing.
+  const pathToValidate = tryResolveFileUrl(resolvedPath);
+  if (pathToValidate === undefined) {
+    errors.push(`${option} is not a valid file:// URL: ${safeRawPath}`);
+    return undefined;
+  }
+
+  const safeResolvedPath = redactUrlForError(pathToValidate);
+
+  // Single statSync covers existence, directory rejection, and the size
+  // warning below — avoids a second syscall and closes the TOCTOU gap a
+  // separate existsSync()+statSync() pair would leave.
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(pathToValidate);
+  } catch (err) {
+    // Only ENOENT actually means "not found" — EACCES (permission denied),
+    // ELOOP (symlink loop), ENOTDIR, etc. are real failures that get masked
+    // (and made undebuggable) if we blanket-label every statSync error the
+    // same way.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") {
+      errors.push(
+        `${option} path not found: ${safeRawPath} (resolved to ${safeResolvedPath})`,
+      );
+    } else {
+      const reason = err instanceof Error ? err.message : String(err);
+      errors.push(
+        `${option} path could not be accessed: ${safeRawPath} (resolved to ${safeResolvedPath}) — ` +
+          `${code ? `${code}: ` : ""}${reason}`,
+      );
+    }
+    return undefined;
+  }
+
+  // #288: reject a directory before it fails cryptically deep in processing
+  // (readFileSync on a dir throws a raw EISDIR).
+  if (stat.isDirectory()) {
+    errors.push(
+      `${option} path is a directory, not a file: ${safeRawPath} (resolved to ${safeResolvedPath})`,
+    );
+    return undefined;
+  }
+
+  // #319: warn (not error) when a local multimodal file is unusually large
+  // so the user isn't surprised by slow processing / token blowups. Safety-
+  // relevant, so always visible (not gated behind --quiet) and written to
+  // stderr — never stdout — so `--format json` output stays parseable.
+  if (warnAtMB !== undefined) {
+    const sizeMB = stat.size / (1024 * 1024);
+    if (sizeMB > warnAtMB) {
+      logger.alwaysStderr(
+        chalk.yellow(
+          `⚠️  ${option} file ${safeRawPath} is ${sizeMB.toFixed(1)}MB ` +
+            `(above the ${warnAtMB}MB soft limit) — processing may be slow ` +
+            `or exceed provider token/size limits.`,
+        ),
+      );
+    }
+  }
+
+  return pathToValidate;
+}
+
 /**
  * Validate --image/--csv/--pdf/--video/--file inputs before a CLI run
- * starts: every local path must exist, must not be a directory, and — for
- * the flags with a soft limit — triggers a size warning above the
- * threshold. URLs/data URIs skip both existence and size checks (#319).
+ * starts: every local path (including `file://` URLs) must exist, must not
+ * be a directory, and — for the flags with a soft limit — triggers a size
+ * warning above the threshold. Genuine http(s)/data: URLs skip both
+ * existence and size checks (#319).
  */
 export function validateCliInputFiles(argv: Record<string, unknown>): void {
   const fileArgs: Array<{
-    option: "--image" | "--csv" | "--pdf" | "--video" | "--file";
+    option: CliValidatedFileOption;
     value?: string | string[];
     warnAtMB?: number;
   }> = [
@@ -74,7 +210,7 @@ export function validateCliInputFiles(argv: Record<string, unknown>): void {
     { option: "--file", value: argv.file as string | string[] | undefined },
   ];
 
-  const missingPaths: string[] = [];
+  const errors: string[] = [];
 
   for (const { option, value, warnAtMB } of fileArgs) {
     if (!value) {
@@ -82,73 +218,35 @@ export function validateCliInputFiles(argv: Record<string, unknown>): void {
     }
 
     const rawPaths = Array.isArray(value) ? value : [value];
-    const resolvedPaths = resolveFilePaths(rawPaths);
-
-    for (let i = 0; i < resolvedPaths.length; i++) {
-      const resolvedPath = resolvedPaths[i];
-      // URLs / data: refs skip both existence and size checks (#319).
-      if (isNonLocalFileReference(resolvedPath)) {
-        continue;
-      }
-
-      // Single statSync covers existence, directory rejection, and the
-      // size warning below — avoids a second syscall and closes the
-      // TOCTOU gap a separate existsSync()+statSync() pair would leave.
-      let stat: fs.Stats;
-      try {
-        stat = fs.statSync(resolvedPath);
-      } catch (err) {
-        // Only ENOENT actually means "not found" — EACCES (permission
-        // denied), ELOOP (symlink loop), ENOTDIR, etc. are real failures
-        // that get masked (and made undebuggable) if we blanket-label
-        // every statSync error the same way.
-        const code = (err as NodeJS.ErrnoException)?.code;
-        if (code === "ENOENT") {
-          missingPaths.push(
-            `${option} path not found: ${rawPaths[i]} (resolved to ${resolvedPath})`,
-          );
-        } else {
-          const reason = err instanceof Error ? err.message : String(err);
-          missingPaths.push(
-            `${option} path could not be accessed: ${rawPaths[i]} (resolved to ${resolvedPath}) — ` +
-              `${code ? `${code}: ` : ""}${reason}`,
-          );
-        }
-        continue;
-      }
-
-      if (stat.isDirectory()) {
-        missingPaths.push(
-          `${option} path is a directory, not a file: ${rawPaths[i]} (resolved to ${resolvedPath})`,
-        );
-        continue;
-      }
-
-      // #319: warn (not error) when a local multimodal file is unusually
-      // large so the user isn't surprised by slow processing / token blowups.
-      if (warnAtMB !== undefined) {
-        const sizeMB = stat.size / (1024 * 1024);
-        if (sizeMB > warnAtMB) {
-          logger.always(
-            chalk.yellow(
-              `⚠️  ${option} file ${rawPaths[i]} is ${sizeMB.toFixed(1)}MB ` +
-                `(above the ${warnAtMB}MB soft limit) — processing may be slow ` +
-                `or exceed provider token/size limits.`,
-            ),
-          );
-        }
-      }
+    for (const rawPath of rawPaths) {
+      validateSingleLocalPath(option, rawPath, errors, warnAtMB);
     }
   }
 
-  if (missingPaths.length > 0) {
-    throw new Error(
-      "❌ One or more input files are invalid:\n" +
-        `${missingPaths.join("\n")}\n` +
-        "💡 Check the path is correct and relative to your current directory, " +
-        "or pass an absolute path / URL.",
-    );
+  if (errors.length > 0) {
+    throw buildInvalidFileError(errors);
   }
+}
+
+/**
+ * #291: validate the batch `<promptsFile>` positional through the same
+ * aggregated-error-friendly path as the multimodal flags above (not found /
+ * unreadable / directory / malformed `file://` URL), instead of a raw
+ * existsSync+readFileSync that throws an unfriendly EISDIR when pointed at
+ * a directory. The `<file>` label (rather than `--file`) keeps the message
+ * from being confused with the `--file` flag, which batch doesn't register
+ * at all (see `createBatchCommand`). Returns the resolved local path for
+ * the caller to read.
+ */
+export function validatePromptsFilePath(rawPath: string): string {
+  const errors: string[] = [];
+  const resolved = validateSingleLocalPath("<file>", rawPath, errors);
+  if (errors.length > 0) {
+    throw buildInvalidFileError(errors);
+  }
+  // `errors` is empty here, so `validateSingleLocalPath` did not return
+  // undefined.
+  return resolved as string;
 }
 
 /**

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -161,8 +161,13 @@ export type StreamCommandArgs = BaseCommandArgs &
 export type BatchCommandArgs = BaseCommandArgs &
   CliToolRoutingFlags &
   CliClassifierRouterFlags & {
-    /** Input file path */
-    file?: string;
+    // #1191 round-5: named `promptsFile`, not `file` — yargs implicitly
+    // treats a positional's key as a recognized flag name too, so keeping
+    // this "file" would let `--file` silently pass strictOptions() despite
+    // not being a registered batch option, colliding with the (unrelated)
+    // common `--file` auto-detect flag that batch intentionally omits.
+    /** Prompts-list file path (the `<promptsFile>` positional) */
+    promptsFile?: string;
     /** AI provider to use */
     provider?: string;
     /** Model name */
@@ -2002,3 +2007,18 @@ export type CliAudioPlayerCommand = {
   command: string;
   args: string[];
 };
+
+// =============================================================================
+// CLI INPUT VALIDATION (from cli/utils/inputValidation.ts)
+// =============================================================================
+
+/**
+ * The CLI flags validated by `validateCliInputFiles` before a
+ * generate/stream/batch run starts (--image/--csv/--pdf/--video/--file).
+ */
+export type CliValidatedFileOption =
+  | "--image"
+  | "--csv"
+  | "--pdf"
+  | "--video"
+  | "--file";

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -397,6 +397,20 @@ class NeuroLinkLogger {
   }
 
   /**
+   * Logs messages unconditionally using `console.error` (stderr).
+   *
+   * Same semantics as `always()` — bypasses log level checks and debug mode
+   * gating — but targets stderr instead of stdout. Use this for output that
+   * must stay visible (safety warnings, notices) without risking corruption
+   * of machine-readable stdout (e.g. `--format json`).
+   *
+   * @param args - The arguments to log. These are passed directly to `console.error`.
+   */
+  alwaysStderr(...args: unknown[]): void {
+    console.error(...args);
+  }
+
+  /**
    * Displays tabular data unconditionally using `console.table`.
    *
    * Similar to the `always` method, this bypasses log level checks and
@@ -499,6 +513,9 @@ export const logger = {
   },
   always: (...args: unknown[]) => {
     neuroLinkLogger.always(...args);
+  },
+  alwaysStderr: (...args: unknown[]) => {
+    neuroLinkLogger.alwaysStderr(...args);
   },
   table: (data: unknown) => {
     neuroLinkLogger.table(data);

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -43,6 +43,7 @@ import { ImageProcessor, imageUtils } from "../src/lib/utils/imageProcessor.js";
 import { ERROR_CODES } from "../src/lib/utils/errorHandling.js";
 import fs, {
   chmodSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -51,9 +52,59 @@ import fs, {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join as pathJoin, resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawn as spawnProcess } from "node:child_process";
 import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
 import http from "node:http";
 import AdmZip from "adm-zip";
+
+const CLI_DIST_PATH = pathJoin(process.cwd(), "dist", "cli", "index.js");
+
+/**
+ * Spawn the built CLI (dist/cli/index.js) and capture exit code + separate
+ * stdout/stderr (plus `out`, the combined stream, for tests that don't care
+ * which stream a message landed on). Used by the CLI-file-validation E2E
+ * tests (#288/#291) — requires a prior `pnpm run build`.
+ */
+function runCliBugfix(
+  args: string[],
+  timeoutMs = 60_000,
+): Promise<{
+  code: number | null;
+  out: string;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    if (!existsSync(CLI_DIST_PATH)) {
+      const message = `dist/cli/index.js not found at ${CLI_DIST_PATH} — run 'pnpm run build:cli' first`;
+      // Surface on stderr too so it's visible when the suite is run directly,
+      // not just via the unhandled-rejection exit path.
+      process.stderr.write(`${message}\n`);
+      reject(new Error(message));
+      return;
+    }
+    const child = spawnProcess(process.execPath, [CLI_DIST_PATH, ...args], {
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += String(d)));
+    child.stderr.on("data", (d) => (stderr += String(d)));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("CLI timed out"));
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, out: stdout + stderr, stdout, stderr });
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
 import { PptxProcessor } from "../src/lib/processors/document/PptxProcessor.js";
 import {
   validateCliInputFiles,
@@ -6725,6 +6776,376 @@ exit 127
         "utf-8",
       );
       return src.includes('"--file <path|url>"');
+    },
+  },
+  // ---------- #288: CLI rejects a directory as a file input (pre-flight) ----------
+  {
+    name: "CLI #288: --image pointing at a directory is rejected with troubleshooting",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-288-"));
+      try {
+        const res = await runCliBugfix([
+          "generate",
+          "hi",
+          "--image",
+          dir,
+          "--dry-run",
+          "--quiet",
+        ]);
+        // Was exit 0 (accepted) before the fix; now rejected pre-flight with a
+        // clear "directory" error + troubleshooting guidance.
+        return (
+          res.code !== 0 &&
+          /directory/i.test(res.out) &&
+          /troubleshoot/i.test(res.out)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- #291: batch recognizes/validates multimodal flags ----------
+  {
+    name: "CLI #291: batch now recognizes --csv (validates it; was silently ignored)",
+    category: "cli-file-validation",
+    fn: async () => {
+      const base = mkdtempSync(pathJoin(tmpdir(), "nl-291-"));
+      try {
+        const promptsFile = pathJoin(base, "prompts.txt");
+        writeFileSync(promptsFile, "What is the total?\nWhich is cheapest?\n");
+        // Before #291, batch ignored --csv entirely, so a bad path was silently
+        // dropped. Now batch validates it → a nonexistent --csv is reported
+        // with troubleshooting guidance (proves the flag is wired in).
+        const bad = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--csv",
+          pathJoin(base, "nope.csv"),
+          "--dry-run",
+        ]);
+        if (
+          !/--csv path not found/i.test(bad.out) ||
+          !/troubleshoot/i.test(bad.out)
+        ) {
+          return false;
+        }
+        // A valid --csv still completes the batch — one result per prompt.
+        // Parse stdout directly (no bracket-scanning): the multimodal attach
+        // notice is routed to stderr (see the dedicated regression test
+        // below), so stdout should be nothing but the JSON payload.
+        const csvFile = pathJoin(base, "data.csv");
+        writeFileSync(csvFile, "product,price\nApple,3\nPear,5\n");
+        const ok = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--csv",
+          csvFile,
+          "--dry-run",
+          "--format",
+          "json",
+        ]);
+        const arr = JSON.parse(ok.stdout.trim());
+        return Array.isArray(arr) && arr.length === 2;
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- stdout/stderr separation: warnings/notices must not corrupt --format json ----------
+  {
+    name: "CLI: batch --format json stdout stays valid JSON even though the multimodal attach notice fires (notice goes to stderr)",
+    category: "cli-file-validation",
+    fn: async () => {
+      const base = mkdtempSync(pathJoin(tmpdir(), "nl-json-safe-"));
+      try {
+        const promptsFile = pathJoin(base, "prompts.txt");
+        writeFileSync(promptsFile, "Q1?\nQ2?\nQ3?\n");
+        const csvFile = pathJoin(base, "data.csv");
+        writeFileSync(csvFile, "a,b\n1,2\n");
+
+        const res = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--csv",
+          csvFile,
+          "--dry-run",
+          "--format",
+          "json",
+        ]);
+
+        if (res.code !== 0) {
+          return false;
+        }
+        // The notice is safety-relevant, so it must fire even though `quiet`
+        // defaults to true — but on stderr, never mixed into stdout.
+        if (!/attached to all prompts/i.test(res.stderr)) {
+          return false;
+        }
+        if (/attached to all prompts/i.test(res.stdout)) {
+          return false;
+        }
+        const parsed = JSON.parse(res.stdout.trim());
+        return Array.isArray(parsed) && parsed.length === 3;
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- #288: statSync throwing after existsSync succeeds (TOCTOU) must not raw-crash ----------
+  {
+    name: "CLI #288: fs.statSync throwing after existsSync succeeds is caught and reported via the aggregated error, not a raw exception",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-288-stat-"));
+      const filePath = pathJoin(dir, "image.png");
+      writeFileSync(filePath, "fake-image-bytes");
+
+      const originalStatSync = fs.statSync;
+      // Simulate the TOCTOU race the review flagged: existsSync sees the
+      // file, but statSync then throws (permission denied, race, etc.).
+      fs.statSync = (() => {
+        const err = new Error("EACCES: permission denied, stat");
+        (err as NodeJS.ErrnoException).code = "EACCES";
+        throw err;
+      }) as unknown as typeof fs.statSync;
+
+      try {
+        validateCliInputFiles({ image: filePath });
+        return false; // should have thrown the aggregated error
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          return false;
+        }
+        // Adapted (post-#1202/#1191 consolidation onto inputValidation.ts's
+        // standalone validateCliInputFiles): the surviving implementation
+        // labels a non-ENOENT statSync failure "could not be accessed" (the
+        // wording proven by the pre-existing "CLI (review #1202 round 2):
+        // --image statSync EACCES ..." test above), not "cannot be read" —
+        // same underlying TOCTOU behavior, reconciled wording.
+        return (
+          /could not be accessed/i.test(error.message) &&
+          /EACCES/.test(error.message) &&
+          /troubleshoot/i.test(error.message)
+        );
+      } finally {
+        fs.statSync = originalStatSync;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- #291: batch <file> positional directory case uses the friendly error path ----------
+  {
+    name: "CLI #291: batch <file> positional pointing at a directory gets the friendly aggregated error, not a raw EISDIR",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-291-dir-"));
+      try {
+        const res = await runCliBugfix(["batch", dir, "--dry-run"]);
+        return (
+          res.code !== 0 &&
+          !/EISDIR/i.test(res.out) &&
+          /directory/i.test(res.out) &&
+          /troubleshoot/i.test(res.out) &&
+          // Must not misattribute the positional to the (nonexistent in
+          // batch) --file flag.
+          !/--file path/i.test(res.out)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- Round-4 (#1191): batch validates multimodal flags BEFORE
+  //            reading/parsing the prompts file, not after ----------
+  {
+    name: "CLI (review #1191 round 4): batch reports an invalid --image path before 'No prompts found', proving multimodal validation runs pre-flight",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-1191-preflight-"));
+      try {
+        // Empty prompts file: if multimodal validation ran AFTER the
+        // prompts file was read/parsed (the pre-fix ordering), batch would
+        // throw "No prompts found in file" here — the --image error would
+        // never surface. Fixed ordering must throw the --image error first.
+        const promptsFile = pathJoin(dir, "empty-prompts.txt");
+        writeFileSync(promptsFile, "");
+        const res = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--image",
+          pathJoin(dir, "nope.png"),
+          "--dry-run",
+        ]);
+        return (
+          res.code !== 0 &&
+          /--image path not found/i.test(res.out) &&
+          !/No prompts found/i.test(res.out)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- Round-2: `file://` URLs must not bypass local-path validation ----------
+  {
+    name: "CLI: --image file:// URL pointing at a directory is rejected (was silently skipped as 'non-local')",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-fileurl-dir-"));
+      try {
+        validateCliInputFiles({ image: pathToFileURL(dir).href });
+        return false; // should have thrown — directory, not a file
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          return false;
+        }
+        return (
+          /directory/i.test(error.message) &&
+          /troubleshoot/i.test(error.message)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "CLI: --image file:// URL pointing at a missing path is rejected (not found)",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-fileurl-missing-"));
+      const missing = pathJoin(dir, "nope.png");
+      try {
+        validateCliInputFiles({ image: pathToFileURL(missing).href });
+        return false; // should have thrown — path not found
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          return false;
+        }
+        return /path not found/i.test(error.message);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "CLI: --image file:// URL pointing at a real file passes validation; http(s) URLs remain skipped",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-fileurl-ok-"));
+      const filePath = pathJoin(dir, "image.png");
+      writeFileSync(filePath, "fake-image-bytes");
+      try {
+        // A valid file:// URL must not throw.
+        validateCliInputFiles({ image: pathToFileURL(filePath).href });
+        // A genuine remote URL to a nonexistent-looking path must still be
+        // skipped entirely (never touches the filesystem).
+        validateCliInputFiles({
+          image: "https://example.com/does/not/exist.png",
+        });
+        return true;
+      } catch {
+        return false;
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- Round-5 (#1191): rawPath must never leak query/fragment or
+  //            embedded credentials into a user-facing error ----------
+  {
+    name: "CLI (review #1191 round 5): a file:// path with a sensitive query string/fragment is redacted before it reaches the error message",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-1191-redact-"));
+      try {
+        const missing = pathJoin(dir, "nope.png");
+        const secretUrl = `${pathToFileURL(missing).href}?token=SECRET123#frag`;
+        validateCliInputFiles({ image: secretUrl });
+        return false; // should have thrown — path not found
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          return false;
+        }
+        return (
+          /path not found/i.test(error.message) &&
+          !error.message.includes("SECRET123") &&
+          !error.message.includes("frag") &&
+          !error.message.includes("?") &&
+          !error.message.includes("#")
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "CLI (review #1191 round 5): a file:// URL with embedded user:pass@ credentials is redacted in the 'not a valid file:// URL' error",
+    category: "cli-file-validation",
+    fn: async () => {
+      try {
+        // Malformed file:// URL (authority segment) — hits the "not a valid
+        // file:// URL" branch, which must still redact credentials/query
+        // before echoing the raw value back.
+        validateCliInputFiles({
+          image: "file://user:hunter2@host/nope.png?token=SECRET#frag",
+        });
+        return false; // should have thrown
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          return false;
+        }
+        return (
+          /not a valid file:\/\/ URL/i.test(error.message) &&
+          !error.message.includes("hunter2") &&
+          !error.message.includes("SECRET") &&
+          !error.message.includes("frag")
+        );
+      }
+    },
+  },
+  // ---------- Round-5 (#1191): batch must not accept --file at all — it
+  //            collides with the <promptsFile> positional ----------
+  {
+    name: "CLI (review #1191 round 5): batch rejects --file as an unknown argument (no collision with the <promptsFile> positional)",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-1191-batchflag-"));
+      try {
+        const promptsFile = pathJoin(dir, "prompts.txt");
+        writeFileSync(promptsFile, "hello\n");
+        const other = pathJoin(dir, "other.txt");
+        writeFileSync(other, "world\n");
+        const res = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--file",
+          other,
+          "--dry-run",
+        ]);
+        return res.code !== 0 && /unknown argument.*file/i.test(res.out.trim());
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "CLI (review #1191 round 5): batch still works normally via the <promptsFile> positional after the --file exclusion",
+    category: "cli-file-validation",
+    fn: async () => {
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-1191-batchok-"));
+      try {
+        const promptsFile = pathJoin(dir, "prompts.txt");
+        writeFileSync(promptsFile, "hello\nworld\n");
+        const res = await runCliBugfix(["batch", promptsFile, "--dry-run"]);
+        return (
+          res.code === 0 &&
+          !/unknown argument/i.test(res.out) &&
+          !/No prompts found/i.test(res.out)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     },
   },
 ];


### PR DESCRIPTION
## What & why

Consolidated CLI-subsystem critical fixes (`commandFactory.ts`).

### #288 (CLI-002) — no file validation before processing
`validateCliInputFiles` only did an `existsSync` check, so a **directory** passed to `--image`/`--csv`/`--pdf`/`--video`/`--file` was accepted and failed cryptically deep in processing (raw `EISDIR`). Now:
- A directory (or missing path) is **rejected up front** with a clear error + a **Troubleshooting** block.
- A **large** file (images > 10 MB, CSV/PDF > 50 MB) prints a **non-blocking** warning, visible without `--debug` (via `logger.always`, since `logger.warn` is hidden by default).

### #291 (CLI-001) — batch ignored multimodal flags
The `batch` command parsed `--image/--csv/--pdf/--video` but **silently discarded** them (`runBatchGenerate` sent only `{ text }`). Now it resolves the multimodal inputs **once** (they attach to every prompt), runs the same pre-flight validation as `generate`/`stream`, warns that the files apply to all prompts, and wires `images/csvFiles/pdfFiles/videoFiles` + `csvOptions/videoOptions` into every batch call.

**Enhancement/known-limit documented:** `--file` (auto-detect) is *not* wired in `batch` because it collides with the `<file>` positional (the prompts-list path) — called out in the CLI and docs so it doesn't become a repeat bug report.

## Testing / proof

CLI **end-to-end** tests (bugfixes suite, spawning the built `dist/cli`):
- `generate hi --image <dir> --dry-run --quiet` → **non-zero-free rejection** with `directory` + `troubleshooting` in the output (was accepted before).
- `batch <prompts> --csv <nonexistent>` → now **validated** (`--csv path not found` + troubleshooting), proving the flag is wired in (previously ignored); a valid `--csv` still completes the batch (2 results for 2 prompts).

`pnpm run check` ✅ (0 errors) · `pnpm run lint` ✅ (0 errors) · `pnpm run build:cli` ✅ · `prettier --check` ✅.

## Risk
Low. Validation only *adds* pre-flight rejection of genuinely-bad inputs (directories / missing files) and non-blocking warnings; valid inputs behave identically. Batch gains multimodal support it was documented to have.

Fixes #288. Fixes #291.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Batch workflows accept image, CSV, PDF, and video inputs and attach the same files to every prompt.
  - The batch prompts input is documented and validated as a dedicated positional prompts file, with clearer handling of flag/argument collisions (notably, `--file` is rejected for batch).

- **Bug Fixes**
  - `--format json` output remains parseable on stdout; notices and large-file warnings are routed to stderr only.
  - Pre-flight input validation now fails fast with aggregated, user-friendly errors (including malformed `file://` and directory paths), even in dry runs and without API keys.

- **Documentation**
  - Updated the multimodal guide with batch workflow details, validation behavior, stderr messaging, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->