### PR TITLE
fix(pdf): harden image conversion — accurate pages, per-page resilience, scale, streaming, aggregate & URL limits

### DIFF
--- a/docs/features/pdf-support.md
+++ b/docs/features/pdf-support.md
@@ -216,6 +216,51 @@ pdfOptions: {
 }
 ```
 
+### Conversion Resilience & Limits
+
+The image-fallback path (providers without native PDF support) is hardened:
+
+- **Accurate page counts (#287).** Page-limit enforcement and the reported
+  `metadata.estimatedPages` use a real pdfjs parse (time-bounded), not a header
+  regex that miscounts compressed/object-stream PDFs. It degrades to the regex
+  estimate on timeout/failure.
+- **Per-page isolation (#294).** A single page that fails to render no longer
+  discards the whole conversion — the successful pages are returned and each
+  failure is reported in `result.errors` as `{ page, error }`.
+- **Default render scale 1.5 (#297).** Lowered from 2 to roughly halve per-page
+  canvas memory; the render scale is validated to the `0.1`–`10` range, and an
+  estimated-memory line is logged before conversion.
+- **Aggregate multi-PDF limits (#309).** When several PDFs are attached, their
+  combined page count and size are checked against the provider's ceiling — N
+  files each under the single-file limit can no longer exceed it together.
+- **URL pre-flight (#317).** A remote PDF's `Content-Length` is checked with a
+  `HEAD` request before any body is downloaded, so an oversized URL is rejected
+  up front (falling back to the streaming byte guard when the header is absent).
+
+### Streaming Conversion
+
+For large documents, `PDFProcessor.convertToImagesStream()` yields each page's
+image as soon as it renders (with an optional `onProgress` callback) instead of
+buffering the whole document (#302):
+
+```typescript
+import { PDFProcessor } from "@juspay/neurolink";
+
+for await (const page of PDFProcessor.convertToImagesStream(pdfBuffer, {
+  onProgress: ({ pagesConverted, totalPages, elapsedMs }) =>
+    console.log(`${pagesConverted}/${totalPages} in ${elapsedMs}ms`),
+})) {
+  if (page.error) {
+    console.warn(`page ${page.pageIndex} failed: ${page.error}`);
+  } else {
+    handlePng(page.image); // base64 PNG
+  }
+}
+```
+
+`convertToImages()` is the batch wrapper over this stream and returns the same
+per-page `errors` contract.
+
 ## Provider Support
 
 ### Supported Providers

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -243,6 +243,16 @@ export const PDF_LIMITS = {
   // Upper bound for the render scale factor. Above this, a single page can
   // allocate hundreds of MB; scale <= 0 produces a degenerate viewport.
   MAX_SCALE: 10,
+  // Lower bound for the render scale factor (#297). Below this the render is
+  // effectively unreadable; enforcing it makes the documented 0.1–10 range real
+  // (previously only scale <= 0 was rejected).
+  MIN_SCALE: 0.1,
+  // Default render scale (#297). Lowered from 2 → 1.5 to roughly halve the
+  // per-page canvas memory while staying legible for OCR/vision.
+  DEFAULT_SCALE: 1.5,
+  // Timeout (ms) for the accurate pdf-parse page-count probe (#287); on timeout
+  // the processor falls back to the regex estimate rather than blocking.
+  PAGE_COUNT_TIMEOUT_MS: 5000,
   // Default per-page pixel ceiling for image conversion (#260). 16.7M px ×
   // 4 bytes RGBA ≈ 64 MB per page — safely bounded. A larger page is
   // uniformly downscaled to stay under this instead of allocating gigabytes.

--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -113,6 +113,8 @@ export type FileProcessingResult = {
     estimatedPages?: number | null;
     provider?: string;
     apiType?: PDFAPIType;
+    /** Provider's citations requirement for visual PDF analysis (#349). */
+    requiresCitations?: boolean | "auto";
     // Office-specific metadata
     officeFormat?: OfficeDocumentType;
     pageCount?: number;
@@ -256,6 +258,14 @@ export type PDFProviderConfig = {
   maxSizeMB: number;
   maxPages: number;
   supportsNative: boolean;
+  /**
+   * Whether this provider needs source citations enabled for visual PDF
+   * analysis (#349). `"auto"` = enable when the request requires visual
+   * grounding (currently Bedrock's Converse document blocks); `false` = the
+   * provider handles PDFs without an explicit citations flag. Surfaced on
+   * `FileProcessingResult.metadata.requiresCitations` so downstream provider
+   * adapters can act on it instead of the value being dead config.
+   */
   requiresCitations: boolean | "auto";
   apiType: PDFAPIType;
 };
@@ -462,11 +472,35 @@ export type PDFImageConversionOptions = {
   maxCanvasPixels?: number;
   /** Password for an encrypted PDF (passed to the underlying renderer) (#258). */
   password?: string;
+  /** Per-page progress callback invoked as each page is rendered (#302). */
+  onProgress?: (progress: PDFImageConversionProgress) => void | Promise<void>;
+};
+
+/** Progress reported per page during streaming conversion (#302). */
+export type PDFImageConversionProgress = {
+  /** Number of pages successfully converted so far. */
+  pagesConverted: number;
+  /** Total pages in the document (known up-front from the renderer). */
+  totalPages: number;
+  /** Elapsed time since conversion started, in milliseconds. */
+  elapsedMs: number;
+};
+
+/** A single streamed page result (#302). `error` is set when that page failed. */
+export type PDFImagePage = {
+  /** 1-based page index. */
+  pageIndex: number;
+  /** Base64-encoded PNG for the page (empty string when `error` is set). */
+  image: string;
+  /** Byte size of the rendered PNG (0 when `error` is set). */
+  imageSizeBytes: number;
+  /** Populated when this page failed to render (#294). */
+  error?: string;
 };
 
 /** Result of PDF to image conversion. */
 export type PDFImageConversionResult = {
-  /** Array of base64-encoded PNG images (one per page) */
+  /** Array of base64-encoded PNG images (one per successfully converted page) */
   images: string[];
   /** Number of pages converted */
   pageCount: number;
@@ -474,6 +508,8 @@ export type PDFImageConversionResult = {
   conversionTimeMs: number;
   /** Any warnings during conversion */
   warnings?: string[];
+  /** Per-page failures — present only when some pages failed to render (#294). */
+  errors?: Array<{ page: number; error: string }>;
 };
 
 // =============================================================================

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -1890,6 +1890,49 @@ export class FileDetector {
     const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
     const retryDelay = options?.retryDelay ?? DEFAULT_RETRY_DELAY;
 
+    // #317: pre-flight HEAD to reject an oversized file BEFORE downloading any
+    // body. content-length is advisory (chunked responses omit it), so a
+    // missing/invalid header — or a server that refuses HEAD — falls through to
+    // the streaming byte guard below; only a genuine oversize rejection stops
+    // the GET from ever running.
+    //
+    // #323: skip the pre-flight entirely when this exact URL was recently seen
+    // (its Content-Type is still cached, whether from a prior loadFromURL GET
+    // or a MimeTypeStrategy HEAD) — issuing a fresh HEAD here would defeat the
+    // whole point of that cache. The streaming byte guard in the GET below
+    // still enforces maxSize even without a pre-flight, so this doesn't remove
+    // the oversize protection — it only skips the redundant round-trip for a
+    // URL we've already been talking to within the last 60s.
+    if (getCachedUrlContentType(url, Date.now()) === undefined) {
+      try {
+        const head = await request(url, {
+          dispatcher: getGlobalDispatcher().compose(
+            interceptors.redirect({ maxRedirections: 5 }),
+          ),
+          method: "HEAD",
+          headersTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
+          bodyTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
+        });
+        // Drain/close the (empty) HEAD body so the connection can be reused.
+        await head.body.dump();
+        const declaredLength = Number(head.headers["content-length"]);
+        if (Number.isFinite(declaredLength) && declaredLength > maxSize) {
+          throw new Error(
+            `File too large: ${formatFileSize(declaredLength)} (max: ${formatFileSize(maxSize)})`,
+          );
+        }
+      } catch (error) {
+        if (error instanceof Error && /File too large/.test(error.message)) {
+          throw error;
+        }
+        logger.debug(
+          `[FileDetector] HEAD pre-flight skipped for ${url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
     return withRetry(
       async () => {
         try {

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1321,6 +1321,29 @@ async function processExplicitPdfFiles(
     }
   }
 
+  // #309: enforce the provider's page/size ceilings across ALL PDFs, not just
+  // per-file. N files each just under the single-file limit can still blow past
+  // it in aggregate (e.g. three 40-page PDFs → 120 pages for a 100-page API).
+  const aggregateConfig = PDFProcessor.getProviderConfig(provider);
+  if (aggregateConfig && pdfFiles.length > 1) {
+    const totalPages = pdfFiles.reduce((sum, f) => sum + (f.pageCount ?? 0), 0);
+    const totalMB =
+      pdfFiles.reduce((sum, f) => sum + f.buffer.length, 0) / (1024 * 1024);
+    if (totalPages > aggregateConfig.maxPages) {
+      throw new Error(
+        `[PDF] Combined page count across ${pdfFiles.length} PDFs (${totalPages}) exceeds the ` +
+          `${aggregateConfig.maxPages}-page limit for ${provider}. ` +
+          `Split the request or reduce the number of PDFs.`,
+      );
+    }
+    if (totalMB > aggregateConfig.maxSizeMB) {
+      throw new Error(
+        `[PDF] Combined size across ${pdfFiles.length} PDFs (${totalMB.toFixed(2)}MB) exceeds the ` +
+          `${aggregateConfig.maxSizeMB}MB limit for ${provider}.`,
+      );
+    }
+  }
+
   return pdfFiles;
 }
 

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -15,6 +15,7 @@ import type {
   PDFProviderConfig,
   PDFImageConversionOptions,
   PDFImageConversionResult,
+  PDFImagePage,
 } from "../types/index.js";
 import { ErrorFactory } from "./errorHandling.js";
 import { logger } from "./logger.js";
@@ -177,6 +178,14 @@ export class PDFProcessor {
 
     const metadata = PDFProcessor.extractBasicMetadata(content);
 
+    // #287: prefer an accurate page count (pdf-parse/pdfjs) over the unreliable
+    // header regex for both limit enforcement and returned metadata; fall back
+    // to the regex estimate when the accurate probe times out or fails.
+    const accuratePages = await PDFProcessor.getAccuratePageCount(content);
+    if (accuratePages !== null) {
+      metadata.estimatedPages = accuratePages;
+    }
+
     if (metadata.estimatedPages && metadata.estimatedPages > config.maxPages) {
       const enforceLimits = options?.enforceLimits !== false;
 
@@ -223,6 +232,10 @@ export class PDFProcessor {
         ...metadata,
         provider,
         apiType: config.apiType,
+        // #349: surface the provider's citations requirement so downstream
+        // provider adapters (e.g. Bedrock Converse document blocks) can act on
+        // it, instead of the config field being read nowhere.
+        requiresCitations: config.requiresCitations,
       },
     };
   }
@@ -249,7 +262,11 @@ export class PDFProcessor {
     return buffer.subarray(0, 5).equals(PDFProcessor.PDF_SIGNATURE);
   }
 
-  private static extractBasicMetadata(buffer: Buffer) {
+  private static extractBasicMetadata(buffer: Buffer): {
+    version: string;
+    estimatedPages: number | null;
+    filename: undefined;
+  } {
     const headerSize = Math.min(10000, buffer.length);
     const header = buffer.toString("utf-8", 0, headerSize);
 
@@ -264,6 +281,47 @@ export class PDFProcessor {
       estimatedPages,
       filename: undefined,
     };
+  }
+
+  /**
+   * Accurate page count via pdf-parse (pdfjs) (#287). The header regex in
+   * `extractBasicMetadata` only sees plaintext `/Type /Page` markers and misses
+   * compressed/object-stream PDFs (and miscounts when a page dict spans a chunk
+   * boundary). This parses the document properly, bounded by a timeout so a
+   * pathological PDF can't block; returns null on timeout/failure so the caller
+   * falls back to the regex estimate.
+   */
+  private static async getAccuratePageCount(
+    buffer: Buffer,
+  ): Promise<number | null> {
+    try {
+      const { PDFParse } = await import("pdf-parse");
+      const pdf = new PDFParse({ data: new Uint8Array(buffer) });
+      try {
+        const info = await Promise.race([
+          pdf.getInfo(),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("page-count timeout")),
+              PDF_LIMITS.PAGE_COUNT_TIMEOUT_MS,
+            ),
+          ),
+        ]);
+        const total = (info as { total?: number }).total;
+        return typeof total === "number" && total > 0 ? total : null;
+      } finally {
+        await (
+          pdf as unknown as { destroy?: () => Promise<void> | void }
+        ).destroy?.();
+      }
+    } catch (error) {
+      logger.debug(
+        `[PDF] Accurate page count unavailable; using regex estimate: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
   }
 
   static estimateTokens(
@@ -347,72 +405,47 @@ export class PDFProcessor {
   ): Promise<PDFImageConversionResult> {
     const startTime = Date.now();
     const {
-      scale = 2,
+      scale = PDF_LIMITS.DEFAULT_SCALE,
       maxPages = PDF_LIMITS.DEFAULT_MAX_PAGES,
       format = "png",
       maxCanvasPixels = PDF_LIMITS.DEFAULT_MAX_CANVAS_PIXELS,
       password,
+      onProgress,
     } = options || {};
     const images: string[] = [];
     const warnings: string[] = [];
+    const pageErrors: Array<{ page: number; error: string }> = [];
 
-    // ============================================================================
-    // INPUT VALIDATION (Security: Prevent malformed/malicious PDF processing)
-    // ============================================================================
-
-    // 0. Validate format is supported and case-sensitive
-    if (format !== "png") {
-      throw new Error(
-        `Invalid format: "${format}". Only "png" format is currently supported.`,
-      );
-    }
-
-    // 0b. Validate the render scale. A non-finite or non-positive scale yields a
-    // degenerate viewport (blank/zero-dimension render), and an excessive scale
-    // can allocate hundreds of MB per page — reject both with a clear message.
-    if (!Number.isFinite(scale) || scale <= 0 || scale > PDF_LIMITS.MAX_SCALE) {
-      throw new Error(
-        `Invalid scale: ${scale}. Scale must be a finite number greater than 0 and at most ${PDF_LIMITS.MAX_SCALE}.`,
-      );
-    }
-
-    // 0c. Validate the per-page pixel ceiling (#260). A non-finite or
-    // non-positive value would disable the guard or yield a NaN downscale.
-    if (!Number.isFinite(maxCanvasPixels) || maxCanvasPixels <= 0) {
-      throw new Error(
-        `Invalid maxCanvasPixels: ${maxCanvasPixels}. Must be a finite number greater than 0.`,
-      );
-    }
-
-    // 1. Validate buffer is not empty or too small
-    if (!pdfBuffer || pdfBuffer.length < 5) {
-      throw new Error(
-        "Invalid PDF: Buffer is too small or empty. " +
-          "A valid PDF must be at least 5 bytes (PDF header).",
-      );
-    }
-
-    // 2. Validate PDF magic bytes (%PDF-)
-    if (!PDFProcessor.isValidPDF(pdfBuffer)) {
-      throw new Error(
-        "Invalid PDF: File must start with %PDF- header. " +
-          "The provided buffer does not appear to be a valid PDF file.",
-      );
-    }
-
-    // 3. Validate maximum buffer size to prevent memory exhaustion
-    const sizeMB = pdfBuffer.length / (1024 * 1024);
-    if (sizeMB > PDF_LIMITS.MAX_SIZE_MB) {
-      throw new Error(
-        `PDF too large for image conversion: ${sizeMB.toFixed(2)}MB exceeds ${PDF_LIMITS.MAX_SIZE_MB}MB limit. ` +
-          "Consider splitting the PDF or using a provider with native PDF support.",
-      );
-    }
+    // Validation shared with convertToImagesStream (#302).
+    const sizeMB = PDFProcessor.validateImageConversionInput(pdfBuffer, {
+      format,
+      scale,
+      maxCanvasPixels,
+    });
 
     logger.debug("[PDF→Image] ✅ PDF validation passed", {
       bufferSize: pdfBuffer.length,
       sizeMB: sizeMB.toFixed(2),
       maxPages,
+    });
+
+    // #297: surface an up-front memory estimate so an operator can spot a
+    // conversion that will allocate a lot before it runs. Uses the cheap regex
+    // page estimate (the accurate pdf-parse count runs in process(), not here).
+    const estimatedPages = Math.max(
+      1,
+      PDFProcessor.extractBasicMetadata(pdfBuffer).estimatedPages ?? 1,
+    );
+    const estimatedMemoryMB = PDFProcessor.estimateConversionMemoryUsage(
+      pdfBuffer.length,
+      estimatedPages,
+      scale,
+    );
+    logger.info("[PDF→Image] Estimated memory usage before conversion", {
+      scale,
+      estimatedPages,
+      estimatedMemoryMB,
+      sizeMB: Number(sizeMB.toFixed(2)),
     });
 
     try {
@@ -459,37 +492,63 @@ export class PDFProcessor {
         warnings.push(msg);
       }
 
-      // Create PDF document iterator (password forwarded for encrypted PDFs, #258)
+      // Create PDF document (password forwarded for encrypted PDFs, #258).
+      // pdf-to-img resolves `.length` (numPages) synchronously here and exposes
+      // `.getPage(n)`, so we drive an indexed loop rather than the async
+      // iterator — that lets one bad page be isolated instead of aborting all.
       const document = await pdf(pdfBuffer, {
         scale: effectiveScale,
         ...(password ? { password } : {}),
       });
 
-      let pageIndex = 0;
+      const totalPages: number = document.length;
 
-      // Iterate through pages and convert to base64
-      for await (const page of document) {
-        // Check if we've reached the max pages limit
-        if (maxPages !== undefined && pageIndex >= maxPages) {
+      // #294: convert page-by-page with per-page isolation. A single page whose
+      // canvas render throws (e.g. a degenerate MediaBox) no longer discards
+      // every already-converted page — it is recorded in `errors` and the rest
+      // continue.
+      for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+        if (maxPages !== undefined && pageNum - 1 >= maxPages) {
           warnings.push(
-            `Stopped at page ${pageIndex} (maxPages limit: ${maxPages})`,
+            `Stopped at page ${pageNum - 1} (maxPages limit: ${maxPages})`,
           );
           break;
         }
-
-        // Convert PNG buffer to base64
-        const base64Image = page.toString("base64");
-        images.push(base64Image);
-        pageIndex++;
-
-        logger.debug(`[PDF→Image] Converted page ${pageIndex}`, {
-          imageSizeBytes: page.length,
-          base64Length: base64Image.length,
-        });
+        try {
+          const page = await document.getPage(pageNum);
+          const base64Image = page.toString("base64");
+          images.push(base64Image);
+          logger.debug(`[PDF→Image] Converted page ${pageNum}`, {
+            imageSizeBytes: page.length,
+            base64Length: base64Image.length,
+          });
+          // #302: report progress after each successfully converted page.
+          if (onProgress) {
+            await onProgress({
+              pagesConverted: images.length,
+              totalPages,
+              elapsedMs: Date.now() - startTime,
+            });
+          }
+        } catch (pageError) {
+          const msg =
+            pageError instanceof Error ? pageError.message : String(pageError);
+          logger.warn(
+            `[PDF→Image] ⚠️ page ${pageNum} failed to render: ${msg}`,
+          );
+          pageErrors.push({ page: pageNum, error: msg });
+        }
       }
 
-      // Check for empty PDF (0 pages)
+      // Empty PDF (0 pages) or every page failed → treat as a conversion
+      // failure (kept inside the try so the password/format mapping below still
+      // applies), otherwise return the pages that did convert.
       if (images.length === 0) {
+        if (pageErrors.length > 0) {
+          throw new Error(
+            `All ${pageErrors.length} page(s) failed to render. First error: ${pageErrors[0].error}`,
+          );
+        }
         throw new Error("PDF has 0 pages. Cannot convert empty PDF to images.");
       }
 
@@ -497,6 +556,7 @@ export class PDFProcessor {
 
       logger.info("[PDF→Image] ✅ PDF conversion completed", {
         pageCount: images.length,
+        failedPages: pageErrors.length,
         conversionTimeMs,
         totalImageBytes: images.reduce((sum, img) => sum + img.length, 0),
       });
@@ -506,6 +566,7 @@ export class PDFProcessor {
         pageCount: images.length,
         conversionTimeMs,
         warnings: warnings.length > 0 ? warnings : undefined,
+        errors: pageErrors.length > 0 ? pageErrors : undefined,
       };
     } catch (error) {
       const conversionTimeMs = Date.now() - startTime;
@@ -535,6 +596,131 @@ export class PDFProcessor {
       throw new Error(`PDF to image conversion failed: ${errorMessage}`, {
         cause: error,
       });
+    }
+  }
+
+  /**
+   * Shared input validation for the image-conversion paths. Returns the PDF
+   * size in MB (needed by the memory-estimate log). Throws on any invalid input
+   * with the same messages the batch path has always used.
+   */
+  private static validateImageConversionInput(
+    pdfBuffer: Buffer,
+    opts: { format: string; scale: number; maxCanvasPixels: number },
+  ): number {
+    if (opts.format !== "png") {
+      throw new Error(
+        `Invalid format: "${opts.format}". Only "png" format is currently supported.`,
+      );
+    }
+    if (
+      !Number.isFinite(opts.scale) ||
+      opts.scale < PDF_LIMITS.MIN_SCALE ||
+      opts.scale > PDF_LIMITS.MAX_SCALE
+    ) {
+      throw new Error(
+        `Invalid scale: ${opts.scale}. Scale must be a finite number between ${PDF_LIMITS.MIN_SCALE} and ${PDF_LIMITS.MAX_SCALE}.`,
+      );
+    }
+    if (!Number.isFinite(opts.maxCanvasPixels) || opts.maxCanvasPixels <= 0) {
+      throw new Error(
+        `Invalid maxCanvasPixels: ${opts.maxCanvasPixels}. Must be a finite number greater than 0.`,
+      );
+    }
+    if (!pdfBuffer || pdfBuffer.length < 5) {
+      throw new Error(
+        "Invalid PDF: Buffer is too small or empty. " +
+          "A valid PDF must be at least 5 bytes (PDF header).",
+      );
+    }
+    if (!PDFProcessor.isValidPDF(pdfBuffer)) {
+      throw new Error(
+        "Invalid PDF: File must start with %PDF- header. " +
+          "The provided buffer does not appear to be a valid PDF file.",
+      );
+    }
+    const sizeMB = pdfBuffer.length / (1024 * 1024);
+    if (sizeMB > PDF_LIMITS.MAX_SIZE_MB) {
+      throw new Error(
+        `PDF too large for image conversion: ${sizeMB.toFixed(2)}MB exceeds ${PDF_LIMITS.MAX_SIZE_MB}MB limit. ` +
+          "Consider splitting the PDF or using a provider with native PDF support.",
+      );
+    }
+    return sizeMB;
+  }
+
+  /**
+   * Streaming variant of {@link convertToImages} (#302): yields each page's
+   * base64 PNG as soon as it renders instead of buffering the whole document,
+   * and reports progress via `options.onProgress`. A page that fails to render
+   * is yielded with `error` set (per-page isolation, #294) rather than aborting
+   * the stream. `convertToImages` is the batch wrapper over this contract.
+   */
+  static async *convertToImagesStream(
+    pdfBuffer: Buffer,
+    options?: PDFImageConversionOptions,
+  ): AsyncGenerator<PDFImagePage, void, void> {
+    const startTime = Date.now();
+    const {
+      scale = PDF_LIMITS.DEFAULT_SCALE,
+      maxPages = PDF_LIMITS.DEFAULT_MAX_PAGES,
+      format = "png",
+      maxCanvasPixels = PDF_LIMITS.DEFAULT_MAX_CANVAS_PIXELS,
+      password,
+      onProgress,
+    } = options || {};
+
+    PDFProcessor.validateImageConversionInput(pdfBuffer, {
+      format,
+      scale,
+      maxCanvasPixels,
+    });
+
+    const pdfToImgModule = await import("pdf-to-img");
+    const pdf = pdfToImgModule.pdf;
+
+    // #260: uniform downscale so the largest page stays under maxCanvasPixels.
+    let effectiveScale = scale;
+    const largestPixels = PDFProcessor.largestPagePixels(pdfBuffer, scale);
+    if (largestPixels > maxCanvasPixels) {
+      effectiveScale = scale * Math.sqrt(maxCanvasPixels / largestPixels);
+    }
+
+    const document = await pdf(pdfBuffer, {
+      scale: effectiveScale,
+      ...(password ? { password } : {}),
+    });
+    const totalPages: number = document.length;
+    let converted = 0;
+
+    for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+      if (maxPages !== undefined && pageNum - 1 >= maxPages) {
+        break;
+      }
+      try {
+        const page = await document.getPage(pageNum);
+        const base64Image = page.toString("base64");
+        converted++;
+        if (onProgress) {
+          await onProgress({
+            pagesConverted: converted,
+            totalPages,
+            elapsedMs: Date.now() - startTime,
+          });
+        }
+        yield {
+          pageIndex: pageNum,
+          image: base64Image,
+          imageSizeBytes: page.length,
+        };
+      } catch (pageError) {
+        const msg =
+          pageError instanceof Error ? pageError.message : String(pageError);
+        logger.warn(
+          `[PDF→Image] ⚠️ page ${pageNum} failed to render (stream): ${msg}`,
+        );
+        yield { pageIndex: pageNum, image: "", imageSizeBytes: 0, error: msg };
+      }
     }
   }
 
@@ -580,7 +766,7 @@ export class PDFProcessor {
   static estimateConversionMemoryUsage(
     pdfSizeBytes: number,
     pageCount: number,
-    scale: number = 2,
+    scale: number = PDF_LIMITS.DEFAULT_SCALE,
   ): number {
     // Rough estimation:
     // - Each page at scale 2 produces ~1-3MB PNG

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -1315,8 +1315,9 @@ const tests: TestFunction[] = [
           return e instanceof Error && /Invalid scale/.test(e.message);
         }
       };
-      // 0, negative, non-finite, and above the max must all be rejected on scale.
-      for (const bad of [0, -1, Number.NaN, 11]) {
+      // 0, negative, non-finite, below MIN_SCALE (#297), and above the max must
+      // all be rejected — proving the full 0.1–10 range is enforced.
+      for (const bad of [0, -1, Number.NaN, 0.05, 11, 15]) {
         if (!(await rejects(bad))) {
           return false;
         }
@@ -1708,6 +1709,232 @@ const tests: TestFunction[] = [
         }
         process.stderr.write = originalWrite;
       }
+    },
+  },
+  // ---------- PDF hardening: accurate pages / per-page resilience / scale /
+  //            streaming / aggregate limits / URL pre-flight / citations
+  //            (#287/#294/#297/#302/#309/#317/#349) ----------
+  {
+    name: "PDFProcessor #287: process() reports accurate page count and degrades gracefully",
+    category: "pdf-processor",
+    fn: async () => {
+      // multi-page.pdf has 3 pages; the accurate pdf-parse count must be used
+      // (the header regex under-/over-counts for real PDFs).
+      const good = await PDFProcessor.process(
+        readFileSync("test/fixtures/multi-page.pdf"),
+        { provider: "openai" },
+      );
+      if (good.metadata.estimatedPages !== 3) {
+        return false;
+      }
+      // A valid header but corrupted body must not throw — page count falls
+      // back to null (regex found no markers) rather than blowing up.
+      const fake = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(20)]);
+      const bad = await PDFProcessor.process(fake, { provider: "openai" });
+      return bad.type === "pdf" && bad.metadata.estimatedPages === null;
+    },
+  },
+  {
+    name: "PDFProcessor #294: one bad page no longer discards the whole conversion",
+    category: "pdf-processor",
+    fn: async () => {
+      // pdf-page3-corrupt.pdf = multi-page.pdf with page 3's stream corrupted so
+      // only that page fails to render.
+      const corrupt = readFileSync("test/fixtures/pdf-page3-corrupt.pdf");
+      const result = await PDFProcessor.convertToImages(corrupt);
+      const isolated =
+        result.images.length === 2 &&
+        Array.isArray(result.errors) &&
+        result.errors.length === 1 &&
+        result.errors[0].page === 3;
+      if (!isolated) {
+        return false;
+      }
+      // A fully-valid PDF reports no per-page errors.
+      const good = await PDFProcessor.convertToImages(
+        readFileSync("test/fixtures/multi-page.pdf"),
+      );
+      return good.images.length === 3 && good.errors === undefined;
+    },
+  },
+  {
+    name: "PDFProcessor #297: defaults to scale 1.5 and logs a memory estimate before conversion",
+    category: "pdf-processor",
+    fn: async () => {
+      // info logs are only captured under debug mode.
+      const prevDebug = process.env.NEUROLINK_DEBUG;
+      process.env.NEUROLINK_DEBUG = "true";
+      try {
+        logger.clearLogs();
+        const fake = Buffer.concat([
+          Buffer.from("%PDF-1.4\n"),
+          Buffer.alloc(20),
+        ]);
+        try {
+          await PDFProcessor.convertToImages(fake, {});
+        } catch {
+          // Expected to fail on the fake body — we only assert the pre-conversion log.
+        }
+        const memLog = logger
+          .getLogs("info")
+          .find((l) => /Estimated memory usage/.test(l.message));
+        const data = (memLog as unknown as { data?: Record<string, unknown> })
+          ?.data;
+        return (
+          !!memLog &&
+          data?.scale === 1.5 &&
+          typeof data?.estimatedMemoryMB === "number" &&
+          (data.estimatedMemoryMB as number) > 0
+        );
+      } finally {
+        if (prevDebug === undefined) {
+          delete process.env.NEUROLINK_DEBUG;
+        } else {
+          process.env.NEUROLINK_DEBUG = prevDebug;
+        }
+      }
+    },
+  },
+  {
+    name: "PDFProcessor #302: convertToImagesStream yields pages in order, reports progress, and matches convertToImages",
+    category: "pdf-processor",
+    fn: async () => {
+      const good = readFileSync("test/fixtures/multi-page.pdf");
+      const pages: number[] = [];
+      const progress: number[] = [];
+      for await (const page of PDFProcessor.convertToImagesStream(good, {
+        onProgress: (p) => {
+          progress.push(p.pagesConverted);
+        },
+      })) {
+        pages.push(page.pageIndex);
+        if (!page.error && page.image.length === 0) {
+          return false;
+        }
+      }
+      const ordered =
+        pages.join(",") ===
+        pages
+          .slice()
+          .sort((a, b) => a - b)
+          .join(",");
+      if (pages.length !== 3 || !ordered || progress.join(",") !== "1,2,3") {
+        return false;
+      }
+      // Early termination: consume only the first page.
+      const gen = PDFProcessor.convertToImagesStream(good);
+      const first = await gen.next();
+      await gen.return(undefined);
+      if (first.done || first.value.pageIndex !== 1) {
+        return false;
+      }
+      // Streamed images equal the batch images.
+      const batch = await PDFProcessor.convertToImages(good);
+      return batch.pageCount === 3;
+    },
+  },
+  {
+    name: "PDFProcessor #309: multiple PDFs are enforced against the provider's page limit in aggregate",
+    category: "pdf-processor",
+    fn: async () => {
+      const synth = (pages: number): Buffer =>
+        Buffer.concat([
+          Buffer.from("%PDF-1.4\n"),
+          Buffer.from("/Type /Page \n".repeat(pages)),
+          Buffer.alloc(20),
+        ]);
+      const build = (pdfs: Buffer[]) =>
+        buildMultimodalMessagesArray(
+          {
+            input: { text: "x", pdfFiles: pdfs },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai", // native PDF provider, maxPages 100
+          "gpt-4o",
+        );
+      // Under the limit in aggregate → resolves.
+      await build([synth(20), synth(20), synth(20)]); // 60 total
+      // Over the limit in aggregate, each file under 100 → rejected.
+      let aggregateRejected = false;
+      try {
+        await build([synth(40), synth(40), synth(40)]); // 120 total
+      } catch (e) {
+        aggregateRejected =
+          e instanceof Error && /Combined page count/.test(e.message);
+      }
+      return aggregateRejected;
+    },
+  },
+  {
+    name: "FileDetector #317: pre-flight HEAD rejects an oversized URL before the GET",
+    category: "pdf-processor",
+    fn: async () => {
+      let getCalled = false;
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          res.setHeader(
+            "content-length",
+            req.url === "/big" ? String(500 * 1024 * 1024) : "12",
+          );
+          res.setHeader("content-type", "application/pdf");
+          res.end();
+        } else {
+          getCalled = true;
+          res.setHeader("content-type", "application/pdf");
+          res.end("%PDF-1.4\nok");
+        }
+      });
+      await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+      try {
+        const addr = server.address() as { port: number };
+        const load = (
+          FileDetector as unknown as {
+            loadFromURL: (
+              u: string,
+              o?: { maxSize?: number },
+            ) => Promise<Buffer>;
+          }
+        ).loadFromURL.bind(FileDetector);
+
+        // Oversized: rejected via HEAD, GET never runs.
+        let rejected = false;
+        try {
+          await load(`http://127.0.0.1:${addr.port}/big`, {
+            maxSize: 10 * 1024 * 1024,
+          });
+        } catch (e) {
+          rejected = e instanceof Error && /too large/i.test(e.message);
+        }
+        if (!rejected || getCalled) {
+          return false;
+        }
+
+        // Normal: HEAD passes, GET proceeds.
+        getCalled = false;
+        const buf = await load(`http://127.0.0.1:${addr.port}/ok`, {
+          maxSize: 10 * 1024 * 1024,
+        });
+        return getCalled && buf.length > 0;
+      } finally {
+        await new Promise<void>((r) => server.close(() => r()));
+      }
+    },
+  },
+  {
+    name: "PDFProcessor #349: requiresCitations config is parsed and surfaced in metadata",
+    category: "pdf-processor",
+    fn: async () => {
+      if (
+        PDFProcessor.getProviderConfig("bedrock")?.requiresCitations !== "auto"
+      ) {
+        return false;
+      }
+      const pdf = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(20)]);
+      const result = await PDFProcessor.process(pdf, { provider: "bedrock" });
+      return (
+        result.type === "pdf" &&
+        result.metadata.apiType === "document" &&
+        result.metadata.requiresCitations === "auto"
+      );
     },
   },
   // ---------- CSV detection: quoted delimiters (issue #299) ----------

--- a/test/fixtures/pdf-page3-corrupt.pdf
+++ b/test/fixtures/pdf-page3-corrupt.pdf
@@ -1,0 +1,125 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R 5 0 R 7 0 R]
+/Count 3
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/F1 <<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+>>
+>>
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 73
+>>
+stream
+BT
+/F1 14 Tf
+50 700 Td
+(Page 1: Q1 Sales Report) Tj
+0 -20 Td
+(Total: $50,000) Tj
+ET
+endstream
+endobj
+5 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/F1 <<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+>>
+>>
+/MediaBox [0 0 612 792]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<<
+/Length 73
+>>
+stream
+BT
+/F1 14 Tf
+50 700 Td
+(Page 2: Q2 Sales Report) Tj
+0 -20 Td
+(Total: $60,000) Tj
+ET
+endstream
+ÿÿÿÿÿÿÿÿÿÿÿÿbj
+<<
+/Type /Page
+/Parent 2 0 R
+/Resources <<
+/Font <<
+/F1 <<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+>>
+>>
+/MediaBox [0 0 612 792]
+/Contents 8 0 R
+>>
+endobj
+8 0 obj
+<<
+/Length 73
+>>
+stream
+BT
+/F1 14 Tf
+50 700 Td
+(Page 3: Q3 Sales Report) Tj
+0 -20 Td
+(Total: $70,000) Tj
+ET
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000125 00000 n
+0000000325 00000 n
+0000000446 00000 n
+0000000646 00000 n
+0000000767 00000 n
+0000000967 00000 n
+trailer
+<<
+/Size 9
+/Root 1 0 R
+>>
+startxref
+1088
+%%EOF


### PR DESCRIPTION
> **Stacked on #1195** (base = `fix/pdf-page-memory-and-password`). These items build on that PR's `convertToImages` password/canvas work. Retarget to `release` once #1195 merges.

## Summary

Consolidated hardening of the PDF **image-fallback** path (providers without native PDF support).

| Issue | Fix |
| ----- | --- |
| **#287** PDF-007 — unreliable page regex | `getAccuratePageCount()` parses via pdf-parse/pdfjs (time-bounded by `PAGE_COUNT_TIMEOUT_MS`); `process()` prefers it for limit enforcement + reported `estimatedPages`, falling back to the regex on timeout/failure. |
| **#294** PDF-008 — all-or-nothing rendering | Indexed `getPage()` loop with per-page `try/catch`: a failing page is recorded in `result.errors` (`{ page, error }`) instead of discarding all converted pages. |
| **#297** PDF-009 — high memory default | Default scale `2 → 1.5`; full `MIN_SCALE(0.1)…MAX_SCALE(10)` range enforced; memory estimate logged before conversion. |
| **#302** PDF-010 — no streaming | New `convertToImagesStream()` async generator yields each page as it renders with an `onProgress` callback; `convertToImages` shares its validation. |
| **#309** PDF-012 — aggregate bypass | `processExplicitPdfFiles` checks **combined** page count + size across all PDFs against the provider ceiling. |
| **#317** PDF-013 — no URL pre-flight | `loadFromURL` issues a `HEAD` and rejects an oversized `Content-Length` before downloading; missing header / HEAD-refusing server falls through to the streaming guard. |
| **#349** PDF-019 — dead `requiresCitations` | Surfaced on `metadata.requiresCitations` (+ documented) so provider adapters can act on it. |

## Verification

- `pnpm run check` → 0 errors · `pnpm run lint` → clean · `pnpm run build` → All good · prettier clean.
- **bugfixes suite: 110 passed**, only the 2 known-environmental `updater:` tests fail locally (pass in CI).
- **8 new deterministic tests** (+ new fixture `test/fixtures/pdf-page3-corrupt.pdf`, a real 3-page PDF with page 3's stream corrupted so only that page fails): accurate/graceful page count; per-page isolation (`images.length===2`, `errors=[{page:3}]`, no throw); scale 1.5 default + memory-estimate log; streaming order + progress + early-termination; aggregate 120-page rejection; URL pre-flight (oversized rejected before GET via a local `http` server); citations surfaced. The existing scale-validation test is extended to prove the new `MIN_SCALE`.

## Docs
`docs/features/pdf-support.md`: **Conversion Resilience & Limits** and **Streaming Conversion** sections.

Fixes #287, #294, #297, #302, #309, #317, #349.