### PR TITLE
fix(tools): null-prototype prompt-listing record + forward disableTools to gate

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -767,9 +767,15 @@ export abstract class BaseProvider implements AIProvider {
     toolFilter?: string[];
     excludeTools?: string[];
     enabledToolNames?: string[];
+    disableTools?: boolean;
   }): ResolvedToolPolicy {
     return resolveToolPolicy({
       options: {
+        // Defense-in-depth: both current call sites already zero the tool
+        // record via shouldUseTools before the gate runs, but forwarding
+        // disableTools makes the gate self-sufficient for any future call
+        // site that forgets the upstream check.
+        disableTools: options.disableTools,
         toolFilter: options.toolFilter,
         excludeTools: options.excludeTools,
         enabledToolNames: options.enabledToolNames,
@@ -786,6 +792,7 @@ export abstract class BaseProvider implements AIProvider {
       excludeTools?: string[];
       enabledToolNames?: string[];
       toolChoice?: unknown;
+      disableTools?: boolean;
     },
   ): Record<string, Tool> {
     const policy = this.getToolPolicy(options);

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -8158,14 +8158,22 @@ Current user's request: ${currentInput}`;
       builtinToolNames: Object.keys(directAgentTools),
     });
 
-    const record: Record<string, ToolInfo> = {};
+    // Null prototype + own-property checks: a tool named "__proto__" must
+    // become an own entry — with a plain `{}`, `"__proto__" in record` is
+    // truthy via the prototype and the tool would be silently dropped from
+    // the listing while surviving the native gate. Matches the hardening on
+    // every other record in the tool-resolution pipeline.
+    const record: Record<string, ToolInfo> = Object.create(null) as Record<
+      string,
+      ToolInfo
+    >;
     for (const tool of tools) {
-      if (!(tool.name in record)) {
+      if (!Object.hasOwn(record, tool.name)) {
         record[tool.name] = tool;
       }
     }
     const gated = applyToolGate(record, policy);
-    const filtered = tools.filter((t) => t.name in gated);
+    const filtered = tools.filter((t) => Object.hasOwn(gated, t.name));
 
     if (filtered.length !== tools.length) {
       logger.debug(`Tool info filtering applied for system prompt`, {

--- a/test/continuous-test-suite-tool-resolution.ts
+++ b/test/continuous-test-suite-tool-resolution.ts
@@ -163,6 +163,12 @@ async function main() {
     assertEqual(gateNames({}, { enabled: false }), [], "instance disable");
   });
 
+  await test("disableTools yields an empty set at the gate itself", async () => {
+    // Defense-in-depth: call sites zero the record via shouldUseTools, but
+    // the gate must also be self-sufficient for future call sites.
+    assertEqual(gateNames({ disableTools: true }), [], "gate-level disable");
+  });
+
   await test("malformed tools.include fails CLOSED, never open", async () => {
     // A broken lockdown config must not expose every tool (fail-open would
     // invert the operator's intent). Objects/numbers → no tools.
@@ -314,6 +320,28 @@ async function main() {
     if (!promptOnly.includes("additional tools if needed")) {
       throw new Error("prompt-only provider lost the tool listing");
     }
+  });
+
+  await test("a tool named __proto__ survives the prompt-listing filter", async () => {
+    const nl = new NeuroLink();
+    const priv = nl as unknown as {
+      applyToolInfoFiltering(
+        tools: ToolInfo[],
+        options: Record<string, unknown>,
+      ): ToolInfo[];
+    };
+    const listing: ToolInfo[] = [
+      { name: "__proto__", description: "hostile name", serverId: "x" },
+      { name: "normal_tool", description: "ok", serverId: "x" },
+    ] as ToolInfo[];
+    const filtered = priv.applyToolInfoFiltering(listing, {});
+    // With a plain {} record, `"__proto__" in record` is truthy via the
+    // prototype and the tool silently vanished from the listing.
+    assertEqual(
+      filtered.map((t) => t.name).sort(),
+      ["__proto__", "normal_tool"],
+      "proto-named tool retained in listing",
+    );
   });
 
   logSection("Part 4 — Discovery (tools.discovery)");


### PR DESCRIPTION
## Description

**What does this PR do?**

Follow-up to #1174, resolving the post-merge review summary left by @Tara-ag. Each claim was verified against the merged code before acting:

1. **Fixed (real, Minor): `applyToolInfoFiltering` used a plain `{}` record.** With a plain object, `"__proto__" in record` is truthy via the prototype, so a tool named `__proto__` was silently dropped from the system-prompt listing while surviving the native gate. The record is now built on `Object.create(null)` and both membership checks use `Object.hasOwn()`, matching the hardening on every other record in the tool-resolution pipeline. Regression test added.
2. **Defense-in-depth (the `disableTools` claim itself was a false positive):** both call sites already zero the tool record via `shouldUseTools` before the gate or discovery run, and discovery cannot inject `search_tools` into an empty record (deferrable names require presence in the record) — so no behavior bug existed. However, `disableTools` is now also forwarded into the resolved policy so the gate is self-sufficient for any future call site that forgets the upstream check. Zero behavior change today; gate-level regression test added.

The third item in the summary (confirmation that hydration mutates only call-scoped records) was answered on the thread with citations: every record handed to a provider is built fresh per call (merge spread → `sortToolRecord` always constructs a new object → discovery partition builds a new hot record), and shared `Tool` instances are never mutated (the Anthropic cacheControl decoration replaces the record entry with a new object; hydration assigns record keys only).

## Related Issues

Follow-up to #1174 (post-merge review).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## How Has This Been Tested?

- `pnpm run test:tool-resolution` — 29/29 (two new regression tests: `__proto__`-named tool survives the prompt-listing filter; `disableTools` yields an empty set at the gate itself).
- `tsc --strict` clean, `pnpm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disabled-tool handling so tools are consistently gated across all tool-resolution paths, even if upstream callers don’t pre-filter.
  * Fixed tool listing/prompt filtering to correctly retain specially named tools (e.g., `__proto__`) without prototype-chain side effects.
* **Tests**
  * Added regression tests covering `disableTools: true` enforcement and the `__proto__` edge case in system-prompt tool listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->