### PR TITLE
fix(multimodal): fail-loud file errors, empty-image guard, CSV content items, audio/video detection, URL cache, tighter MessageContent

### DIFF
--- a/src/lib/core/modules/MessageBuilder.ts
+++ b/src/lib/core/modules/MessageBuilder.ts
@@ -36,7 +36,18 @@ function computeTotalContentLength(messages: ModelMessage[]): number {
 }
 
 /**
- * Check whether input contains multimodal content (images, files, PDFs, CSVs).
+ * Check whether input contains multimodal content (images, files, PDFs, CSVs,
+ * audio, video). #284: audioFiles/videoFiles were previously ignored here, so a
+ * request carrying only audio or video was misrouted to the text-only path.
+ *
+ * Intentional (round-2 review): routing audio/video through `isMultimodal`
+ * does NOT mean vision is required. `buildMultimodalMessagesArray` folds
+ * `audioFiles`/`videoFiles` into `inp.files` for auto-detection, and
+ * `appendDetectedFileResult` injects their content as plain text markers
+ * (`## Audio File:` / `## Video File:`), not image/vision blocks — see
+ * `test/continuous-test-suite-bugfixes.ts` ("MessageBuilder #284: ...").
+ * "Multimodal" here means "needs the multimodal builder so the payload isn't
+ * dropped", not "needs a vision model".
  */
 function detectMultimodal(opts: TextGenerationOptions | StreamOptions): {
   isMultimodal: boolean;
@@ -49,11 +60,20 @@ function detectMultimodal(opts: TextGenerationOptions | StreamOptions): {
   const hasCSVFiles = !!input?.csvFiles?.length;
   const hasPdfFiles = !!input?.pdfFiles?.length;
   const hasFiles = !!input?.files?.length;
+  const hasAudioFiles = !!input?.audioFiles?.length;
+  const hasVideoFiles = !!input?.videoFiles?.length;
   return {
     isMultimodal:
-      hasImages || hasContent || hasCSVFiles || hasPdfFiles || hasFiles,
+      hasImages ||
+      hasContent ||
+      hasCSVFiles ||
+      hasPdfFiles ||
+      hasFiles ||
+      hasAudioFiles ||
+      hasVideoFiles,
     hasImages,
-    hasFiles: hasCSVFiles || hasPdfFiles || hasFiles,
+    hasFiles:
+      hasCSVFiles || hasPdfFiles || hasFiles || hasAudioFiles || hasVideoFiles,
   };
 }
 
@@ -100,6 +120,12 @@ export class MessageBuilder {
               content: input?.content,
               csvFiles: input?.csvFiles,
               pdfFiles: input?.pdfFiles,
+              // #284: audioFiles/videoFiles must be forwarded too, or the
+              // multimodal builder receives an empty payload despite
+              // detectMultimodal() correctly routing audio/video-only
+              // requests here.
+              audioFiles: input?.audioFiles,
+              videoFiles: input?.videoFiles,
               files: input?.files,
             },
             csvOptions: options.csvOptions,
@@ -244,6 +270,10 @@ export class MessageBuilder {
               content: input?.content,
               csvFiles: input?.csvFiles,
               pdfFiles: input?.pdfFiles,
+              // #284: forward audioFiles/videoFiles here too — see the
+              // matching comment in buildMessages() above.
+              audioFiles: input?.audioFiles,
+              videoFiles: input?.videoFiles,
               files: input?.files,
             },
             csvOptions: options.csvOptions,

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -67,6 +67,7 @@ export type GenerateOptions = {
     images?: Array<Buffer | string | ImageWithAltText>;
     csvFiles?: Array<Buffer | string>; // Explicit CSV files
     pdfFiles?: Array<Buffer | string>; // Explicit PDF files
+    audioFiles?: Array<Buffer | string>; // Explicit audio files (metadata/transcript extraction)
     videoFiles?: Array<Buffer | string>; // Explicit video files
     files?: Array<Buffer | string | FileWithMetadata>; // Auto-detect file types
     content?: Content[]; // Advanced multimodal content

--- a/src/lib/types/multimodal.ts
+++ b/src/lib/types/multimodal.ts
@@ -487,15 +487,46 @@ export type MultimodalInput = {
 // ============================================
 
 /**
- * Content format for multimodal messages (used internally)
- * Compatible with Vercel AI SDK message format
+ * Content format for multimodal messages (used internally).
+ *
+ * #325: the loose `[key: string]: unknown` index signature has been replaced
+ * with the concrete fields the codebase actually reads/writes across the
+ * text / image / file / tool-call / tool-result shapes. This keeps the broad
+ * structural compatibility the internal pipeline relies on (a single object
+ * type, not a strict discriminated union that would force narrowing at every
+ * consumer) while removing the "any key is allowed" hole that let typos and
+ * unrelated keys through unchecked.
  */
 export type MessageContent = {
   type: string;
+  /** Text content (`type: "text"`). */
   text?: string;
+  /** Base64 / data-URI image (`type: "image"`). */
   image?: string;
+  /** MIME type for image/file parts. */
   mimeType?: string;
-  [key: string]: unknown; // Index signature for compatibility with Vercel AI SDK
+  /** Raw file bytes or base64 (`type: "file"`/document parts). */
+  data?: string | Buffer;
+  /** File name for document/file parts. */
+  name?: string;
+  /** File name (alias used by some file parts). */
+  filename?: string;
+  /** Tool-call identifier (`type: "tool-call"`/`"tool-result"`). */
+  toolCallId?: string;
+  /** Tool name (`type: "tool-call"`/`"tool-result"`). */
+  toolName?: string;
+  /** Tool-call arguments (`type: "tool-call"`). */
+  args?: Record<string, unknown>;
+  /** Tool-result payload (`type: "tool-result"`). */
+  result?: unknown;
+  /** Whether a tool-result represents an error (`type: "tool-result"`). */
+  isError?: boolean;
+  /**
+   * Provider-specific per-block options (e.g. Anthropic cache_control).
+   * Read as `item.providerOptions` when converting `MessageContent[]` to
+   * `ModelMessage[]` in `MessageBuilder.ts`.
+   */
+  providerOptions?: Record<string, unknown>;
 };
 
 /**

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -237,6 +237,7 @@ export type StreamOptions = {
     images?: Array<Buffer | string | ImageWithAltText>;
     csvFiles?: Array<Buffer | string>; // Explicit CSV files (converted to text)
     pdfFiles?: Array<Buffer | string>; // Explicit PDF files (processed as binary documents, not converted to text)
+    audioFiles?: Array<Buffer | string>; // Explicit audio files (metadata/transcript extraction)
     videoFiles?: Array<Buffer | string>; // Explicit video files
     files?: Array<Buffer | string | FileWithMetadata>; // Auto-detect file types
     content?: Content[]; // Advanced multimodal content

--- a/src/lib/utils/errorHandling.ts
+++ b/src/lib/utils/errorHandling.ts
@@ -55,6 +55,11 @@ export const ERROR_CODES = {
   IMAGE_TOO_SMALL: "IMAGE_TOO_SMALL",
   INVALID_IMAGE_FORMAT: "INVALID_IMAGE_FORMAT",
   INVALID_IMAGE_SIZE: "INVALID_IMAGE_SIZE",
+  IMAGE_BUFFER_INVALID: "IMAGE_BUFFER_INVALID",
+
+  // Generic file/CSV processing errors
+  FILE_PROCESSING_FAILED: "FILE_PROCESSING_FAILED",
+  CSV_PROCESSING_FAILED: "CSV_PROCESSING_FAILED",
 
   // PDF validation errors
   PDF_PAGE_LIMIT_EXCEEDED: "PDF_PAGE_LIMIT_EXCEEDED",
@@ -732,6 +737,23 @@ export class ErrorFactory {
     });
   }
 
+  /**
+   * Create an image buffer validation error: empty, undersized, or a
+   * truncated buffer detected by `ImageProcessor.validateBufferNotEmpty()`.
+   * Takes the fully-formed message so call sites keep their specific
+   * byte-count detail instead of a fixed generic message.
+   */
+  static imageBufferInvalid(message: string): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.IMAGE_BUFFER_INVALID,
+      message,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: { field: "input.images" },
+    });
+  }
+
   // ============================================================================
   // RATE LIMITER ERRORS
   // ============================================================================
@@ -1071,6 +1093,50 @@ export class ErrorFactory {
       severity: ErrorSeverity.HIGH,
       retriable: false,
       context: context || {},
+    });
+  }
+
+  // ============================================================================
+  // GENERIC FILE / CSV PROCESSING ERRORS
+  // ============================================================================
+
+  /**
+   * Create a generic file-processing-failed error (e.g. an unrecognized or
+   * corrupt file in `processUnifiedFilesArray`). Preserves the original error
+   * as `originalError` (stack + message copied onto the new error's context).
+   */
+  static fileProcessingFailed(
+    filename: string,
+    originalError: Error,
+  ): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.FILE_PROCESSING_FAILED,
+      message: `Failed to process file "${filename}": ${originalError.message}`,
+      category: ErrorCategory.EXECUTION,
+      severity: ErrorSeverity.HIGH,
+      retriable: false,
+      context: { filename },
+      originalError,
+    });
+  }
+
+  /**
+   * Create a generic CSV-processing-failed error (explicit `csvFiles` path,
+   * distinct from `fileProcessingFailed` so callers can classify CSV-specific
+   * failures separately). Preserves the original error as `originalError`.
+   */
+  static csvProcessingFailed(
+    filename: string,
+    originalError: Error,
+  ): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.CSV_PROCESSING_FAILED,
+      message: `Failed to process CSV file "${filename}": ${originalError.message}`,
+      category: ErrorCategory.EXECUTION,
+      severity: ErrorSeverity.HIGH,
+      retriable: false,
+      context: { filename },
+      originalError,
     });
   }
 }

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -41,6 +41,7 @@ import { tracers, ATTR, withSpan } from "../telemetry/index.js";
 import { CSVProcessor } from "./csvProcessor.js";
 import { ImageProcessor } from "./imageProcessor.js";
 import { logger } from "./logger.js";
+import { withTimeout } from "./errorHandling.js";
 import { redactUrlForError, sanitizeErrorCause } from "./logSanitize.js";
 import {
   mimeHintToExtension,
@@ -54,6 +55,91 @@ import { PDFProcessor } from "./pdfProcessor.js";
  */
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY = 1000; // milliseconds
+
+/**
+ * Short-TTL cache of URL → Content-Type (#323). A URL is commonly detected more
+ * than once (repeated multimodal prompts reuse the same asset URL); caching the
+ * HEAD's content-type avoids re-issuing the HEAD each time. `loadFromURL` also
+ * populates it from its GET response, so once a URL's body has been fetched a
+ * subsequent detection needs no network round-trip at all.
+ *
+ * Trade-off (round-2 review): this is a module-level cache shared by every
+ * request in the process, and correctness relies solely on the 60s TTL — a
+ * signed URL whose response changes at the same path within that window would
+ * read stale. That is an intentional, bounded trade-off (60s of possible
+ * staleness for far fewer HEAD round-trips), not a freshness guarantee.
+ * Expired entries are removed lazily on their next `get()` (see
+ * `getCachedUrlContentType`); `setCachedUrlContentType` additionally sweeps
+ * expired entries opportunistically once the cache hits its size cap, so a
+ * URL that is cached once and never looked up again doesn't linger until the
+ * FIFO eviction below forces it out.
+ */
+const URL_CONTENT_TYPE_TTL_MS = 60_000;
+const URL_CONTENT_TYPE_CACHE_MAX_SIZE = 512;
+const urlContentTypeCache = new Map<
+  string,
+  { contentType: string; expiresAt: number }
+>();
+
+function getCachedUrlContentType(url: string, now: number): string | undefined {
+  const hit = urlContentTypeCache.get(url);
+  if (hit && hit.expiresAt > now) {
+    // Bump recency: Map iteration order follows insertion order, and the
+    // eviction below deletes the *first* key, so a plain `get` on a hot
+    // entry would leave it first in line for eviction despite being the
+    // most recently used. Re-inserting turns the size-bounded FIFO below
+    // into an actual LRU.
+    urlContentTypeCache.delete(url);
+    urlContentTypeCache.set(url, hit);
+    return hit.contentType;
+  }
+  if (hit) {
+    // Entry exists but its TTL has passed — treat as a miss and evict it
+    // immediately rather than serving (or retaining) stale data.
+    urlContentTypeCache.delete(url);
+  }
+  return undefined;
+}
+
+/**
+ * Opportunistically remove already-expired entries. Only called once the
+ * cache is at its size cap (see `setCachedUrlContentType`) so it doesn't add
+ * an O(n) scan to the common-case hot path.
+ */
+function pruneExpiredUrlContentTypeEntries(now: number): void {
+  for (const [key, entry] of urlContentTypeCache) {
+    if (entry.expiresAt <= now) {
+      urlContentTypeCache.delete(key);
+    }
+  }
+}
+
+function setCachedUrlContentType(
+  url: string,
+  contentType: string,
+  now: number,
+): void {
+  if (!contentType) {
+    return;
+  }
+  urlContentTypeCache.set(url, {
+    contentType,
+    expiresAt: now + URL_CONTENT_TYPE_TTL_MS,
+  });
+  // Bound the cache so a long-lived process can't grow it unbounded. Prefer
+  // reclaiming already-expired entries first; only fall back to evicting the
+  // oldest still-live entry (FIFO/LRU-ish, see getCachedUrlContentType) if
+  // the cache is still over the cap after pruning.
+  if (urlContentTypeCache.size > URL_CONTENT_TYPE_CACHE_MAX_SIZE) {
+    pruneExpiredUrlContentTypeEntries(now);
+  }
+  if (urlContentTypeCache.size > URL_CONTENT_TYPE_CACHE_MAX_SIZE) {
+    const oldest = urlContentTypeCache.keys().next().value;
+    if (oldest !== undefined) {
+      urlContentTypeCache.delete(oldest);
+    }
+  }
+}
 
 /**
  * Retryable network error codes (Node.js/undici network errors)
@@ -1824,6 +1910,14 @@ export class FileDetector {
             );
           }
 
+          // #323: cache the Content-Type from this GET so a subsequent detection
+          // of the same URL needs no HEAD.
+          setCachedUrlContentType(
+            url,
+            (response.headers["content-type"] as string) || "",
+            Date.now(),
+          );
+
           const chunks: Buffer[] = [];
           let totalSize = 0;
 
@@ -2233,15 +2327,30 @@ class MimeTypeStrategy implements DetectionStrategy {
     }
 
     try {
-      const response = await request(input, {
-        dispatcher: getGlobalDispatcher().compose(
-          interceptors.redirect({ maxRedirections: 5 }),
-        ),
-        method: "HEAD",
-        headersTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
-        bodyTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
-      });
-      const contentType = (response.headers["content-type"] as string) || "";
+      // #323: reuse a recently-seen Content-Type for this URL instead of
+      // re-issuing a HEAD (populated here and by loadFromURL's GET).
+      const now = Date.now();
+      let contentType = getCachedUrlContentType(input, now);
+      if (contentType === undefined) {
+        // Wrap the whole HEAD (request + body drain) in withTimeout so a stalled
+        // dump() can't hang detection, per the project's async-timeout guideline.
+        contentType = await withTimeout(
+          (async () => {
+            const response = await request(input, {
+              dispatcher: getGlobalDispatcher().compose(
+                interceptors.redirect({ maxRedirections: 5 }),
+              ),
+              method: "HEAD",
+              headersTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
+              bodyTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
+            });
+            await response.body.dump();
+            return (response.headers["content-type"] as string) || "";
+          })(),
+          FileDetector.DEFAULT_HEAD_TIMEOUT,
+        );
+        setCachedUrlContentType(input, contentType, now);
+      }
       const type = this.mimeToFileType(contentType);
 
       return {

--- a/src/lib/utils/imageProcessor.ts
+++ b/src/lib/utils/imageProcessor.ts
@@ -20,6 +20,25 @@ import { ErrorFactory, NeuroLinkError } from "./errorHandling.js";
 import type { ProcessedImage, FileProcessingResult } from "../types/index.js";
 
 /**
+ * Minimum bytes required just to detect an image format from magic bytes (#293).
+ */
+export const MIN_IMAGE_SIZE = 12;
+
+/**
+ * Minimum plausible byte size for a non-empty image of each format (#293). A
+ * buffer that carries a format's magic bytes but is smaller than this is
+ * truncated/corrupt and would fail (or render blank) downstream — reject early
+ * with a clear message instead.
+ */
+export const MIN_VALID_IMAGE_SIZE: Record<string, number> = {
+  "image/png": 67,
+  "image/jpeg": 125,
+  "image/gif": 43,
+  "image/webp": 20,
+  "image/avif": 100,
+};
+
+/**
  * Network error codes that should trigger a retry
  */
 const RETRYABLE_ERROR_CODES = new Set([
@@ -119,13 +138,9 @@ export class ImageProcessor {
     content: Buffer,
     _options?: unknown,
   ): Promise<FileProcessingResult> {
-    // Validate content is non-empty before processing
-    if (content.length === 0) {
-      logger.error("Empty buffer provided");
-      throw new Error("Invalid image processing: buffer is empty");
-    }
-
-    const mediaType = this.detectImageType(content);
+    // #293: reject empty AND small/truncated buffers (not just 0 bytes) before
+    // processing; returns the detected media type.
+    const mediaType = this.validateBufferNotEmpty(content);
 
     // #261/#286 follow-up: fail loud instead of packaging the octet-stream
     // sentinel as a "valid" image (see assertKnownImageType() above).
@@ -149,6 +164,92 @@ export class ImageProcessor {
         size: content.length,
       },
     } satisfies FileProcessingResult;
+  }
+
+  /**
+   * Strict magic-byte match: does `content` actually begin with `mediaType`'s
+   * signature? `detectImageType` returns `image/jpeg` as a *fallback* for
+   * unrecognized data, so a per-format minimum must only be enforced when the
+   * bytes genuinely match — otherwise valid BMP/TIFF/unknown buffers would be
+   * wrongly rejected as "truncated jpeg" (#293 review).
+   */
+  private static hasStrictImageMagic(
+    content: Buffer,
+    mediaType: string,
+  ): boolean {
+    const b = content;
+    switch (mediaType) {
+      case "image/png":
+        return (
+          b.length >= 4 &&
+          b[0] === 0x89 &&
+          b[1] === 0x50 &&
+          b[2] === 0x4e &&
+          b[3] === 0x47
+        );
+      case "image/jpeg":
+        return b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff;
+      case "image/gif":
+        return b.length >= 3 && b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46;
+      case "image/webp":
+        return (
+          b.length >= 12 &&
+          b.subarray(0, 4).toString("latin1") === "RIFF" &&
+          b.subarray(8, 12).toString("latin1") === "WEBP"
+        );
+      case "image/avif":
+        return (
+          b.length >= 12 &&
+          b.subarray(4, 8).toString("latin1") === "ftyp" &&
+          b.subarray(8, 12).toString("latin1").startsWith("avif")
+        );
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Validate that a buffer is a plausibly-complete image (#293): non-empty and,
+   * for a strictly-identified raster format, at least the minimum plausible byte
+   * size. Returns the detected media type.
+   *
+   * @throws Error when the buffer is empty or a recognized format is truncated.
+   */
+  private static validateBufferNotEmpty(content: Buffer): string {
+    if (content.length === 0) {
+      logger.error("Empty buffer provided");
+      throw ErrorFactory.imageBufferInvalid(
+        "Invalid image processing: buffer is empty",
+      );
+    }
+    const mediaType = this.detectImageType(content);
+    // SVG is text and can be legitimately tiny (e.g. `<svg/>`), so the raster
+    // size floors don't apply to it (#293 review).
+    if (mediaType === "image/svg+xml") {
+      return mediaType;
+    }
+    // A buffer too small to carry any raster header is not a usable image.
+    if (content.length < MIN_IMAGE_SIZE) {
+      throw ErrorFactory.imageBufferInvalid(
+        `Invalid image processing: buffer too small (${content.length} bytes) — ` +
+          `a minimum of ${MIN_IMAGE_SIZE} bytes is required for a valid image.`,
+      );
+    }
+    // Only enforce a per-format minimum when the format was strictly identified
+    // from magic bytes (never from detectImageType's jpeg fallback), so valid
+    // BMP/TIFF/unknown buffers are not mis-rejected as "truncated jpeg".
+    const minForFormat = MIN_VALID_IMAGE_SIZE[mediaType];
+    if (
+      minForFormat !== undefined &&
+      content.length < minForFormat &&
+      this.hasStrictImageMagic(content, mediaType)
+    ) {
+      throw ErrorFactory.imageBufferInvalid(
+        `Invalid image processing: ${mediaType} buffer is truncated ` +
+          `(${content.length} bytes, minimum ${minForFormat} for a valid ${mediaType}).`,
+      );
+    }
+    return mediaType;
   }
 
   /**

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -15,10 +15,11 @@ import {
   FILE_READ_BUDGET_PERCENT,
 } from "../context/fileTokenBudget.js";
 import type { FileReferenceRegistry } from "../files/fileReferenceRegistry.js";
-import { SIZE_TIER_THRESHOLDS } from "../types/index.js";
+import { isCSVContent, SIZE_TIER_THRESHOLDS } from "../types/index.js";
 import type {
   ChatMessage,
   Content,
+  CSVContent,
   FileInput,
   FileWithMetadata,
   GenerateOptions,
@@ -29,10 +30,10 @@ import type {
   TextGenerationOptions,
 } from "../types/index.js";
 import { tracers, ATTR, withSpan } from "../telemetry/index.js";
-import { NeuroLinkError } from "./errorHandling.js";
+import { ErrorFactory, NeuroLinkError, withTimeout } from "./errorHandling.js";
 import { FileDetector } from "./fileDetector.js";
 import { getImageCache } from "./imageCache.js";
-import { ImageProcessor } from "./imageProcessor.js";
+import { ImageProcessor, imageUtils } from "./imageProcessor.js";
 import { logger } from "./logger.js";
 import { PDFImageConverter, PDFProcessor } from "./pdfProcessor.js";
 import { urlDownloadRateLimiter } from "./rateLimiter.js";
@@ -1080,8 +1081,15 @@ export async function processUnifiedFilesArray(
           );
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
+          // #273: don't silently drop a failed file — log, then throw so the
+          // caller learns the file couldn't be processed (matches the explicit
+          // pdf/csv paths' fail-loud behavior).
           logger.error(
-            `[NEUROLINK] File skipped/failed: ${filename} — reason: ${errMsg}`,
+            `[NEUROLINK] File processing failed: ${filename} — reason: ${errMsg}`,
+          );
+          throw ErrorFactory.fileProcessingFailed(
+            filename,
+            error instanceof Error ? error : new Error(errMsg),
           );
         }
       }
@@ -1179,10 +1187,15 @@ async function processExplicitCsvFiles(
       options.input.text += csvSection;
       logger.info(`[CSV] ✅ Processed: ${filename}`);
     } catch (error) {
-      logger.error(`[CSV] ❌ Failed:`, error);
       const filename = extractFilename(csvFile, i);
-      options.input.text += `\n\n## CSV Data Error: Failed to process "${filename}"`;
-      options.input.text += `\nReason: ${error instanceof Error ? error.message : "Unknown error"}`;
+      const errMsg = error instanceof Error ? error.message : String(error);
+      // #273: fail loud instead of embedding the error into the prompt text
+      // (which the model would then "analyze"). Log, then throw.
+      logger.error(`[CSV] ❌ Failed to process ${filename}: ${errMsg}`);
+      throw ErrorFactory.csvProcessingFailed(
+        filename,
+        error instanceof Error ? error : new Error(errMsg),
+      );
     }
   }
 }
@@ -1367,6 +1380,19 @@ export async function buildMultimodalMessagesArray(
   // rest of this function, avoiding 60+ "possibly undefined" errors.
   const inp = options.input;
 
+  // #284: audioFiles/videoFiles have no dedicated processor — route them
+  // through the same auto-detecting `files` pipeline that already
+  // understands "audio"/"video" FileDetector results (see
+  // appendDetectedFileResult), instead of silently dropping them once
+  // detectMultimodal() routes an audio/video-only request here.
+  if (inp.audioFiles?.length || inp.videoFiles?.length) {
+    inp.files = [
+      ...(inp.files || []),
+      ...(inp.audioFiles || []),
+      ...(inp.videoFiles || []),
+    ];
+  }
+
   // Compute provider-specific max PDF size once for consistent validation
   const pdfConfig = PDFProcessor.getProviderConfig(provider);
   const maxSize = pdfConfig
@@ -1397,6 +1423,13 @@ export async function buildMultimodalMessagesArray(
 
   // If no images or PDFs, use standard message building and convert to MultimodalChatMessage[]
   if (!hasImages && !hasPDFs) {
+    // #289: CSV content[] items don't need vision, so they never reach the
+    // multimodal converter below — process them into the prompt text here
+    // (otherwise a `content: [{type:"csv"}]`-only request silently drops it).
+    const csvContentItems = inp.content?.filter(isCSVContent) ?? [];
+    if (csvContentItems.length > 0) {
+      inp.text = await appendCsvContentToText(csvContentItems, inp.text ?? "");
+    }
     if (inp.csvFiles) {
       inp.csvFiles = [];
     }
@@ -1563,6 +1596,59 @@ export async function buildMultimodalMessagesArray(
 }
 
 /**
+ * Timeout for detecting/parsing an in-memory CSV `content[]` buffer (#325
+ * review, round 2). Bounds a stalled detector rather than blocking the
+ * request indefinitely.
+ */
+const CSV_CONTENT_DETECTION_TIMEOUT_MS = 30_000;
+
+/**
+ * #289: process CSV `content[]` items into appended prompt text. CSV is
+ * delivered to the model as text (like the explicit `csvFiles` path), so this
+ * is shared by both the no-vision gate and the multimodal converter.
+ */
+async function appendCsvContentToText(
+  csvItems: CSVContent[],
+  baseText: string,
+): Promise<string> {
+  let text = baseText;
+  for (const csv of csvItems) {
+    const raw = csv.data;
+    if (raw === undefined) {
+      continue;
+    }
+    // #325: raw CSV text (e.g. "a,b\n1,2") is not base64 — decoding it as
+    // base64 silently corrupts the content. Only treat the string as base64
+    // when it actually validates as such; otherwise treat it as literal
+    // UTF-8 CSV text, matching how Buffer inputs are already handled as-is.
+    const buffer =
+      typeof raw === "string"
+        ? imageUtils.isValidBase64(raw)
+          ? Buffer.from(raw, "base64")
+          : Buffer.from(raw, "utf-8")
+        : raw;
+    const name = csv.metadata?.filename || "data.csv";
+    // #325 review (round 2): a stalled/hung detector must not block the
+    // request indefinitely — wrap with the project's standard withTimeout.
+    const result = await withTimeout(
+      FileDetector.detectAndProcess(buffer, {
+        allowedTypes: ["csv"],
+        csvOptions: {
+          maxRows: csv.metadata?.maxRows,
+          formatStyle: csv.metadata?.formatStyle,
+        },
+      }),
+      CSV_CONTENT_DETECTION_TIMEOUT_MS,
+      new Error(
+        `Timed out processing CSV content "${name}" after ${CSV_CONTENT_DETECTION_TIMEOUT_MS}ms`,
+      ),
+    );
+    text += `${text ? "\n\n" : ""}## CSV Data from ${name}\n${result.content}`;
+  }
+  return text;
+}
+
+/**
  * Convert advanced content format to provider-specific format
  */
 async function convertContentToProviderFormat(
@@ -1573,9 +1659,16 @@ async function convertContentToProviderFormat(
   const textContent = content.find((c) => c.type === "text");
   const imageContent = content.filter((c) => c.type === "image");
   const pdfContent = content.filter((c) => c.type === "pdf");
+  const csvContent = content.filter(isCSVContent);
 
   // Allow empty text when multimodal content is present (enables image-only or PDF-only queries)
-  const text = textContent?.text || "";
+  let text = textContent?.text || "";
+
+  // #289: CSV content[] items were silently dropped — fold each into the text.
+  if (csvContent.length > 0) {
+    text = await appendCsvContentToText(csvContent, text);
+  }
+
   const hasMultimodal = imageContent.length > 0 || pdfContent.length > 0;
 
   // Validate that we have at least some content
@@ -1583,7 +1676,7 @@ async function convertContentToProviderFormat(
     throw new Error("Content must include either text or multimodal content");
   }
 
-  // Text-only case
+  // Text-only case (CSV has already been folded into `text`)
   if (imageContent.length === 0 && pdfContent.length === 0) {
     return text;
   }

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -52,6 +52,7 @@ import {
 import { tmpdir } from "node:os";
 import { basename, join as pathJoin, resolve as resolvePath } from "node:path";
 import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
+import http from "node:http";
 import AdmZip from "adm-zip";
 import { PptxProcessor } from "../src/lib/processors/document/PptxProcessor.js";
 
@@ -5843,6 +5844,9 @@ exit 127
     category: "image-processor",
     fn: async () => {
       // Minimal ISO-BMFF AVIF: box-size, 'ftyp', major brand, minor version.
+      // Padded to >= MIN_VALID_IMAGE_SIZE["image/avif"] (100 bytes) so the
+      // #293 truncated-buffer guard doesn't reject this strictly-identified
+      // AVIF as a corrupt/incomplete file before detection is even asserted.
       const mkAvif = (brand: string): Buffer =>
         Buffer.concat([
           Buffer.from([0x00, 0x00, 0x00, 0x18]),
@@ -5850,6 +5854,7 @@ exit 127
           Buffer.from(brand, "ascii"),
           Buffer.from([0x00, 0x00, 0x00, 0x00]),
           Buffer.from("mif1", "ascii"),
+          Buffer.alloc(100),
         ]);
       // Before the fix, an AVIF ftyp buffer was misrouted to the video pipeline
       // (video/mp4). It must now resolve to an image through FileDetector — the
@@ -5916,10 +5921,12 @@ exit 127
         return false;
       }
       // Regression: a genuine PNG must still detect as image/png through the
-      // real user-facing path, not swept into the new fallback.
+      // real user-facing path, not swept into the new fallback. Padded to
+      // >= MIN_VALID_IMAGE_SIZE["image/png"] (67 bytes) so the #293
+      // truncated-buffer guard doesn't reject it as corrupt/incomplete.
       const png = Buffer.concat([
         Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-        Buffer.alloc(16),
+        Buffer.alloc(64),
       ]);
       const det = await FileDetector.detectAndProcess(png, {
         allowedTypes: ["image", "unknown"],
@@ -6111,6 +6118,321 @@ exit 127
         combined.includes("secret-retry-host.test/path") &&
         !combined.includes("SUPERSECRET456")
       );
+    },
+  },
+  // ---------- MessageBuilder / FileDetector / Types hardening
+  //            (#273/#284/#289/#293/#323/#325) ----------
+  {
+    name: "MessageBuilder #284: audio/video-only inputs count as multimodal",
+    category: "message-builder",
+    fn: async () => {
+      // detectMultimodal() now defers to this canonical guard, which checks
+      // audioFiles/videoFiles — an audio/video-only request must be multimodal.
+      const videoOnly = isMultimodalInput({
+        videoFiles: [Buffer.from("x")],
+      } as Parameters<typeof isMultimodalInput>[0]);
+      const audioOnly = isMultimodalInput({
+        audioFiles: [Buffer.from("x")],
+      } as Parameters<typeof isMultimodalInput>[0]);
+      const textOnly = isMultimodalInput({
+        text: "hi",
+      } as Parameters<typeof isMultimodalInput>[0]);
+      return videoOnly === true && audioOnly === true && textOnly === false;
+    },
+  },
+  {
+    name: "MessageBuilder #284: audioFiles/videoFiles content actually reaches the built message",
+    category: "message-builder",
+    fn: async () => {
+      // Routing alone (the test above) isn't enough — Tara-ag's follow-up
+      // review found audioFiles/videoFiles were routed to the multimodal
+      // builder but then never forwarded into it, so the payload was
+      // silently dropped end-to-end. This proves the actual message content
+      // carries the "## Video File:"/"## Audio File:" markers that
+      // appendDetectedFileResult() emits, using magic-bytes-only buffers so
+      // FileDetector's graceful-degradation fallback (no real media
+      // decoding) keeps this deterministic and network-free.
+      const riffWave = Buffer.concat([
+        Buffer.from("RIFF"),
+        Buffer.from([0, 0, 0, 0]),
+        Buffer.from("WAVE"),
+        Buffer.alloc(16),
+      ]);
+      const ftypMp4 = Buffer.concat([
+        Buffer.from([0, 0, 0, 0x18]),
+        Buffer.from("ftyp"),
+        Buffer.from("mp42"),
+        Buffer.alloc(16),
+      ]);
+
+      const videoMessages = await buildMultimodalMessagesArray(
+        {
+          input: { text: "describe this", videoFiles: [ftypMp4] },
+        } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+        "openai",
+        "gpt-4o",
+      );
+      const audioMessages = await buildMultimodalMessagesArray(
+        {
+          input: { text: "describe this", audioFiles: [riffWave] },
+        } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+        "openai",
+        "gpt-4o",
+      );
+
+      const videoHasMarker =
+        JSON.stringify(videoMessages).includes("## Video File:");
+      const audioHasMarker =
+        JSON.stringify(audioMessages).includes("## Audio File:");
+      return videoHasMarker && audioHasMarker;
+    },
+  },
+  {
+    name: "ImageProcessor #293: rejects empty, too-small, and truncated image buffers",
+    category: "image-processor",
+    fn: async () => {
+      const rejects = async (buf: Buffer, re: RegExp): Promise<boolean> => {
+        try {
+          await ImageProcessor.process(buf);
+          return false;
+        } catch (e) {
+          return e instanceof Error && re.test(e.message);
+        }
+      };
+      const emptyOk = await rejects(Buffer.alloc(0), /buffer is empty/);
+      const tinyOk = await rejects(Buffer.from([0x89, 0x50]), /too small/);
+      // A PNG magic-byte header padded to 30 bytes is truncated (< 67).
+      const truncated = Buffer.alloc(30);
+      truncated[0] = 0x89;
+      truncated[1] = 0x50;
+      truncated[2] = 0x4e;
+      truncated[3] = 0x47;
+      const truncOk = await rejects(truncated, /truncated/);
+      // Review fix: a non-jpeg buffer (BMP "BM" magic, 100 bytes) that
+      // detectImageType falls back to "image/jpeg" must NOT be rejected as a
+      // truncated jpeg — the minimum only applies on a strict magic match.
+      const bmp = Buffer.alloc(100);
+      bmp[0] = 0x42;
+      bmp[1] = 0x4d;
+      const bmpOk = await ImageProcessor.process(bmp).then(
+        () => true,
+        () => false,
+      );
+      // Review fix: a tiny valid SVG must be allowed (text, not raster).
+      const svgOk = await ImageProcessor.process(Buffer.from("<svg/>")).then(
+        () => true,
+        () => false,
+      );
+      return emptyOk && tinyOk && truncOk && bmpOk && svgOk;
+    },
+  },
+  {
+    name: "MessageBuilder #273: a failed CSV/file input throws instead of being silently dropped",
+    category: "message-builder",
+    fn: async () => {
+      const badCsv = await buildMultimodalMessagesArray(
+        {
+          input: { text: "hi", csvFiles: ["/nonexistent/does-not-exist.csv"] },
+        } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+        "openai",
+        "gpt-4o",
+      ).then(
+        () => false,
+        (e) =>
+          e instanceof Error && /Failed to process CSV file/.test(e.message),
+      );
+      const badFile = await buildMultimodalMessagesArray(
+        {
+          input: { text: "hi", files: ["/nonexistent/does-not-exist.bin"] },
+        } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+        "openai",
+        "gpt-4o",
+      ).then(
+        () => false,
+        (e) => e instanceof Error && /Failed to process file/.test(e.message),
+      );
+      return badCsv && badFile;
+    },
+  },
+  {
+    name: "MessageBuilder #289: CSV content[] items are processed (not silently dropped)",
+    category: "message-builder",
+    fn: async () => {
+      const csvBuf = Buffer.from("a,b\n1,2\n3,4\n");
+      const build = (opts: Record<string, unknown>) =>
+        buildMultimodalMessagesArray(
+          opts as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai",
+          "gpt-4o",
+        );
+      // CSV-only content (no image/pdf) — the previously-gated path.
+      const csvOnly = JSON.stringify(
+        await build({
+          input: {
+            text: "analyze",
+            content: [
+              {
+                type: "csv",
+                data: csvBuf,
+                metadata: { filename: "t.csv", formatStyle: "json" },
+              },
+            ],
+          },
+        }),
+      );
+      return csvOnly.includes("CSV Data from t.csv");
+    },
+  },
+  {
+    name: "MessageBuilder #325: raw (non-base64) CSV string content is not corrupted by forced base64 decoding",
+    category: "message-builder",
+    fn: async () => {
+      // Reviewer-reported bug: appendCsvContentToText() used to
+      // unconditionally Buffer.from(raw, "base64") any string `data`, which
+      // silently mangles genuine raw CSV text (e.g. "a,b\n1,2") since it
+      // isn't valid base64. It must now be detected as non-base64 and
+      // decoded as UTF-8 instead, so the CSV content parses correctly.
+      const rawCsvText = "a,b\n1,2\n3,4\n";
+      const messages = await buildMultimodalMessagesArray(
+        {
+          input: {
+            text: "analyze",
+            content: [
+              {
+                type: "csv",
+                data: rawCsvText,
+                metadata: { filename: "raw.csv", formatStyle: "json" },
+              },
+            ],
+          },
+        } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+        "openai",
+        "gpt-4o",
+      );
+      const serialized = JSON.stringify(messages);
+      // A corrupted decode would produce garbled bytes/mojibake instead of
+      // recognizable "a"/"b"/"1"/"2" values in the parsed JSON CSV output.
+      // Note: `messages` is stringified twice over (once by
+      // appendCsvContentToText's JSON-format CSV output, again by this
+      // JSON.stringify), so the inner quotes appear escaped (\"a\").
+      return (
+        serialized.includes("CSV Data from raw.csv") &&
+        serialized.includes('\\"a\\": \\"1\\"') &&
+        serialized.includes('\\"b\\": \\"2\\"')
+      );
+    },
+  },
+  {
+    name: "Types #325: MessageContent exposes concrete fields without a loose index signature",
+    category: "types",
+    fn: async () => {
+      // Compile-time guarantee: the enumerated fields are all assignable, and an
+      // unknown key would now be a type error (verified by `pnpm run check`).
+      type MessageContentT = import("../src/lib/types/index.js").MessageContent;
+      type MultimodalChatMessageT =
+        import("../src/lib/types/index.js").MultimodalChatMessage;
+      const items: MessageContentT[] = [
+        { type: "text", text: "hi" },
+        { type: "image", image: "b64", mimeType: "image/png" },
+        {
+          type: "file",
+          data: Buffer.from("x"),
+          name: "a.pdf",
+          mimeType: "application/pdf",
+        },
+        {
+          type: "tool-call",
+          toolCallId: "1",
+          toolName: "t",
+          args: { a: 1 },
+        },
+        { type: "tool-result", toolCallId: "1", toolName: "t", result: 42 },
+      ];
+      // Negative case: an unsupported key must be a type error. If the
+      // removed index signature is ever reintroduced, this assignment stops
+      // erroring and the unused `@ts-expect-error` directive fails
+      // `pnpm run check`, catching the regression.
+      // @ts-expect-error -- MessageContent must reject unsupported fields
+      const invalidItem: MessageContentT = {
+        type: "text",
+        text: "hi",
+        unsupported: true,
+      };
+      void invalidItem;
+
+      // Runtime guard (Tara-ag round-2): the type-level check above can't
+      // catch a future runtime filtering regression, so also exercise the
+      // real conversion path and assert the known-good fields survive
+      // unstripped. tool-call/tool-result are not valid ModelMessage content
+      // parts and are intentionally dropped by convertContentItem — only
+      // text/image/file are expected to come through.
+      const chatMessages: MultimodalChatMessageT[] = [
+        { role: "user", content: items },
+      ];
+      const [converted] = convertToModelMessages(chatMessages);
+      const convertedContent = converted?.content;
+      const runtimeFieldsPreserved =
+        Array.isArray(convertedContent) &&
+        convertedContent.length === 3 &&
+        (convertedContent[0] as { type: string; text?: string }).text ===
+          "hi" &&
+        (convertedContent[1] as { type: string; image?: string }).image ===
+          "b64" &&
+        (convertedContent[1] as { mediaType?: string }).mediaType ===
+          "image/png" &&
+        Buffer.isBuffer((convertedContent[2] as { data?: unknown }).data) &&
+        (convertedContent[2] as { mediaType?: string }).mediaType ===
+          "application/pdf";
+
+      return (
+        items.length === 5 && items[0].text === "hi" && runtimeFieldsPreserved
+      );
+    },
+  },
+  {
+    name: "FileDetector #323: a cached URL Content-Type avoids a redundant HEAD",
+    category: "file-detector",
+    fn: async () => {
+      let headCount = 0;
+      // A real (1x1) valid PNG — the 4-byte magic-only stub previously used
+      // here is rejected by the buffer-size image validation added in this
+      // PR, so the test only "passed" because detectAndProcess() always
+      // threw, not because the caching path actually succeeded.
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          headCount++;
+          res.setHeader("content-type", "image/png");
+          res.end();
+        } else {
+          res.setHeader("content-type", "image/png");
+          res.end(png);
+        }
+      });
+      await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+      try {
+        const addr = server.address() as { port: number };
+        const url = `http://127.0.0.1:${addr.port}/img-323.png`;
+        const load = (
+          FileDetector as unknown as {
+            loadFromURL: (
+              u: string,
+              o?: { maxSize?: number },
+            ) => Promise<Buffer>;
+          }
+        ).loadFromURL.bind(FileDetector);
+        // GET populates the content-type cache.
+        await load(url, { maxSize: 1024 });
+        // A subsequent detection of the same URL must NOT issue a HEAD.
+        headCount = 0;
+        const result = await FileDetector.detectAndProcess(url);
+        return result.type === "image" && headCount === 0;
+      } finally {
+        await new Promise<void>((r) => server.close(() => r()));
+      }
     },
   },
 ];


### PR DESCRIPTION
## Summary

Consolidated **MessageBuilder / FileDetector / types** hardening — the last of the multimodal-subsystem backlog.

| Issue | Fix |
| ----- | --- |
| **#273** MB-004 — inconsistent file-error handling | `processUnifiedFilesArray` (`files[]`) and `processExplicitCsvFiles` (`csvFiles[]`) no longer swallow a failure (silent log / error text baked into the prompt) — both **log then throw** `Failed to process …`. |
| **#284** MB-006 — audio/video ignored | `detectMultimodal()` now checks `audioFiles`/`videoFiles` (matching the canonical `isMultimodalInput` guard), so an audio/video-only request reaches the multimodal builder. |
| **#289** MB-007 — CSV `content[]` items dropped | `convertContentToProviderFormat()` processes `type:"csv"` items, and the no-vision gate folds CSV-only content into the prompt (previously fell through to the text path). Shared via `appendCsvContentToText()`. |
| **#293** IMG-010 — no empty/truncated image handling | `ImageProcessor.process()` rejects empty, `< 12`-byte, and format-truncated buffers (`MIN_IMAGE_SIZE` + per-format `MIN_VALID_IMAGE_SIZE`), not just 0-byte. |
| **#323** FD-007 — double HTTP request | A short-TTL URL→`Content-Type` cache (populated by `MimeTypeStrategy`'s HEAD **and** `loadFromURL`'s GET) eliminates the redundant HEAD when a URL is detected more than once / after its body was fetched. |
| **#325** TD-008 — loose `MessageContent` index signature | Replaced `[key: string]: unknown` with the concrete fields the codebase reads (`text`/`image`/`mimeType`/`data`/`name`/`filename`/tool-call + tool-result), removing the "any key allowed" hole (the build confirmed no consumer relied on an un-enumerated key). |

## Verification

- `pnpm run check` → 0 errors · `pnpm run lint` → clean · `pnpm run build` → All good · prettier clean.
- **bugfixes suite** green except the 2 known-environmental `updater:` tests.
- **6 new deterministic tests**: image empty/tiny/truncated rejection; fail-loud CSV+file errors; CSV `content[]` processed; audio/video-only counts as multimodal; `MessageContent` concrete fields; and a local-server test proving a cached URL Content-Type issues **0** HEAD requests.

Fixes #273, #284, #289, #293, #323, #325.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `audioFiles` support to multimodal and streaming inputs (audio/video-only now route correctly as multimodal).
* **Bug Fixes**
  * CSV/file processing now fails loudly instead of being silently ignored or placeholder-filled.
  * CSV `content[]` is preserved and folded into prompt text when vision isn’t used.
  * Improved image validation (rejects empty/too-small/truncated buffers more reliably).
* **Performance**
  * Reduced repeated remote MIME lookups via short-lived URL content-type caching.
* **Tests**
  * Added coverage for multimodal routing, CSV handling, stricter content typing, image hardening, and MIME caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->