### PR TITLE
feat(proxy): add deterministic request replay

### DIFF
--- a/docs/features/claude-proxy-observability.md
+++ b/docs/features/claude-proxy-observability.md
@@ -115,6 +115,31 @@ Do not point dashboard panels at the stale log stream `neurolink_proxy_logs` unl
 - In OpenObserve, body captures arrive in the same `neurolink_proxy` log stream with `event.name=proxy.body_capture`, so request panels must filter to request-summary rows, for example `http_method IS NOT NULL`.
 - Attempt logs are local-only on purpose. They should help explain retries without inflating dashboard request counts.
 
+### Deterministic Request Reconstruction
+
+When body capture is enabled, export one request and its upstream attempts without contacting the proxy or provider:
+
+```bash
+neurolink proxy replay export \
+  --request-id <request-id> \
+  --output replay.json
+```
+
+Use `--attempt <number>` to select a specific upstream attempt and `--logs-dir <path>` for a non-default log directory. The command verifies that every compressed artifact remains inside the managed body directory and matches the SHA-256 value in its debug index. The generated bundle is deterministic, redacted, written with `0o600` permissions, and reports missing phases, missing artifacts, and truncation instead of presenting partial evidence as complete.
+
+Credentials are never included in a replay bundle. To perform a direct comparison, inject each redacted header from a named environment variable and explicitly permit network execution:
+
+```bash
+export ANTHROPIC_AUTHORIZATION='Bearer ...'
+neurolink proxy replay compare \
+  --bundle replay.json \
+  --output comparison.json \
+  --execute \
+  --header-env authorization=ANTHROPIC_AUTHORIZATION
+```
+
+The direct response is bounded and redacted using the same rules as proxy body logging. The comparison records status, content type, body hash, JSON shape, time to headers, and total duration. Redirects are not followed. HTTPS is required except for loopback fixture testing. A truncated or body-redacted request requires a complete `--body-file` override before execution.
+
 ## What This Dashboard Should Answer
 
 Use the dashboard to answer seven operational questions:

--- a/src/cli/commands/proxyReplay.ts
+++ b/src/cli/commands/proxyReplay.ts
@@ -1,0 +1,212 @@
+import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { Argv, CommandModule } from "yargs";
+import chalk from "chalk";
+import {
+  compareProxyReplayBundle,
+  exportProxyReplayBundle,
+  isValidProxyReplayHeaderName,
+  readProxyReplayBundle,
+  writeProxyReplayDocument,
+} from "../../lib/proxy/proxyReplay.js";
+import type { ProxyReplayArgs } from "../../lib/types/index.js";
+import { logger } from "../../lib/utils/logger.js";
+
+const ACTIONS = ["export", "compare"] as const;
+const MAX_BODY_OVERRIDE_BYTES = 16 * 1024 * 1024;
+
+function requiredValue(value: string | undefined, option: string): string {
+  if (!value) {
+    throw new Error(`${option} is required for this action`);
+  }
+  return value;
+}
+
+function resolveHeaderValues(mappings: string[] | undefined) {
+  const values: Record<string, string> = {};
+  for (const mapping of mappings ?? []) {
+    const separator = mapping.indexOf("=");
+    if (separator <= 0 || separator === mapping.length - 1) {
+      throw new Error(
+        `Invalid --header-env value "${mapping}". Use header-name=ENV_VAR.`,
+      );
+    }
+    const header = mapping.slice(0, separator).trim().toLowerCase();
+    if (!isValidProxyReplayHeaderName(header)) {
+      throw new Error(`Invalid header name in --header-env: ${header}`);
+    }
+    const environmentName = mapping.slice(separator + 1).trim();
+    const value = process.env[environmentName];
+    if (!value) {
+      throw new Error(
+        `Environment variable ${environmentName} is empty or unset for header ${header}`,
+      );
+    }
+    values[header] = value;
+  }
+  return values;
+}
+
+async function readBodyOverride(filePath: string | undefined) {
+  if (!filePath) {
+    return undefined;
+  }
+  const resolvedPath = resolve(filePath);
+  const info = await stat(resolvedPath);
+  if (!info.isFile() || info.size > MAX_BODY_OVERRIDE_BYTES) {
+    throw new Error(
+      `Body override must be a regular file no larger than ${MAX_BODY_OVERRIDE_BYTES} bytes`,
+    );
+  }
+  return readFile(resolvedPath, "utf8");
+}
+
+function printResult(
+  format: "text" | "json",
+  value: Record<string, unknown>,
+): void {
+  logger.always(
+    format === "json"
+      ? JSON.stringify(value)
+      : Object.entries(value)
+          .map(([key, child]) => `${key}: ${String(child)}`)
+          .join("\n"),
+  );
+}
+
+export const proxyReplayCommand: CommandModule<object, ProxyReplayArgs> = {
+  command: "replay <action>",
+  describe: "Export captured proxy requests or compare them directly upstream",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("action", {
+        type: "string",
+        choices: [...ACTIONS],
+        describe: "Replay action",
+      })
+      .option("request-id", {
+        type: "string",
+        alias: "requestId",
+        description: "Captured proxy request ID to export",
+      })
+      .option("attempt", {
+        type: "number",
+        description: "Specific upstream attempt to reconstruct",
+      })
+      .option("logs-dir", {
+        type: "string",
+        alias: "logsDir",
+        description: "Proxy log directory",
+      })
+      .option("bundle", {
+        type: "string",
+        description: "Replay bundle to compare directly upstream",
+      })
+      .option("output", {
+        type: "string",
+        alias: "o",
+        description: "Destination JSON file",
+      })
+      .option("execute", {
+        type: "boolean",
+        default: false,
+        description: "Explicitly permit the direct upstream request",
+      })
+      .option("header-env", {
+        type: "string",
+        array: true,
+        alias: "headerEnv",
+        description:
+          "Inject a redacted header from an environment variable (header=ENV_VAR)",
+      })
+      .option("body-file", {
+        type: "string",
+        alias: "bodyFile",
+        description:
+          "Complete request body override for redacted/truncated captures",
+      })
+      .option("url", {
+        type: "string",
+        description: "Explicit direct endpoint override",
+      })
+      .option("timeout-ms", {
+        type: "number",
+        alias: "timeoutMs",
+        default: 120_000,
+        description: "Direct request timeout",
+      })
+      .option("format", {
+        type: "string",
+        choices: ["text", "json"] as const,
+        default: "text" as const,
+        description: "Command summary format",
+      })
+      .option("quiet", {
+        type: "boolean",
+        alias: "q",
+        default: false,
+        description: "Suppress non-essential output",
+      })
+      .example(
+        "neurolink proxy replay export --request-id req-123 --output replay.json",
+        "Create a deterministic offline replay bundle",
+      )
+      .example(
+        "neurolink proxy replay compare --bundle replay.json --output comparison.json --execute --header-env authorization=ANTHROPIC_AUTHORIZATION",
+        "Execute the captured upstream request with an environment-backed credential",
+      ) as Argv<ProxyReplayArgs>,
+  handler: async (argv) => {
+    try {
+      const output = requiredValue(argv.output, "--output");
+      if (argv.action === "export") {
+        const requestId = requiredValue(argv.requestId, "--request-id");
+        const bundle = await exportProxyReplayBundle({
+          requestId,
+          logsDir: argv.logsDir,
+          attempt: argv.attempt,
+        });
+        const written = await writeProxyReplayDocument(output, bundle);
+        if (!argv.quiet) {
+          printResult(argv.format ?? "text", {
+            action: "export",
+            output: written.path,
+            sha256: written.sha256,
+            captures: bundle.completeness.captures,
+            replayable: bundle.completeness.replayable,
+            blockers: bundle.completeness.blockers.join(",") || "none",
+          });
+        }
+        return;
+      }
+
+      const bundlePath = requiredValue(argv.bundle, "--bundle");
+      const bundle = await readProxyReplayBundle(bundlePath);
+      const comparison = await compareProxyReplayBundle(bundle, {
+        execute: argv.execute === true,
+        headerValues: resolveHeaderValues(argv.headerEnv),
+        bodyOverride: await readBodyOverride(argv.bodyFile),
+        urlOverride: argv.url,
+        timeoutMs: argv.timeoutMs,
+      });
+      const written = await writeProxyReplayDocument(output, comparison);
+      if (!argv.quiet) {
+        printResult(argv.format ?? "text", {
+          action: "compare",
+          output: written.path,
+          sha256: written.sha256,
+          status: comparison.direct.status,
+          statusMatches: comparison.comparison.statusMatches,
+          bodyHashMatches: comparison.comparison.bodyHashMatches,
+          jsonShapeMatches: comparison.comparison.jsonShapeMatches,
+        });
+      }
+    } catch (error) {
+      logger.error(
+        chalk.red(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+      process.exitCode = 1;
+    }
+  },
+};

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -23,6 +23,7 @@ import {
   proxyUninstallCommand,
 } from "./commands/proxy.js";
 import { proxyAnalyzeCommand } from "./commands/proxyAnalyze.js";
+import { proxyReplayCommand } from "./commands/proxyReplay.js";
 import { EvaluateCommandFactory } from "./commands/evaluate.js";
 import { TaskCommandFactory } from "./commands/task.js";
 import { AutoresearchCommandFactory } from "./commands/autoresearch.js";
@@ -257,6 +258,7 @@ export function initializeCliParser() {
             .command(proxyStartCommand)
             .command(proxyStatusCommand)
             .command(proxyAnalyzeCommand)
+            .command(proxyReplayCommand)
             .command(proxyTelemetryCommand)
             .command(proxySetupCommand)
             .command(proxyGuardCommand)
@@ -264,7 +266,7 @@ export function initializeCliParser() {
             .command(proxyUninstallCommand)
             .demandCommand(
               1,
-              "Please specify a proxy subcommand: start, status, analyze, telemetry <setup|start|stop|status|logs|import-dashboard>, setup, guard, install, or uninstall",
+              "Please specify a proxy subcommand: start, status, analyze, replay <export|compare>, telemetry <setup|start|stop|status|logs|import-dashboard>, setup, guard, install, or uninstall",
             ),
         handler: () => {},
       })

--- a/src/lib/proxy/proxyReplay.ts
+++ b/src/lib/proxy/proxyReplay.ts
@@ -1,0 +1,1051 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, createReadStream } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  stat,
+  unlink,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { createInterface } from "node:readline";
+import { gunzipSync } from "node:zlib";
+import type {
+  CompareProxyReplayOptions,
+  ExportProxyReplayOptions,
+  ProxyReplayBundle,
+  ProxyReplayCapture,
+  ProxyReplayComparison,
+  ProxyReplayJsonRecord,
+} from "../types/index.js";
+import {
+  prepareProxyBodyForLogging,
+  redactProxyHeadersForLogging,
+} from "./requestLogger.js";
+
+const DEBUG_FILE_PATTERN = /^proxy-debug-\d{4}-\d{2}-\d{2}\.jsonl$/;
+const BUNDLE_KIND = "neurolink.proxy.replay-bundle";
+const COMPARISON_KIND = "neurolink.proxy.replay-comparison";
+const MAX_COMPRESSED_ARTIFACT_BYTES = 2 * 1024 * 1024;
+const MAX_ARTIFACT_BYTES = 2 * 1024 * 1024;
+const MAX_BUNDLE_BYTES = 16 * 1024 * 1024;
+const MAX_DIRECT_RESPONSE_BYTES = 1024 * 1024;
+const REDACTED_VALUE = "[REDACTED]";
+const TRUSTED_CAPTURED_ENDPOINTS = new Set([
+  "https://api.anthropic.com/v1/messages?beta=true",
+]);
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const SENSITIVE_QUERY_NAME_PATTERN =
+  /token|secret|key|password|credential|authorization/i;
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export function isValidProxyReplayHeaderName(name: string): boolean {
+  return HEADER_NAME_PATTERN.test(name);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function recordValue(value: unknown): ProxyReplayJsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as ProxyReplayJsonRecord)
+    : null;
+}
+
+function headersValue(value: unknown): Record<string, string> {
+  const record = recordValue(value);
+  if (!record) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      )
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return (
+    value === null || (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function isNullableSha256(value: unknown): value is string | null {
+  return (
+    value === null || (typeof value === "string" && SHA256_PATTERN.test(value))
+  );
+}
+
+function isHeaderRecord(value: unknown): value is Record<string, string> {
+  const record = recordValue(value);
+  return (
+    record !== null &&
+    Object.entries(record).every(
+      ([name, headerValue]) =>
+        isValidProxyReplayHeaderName(name) &&
+        typeof headerValue === "string" &&
+        !/[\r\n]/.test(headerValue),
+    )
+  );
+}
+
+function isReplayCapture(value: unknown): value is ProxyReplayCapture {
+  const capture = recordValue(value);
+  const source = recordValue(capture?.source);
+  return Boolean(
+    capture &&
+    typeof capture.timestamp === "string" &&
+    typeof capture.phase === "string" &&
+    isNullableNumber(capture.attempt) &&
+    isNullableString(capture.model) &&
+    (capture.stream === null || typeof capture.stream === "boolean") &&
+    isNullableString(capture.account) &&
+    isNullableString(capture.accountType) &&
+    isNullableNumber(capture.responseStatus) &&
+    isNullableNumber(capture.durationMs) &&
+    isNullableString(capture.contentType) &&
+    isHeaderRecord(capture.headers) &&
+    isNullableString(capture.body) &&
+    isNullableSha256(capture.bodySha256) &&
+    typeof capture.bodyTruncated === "boolean" &&
+    isNullableNumber(capture.observedBodyBytes) &&
+    (capture.metadata === null || recordValue(capture.metadata)) &&
+    source &&
+    typeof source.indexFile === "string" &&
+    Number.isInteger(source.indexLine) &&
+    Number(source.indexLine) >= 1 &&
+    isNullableString(source.artifactPath) &&
+    isStringArray(capture.issues),
+  );
+}
+
+function assertProxyReplayBundle(
+  value: unknown,
+): asserts value is ProxyReplayBundle {
+  const bundle = recordValue(value);
+  const source = recordValue(bundle?.source);
+  const completeness = recordValue(bundle?.completeness);
+  const request = recordValue(bundle?.request);
+  const valid = Boolean(
+    bundle?.kind === BUNDLE_KIND &&
+    bundle.schemaVersion === 1 &&
+    typeof bundle.requestId === "string" &&
+    bundle.requestId.length > 0 &&
+    Number.isInteger(bundle.selectedAttempt) &&
+    Number(bundle.selectedAttempt) >= 1 &&
+    source &&
+    typeof source.logsDirectory === "string" &&
+    isStringArray(source.indexFiles) &&
+    completeness &&
+    Number.isInteger(completeness.captures) &&
+    isStringArray(completeness.phasesPresent) &&
+    isStringArray(completeness.missingRequiredPhases) &&
+    Number.isInteger(completeness.truncatedCaptures) &&
+    Number.isInteger(completeness.artifactsWithIssues) &&
+    typeof completeness.replayable === "boolean" &&
+    isStringArray(completeness.blockers) &&
+    request &&
+    ["POST", "PUT", "PATCH"].includes(String(request.method)) &&
+    isNullableString(request.url) &&
+    isHeaderRecord(request.headers) &&
+    isStringArray(request.requiredHeaderInputs) &&
+    request.requiredHeaderInputs.every((name) =>
+      isValidProxyReplayHeaderName(name),
+    ) &&
+    isNullableString(request.body) &&
+    isNullableSha256(request.bodySha256) &&
+    typeof request.bodyTruncated === "boolean" &&
+    isNullableString(request.contentType) &&
+    isNullableString(request.account) &&
+    isNullableString(request.accountType) &&
+    isNullableString(request.model) &&
+    (request.stream === null || typeof request.stream === "boolean") &&
+    Array.isArray(bundle.captures) &&
+    bundle.captures.every(isReplayCapture) &&
+    (bundle.capturedResponse === null ||
+      isReplayCapture(bundle.capturedResponse)),
+  );
+  if (!valid) {
+    throw new Error("Invalid or unsupported NeuroLink proxy replay bundle");
+  }
+  const typedBundle = value as ProxyReplayBundle;
+  const captures = [
+    ...typedBundle.captures,
+    ...(typedBundle.capturedResponse ? [typedBundle.capturedResponse] : []),
+  ];
+  const hashedBodies = [typedBundle.request, ...captures];
+  for (const capture of hashedBodies) {
+    if (
+      capture.body !== null &&
+      capture.bodySha256 !== null &&
+      sha256(capture.body) !== capture.bodySha256
+    ) {
+      throw new Error("Proxy replay bundle contains a body hash mismatch");
+    }
+  }
+  if (
+    stableJson(redactProxyHeadersForLogging(typedBundle.request.headers)) !==
+    stableJson(typedBundle.request.headers)
+  ) {
+    throw new Error(
+      "Proxy replay bundle contains an unredacted request header",
+    );
+  }
+  for (const capture of captures) {
+    if (
+      stableJson(redactProxyHeadersForLogging(capture.headers)) !==
+      stableJson(capture.headers)
+    ) {
+      throw new Error(
+        "Proxy replay bundle contains an unredacted capture header",
+      );
+    }
+    if (
+      capture.body !== null &&
+      prepareProxyBodyForLogging(capture.body).value !== capture.body
+    ) {
+      throw new Error(
+        "Proxy replay bundle contains an unredacted capture body",
+      );
+    }
+  }
+  if (
+    typedBundle.request.body !== null &&
+    prepareProxyBodyForLogging(typedBundle.request.body).value !==
+      typedBundle.request.body
+  ) {
+    throw new Error("Proxy replay bundle contains an unredacted request body");
+  }
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate);
+  return child === "" || (!child.startsWith(`..${sep}`) && child !== "..");
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as ProxyReplayJsonRecord)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stableValue(child)]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(stableValue(value));
+}
+
+export function serializeProxyReplayDocument(value: unknown): string {
+  return `${JSON.stringify(stableValue(value), null, 2)}\n`;
+}
+
+async function discoverDebugFiles(logsDir: string): Promise<string[]> {
+  const entries = await readdir(logsDir, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      throw new Error(
+        `Unable to read proxy logs at ${logsDir}: ${error.message}`,
+      );
+    },
+  );
+  return entries
+    .filter((entry) => entry.isFile() && DEBUG_FILE_PATTERN.test(entry.name))
+    .map((entry) => join(logsDir, entry.name))
+    .sort();
+}
+
+async function findRequestIndexEntries(
+  files: string[],
+  requestId: string,
+): Promise<
+  Array<{
+    index: ProxyReplayJsonRecord;
+    filePath: string;
+    line: number;
+  }>
+> {
+  const matches: Array<{
+    index: ProxyReplayJsonRecord;
+    filePath: string;
+    line: number;
+  }> = [];
+  const encodedRequestId = JSON.stringify(requestId);
+  for (const filePath of files) {
+    const lines = createInterface({
+      input: createReadStream(filePath, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+    let lineNumber = 0;
+    for await (const line of lines) {
+      lineNumber += 1;
+      if (!line.includes(encodedRequestId)) {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const index = recordValue(parsed);
+      if (index?.type === "body_capture" && index.requestId === requestId) {
+        matches.push({ index, filePath, line: lineNumber });
+      }
+    }
+  }
+  return matches;
+}
+
+async function loadArtifact(args: {
+  logsDir: string;
+  bodyPath: string;
+  expectedRequestId: string;
+  expectedPhase: string;
+  expectedSha256: string | null;
+}): Promise<{ artifact: ProxyReplayJsonRecord; relativePath: string }> {
+  const bodyRoot = resolve(args.logsDir, "bodies");
+  const candidate = resolve(
+    isAbsolute(args.bodyPath)
+      ? args.bodyPath
+      : join(args.logsDir, args.bodyPath),
+  );
+  if (!isWithin(bodyRoot, candidate)) {
+    throw new Error(
+      `Body artifact escapes the logs body directory: ${args.bodyPath}`,
+    );
+  }
+
+  const [bodyRootReal, candidateReal, candidateLstat] = await Promise.all([
+    realpath(bodyRoot),
+    realpath(candidate),
+    lstat(candidate),
+  ]);
+  if (
+    !isWithin(bodyRootReal, candidateReal) ||
+    candidateLstat.isSymbolicLink()
+  ) {
+    throw new Error(
+      `Body artifact failed path-containment checks: ${args.bodyPath}`,
+    );
+  }
+  const handle = await open(
+    candidateReal,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+  );
+  let compressed: Buffer;
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) {
+      throw new Error(`Body artifact is not a regular file: ${args.bodyPath}`);
+    }
+    if (info.size > MAX_COMPRESSED_ARTIFACT_BYTES) {
+      throw new Error(
+        `Compressed body artifact exceeds the ${MAX_COMPRESSED_ARTIFACT_BYTES}-byte safety limit`,
+      );
+    }
+    compressed = await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+  const payload = gunzipSync(compressed, {
+    maxOutputLength: MAX_ARTIFACT_BYTES,
+  });
+  const artifact = recordValue(JSON.parse(payload.toString("utf8")));
+  if (!artifact) {
+    throw new Error(`Body artifact is not a JSON object: ${args.bodyPath}`);
+  }
+  if (
+    artifact.requestId !== args.expectedRequestId ||
+    artifact.phase !== args.expectedPhase
+  ) {
+    throw new Error(
+      `Body artifact identity does not match its debug index: ${args.bodyPath}`,
+    );
+  }
+  const body = typeof artifact.body === "string" ? artifact.body : null;
+  if (
+    body !== null &&
+    args.expectedSha256 &&
+    sha256(body) !== args.expectedSha256
+  ) {
+    throw new Error(
+      `Body artifact SHA-256 does not match its debug index: ${args.bodyPath}`,
+    );
+  }
+
+  return {
+    artifact,
+    relativePath: relative(args.logsDir, candidateReal).split(sep).join("/"),
+  };
+}
+
+async function materializeCapture(args: {
+  logsDir: string;
+  requestId: string;
+  index: ProxyReplayJsonRecord;
+  filePath: string;
+  line: number;
+}): Promise<ProxyReplayCapture> {
+  const phase = stringValue(args.index.phase) ?? "unknown";
+  const expectedSha256 = stringValue(args.index.bodySha256);
+  const issues: string[] = [];
+  let artifact: ProxyReplayJsonRecord | null = null;
+  let artifactPath: string | null = null;
+  const bodyPath = stringValue(args.index.bodyPath);
+  if (!bodyPath) {
+    issues.push("body_artifact_missing");
+  } else {
+    try {
+      const loaded = await loadArtifact({
+        logsDir: args.logsDir,
+        bodyPath,
+        expectedRequestId: args.requestId,
+        expectedPhase: phase,
+        expectedSha256,
+      });
+      artifact = loaded.artifact;
+      artifactPath = loaded.relativePath;
+      for (const field of [
+        "timestamp",
+        "requestId",
+        "phase",
+        "model",
+        "stream",
+        "account",
+        "accountType",
+        "attempt",
+        "responseStatus",
+        "durationMs",
+        "contentType",
+        "headers",
+        "metadata",
+      ]) {
+        if (stableJson(artifact[field]) !== stableJson(args.index[field])) {
+          throw new Error(
+            `Body artifact ${field} does not match its debug index: ${bodyPath}`,
+          );
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        issues.push("body_artifact_missing");
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  const source = artifact ?? args.index;
+  const body = typeof artifact?.body === "string" ? artifact.body : null;
+  if (body !== null && !expectedSha256) {
+    issues.push("body_hash_missing");
+  }
+  return {
+    timestamp:
+      stringValue(source.timestamp) ?? stringValue(args.index.timestamp) ?? "",
+    phase,
+    attempt: finiteNumber(source.attempt),
+    model: stringValue(source.model),
+    stream: typeof source.stream === "boolean" ? source.stream : null,
+    account: stringValue(source.account),
+    accountType: stringValue(source.accountType),
+    responseStatus: finiteNumber(source.responseStatus),
+    durationMs: finiteNumber(source.durationMs),
+    contentType: stringValue(source.contentType),
+    headers: headersValue(source.headers),
+    body,
+    bodySha256: body === null ? expectedSha256 : sha256(body),
+    bodyTruncated: args.index.bodyTruncated === true,
+    observedBodyBytes: finiteNumber(args.index.observedBodyBytes),
+    metadata: recordValue(source.metadata),
+    source: {
+      indexFile: basename(args.filePath),
+      indexLine: args.line,
+      artifactPath,
+    },
+    issues,
+  };
+}
+
+function captureSort(
+  left: ProxyReplayCapture,
+  right: ProxyReplayCapture,
+): number {
+  return (
+    left.timestamp.localeCompare(right.timestamp) ||
+    (left.attempt ?? -1) - (right.attempt ?? -1) ||
+    left.phase.localeCompare(right.phase) ||
+    left.source.indexFile.localeCompare(right.source.indexFile) ||
+    left.source.indexLine - right.source.indexLine
+  );
+}
+
+function findCapture(
+  captures: ProxyReplayCapture[],
+  phase: string,
+  attempt?: number,
+): ProxyReplayCapture | null {
+  const matches = captures.filter(
+    (capture) =>
+      capture.phase === phase &&
+      (attempt === undefined || capture.attempt === attempt),
+  );
+  return matches.at(-1) ?? null;
+}
+
+export async function exportProxyReplayBundle(
+  options: ExportProxyReplayOptions,
+): Promise<ProxyReplayBundle> {
+  if (!options.requestId || options.requestId.length > 256) {
+    throw new Error("requestId must contain between 1 and 256 characters");
+  }
+  if (
+    options.attempt !== undefined &&
+    (!Number.isInteger(options.attempt) || options.attempt < 1)
+  ) {
+    throw new Error("attempt must be a positive integer");
+  }
+  const logsDir = resolve(
+    options.logsDir ?? join(homedir(), ".neurolink", "logs"),
+  );
+  const debugFiles = await discoverDebugFiles(logsDir);
+  const indexEntries = await findRequestIndexEntries(
+    debugFiles,
+    options.requestId,
+  );
+  if (indexEntries.length === 0) {
+    throw new Error(`No body captures found for request ${options.requestId}`);
+  }
+  const captures = (
+    await Promise.all(
+      indexEntries.map((entry) =>
+        materializeCapture({ logsDir, requestId: options.requestId, ...entry }),
+      ),
+    )
+  ).sort(captureSort);
+  const upstreamAttempts = captures
+    .filter(
+      (capture) =>
+        capture.phase === "upstream_request" && capture.attempt !== null,
+    )
+    .map((capture) => capture.attempt as number);
+  const selectedAttempt =
+    options.attempt ??
+    upstreamAttempts.reduce(
+      (highest, attempt) => Math.max(highest, attempt),
+      Number.NEGATIVE_INFINITY,
+    );
+  if (!Number.isFinite(selectedAttempt)) {
+    throw new Error(
+      `Request ${options.requestId} has no captured upstream attempt`,
+    );
+  }
+  const upstreamRequest = findCapture(
+    captures,
+    "upstream_request",
+    selectedAttempt,
+  );
+  if (!upstreamRequest) {
+    throw new Error(
+      `Request ${options.requestId} has no upstream_request capture for attempt ${selectedAttempt}`,
+    );
+  }
+  const capturedResponse = findCapture(
+    captures,
+    "upstream_response",
+    selectedAttempt,
+  );
+  const phasesPresent = [
+    ...new Set(captures.map((capture) => capture.phase)),
+  ].sort();
+  const missingRequiredPhases = [
+    ...(findCapture(captures, "client_request") ? [] : ["client_request"]),
+    ...(upstreamRequest ? [] : ["upstream_request"]),
+    ...(capturedResponse ? [] : ["upstream_response"]),
+    ...(findCapture(captures, "client_response") ? [] : ["client_response"]),
+  ];
+  const requiredHeaderInputs = Object.entries(upstreamRequest.headers)
+    .filter(([, value]) => value === REDACTED_VALUE)
+    .map(([name]) => name.toLowerCase())
+    .sort();
+  const metadata = upstreamRequest.metadata ?? {};
+  const url = stringValue(metadata.upstreamUrl);
+  const method = (stringValue(metadata.upstreamMethod) ?? "POST").toUpperCase();
+  const blockers = [
+    ...missingRequiredPhases.map((phase) => `missing_phase:${phase}`),
+    ...(url ? [] : ["missing_upstream_url"]),
+    ...(upstreamRequest.body === null ? ["missing_upstream_request_body"] : []),
+    ...(upstreamRequest.bodyTruncated
+      ? ["upstream_request_body_truncated"]
+      : []),
+    ...(upstreamRequest.body?.includes(REDACTED_VALUE)
+      ? ["upstream_request_body_contains_redactions"]
+      : []),
+    ...captures.flatMap((capture) =>
+      capture.issues.map(
+        (issue) => `${capture.phase}:${capture.attempt ?? "none"}:${issue}`,
+      ),
+    ),
+  ].sort();
+
+  return {
+    schemaVersion: 1,
+    kind: BUNDLE_KIND,
+    requestId: options.requestId,
+    selectedAttempt,
+    source: {
+      logsDirectory: basename(logsDir),
+      indexFiles: [
+        ...new Set(captures.map((capture) => capture.source.indexFile)),
+      ].sort(),
+    },
+    completeness: {
+      captures: captures.length,
+      phasesPresent,
+      missingRequiredPhases,
+      truncatedCaptures: captures.filter((capture) => capture.bodyTruncated)
+        .length,
+      artifactsWithIssues: captures.filter(
+        (capture) => capture.issues.length > 0,
+      ).length,
+      replayable: blockers.length === 0,
+      blockers,
+    },
+    request: {
+      method,
+      url,
+      headers: upstreamRequest.headers,
+      requiredHeaderInputs,
+      body: upstreamRequest.body,
+      bodySha256: upstreamRequest.bodySha256,
+      bodyTruncated: upstreamRequest.bodyTruncated,
+      contentType: upstreamRequest.contentType,
+      account: upstreamRequest.account,
+      accountType: upstreamRequest.accountType,
+      model: upstreamRequest.model,
+      stream: upstreamRequest.stream,
+    },
+    capturedResponse,
+    captures,
+  };
+}
+
+export async function writeProxyReplayDocument(
+  outputPath: string,
+  document: unknown,
+): Promise<{ path: string; sha256: string }> {
+  const resolvedPath = resolve(outputPath);
+  const outputDirectory = dirname(resolvedPath);
+  await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+  const existing = await lstat(resolvedPath).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    },
+  );
+  if (existing?.isSymbolicLink()) {
+    throw new Error(`Refusing to replace symlink output path: ${resolvedPath}`);
+  }
+  const serialized = serializeProxyReplayDocument(document);
+  const documentBytes = Buffer.byteLength(serialized, "utf8");
+  if (documentBytes > MAX_BUNDLE_BYTES) {
+    throw new Error(
+      `Replay document exceeds the ${MAX_BUNDLE_BYTES}-byte safety limit`,
+    );
+  }
+  const temporaryPath = join(
+    outputDirectory,
+    `.${basename(resolvedPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const handle = await open(
+    temporaryPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+    0o600,
+  );
+  try {
+    try {
+      await handle.writeFile(serialized);
+      await handle.chmod(0o600);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, resolvedPath);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+  return { path: resolvedPath, sha256: sha256(serialized) };
+}
+
+export async function readProxyReplayBundle(
+  bundlePath: string,
+): Promise<ProxyReplayBundle> {
+  const resolvedPath = resolve(bundlePath);
+  const info = await stat(resolvedPath);
+  if (!info.isFile() || info.size > MAX_BUNDLE_BYTES) {
+    throw new Error(
+      `Replay bundle must be a regular file no larger than ${MAX_BUNDLE_BYTES} bytes`,
+    );
+  }
+  const parsed = JSON.parse(await readFile(resolvedPath, "utf8")) as unknown;
+  assertProxyReplayBundle(parsed);
+  return parsed;
+}
+
+function normalizedContentType(value: string | null): string | null {
+  return value?.split(";", 1)[0]?.trim().toLowerCase() || null;
+}
+
+function jsonShape(body: string): string[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  const paths: string[] = [];
+  const walk = (value: unknown, path: string, depth: number): void => {
+    if (paths.length >= 2_000 || depth > 20) {
+      return;
+    }
+    if (Array.isArray(value)) {
+      paths.push(`${path}:array`);
+      value
+        .slice(0, 20)
+        .forEach((child, index) => walk(child, `${path}/${index}`, depth + 1));
+      return;
+    }
+    if (value && typeof value === "object") {
+      paths.push(`${path}:object`);
+      for (const [key, child] of Object.entries(
+        value as ProxyReplayJsonRecord,
+      ).sort(([left], [right]) => left.localeCompare(right))) {
+        walk(
+          child,
+          `${path}/${key.replaceAll("~", "~0").replaceAll("/", "~1")}`,
+          depth + 1,
+        );
+      }
+      return;
+    }
+    paths.push(`${path}:${value === null ? "null" : typeof value}`);
+  };
+  walk(parsed, "", 0);
+  return paths;
+}
+
+function validateDirectEndpoint(value: string, explicitOverride: boolean): URL {
+  if (!value) {
+    throw new Error(
+      "Replay bundle has no upstream URL; provide an explicit URL override",
+    );
+  }
+  const endpoint = new URL(value);
+  if (endpoint.username || endpoint.password || endpoint.hash) {
+    throw new Error(
+      "Replay endpoint must not contain credentials or a fragment",
+    );
+  }
+  for (const name of endpoint.searchParams.keys()) {
+    if (SENSITIVE_QUERY_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `Replay endpoint must not contain a sensitive query parameter: ${name}`,
+      );
+    }
+  }
+  const loopback = ["127.0.0.1", "::1", "[::1]", "localhost"].includes(
+    endpoint.hostname,
+  );
+  if (
+    endpoint.protocol !== "https:" &&
+    !(endpoint.protocol === "http:" && loopback)
+  ) {
+    throw new Error(
+      "Replay endpoint must use HTTPS; HTTP is allowed only for loopback testing",
+    );
+  }
+  if (
+    !explicitOverride &&
+    !TRUSTED_CAPTURED_ENDPOINTS.has(endpoint.toString())
+  ) {
+    throw new Error(
+      "Replay bundle contains an untrusted endpoint; pass an explicit URL override to authorize it",
+    );
+  }
+  return endpoint;
+}
+
+async function readBoundedResponse(response: Response): Promise<{
+  body: string;
+  observedBytes: number;
+  truncated: boolean;
+}> {
+  if (!response.body) {
+    return { body: "", observedBytes: 0, truncated: false };
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let storedBytes = 0;
+  let observedBytes = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) {
+        break;
+      }
+      observedBytes += next.value.byteLength;
+      if (storedBytes < MAX_DIRECT_RESPONSE_BYTES) {
+        const remaining = MAX_DIRECT_RESPONSE_BYTES - storedBytes;
+        chunks.push(next.value.slice(0, remaining));
+        storedBytes += Math.min(remaining, next.value.byteLength);
+      }
+      if (observedBytes > MAX_DIRECT_RESPONSE_BYTES) {
+        truncated = true;
+        await reader
+          .cancel("bounded replay comparison capture")
+          .catch(() => undefined);
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return {
+    body: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString(
+      "utf8",
+    ),
+    observedBytes,
+    truncated,
+  };
+}
+
+export async function compareProxyReplayBundle(
+  bundle: ProxyReplayBundle,
+  options: CompareProxyReplayOptions,
+): Promise<ProxyReplayComparison> {
+  assertProxyReplayBundle(bundle);
+  if (!options.execute) {
+    throw new Error(
+      "Direct replay is disabled unless execute=true is explicitly provided",
+    );
+  }
+  if (!["POST", "PUT", "PATCH"].includes(bundle.request.method)) {
+    throw new Error(
+      `Unsupported replay request method: ${bundle.request.method}`,
+    );
+  }
+  const requestBody = options.bodyOverride ?? bundle.request.body;
+  if (requestBody === null) {
+    throw new Error("Replay request body is missing; provide a body override");
+  }
+  if (
+    options.bodyOverride === undefined &&
+    (bundle.request.bodyTruncated || requestBody.includes(REDACTED_VALUE))
+  ) {
+    throw new Error(
+      "Captured replay body is truncated or redacted; provide a complete body override",
+    );
+  }
+  if (
+    options.bodyOverride === undefined &&
+    bundle.request.bodySha256 === null
+  ) {
+    throw new Error(
+      "Captured replay body has no verified hash; provide a complete body override",
+    );
+  }
+  const endpoint = validateDirectEndpoint(
+    options.urlOverride ?? bundle.request.url ?? "",
+    options.urlOverride !== undefined,
+  );
+  const suppliedHeaders = Object.fromEntries(
+    Object.entries(options.headerValues ?? {}).map(([name, value]) => [
+      name.toLowerCase(),
+      value,
+    ]),
+  );
+  const invalidHeaderNames = Object.keys(suppliedHeaders).filter(
+    (name) => !isValidProxyReplayHeaderName(name),
+  );
+  if (invalidHeaderNames.length > 0) {
+    throw new Error(
+      `Invalid replay header names: ${invalidHeaderNames.join(", ")}`,
+    );
+  }
+  const requiredHeaderInputs = [
+    ...new Set([
+      ...bundle.request.requiredHeaderInputs.map((name) => name.toLowerCase()),
+      ...Object.entries(bundle.request.headers)
+        .filter(([, value]) => value === REDACTED_VALUE)
+        .map(([name]) => name.toLowerCase()),
+    ]),
+  ].sort();
+  const missingHeaderValues = requiredHeaderInputs.filter(
+    (name) => !suppliedHeaders[name],
+  );
+  if (missingHeaderValues.length > 0) {
+    throw new Error(
+      `Missing environment-backed values for redacted headers: ${missingHeaderValues.join(", ")}`,
+    );
+  }
+  const requestHeaders: Record<string, string> = {};
+  for (const [name, capturedValue] of Object.entries(bundle.request.headers)) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) {
+      continue;
+    }
+    requestHeaders[lower] =
+      capturedValue === REDACTED_VALUE
+        ? (suppliedHeaders[lower] as string)
+        : capturedValue;
+  }
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 600_000) {
+    throw new Error(
+      "Replay timeout must be between 1000 and 600000 milliseconds",
+    );
+  }
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  const response = await (options.fetchImpl ?? fetch)(endpoint, {
+    method: bundle.request.method,
+    headers: requestHeaders,
+    body: requestBody,
+    redirect: "manual",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const headersAt = now();
+  const rawResponseHeaders = Object.fromEntries(response.headers.entries());
+  const directCapture = await readBoundedResponse(response);
+  const endedAt = now();
+  const preparedBody = prepareProxyBodyForLogging(directCapture.body);
+  const redactedBody = preparedBody.value ?? "";
+  const captured = bundle.capturedResponse;
+  const capturedShape = captured?.body ? jsonShape(captured.body) : null;
+  const directShape = jsonShape(redactedBody);
+  const capturedContentType = normalizedContentType(
+    captured?.contentType ?? null,
+  );
+  const directContentType = normalizedContentType(
+    response.headers.get("content-type"),
+  );
+
+  return {
+    schemaVersion: 1,
+    kind: COMPARISON_KIND,
+    requestId: bundle.requestId,
+    selectedAttempt: bundle.selectedAttempt,
+    endpoint: endpoint.toString(),
+    request: {
+      method: bundle.request.method,
+      headers: redactProxyHeadersForLogging(requestHeaders) ?? {},
+      bodySha256: sha256(requestBody),
+      bodyBytes: Buffer.byteLength(requestBody, "utf8"),
+      usedBodyOverride: options.bodyOverride !== undefined,
+    },
+    captured: captured
+      ? {
+          status: captured.responseStatus,
+          contentType: captured.contentType,
+          bodySha256: captured.bodySha256,
+          bodyBytes: captured.observedBodyBytes,
+          bodyTruncated: captured.bodyTruncated,
+          jsonShape: capturedShape,
+        }
+      : null,
+    direct: {
+      status: response.status,
+      headers: redactProxyHeadersForLogging(rawResponseHeaders) ?? {},
+      contentType: response.headers.get("content-type"),
+      body: redactedBody,
+      bodySha256: sha256(redactedBody),
+      observedBodyBytes: directCapture.observedBytes,
+      storedBodyBytes: Buffer.byteLength(redactedBody, "utf8"),
+      bodyTruncated: directCapture.truncated || preparedBody.truncated,
+      timeToHeadersMs: headersAt - startedAt,
+      totalMs: endedAt - startedAt,
+      jsonShape: directShape,
+    },
+    comparison: {
+      statusMatches:
+        captured && captured.responseStatus !== null
+          ? captured.responseStatus === response.status
+          : null,
+      contentTypeMatches: captured
+        ? capturedContentType !== null && directContentType !== null
+          ? capturedContentType === directContentType
+          : null
+        : null,
+      bodyHashMatches:
+        captured?.bodySha256 &&
+        !captured.bodyTruncated &&
+        !directCapture.truncated &&
+        !preparedBody.truncated
+          ? captured.bodySha256 === sha256(redactedBody)
+          : null,
+      jsonShapeMatches:
+        capturedShape &&
+        directShape &&
+        !captured?.bodyTruncated &&
+        !directCapture.truncated &&
+        !preparedBody.truncated
+          ? JSON.stringify(capturedShape) === JSON.stringify(directShape)
+          : null,
+    },
+  };
+}

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -418,6 +418,27 @@ function prepareRedactedBody(body: unknown): {
   return truncateUtf8String(redacted, MAX_CAPTURED_BODY_BYTES);
 }
 
+/** Shared redaction used by offline replay exports and direct comparisons. */
+export function redactProxyHeadersForLogging(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return redactHeaders(headers);
+}
+
+/**
+ * Apply the same bounded body redaction used by persisted proxy captures.
+ * `value` and `bytes` are omitted only when the input is null or undefined.
+ * This performs serialization immediately, so callers must keep it off proxy
+ * hot paths unless body processing has already been explicitly requested.
+ */
+export function prepareProxyBodyForLogging(body: unknown): {
+  value?: string;
+  bytes?: number;
+  truncated: boolean;
+} {
+  return prepareRedactedBody(body);
+}
+
 function collectManagedLogFiles(rootDir: string): ManagedLogFile[] {
   const managedFiles: ManagedLogFile[] = [];
 

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -1417,6 +1417,10 @@ async function handleClaudePassthroughRequest(args: {
     account: "passthrough",
     accountType: "passthrough",
     attempt: 1,
+    metadata: {
+      upstreamMethod: "POST",
+      upstreamUrl: "https://api.anthropic.com/v1/messages?beta=true",
+    },
   });
 
   let response: Response;
@@ -4148,6 +4152,7 @@ async function handleAnthropicAuthRetry(args: {
   accountState: RuntimeAccountState;
   headers: Record<string, string>;
   buildUpstreamBody: (token: string) => { bodyStr: string; sessionId?: string };
+  url: string;
   enabledAccounts: ProxyPassthroughAccount[];
   orderedAccounts: ProxyPassthroughAccount[];
   tracer?: ProxyTracer;
@@ -4182,6 +4187,7 @@ async function handleAnthropicAuthRetry(args: {
     accountState,
     headers,
     buildUpstreamBody,
+    url,
     enabledAccounts,
     orderedAccounts,
     tracer,
@@ -4271,18 +4277,16 @@ async function handleAnthropicAuthRetry(args: {
       account: account.label,
       accountType: account.type,
       attempt: retryAttemptNumber,
+      metadata: { upstreamMethod: "POST", upstreamUrl: url },
     });
 
     try {
-      const retryResp = await fetch(
-        "https://api.anthropic.com/v1/messages?beta=true",
-        {
-          method: "POST",
-          headers,
-          body: retryBodyStr,
-          signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
-        },
-      );
+      const retryResp = await fetch(url, {
+        method: "POST",
+        headers,
+        body: retryBodyStr,
+        signal: AbortSignal.timeout(UPSTREAM_FETCH_TIMEOUT_MS),
+      });
       if (retryResp.ok) {
         authRetrySucceeded = true;
         accountState.consecutiveRefreshFailures = 0;
@@ -5332,6 +5336,7 @@ async function prepareAnthropicAccountAttempt(args: {
     account: account.label,
     accountType: account.type,
     attempt: attemptNumber,
+    metadata: { upstreamMethod: "POST", upstreamUrl: url },
   });
 
   return {
@@ -5894,6 +5899,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
           accountState,
           headers: preparedAttempt.headers,
           buildUpstreamBody: preparedAttempt.buildUpstreamBody,
+          url,
           enabledAccounts,
           orderedAccounts,
           tracer,

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -933,6 +933,23 @@ export type ProxyAnalyzeArgs = {
   quiet?: boolean;
 };
 
+/** Arguments accepted by `neurolink proxy replay <export|compare>`. */
+export type ProxyReplayArgs = {
+  action?: "export" | "compare";
+  requestId?: string;
+  attempt?: number;
+  logsDir?: string;
+  bundle?: string;
+  output?: string;
+  execute?: boolean;
+  headerEnv?: string[];
+  bodyFile?: string;
+  url?: string;
+  timeoutMs?: number;
+  format?: "text" | "json";
+  quiet?: boolean;
+};
+
 /** Arguments accepted by hidden `neurolink proxy guard` command */
 export type ProxyGuardArgs = {
   host?: string;

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1460,6 +1460,133 @@ export type ProxyBodyCaptureEntry = {
   metadata?: Record<string, unknown>;
 };
 
+/** JSON object retained in deterministic proxy replay artifacts. */
+export type ProxyReplayJsonRecord = Record<string, unknown>;
+
+/** One verified body-capture record in a proxy replay bundle. */
+export type ProxyReplayCapture = {
+  timestamp: string;
+  phase: string;
+  attempt: number | null;
+  model: string | null;
+  stream: boolean | null;
+  account: string | null;
+  accountType: string | null;
+  responseStatus: number | null;
+  durationMs: number | null;
+  contentType: string | null;
+  headers: Record<string, string>;
+  body: string | null;
+  bodySha256: string | null;
+  bodyTruncated: boolean;
+  observedBodyBytes: number | null;
+  metadata: ProxyReplayJsonRecord | null;
+  source: {
+    indexFile: string;
+    indexLine: number;
+    artifactPath: string | null;
+  };
+  issues: string[];
+};
+
+/** Deterministic, redacted reconstruction of one captured proxy request. */
+export type ProxyReplayBundle = {
+  schemaVersion: 1;
+  kind: "neurolink.proxy.replay-bundle";
+  requestId: string;
+  selectedAttempt: number;
+  source: {
+    logsDirectory: string;
+    indexFiles: string[];
+  };
+  completeness: {
+    captures: number;
+    phasesPresent: string[];
+    missingRequiredPhases: string[];
+    truncatedCaptures: number;
+    artifactsWithIssues: number;
+    replayable: boolean;
+    blockers: string[];
+  };
+  request: {
+    method: string;
+    url: string | null;
+    headers: Record<string, string>;
+    requiredHeaderInputs: string[];
+    body: string | null;
+    bodySha256: string | null;
+    bodyTruncated: boolean;
+    contentType: string | null;
+    account: string | null;
+    accountType: string | null;
+    model: string | null;
+    stream: boolean | null;
+  };
+  capturedResponse: ProxyReplayCapture | null;
+  captures: ProxyReplayCapture[];
+};
+
+/** Redacted direct-upstream response and comparison with captured evidence. */
+export type ProxyReplayComparison = {
+  schemaVersion: 1;
+  kind: "neurolink.proxy.replay-comparison";
+  requestId: string;
+  selectedAttempt: number;
+  endpoint: string;
+  request: {
+    method: string;
+    headers: Record<string, string>;
+    bodySha256: string;
+    bodyBytes: number;
+    usedBodyOverride: boolean;
+  };
+  captured: {
+    status: number | null;
+    contentType: string | null;
+    bodySha256: string | null;
+    bodyBytes: number | null;
+    bodyTruncated: boolean;
+    jsonShape: string[] | null;
+  } | null;
+  direct: {
+    status: number;
+    headers: Record<string, string>;
+    contentType: string | null;
+    body: string;
+    bodySha256: string;
+    observedBodyBytes: number;
+    storedBodyBytes: number;
+    bodyTruncated: boolean;
+    timeToHeadersMs: number;
+    totalMs: number;
+    jsonShape: string[] | null;
+  };
+  comparison: {
+    statusMatches: boolean | null;
+    contentTypeMatches: boolean | null;
+    bodyHashMatches: boolean | null;
+    jsonShapeMatches: boolean | null;
+  };
+};
+
+/** Inputs for deterministic proxy replay bundle export. */
+export type ExportProxyReplayOptions = {
+  requestId: string;
+  logsDir?: string;
+  attempt?: number;
+};
+
+/** Inputs for an explicitly authorized direct-upstream comparison. */
+export type CompareProxyReplayOptions = {
+  execute: boolean;
+  headerValues?: Record<string, string>;
+  bodyOverride?: string;
+  urlOverride?: string;
+  timeoutMs?: number;
+  now?: () => number;
+  fetchImpl?: typeof fetch;
+};
+
 /** Persisted artifact produced when a body is stored to disk. */
 export type StoredBodyArtifact = {
   bodyPath?: string;

--- a/test/proxyReplay.test.ts
+++ b/test/proxyReplay.test.ts
@@ -1,0 +1,716 @@
+import { createServer, type Server } from "node:http";
+import { once } from "node:events";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { gunzip, gzip } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxyReplayCommand } from "../src/cli/commands/proxyReplay.js";
+import {
+  compareProxyReplayBundle,
+  exportProxyReplayBundle,
+  readProxyReplayBundle,
+  serializeProxyReplayDocument,
+  writeProxyReplayDocument,
+} from "../src/lib/proxy/proxyReplay.js";
+import type { ProxyReplayBundle } from "../src/lib/types/index.js";
+import {
+  initRequestLogger,
+  logBodyCapture,
+} from "../src/lib/proxy/requestLogger.js";
+import { logger } from "../src/lib/utils/logger.js";
+
+const gunzipAsync = promisify(gunzip);
+const gzipAsync = promisify(gzip);
+const temporaryDirectories: string[] = [];
+const servers: Server[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "neurolink-replay-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  initRequestLogger(false);
+  await Promise.allSettled(servers.splice(0).map(closeServer));
+  await Promise.allSettled(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function captureRequest(args: {
+  logsDir: string;
+  requestId?: string;
+  attempt?: number;
+  url?: string;
+  requestBody?: string;
+  responseBody?: string;
+  includeResponse?: boolean;
+}) {
+  initRequestLogger(true, args.logsDir);
+  const requestId = args.requestId ?? "request-replay-1";
+  const attempt = args.attempt ?? 1;
+  const timestamp = "2026-07-19T10:00:00.000Z";
+  const requestBody =
+    args.requestBody ??
+    JSON.stringify({
+      model: "claude-sonnet-5",
+      messages: [{ role: "user", content: "hello" }],
+    });
+  const responseBody =
+    args.responseBody ??
+    JSON.stringify({ id: "message-1", type: "message", content: [] });
+  await logBodyCapture({
+    timestamp,
+    requestId,
+    phase: "client_request",
+    model: "claude-sonnet-5",
+    stream: false,
+    headers: {
+      authorization: "Bearer client-secret",
+      "content-type": "application/json",
+    },
+    body: requestBody,
+  });
+  await logBodyCapture({
+    timestamp: "2026-07-19T10:00:00.010Z",
+    requestId,
+    phase: "upstream_request",
+    model: "claude-sonnet-5",
+    stream: false,
+    headers: {
+      authorization: "Bearer upstream-secret",
+      "content-type": "application/json",
+      "anthropic-version": "2023-06-01",
+    },
+    body: requestBody,
+    account: "fixture@example.com",
+    accountType: "oauth",
+    attempt,
+    metadata: {
+      upstreamMethod: "POST",
+      upstreamUrl:
+        args.url ?? "https://api.anthropic.com/v1/messages?beta=true",
+    },
+  });
+  if (args.includeResponse !== false) {
+    await logBodyCapture({
+      timestamp: "2026-07-19T10:00:00.020Z",
+      requestId,
+      phase: "upstream_response",
+      model: "claude-sonnet-5",
+      stream: false,
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "upstream-1",
+      },
+      contentType: "application/json",
+      body: responseBody,
+      responseStatus: 200,
+      account: "fixture@example.com",
+      accountType: "oauth",
+      attempt,
+    });
+    await logBodyCapture({
+      timestamp: "2026-07-19T10:00:00.030Z",
+      requestId,
+      phase: "client_response",
+      model: "claude-sonnet-5",
+      stream: false,
+      headers: { "content-type": "application/json" },
+      contentType: "application/json",
+      body: responseBody,
+      responseStatus: 200,
+      account: "fixture@example.com",
+      accountType: "oauth",
+      attempt,
+    });
+  }
+  return { requestId, requestBody, responseBody };
+}
+
+async function debugIndex(logsDir: string): Promise<string> {
+  const files = await readdir(logsDir);
+  const file = files.find((entry) => entry.startsWith("proxy-debug-"));
+  if (!file) {
+    throw new Error("debug index not found");
+  }
+  return join(logsDir, file);
+}
+
+describe("proxy replay bundle export", () => {
+  it("captures the exact upstream method and URL at every Anthropic request site", async () => {
+    const source = await readFile(
+      new URL("../src/lib/server/routes/claudeProxyRoutes.ts", import.meta.url),
+      "utf8",
+    );
+    const blocks = [
+      ...source.matchAll(
+        /logProxyBody\(\{\s*phase: "upstream_request",[\s\S]*?\n\s*\}\);/g,
+      ),
+    ].map((match) => match[0]);
+    expect(blocks).toHaveLength(3);
+    for (const block of blocks) {
+      expect(block).toContain("metadata:");
+      expect(block).toContain('upstreamMethod: "POST"');
+      expect(block).toMatch(
+        /upstreamUrl: (?:url|"https:\/\/api\.anthropic\.com\/v1\/messages\?beta=true")/,
+      );
+    }
+  });
+
+  it("exports deterministic, redacted, hash-verified evidence with restrictive permissions", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+
+    const first = await exportProxyReplayBundle({ requestId, logsDir });
+    const second = await exportProxyReplayBundle({ requestId, logsDir });
+    expect(serializeProxyReplayDocument(first)).toBe(
+      serializeProxyReplayDocument(second),
+    );
+    expect(first.completeness).toMatchObject({
+      captures: 4,
+      replayable: true,
+      blockers: [],
+    });
+    expect(first.request).toMatchObject({
+      method: "POST",
+      url: "https://api.anthropic.com/v1/messages?beta=true",
+      requiredHeaderInputs: ["authorization"],
+      account: "fixture@example.com",
+      accountType: "oauth",
+    });
+    expect(first.request.headers.authorization).toBe("[REDACTED]");
+
+    const output = join(logsDir, "exports", "request.json");
+    const written = await writeProxyReplayDocument(output, first);
+    const serialized = await readFile(written.path, "utf8");
+    expect(serialized).not.toContain("upstream-secret");
+    expect(serialized).not.toContain("client-secret");
+    expect((await stat(written.path)).mode & 0o777).toBe(0o600);
+    expect(await readProxyReplayBundle(written.path)).toEqual(first);
+  });
+
+  it("honors quiet mode while still writing the CLI export", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const output = join(logsDir, "quiet-export.json");
+    const always = vi
+      .spyOn(logger, "always")
+      .mockImplementation(() => undefined);
+
+    await proxyReplayCommand.handler({
+      $0: "neurolink",
+      _: ["proxy", "replay"],
+      action: "export",
+      requestId,
+      logsDir,
+      output,
+      format: "text",
+      quiet: true,
+    });
+
+    expect(always).not.toHaveBeenCalled();
+    expect((await stat(output)).isFile()).toBe(true);
+  });
+
+  it("selects the latest upstream attempt unless an attempt is requested", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir, attempt: 1 });
+    await captureRequest({
+      logsDir,
+      requestId,
+      attempt: 2,
+      requestBody: JSON.stringify({
+        model: "claude-sonnet-5",
+        messages: [{ role: "user", content: "retry" }],
+      }),
+    });
+
+    expect(
+      (await exportProxyReplayBundle({ requestId, logsDir })).selectedAttempt,
+    ).toBe(2);
+    expect(
+      (await exportProxyReplayBundle({ requestId, logsDir, attempt: 1 }))
+        .selectedAttempt,
+    ).toBe(1);
+  });
+
+  it("evaluates response completeness for the selected attempt", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir, attempt: 1 });
+    await captureRequest({
+      logsDir,
+      requestId,
+      attempt: 2,
+      includeResponse: false,
+    });
+
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    expect(bundle.selectedAttempt).toBe(2);
+    expect(bundle.capturedResponse).toBeNull();
+    expect(bundle.completeness.missingRequiredPhases).toContain(
+      "upstream_response",
+    );
+  });
+
+  it("reports missing phases and refuses to claim the bundle is replayable", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({
+      logsDir,
+      includeResponse: false,
+    });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    expect(bundle.completeness.replayable).toBe(false);
+    expect(bundle.completeness.missingRequiredPhases).toEqual([
+      "upstream_response",
+      "client_response",
+    ]);
+    expect(bundle.capturedResponse).toBeNull();
+  });
+
+  it("marks truncated request evidence as non-replayable", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({
+      logsDir,
+      requestBody: JSON.stringify({ content: "x".repeat(1024 * 1024 + 256) }),
+    });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    expect(bundle.request.bodyTruncated).toBe(true);
+    expect(bundle.completeness.replayable).toBe(false);
+    expect(bundle.completeness.blockers).toContain(
+      "upstream_request_body_truncated",
+    );
+  });
+
+  it("retains a diagnostic bundle when a managed artifact has been removed", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const indexPath = await debugIndex(logsDir);
+    const entries = (await readFile(indexPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const upstreamRequest = entries.find(
+      (entry) => entry.phase === "upstream_request",
+    );
+    if (!upstreamRequest) {
+      throw new Error("upstream request index entry not found");
+    }
+    await rm(String(upstreamRequest.bodyPath));
+
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    expect(bundle.completeness.replayable).toBe(false);
+    expect(bundle.completeness.blockers).toContain(
+      "upstream_request:1:body_artifact_missing",
+    );
+  });
+
+  it("fails closed when an index points outside the managed body directory", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const indexPath = await debugIndex(logsDir);
+    const lines = (await readFile(indexPath, "utf8")).trim().split("\n");
+    const first = JSON.parse(lines[0]) as Record<string, unknown>;
+    first.bodyPath = join(logsDir, "outside.json.gz");
+    lines[0] = JSON.stringify(first);
+    await writeFile(indexPath, `${lines.join("\n")}\n`);
+
+    await expect(
+      exportProxyReplayBundle({ requestId, logsDir }),
+    ).rejects.toThrow("escapes the logs body directory");
+  });
+
+  it("fails closed when artifact contents no longer match the indexed hash", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const indexPath = await debugIndex(logsDir);
+    const first = JSON.parse(
+      (await readFile(indexPath, "utf8")).trim().split("\n")[0],
+    ) as Record<string, unknown>;
+    const artifactPath = String(first.bodyPath);
+    const artifact = JSON.parse(
+      (await gunzipAsync(await readFile(artifactPath))).toString("utf8"),
+    ) as Record<string, unknown>;
+    artifact.body = "tampered";
+    await writeFile(artifactPath, await gzipAsync(JSON.stringify(artifact)));
+    await chmod(artifactPath, 0o600);
+
+    await expect(
+      exportProxyReplayBundle({ requestId, logsDir }),
+    ).rejects.toThrow("SHA-256 does not match");
+  });
+
+  it("fails closed when artifact metadata diverges from the debug index", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const indexPath = await debugIndex(logsDir);
+    const entries = (await readFile(indexPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const upstreamRequest = entries.find(
+      (entry) => entry.phase === "upstream_request",
+    );
+    if (!upstreamRequest) {
+      throw new Error("upstream request index entry not found");
+    }
+    const artifactPath = String(upstreamRequest.bodyPath);
+    const artifact = JSON.parse(
+      (await gunzipAsync(await readFile(artifactPath))).toString("utf8"),
+    ) as Record<string, unknown>;
+    artifact.metadata = {
+      upstreamMethod: "POST",
+      upstreamUrl: "https://tampered.example/v1/messages",
+    };
+    await writeFile(artifactPath, await gzipAsync(JSON.stringify(artifact)));
+
+    await expect(
+      exportProxyReplayBundle({ requestId, logsDir }),
+    ).rejects.toThrow("metadata does not match");
+  });
+
+  it("does not follow a symlink when writing an export", async () => {
+    const directory = await makeTempDir();
+    const target = join(directory, "target.json");
+    const output = join(directory, "output.json");
+    await writeFile(target, "preserve-me");
+    await symlink(target, output);
+
+    await expect(
+      writeProxyReplayDocument(output, { safe: true }),
+    ).rejects.toThrow();
+    expect(await readFile(target, "utf8")).toBe("preserve-me");
+  });
+
+  it("refuses to write a replay document that cannot be read back", async () => {
+    const directory = await makeTempDir();
+    const output = join(directory, "oversized.json");
+
+    await expect(
+      writeProxyReplayDocument(output, {
+        payload: "x".repeat(16 * 1024 * 1024),
+      }),
+    ).rejects.toThrow("safety limit");
+    await expect(stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects malformed bundle contracts before direct execution", async () => {
+    const directory = await makeTempDir();
+    const bundlePath = join(directory, "malformed.json");
+    await writeFile(
+      bundlePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: "neurolink.proxy.replay-bundle",
+        requestId: "malformed",
+        selectedAttempt: 1,
+        completeness: {},
+        request: {
+          method: "POST",
+          url: "https://example.com",
+          headers: { authorization: 42 },
+          requiredHeaderInputs: [],
+          body: "{}",
+          bodyTruncated: false,
+        },
+        captures: [],
+        capturedResponse: null,
+      }),
+    );
+    await expect(readProxyReplayBundle(bundlePath)).rejects.toThrow(
+      "Invalid or unsupported",
+    );
+  });
+});
+
+describe("direct upstream replay comparison", () => {
+  it("requires explicit execution and all redacted header values", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+
+    await expect(
+      compareProxyReplayBundle(bundle, { execute: false }),
+    ).rejects.toThrow("execute=true");
+    await expect(
+      compareProxyReplayBundle(bundle, { execute: true }),
+    ).rejects.toThrow("Missing environment-backed values");
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        headerValues: {
+          authorization: "Bearer direct-secret",
+          "invalid header": "value",
+        },
+      }),
+    ).rejects.toThrow("Invalid replay header names");
+  });
+
+  it("executes only an explicit loopback/HTTPS request and redacts comparison output", async () => {
+    let receivedAuthorization = "";
+    let receivedBody = "";
+    const server = createServer((request, response) => {
+      receivedAuthorization = request.headers.authorization ?? "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        receivedBody += String(chunk);
+      });
+      request.on("end", () => {
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "set-cookie": "private-cookie",
+        });
+        response.end(
+          JSON.stringify({
+            id: "message-2",
+            type: "message",
+            content: [],
+            access_token: "response-secret",
+          }),
+        );
+      });
+    });
+    servers.push(server);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("fixture server did not expose a port");
+    }
+
+    const logsDir = await makeTempDir();
+    const { requestId, requestBody } = await captureRequest({
+      logsDir,
+      url: `http://127.0.0.1:${address.port}/v1/messages`,
+    });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    const comparison = await compareProxyReplayBundle(bundle, {
+      execute: true,
+      headerValues: { authorization: "Bearer direct-secret" },
+      urlOverride: bundle.request.url ?? undefined,
+      timeoutMs: 5_000,
+    });
+
+    expect(receivedAuthorization).toBe("Bearer direct-secret");
+    expect(receivedBody).toBe(requestBody);
+    expect(comparison.direct.status).toBe(200);
+    expect(comparison.request.headers.authorization).toBe("[REDACTED]");
+    expect(comparison.direct.headers["set-cookie"]).toBe("[REDACTED]");
+    expect(comparison.direct.body).toContain('"access_token":"[REDACTED]"');
+    expect(serializeProxyReplayDocument(comparison)).not.toContain(
+      "direct-secret",
+    );
+    expect(serializeProxyReplayDocument(comparison)).not.toContain(
+      "response-secret",
+    );
+    expect(comparison.comparison).toMatchObject({
+      statusMatches: true,
+      contentTypeMatches: true,
+      jsonShapeMatches: false,
+    });
+  });
+
+  it("requires a complete override when the captured request body was redacted", async () => {
+    const bundle = {
+      schemaVersion: 1,
+      kind: "neurolink.proxy.replay-bundle",
+      requestId: "redacted-request",
+      selectedAttempt: 1,
+      source: { logsDirectory: "logs", indexFiles: [] },
+      completeness: {
+        captures: 0,
+        phasesPresent: [],
+        missingRequiredPhases: [],
+        truncatedCaptures: 0,
+        artifactsWithIssues: 0,
+        replayable: false,
+        blockers: ["upstream_request_body_contains_redactions"],
+      },
+      request: {
+        method: "POST",
+        url: "https://example.com/v1/messages",
+        headers: {},
+        requiredHeaderInputs: [],
+        body: '{"api_key":"[REDACTED]"}',
+        bodySha256: null,
+        bodyTruncated: false,
+        contentType: "application/json",
+        account: null,
+        accountType: null,
+        model: null,
+        stream: false,
+      },
+      capturedResponse: null,
+      captures: [],
+    } satisfies ProxyReplayBundle;
+
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        fetchImpl: async () => new Response("{}", { status: 200 }),
+      }),
+    ).rejects.toThrow("provide a complete body override");
+
+    let replayedBody = "";
+    const comparison = await compareProxyReplayBundle(bundle, {
+      execute: true,
+      bodyOverride: '{"api_key":"replacement"}',
+      urlOverride: "https://example.com/v1/messages",
+      fetchImpl: async (_input, init) => {
+        replayedBody = String(init?.body);
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    expect(replayedBody).toBe('{"api_key":"replacement"}');
+    expect(comparison.request.usedBodyOverride).toBe(true);
+    expect(serializeProxyReplayDocument(comparison)).not.toContain(
+      "replacement",
+    );
+  });
+
+  it("bounds direct response evidence and disables incomplete body comparison", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    const responseBody = "x".repeat(1024 * 1024 + 256);
+
+    const comparison = await compareProxyReplayBundle(bundle, {
+      execute: true,
+      headerValues: { authorization: "Bearer direct-secret" },
+      fetchImpl: async () =>
+        new Response(responseBody, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+    });
+
+    expect(comparison.direct.bodyTruncated).toBe(true);
+    expect(comparison.direct.observedBodyBytes).toBe(responseBody.length);
+    expect(comparison.direct.storedBodyBytes).toBeLessThanOrEqual(1024 * 1024);
+    expect(comparison.comparison.bodyHashMatches).toBeNull();
+  });
+
+  it("rejects a captured request body whose replay hash no longer matches", async () => {
+    const logsDir = await makeTempDir();
+    const { requestId } = await captureRequest({ logsDir });
+    const bundle = await exportProxyReplayBundle({ requestId, logsDir });
+    const originalBody = bundle.request.body;
+    bundle.request.body = '{"model":"tampered"}';
+
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        headerValues: { authorization: "Bearer direct-secret" },
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("body hash mismatch");
+
+    bundle.request.body = originalBody;
+    bundle.request.headers.authorization = "unredacted-secret";
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("unredacted request header");
+
+    bundle.request.headers.authorization = "[REDACTED]";
+    const responseCapture = bundle.captures.find(
+      (capture) => capture.phase === "upstream_response",
+    );
+    if (!responseCapture) {
+      throw new Error("upstream response capture not found");
+    }
+    responseCapture.headers["set-cookie"] = "unredacted-cookie";
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        headerValues: { authorization: "Bearer direct-secret" },
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("unredacted capture header");
+  });
+
+  it("rejects non-loopback plaintext endpoints before calling fetch", async () => {
+    const bundle = {
+      schemaVersion: 1,
+      kind: "neurolink.proxy.replay-bundle",
+      requestId: "unsafe-url",
+      selectedAttempt: 1,
+      source: { logsDirectory: "logs", indexFiles: [] },
+      completeness: {
+        captures: 0,
+        phasesPresent: [],
+        missingRequiredPhases: [],
+        truncatedCaptures: 0,
+        artifactsWithIssues: 0,
+        replayable: true,
+        blockers: [],
+      },
+      request: {
+        method: "POST",
+        url: "http://example.com/v1/messages",
+        headers: {},
+        requiredHeaderInputs: [],
+        body: "{}",
+        bodySha256:
+          "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        bodyTruncated: false,
+        contentType: "application/json",
+        account: null,
+        accountType: null,
+        model: null,
+        stream: false,
+      },
+      capturedResponse: null,
+      captures: [],
+    } satisfies ProxyReplayBundle;
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("HTTPS");
+
+    bundle.request.url = "https://example.com/v1/messages?api_key=secret";
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("sensitive query parameter");
+
+    bundle.request.url = "https://example.com/v1/messages";
+    await expect(
+      compareProxyReplayBundle(bundle, {
+        execute: true,
+        fetchImpl: async () => new Response("{}"),
+      }),
+    ).rejects.toThrow("explicit URL override");
+  });
+});


### PR DESCRIPTION
## Summary
- add `neurolink proxy replay export` to reconstruct one captured request and exact upstream attempt from local debug indexes and compressed artifacts
- add explicit `neurolink proxy replay compare` execution with environment-backed credentials and deterministic redacted comparison output
- persist the exact upstream method and URL at every Anthropic request site, including auth retry attempts

## Safety
- verifies artifact containment, metadata, SHA-256, compressed/decompressed and bundle size limits, truncation, and missing phases
- writes deterministic output atomically with `0600` permissions and refuses symlink outputs
- requires `--execute`, rejects missing/redacted request evidence, tampered or unredacted captures, invalid header names, unsafe URLs, redirects, and implicit nonstandard endpoints
- bounds, cancels on timeout, and redacts direct responses using the existing proxy logging rules
- preserves existing full-response logging behavior and does not change or contact the live proxy

## Validation
- `pnpm exec vitest run test/proxyReplay.test.ts` (20/20)
- repository Vitest suite excluding standalone env guard (335 tests; one pre-existing 5-second `modelPool` timing flake reproduced independently)
- `pnpm run test:bugfixes` (101/101)
- `pnpm run test:envguard` (118/118)
- `pnpm run test:log-sanitize` (49/49)
- `pnpm run test:ssrf` (42/42)
- `pnpm run proxy:performance` (all budgets passed; zero drops/failures)
- `pnpm run check`, `pnpm run lint`, `pnpm run build:cli`
- full pre-commit validation, Gitleaks/security scan, production/package/browser builds, and `publint`
