### PR TITLE
fix(ai): enable tool routing only for main Neurolink calls

### DIFF
--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -1166,9 +1166,8 @@ export class CLICommandFactory {
         | "api"
         | undefined,
       enableBeta: argv.enableBeta as boolean | undefined,
-      // Tool-routing flags — constructor-level config, not a per-call option.
-      // Passed through the options bag so handlers can inject into the SDK
-      // instance before the first getOrCreateNeuroLink() call.
+      // Tool-routing flags. Config is injected into the SDK instance; the
+      // boolean flag is also forwarded per call as useToolRouting.
       toolRouting: argv.toolRouting as boolean | undefined,
       toolRoutingTimeout: argv.toolRoutingTimeout as number | undefined,
       toolRoutingRouterProvider: argv.toolRoutingRouterProvider as
@@ -3753,6 +3752,7 @@ export class CLICommandFactory {
             ? enhancedOptions.timeout * 1000
             : undefined,
           disableTools: enhancedOptions.disableTools,
+          useToolRouting: enhancedOptions.toolRouting === true,
           enabledToolNames: enhancedOptions.enabledToolNames as
             | string[]
             | undefined,
@@ -4101,6 +4101,7 @@ export class CLICommandFactory {
           ? (enhancedOptions.timeout as number) * 1000
           : undefined,
         disableTools: enhancedOptions.disableTools as boolean | undefined,
+        useToolRouting: enhancedOptions.toolRouting === true,
         enabledToolNames: enhancedOptions.enabledToolNames as
           | string[]
           | undefined,
@@ -4904,6 +4905,7 @@ export class CLICommandFactory {
                 ? enhancedOptions.timeout * 1000
                 : undefined,
               disableTools: enhancedOptions.disableTools,
+              useToolRouting: enhancedOptions.toolRouting === true,
               enabledToolNames: enhancedOptions.enabledToolNames as
                 | string[]
                 | undefined,

--- a/src/cli/loop/optionsSchema.ts
+++ b/src/cli/loop/optionsSchema.ts
@@ -121,6 +121,11 @@ export const textGenerationOptionsSchema: Record<
     type: "boolean",
     description: "Disable all tool usage for the AI.",
   },
+  useToolRouting: {
+    type: "boolean",
+    description:
+      "Pre-call tool routing for this request. Follows the SDK's toolRouting configuration unless set to false to skip routing for one call.",
+  },
   enabledToolNames: {
     type: "string",
     description:

--- a/src/lib/core/toolRouting.ts
+++ b/src/lib/core/toolRouting.ts
@@ -1,12 +1,12 @@
 /**
  * Pre-call tool routing.
  *
- * Once per stream() turn, a cheap router LLM call receives the user query and
- * the catalog of routable tool servers (id + description) and picks the
- * servers whose tools are plausibly needed. The tools of every unpicked
- * server are returned as an exclusion list, which the caller appends to the
- * request's `excludeTools` — the per-call denylist the provider enforces in
- * `baseProvider.applyToolFiltering`.
+ * For an explicitly opted-in generate()/stream() call, a cheap router LLM
+ * receives the user query and the catalog of routable tool servers (id +
+ * description) and picks the servers whose tools are plausibly needed. The
+ * tools of every unpicked server are returned as an exclusion list, which the
+ * caller appends to the request's `excludeTools` — the per-call denylist the
+ * provider enforces in `baseProvider.applyToolFiltering`.
  *
  * Denylist (not allowlist) semantics: the router only knows the declared
  * server catalog — a strict subset of the real tool set. Excluding unpicked

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -1320,6 +1320,9 @@ export class NeuroLink {
           generate: (genOptions) =>
             this.generate({
               ...genOptions,
+              // Auxiliary call: classifying a turn must not itself trigger a
+              // tool-routing hop (BZ-4440).
+              useToolRouting: false,
             }),
           logger: {
             debug: (message, meta) =>
@@ -4613,17 +4616,21 @@ Current user's request: ${currentInput}`;
         return earlyResult;
       }
 
-      // Pre-call tool routing for generate(): mirrors the stream() routing path.
-      // Runs inside the generate's Langfuse context (setLangfuseContextFromOptions)
-      // so the router's own generation span nests under this turn's trace.
-      // After the early-result short-circuit so workflow/media turns skip it.
+      // Pre-call tool routing for generate(). Constructor-level `toolRouting`
+      // still decides whether routing is active at all (applyToolRoutingExclusions
+      // no-ops unless it is enabled with a non-empty catalog); this flag is a
+      // per-call OPT-OUT. Auxiliary internal calls pass false so they stop
+      // paying for a router hop, while existing SDK callers that configured
+      // routing on the constructor keep the behaviour they have today.
       const result = await this.setLangfuseContextFromOptions(
         options,
         async () => {
-          await this.applyToolRoutingExclusions(
-            options,
-            options.input?.text ?? "",
-          );
+          if (options.useToolRouting !== false) {
+            await this.applyToolRoutingExclusions(
+              options,
+              options.input?.text ?? "",
+            );
+          }
           return this.runStandardGenerateRequest(
             options,
             originalPrompt,
@@ -9008,20 +9015,15 @@ Current user's request: ${currentInput}`;
       // tool calls) parents under it — one Langfuse trace per turn, not a forest.
       const streamSpanContext = trace.setSpan(context.active(), streamSpan);
 
-      // Pre-call tool routing: run inside the stream-span + Langfuse context so
-      // the router's own generation span nests under this turn's trace instead
-      // of starting a separate one. Asks a cheap router LLM which tool servers
-      // the query needs and appends the unpicked servers' tools to
-      // `excludeTools`. Fails open (no exclusions). Routes on the current
-      // prompt enriched with a bounded window of recent conversation turns
-      // (pulled from conversation memory) so contextless follow-ups still
-      // classify correctly. After the workflow short-circuit, so workflow
-      // streams skip it.
-      await context.with(streamSpanContext, () =>
-        this.setLangfuseContextFromOptions(options, () =>
-          this.applyToolRoutingExclusions(options, originalPrompt),
-        ),
-      );
+      // Pre-call tool routing. Per-call OPT-OUT (see generate() above):
+      // constructor-level `toolRouting` remains the activation switch.
+      if (options.useToolRouting !== false) {
+        await context.with(streamSpanContext, () =>
+          this.setLangfuseContextFromOptions(options, () =>
+            this.applyToolRoutingExclusions(options, originalPrompt),
+          ),
+        );
+      }
 
       // Pre-call classifier router for stream: opt-in, fails open. Runs before
       // the request router so it takes precedence.
@@ -9102,13 +9104,14 @@ Current user's request: ${currentInput}`;
   }
 
   /**
-   * Pre-call tool routing for both stream() and generate() turns: runs the
-   * router LLM once per turn and appends the unpicked servers' registered tool
-   * names to `options.excludeTools` — the per-call denylist enforced by
-   * `baseProvider.applyToolFiltering`. No-op unless `toolRouting.enabled` is
-   * true and a non-empty server catalog has been supplied. Never throws (the
-   * resolver fails open to an empty exclusion list). Accepts both StreamOptions
-   * and GenerateOptions since both share the required fields.
+   * Pre-call tool routing for explicitly opted-in stream() and generate()
+   * turns: runs the router LLM once per turn and appends the unpicked servers'
+   * registered tool names to `options.excludeTools` — the per-call denylist
+   * enforced by `baseProvider.applyToolFiltering`. No-op unless
+   * constructor-level `toolRouting.enabled` is true and a non-empty server
+   * catalog has been supplied. Never throws (the resolver fails open to an
+   * empty exclusion list). Accepts both StreamOptions and GenerateOptions
+   * since both share the required fields.
    */
   private async applyToolRoutingExclusions(
     options: StreamOptions | GenerateOptions,
@@ -9396,6 +9399,8 @@ Current user's request: ${currentInput}`;
             this.generate({
               ...generateOptions,
               abortSignal: options.abortSignal,
+              // The router's own LLM call must never re-enter routing.
+              useToolRouting: false,
             }),
           emitDecision: captureDecision,
           // L2 / ITEM D — only populated when embedding is configured.
@@ -9573,9 +9578,9 @@ Current user's request: ${currentInput}`;
    * Supplies (or replaces) the pre-call tool routing server catalog.
    *
    * For hosts that only know their tool servers after constructing NeuroLink
-   * (e.g. tools are registered per session/conversation). Routing must still
-   * be enabled via the constructor's `toolRouting.enabled` — setting servers
-   * alone does not activate it.
+   * (e.g. tools are registered per session/conversation). Routing still
+   * requires constructor `toolRouting.enabled` — setting servers alone does
+   * not activate it. A single call can opt out with `useToolRouting: false`.
    */
   setToolRoutingServers(servers: ToolRoutingServerDescriptor[]): void {
     if (!this.toolRoutingConfig) {
@@ -12125,6 +12130,8 @@ Current user's request: ${currentInput}`;
         input: { text: probeText },
         maxTokens: 16,
         disableTools: true,
+        // Auxiliary call: a credential probe must not spend a router hop.
+        useToolRouting: false,
       } as GenerateOptions);
       return { provider, status: "ok", detail: "credentials valid" };
     } catch (err) {

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -431,6 +431,14 @@ export type GenerateOptions = {
    */
   disableTools?: boolean;
 
+  /**
+   * Per-call opt-in to use pre-call tool routing.
+   * Constructor-level `toolRouting` supplies router configuration and server
+   * catalog, but routing runs only when this flag is explicitly true.
+   * Default: false.
+   */
+  useToolRouting?: boolean;
+
   /** Include only these tools by name (whitelist). If set, only matching tools are available. */
   toolFilter?: string[];
 
@@ -1264,6 +1272,16 @@ export type TextGenerationOptions = {
   disableTools?: boolean; // Disable tools (tools are enabled by default)
   /** Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled). */
   disableToolCallRepair?: boolean;
+  /**
+   * Per-call control over pre-call tool routing.
+   * Constructor-level `toolRouting` supplies router configuration and the
+   * server catalog; this flag only overrides whether routing runs for one
+   * call. Unset means "follow the instance configuration", so an instance
+   * with `toolRouting` configured keeps routing as before. NeuroLink's own
+   * auxiliary calls (suggestions, evaluation, summarisation) pass `false` so
+   * they no longer pay for a router hop.
+   */
+  useToolRouting?: boolean;
   maxSteps?: number; // Maximum tool execution steps (default: 200)
 
   /** Include only these tools by name (whitelist). If set, only matching tools are available. */

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -417,6 +417,16 @@ export type StreamOptions = {
   /** Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture. */
   toolExecutionCapture?: ToolExecutionCaptureOptions;
   disableTools?: boolean;
+  /**
+   * Per-call control over pre-call tool routing.
+   * Constructor-level `toolRouting` supplies router configuration and the
+   * server catalog; this flag only overrides whether routing runs for one
+   * call. Unset means "follow the instance configuration", so an instance
+   * with `toolRouting` configured keeps routing as before. NeuroLink's own
+   * auxiliary calls (classifier, router, credential probe) pass `false` so
+   * they no longer pay for a router hop.
+   */
+  useToolRouting?: boolean;
   /** Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled). */
   disableToolCallRepair?: boolean;
   maxSteps?: number; // Maximum tool execution steps. Defaults to 5 in the implementation if not specified.

--- a/src/lib/types/toolRouting.ts
+++ b/src/lib/types/toolRouting.ts
@@ -3,10 +3,11 @@
  *
  * Host applications can register large numbers of custom tools (typically MCP
  * server tools) whose names are prefixed with their server id
- * (`${serverId}_${toolName}`). When tool routing is enabled, a cheap router
- * LLM call runs once per `stream()` turn, picks the servers relevant to the
- * user query, and the tools of every unpicked server are appended to the
- * request's `excludeTools` denylist before the main model call.
+ * (`${serverId}_${toolName}`). When a call explicitly sets
+ * `useToolRouting: true`, a cheap router LLM call picks the servers
+ * relevant to the user query, and the tools of every unpicked server are
+ * appended to the request's `excludeTools` denylist before the main model
+ * call.
  *
  * Denylist semantics are deliberate: the router only knows the declared
  * server catalog — a strict subset of the real tool set. Excluding unpicked
@@ -111,7 +112,10 @@ export type ToolRoutingEmbeddingConfig = {
 
 /** Constructor-level configuration for pre-call tool routing. */
 export type ToolRoutingConfig = {
-  /** Master switch. Routing runs only when true AND the server catalog is non-empty. */
+  /**
+   * Constructor-level master switch. A call still must pass
+   * `useToolRouting: true`, and the server catalog must be non-empty.
+   */
   enabled: boolean;
   /**
    * Routable server catalog. Hosts that only know their servers after

--- a/src/lib/utils/optionsConversion.ts
+++ b/src/lib/utils/optionsConversion.ts
@@ -33,6 +33,7 @@ export function convertGenerateToStreamOptions(
     // Tool configuration
     tools: generateOptions.tools,
     disableTools: generateOptions.disableTools,
+    useToolRouting: generateOptions.useToolRouting,
     // maxSteps only exists in StreamOptions, not GenerateOptions
 
     // Analytics and evaluation
@@ -76,6 +77,7 @@ export function convertStreamToGenerateOptions(
     // Tool configuration
     tools: streamOptions.tools,
     disableTools: streamOptions.disableTools,
+    useToolRouting: streamOptions.useToolRouting,
     // Note: maxSteps exists in StreamOptions but not in GenerateOptions
 
     // Analytics and evaluation

--- a/test/continuous-test-suite-tool-routing.ts
+++ b/test/continuous-test-suite-tool-routing.ts
@@ -610,7 +610,104 @@ await test("second identical resolveToolRoutingExclusions call reuses cached res
 });
 
 // ============================================================================
-// Part 5 — LIVE-gated: NeuroLink.generate() wiring
+// Part 5 — BZ-4440: the per-call routing gate on generate()/stream()
+// ============================================================================
+
+/**
+ * Drive a NeuroLink call far enough to pass the routing gate, then let it fail.
+ * The gate runs before provider resolution, so an unroutable provider aborts
+ * the turn cheaply while still proving whether routing was consulted — no API
+ * key and no network required.
+ */
+function routedSdk(): InstanceType<typeof NeuroLink> {
+  const sdk = new NeuroLink({
+    toolRouting: {
+      enabled: true,
+      routerModel: { provider: "openai", model: "gpt-4o-mini", temperature: 0 },
+    },
+  });
+  sdk.setToolRoutingServers([
+    { id: "analytics", description: "Sales and payment analytics" },
+    { id: "shipping", description: "Shipment tracking" },
+  ]);
+  return sdk;
+}
+
+async function gateCallCount(
+  callOptions: Record<string, unknown>,
+): Promise<number> {
+  const sdk = routedSdk();
+  const proto = Object.getPrototypeOf(sdk) as Record<string, unknown>;
+  const spy = stub(proto, "applyToolRoutingExclusions", async () => undefined);
+  try {
+    return await withStubs([spy], async () => {
+      try {
+        await sdk.generate({
+          input: { text: "how are sales doing?" },
+          provider: "this-provider-does-not-exist",
+          ...callOptions,
+        } as never);
+      } catch {
+        // Expected — the turn dies after the gate, which is all we measure.
+      }
+      return spy.callCount;
+    });
+  } finally {
+    spy.restore();
+  }
+}
+
+await test("BZ-4440: a routed instance still routes a plain generate call", async () => {
+  // Regression guard. Gating routing behind an explicit per-call opt-in would
+  // silently disable routing for every existing SDK caller that configured
+  // `toolRouting` on the constructor. Unset must keep meaning "follow the
+  // instance configuration".
+  assertEqual(await gateCallCount({}), 1, "routing consulted when flag unset");
+});
+
+await test("BZ-4440: useToolRouting:false skips routing for that call", async () => {
+  // The actual fix: auxiliary calls opt out so they stop paying a router hop.
+  assertEqual(
+    await gateCallCount({ useToolRouting: false }),
+    0,
+    "routing skipped when explicitly opted out",
+  );
+});
+
+await test("BZ-4440: useToolRouting:true routes as before", async () => {
+  assertEqual(
+    await gateCallCount({ useToolRouting: true }),
+    1,
+    "routing consulted when explicitly requested",
+  );
+});
+
+await test("BZ-4440: an unrouted instance never consults routing", async () => {
+  const sdk = new NeuroLink();
+  const proto = Object.getPrototypeOf(sdk) as Record<string, unknown>;
+  const spy = stub(proto, "applyToolRoutingExclusions", async () => undefined);
+  try {
+    await withStubs([spy], async () => {
+      try {
+        await sdk.generate({
+          input: { text: "hello" },
+          provider: "this-provider-does-not-exist",
+        } as never);
+      } catch {
+        // Expected.
+      }
+    });
+    // The gate is reached, but applyToolRoutingExclusions is a no-op without
+    // config; asserting it is still *called* documents that the instance-level
+    // switch — not the per-call flag — is what activates routing.
+    assertEqual(spy.callCount, 1, "gate defers to the instance configuration");
+  } finally {
+    spy.restore();
+  }
+});
+
+// ============================================================================
+// Part 6 — LIVE-gated: NeuroLink.generate() wiring
 // ============================================================================
 
 await test("NeuroLink generate() routing narrows tools (live — skips without API keys)", async () => {
@@ -666,7 +763,7 @@ await test("NeuroLink generate() routing narrows tools (live — skips without A
     // was triggered (if it fails open, tools are unchanged — acceptable).
     const result = await sdk.generate({
       input: { text: "show me yesterday's sales figures" },
-      disableTools: false,
+      useToolRouting: true,
     });
 
     assert(


### PR DESCRIPTION
# Pull Request

## Description

**What does this PR do?**

Adds explicit per-call tool-routing control via `useToolRouting`, so the tool-routing LLM only runs for requests that intentionally opt in. Constructor-level `toolRouting` remains the enablement/configuration surface, while `generate()` and `stream()` now require `useToolRouting: true` to apply pre-call server filtering.

This prevents auxiliary Neurolink calls, such as chat suggestion generation, from redundantly invoking the tool-routing LLM.

[
<img width="1046" height="964" alt="Screenshot 2026-07-17 at 7 24 14 PM" src="https://github.com/user-attachments/assets/e6f090fe-63e9-481c-8226-a4364fbe3589" />
<img width="1046" height="960" alt="Screenshot 2026-07-17 at 7 24 08 PM" src="https://github.com/user-attachments/assets/655faafd-9243-4812-aac3-93b6ed7d05e9" />
](url)

plane ticket: https://plane.breezehq.dev/breeze/browse/BZ-4440/

## Related Issues

**Does this PR close any issues?**

Relates to redundant tool-routing LLM calls observed in Langfuse traces for AI chat suggestions.

## Type of Change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test coverage improvement
- [ ] Build/CI configuration
- [ ] Other (please describe):

## Motivation and Context

**Why is this change needed? What problem does it solve?**

The tool-routing LLM should filter tool servers for the main user-facing LLM request only. Because routing was tied only to constructor-level configuration, auxiliary calls sharing the same Neurolink instance could also trigger routing.

In Lighthouse, the suggestions endpoint uses `generate()` to create follow-up suggestions after chat responses. Those suggestion calls do not need tool-server filtering, so running the router there adds unnecessary latency and cost.

This change separates router configuration from per-call router usage:

- `toolRouting.enabled` configures whether the router is available on a Neurolink instance.
- `useToolRouting: true` opts a specific `generate()` or `stream()` call into routing.

## Changes Made

**What specific changes were made?**

- Added `useToolRouting?: boolean` to Neurolink generation and stream option types.
- Gated `generate()` tool routing behind `options.useToolRouting === true`.
- Gated `stream()` tool routing behind `options.useToolRouting === true`.
- Preserved `useToolRouting` during generate/stream option conversion.
- Updated CLI wiring so `--tool-routing` maps to `useToolRouting: true`.
- Updated docs/comments to clarify constructor-level `toolRouting` is configuration, not automatic per-call usage.
- Added regression tests for routed and unrouted `generate()` and `stream()` calls.
- Passed `useToolRouting: true` from the Lighthouse main chat stream call.
- Left Lighthouse chat suggestions and auxiliary internal `generate()` calls unrouted.

## Breaking Changes

**Does this PR introduce breaking changes?**

- [x] No breaking changes
- [ ] Yes, breaking changes (describe below)

If yes, describe:

- N/A

## Testing

**How has this been tested?**

Please describe the tests you ran and their results:

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests pass
- [ ] Manual testing completed
- [ ] Tested with multiple providers: not run
- [ ] Tested on multiple platforms: not run

### Test Coverage

- [x] All new code is covered by tests
- [x] Existing tests pass
- [ ] Coverage percentage maintained or improved

### Commands Run

```sh
pnpm exec vitest run test/toolRouting.test.ts
pnpm run typecheck
pnpm exec prettier --check src/lib/neurolink.ts src/lib/types/generate.ts src/lib/types/stream.ts src/lib/types/toolRouting.ts src/lib/utils/optionsConversion.ts src/cli/factories/commandFactory.ts src/cli/loop/optionsSchema.ts test/toolRouting.test.ts test/continuous-test-suite-tool-routing.ts
pnpm run check
git diff --check
```

For Lighthouse:

```sh
pnpm exec prettier --check src/lib/services/server/ai/core/sessionInstanceManager.ts
git diff --check -- src/lib/services/server/ai/core/sessionInstanceManager.ts
pnpm run check
```

`pnpm run check` in Lighthouse failed on existing unrelated Svelte/type errors outside the touched file. The touched Lighthouse file passed Prettier and diff checks.

### Manual Testing Steps

Provide steps for manual testing:

1. Enable Lighthouse `toolRoutingEnabled`.
2. Send a normal AI chat prompt through the main chat stream.
3. Verify the main stream call passes `useToolRouting: true` and the router LLM runs once before the main response.
4. Let chat suggestions generate after the response.
5. Verify the suggestions `generate()` call does not pass `useToolRouting` and does not invoke the router LLM.

## Code Quality

**Have you followed code quality standards?**

- [ ] Code follows the project's style guidelines (ESLint passes)
- [x] Code is properly formatted (Prettier applied)
- [x] Self-review of code completed
- [x] No console.log statements (using logger instead)
- [x] No hardcoded API keys or secrets
- [x] TypeScript strict mode compliance
- [x] Proper error handling implemented
- [x] TODO/FIXME comments reference issues

## Documentation

**Have you updated documentation?**

- [x] JSDoc comments added/updated for public APIs
- [ ] README.md updated (if needed)
- [ ] Documentation in /docs updated (if needed)
- [ ] Code examples added/updated (if needed)
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Migration guide provided (if breaking changes)

## Commit Message Format

**Does your commit follow semantic commit conventions?**

- [x] Commit message follows format: `type(scope): description`
- [x] Valid type used: feat, fix, docs, style, refactor, test, chore, build, ci, perf, revert
- [x] Scope specified (e.g., providers, cli, docs, middleware)

Example:

```text
fix(ai): enable tool routing only for main Neurolink calls
```

## Dependencies

**Does this PR add, update, or remove dependencies?**

- [x] No dependency changes
- [ ] Dependencies added (list below)
- [ ] Dependencies updated (list below)
- [ ] Dependencies removed (list below)

If yes, list dependencies and justification:

```text
N/A
```

## Performance Impact

**Does this change affect performance?**

- [ ] No performance impact
- [x] Performance improved (provide metrics)
- [ ] Performance degraded (justify why acceptable)

If applicable, provide benchmark results:

```text
Before: chat suggestions could trigger an unnecessary tool-routing LLM call.
After: chat suggestions remain unrouted unless explicitly opted in.
Improvement: avoids one redundant router LLM call for suggestion generation paths.
```

## Security Considerations

**Are there any security implications?**

- [x] No security implications
- [ ] Security review needed
- [ ] Security vulnerability fixed

If applicable, describe:

- N/A

## Deployment Notes

**Special deployment instructions?**

- [x] No special deployment steps
- [ ] Requires environment variable changes (list below)
- [ ] Requires database migration
- [ ] Requires Redis schema update
- [ ] Other (describe below)

## Screenshots / Videos

**If applicable, add screenshots or videos to demonstrate changes:**

N/A

## Reviewer Checklist

For reviewers:

- [ ] Code follows project style and conventions
- [ ] Changes are well-documented
- [ ] Tests provide adequate coverage
- [ ] No obvious performance issues
- [ ] No security vulnerabilities introduced
- [ ] Breaking changes are properly documented
- [ ] Documentation is clear and accurate

## Additional Notes

**Any additional information for reviewers:**

This PR intentionally keeps auxiliary `generate()` calls unrouted unless they explicitly pass `useToolRouting: true`. That includes chat suggestions, Kriya planning, HITL argument classification, and media-generation helper paths.

---

## Pre-submission Checklist

Before submitting, ensure you have:

- [ ] Read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] Verified all automated pre-commit checks pass
- [ ] Tested changes locally with `pnpm test`
- [ ] Built the project successfully with `pnpm build`
- [ ] Run `pnpm run validate:all` and all checks pass
- [x] Reviewed your own code for obvious issues
- [x] Ensured commit messages follow semantic format
- [x] Updated relevant documentation
- [x] Added tests for new functionality
- [ ] Checked that CI/CD pipeline passes (after creating PR)

Thank you for contributing to NeuroLink!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit per-request `useToolRouting` option for generate, stream, and batch operations.
  * Tool routing now runs only when explicitly enabled for a request and routing configuration is available.
  * CLI users can enable pre-call tool routing with the `--tool-routing` flag.

* **Documentation**
  * Clarified tool-routing activation requirements and behavior.

* **Tests**
  * Added coverage verifying routing is skipped by default and activated when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->