### PR TITLE
fix(csv): RFC-4180 quote-aware columns + delimiter (TSV) detection (#359, #361)

### DIFF
--- a/docs/features/csv-support.md
+++ b/docs/features/csv-support.md
@@ -14,10 +14,12 @@ NeuroLink provides seamless CSV file support as a **multimodal input type** - at
 CSV support in NeuroLink works just like image support - it's a multimodal input that gets automatically processed and injected into your prompts. The system:
 
 1. **Auto-detects** CSV files using FileDetector (magic bytes, MIME types, extensions, content heuristics)
-2. **Parses** CSV data using streaming parser for memory efficiency
+2. **Parses** CSV data using a streaming parser for memory efficiency
 3. **Formats** CSV content into LLM-optimized text (markdown/json)
 4. **Injects** formatted CSV data into your prompt text
 5. **Works** with ALL AI providers (not limited to vision models)
+
+**Delimiter auto-detection:** the delimiter is detected from the content (comma, **tab / `.tsv`**, semicolon, or pipe) — so tab- and semicolon-separated files parse into the correct columns instead of collapsing into one. Comma remains the default on ambiguity, and parsing is **RFC-4180 quote-aware** (a delimiter inside a `"…"` quoted field, e.g. `"Smith, John"`, does not split the field). The detected delimiter is reported in `metadata.detectedDelimiter`.
 
 ## Quick Start
 

--- a/src/lib/rag/document/loaders.ts
+++ b/src/lib/rag/document/loaders.ts
@@ -28,6 +28,13 @@ import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { basename, extname } from "path";
 import { logger } from "../../utils/logger.js";
+import {
+  CSVProcessor,
+  stripBom,
+  stripMetadataLine,
+  splitCsvLines,
+} from "../../utils/csvProcessor.js";
+import { splitCSVFields } from "../../utils/csvUtils.js";
 import type {
   DocumentType,
   LoaderOptions,
@@ -143,19 +150,43 @@ export class CSVLoader extends TextLoader {
   async load(source: string, options?: CSVLoaderOptions): Promise<MDocument> {
     const content = await this.loadContent(source, options?.encoding);
     const {
-      delimiter = ",",
+      delimiter,
       hasHeader = true,
       columns,
       outputFormat = "text",
     } = options || {};
 
-    const lines = content.split("\n").filter((line) => line.trim());
+    // #361: an explicit delimiter always wins; otherwise detect it from the
+    // content + extension so a .tsv fed through RAG isn't collapsed into one
+    // comma-column (CSVLoader.canHandle already accepts .tsv).
+    const effectiveDelimiter =
+      delimiter ?? CSVProcessor.detectDelimiter(content, extname(source));
+
+    // Route header/row parsing through the same shared, quote-aware path
+    // detectDelimiter() above already uses internally: a quote-aware logical
+    // row split (splitCsvLines — a newline inside a quoted field stays part
+    // of that field instead of breaking the row) with a leading Excel `sep=`
+    // preamble line stripped (stripMetadataLine), so it can't be parsed as
+    // the header. Field-level splitting also goes through the shared
+    // RFC-4180-aware splitCSVFields() instead of the loader's own naive
+    // backslash-escape parser, which didn't handle doubled-quote (`""`)
+    // escaping or quoted delimiters in the headerless-columns branch.
+    const { dataLines: strippedLines } = stripMetadataLine(
+      splitCsvLines(stripBom(content)),
+    );
+    const lines = strippedLines.filter((line) => line.trim());
+
     const headers = hasHeader
-      ? this.parseCSVLine(lines[0], delimiter)
-      : columns || lines[0]?.split(delimiter).map((_, i) => `col${i + 1}`);
+      ? splitCSVFields(lines[0] ?? "", effectiveDelimiter).map((h) => h.trim())
+      : columns ||
+        splitCSVFields(lines[0] ?? "", effectiveDelimiter).map(
+          (_, i) => `col${i + 1}`,
+        );
 
     const dataLines = hasHeader ? lines.slice(1) : lines;
-    const rows = dataLines.map((line) => this.parseCSVLine(line, delimiter));
+    const rows = dataLines.map((line) =>
+      splitCSVFields(line, effectiveDelimiter).map((field) => field.trim()),
+    );
 
     let formattedContent: string;
 
@@ -192,38 +223,24 @@ export class CSVLoader extends TextLoader {
     return ext === ".csv" || ext === ".tsv";
   }
 
-  private parseCSVLine(line: string, delimiter: string): string[] {
-    const result: string[] = [];
-    let current = "";
-    let inQuotes = false;
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-
-      if (char === '"' && (i === 0 || line[i - 1] !== "\\")) {
-        inQuotes = !inQuotes;
-      } else if (char === delimiter && !inQuotes) {
-        result.push(current.trim());
-        current = "";
-      } else {
-        current += char;
-      }
-    }
-
-    result.push(current.trim());
-    return result;
-  }
-
   private toMarkdownTable(headers: string[], rows: string[][]): string {
-    const headerRow = `| ${headers.join(" | ")} |`;
-    const separator = `| ${headers.map(() => "---").join(" | ")} |`;
-    const dataRows = rows.map((row) => `| ${row.join(" | ")} |`);
+    const safeHeaders = headers.map((h) => this.collapseEmbeddedNewlines(h));
+    const headerRow = `| ${safeHeaders.join(" | ")} |`;
+    const separator = `| ${safeHeaders.map(() => "---").join(" | ")} |`;
+    const dataRows = rows.map(
+      (row) =>
+        `| ${row.map((cell) => this.collapseEmbeddedNewlines(cell)).join(" | ")} |`,
+    );
     return [headerRow, separator, ...dataRows].join("\n");
   }
 
   private toTextTable(headers: string[], rows: string[][]): string {
-    const allRows = [headers, ...rows];
-    const colWidths = headers.map((_, i) =>
+    const safeHeaders = headers.map((h) => this.collapseEmbeddedNewlines(h));
+    const safeRows = rows.map((row) =>
+      row.map((cell) => this.collapseEmbeddedNewlines(cell)),
+    );
+    const allRows = [safeHeaders, ...safeRows];
+    const colWidths = safeHeaders.map((_, i) =>
       Math.max(...allRows.map((row) => (row[i] || "").length)),
     );
 
@@ -231,10 +248,25 @@ export class CSVLoader extends TextLoader {
       row.map((cell, i) => (cell || "").padEnd(colWidths[i])).join(" | ");
 
     return [
-      formatRow(headers),
+      formatRow(safeHeaders),
       colWidths.map((w) => "-".repeat(w)).join("-+-"),
-      ...rows.map(formatRow),
+      ...safeRows.map(formatRow),
     ].join("\n");
+  }
+
+  /**
+   * Collapse embedded newlines to a single space so one logical CSV row
+   * renders as exactly one line in the text/markdown table output.
+   *
+   * The shared quote-aware parser (`splitCsvLines` + `splitCSVFields`)
+   * preserves newlines embedded inside a quoted field verbatim — correct
+   * for the `json` output format (where `JSON.stringify` escapes them), but
+   * left as-is here it would split a single record across multiple
+   * physical table rows. Mirrors the same normalization `CSVProcessor`
+   * already applies in its own markdown formatter.
+   */
+  private collapseEmbeddedNewlines(cell: string): string {
+    return cell.replace(/\r\n|\n|\r/g, " ");
   }
 }
 

--- a/src/lib/utils/csvProcessor.ts
+++ b/src/lib/utils/csvProcessor.ts
@@ -6,7 +6,14 @@
 
 import csvParser from "csv-parser";
 import { Readable } from "stream";
+import { extname } from "path";
 import { logger } from "./logger.js";
+import {
+  countCSVColumns,
+  splitCSVFields,
+  detectDelimiter as detectDelimiterUtil,
+  CANDIDATE_DELIMITERS,
+} from "./csvUtils.js";
 import type {
   FileProcessingResult,
   CSVProcessorOptions,
@@ -569,8 +576,12 @@ function detectHasHeaders(
  * - Lines with significantly different delimiter count than line 2
  * - Lines that don't match CSV structure of subsequent lines
  */
-/** Strip a leading UTF-8 BOM (U+FEFF) if present. */
-function stripBom(text: string): string {
+/**
+ * Strip a leading UTF-8 BOM (U+FEFF) if present. Exported so every entry
+ * point that sniffs raw text (including the RAG CSVLoader) normalizes BOMs
+ * the same way before metadata/delimiter detection.
+ */
+export function stripBom(text: string): string {
   return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
 }
 
@@ -624,6 +635,37 @@ function isMetadataLine(lines: string[]): boolean {
 }
 
 /**
+ * Strip a leading metadata line (e.g. Excel's `sep=;` preamble) from
+ * already-split lines, and read the delimiter it explicitly declares.
+ * Excel semantics: an explicit `sep=<char>` always wins over frequency-based
+ * detection; a metadata line without a recognized delimiter character is
+ * simply dropped from the sample without forcing a delimiter. This is the
+ * single place process(), detectDelimiter(), parseCSVFile(), and
+ * parseCSVString() all go through, so none of them detect a delimiter over
+ * the raw, un-stripped lines (which lets the preamble skew detection).
+ * Exported so non-CSVProcessor callers (the RAG CSVLoader) share it too.
+ */
+export function stripMetadataLine(lines: string[]): {
+  dataLines: string[];
+  hasMetadataLine: boolean;
+  explicitDelimiter?: string;
+} {
+  if (!isMetadataLine(lines)) {
+    return { dataLines: lines, hasMetadataLine: false };
+  }
+  const sepChar = lines[0]?.trim().match(/^sep=(.)/i)?.[1];
+  const explicitDelimiter =
+    sepChar && (CANDIDATE_DELIMITERS as readonly string[]).includes(sepChar)
+      ? sepChar
+      : undefined;
+  return {
+    dataLines: lines.slice(1),
+    hasMetadataLine: true,
+    explicitDelimiter,
+  };
+}
+
+/**
  * Split CSV text into logical rows for metadata detection and raw row limiting.
  *
  * Supports Unix (LF), Windows (CRLF), and classic Mac (CR) line endings, and is
@@ -632,8 +674,12 @@ function isMetadataLine(lines: string[]): boolean {
  * `""` inside quotes is the RFC-4180 escaped quote and does not toggle the quote
  * state. For unquoted input this yields exactly the same result as a plain
  * `split(/\r\n|\n|\r/)`.
+ *
+ * Exported so non-CSVProcessor callers (the RAG CSVLoader) get the same
+ * quote-aware row boundaries instead of a physical `content.split("\n")`,
+ * which would break rows on a newline embedded in a quoted field.
  */
-function splitCsvLines(csvString: string): string[] {
+export function splitCsvLines(csvString: string): string[] {
   const rows: string[] = [];
   let current = "";
   let inQuotes = false;
@@ -715,22 +761,28 @@ export class CSVProcessor {
 
     const csvString = content.toString("utf-8");
 
+    // #361: split once and strip a leading Excel `sep=` metadata line before
+    // detecting the delimiter (comma/tab/semicolon/pipe), so the preamble
+    // can't skew detection — then reuse dataLines below instead of
+    // re-splitting csvString for the raw-format row handling.
+    const lines = splitCsvLines(csvString);
+    const { dataLines, hasMetadataLine, explicitDelimiter } =
+      stripMetadataLine(lines);
+    const delimiter =
+      explicitDelimiter ??
+      detectDelimiterUtil(dataLines, extension ?? undefined);
+
     // For raw format, return CSV text with row limit (no parsing needed)
     // This preserves the CSV shape while normalizing line endings for row handling.
     if (formatStyle === "raw") {
-      const lines = splitCsvLines(csvString);
-      const hasMetadataLine = isMetadataLine(lines);
-
       if (hasMetadataLine) {
         logger.debug(
           "[CSVProcessor] Detected metadata line, skipping first line",
         );
       }
 
-      // Skip metadata line if present, then take header + maxRows data rows
-      const csvLines = hasMetadataLine
-        ? lines.slice(1) // Skip metadata line
-        : lines;
+      // dataLines already has the metadata line (if any) stripped.
+      const csvLines = dataLines;
 
       const limitedLines = csvLines.slice(0, 1 + maxRows); // header + data rows
 
@@ -762,14 +814,20 @@ export class CSVProcessor {
       logger.info("[CSVProcessor] ✅ Processed CSV file", {
         formatStyle: "raw",
         rowCount,
-        columnCount: (limitedLines[0] || "").split(",").length,
+        columnCount: countCSVColumns(limitedLines[0] || "", delimiter),
         truncated: wasTruncated,
       });
 
-      // Parse a sample for enhanced metadata analysis (raw format still benefits from column analysis)
-      const sampleForAnalysis = await this.parseCSVString(
-        limitedCSV,
-        Math.min(rowCount, 500),
+      // Parse a sample for enhanced metadata analysis (raw format still
+      // benefits from column analysis). Reuse the already-split, already
+      // metadata-stripped `dataLines` via the shared parseCSVLines() core
+      // instead of routing `limitedCSV` back through parseCSVString(), which
+      // would re-split/re-join it and re-run a redundant BOM/metadata pass.
+      const sampleRows = Math.min(rowCount, 500);
+      const sampleForAnalysis = await this.parseCSVLines(
+        dataLines.slice(0, 1 + sampleRows),
+        sampleRows,
+        delimiter,
       );
       const { columnMetadata, dataQualityWarnings, dataQualityScore } =
         analyzeColumns(sampleForAnalysis);
@@ -791,16 +849,16 @@ export class CSVProcessor {
           size: content.length,
           rowCount,
           totalLines: limitedLines.length,
-          columnCount: (limitedLines[0] || "").split(",").length,
+          columnCount: countCSVColumns(limitedLines[0] || "", delimiter),
           extension,
           columnMetadata,
           dataQualityWarnings,
           dataQualityScore,
           hasHeaders: detectHasHeaders(
-            (limitedLines[0] || "").split(","),
+            splitCSVFields(limitedLines[0] || "", delimiter),
             undefined,
           ),
-          detectedDelimiter: ",",
+          detectedDelimiter: delimiter,
         },
       };
     }
@@ -814,7 +872,10 @@ export class CSVProcessor {
       },
     );
 
-    const rows = await this.parseCSVString(csvString, maxRows);
+    // dataLines was already split and metadata-stripped above (alongside
+    // `delimiter`) — reuse it instead of routing through parseCSVString(),
+    // which would re-split csvString and re-run metadata detection.
+    const rows = await this.parseCSVLines(dataLines, maxRows, delimiter);
 
     // Filter out empty rows (empty objects or rows with only whitespace values from blank lines)
     const nonEmptyRows = rows.filter((row) => {
@@ -909,15 +970,26 @@ export class CSVProcessor {
           columnNames,
           nonEmptyRows as Record<string, unknown>[],
         ),
-        detectedDelimiter: ",",
+        detectedDelimiter: delimiter,
       },
     };
   }
 
   /**
-   * Parse CSV string into array of row objects using streaming
-   * Memory-efficient for large files
+   * Detect the delimiter of DSV content (comma/tab/semicolon/pipe), respecting
+   * RFC-4180 quoting. An optional extension hint (`tsv` → tab, `psv` → pipe)
+   * breaks ambiguity. Used by callers (e.g. the RAG CSV loader) that parse
+   * DSV content themselves and need the same detection (#361). A leading
+   * Excel `sep=` metadata line is stripped before sampling so it can't skew
+   * detection, and an explicit `sep=<char>` value wins outright.
    */
+  static detectDelimiter(csvString: string, extensionHint?: string): string {
+    const { dataLines, explicitDelimiter } = stripMetadataLine(
+      splitCsvLines(stripBom(csvString)),
+    );
+    return explicitDelimiter ?? detectDelimiterUtil(dataLines, extensionHint);
+  }
+
   /**
    * Parse CSV file from disk using streaming (memory efficient)
    *
@@ -951,9 +1023,13 @@ export class CSVProcessor {
       let buffer = "";
       lineReader.on("data", (chunk: string | Buffer) => {
         buffer += chunk.toString();
-        const splitBuffer = buffer.endsWith("\r")
-          ? buffer.slice(0, -1)
-          : buffer;
+        // Strip a leading UTF-8 BOM before the `sep=` check below, same as
+        // process(), parseCSVString(), and detectDelimiter() — otherwise an
+        // Excel export starting with a BOM + "sep=;" fails the /^sep=/i match.
+        const normalizedBuffer = stripBom(buffer);
+        const splitBuffer = normalizedBuffer.endsWith("\r")
+          ? normalizedBuffer.slice(0, -1)
+          : normalizedBuffer;
         const lines = splitCsvLines(splitBuffer);
         if (lines.length >= 2) {
           firstLines.push(lines[0], lines[1]);
@@ -962,14 +1038,28 @@ export class CSVProcessor {
         }
       });
       lineReader.on("end", () => resolve());
-      // Metadata sniffing is best-effort — a read error here must not crash.
-      lineReader.on("error", () => resolve());
+      // Metadata sniffing is best-effort — a read error here must not crash
+      // (the main read stream below will surface a real failure properly),
+      // but silently dropping it loses the diagnostic entirely, so log it.
+      lineReader.on("error", (error: Error) => {
+        logger.warn(
+          `[CSVProcessor] Metadata sniffing read failed for ${filePath}, proceeding without it: ${error.message}`,
+          { cause: error },
+        );
+        resolve();
+      });
     });
 
     await fileHandle.close();
 
-    const hasMetadataLine = isMetadataLine(firstLines);
+    const { dataLines, hasMetadataLine, explicitDelimiter } =
+      stripMetadataLine(firstLines);
     const skipLines = hasMetadataLine ? 1 : 0;
+    // #361: pick the delimiter from the sniffed lines (metadata line
+    // stripped) + file extension so .tsv / semicolon / pipe files aren't
+    // collapsed into one column, and a `sep=` preamble can't skew detection.
+    const fileDelimiter =
+      explicitDelimiter ?? detectDelimiterUtil(dataLines, extname(filePath));
 
     if (hasMetadataLine) {
       logger.debug(
@@ -980,10 +1070,12 @@ export class CSVProcessor {
     return new Promise((resolve, reject) => {
       const rows: unknown[] = [];
       let count = 0;
-      let lineCount = 0;
 
       const source = fs.createReadStream(filePath, { encoding: "utf-8" });
-      const parser = csvParser();
+      // Pass skipLines through to csv-parser itself so it skips the `sep=`
+      // metadata line BEFORE picking headers — otherwise csv-parser treats
+      // that line as the header row and the real header becomes a data row.
+      const parser = csvParser({ separator: fileDelimiter, skipLines });
 
       const abort = () => {
         source.destroy();
@@ -1004,11 +1096,6 @@ export class CSVProcessor {
       source
         .pipe(parser)
         .on("data", (row: unknown) => {
-          lineCount++;
-          if (lineCount <= skipLines) {
-            return;
-          }
-
           rows.push(row);
           count++;
 
@@ -1048,6 +1135,7 @@ export class CSVProcessor {
   static async parseCSVString(
     csvString: string,
     maxRows: number = 1000,
+    delimiter?: string,
   ): Promise<unknown[]> {
     if (typeof csvString !== "string" || csvString.trim().length === 0) {
       throw new Error(
@@ -1057,22 +1145,51 @@ export class CSVProcessor {
     // Strip a leading UTF-8 BOM (common in Excel exports) so it does not glue
     // onto the first column name and break downstream key lookups.
     const normalized = stripBom(csvString);
-    const clampedMaxRows = Math.max(1, Math.min(10000, maxRows));
 
     logger.debug("[CSVProcessor] Starting string parsing", {
       inputLength: normalized.length,
-      maxRows: clampedMaxRows,
+      maxRows,
     });
 
-    // Detect and skip metadata line
+    // Detect and skip a leading metadata line before detecting the
+    // delimiter, so a `sep=` preamble can't skew detection (#361).
     const lines = splitCsvLines(normalized);
-    const hasMetadataLine = isMetadataLine(lines);
-    const csvData = hasMetadataLine
-      ? lines.slice(1).join("\n")
-      : lines.join("\n");
+    const { dataLines, hasMetadataLine, explicitDelimiter } =
+      stripMetadataLine(lines);
+    // Caller-provided delimiter wins, then an explicit `sep=` declaration,
+    // then frequency-based detection over the post-metadata lines.
+    const effectiveDelimiter =
+      delimiter ?? explicitDelimiter ?? detectDelimiterUtil(dataLines);
 
     if (hasMetadataLine) {
       logger.debug("[CSVProcessor] Detected metadata line in string, skipping");
+    }
+
+    return this.parseCSVLines(dataLines, maxRows, effectiveDelimiter);
+  }
+
+  /**
+   * Stream-parse already-split, metadata-stripped data lines into row
+   * objects with a known delimiter. Shared core for parseCSVString() and
+   * process(), both of which need this after already splitting the content
+   * and resolving the delimiter once — calling parseCSVString() directly
+   * from process() would re-split and re-run metadata/delimiter detection
+   * over the same content a second time.
+   */
+  private static parseCSVLines(
+    dataLines: string[],
+    maxRows: number,
+    delimiter: string,
+  ): Promise<unknown[]> {
+    const clampedMaxRows = Math.max(1, Math.min(10000, maxRows));
+    const csvData = dataLines.join("\n");
+    if (csvData.trim().length === 0) {
+      // Shared core for both process() and parseCSVString() — use a generic
+      // message rather than naming one specific entry point, since either
+      // caller can land here with empty post-metadata data lines.
+      return Promise.reject(
+        new Error("CSVProcessor: CSV data must be a non-empty string"),
+      );
     }
 
     return new Promise((resolve, reject) => {
@@ -1080,7 +1197,7 @@ export class CSVProcessor {
       let count = 0;
 
       const source = Readable.from([csvData]);
-      const parser = csvParser();
+      const parser = csvParser({ separator: delimiter });
 
       const abort = () => {
         source.destroy();

--- a/src/lib/utils/csvUtils.ts
+++ b/src/lib/utils/csvUtils.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared, RFC-4180-aware delimiter-separated-value helpers.
+ *
+ * Consolidates quote-aware field counting/splitting that was previously
+ * duplicated across csvProcessor.ts and fileDetector.ts (#359), and adds
+ * delimiter detection so TSV / semicolon / pipe files parse correctly (#361).
+ * Keeping these in one module prevents the same quoting edge case from having
+ * to be fixed in three places and drifting out of sync.
+ */
+
+/** Delimiter candidates, in tie-break preference order (comma first). */
+export const CANDIDATE_DELIMITERS = [",", "\t", ";", "|"] as const;
+
+/**
+ * Split a single line into fields, respecting RFC-4180 quoting: a delimiter
+ * inside a `"…"` quoted field does not split, and `""` is an escaped quote.
+ */
+export function splitCSVFields(line: string, delimiter = ","): string[] {
+  const fields: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        field += '"';
+        i++; // consume the escaped quote
+        continue;
+      }
+      inQuotes = !inQuotes;
+    } else if (ch === delimiter && !inQuotes) {
+      fields.push(field);
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
+/** Count fields in a single line, respecting RFC-4180 quoting. */
+export function countCSVColumns(line: string, delimiter = ","): number {
+  return splitCSVFields(line, delimiter).length;
+}
+
+/**
+ * Detect the delimiter of DSV content by testing comma/tab/semicolon/pipe
+ * against up to 5 sampled non-empty lines and keeping the candidate with the
+ * most consistent (>1) column count. Comma wins ties and the "nothing splits"
+ * case, so plain CSVs are never reclassified. An optional extension hint
+ * (`tsv` → tab, `psv` → pipe) breaks ambiguity in the file's favor.
+ */
+export function detectDelimiter(
+  lines: string[],
+  extensionHint?: string,
+): string {
+  const sample = lines.filter((l) => l.trim() !== "").slice(0, 5);
+  if (sample.length === 0) {
+    return ",";
+  }
+
+  const hint = extensionHint?.toLowerCase().replace(/^\./, "");
+  const hinted = hint === "tsv" ? "\t" : hint === "psv" ? "|" : undefined;
+
+  let best = ",";
+  let bestScore = -1;
+
+  for (const delim of CANDIDATE_DELIMITERS) {
+    const counts = sample.map((l) => countCSVColumns(l, delim));
+    const headerCols = counts[0];
+    if (headerCols <= 1) {
+      continue; // this delimiter doesn't split the header — not the delimiter
+    }
+    const consistent = counts.every((c) => c === headerCols);
+    // Prefer: a matching extension hint, then consistency, then more columns,
+    // with a small comma bias so comma stays the default on ties.
+    const score =
+      (delim === hinted ? 1000 : 0) +
+      (consistent ? 100 : 0) +
+      headerCols +
+      (delim === "," ? 0.5 : 0);
+    if (score > bestScore) {
+      bestScore = score;
+      best = delim;
+    }
+  }
+
+  // Nothing split multi-column, but the extension says otherwise — honor it.
+  if (bestScore < 0 && hinted) {
+    return hinted;
+  }
+  return best;
+}

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -21,6 +21,7 @@ import {
   buildMultimodalMessagesArray,
 } from "../src/lib/utils/messageBuilder.js";
 import { CSVProcessor } from "../src/lib/utils/csvProcessor.js";
+import { CSVLoader } from "../src/lib/rag/document/loaders.js";
 import { PDFProcessor } from "../src/lib/utils/pdfProcessor.js";
 import { directAgentTools } from "../src/lib/agent/directTools.js";
 import { isMultimodalInput } from "../src/lib/types/index.js";
@@ -4026,6 +4027,400 @@ exit 127
       return (
         /execFileAsync\(command, args, \{\s*timeout:/.test(source) &&
         source.includes("killSignal")
+      );
+    },
+  },
+  // ---------- #359: quote-aware column counting (RFC 4180) ----------
+  {
+    name: "CSVProcessor #359: quoted commas do not inflate columnCount (raw + detect path)",
+    category: "csv-processor",
+    fn: async () => {
+      const csv =
+        '"Full Name, Legal",Age,City\n"Smith, John",30,NYC\n"Doe, Jane",25,LA\n';
+      // Direct: was 4 (naive split on the quoted comma), must be 3.
+      const raw = await CSVProcessor.process(Buffer.from(csv), {
+        formatStyle: "raw",
+      });
+      if (raw.metadata.columnCount !== 3) {
+        return false;
+      }
+      // End-to-end through the real detect+process path (generate({ files })).
+      const det = await FileDetector.detectAndProcess(Buffer.from(csv));
+      return det.metadata?.columnCount === 3;
+    },
+  },
+  // ---------- #361: delimiter detection (TSV / semicolon / pipe) ----------
+  {
+    name: "CSVProcessor #361: detects tab/semicolon/pipe delimiters; comma unchanged",
+    category: "csv-processor",
+    fn: async () => {
+      // Tab-separated → parsed into name/age/city keys, delimiter reported.
+      const tsv = "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA";
+      const tabJson = (await CSVProcessor.process(Buffer.from(tsv), {
+        formatStyle: "json",
+      })) as { metadata: { detectedDelimiter?: string } };
+      if (tabJson.metadata.detectedDelimiter !== "\t") {
+        return false;
+      }
+      const tabRaw = await CSVProcessor.process(Buffer.from(tsv), {
+        formatStyle: "raw",
+      });
+      if (tabRaw.metadata.columnCount !== 3) {
+        return false;
+      }
+      // Semicolon.
+      const semi = "id;qty;price\n1;5;9.99\n2;3;4.50";
+      const semiRaw = await CSVProcessor.process(Buffer.from(semi), {
+        formatStyle: "raw",
+      });
+      if (
+        semiRaw.metadata.detectedDelimiter !== ";" ||
+        semiRaw.metadata.columnCount !== 3
+      ) {
+        return false;
+      }
+      // Pipe.
+      const pipe = "sku|qty|price\nA1|5|9.99\nA2|3|4.50";
+      const pipeRaw = await CSVProcessor.process(Buffer.from(pipe), {
+        formatStyle: "raw",
+      });
+      if (
+        pipeRaw.metadata.detectedDelimiter !== "|" ||
+        pipeRaw.metadata.columnCount !== 3
+      ) {
+        return false;
+      }
+      const pipeJson = (await CSVProcessor.process(Buffer.from(pipe), {
+        formatStyle: "json",
+      })) as {
+        metadata: { detectedDelimiter?: string; columnCount?: number };
+        content: string;
+      };
+      if (
+        pipeJson.metadata.detectedDelimiter !== "|" ||
+        pipeJson.metadata.columnCount !== 3
+      ) {
+        return false;
+      }
+      const pipeRows = JSON.parse(pipeJson.content) as Array<
+        Record<string, string>
+      >;
+      if (
+        pipeRows.length !== 2 ||
+        pipeRows[0].sku !== "A1" ||
+        pipeRows[0].qty !== "5" ||
+        pipeRows[0].price !== "9.99" ||
+        pipeRows[1].sku !== "A2"
+      ) {
+        return false;
+      }
+      // No regression: plain comma stays comma.
+      const comma = await CSVProcessor.process(Buffer.from("a,b\n1,2"), {
+        formatStyle: "raw",
+      });
+      if (
+        comma.metadata.detectedDelimiter !== "," ||
+        comma.metadata.columnCount !== 2
+      ) {
+        return false;
+      }
+      // End-to-end: a real .tsv file via the detect+process path.
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-361-"));
+      try {
+        const tsvPath = pathJoin(dir, "data.tsv");
+        writeFileSync(tsvPath, tsv);
+        const det = await FileDetector.detectAndProcess(tsvPath, {
+          allowedTypes: ["csv"],
+        });
+        return (
+          det.type === "csv" &&
+          det.metadata?.columnCount === 3 &&
+          det.metadata?.detectedDelimiter === "\t"
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- #361 follow-up: `sep=` metadata line vs. delimiter detection ----------
+  {
+    name: "CSVProcessor: explicit sep=; metadata line wins over frequency-based tie-break (Excel semantics)",
+    category: "csv-processor",
+    fn: async () => {
+      // Header/data are ambiguous on their own — with the metadata line
+      // stripped but no explicit-declaration override, frequency detection
+      // ties between comma and semicolon and comma wins on its tie-break
+      // bias. The explicit `sep=;` declaration must win outright instead.
+      const csv = "sep=;\na,b;c\n1,2;3\n4,5;6";
+
+      if (CSVProcessor.detectDelimiter(csv) !== ";") {
+        return false;
+      }
+
+      const raw = await CSVProcessor.process(Buffer.from(csv), {
+        formatStyle: "raw",
+      });
+      if (
+        raw.metadata.detectedDelimiter !== ";" ||
+        raw.metadata.columnCount !== 2 ||
+        raw.content.includes("sep=;")
+      ) {
+        return false;
+      }
+
+      const json = (await CSVProcessor.process(Buffer.from(csv), {
+        formatStyle: "json",
+      })) as {
+        metadata: {
+          detectedDelimiter?: string;
+          columnCount?: number;
+          rowCount?: number;
+        };
+      };
+      if (
+        json.metadata.detectedDelimiter !== ";" ||
+        json.metadata.columnCount !== 2 ||
+        json.metadata.rowCount !== 2
+      ) {
+        return false;
+      }
+
+      // parseCSVString() self-detection (no delimiter arg passed).
+      const rows = (await CSVProcessor.parseCSVString(csv, 10)) as Array<
+        Record<string, string>
+      >;
+      return (
+        rows.length === 2 &&
+        rows[0]["a,b"] === "1,2" &&
+        rows[0].c === "3" &&
+        rows[1]["a,b"] === "4,5" &&
+        rows[1].c === "6"
+      );
+    },
+  },
+  {
+    name: "CSVProcessor: sep=; is honored by parseCSVFile()'s streamed delimiter detection",
+    category: "csv-processor",
+    fn: async () => {
+      const csv = "sep=;\nid;name;amount\n1;Widget;100\n2;Gadget;200";
+      if (CSVProcessor.detectDelimiter(csv) !== ";") {
+        return false;
+      }
+
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-sep-"));
+      try {
+        const filePath = pathJoin(dir, "data.csv");
+        writeFileSync(filePath, csv);
+        const fileRows = (await CSVProcessor.parseCSVFile(
+          filePath,
+          10,
+        )) as Array<Record<string, string>>;
+        // The metadata row is skipped via csv-parser's own `skipLines`
+        // (passed through from the sniffed metadata detection), so the real
+        // header line ("id;name;amount") is used for keys — not misparsed
+        // as a data row keyed off "sep=;". Assert actual column names, not
+        // just value counts, to prove the header wasn't garbled.
+        return (
+          fileRows.length === 2 &&
+          fileRows[0].id === "1" &&
+          fileRows[0].name === "Widget" &&
+          fileRows[0].amount === "100" &&
+          fileRows[1].id === "2" &&
+          fileRows[1].name === "Gadget" &&
+          fileRows[1].amount === "200"
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- round-3 review: skipLines must reach csv-parser itself, not just the manual data-event counter ----------
+  {
+    name: "CSVProcessor.parseCSVFile: skipLines is passed to csv-parser so the sep= line never becomes the header",
+    category: "csv-processor",
+    fn: async () => {
+      // Before this fix, `skipLines` was computed but never handed to
+      // csv-parser, so csv-parser used the "sep=;" line as the header row —
+      // producing a column literally named "sep=;" — and a manual
+      // lineCount-based skip in the "data" handler discarded the *real*
+      // header (now misparsed as the first data row) to compensate. That
+      // compensation hid the wrong keys instead of fixing them.
+      const csv = "sep=;\nid;name;amount\n1;Widget;100\n2;Gadget;200";
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-sep-header-"));
+      try {
+        const filePath = pathJoin(dir, "data.csv");
+        writeFileSync(filePath, csv);
+        const fileRows = (await CSVProcessor.parseCSVFile(
+          filePath,
+          10,
+        )) as Array<Record<string, string>>;
+        const keys = Object.keys(fileRows[0]);
+        return (
+          fileRows.length === 2 &&
+          keys.sort().join(",") === "amount,id,name" &&
+          !keys.some((k) => k.includes("sep=")) &&
+          fileRows[0].id === "1" &&
+          fileRows[1].id === "2"
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "CSVProcessor: delimiter detection isn't fooled by a non-sep metadata line containing stray delimiter chars",
+    category: "csv-processor",
+    fn: async () => {
+      // "A;B;C;D,x" isn't a `sep=` line, but it IS recognized as metadata
+      // (comma count differs from the real comma-delimited header below),
+      // and its stray semicolons used to out-score comma in frequency
+      // detection when the metadata line was left in the sample: comma is
+      // the correct delimiter, but pre-fix this detected ';' and produced a
+      // single garbled column.
+      const csv = "A;B;C;D,x\nid,name,amount\n1,Widget,100\n2,Gadget,200";
+
+      if (CSVProcessor.detectDelimiter(csv) !== ",") {
+        return false;
+      }
+
+      const json = (await CSVProcessor.process(Buffer.from(csv), {
+        formatStyle: "json",
+      })) as {
+        metadata: {
+          detectedDelimiter?: string;
+          columnCount?: number;
+          rowCount?: number;
+        };
+      };
+      if (
+        json.metadata.detectedDelimiter !== "," ||
+        json.metadata.columnCount !== 3 ||
+        json.metadata.rowCount !== 2
+      ) {
+        return false;
+      }
+
+      const rows = (await CSVProcessor.parseCSVString(csv, 10)) as Array<
+        Record<string, string>
+      >;
+      return (
+        rows.length === 2 &&
+        rows[0].id === "1" &&
+        rows[0].name === "Widget" &&
+        rows[0].amount === "100"
+      );
+    },
+  },
+  // ---------- round-2 review: BOM must be stripped before parseCSVFile()'s sep= check ----------
+  {
+    name: "CSVProcessor.parseCSVFile: strips a leading UTF-8 BOM before the sep= metadata check",
+    category: "csv-processor",
+    fn: async () => {
+      // Excel exports often start with a BOM immediately followed by the
+      // `sep=;` preamble. Pre-fix, parseCSVFile() never stripped the BOM
+      // before matching /^sep=/i, so the preamble wasn't recognized as
+      // metadata (unlike process()/parseCSVString()/detectDelimiter(), which
+      // all strip it): skipLines stayed 0 and the real header line
+      // ("id;name;amount") leaked into the parsed rows as data, giving 3
+      // rows instead of 2.
+      const csv = "﻿sep=;\nid;name;amount\n1;Widget;100\n2;Gadget;200";
+      if (CSVProcessor.detectDelimiter(csv) !== ";") {
+        return false;
+      }
+
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-bom-sep-"));
+      try {
+        const filePath = pathJoin(dir, "data.csv");
+        writeFileSync(filePath, csv);
+        const fileRows = (await CSVProcessor.parseCSVFile(
+          filePath,
+          10,
+        )) as Array<Record<string, string>>;
+        return (
+          fileRows.length === 2 &&
+          fileRows[0].id === "1" &&
+          fileRows[0].name === "Widget" &&
+          fileRows[0].amount === "100" &&
+          fileRows[1].id === "2" &&
+          fileRows[1].name === "Gadget" &&
+          fileRows[1].amount === "200"
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- round-2 review: CSVLoader must share the quote-aware, metadata-stripping path ----------
+  {
+    name: "CSVLoader: quoted multiline field and sep= preamble routed through shared quote-aware parsing",
+    category: "csv-processor",
+    fn: async () => {
+      // A newline embedded inside a quoted field must not be treated as a
+      // row boundary by a physical content.split("\n") (pre-fix, this would
+      // have split "Hello\nWorld" into two ragged physical lines and thrown
+      // off every row after it). A leading Excel `sep=;` preamble must also
+      // not be parsed as the header (pre-fix it was).
+      const csv =
+        'sep=;\nname;note;age\n"Alice";"Hello\nWorld";30\n"Bob";"Simple note";25\n';
+      const doc = await new CSVLoader().load(csv, { outputFormat: "json" });
+      const meta = doc.getMetadata();
+      const rows = JSON.parse(doc.getContent()) as Array<
+        Record<string, string>
+      >;
+      return (
+        meta.columnCount === 3 &&
+        meta.rowCount === 2 &&
+        Array.isArray(meta.columns) &&
+        (meta.columns as string[]).join(",") === "name,note,age" &&
+        rows.length === 2 &&
+        rows[0].name === "Alice" &&
+        rows[0].note === "Hello\nWorld" &&
+        rows[0].age === "30" &&
+        rows[1].name === "Bob" &&
+        rows[1].note === "Simple note" &&
+        rows[1].age === "25"
+      );
+    },
+  },
+  // ---------- round-4 review: embedded newlines must not split a row across output lines ----------
+  {
+    name: "CSVLoader: embedded newline in a quoted field renders as one row in the default text format",
+    category: "csv-processor",
+    fn: async () => {
+      const csv =
+        'name;note;age\n"Alice";"Hello\nWorld";30\n"Bob";"Simple note";25\n';
+      const doc = await new CSVLoader().load(csv, { outputFormat: "text" });
+      const content = doc.getContent();
+      const lines = content.split("\n");
+      // Header + separator + exactly 2 data lines = 4 lines total; a
+      // pre-fix implementation would split Alice's row across 2 physical
+      // lines, producing 5.
+      return (
+        lines.length === 4 &&
+        content.includes("Hello World") &&
+        !content.includes("Hello\nWorld") &&
+        lines[2].includes("Alice") &&
+        lines[2].includes("Hello World") &&
+        lines[3].includes("Bob")
+      );
+    },
+  },
+  {
+    name: "CSVLoader: embedded newline in a quoted field renders as one row in the markdown table format",
+    category: "csv-processor",
+    fn: async () => {
+      const csv =
+        'name;note;age\n"Alice";"Hello\nWorld";30\n"Bob";"Simple note";25\n';
+      const doc = await new CSVLoader().load(csv, { outputFormat: "markdown" });
+      const content = doc.getContent();
+      const lines = content.split("\n");
+      // Header row + separator row + exactly 2 data rows = 4 lines total.
+      return (
+        lines.length === 4 &&
+        content.includes("Hello World") &&
+        !content.includes("Hello\nWorld") &&
+        lines[2].startsWith("| Alice | Hello World | 30 |") &&
+        lines[3].startsWith("| Bob | Simple note | 25 |")
       );
     },
   },


### PR DESCRIPTION
## What & why

Consolidated CSV-subsystem critical fixes around a new shared module.

### #359 (CSV-001) — naive comma splitting corrupts quoted fields
The raw-format branch of `CSVProcessor.process()` counted columns / split the header with a bare `.split(",")`, so a quoted field containing a comma (`"Smith, John"`) **inflated `columnCount`** (4 instead of 3) and corrupted header detection.

### #361 (CSV-002) — TSV / DSV files not supported
Both `csv-parser` call sites (`parseCSVFile`, `parseCSVString`) used the hard-coded **comma** default, so **tab / semicolon / pipe** files collapsed into one ragged column, and `metadata.detectedDelimiter` always lied `","`.

## Fix

New **`src/lib/utils/csvUtils.ts`** — the single shared implementation both issues asked for: `countCSVColumns`, `splitCSVFields` (RFC-4180 quote-aware), and `detectDelimiter` (comma/tab/semicolon/pipe, with an extension hint; comma wins ties, so plain CSVs are untouched).

`process()` now detects the delimiter **once** and threads it through the raw branch, both parse paths (`csvParser({ separator })`), and the reported `metadata.detectedDelimiter`.

### Enhancement gap → closed
The RAG CSV loader (`loaders.ts`) already accepted `.tsv` but hard-defaulted `delimiter=","`. It now detects the delimiter when one isn't explicitly passed — so a `.tsv` fed through `rag: { files }` isn't mis-parsed either.

## Testing / proof

New bugfixes-suite tests (deterministic, no API keys):
- Quoted-comma header → `columnCount === 3` (direct **and** via `FileDetector.detectAndProcess` — the real `generate({ files })` path).
- Tab and semicolon delimiters detected with correct `columnCount`; **plain comma unchanged** (no-regression guard).
- A real `.tsv` file through `detectAndProcess` → `type: csv`, 3 columns, `detectedDelimiter === "\t"`.

`pnpm run check` ✅ (0 errors) · `pnpm run lint` ✅ (0 errors) · `pnpm run build` ✅ · `prettier --check` ✅.

## Note
`fileDetector.ts`'s `ContentHeuristicStrategy` still has its own quote-aware counter; folding it into `csvUtils` is a low-risk follow-up (its detection heuristic is unaffected here).

Fixes #359. Fixes #361.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic delimiter detection for comma, tab/TSV, semicolon, and pipe (comma fallback on ambiguity), including Excel-style `sep=<char>` precedence.
  * Quote-aware RFC-4180 CSV parsing and exposure of the resolved delimiter in processing metadata.

* **Bug Fixes**
  * Prevented `sep=` / metadata lines from being treated as headers; improved UTF-8 BOM and metadata stripping.
  * Normalized embedded newlines in table headers/cells while keeping multiline quoted fields correctly handled.

* **Tests**
  * Expanded end-to-end coverage for delimiter detection, `sep=` precedence, streamed parsing behavior, BOM stripping, and multiline quoted fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->