### PR TITLE
feat(proxy): hot-reload routing configuration

### DIFF
--- a/docs/features/claude-proxy-architecture.md
+++ b/docs/features/claude-proxy-architecture.md
@@ -366,8 +366,9 @@ When falling back to non-Anthropic providers, the proxy passes tools, thinking c
 proxy.ts (CLI command)
   │
   ├── Creates NeuroLink instance (NEUROLINK_SKIP_MCP=true)
-  ├── Loads proxy config (~/.neurolink/proxy-config.yaml)
-  ├── Creates ModelRouter (if routing configured)
+  ├── Loads the first last-known-good runtime config generation
+  ├── Watches proxy config + proxy env files (debounced; SIGHUP supported)
+  ├── Atomically publishes immutable routing snapshots for new requests
   ├── Initializes requestLogger + usageStats + OpenTelemetry (OTLP traces/metrics/logs)
   ├── Builds Hono app
   │     │

--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -267,14 +267,14 @@ Run `neurolink auth list` to see all accounts and their current status.
 
 ### `neurolink auth set-primary`
 
-Designate the proxy's primary (home) Anthropic account by email/label. Writes `routing.primary-account` to the proxy config YAML; the proxy reads it on startup and tries this account first under fill-first (or uses it as the home reference under round-robin). Does **not** touch the encrypted token store and does **not** require re-OAuthing any account.
+Designate the proxy's primary (home) Anthropic account by email/label. Writes `routing.primary-account` to the proxy config YAML; a running proxy watching that exact file applies it automatically and tries this account first under fill-first (or uses it as the home reference under round-robin). Does **not** touch the encrypted token store and does **not** require re-OAuthing any account.
 
 | Argument   | Type     | Required | Description                                                               |
 | ---------- | -------- | -------- | ------------------------------------------------------------------------- |
 | `<email>`  | `string` | **Yes**  | Email/label of the Anthropic account to make primary.                     |
 | `--config` | `string` | No       | Path to the proxy config file. Default: `~/.neurolink/proxy-config.yaml`. |
 
-If the email is not currently authenticated in the token store, the command still writes the field and prints a warning — the setting activates automatically once the account is added via `auth login --add`. If a proxy is currently running, a restart hint is printed.
+If the email is not currently authenticated in the token store, the command still writes the field and prints a warning — the setting activates automatically once the account is added via `auth login --add`. For a running proxy, the command reports whether it watches the edited path, watches a different path, or predates hot-reload support.
 
 **Examples:**
 
@@ -312,7 +312,7 @@ Source: /Users/.../.neurolink/proxy-config.yaml
 
 ### `neurolink auth clear-primary`
 
-Remove `routing.primary-account` (and `routing.primaryAccount`) from the proxy config. The proxy reverts to insertion-order fallback on next start.
+Remove `routing.primary-account` (and `routing.primaryAccount`) from the proxy config. A running proxy watching that file reverts to insertion-order fallback on its next valid configuration generation.
 
 | Argument   | Type     | Required | Description                                                               |
 | ---------- | -------- | -------- | ------------------------------------------------------------------------- |
@@ -331,6 +331,23 @@ Idempotent — clearing when no primary is configured prints `No primary account
 ## 2. Config File (`~/.neurolink/proxy-config.yaml`)
 
 The proxy loads its configuration from a YAML (or JSON) file. The default location is `~/.neurolink/proxy-config.yaml`. Override it with `--config`.
+
+### Runtime Reload Semantics
+
+The running proxy watches the resolved config path and proxy env path. Changes are debounced, parsed, validated, and converted into a complete immutable routing snapshot before one pointer swap publishes the next generation. Each request captures one generation, so a reload never changes model routing, fallback order, or account eligibility midway through that request.
+
+The following values reload without restarting:
+
+- `routing.strategy`, unless `--strategy` supplied a fixed CLI override
+- model mappings, fallback chain, and passthrough models
+- primary account and account allowlist
+- quota routing, session soft limit, and reset tolerance
+- env interpolation used by those routing fields
+- `NEUROLINK_PROXY_QUOTA_ROUTING`, `NEUROLINK_PROXY_SESSION_SOFT_LIMIT`, and `NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS` from the proxy env file
+
+Malformed, invalid, or deleted previously observed files do not partially apply. The last-known-good generation remains active, and `/status` exposes `config.generation`, `config.lastReloadError`, and `config.consecutiveFailures`. `neurolink proxy status` presents the same information. `SIGHUP` requests an immediate reload; normal edits need no signal.
+
+Listener address, port, passthrough mode, keep-alive dispatcher settings, telemetry initialization, and executable code remain startup concerns. Those require process replacement; editing their env values is intentionally not presented as a successful hot reload.
 
 YAML parsing uses `js-yaml` when available; otherwise falls back to `JSON.parse`.
 
@@ -400,6 +417,12 @@ accounts:
 routing:
   # Account selection strategy: "round-robin" | "fill-first"
   strategy: "fill-first"
+
+  # Quota-aware ordering controls for fill-first. Environment variables with
+  # matching names take precedence when present in the proxy env file.
+  quota-routing: true
+  session-soft-limit: 0.97
+  session-reset-tolerance-ms: 900000
 
   # Primary (home) account: under fill-first this account is tried first;
   # under round-robin it is the home reference for cooling resets and the
@@ -513,14 +536,17 @@ cloaking:
 
 #### Routing Fields
 
-| Field                                      | Type                            | Default  | Required | Description                                                                                                                                                                                                                                                                    |
-| ------------------------------------------ | ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `strategy`                                 | `"round-robin" \| "fill-first"` | _(none)_ | No       | Account selection strategy. `round-robin` rotates across accounts. `fill-first` uses one account until exhausted.                                                                                                                                                              |
-| `primary-account` / `primaryAccount`       | `string`                        | _(none)_ | No       | Email/label of the Anthropic account to treat as primary (home). Resolved per-request to `anthropic:<email>`; falls back to insertion-order index 0 when absent or when the configured account isn't currently authenticated. Manage via `neurolink auth set-primary <email>`. |
-| `account-allowlist` / `accountAllowlist`   | `string[]`                      | _(none)_ | No       | Allowed Anthropic account labels/keys. When present, unlisted TokenStore, legacy, and environment credentials are excluded before loading or refresh. Empty denies all; absent is unrestricted. Special fallback labels are `legacy-default` and `env`.                        |
-| `model-mappings` / `modelMappings`         | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                                                                                                                                                                                       |
-| `fallback-chain` / `fallbackChain`         | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                                                                                                                                                                              |
-| `passthrough-models` / `passthroughModels` | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                                                                                                                                                                                    |
+| Field                                                    | Type                            | Default  | Required | Description                                                                                                                                                                                                                                                                    |
+| -------------------------------------------------------- | ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy`                                               | `"round-robin" \| "fill-first"` | _(none)_ | No       | Account selection strategy. `round-robin` rotates across accounts. `fill-first` uses one account until exhausted.                                                                                                                                                              |
+| `primary-account` / `primaryAccount`                     | `string`                        | _(none)_ | No       | Email/label of the Anthropic account to treat as primary (home). Resolved per-request to `anthropic:<email>`; falls back to insertion-order index 0 when absent or when the configured account isn't currently authenticated. Manage via `neurolink auth set-primary <email>`. |
+| `account-allowlist` / `accountAllowlist`                 | `string[]`                      | _(none)_ | No       | Allowed Anthropic account labels/keys. When present, unlisted TokenStore, legacy, and environment credentials are excluded before loading or refresh. Empty denies all; absent is unrestricted. Special fallback labels are `legacy-default` and `env`.                        |
+| `model-mappings` / `modelMappings`                       | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                                                                                                                                                                                       |
+| `fallback-chain` / `fallbackChain`                       | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                                                                                                                                                                              |
+| `passthrough-models` / `passthroughModels`               | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                                                                                                                                                                                    |
+| `quota-routing` / `quotaRouting`                         | `boolean`                       | `true`   | No       | Enables quota-optimized ordering for fill-first with multiple accounts. The environment override takes precedence.                                                                                                                                                             |
+| `session-soft-limit` / `sessionSoftLimit`                | `number`                        | `0.97`   | No       | Session utilization in `(0, 1]` at which quota routing proactively demotes an account.                                                                                                                                                                                         |
+| `session-reset-tolerance-ms` / `sessionResetToleranceMs` | `integer`                       | `900000` | No       | Positive reset-time bucket width used to compare session windows before weekly utilization.                                                                                                                                                                                    |
 
 #### ModelMapping Fields
 
@@ -558,6 +584,9 @@ The config loader validates the following:
 - Each account must have a non-empty string `apiKey`.
 - If `version` is present, it must be a number.
 - `routing.account-allowlist` must be an array of non-empty strings when present.
+- `routing.quota-routing` must be a boolean when present.
+- `routing.session-soft-limit` must be a number in `(0, 1]` when present.
+- `routing.session-reset-tolerance-ms` must be a positive integer when present.
 - Plaintext API keys (not using `${ENV_VAR}` references) trigger a warning.
 
 An absent default config is optional. An existing config that cannot be read or
@@ -568,19 +597,22 @@ routing.
 
 ## 3. Environment Variables
 
-| Variable                         | Purpose                                                                                                                                                                                                                                 | Used By                                          |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `ANTHROPIC_API_KEY`              | Anthropic API key. Used as a fallback credential when no OAuth accounts are found.                                                                                                                                                      | Proxy routes, Anthropic provider                 |
-| `ANTHROPIC_OAUTH_TOKEN`          | OAuth access token for Anthropic (alternative to stored tokens).                                                                                                                                                                        | Anthropic provider, providerConfig               |
-| `CLAUDE_OAUTH_TOKEN`             | Alias for `ANTHROPIC_OAUTH_TOKEN`. Checked as a fallback.                                                                                                                                                                               | Anthropic provider, providerConfig               |
-| `NEUROLINK_SKIP_MCP`             | Set to `"true"` to skip MCP server initialization. Automatically set by `proxy start` (tools come from Claude Code, not local MCP servers).                                                                                             | `NeuroLink` constructor                          |
-| `NEUROLINK_LOG_LEVEL`            | Log level for the NeuroLink logger. Values: `error`, `warn`, `info`, `debug`.                                                                                                                                                           | Logger utility                                   |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`    | OTLP HTTP endpoint for proxy telemetry export. Written automatically to `~/.neurolink/.env` by `neurolink proxy telemetry setup`. Example: `http://localhost:14318`.                                                                    | Proxy OTEL init (`initializeProxyOpenTelemetry`) |
-| `NEUROLINK_ENV_FILE`             | Path to a `.env` file the proxy should load at startup. Overrides the default `~/.neurolink/.env` auto-load.                                                                                                                            | `proxyEnv.ts` (`resolveProxyEnvFile`)            |
-| `NEUROLINK_PROXY_AUTO_UPDATE`    | Automatic package updates for launchd installations. Enabled by default; set to `0`, `off`, or `false` to disable. Updates use the package manager owning the running install and restart only after all requests and streams are idle. | Dedicated launchd updater worker                 |
-| `NEUROLINK_PACKAGE_MANAGER_PATH` | Optional absolute path to the npm or pnpm executable used by the updater. The candidate is still rejected unless its writable global root owns the running NeuroLink installation.                                                      | Dedicated launchd updater worker                 |
-| `NEUROLINK_PACKAGE_MANAGER`      | Optional `npm` or `pnpm` type for `NEUROLINK_PACKAGE_MANAGER_PATH`. When omitted, the updater infers the type from the executable name.                                                                                                 | Dedicated launchd updater worker                 |
-| `NEUROLINK_PNPM_PATH`            | Legacy pnpm-specific updater override. Prefer `NEUROLINK_PACKAGE_MANAGER_PATH` for new installations.                                                                                                                                   | Dedicated launchd updater worker                 |
+| Variable                                     | Purpose                                                                                                                                                                                                                                 | Used By                                          |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `ANTHROPIC_API_KEY`                          | Anthropic API key. Used as a fallback credential when no OAuth accounts are found.                                                                                                                                                      | Proxy routes, Anthropic provider                 |
+| `ANTHROPIC_OAUTH_TOKEN`                      | OAuth access token for Anthropic (alternative to stored tokens).                                                                                                                                                                        | Anthropic provider, providerConfig               |
+| `CLAUDE_OAUTH_TOKEN`                         | Alias for `ANTHROPIC_OAUTH_TOKEN`. Checked as a fallback.                                                                                                                                                                               | Anthropic provider, providerConfig               |
+| `NEUROLINK_SKIP_MCP`                         | Set to `"true"` to skip MCP server initialization. Automatically set by `proxy start` (tools come from Claude Code, not local MCP servers).                                                                                             | `NeuroLink` constructor                          |
+| `NEUROLINK_LOG_LEVEL`                        | Log level for the NeuroLink logger. Values: `error`, `warn`, `info`, `debug`.                                                                                                                                                           | Logger utility                                   |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                | OTLP HTTP endpoint for proxy telemetry export. Written automatically to `~/.neurolink/.env` by `neurolink proxy telemetry setup`. Example: `http://localhost:14318`.                                                                    | Proxy OTEL init (`initializeProxyOpenTelemetry`) |
+| `NEUROLINK_ENV_FILE`                         | Path to a `.env` file the proxy should load at startup. Overrides the default `~/.neurolink/.env` auto-load.                                                                                                                            | `proxyEnv.ts` (`resolveProxyEnvFile`)            |
+| `NEUROLINK_PROXY_AUTO_UPDATE`                | Automatic package updates for launchd installations. Enabled by default; set to `0`, `off`, or `false` to disable. Updates use the package manager owning the running install and restart only after all requests and streams are idle. | Dedicated launchd updater worker                 |
+| `NEUROLINK_PROXY_QUOTA_ROUTING`              | Quota-aware fill-first ordering. Enabled by default; set to `0`, `off`, or `false` to disable. Reloads from the proxy env file at runtime.                                                                                              | Runtime routing configuration                    |
+| `NEUROLINK_PROXY_SESSION_SOFT_LIMIT`         | Session utilization threshold in `(0, 1]`; defaults to `0.97`. Reloads from the proxy env file at runtime.                                                                                                                              | Runtime routing configuration                    |
+| `NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS` | Positive reset-time bucket width in milliseconds; defaults to `900000`. Reloads from the proxy env file at runtime.                                                                                                                     | Runtime routing configuration                    |
+| `NEUROLINK_PACKAGE_MANAGER_PATH`             | Optional absolute path to the npm or pnpm executable used by the updater. The candidate is still rejected unless its writable global root owns the running NeuroLink installation.                                                      | Dedicated launchd updater worker                 |
+| `NEUROLINK_PACKAGE_MANAGER`                  | Optional `npm` or `pnpm` type for `NEUROLINK_PACKAGE_MANAGER_PATH`. When omitted, the updater infers the type from the executable name.                                                                                                 | Dedicated launchd updater worker                 |
+| `NEUROLINK_PNPM_PATH`                        | Legacy pnpm-specific updater override. Prefer `NEUROLINK_PACKAGE_MANAGER_PATH` for new installations.                                                                                                                                   | Dedicated launchd updater worker                 |
 
 ### Proxy Env File Resolution Order
 
@@ -591,7 +623,7 @@ When the proxy starts, it loads env vars from a `.env` file using this priority:
 3. `~/.neurolink/.env` — loaded automatically if the file exists (created by `neurolink proxy telemetry setup`).
 4. Nothing — proxy starts without extra env vars; telemetry remains disabled unless env vars are already set in the shell, and the proxy emits a startup log explaining how to enable it unless output is suppressed.
 
-The `--env-file` flag is baked into the launchd plist by `proxy install`, so the service always loads from the same file across reboots.
+The `--env-file` flag is baked into the launchd plist by `proxy install`, so the service always loads from the same file across reboots. The three runtime routing variables above and routing interpolation are reread transactionally; other env settings remain startup-only.
 
 **Priority for Anthropic credentials** (checked in order by the proxy routes):
 
@@ -636,20 +668,20 @@ After starting the proxy, restart Claude Code for the new settings to take effec
 
 All NeuroLink proxy files are stored under `~/.neurolink/` (with `0o700` directory permissions).
 
-| File                                                         | Permissions  | Description                                                                                                                                                                                                                                                                                                            |
-| ------------------------------------------------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `~/.neurolink/tokens.json`                                   | `0o600`      | **TokenStore** -- Multi-provider OAuth token storage. Stores tokens keyed by `provider:label` (e.g., `anthropic:personal`). XOR-obfuscated by default (not plaintext).                                                                                                                                                 |
-| `~/.neurolink/anthropic-credentials.json`                    | `0o600`      | **Legacy credentials** -- Single-account OAuth tokens. Used as a fallback when no compound keys exist in `tokens.json`. Updated on token refresh (pre-request or on-401).                                                                                                                                              |
-| `~/.neurolink/proxy-config.yaml`                             | user default | **Proxy config** -- YAML/JSON configuration file. Loaded by `proxy start` (default path, overridable with `--config`).                                                                                                                                                                                                 |
-| `~/.neurolink/.env`                                          | `0o600`      | **Proxy env file** — Auto-loaded by the proxy on startup. Created with mode `0o600` by `neurolink proxy telemetry setup` with `OTEL_EXPORTER_OTLP_ENDPOINT`. Add any provider API keys or proxy env vars here to avoid exporting them in every shell session. Override path with `--env-file` or `NEUROLINK_ENV_FILE`. |
-| `~/.neurolink/proxy-state.json`                              | user default | **Proxy state** -- Runtime state persisted by the running proxy (PID, port, host, strategy, start time, fallback chain, account allowlist, foreground guard PID). Used by `proxy status` and the fail-open guard.                                                                                                      |
-| `~/.neurolink/logs/proxy-YYYY-MM-DD.jsonl`                   | `0o600`      | **Request summary logs** -- One JSONL entry per completed proxied request. Includes requestId, method, path, model, status, account label, response time, token usage, and trace correlation fields.                                                                                                                   |
-| `~/.neurolink/logs/proxy-attempts-YYYY-MM-DD.jsonl`          | `0o600`      | **Attempt logs** -- One JSONL entry per upstream attempt. Useful for retry, failover, and cooldown debugging without inflating request totals.                                                                                                                                                                         |
-| `~/.neurolink/logs/proxy-debug-YYYY-MM-DD.jsonl`             | `0o600`      | **Debug index logs** -- Redacted body-capture index rows with phase, headers, status, duration, and the stored body artifact path.                                                                                                                                                                                     |
-| `~/.neurolink/logs/bodies/YYYY-MM-DD/<request-id>/*.json.gz` | `0o600`      | **Body artifacts** -- Compressed redacted request and response bodies captured for debugging.                                                                                                                                                                                                                          |
-| `~/.neurolink/account-quotas.json`                           | user default | **Account quotas** -- Cached quota/utilization data from Anthropic's `unified-5h` and `unified-7d` rate-limit headers. Flushed to disk every 5 seconds.                                                                                                                                                                |
-| `~/.neurolink/account-cooldowns.json`                        | `0o600`      | **Account cooldowns** -- Extend-only rate-limit and transient-auth recovery timestamps. Persisted atomically so a proxy restart cannot immediately retry a known-exhausted account.                                                                                                                                    |
-| `~/.claude/settings.json`                                    | user default | **Claude Code settings** -- Auto-configured with `ANTHROPIC_BASE_URL` and `ENABLE_TOOL_SEARCH` when the proxy starts. Cleaned up on shutdown.                                                                                                                                                                          |
+| File                                                         | Permissions  | Description                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/.neurolink/tokens.json`                                   | `0o600`      | **TokenStore** -- Multi-provider OAuth token storage. Stores tokens keyed by `provider:label` (e.g., `anthropic:personal`). XOR-obfuscated by default (not plaintext).                                                                                                  |
+| `~/.neurolink/anthropic-credentials.json`                    | `0o600`      | **Legacy credentials** -- Single-account OAuth tokens. Used as a fallback when no compound keys exist in `tokens.json`. Updated on token refresh (pre-request or on-401).                                                                                               |
+| `~/.neurolink/proxy-config.yaml`                             | user default | **Proxy config** -- YAML/JSON configuration file. Loaded and watched by `proxy start` (default path, overridable with `--config`). Valid routing changes publish a new runtime generation.                                                                              |
+| `~/.neurolink/.env`                                          | `0o600`      | **Proxy env file** — Auto-loaded and watched by the proxy. Runtime routing variables and routing interpolation reload transactionally; startup-only variables do not. Created by `neurolink proxy telemetry setup`. Override with `--env-file` or `NEUROLINK_ENV_FILE`. |
+| `~/.neurolink/proxy-state.json`                              | user default | **Proxy state** -- Runtime state persisted by the running proxy (PID, listener, strategy, fallback chain, account allowlist, config path/generation/reload error, and supervisor PIDs). Used by `proxy status`, auth config commands, and the fail-open guard.          |
+| `~/.neurolink/logs/proxy-YYYY-MM-DD.jsonl`                   | `0o600`      | **Request summary logs** -- One JSONL entry per completed proxied request. Includes requestId, method, path, model, status, account label, response time, token usage, and trace correlation fields.                                                                    |
+| `~/.neurolink/logs/proxy-attempts-YYYY-MM-DD.jsonl`          | `0o600`      | **Attempt logs** -- One JSONL entry per upstream attempt. Useful for retry, failover, and cooldown debugging without inflating request totals.                                                                                                                          |
+| `~/.neurolink/logs/proxy-debug-YYYY-MM-DD.jsonl`             | `0o600`      | **Debug index logs** -- Redacted body-capture index rows with phase, headers, status, duration, and the stored body artifact path.                                                                                                                                      |
+| `~/.neurolink/logs/bodies/YYYY-MM-DD/<request-id>/*.json.gz` | `0o600`      | **Body artifacts** -- Compressed redacted request and response bodies captured for debugging.                                                                                                                                                                           |
+| `~/.neurolink/account-quotas.json`                           | user default | **Account quotas** -- Cached quota/utilization data from Anthropic's `unified-5h` and `unified-7d` rate-limit headers. Flushed to disk every 5 seconds.                                                                                                                 |
+| `~/.neurolink/account-cooldowns.json`                        | `0o600`      | **Account cooldowns** -- Extend-only rate-limit and transient-auth recovery timestamps. Persisted atomically so a proxy restart cannot immediately retry a known-exhausted account.                                                                                     |
+| `~/.claude/settings.json`                                    | user default | **Claude Code settings** -- Auto-configured with `ANTHROPIC_BASE_URL` and `ENABLE_TOOL_SEARCH` when the proxy starts. Cleaned up on shutdown.                                                                                                                           |
 
 ### TokenStore Details
 

--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -136,11 +136,11 @@ By default the "first" account is the first key in token-store insertion order. 
 
 ```bash
 neurolink auth set-primary alice@example.com
-neurolink proxy stop && neurolink proxy start
+neurolink proxy status   # Config: generation N
 curl http://127.0.0.1:55669/status   # stats.primaryAccount.label = alice@example.com
 ```
 
-After a 429 cools off, traffic returns to the configured primary (not literal index 0). When the configured account is missing or disabled, the proxy logs a warning at startup and falls back to insertion-order index 0. See the [config reference](./claude-proxy-config-reference.md#neurolink-auth-set-primary) for the full CLI surface (`set-primary` / `get-primary` / `clear-primary`).
+After a 429 cools off, traffic returns to the configured primary (not literal index 0). When the configured account is missing or disabled, the proxy logs a warning while loading the configuration and falls back to insertion-order index 0. See the [config reference](./claude-proxy-config-reference.md#neurolink-auth-set-primary) for the full CLI surface (`set-primary` / `get-primary` / `clear-primary`).
 
 #### Restricting eligible accounts
 
@@ -174,7 +174,7 @@ Fallback requests go through NeuroLink's `stream()` pipeline (translation mode),
 
 ### Proxy config file
 
-The proxy loads configuration from `~/.neurolink/proxy-config.yaml` by default (override with `--config`). The file supports YAML or JSON format with environment variable interpolation.
+The proxy loads configuration from `~/.neurolink/proxy-config.yaml` by default (override with `--config`). The file supports YAML or JSON format with environment variable interpolation. The running proxy watches this file and its resolved proxy env file. Valid routing edits are published atomically for new requests; in-flight requests keep their original generation. Invalid or deleted observed files are rejected and the last-known-good generation remains active.
 
 ```yaml
 # ~/.neurolink/proxy-config.yaml
@@ -193,6 +193,9 @@ accounts:
 # Routing configuration
 routing:
   strategy: fill-first # or round-robin
+  quota-routing: true
+  session-soft-limit: 0.97
+  session-reset-tolerance-ms: 900000
   primary-account: primary@example.com
   account-allowlist:
     - primary@example.com
@@ -838,13 +841,12 @@ WebSocket-based connections for real-time bidirectional communication.
 
 ### Hot-Reload of Config Files
 
-**Priority: Low** | **Complexity: Low** | **Partially Implemented**
+**Implemented**
 
-Watch configuration files for changes and reload without restart.
-
-- **Credentials hot-reload:** Already implemented — accounts are loaded per-request from disk, and runtime state auto-resets when credentials change (including re-enabling disabled accounts)
-- **What's missing:** Config file hot-reload (`proxy-config.yaml`) — currently requires proxy restart. Could use `chokidar` or `fs.watch` to detect YAML changes and reload ModelRouter, strategy, and other settings
-- **CLIProxyAPI pattern:** Uses `fsnotify` with debouncing (50ms for files, 150ms for config) and SHA256 change detection
+- **Credentials:** Accounts are loaded per request, and runtime state resets when credentials change.
+- **Routing config:** The config and proxy env files are polled with debouncing and SHA256 effective-config detection. Model mappings, fallback chain, passthrough models, strategy, primary account, account allowlist, and quota routing controls apply to the next request without a restart.
+- **Failure behavior:** Parse, validation, missing-file, and primary/allowlist conflicts leave the last-known-good generation active. `/status` and `neurolink proxy status` report the generation and last rejection.
+- **Manual trigger:** Send `SIGHUP` to request an immediate serialized reload. File watching remains the normal path.
 
 ### Quota-Aware Routing
 

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -42,6 +42,7 @@ import type {
   AuthStatusResult,
   CliProxyConfigDoc,
   OAuthTokens as OAuthTokensType,
+  ProxyState,
   StoredCredentials,
   SupportedProvider,
   YamlModule,
@@ -1086,23 +1087,61 @@ function readPrimaryFromRouting(
 
 /** Best-effort detection of a running proxy. Mirrors `proxy status` semantics
  *  without importing the proxy module. */
-function detectRunningProxyPid(): number | undefined {
+function detectRunningProxyState(): ProxyState | undefined {
   try {
     const stateFile = path.join(NEUROLINK_CONFIG_DIR, "proxy-state.json");
     if (!fs.existsSync(stateFile)) {
       return undefined;
     }
-    const parsed = JSON.parse(fs.readFileSync(stateFile, "utf-8")) as {
-      pid?: number;
-    };
+    const parsed = JSON.parse(
+      fs.readFileSync(stateFile, "utf-8"),
+    ) as ProxyState;
     if (!parsed.pid || typeof parsed.pid !== "number") {
       return undefined;
     }
     process.kill(parsed.pid, 0);
-    return parsed.pid;
+    return parsed;
   } catch {
     return undefined;
   }
+}
+
+function reportRunningProxyConfigUpdate(filePath: string): void {
+  const state = detectRunningProxyState();
+  if (!state) {
+    return;
+  }
+  logger.always("");
+  const editedPath = path.resolve(filePath);
+  const watchedPath = state.configFile
+    ? path.resolve(state.configFile)
+    : undefined;
+  if (watchedPath === editedPath) {
+    logger.always(
+      chalk.green(
+        `✓ Running proxy PID ${state.pid} is watching this file and will apply the change automatically.`,
+      ),
+    );
+    logger.always(
+      chalk.gray(
+        "  Verify the active generation with `neurolink proxy status`.",
+      ),
+    );
+    return;
+  }
+  if (watchedPath) {
+    logger.always(
+      chalk.yellow(
+        `⚠ Running proxy PID ${state.pid} watches ${watchedPath}, not ${editedPath}; this change will not affect that process.`,
+      ),
+    );
+    return;
+  }
+  logger.always(
+    chalk.yellow(
+      `⚠ Running proxy PID ${state.pid} does not report hot-reload support. Restart it to pick up the change.`,
+    ),
+  );
 }
 
 /**
@@ -1160,17 +1199,7 @@ export async function handleSetPrimary(argv: AuthCommandArgs): Promise<void> {
       );
     }
 
-    // Restart hint
-    const pid = detectRunningProxyPid();
-    if (pid) {
-      logger.always("");
-      logger.always(
-        chalk.yellow(
-          `⚠ A proxy is currently running (PID ${pid}). Restart it to pick\n` +
-            "  up the change: `neurolink proxy stop && neurolink proxy start`.",
-        ),
-      );
-    }
+    reportRunningProxyConfigUpdate(filePath);
   } catch (err) {
     logger.error(chalk.red("Failed to set primary account:"));
     logger.error(
@@ -1270,16 +1299,7 @@ export async function handleClearPrimary(argv: AuthCommandArgs): Promise<void> {
     logger.always(chalk.green(`✓ Cleared primary account (was: ${before})`));
     logger.always(chalk.green(`✓ Saved to ${filePath}`));
 
-    const pid = detectRunningProxyPid();
-    if (pid) {
-      logger.always("");
-      logger.always(
-        chalk.yellow(
-          `⚠ A proxy is currently running (PID ${pid}). Restart it to pick\n` +
-            "  up the change: `neurolink proxy stop && neurolink proxy start`.",
-        ),
-      );
-    }
+    reportRunningProxyConfigUpdate(filePath);
   } catch (err) {
     logger.error(chalk.red("Failed to clear primary account:"));
     logger.error(

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -32,6 +32,7 @@ import type {
   AccountAllowlist,
   FallbackInfo,
   LoadedProxyConfig,
+  ModelRouterInterface,
   ProxyGuardArgs,
   ProxyNeurolinkRuntime,
   ProxySpinner,
@@ -44,11 +45,12 @@ import type {
   ProxyTelemetryAction,
   ProxyTelemetryArgs,
   ProxyRuntimeActivity,
+  ProxyRuntimeConfigSnapshot,
   RuntimeRequestMetadata,
   StatusStats,
 } from "../../lib/types/index.js";
-import type { ModelRouter } from "../../lib/proxy/modelRouter.js";
 import { configureProxyKeepAliveDispatcher } from "../../lib/proxy/proxyDispatcher.js";
+import { ProxyRuntimeConfigStore } from "../../lib/proxy/runtimeConfig.js";
 import {
   anthropicAccountKeysEqual,
   createAccountAllowlist,
@@ -951,159 +953,9 @@ async function createProxyNeurolinkRuntime(logsDir?: string) {
   return { neurolink, cleanupLogs };
 }
 
-async function loadProxyStartConfiguration(
-  argv: ProxyStartArgs,
-  spinner: ProxySpinner,
-): Promise<{
-  configPath: string;
-  proxyConfig: LoadedProxyConfig | null;
-  strategy: ProxyStartStrategy;
-  modelRouter: ModelRouter | undefined;
-  passthrough: boolean;
-  primaryAccountKey: string | undefined;
-  accountAllowlist: AccountAllowlist | undefined;
-}> {
-  const configPath =
-    argv.config ?? join(homedir(), ".neurolink", "proxy-config.yaml");
-  let proxyConfig: LoadedProxyConfig | null = null;
-
-  try {
-    const { loadProxyConfig } = await import("../../lib/proxy/proxyConfig.js");
-    proxyConfig = (await loadProxyConfig(configPath)) as LoadedProxyConfig;
-    if (spinner) {
-      spinner.text = `Loaded proxy config from ${configPath}`;
-    }
-  } catch (configError) {
-    const isNotFound =
-      configError instanceof Error &&
-      "code" in configError &&
-      (configError as NodeJS.ErrnoException).code === "ENOENT";
-    if (argv.config || !isNotFound) {
-      if (spinner) {
-        spinner.fail(chalk.red(`Failed to load proxy config: ${configPath}`));
-      }
-      throw configError;
-    }
-  }
-
-  const strategy = (argv.strategy ??
-    proxyConfig?.routing?.strategy ??
-    "fill-first") as ProxyStartStrategy;
-  let modelRouter: ModelRouter | undefined;
-
-  if (proxyConfig?.routing) {
-    const { ModelRouter } = await import("../../lib/proxy/modelRouter.js");
-    modelRouter = new ModelRouter({
-      strategy,
-      modelMappings: proxyConfig.routing.modelMappings ?? [],
-      fallbackChain: proxyConfig.routing.fallbackChain ?? [],
-      passthroughModels: proxyConfig.routing.passthroughModels,
-    });
-  }
-
-  const primaryAccountKey = await resolveBootPrimaryAccountKey(
-    proxyConfig?.routing?.primaryAccount,
-  );
-  const accountAllowlist = await resolveBootAccountAllowlist(
-    proxyConfig?.routing?.accountAllowlist,
-  );
-  if (
-    primaryAccountKey &&
-    !isAccountAllowed(primaryAccountKey, accountAllowlist)
-  ) {
-    throw new Error(
-      `Configured routing.primaryAccount=${proxyConfig?.routing?.primaryAccount} is excluded by routing.accountAllowlist`,
-    );
-  }
-
-  return {
-    configPath,
-    proxyConfig,
-    strategy,
-    modelRouter,
-    passthrough: argv.passthrough ?? false,
-    primaryAccountKey,
-    accountAllowlist,
-  };
-}
-
-async function resolveBootAccountAllowlist(
-  configuredAccounts: string[] | undefined,
-): Promise<AccountAllowlist | undefined> {
-  const allowlist = createAccountAllowlist(configuredAccounts);
-  if (allowlist === undefined) {
-    return undefined;
-  }
-  if (allowlist.size === 0) {
-    logger.warn(
-      "[proxy] routing.accountAllowlist is empty; all stored Anthropic credentials are denied",
-    );
-    return allowlist;
-  }
-
-  try {
-    const { tokenStore } = await import("../../lib/auth/tokenStore.js");
-    const known = new Set(
-      (await tokenStore.listByPrefix("anthropic:")).map(
-        normalizeAnthropicAccountKey,
-      ),
-    );
-    known.add(LEGACY_ANTHROPIC_ACCOUNT_KEY);
-    known.add(ENV_ANTHROPIC_ACCOUNT_KEY);
-    for (const key of allowlist) {
-      if (!known.has(key)) {
-        logger.warn(
-          `[proxy] WARN: routing.accountAllowlist entry ${key} is allowed but not currently authenticated`,
-        );
-      }
-    }
-  } catch (err) {
-    logger.debug(
-      `[proxy] could not validate account allowlist against token store: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  return allowlist;
-}
-
-/** Resolve the operator's configured primary email to a stable token-store
- *  key (anthropic:<email>). Cross-checks the token store and emits a one-time
- *  startup warning if the configured account isn't authenticated — but still
- *  returns the key so it activates automatically once the user runs
- *  `auth login --add`. */
-async function resolveBootPrimaryAccountKey(
-  primaryEmail: string | undefined,
-): Promise<string | undefined> {
-  const trimmed = primaryEmail?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const key = normalizeAnthropicAccountKey(trimmed);
-  try {
-    const { tokenStore } = await import("../../lib/auth/tokenStore.js");
-    const known = await tokenStore.listByPrefix("anthropic:");
-    if (!known.some((knownKey) => anthropicAccountKeysEqual(knownKey, key))) {
-      logger.warn(
-        `[proxy] WARN: configured routing.primaryAccount=${trimmed} not ` +
-          `found in token store; falling back to first enabled account. ` +
-          `Run \`neurolink auth login --add\` to authenticate it, or ` +
-          `\`neurolink auth clear-primary\` to remove the setting.`,
-      );
-    }
-  } catch (err) {
-    logger.debug(
-      `[proxy] could not validate primary account against token store: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  return key;
-}
-
 export async function createProxyStartApp(params: {
   neurolink: ProxyNeurolinkRuntime["neurolink"];
-  modelRouter: ModelRouter | undefined;
+  modelRouter: ModelRouterInterface | undefined;
   strategy: ProxyStartStrategy;
   passthrough: boolean;
   port: number;
@@ -1111,6 +963,7 @@ export async function createProxyStartApp(params: {
   proxyConfig: LoadedProxyConfig | null;
   primaryAccountKey: string | undefined;
   accountAllowlist: AccountAllowlist | undefined;
+  runtimeConfigStore?: ProxyRuntimeConfigStore;
 }) {
   const { createClaudeProxyRoutes } =
     await import("../../lib/server/routes/claudeProxyRoutes.js");
@@ -1229,19 +1082,29 @@ export async function createProxyStartApp(params: {
     }
   });
 
+  const runtimeConfigStore = params.runtimeConfigStore;
+  const runtimeConfigProvider = runtimeConfigStore
+    ? () => runtimeConfigStore.getSnapshot()
+    : undefined;
   const routeGroup = createClaudeProxyRoutes(
     params.modelRouter,
     "",
     params.strategy,
     params.passthrough,
     params.primaryAccountKey,
-    params.accountAllowlist,
+    runtimeConfigProvider
+      ? {
+          accountAllowlist: params.accountAllowlist,
+          runtimeConfigProvider,
+        }
+      : params.accountAllowlist,
   );
 
   const openaiRouteGroup = createOpenAIProxyRoutes(
     params.modelRouter,
     "",
     params.port,
+    runtimeConfigProvider,
   );
   const allProxyRoutes = [...routeGroup.routes, ...openaiRouteGroup.routes];
 
@@ -1397,17 +1260,34 @@ export async function createProxyStartApp(params: {
     });
   }
 
-  app.get("/health", (c) =>
-    c.json(
+  app.get("/health", (c) => {
+    const runtimeConfig = params.runtimeConfigStore?.getSnapshot();
+    return c.json(
       buildProxyHealthResponse(readiness, {
-        strategy: params.strategy,
-        passthrough: params.passthrough,
+        strategy: runtimeConfig ? runtimeConfig.strategy : params.strategy,
+        passthrough: runtimeConfig
+          ? runtimeConfig.passthrough
+          : params.passthrough,
         version: PROXY_VERSION,
       }),
-    ),
-  );
+    );
+  });
 
   app.get("/status", async (c) => {
+    const runtimeConfig = params.runtimeConfigStore?.getSnapshot();
+    const runtimeConfigStatus = params.runtimeConfigStore?.getStatus();
+    const activeStrategy = runtimeConfig
+      ? runtimeConfig.strategy
+      : params.strategy;
+    const activePassthrough = runtimeConfig
+      ? runtimeConfig.passthrough
+      : params.passthrough;
+    const activeProxyConfig = runtimeConfig
+      ? runtimeConfig.proxyConfig
+      : params.proxyConfig;
+    const activeAccountAllowlist = runtimeConfig
+      ? runtimeConfig.accountAllowlist
+      : params.accountAllowlist;
     const { getStats } = await import("../../lib/proxy/usageStats.js");
     const { loadAccountCooldowns } =
       await import("../../lib/proxy/accountCooldown.js");
@@ -1430,13 +1310,11 @@ export async function createProxyStartApp(params: {
     }
     const now = Date.now();
     const health = buildProxyHealthResponse(readiness, {
-      strategy: params.strategy,
-      passthrough: params.passthrough,
+      strategy: activeStrategy,
+      passthrough: activePassthrough,
       version: PROXY_VERSION,
     });
-    const primaryAccount = await resolveStatusPrimaryAccount(
-      params.proxyConfig,
-    );
+    const primaryAccount = await resolveStatusPrimaryAccount(activeProxyConfig);
     return c.json({
       status: "running",
       ready: health.ready,
@@ -1445,7 +1323,7 @@ export async function createProxyStartApp(params: {
       pid: process.pid,
       port: params.port,
       host: params.host,
-      strategy: params.strategy,
+      strategy: activeStrategy,
       uptime: process.uptime(),
       version: PROXY_VERSION,
       health,
@@ -1510,14 +1388,31 @@ export async function createProxyStartApp(params: {
             }
           : null,
       },
-      config: params.proxyConfig
+      config: params.runtimeConfigStore
         ? {
-            hasRouting: !!params.proxyConfig.routing,
-            accountAllowlist: params.accountAllowlist
-              ? [...params.accountAllowlist]
+            hasRouting: !!activeProxyConfig?.routing,
+            accountAllowlist: activeAccountAllowlist
+              ? [...activeAccountAllowlist]
               : null,
+            generation: runtimeConfig?.generation ?? null,
+            loadedAt: runtimeConfig?.loadedAt ?? null,
+            hash: runtimeConfig?.configHash ?? null,
+            watching: runtimeConfigStatus?.watching ?? false,
+            lastReloadAttemptAt:
+              runtimeConfigStatus?.lastReloadAttemptAt ?? null,
+            lastReloadAt: runtimeConfigStatus?.lastReloadAt ?? null,
+            lastReloadSource: runtimeConfigStatus?.lastReloadSource ?? null,
+            lastReloadError: runtimeConfigStatus?.lastReloadError ?? null,
+            consecutiveFailures: runtimeConfigStatus?.consecutiveFailures ?? 0,
           }
-        : null,
+        : params.proxyConfig
+          ? {
+              hasRouting: !!params.proxyConfig.routing,
+              accountAllowlist: params.accountAllowlist
+                ? [...params.accountAllowlist]
+                : null,
+            }
+          : null,
     });
   });
 
@@ -1751,7 +1646,7 @@ async function refreshProxyTokensInBackground(
 
 function startProxyBackgroundMaintenance(
   cleanupLogs: (days: number, maxMb: number) => void,
-  accountAllowlist?: AccountAllowlist,
+  getAccountAllowlist: () => AccountAllowlist | undefined,
 ): {
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
@@ -1761,7 +1656,7 @@ function startProxyBackgroundMaintenance(
       return;
     }
     backgroundRefreshInProgress = true;
-    void refreshProxyTokensInBackground(accountAllowlist)
+    void refreshProxyTokensInBackground(getAccountAllowlist())
       .catch((error) => {
         logger.debug(
           `[proxy] background token refresh cycle failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -1794,6 +1689,7 @@ function registerProxyShutdownHandlers(params: {
   refreshInterval: NodeJS.Timeout;
   logCleanupInterval: NodeJS.Timeout;
   updaterSupervisor?: { stop: () => void };
+  stopRuntimeConfig?: () => void;
 }): void {
   let shutdownStarted = false;
 
@@ -1837,6 +1733,7 @@ function registerProxyShutdownHandlers(params: {
     clearInterval(params.refreshInterval);
     clearInterval(params.logCleanupInterval);
     params.updaterSupervisor?.stop();
+    params.stopRuntimeConfig?.();
     logger.always(`\nShutting down proxy (${signal})...`);
     let exitCode = signal === "SIGINT" ? 0 : 1;
 
@@ -1916,6 +1813,7 @@ async function startProxyRuntime(params: {
   loadedEnvFile: string | undefined;
   passthrough: boolean;
   cleanupLogs: ProxyNeurolinkRuntime["cleanupLogs"];
+  runtimeConfigStore?: ProxyRuntimeConfigStore;
 }): Promise<void> {
   const { serve } = await import("@hono/node-server");
   const server = serve({
@@ -1970,17 +1868,31 @@ async function startProxyRuntime(params: {
         })
       : undefined;
   const updaterPid = updaterSupervisor?.currentPid();
+  const initialRuntimeConfig = params.runtimeConfigStore?.getSnapshot();
+  const activeStrategy = initialRuntimeConfig
+    ? initialRuntimeConfig.strategy
+    : params.strategy;
+  const activeProxyConfig = initialRuntimeConfig
+    ? initialRuntimeConfig.proxyConfig
+    : params.proxyConfig;
+  const activeAccountAllowlist = initialRuntimeConfig
+    ? initialRuntimeConfig.accountAllowlist
+    : params.accountAllowlist;
+  const activePassthrough = initialRuntimeConfig
+    ? initialRuntimeConfig.passthrough
+    : params.passthrough;
   const fallbackChain: FallbackInfo[] | undefined =
-    params.proxyConfig?.routing?.fallbackChain?.map((entry) => ({
+    activeProxyConfig?.routing?.fallbackChain?.map((entry) => ({
       provider: entry.provider as string,
       model: entry.model as string,
     }));
+  const initialConfigStatus = params.runtimeConfigStore?.getStatus();
 
   saveProxyState({
     pid: process.pid,
     port: params.port,
     host: params.host,
-    strategy: params.strategy,
+    strategy: activeStrategy,
     startTime: new Date().toISOString(),
     ready: true,
     readyAt: params.readiness.readyAtMs
@@ -1990,14 +1902,63 @@ async function startProxyRuntime(params: {
     statusPath: "/status",
     envFile: params.loadedEnvFile,
     fallbackChain,
-    accountAllowlist: params.accountAllowlist
-      ? [...params.accountAllowlist]
+    accountAllowlist: activeAccountAllowlist
+      ? [...activeAccountAllowlist]
       : undefined,
     guardPid,
     updaterPid,
     managedBy: managedByLaunchd ? "launchd" : "manual",
-    passthrough: params.passthrough,
+    passthrough: activePassthrough,
+    configGeneration: initialRuntimeConfig?.generation,
+    configLoadedAt: initialRuntimeConfig?.loadedAt,
+    lastConfigReloadError: initialConfigStatus?.lastReloadError,
+    configFile: initialConfigStatus?.configPath,
   });
+
+  const persistRuntimeConfig = (snapshot: ProxyRuntimeConfigSnapshot): void => {
+    const state = loadProxyState();
+    if (!state || state.pid !== process.pid) {
+      return;
+    }
+    const status = params.runtimeConfigStore?.getStatus();
+    const currentFallbackChain =
+      snapshot.proxyConfig?.routing?.fallbackChain?.map((entry) => ({
+        provider: entry.provider as string,
+        model: entry.model as string,
+      }));
+    saveProxyState({
+      ...state,
+      strategy: snapshot.strategy,
+      fallbackChain: currentFallbackChain,
+      accountAllowlist: snapshot.accountAllowlist
+        ? [...snapshot.accountAllowlist]
+        : undefined,
+      passthrough: snapshot.passthrough,
+      configGeneration: snapshot.generation,
+      configLoadedAt: snapshot.loadedAt,
+      lastConfigReloadError: status?.lastReloadError,
+    });
+  };
+  let stopRuntimeConfig: (() => void) | undefined;
+  if (params.runtimeConfigStore) {
+    const runtimeConfigStore = params.runtimeConfigStore;
+    const unsubscribeReload = runtimeConfigStore.subscribeReload(() => {
+      persistRuntimeConfig(runtimeConfigStore.getSnapshot());
+    });
+    const reloadOnSighup = (): void => {
+      void runtimeConfigStore.reload("sighup");
+    };
+    runtimeConfigStore.startWatching();
+    process.on("SIGHUP", reloadOnSighup);
+    stopRuntimeConfig = () => {
+      process.off("SIGHUP", reloadOnSighup);
+      unsubscribeReload();
+      runtimeConfigStore.stopWatching();
+    };
+    logger.always(
+      `[proxy] watching configuration generation ${initialRuntimeConfig?.generation ?? 1}; send SIGHUP to reload immediately`,
+    );
+  }
 
   if (params.spinner) {
     params.spinner.succeed(chalk.green("Claude proxy started successfully"));
@@ -2006,7 +1967,7 @@ async function startProxyRuntime(params: {
   const isDev = params.argv.dev ?? false;
   const normalizedHost = params.host === "0.0.0.0" ? "localhost" : params.host;
   const url = `http://${normalizedHost}:${params.port}`;
-  printProxyBanner(url, params.strategy);
+  printProxyBanner(url, activeStrategy);
 
   if (isDev) {
     logger.always(
@@ -2014,10 +1975,10 @@ async function startProxyRuntime(params: {
     );
   } else {
     logger.always(
-      `  ${chalk.bold("Mode:")}       ${chalk.cyan(params.passthrough ? "passthrough" : "full")}`,
+      `  ${chalk.bold("Mode:")}       ${chalk.cyan(activePassthrough ? "passthrough" : "full")}`,
     );
   }
-  if (params.passthrough) {
+  if (activePassthrough) {
     logger.always(
       chalk.yellow(
         "  ! Passthrough mode forwards client auth directly to Anthropic",
@@ -2065,9 +2026,10 @@ async function startProxyRuntime(params: {
     );
   }
 
-  const maintenance = startProxyBackgroundMaintenance(
-    params.cleanupLogs,
-    params.accountAllowlist,
+  const maintenance = startProxyBackgroundMaintenance(params.cleanupLogs, () =>
+    params.runtimeConfigStore
+      ? params.runtimeConfigStore.getSnapshot().accountAllowlist
+      : params.accountAllowlist,
   );
   registerProxyShutdownHandlers({
     server,
@@ -2075,6 +2037,7 @@ async function startProxyRuntime(params: {
     port: params.port,
     isDev,
     updaterSupervisor,
+    stopRuntimeConfig,
     ...maintenance,
   });
 }
@@ -2109,6 +2072,11 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
     if (!isDev) {
       await ensureProxyStartAllowed(spinner);
     }
+    const baseEnv = { ...process.env };
+    const envResolution = resolveProxyEnvFile({
+      explicitEnvFile: argv.envFile,
+      env: baseEnv,
+    });
     const loadedEnvFile = await loadProxyStartEnv(argv, spinner);
 
     // Reuse upstream TCP connections (longer keep-alive + bounded pool) instead
@@ -2119,6 +2087,19 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
     const { neurolink, cleanupLogs } = await createProxyNeurolinkRuntime(
       devPaths?.logsDir,
     );
+    const configPath = argv.config
+      ? resolve(argv.config)
+      : join(homedir(), ".neurolink", "proxy-config.yaml");
+    const runtimeConfigStore = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: Boolean(argv.config),
+      envFilePath: envResolution.path ?? join(homedir(), ".neurolink", ".env"),
+      envFileRequired: envResolution.required,
+      baseEnv,
+      strategyOverride: argv.strategy as ProxyStartStrategy | undefined,
+      passthrough: argv.passthrough ?? false,
+    });
+    const initialConfig = runtimeConfigStore.getSnapshot();
     const {
       proxyConfig,
       strategy,
@@ -2126,7 +2107,10 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       passthrough,
       primaryAccountKey,
       accountAllowlist,
-    } = await loadProxyStartConfiguration(argv, spinner);
+    } = initialConfig;
+    if (spinner && proxyConfig) {
+      spinner.text = `Loaded proxy config from ${configPath}`;
+    }
 
     if (spinner) {
       spinner.text = "Configuring server...";
@@ -2144,6 +2128,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       proxyConfig,
       primaryAccountKey,
       accountAllowlist,
+      runtimeConfigStore,
     });
 
     await initializeProxyOpenTelemetry();
@@ -2165,6 +2150,7 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
       loadedEnvFile,
       passthrough,
       cleanupLogs,
+      runtimeConfigStore,
     });
   } catch (error) {
     if (spinner) {
@@ -2388,6 +2374,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         envFile: null as string | null,
         fallbackChain: null as FallbackInfo[] | null,
         accountAllowlist: null as string[] | null,
+        configGeneration: null as number | null,
+        configLoadedAt: null as string | null,
+        lastConfigReloadError: null as string | null,
         autoUpdateEnabled: isProxyAutoUpdateEnabled(),
         updaterPid: null as number | null,
         updaterRunning: false,
@@ -2409,6 +2398,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         status.envFile = state.envFile ?? null;
         status.fallbackChain = state.fallbackChain ?? null;
         status.accountAllowlist = state.accountAllowlist ?? null;
+        status.configGeneration = state.configGeneration ?? null;
+        status.configLoadedAt = state.configLoadedAt ?? null;
+        status.lastConfigReloadError = state.lastConfigReloadError ?? null;
         status.updaterPid = state.updaterPid ?? null;
         status.updaterRunning = state.updaterPid
           ? isProcessRunning(state.updaterPid)
@@ -2417,6 +2409,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
 
       // Fetch live stats before rendering (JSON or text)
       let liveStats: Record<string, unknown> | null = null;
+      let liveConfig: Record<string, unknown> | null = null;
       if (status.running && status.url) {
         try {
           const statusResp = await fetch(`${status.url}/status`);
@@ -2426,6 +2419,17 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
               unknown
             >;
             liveStats = statusData.stats as Record<string, unknown> | null;
+            liveConfig = statusData.config as Record<string, unknown> | null;
+            if (typeof liveConfig?.generation === "number") {
+              status.configGeneration = liveConfig.generation;
+            }
+            if (typeof liveConfig?.loadedAt === "string") {
+              status.configLoadedAt = liveConfig.loadedAt;
+            }
+            status.lastConfigReloadError =
+              typeof liveConfig?.lastReloadError === "string"
+                ? liveConfig.lastReloadError
+                : null;
           }
         } catch {
           // Non-fatal — live stats unavailable
@@ -2433,7 +2437,13 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
       }
 
       if (argv.format === "json") {
-        logger.always(JSON.stringify({ ...status, stats: liveStats }, null, 2));
+        logger.always(
+          JSON.stringify(
+            { ...status, stats: liveStats, config: liveConfig },
+            null,
+            2,
+          ),
+        );
         return;
       }
 
@@ -2459,6 +2469,19 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         logger.always(
           `  ${chalk.bold("Mode:")}       ${chalk.cyan(status.mode ?? "full")}`,
         );
+        if (status.configGeneration !== null) {
+          logger.always(
+            `  ${chalk.bold("Config:")}     ${chalk.cyan(`generation ${status.configGeneration}`)}` +
+              (status.configLoadedAt
+                ? chalk.gray(` (${status.configLoadedAt})`)
+                : ""),
+          );
+        }
+        if (status.lastConfigReloadError) {
+          logger.always(
+            `  ${chalk.bold("Config error:")} ${chalk.red(status.lastConfigReloadError)}`,
+          );
+        }
         logger.always(
           `  ${chalk.bold("Started:")}    ${chalk.cyan(status.startTime)}`,
         );

--- a/src/lib/proxy/proxyConfig.ts
+++ b/src/lib/proxy/proxyConfig.ts
@@ -289,6 +289,47 @@ export function validateProxyConfig(config: unknown): string[] {
         });
       }
     }
+
+    const rawQuotaRouting = routing["quota-routing"] ?? routing.quotaRouting;
+    const normalizedQuotaRouting =
+      typeof rawQuotaRouting === "string"
+        ? rawQuotaRouting.trim().toLowerCase()
+        : undefined;
+    if (
+      rawQuotaRouting !== undefined &&
+      typeof rawQuotaRouting !== "boolean" &&
+      normalizedQuotaRouting !== "true" &&
+      normalizedQuotaRouting !== "false"
+    ) {
+      errors.push("routing.quota-routing must be a boolean");
+    }
+
+    const rawSessionSoftLimit =
+      routing["session-soft-limit"] ?? routing.sessionSoftLimit;
+    if (rawSessionSoftLimit !== undefined) {
+      const sessionSoftLimit = Number(rawSessionSoftLimit);
+      if (
+        !Number.isFinite(sessionSoftLimit) ||
+        sessionSoftLimit <= 0 ||
+        sessionSoftLimit > 1
+      ) {
+        errors.push("routing.session-soft-limit must be a number in (0, 1]");
+      }
+    }
+
+    const rawSessionResetToleranceMs =
+      routing["session-reset-tolerance-ms"] ?? routing.sessionResetToleranceMs;
+    if (rawSessionResetToleranceMs !== undefined) {
+      const sessionResetToleranceMs = Number(rawSessionResetToleranceMs);
+      if (
+        !Number.isInteger(sessionResetToleranceMs) ||
+        sessionResetToleranceMs <= 0
+      ) {
+        errors.push(
+          "routing.session-reset-tolerance-ms must be a positive integer",
+        );
+      }
+    }
   }
 
   if (!hasAccounts && !hasRouting) {
@@ -379,6 +420,9 @@ function warnPlaintextApiKeys(
  * - `model-mappings` / `modelMappings` — array of {from, to, provider}
  * - `fallback-chain` / `fallbackChain` — array of {provider, model}
  * - `passthroughModels` / `passthrough-models` — array of model IDs
+ * - `quota-routing` / `quotaRouting` — quota-aware fill-first ordering
+ * - `session-soft-limit` / `sessionSoftLimit` — proactive handoff threshold
+ * - `session-reset-tolerance-ms` / `sessionResetToleranceMs` — reset bucket
  * - `account-allowlist` / `accountAllowlist` — allowed Anthropic account IDs
  *
  * Accepts both camelCase and kebab-case keys for YAML-friendliness.
@@ -457,6 +501,54 @@ function parseRoutingConfig(
     raw.passthroughModels) as unknown[] | undefined;
   if (Array.isArray(rawPassthrough)) {
     result.passthroughModels = rawPassthrough.map(String);
+  }
+
+  const rawQuotaRouting = raw["quota-routing"] ?? raw.quotaRouting;
+  if (rawQuotaRouting !== undefined) {
+    if (typeof rawQuotaRouting === "boolean") {
+      result.quotaRouting = rawQuotaRouting;
+    } else if (
+      typeof rawQuotaRouting === "string" &&
+      ["true", "false"].includes(rawQuotaRouting.trim().toLowerCase())
+    ) {
+      result.quotaRouting = rawQuotaRouting.trim().toLowerCase() === "true";
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.quotaRouting: expected boolean, got ${typeof rawQuotaRouting}`,
+      );
+    }
+  }
+
+  const rawSessionSoftLimit = raw["session-soft-limit"] ?? raw.sessionSoftLimit;
+  if (rawSessionSoftLimit !== undefined) {
+    const sessionSoftLimit = Number(rawSessionSoftLimit);
+    if (
+      Number.isFinite(sessionSoftLimit) &&
+      sessionSoftLimit > 0 &&
+      sessionSoftLimit <= 1
+    ) {
+      result.sessionSoftLimit = sessionSoftLimit;
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.sessionSoftLimit: expected number in (0, 1], got ${String(rawSessionSoftLimit)}`,
+      );
+    }
+  }
+
+  const rawSessionResetToleranceMs =
+    raw["session-reset-tolerance-ms"] ?? raw.sessionResetToleranceMs;
+  if (rawSessionResetToleranceMs !== undefined) {
+    const sessionResetToleranceMs = Number(rawSessionResetToleranceMs);
+    if (
+      Number.isInteger(sessionResetToleranceMs) &&
+      sessionResetToleranceMs > 0
+    ) {
+      result.sessionResetToleranceMs = sessionResetToleranceMs;
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.sessionResetToleranceMs: expected positive integer, got ${String(rawSessionResetToleranceMs)}`,
+      );
+    }
   }
 
   // Primary account (accept kebab-case or camelCase). Email or label of the

--- a/src/lib/proxy/runtimeConfig.ts
+++ b/src/lib/proxy/runtimeConfig.ts
@@ -1,0 +1,606 @@
+import { createHash } from "node:crypto";
+import { watchFile, unwatchFile } from "node:fs";
+import type { Stats } from "node:fs";
+import { readFile } from "node:fs/promises";
+import {
+  createAccountAllowlist,
+  ENV_ANTHROPIC_ACCOUNT_KEY,
+  isAccountAllowed,
+  LEGACY_ANTHROPIC_ACCOUNT_KEY,
+  normalizeAnthropicAccountKey,
+} from "./accountSelection.js";
+import { ModelRouter } from "./modelRouter.js";
+import { loadProxyConfig } from "./proxyConfig.js";
+import type {
+  AccountAllowlist,
+  LoadedProxyConfig,
+  ProxyRuntimeConfigListener,
+  ProxyRuntimeConfigReloadListener,
+  ProxyRuntimeConfigReloadResult,
+  ProxyRuntimeConfigReloadSource,
+  ProxyRuntimeConfigSnapshot,
+  ProxyRuntimeConfigStatus,
+  ProxyRuntimeConfigStoreOptions,
+  ProxyStartStrategy,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+
+const DEFAULT_WATCH_INTERVAL_MS = 1_000;
+const DEFAULT_WATCH_DEBOUNCE_MS = 100;
+const DEFAULT_SESSION_SOFT_LIMIT = 0.97;
+const DEFAULT_SESSION_RESET_TOLERANCE_MS = 15 * 60 * 1_000;
+
+function errorCode(error: unknown): string | undefined {
+  let current = error;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string") {
+      return code;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function normalizeStrategy(
+  configured: string | undefined,
+  override: ProxyStartStrategy | undefined,
+): ProxyStartStrategy {
+  if (override) {
+    return override;
+  }
+  return configured === "round-robin" ? "round-robin" : "fill-first";
+}
+
+function resolveQuotaRoutingEnabled(
+  envValue: string | undefined,
+  configured: boolean | undefined,
+): boolean {
+  if (envValue === undefined) {
+    return configured ?? true;
+  }
+  const normalized = envValue.trim().toLowerCase();
+  return normalized !== "off" && normalized !== "false" && normalized !== "0";
+}
+
+function resolveSessionSoftLimit(
+  envValue: string | undefined,
+  configured: number | undefined,
+  rejectInvalid: boolean,
+): number {
+  if (envValue !== undefined) {
+    const parsed = Number(envValue);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed <= 1) {
+      return parsed;
+    }
+    const message =
+      `Invalid NEUROLINK_PROXY_SESSION_SOFT_LIMIT=${envValue}; ` +
+      "expected number in (0, 1]";
+    if (rejectInvalid) {
+      throw new Error(message);
+    }
+    logger.warn(`[proxy-config] ${message}; using configured/default value`);
+  }
+  return configured ?? DEFAULT_SESSION_SOFT_LIMIT;
+}
+
+function resolveSessionResetToleranceMs(
+  envValue: string | undefined,
+  configured: number | undefined,
+  rejectInvalid: boolean,
+): number {
+  if (envValue !== undefined) {
+    const parsed = Number(envValue);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+    const message =
+      `Invalid NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS=${envValue}; ` +
+      "expected positive integer";
+    if (rejectInvalid) {
+      throw new Error(message);
+    }
+    logger.warn(`[proxy-config] ${message}; using configured/default value`);
+  }
+  return configured ?? DEFAULT_SESSION_RESET_TOLERANCE_MS;
+}
+
+async function resolvePrimaryAccountKey(
+  primaryEmail: string | undefined,
+): Promise<string | undefined> {
+  const trimmed = primaryEmail?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const key = normalizeAnthropicAccountKey(trimmed);
+  try {
+    const { tokenStore } = await import("../auth/tokenStore.js");
+    const known = await tokenStore.listByPrefix("anthropic:");
+    if (
+      !known.some((knownKey) => normalizeAnthropicAccountKey(knownKey) === key)
+    ) {
+      logger.warn(
+        `[proxy] WARN: configured routing.primaryAccount=${trimmed} not found in token store; it will activate after authentication`,
+      );
+    }
+  } catch (error) {
+    logger.debug(
+      `[proxy] could not validate primary account against token store: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return key;
+}
+
+async function resolveAccountAllowlist(
+  configuredAccounts: string[] | undefined,
+): Promise<AccountAllowlist | undefined> {
+  const allowlist = createAccountAllowlist(configuredAccounts);
+  if (allowlist === undefined) {
+    return undefined;
+  }
+  if (allowlist.size === 0) {
+    logger.warn(
+      "[proxy] routing.accountAllowlist is empty; all stored Anthropic credentials are denied",
+    );
+    return allowlist;
+  }
+
+  try {
+    const { tokenStore } = await import("../auth/tokenStore.js");
+    const known = new Set(
+      (await tokenStore.listByPrefix("anthropic:")).map(
+        normalizeAnthropicAccountKey,
+      ),
+    );
+    known.add(LEGACY_ANTHROPIC_ACCOUNT_KEY);
+    known.add(ENV_ANTHROPIC_ACCOUNT_KEY);
+    for (const key of allowlist) {
+      if (!known.has(key)) {
+        logger.warn(
+          `[proxy] WARN: routing.accountAllowlist entry ${key} is allowed but not currently authenticated`,
+        );
+      }
+    }
+  } catch (error) {
+    logger.debug(
+      `[proxy] could not validate account allowlist against token store: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return allowlist;
+}
+
+function cloneLoadedConfig(
+  loaded: LoadedProxyConfig | null,
+): LoadedProxyConfig | null {
+  if (!loaded) {
+    return null;
+  }
+  const routing = loaded.routing;
+  if (!routing) {
+    return Object.freeze({});
+  }
+  return Object.freeze({
+    routing: Object.freeze({
+      ...routing,
+      ...(routing.modelMappings
+        ? {
+            modelMappings: Object.freeze(
+              routing.modelMappings.map((entry) => Object.freeze({ ...entry })),
+            ),
+          }
+        : {}),
+      ...(routing.fallbackChain
+        ? {
+            fallbackChain: Object.freeze(
+              routing.fallbackChain.map((entry) => Object.freeze({ ...entry })),
+            ),
+          }
+        : {}),
+      ...(routing.passthroughModels
+        ? { passthroughModels: Object.freeze([...routing.passthroughModels]) }
+        : {}),
+      ...(routing.accountAllowlist
+        ? { accountAllowlist: Object.freeze([...routing.accountAllowlist]) }
+        : {}),
+    }),
+  }) as LoadedProxyConfig;
+}
+
+function assertResolvedRoutingValues(value: unknown, path = "routing"): void {
+  if (typeof value === "string") {
+    if (value.includes("${")) {
+      throw new Error(`Unresolved environment placeholder at ${path}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      assertResolvedRoutingValues(entry, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      assertResolvedRoutingValues(entry, `${path}.${key}`);
+    }
+  }
+}
+
+async function buildCandidate(
+  options: ProxyRuntimeConfigStoreOptions,
+  generation: number,
+  allowMissingConfig: boolean,
+  allowMissingEnvFile: boolean,
+  rejectInvalidHotEnv: boolean,
+): Promise<{
+  snapshot: ProxyRuntimeConfigSnapshot;
+  configFilePresent: boolean;
+  envFilePresent: boolean;
+}> {
+  const effectiveEnv = { ...options.baseEnv };
+  let envFilePresent = false;
+  if (options.envFilePath) {
+    try {
+      const envContent = await readFile(options.envFilePath, "utf8");
+      const { parse } = await import("dotenv");
+      Object.assign(effectiveEnv, parse(envContent));
+      envFilePresent = true;
+    } catch (error) {
+      if (
+        !isMissingFileError(error) ||
+        options.envFileRequired ||
+        !allowMissingEnvFile
+      ) {
+        throw new Error(
+          `Failed to load proxy env file ${options.envFilePath}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+    }
+  }
+
+  let loadedConfig: LoadedProxyConfig | null = null;
+  let configFilePresent = false;
+  try {
+    loadedConfig = (await loadProxyConfig(options.configPath, {
+      env: effectiveEnv,
+    })) as LoadedProxyConfig;
+    configFilePresent = true;
+  } catch (error) {
+    if (
+      !isMissingFileError(error) ||
+      options.configRequired ||
+      !allowMissingConfig
+    ) {
+      throw error;
+    }
+  }
+
+  const proxyConfig = cloneLoadedConfig(loadedConfig);
+  const routing = proxyConfig?.routing;
+  assertResolvedRoutingValues(routing);
+  const strategy = normalizeStrategy(
+    routing?.strategy,
+    options.strategyOverride,
+  );
+  const primaryAccountKey = await resolvePrimaryAccountKey(
+    routing?.primaryAccount,
+  );
+  const accountAllowlist = await resolveAccountAllowlist(
+    routing?.accountAllowlist,
+  );
+  if (
+    primaryAccountKey &&
+    !isAccountAllowed(primaryAccountKey, accountAllowlist)
+  ) {
+    throw new Error(
+      `Configured routing.primaryAccount=${routing?.primaryAccount} is excluded by routing.accountAllowlist`,
+    );
+  }
+
+  const quotaRoutingEnabled = resolveQuotaRoutingEnabled(
+    effectiveEnv.NEUROLINK_PROXY_QUOTA_ROUTING,
+    routing?.quotaRouting,
+  );
+  const sessionSoftLimit = resolveSessionSoftLimit(
+    effectiveEnv.NEUROLINK_PROXY_SESSION_SOFT_LIMIT,
+    routing?.sessionSoftLimit,
+    rejectInvalidHotEnv,
+  );
+  const sessionResetToleranceMs = resolveSessionResetToleranceMs(
+    effectiveEnv.NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS,
+    routing?.sessionResetToleranceMs,
+    rejectInvalidHotEnv,
+  );
+  const modelRouter = routing
+    ? new ModelRouter({
+        strategy,
+        modelMappings: routing.modelMappings ?? [],
+        fallbackChain: routing.fallbackChain ?? [],
+        passthroughModels: routing.passthroughModels,
+        quotaRouting: routing.quotaRouting,
+        sessionSoftLimit: routing.sessionSoftLimit,
+        sessionResetToleranceMs: routing.sessionResetToleranceMs,
+        primaryAccount: routing.primaryAccount,
+        accountAllowlist: routing.accountAllowlist,
+      })
+    : undefined;
+  const fingerprintSource = JSON.stringify({
+    strategy,
+    passthrough: options.passthrough,
+    routing: routing ?? null,
+    primaryAccountKey,
+    accountAllowlist: accountAllowlist ? [...accountAllowlist].sort() : null,
+    quotaRoutingEnabled,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+  });
+  const configHash = createHash("sha256")
+    .update(fingerprintSource)
+    .digest("hex")
+    .slice(0, 16);
+
+  return {
+    snapshot: Object.freeze({
+      generation,
+      loadedAt: new Date().toISOString(),
+      configHash,
+      proxyConfig,
+      strategy,
+      modelRouter,
+      passthrough: options.passthrough,
+      primaryAccountKey,
+      accountAllowlist,
+      quotaRoutingEnabled,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+    }),
+    configFilePresent,
+    envFilePresent,
+  };
+}
+
+/** Atomic last-known-good runtime configuration with file-triggered reloads. */
+export class ProxyRuntimeConfigStore {
+  private readonly options: ProxyRuntimeConfigStoreOptions;
+  private currentSnapshot: ProxyRuntimeConfigSnapshot;
+  private status: ProxyRuntimeConfigStatus;
+  private readonly listeners = new Set<ProxyRuntimeConfigListener>();
+  private readonly reloadListeners =
+    new Set<ProxyRuntimeConfigReloadListener>();
+  private reloadQueue: Promise<void> = Promise.resolve();
+  private reloadTimer: ReturnType<typeof setTimeout> | undefined;
+  private configFileObserved: boolean;
+  private envFileObserved: boolean;
+  private readonly watchListener = (current: Stats, previous: Stats): void => {
+    if (
+      current.mtimeMs === previous.mtimeMs &&
+      current.size === previous.size &&
+      current.nlink === previous.nlink
+    ) {
+      return;
+    }
+    this.scheduleWatchReload();
+  };
+
+  private constructor(
+    options: ProxyRuntimeConfigStoreOptions,
+    snapshot: ProxyRuntimeConfigSnapshot,
+    configFileObserved: boolean,
+    envFileObserved: boolean,
+  ) {
+    this.options = { ...options, baseEnv: { ...options.baseEnv } };
+    this.currentSnapshot = snapshot;
+    this.configFileObserved = configFileObserved;
+    this.envFileObserved = envFileObserved;
+    this.status = {
+      configPath: options.configPath,
+      ...(options.envFilePath ? { envFilePath: options.envFilePath } : {}),
+      generation: snapshot.generation,
+      loadedAt: snapshot.loadedAt,
+      configHash: snapshot.configHash,
+      watching: false,
+      consecutiveFailures: 0,
+    };
+  }
+
+  static async create(
+    options: ProxyRuntimeConfigStoreOptions,
+  ): Promise<ProxyRuntimeConfigStore> {
+    const candidate = await buildCandidate(options, 1, true, true, false);
+    return new ProxyRuntimeConfigStore(
+      options,
+      candidate.snapshot,
+      candidate.configFilePresent,
+      candidate.envFilePresent,
+    );
+  }
+
+  getSnapshot(): ProxyRuntimeConfigSnapshot {
+    return this.currentSnapshot;
+  }
+
+  getStatus(): ProxyRuntimeConfigStatus {
+    return { ...this.status };
+  }
+
+  subscribe(listener: ProxyRuntimeConfigListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  subscribeReload(listener: ProxyRuntimeConfigReloadListener): () => void {
+    this.reloadListeners.add(listener);
+    return () => this.reloadListeners.delete(listener);
+  }
+
+  reload(
+    source: ProxyRuntimeConfigReloadSource = "manual",
+  ): Promise<ProxyRuntimeConfigReloadResult> {
+    const run = this.reloadQueue.then(
+      () => this.performReload(source),
+      () => this.performReload(source),
+    );
+    this.reloadQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  startWatching(): void {
+    if (this.status.watching) {
+      return;
+    }
+    const interval = Math.max(
+      50,
+      this.options.watchIntervalMs ?? DEFAULT_WATCH_INTERVAL_MS,
+    );
+    watchFile(
+      this.options.configPath,
+      { interval, persistent: false },
+      this.watchListener,
+    );
+    if (this.options.envFilePath) {
+      watchFile(
+        this.options.envFilePath,
+        { interval, persistent: false },
+        this.watchListener,
+      );
+    }
+    this.status = { ...this.status, watching: true };
+  }
+
+  stopWatching(): void {
+    if (!this.status.watching) {
+      return;
+    }
+    unwatchFile(this.options.configPath, this.watchListener);
+    if (this.options.envFilePath) {
+      unwatchFile(this.options.envFilePath, this.watchListener);
+    }
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+      this.reloadTimer = undefined;
+    }
+    this.status = { ...this.status, watching: false };
+  }
+
+  private scheduleWatchReload(): void {
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+    }
+    this.reloadTimer = setTimeout(
+      () => {
+        this.reloadTimer = undefined;
+        void this.reload("watch");
+      },
+      Math.max(0, this.options.watchDebounceMs ?? DEFAULT_WATCH_DEBOUNCE_MS),
+    );
+    this.reloadTimer.unref?.();
+  }
+
+  private async performReload(
+    source: ProxyRuntimeConfigReloadSource,
+  ): Promise<ProxyRuntimeConfigReloadResult> {
+    const attemptedAt = new Date().toISOString();
+    this.status = {
+      ...this.status,
+      lastReloadAttemptAt: attemptedAt,
+      lastReloadSource: source,
+    };
+    try {
+      const candidate = await buildCandidate(
+        this.options,
+        this.currentSnapshot.generation + 1,
+        !this.configFileObserved,
+        !this.envFileObserved,
+        true,
+      );
+      this.configFileObserved ||= candidate.configFilePresent;
+      this.envFileObserved ||= candidate.envFilePresent;
+      if (candidate.snapshot.configHash === this.currentSnapshot.configHash) {
+        this.status = {
+          ...this.status,
+          lastReloadAt: attemptedAt,
+          lastReloadError: undefined,
+          consecutiveFailures: 0,
+        };
+        const result = {
+          applied: true,
+          changed: false,
+          generation: this.currentSnapshot.generation,
+        };
+        this.notifyReloadListeners(result);
+        return result;
+      }
+
+      this.currentSnapshot = candidate.snapshot;
+      this.status = {
+        ...this.status,
+        generation: candidate.snapshot.generation,
+        loadedAt: candidate.snapshot.loadedAt,
+        configHash: candidate.snapshot.configHash,
+        lastReloadAt: attemptedAt,
+        lastReloadError: undefined,
+        consecutiveFailures: 0,
+      };
+      logger.always(
+        `[proxy] configuration generation ${candidate.snapshot.generation} applied via ${source}`,
+      );
+      for (const listener of this.listeners) {
+        try {
+          listener(candidate.snapshot);
+        } catch (error) {
+          logger.warn(
+            `[proxy] runtime config listener failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      const result = {
+        applied: true,
+        changed: true,
+        generation: candidate.snapshot.generation,
+      };
+      this.notifyReloadListeners(result);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.status = {
+        ...this.status,
+        lastReloadError: message,
+        consecutiveFailures: this.status.consecutiveFailures + 1,
+      };
+      logger.warn(
+        `[proxy] configuration reload rejected; keeping generation ${this.currentSnapshot.generation}: ${message}`,
+      );
+      const result = {
+        applied: false,
+        changed: false,
+        generation: this.currentSnapshot.generation,
+        error: message,
+      };
+      this.notifyReloadListeners(result);
+      return result;
+    }
+  }
+
+  private notifyReloadListeners(result: ProxyRuntimeConfigReloadResult): void {
+    for (const listener of this.reloadListeners) {
+      try {
+        listener(result, this.getStatus());
+      } catch (error) {
+        logger.warn(
+          `[proxy] runtime config reload listener failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+}

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -55,7 +55,6 @@ import {
   handleTranslatedStreamRequest,
   hasTranslatedOutput,
 } from "../../proxy/proxyTranslationEngine.js";
-import type { ModelRouter } from "../../proxy/modelRouter.js";
 import { tracers } from "../../telemetry/tracers.js";
 import { withSpan } from "../../telemetry/withSpan.js";
 import { ProxyTracer, recordFallbackAttempt } from "../../proxy/proxyTracer.js";
@@ -104,10 +103,12 @@ import type {
   ClaudeLoggedErrorBuilder,
   ClaudeRequest,
   ClaudeRequestRuntimeContext,
+  ClaudeProxyRouteRuntimeOptions,
   ClaudeSnapshot,
   ClaudeSnapshotBody,
   InternalResult,
   LoadedClaudeAccountContext,
+  ModelRouterInterface,
   ParsedClaudeError,
   ParsedClaudeRequest,
   PreparedAnthropicAccountAttempt,
@@ -147,10 +148,9 @@ const BLOCKED_UPSTREAM_HEADERS = new Set([
 let primaryAccountIndex = 0;
 /** Track account count so we can reset primaryAccountIndex when it changes. */
 let lastKnownAccountCount = 0;
-/** Stable account key (e.g. "anthropic:user@example.com") of the configured
- *  home/primary account. Set once at proxy boot from routing.primaryAccount.
- *  When undefined, home semantics fall back to enabledAccounts[0] (insertion
- *  order) — preserves pre-existing behavior. */
+/** Stable account key used by legacy fixed-config route factories. Runtime
+ *  config providers pass the request generation's primary key explicitly.
+ *  When undefined, home semantics retain insertion-order behavior. */
 let configuredPrimaryAccountKey: string | undefined;
 let configuredAccountAllowlist: AccountAllowlist | undefined;
 
@@ -243,8 +243,10 @@ function advancePrimaryIfCurrent(
  *  no key is configured or the key cannot be matched (account disabled/
  *  removed). The resolution is per-request because enabledAccounts membership
  *  can shift between requests. */
-function resolveHomeIndex(enabledAccounts: ProxyPassthroughAccount[]): number {
-  const primaryAccountKey = configuredPrimaryAccountKey;
+function resolveHomeIndex(
+  enabledAccounts: ProxyPassthroughAccount[],
+  primaryAccountKey: string | undefined = configuredPrimaryAccountKey,
+): number {
   if (!primaryAccountKey) {
     return 0;
   }
@@ -260,11 +262,12 @@ function resolveHomeIndex(enabledAccounts: ProxyPassthroughAccount[]): number {
  *  request. Home is resolved fresh per call via resolveHomeIndex. */
 function maybeResetPrimaryToHome(
   enabledAccounts: ProxyPassthroughAccount[],
+  primaryAccountKey: string | undefined = configuredPrimaryAccountKey,
 ): void {
   if (enabledAccounts.length <= 1) {
     return;
   }
-  const homeIndex = resolveHomeIndex(enabledAccounts);
+  const homeIndex = resolveHomeIndex(enabledAccounts, primaryAccountKey);
   if (primaryAccountIndex === homeIndex) {
     return;
   }
@@ -689,12 +692,10 @@ function accountSortMetrics(
 function orderAccountsByQuota(
   accounts: ProxyPassthroughAccount[],
   now: number,
+  primaryKey: string | undefined = configuredPrimaryAccountKey,
+  sessionSoftLimit: number = getSessionSoftLimit(),
+  sessionResetToleranceMs: number = getSessionResetToleranceMs(),
 ): ProxyPassthroughAccount[] {
-  const primaryKey = configuredPrimaryAccountKey;
-  // Read the env-tunable thresholds once per sort: cheaper than per-compare,
-  // and a mid-sort env change can never make the comparator intransitive.
-  const sessionSoftLimit = getSessionSoftLimit();
-  const sessionResetToleranceMs = getSessionResetToleranceMs();
   const metrics = (key: string) =>
     accountSortMetrics(key, now, sessionSoftLimit, sessionResetToleranceMs);
   return [...accounts].sort((a, b) => {
@@ -1300,7 +1301,7 @@ async function handleTranslatedClaudeRequest(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
   route: { provider: string; model: string };
-  modelRouter?: ModelRouter;
+  modelRouter?: ModelRouterInterface;
   tracer?: ProxyTracer;
   requestStartTime: number;
   logProxyBody: ProxyBodyCaptureLogger;
@@ -2050,6 +2051,11 @@ async function loadClaudeProxyAccounts(args: {
   tracer?: ProxyTracer;
   requestStartTime: number;
   accountStrategy: "round-robin" | "fill-first";
+  primaryAccountKey?: string;
+  accountAllowlist?: AccountAllowlist;
+  quotaRoutingEnabled?: boolean;
+  sessionSoftLimit?: number;
+  sessionResetToleranceMs?: number;
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
 }): Promise<LoadedClaudeAccountContext | { response: unknown }> {
   const {
@@ -2058,6 +2064,11 @@ async function loadClaudeProxyAccounts(args: {
     tracer,
     requestStartTime,
     accountStrategy,
+    primaryAccountKey = configuredPrimaryAccountKey,
+    accountAllowlist = configuredAccountAllowlist,
+    quotaRoutingEnabled = isQuotaRoutingEnabled(),
+    sessionSoftLimit = getSessionSoftLimit(),
+    sessionResetToleranceMs = getSessionResetToleranceMs(),
     buildLoggedClaudeError,
   } = args;
   const fs = await import("fs");
@@ -2074,7 +2085,7 @@ async function loadClaudeProxyAccounts(args: {
 
   const compoundKeys = await tokenStore.listByPrefix("anthropic:");
   for (const key of compoundKeys) {
-    if (!isAccountAllowed(key, configuredAccountAllowlist)) {
+    if (!isAccountAllowed(key, accountAllowlist)) {
       logger.debug(
         `[proxy] skipping account=${key} (not in account allowlist)`,
       );
@@ -2223,7 +2234,7 @@ async function loadClaudeProxyAccounts(args: {
     shouldLoadFallbackCredential(
       compoundKeys.length,
       LEGACY_ANTHROPIC_ACCOUNT_KEY,
-      configuredAccountAllowlist,
+      accountAllowlist,
     )
   ) {
     try {
@@ -2252,7 +2263,7 @@ async function loadClaudeProxyAccounts(args: {
     shouldLoadFallbackCredential(
       compoundKeys.length,
       ENV_ANTHROPIC_ACCOUNT_KEY,
-      configuredAccountAllowlist,
+      accountAllowlist,
     )
   ) {
     accounts.push({
@@ -2264,7 +2275,7 @@ async function loadClaudeProxyAccounts(args: {
   }
 
   if (accounts.length === 0) {
-    const noCredentialsMessage = configuredAccountAllowlist
+    const noCredentialsMessage = accountAllowlist
       ? "No allowed Anthropic credentials are currently available"
       : compoundKeys.length > 0
         ? "Configured Anthropic accounts are disabled or unavailable"
@@ -2314,12 +2325,18 @@ async function loadClaudeProxyAccounts(args: {
   const quotaOrdered =
     accountStrategy === "fill-first" &&
     orderedAccounts.length > 1 &&
-    isQuotaRoutingEnabled();
+    quotaRoutingEnabled;
   if (quotaOrdered) {
     // Fill-first with a smart fill order: spend the account whose window resets
     // soonest first (max utilization), proactively skipping any whose window is
     // rejected until its reset. Supersedes the static home/primary index.
-    orderedAccounts = orderAccountsByQuota(enabledAccounts, Date.now());
+    orderedAccounts = orderAccountsByQuota(
+      enabledAccounts,
+      Date.now(),
+      primaryAccountKey,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+    );
     if (logger.shouldLog("debug")) {
       logger.debug(
         `[proxy] quota-ordered fill sequence: ${orderedAccounts
@@ -2332,7 +2349,10 @@ async function loadClaudeProxyAccounts(args: {
       accountStrategy === "round-robin" &&
       orderedAccounts.length !== lastKnownAccountCount
     ) {
-      primaryAccountIndex = resolveHomeIndex(orderedAccounts);
+      primaryAccountIndex = resolveHomeIndex(
+        orderedAccounts,
+        primaryAccountKey,
+      );
       lastKnownAccountCount = orderedAccounts.length;
     }
     if (orderedAccounts.length > 1) {
@@ -2588,7 +2608,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
   parsedFallbackRequest: ParsedClaudeRequest;
-  modelRouter?: ModelRouter;
+  modelRouter?: ModelRouterInterface;
   tracer?: ProxyTracer;
   requestStartTime: number;
   logProxyBody: ProxyBodyCaptureLogger;
@@ -5432,10 +5452,15 @@ function shouldAttemptClaudeFallback(loopState: AnthropicLoopState): boolean {
 async function handleAnthropicRoutedClaudeRequest(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
-  modelRouter?: ModelRouter;
+  modelRouter?: ModelRouterInterface;
   tracer?: ProxyTracer;
   requestStartTime: number;
   accountStrategy: "round-robin" | "fill-first";
+  primaryAccountKey?: string;
+  accountAllowlist?: AccountAllowlist;
+  quotaRoutingEnabled?: boolean;
+  sessionSoftLimit?: number;
+  sessionResetToleranceMs?: number;
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: ClaudeFinalRequestLogger;
@@ -5447,6 +5472,11 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     tracer,
     requestStartTime,
     accountStrategy,
+    primaryAccountKey,
+    accountAllowlist,
+    quotaRoutingEnabled = isQuotaRoutingEnabled(),
+    sessionSoftLimit = getSessionSoftLimit(),
+    sessionResetToleranceMs = getSessionResetToleranceMs(),
     buildLoggedClaudeError,
     logProxyBody,
     logFinalRequest,
@@ -5458,6 +5488,11 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     tracer,
     requestStartTime,
     accountStrategy,
+    primaryAccountKey,
+    accountAllowlist,
+    quotaRoutingEnabled,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
     buildLoggedClaudeError,
   });
   if ("response" in loadedAccounts) {
@@ -5493,9 +5528,9 @@ async function handleAnthropicRoutedClaudeRequest(args: {
   const usingQuotaOrder =
     accountStrategy === "fill-first" &&
     enabledAccounts.length > 1 &&
-    isQuotaRoutingEnabled();
+    quotaRoutingEnabled;
   if (!usingQuotaOrder) {
-    maybeResetPrimaryToHome(enabledAccounts);
+    maybeResetPrimaryToHome(enabledAccounts, primaryAccountKey);
   }
 
   // Never re-hammer accounts with a known active cooldown. When every account
@@ -5921,6 +5956,16 @@ async function handleAnthropicRoutedClaudeRequest(args: {
 // Route factory
 // ---------------------------------------------------------------------------
 
+function isClaudeProxyRouteRuntimeOptions(
+  value: AccountAllowlist | ClaudeProxyRouteRuntimeOptions | undefined,
+): value is ClaudeProxyRouteRuntimeOptions {
+  return (
+    value !== undefined &&
+    "runtimeConfigProvider" in value &&
+    typeof value.runtimeConfigProvider === "function"
+  );
+}
+
 /**
  * Create Claude-compatible proxy routes.
  *
@@ -5932,13 +5977,25 @@ async function handleAnthropicRoutedClaudeRequest(args: {
  * @returns RouteGroup with Claude-compatible endpoints.
  */
 export function createClaudeProxyRoutes(
-  modelRouter?: ModelRouter,
+  modelRouter?: ModelRouterInterface,
   basePath: string = "",
   accountStrategy: "round-robin" | "fill-first" = "fill-first",
   passthroughMode: boolean = false,
   primaryAccountKey?: string,
-  accountAllowlist?: AccountAllowlist,
+  accountAllowlistOrRuntimeOptions?:
+    | AccountAllowlist
+    | ClaudeProxyRouteRuntimeOptions,
 ): RouteGroup {
+  const accountAllowlist = isClaudeProxyRouteRuntimeOptions(
+    accountAllowlistOrRuntimeOptions,
+  )
+    ? accountAllowlistOrRuntimeOptions.accountAllowlist
+    : accountAllowlistOrRuntimeOptions;
+  const runtimeConfigProvider = isClaudeProxyRouteRuntimeOptions(
+    accountAllowlistOrRuntimeOptions,
+  )
+    ? accountAllowlistOrRuntimeOptions.runtimeConfigProvider
+    : undefined;
   configuredPrimaryAccountKey = primaryAccountKey;
   configuredAccountAllowlist = accountAllowlist
     ? new Set(accountAllowlist)
@@ -5953,6 +6010,18 @@ export function createClaudeProxyRoutes(
         method: "POST",
         path: `${basePath}/v1/messages`,
         handler: async (ctx: ServerContext) => {
+          const requestRouting = runtimeConfigProvider?.() ?? {
+            generation: 0,
+            strategy: accountStrategy,
+            modelRouter,
+            passthrough: passthroughMode,
+            primaryAccountKey,
+            accountAllowlist,
+            quotaRoutingEnabled: isQuotaRoutingEnabled(),
+            sessionSoftLimit: getSessionSoftLimit(),
+            sessionResetToleranceMs: getSessionResetToleranceMs(),
+          };
+          const requestModelRouter = requestRouting.modelRouter;
           const body = ctx.body as ClaudeRequest | undefined;
 
           // 1. Validate
@@ -5969,7 +6038,7 @@ export function createClaudeProxyRoutes(
           // 2. Resolve model via router (or pass through to anthropic)
           // Guard: without a model router, only Claude models are allowed.
           const modelLower = body.model.toLowerCase();
-          if (!modelRouter && !modelLower.startsWith("claude-")) {
+          if (!requestModelRouter && !modelLower.startsWith("claude-")) {
             return buildClaudeError(
               404,
               `Model '${body.model}' is not an Anthropic model. ` +
@@ -5978,7 +6047,7 @@ export function createClaudeProxyRoutes(
             );
           }
 
-          const route = modelRouter?.resolve(body.model) ?? {
+          const route = requestModelRouter?.resolve(body.model) ?? {
             provider: "anthropic",
             model: body.model,
           };
@@ -6014,7 +6083,7 @@ export function createClaudeProxyRoutes(
             if (route.provider === "anthropic") {
               tracer?.setMode("passthrough");
 
-              if (passthroughMode) {
+              if (requestRouting.passthrough) {
                 return handleClaudePassthroughRequest({
                   ctx,
                   body,
@@ -6028,10 +6097,15 @@ export function createClaudeProxyRoutes(
               return handleAnthropicRoutedClaudeRequest({
                 ctx,
                 body,
-                modelRouter,
+                modelRouter: requestModelRouter,
                 tracer,
                 requestStartTime,
-                accountStrategy,
+                accountStrategy: requestRouting.strategy,
+                primaryAccountKey: requestRouting.primaryAccountKey,
+                accountAllowlist: requestRouting.accountAllowlist,
+                quotaRoutingEnabled: requestRouting.quotaRoutingEnabled,
+                sessionSoftLimit: requestRouting.sessionSoftLimit,
+                sessionResetToleranceMs: requestRouting.sessionResetToleranceMs,
                 buildLoggedClaudeError,
                 logProxyBody,
                 logFinalRequest,
@@ -6044,7 +6118,7 @@ export function createClaudeProxyRoutes(
                   provider: route.provider,
                   model: route.model,
                 },
-                modelRouter,
+                modelRouter: requestModelRouter,
                 tracer,
                 requestStartTime,
                 logProxyBody,
@@ -6082,15 +6156,19 @@ export function createClaudeProxyRoutes(
       {
         method: "GET",
         path: `${basePath}/v1/models`,
-        handler: async (_ctx: ServerContext) =>
-          withSpan(
+        handler: async (_ctx: ServerContext) => {
+          const requestModelRouter = runtimeConfigProvider
+            ? runtimeConfigProvider().modelRouter
+            : modelRouter;
+          return withSpan(
             {
               name: "neurolink.http.claudeProxy.listModels",
               tracer: tracers.http,
               attributes: { "http.route": `${basePath}/v1/models` },
             },
-            async () => buildAnthropicModelsListResponse(modelRouter),
-          ),
+            async () => buildAnthropicModelsListResponse(requestModelRouter),
+          );
+        },
         description: "List available models (Anthropic schema)",
         tags: ["claude-proxy", "models"],
       },

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -19,7 +19,6 @@ import {
   createClaudeToOpenAIStreamTransform,
   parseOpenAIRequest,
 } from "../../proxy/openaiFormat.js";
-import type { ModelRouter } from "../../proxy/modelRouter.js";
 import { ProxyTracer } from "../../proxy/proxyTracer.js";
 import {
   buildModelsListResponse,
@@ -30,8 +29,10 @@ import { logRequest } from "../../proxy/requestLogger.js";
 import { buildProxyTranslationPlan } from "../../proxy/routingPolicy.js";
 import type {
   ClaudeResponse,
+  ModelRouterInterface,
   OpenAICompletionRequest,
   ParsedOpenAIRequest,
+  ProxyRuntimeConfigProvider,
   RouteGroup,
   ServerContext,
 } from "../../types/index.js";
@@ -330,9 +331,10 @@ async function handleOpenAIToAnthropicBridge(args: {
  * @returns RouteGroup with OpenAI-compatible endpoints.
  */
 export function createOpenAIProxyRoutes(
-  modelRouter?: ModelRouter,
+  modelRouter?: ModelRouterInterface,
   basePath: string = "",
   loopbackPort: number = DEFAULT_LOOPBACK_PORT,
+  runtimeConfigProvider?: ProxyRuntimeConfigProvider,
 ): RouteGroup {
   return {
     prefix: `${basePath}/v1`,
@@ -345,6 +347,9 @@ export function createOpenAIProxyRoutes(
         path: `${basePath}/v1/chat/completions`,
         description: "OpenAI-compatible chat completions (translation mode)",
         handler: async (ctx: ServerContext) => {
+          const requestModelRouter = runtimeConfigProvider
+            ? runtimeConfigProvider().modelRouter
+            : modelRouter;
           const requestStartTime = Date.now();
           const body = ctx.body as OpenAICompletionRequest | undefined;
 
@@ -357,8 +362,8 @@ export function createOpenAIProxyRoutes(
           }
 
           // --- Resolve target provider/model ---
-          const route = modelRouter
-            ? modelRouter.resolve(body.model)
+          const route = requestModelRouter
+            ? requestModelRouter.resolve(body.model)
             : { provider: null, model: body.model };
           const targetProvider = route.provider ?? undefined;
           const targetModel = route.model ?? body.model;
@@ -423,7 +428,7 @@ export function createOpenAIProxyRoutes(
               provider: targetProvider ?? "auto",
               model: targetModel,
             },
-            modelRouter?.getFallbackChain() ?? [],
+            requestModelRouter?.getFallbackChain() ?? [],
             body.model,
             // The classifier only reads fields present on both types.
             adapted as Parameters<typeof buildProxyTranslationPlan>[3],
@@ -497,7 +502,10 @@ export function createOpenAIProxyRoutes(
         path: `${basePath}/v1/models`,
         description: "List available models in OpenAI format",
         handler: async () => {
-          return buildModelsListResponse(modelRouter);
+          const requestModelRouter = runtimeConfigProvider
+            ? runtimeConfigProvider().modelRouter
+            : modelRouter;
+          return buildModelsListResponse(requestModelRouter);
         },
       },
     ],

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -966,6 +966,14 @@ export type ProxyState = {
   managedBy?: "launchd" | "manual";
   /** Whether the proxy is running in transparent passthrough mode */
   passthrough?: boolean;
+  /** Active hot-reload configuration generation. */
+  configGeneration?: number;
+  /** Timestamp when the active configuration generation was loaded. */
+  configLoadedAt?: string;
+  /** Last rejected hot-reload error, when any. */
+  lastConfigReloadError?: string;
+  /** Absolute path watched for proxy routing configuration changes. */
+  configFile?: string;
 };
 
 // ============================================================================

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -21,6 +21,7 @@ import type { MCPToolRegistry } from "../mcp/toolRegistry.js";
 import type { ProxyTracer } from "../proxy/proxyTracer.js";
 import type {
   FallbackEntry,
+  ModelMapping,
   ProxyRoutingConfig,
   CloakingConfig,
 } from "./subscription.js";
@@ -34,6 +35,8 @@ export type ModelRouterInterface = {
   resolve(requestedModel: string): RouteResult;
   isClaudeTarget(requestedModel: string): boolean;
   getFallbackChain(): FallbackEntry[];
+  getModelMappings?: () => ModelMapping[];
+  getPassthroughModels?: () => string[];
 };
 
 // =============================================================================
@@ -1500,6 +1503,89 @@ export type LoadedProxyConfig = {
     strategy?: ProxyStartStrategy;
   };
 };
+
+/** Routing values captured once when a proxy request begins. */
+export type ProxyRequestRoutingSnapshot = {
+  generation: number;
+  strategy: ProxyStartStrategy;
+  modelRouter?: ModelRouterInterface;
+  passthrough: boolean;
+  primaryAccountKey?: string;
+  accountAllowlist?: ReadonlySet<string>;
+  quotaRoutingEnabled: boolean;
+  sessionSoftLimit: number;
+  sessionResetToleranceMs: number;
+};
+
+/** Immutable last-known-good proxy configuration published at runtime. */
+export type ProxyRuntimeConfigSnapshot = ProxyRequestRoutingSnapshot & {
+  loadedAt: string;
+  configHash: string;
+  proxyConfig: LoadedProxyConfig | null;
+};
+
+/** Source that requested a runtime configuration reload. */
+export type ProxyRuntimeConfigReloadSource =
+  | "startup"
+  | "watch"
+  | "sighup"
+  | "manual";
+
+/** Result returned after a serialized runtime configuration reload attempt. */
+export type ProxyRuntimeConfigReloadResult = {
+  applied: boolean;
+  changed: boolean;
+  generation: number;
+  error?: string;
+};
+
+/** Safe runtime configuration diagnostics exposed through proxy status. */
+export type ProxyRuntimeConfigStatus = {
+  configPath: string;
+  envFilePath?: string;
+  generation: number;
+  loadedAt: string;
+  configHash: string;
+  watching: boolean;
+  lastReloadAttemptAt?: string;
+  lastReloadAt?: string;
+  lastReloadSource?: ProxyRuntimeConfigReloadSource;
+  lastReloadError?: string;
+  consecutiveFailures: number;
+};
+
+/** Constructor options for the proxy runtime configuration store. */
+export type ProxyRuntimeConfigStoreOptions = {
+  configPath: string;
+  configRequired: boolean;
+  envFilePath?: string;
+  envFileRequired?: boolean;
+  baseEnv: Record<string, string | undefined>;
+  strategyOverride?: ProxyStartStrategy;
+  passthrough: boolean;
+  watchIntervalMs?: number;
+  watchDebounceMs?: number;
+};
+
+/** Runtime configuration provider captured by route factories. */
+export type ProxyRuntimeConfigProvider = () => ProxyRequestRoutingSnapshot;
+
+/** Optional runtime configuration wiring for Claude proxy route factories. */
+export type ClaudeProxyRouteRuntimeOptions = {
+  accountAllowlist?: AccountAllowlist;
+  runtimeConfigProvider: ProxyRuntimeConfigProvider;
+};
+
+/** Listener invoked after a new configuration generation is published. */
+export type ProxyRuntimeConfigListener = (
+  snapshot: ProxyRuntimeConfigSnapshot,
+) => void;
+
+/** Listener invoked after every successful or rejected reload attempt. */
+export type ProxyRuntimeConfigReloadListener = (
+  result: ProxyRuntimeConfigReloadResult,
+  status: ProxyRuntimeConfigStatus,
+) => void;
 
 /**
  * Handle for a NeuroLink runtime created by the proxy start command.

--- a/src/lib/types/subscription.ts
+++ b/src/lib/types/subscription.ts
@@ -1117,6 +1117,12 @@ export type ProxyRoutingConfig = {
   modelMappings: ModelMapping[];
   fallbackChain: FallbackEntry[];
   passthroughModels?: string[];
+  /** Enable quota-aware fill-first account ordering. Defaults to true. */
+  quotaRouting?: boolean;
+  /** Session utilization threshold used to proactively demote an account. */
+  sessionSoftLimit?: number;
+  /** Reset-time bucket width used when ordering quota windows. */
+  sessionResetToleranceMs?: number;
   /** Email/label of the Anthropic account that should be tried first
    *  ("home"). When absent, falls back to insertion-order index 0.
    *  Resolved per-request to a stable key (anthropic:<email>); does not

--- a/test/proxyConfigHotReload.test.ts
+++ b/test/proxyConfigHotReload.test.ts
@@ -1,0 +1,704 @@
+import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProxyRuntimeConfigStore } from "../src/lib/proxy/runtimeConfig.js";
+import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
+import { createClaudeProxyRoutes } from "../src/lib/server/routes/claudeProxyRoutes.js";
+import { createOpenAIProxyRoutes } from "../src/lib/server/routes/openaiProxyRoutes.js";
+import { resetStats } from "../src/lib/proxy/usageStats.js";
+import { createProxyStartApp } from "../src/cli/commands/proxy.js";
+
+const tempDirs: string[] = [];
+const stores: ProxyRuntimeConfigStore[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "neurolink-config-reload-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+function routingConfig(
+  strategy: "fill-first" | "round-robin",
+  targetModel: string,
+  fallbackModel: string,
+) {
+  return {
+    routing: {
+      strategy,
+      modelMappings: [
+        { from: "hot-model", to: targetModel, provider: "vertex" },
+      ],
+      fallbackChain: [{ provider: "openai", model: fallbackModel }],
+      passthroughModels: ["claude-passthrough"],
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const store of stores.splice(0)) {
+    store.stopWatching();
+  }
+  resetStats();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("proxy runtime configuration", () => {
+  it("parses kebab-case quota routing controls", async () => {
+    const parsed = await parseProxyConfigString(
+      `
+routing:
+  strategy: fill-first
+  model-mappings: []
+  fallback-chain: []
+  quota-routing: \${QUOTA_ROUTING}
+  session-soft-limit: 0.91
+  session-reset-tolerance-ms: 45000
+`,
+      {
+        env: { QUOTA_ROUTING: "false" },
+      },
+    );
+
+    expect(parsed.routing).toMatchObject({
+      quotaRouting: false,
+      sessionSoftLimit: 0.91,
+      sessionResetToleranceMs: 45_000,
+    });
+  });
+
+  it("atomically publishes a new immutable routing generation", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        routing: {
+          ...routingConfig("fill-first", "old-primary", "old-fallback").routing,
+          quotaRouting: false,
+          sessionSoftLimit: 0.82,
+          sessionResetToleranceMs: 1_500,
+          primaryAccount: "Primary@Example.com",
+          accountAllowlist: ["Primary@Example.com", "Secondary@Example.com"],
+        },
+      }),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+
+    const first = store.getSnapshot();
+    expect(first).toMatchObject({
+      generation: 1,
+      strategy: "fill-first",
+      quotaRoutingEnabled: false,
+      sessionSoftLimit: 0.82,
+      sessionResetToleranceMs: 1_500,
+      primaryAccountKey: "anthropic:primary@example.com",
+    });
+    expect(first.accountAllowlist).toEqual(
+      new Set([
+        "anthropic:primary@example.com",
+        "anthropic:secondary@example.com",
+      ]),
+    );
+    expect(first.modelRouter?.resolve("hot-model")).toEqual({
+      provider: "vertex",
+      model: "old-primary",
+    });
+
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        routingConfig("round-robin", "new-primary", "new-fallback"),
+      ),
+    );
+    await expect(store.reload("manual")).resolves.toEqual({
+      applied: true,
+      changed: true,
+      generation: 2,
+    });
+
+    const second = store.getSnapshot();
+    expect(second).not.toBe(first);
+    expect(second).toMatchObject({ generation: 2, strategy: "round-robin" });
+    expect(second.modelRouter?.resolve("hot-model")).toEqual({
+      provider: "vertex",
+      model: "new-primary",
+    });
+    expect(second.accountAllowlist).toBeUndefined();
+    expect(first.modelRouter?.resolve("hot-model")).toEqual({
+      provider: "vertex",
+      model: "old-primary",
+    });
+  });
+
+  it("retains last-known-good config after invalid edits and deletion", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    const originalConfig = routingConfig(
+      "fill-first",
+      "stable-primary",
+      "stable-fallback",
+    );
+    await writeFile(configPath, JSON.stringify(originalConfig));
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+    const stable = store.getSnapshot();
+
+    await writeFile(configPath, "{ malformed json");
+    const malformed = await store.reload("watch");
+    expect(malformed).toMatchObject({
+      applied: false,
+      changed: false,
+      generation: 1,
+    });
+    expect(store.getSnapshot()).toBe(stable);
+    expect(store.getStatus()).toMatchObject({
+      generation: 1,
+      consecutiveFailures: 1,
+      lastReloadSource: "watch",
+    });
+    expect(store.getStatus().lastReloadError).toContain(
+      "Failed to parse JSON proxy config",
+    );
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        routing: {
+          ...routingConfig("round-robin", "bad", "bad").routing,
+          sessionSoftLimit: 2,
+        },
+      }),
+    );
+    const invalid = await store.reload("manual");
+    expect(invalid.applied).toBe(false);
+    expect(invalid.error).toContain(
+      "routing.session-soft-limit must be a number in (0, 1]",
+    );
+    expect(store.getSnapshot()).toBe(stable);
+    expect(store.getStatus().consecutiveFailures).toBe(2);
+
+    await writeFile(configPath, JSON.stringify(originalConfig));
+    await expect(store.reload("manual")).resolves.toEqual({
+      applied: true,
+      changed: false,
+      generation: 1,
+    });
+    expect(store.getStatus()).toMatchObject({
+      consecutiveFailures: 0,
+      lastReloadError: undefined,
+    });
+
+    await unlink(configPath);
+    const deleted = await store.reload("manual");
+    expect(deleted.applied).toBe(false);
+    expect(deleted.error).toContain("Failed to read proxy config file");
+    expect(store.getSnapshot()).toBe(stable);
+  });
+
+  it("reloads routing env overrides and interpolation without mutating process.env", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    const envFilePath = join(dir, ".env");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        routing: {
+          strategy: "fill-first",
+          modelMappings: [
+            {
+              from: "hot-model",
+              to: "${TARGET_MODEL}",
+              provider: "vertex",
+            },
+          ],
+          fallbackChain: [],
+          quotaRouting: true,
+          sessionSoftLimit: 0.9,
+          sessionResetToleranceMs: 2_000,
+        },
+      }),
+    );
+    await writeFile(
+      envFilePath,
+      [
+        "TARGET_MODEL=from-env-v1",
+        "NEUROLINK_PROXY_QUOTA_ROUTING=off",
+        "NEUROLINK_PROXY_SESSION_SOFT_LIMIT=0.75",
+        "NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS=9000",
+      ].join("\n"),
+    );
+    const originalTargetModel = process.env.TARGET_MODEL;
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      envFilePath,
+      envFileRequired: true,
+      baseEnv: {},
+      strategyOverride: "round-robin",
+      passthrough: false,
+    });
+    stores.push(store);
+
+    expect(store.getSnapshot()).toMatchObject({
+      strategy: "round-robin",
+      quotaRoutingEnabled: false,
+      sessionSoftLimit: 0.75,
+      sessionResetToleranceMs: 9_000,
+    });
+    expect(store.getSnapshot().modelRouter?.resolve("hot-model").model).toBe(
+      "from-env-v1",
+    );
+    expect(process.env.TARGET_MODEL).toBe(originalTargetModel);
+
+    await writeFile(
+      envFilePath,
+      [
+        "TARGET_MODEL=from-env-v2",
+        "NEUROLINK_PROXY_QUOTA_ROUTING=on",
+        "NEUROLINK_PROXY_SESSION_SOFT_LIMIT=0.88",
+        "NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS=12000",
+      ].join("\n"),
+    );
+    await store.reload("manual");
+    expect(store.getSnapshot()).toMatchObject({
+      generation: 2,
+      strategy: "round-robin",
+      quotaRoutingEnabled: true,
+      sessionSoftLimit: 0.88,
+      sessionResetToleranceMs: 12_000,
+    });
+    expect(store.getSnapshot().modelRouter?.resolve("hot-model").model).toBe(
+      "from-env-v2",
+    );
+
+    const stable = store.getSnapshot();
+    await writeFile(
+      envFilePath,
+      [
+        "NEUROLINK_PROXY_QUOTA_ROUTING=on",
+        "NEUROLINK_PROXY_SESSION_SOFT_LIMIT=0.88",
+        "NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS=12000",
+      ].join("\n"),
+    );
+    const unresolved = await store.reload("manual");
+    expect(unresolved.applied).toBe(false);
+    expect(unresolved.error).toContain(
+      "Unresolved environment placeholder at routing.modelMappings[0].to",
+    );
+    expect(store.getSnapshot()).toBe(stable);
+
+    await writeFile(
+      envFilePath,
+      [
+        "TARGET_MODEL=ignored-invalid-env",
+        "NEUROLINK_PROXY_QUOTA_ROUTING=on",
+        "NEUROLINK_PROXY_SESSION_SOFT_LIMIT=0.88oops",
+        "NEUROLINK_PROXY_SESSION_RESET_TOLERANCE_MS=12000",
+      ].join("\n"),
+    );
+    const invalidEnv = await store.reload("manual");
+    expect(invalidEnv.applied).toBe(false);
+    expect(invalidEnv.error).toContain(
+      "Invalid NEUROLINK_PROXY_SESSION_SOFT_LIMIT=0.88oops",
+    );
+    expect(store.getSnapshot()).toBe(stable);
+
+    await unlink(envFilePath);
+    expect((await store.reload("manual")).applied).toBe(false);
+    expect(store.getSnapshot()).toBe(stable);
+  });
+
+  it("serializes concurrent reload attempts and notifies rejected reloads", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("fill-first", "v1", "fallback-v1")),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+    const reloadEvents = vi.fn();
+    store.subscribeReload(reloadEvents);
+
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("round-robin", "v2", "fallback-v2")),
+    );
+    const [first, second] = await Promise.all([
+      store.reload("manual"),
+      store.reload("sighup"),
+    ]);
+    expect(first).toEqual({ applied: true, changed: true, generation: 2 });
+    expect(second).toEqual({ applied: true, changed: false, generation: 2 });
+    expect(store.getSnapshot().generation).toBe(2);
+
+    await writeFile(configPath, "not-json");
+    expect((await store.reload("watch")).applied).toBe(false);
+    expect(reloadEvents).toHaveBeenCalledTimes(3);
+    expect(reloadEvents.mock.calls[2][1]).toMatchObject({
+      generation: 2,
+      consecutiveFailures: 1,
+      lastReloadSource: "watch",
+    });
+  });
+
+  it("watches config changes and stops cleanly", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("fill-first", "v1", "fallback-v1")),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+      watchIntervalMs: 50,
+      watchDebounceMs: 10,
+    });
+    stores.push(store);
+    store.startWatching();
+    expect(store.getStatus().watching).toBe(true);
+
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("round-robin", "v2", "fallback-v2")),
+    );
+    await waitFor(() => store.getSnapshot().generation === 2);
+    expect(store.getSnapshot().strategy).toBe("round-robin");
+
+    store.stopWatching();
+    expect(store.getStatus().watching).toBe(false);
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("fill-first", "v3", "fallback-v3")),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(store.getSnapshot().generation).toBe(2);
+  });
+
+  it("detects config and env files created after startup", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    const envFilePath = join(dir, ".env");
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: false,
+      envFilePath,
+      envFileRequired: false,
+      baseEnv: {},
+      passthrough: false,
+      watchIntervalMs: 50,
+      watchDebounceMs: 10,
+    });
+    stores.push(store);
+    expect(store.getSnapshot()).toMatchObject({
+      generation: 1,
+      strategy: "fill-first",
+      modelRouter: undefined,
+    });
+    store.startWatching();
+
+    await writeFile(envFilePath, "TARGET_MODEL=created-after-startup\n");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        routing: {
+          strategy: "round-robin",
+          modelMappings: [
+            {
+              from: "hot-model",
+              to: "${TARGET_MODEL}",
+              provider: "vertex",
+            },
+          ],
+          fallbackChain: [],
+        },
+      }),
+    );
+
+    await waitFor(() => store.getSnapshot().generation === 2);
+    expect(store.getSnapshot().strategy).toBe("round-robin");
+    expect(store.getSnapshot().modelRouter?.resolve("hot-model").model).toBe(
+      "created-after-startup",
+    );
+  });
+});
+
+describe("request routing snapshots", () => {
+  it("reports the active generation through the in-process proxy app", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("fill-first", "v1", "fallback-v1")),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+    store.startWatching();
+    const initial = store.getSnapshot();
+    const { app } = await createProxyStartApp({
+      neurolink: { getToolRegistry: () => ({}) } as never,
+      modelRouter: initial.modelRouter,
+      strategy: initial.strategy,
+      passthrough: initial.passthrough,
+      port: 55124,
+      host: "127.0.0.1",
+      proxyConfig: initial.proxyConfig,
+      primaryAccountKey: initial.primaryAccountKey,
+      accountAllowlist: initial.accountAllowlist,
+      runtimeConfigStore: store,
+    });
+
+    const firstHealth = await (await app.request("/health")).json();
+    expect(firstHealth).toMatchObject({ strategy: "fill-first" });
+
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("round-robin", "v2", "fallback-v2")),
+    );
+    await store.reload("manual");
+    const secondHealth = await (await app.request("/health")).json();
+    expect(secondHealth).toMatchObject({ strategy: "round-robin" });
+
+    const status = await (await app.request("/status")).json();
+    expect(status).toMatchObject({
+      strategy: "round-robin",
+      config: {
+        generation: 2,
+        watching: true,
+        lastReloadSource: "manual",
+        lastReloadError: null,
+        consecutiveFailures: 0,
+      },
+    });
+
+    await writeFile(configPath, "{broken");
+    await store.reload("watch");
+    const rejectedStatus = await (await app.request("/status")).json();
+    expect(rejectedStatus).toMatchObject({
+      strategy: "round-robin",
+      config: {
+        generation: 2,
+        lastReloadSource: "watch",
+        consecutiveFailures: 1,
+      },
+    });
+    expect(rejectedStatus.config.lastReloadError).toContain(
+      "Failed to parse JSON proxy config",
+    );
+  });
+
+  it("updates model discovery on the next request", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(routingConfig("fill-first", "v1", "fallback-v1")),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+    const routeGroup = createClaudeProxyRoutes(
+      store.getSnapshot().modelRouter,
+      "",
+      "fill-first",
+      false,
+      undefined,
+      {
+        runtimeConfigProvider: () => store.getSnapshot(),
+      },
+    );
+    const openAIRouteGroup = createOpenAIProxyRoutes(
+      store.getSnapshot().modelRouter,
+      "",
+      55124,
+      () => store.getSnapshot(),
+    );
+    const modelsRoute = routeGroup.routes.find(
+      (route) => route.method === "GET" && route.path === "/v1/models",
+    );
+    expect(modelsRoute).toBeDefined();
+    const openAIModelsRoute = openAIRouteGroup.routes.find(
+      (route) => route.method === "GET" && route.path === "/v1/models",
+    );
+    expect(openAIModelsRoute).toBeDefined();
+    const first = (await modelsRoute!.handler({} as never)) as {
+      data: Array<{ id: string }>;
+    };
+    expect(first.data.map((model) => model.id)).toContain("hot-model");
+    const firstOpenAI = (await openAIModelsRoute!.handler({} as never)) as {
+      data: Array<{ id: string }>;
+    };
+    expect(firstOpenAI.data.map((model) => model.id)).toContain("hot-model");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        routing: {
+          strategy: "fill-first",
+          modelMappings: [
+            { from: "new-hot-model", to: "v2", provider: "vertex" },
+          ],
+          fallbackChain: [],
+        },
+      }),
+    );
+    await store.reload("manual");
+    const second = (await modelsRoute!.handler({} as never)) as {
+      data: Array<{ id: string }>;
+    };
+    expect(second.data.map((model) => model.id)).toContain("new-hot-model");
+    expect(second.data.map((model) => model.id)).not.toContain("hot-model");
+    const secondOpenAI = (await openAIModelsRoute!.handler({} as never)) as {
+      data: Array<{ id: string }>;
+    };
+    expect(secondOpenAI.data.map((model) => model.id)).toContain(
+      "new-hot-model",
+    );
+    expect(secondOpenAI.data.map((model) => model.id)).not.toContain(
+      "hot-model",
+    );
+  });
+
+  it("keeps one generation for an in-flight fallback chain", async () => {
+    const dir = await createTempDir();
+    const configPath = join(dir, "proxy-config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        routingConfig("fill-first", "old-primary", "old-fallback"),
+      ),
+    );
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    stores.push(store);
+    const routeGroup = createClaudeProxyRoutes(
+      store.getSnapshot().modelRouter,
+      "",
+      "fill-first",
+      false,
+      undefined,
+      {
+        runtimeConfigProvider: () => store.getSnapshot(),
+      },
+    );
+    const messagesRoute = routeGroup.routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+    expect(messagesRoute).toBeDefined();
+
+    let releaseFirstAttempt: (() => void) | undefined;
+    let signalFirstAttempt: (() => void) | undefined;
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      signalFirstAttempt = resolve;
+    });
+    const firstAttemptGate = new Promise<void>((resolve) => {
+      releaseFirstAttempt = resolve;
+    });
+    const attemptedRoutes: Array<{ provider?: string; model?: string }> = [];
+    const stream = vi.fn(async (options: Record<string, unknown>) => {
+      attemptedRoutes.push({
+        provider:
+          typeof options.provider === "string" ? options.provider : undefined,
+        model: typeof options.model === "string" ? options.model : undefined,
+      });
+      if (attemptedRoutes.length === 1) {
+        signalFirstAttempt?.();
+        await firstAttemptGate;
+        throw new Error("force old fallback");
+      }
+      return {
+        stream: (async function* () {
+          yield { content: "fallback succeeded" };
+        })(),
+        model: options.model,
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        toolCalls: [],
+      };
+    });
+    const request = messagesRoute!.handler({
+      requestId: "hot-reload-in-flight",
+      method: "POST",
+      path: "/v1/messages",
+      headers: {},
+      query: {},
+      params: {},
+      body: {
+        model: "hot-model",
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+      },
+      neurolink: { stream },
+      toolRegistry: {},
+      timestamp: Date.now(),
+      metadata: {},
+    } as never);
+
+    await firstAttemptStarted;
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        routingConfig("round-robin", "new-primary", "new-fallback"),
+      ),
+    );
+    await store.reload("manual");
+    releaseFirstAttempt?.();
+    await expect(request).resolves.toMatchObject({ type: "message" });
+    expect(attemptedRoutes).toEqual([
+      { provider: "vertex", model: "old-primary" },
+      { provider: "openai", model: "old-fallback" },
+    ]);
+    expect(store.getSnapshot().modelRouter?.resolve("hot-model").model).toBe(
+      "new-primary",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add an atomic last-known-good runtime configuration store for the Claude/OpenAI proxy
- watch the resolved proxy config and proxy env files with debounced, serialized reloads
- capture one immutable routing generation per request so in-flight routing and fallback behavior cannot change mid-request
- hot-reload strategy, model mappings, fallback chain, passthrough models, primary account, account allowlist, quota routing controls, and routing env interpolation
- expose generation and rejected-reload diagnostics through `/status`, `/health`, persisted proxy state, and `neurolink proxy status`
- support immediate reload via `SIGHUP` and update auth primary-account messaging for watched paths
- document hot-reload semantics and startup-only boundaries

## Safety And Compatibility

- malformed, semantically invalid, unresolved, or deleted previously observed files are rejected without changing the active generation
- reload candidates are fully parsed and validated before one pointer swap
- request handling reads one in-memory snapshot; it performs no per-request config file I/O
- existing fixed-config route factory calls remain supported
- listener host/port, passthrough process mode, telemetry initialization, keep-alive setup, and executable code remain startup-only
- no dependency changes

The first deployment still needs the normal process replacement to load this release. After that, supported routing/config changes apply without restarting the proxy. Zero-downtime executable upgrades are intentionally a separate process-handoff change.

## Testing

- `pnpm exec vitest run test/proxyConfigHotReload.test.ts test/proxyReliabilityHardening.test.ts test/proxyUpdaterFallback.test.ts` - 69 passed
- `pnpm run build:cli` - passed on the rebased `9.91.1` release head
- targeted Prettier - passed
- targeted ESLint - 0 errors; existing max-lines warnings only
- repository pre-commit hook - full validation, lint, security validation, package build, CLI/browser builds, and publint passed

No proxy server was launched and no live proxy process, endpoint, config, or state was touched during implementation or testing.