### PR TITLE
fix(multimodal): close post-merge review gaps (batch parity, pdf limits, url-secret redaction, supervisor identity)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,196 @@
+# Migration Guide: Breaking Changes
+
+This document tracks **breaking changes** shipped in specific NeuroLink
+releases — changes to public SDK/CLI surface that require an update on the
+consumer side, as opposed to the additive/backward-compatible changes covered
+by [`docs/guides/migration-guide.md`](./guides/migration-guide.md) and the
+auto-generated changelog (see the
+[GitHub releases page](https://github.com/juspay/neurolink/releases)).
+
+Three breaking changes shipped across 9.94.x–9.95.x. Each is intentional and
+stays as shipped — this document exists so downstream consumers know what
+changed and how to adapt.
+
+## Policy
+
+Per this repository's `CLAUDE.md` (Critical Rule 5), the public SDK API must
+not break existing callers. The three breaking changes below shipped in
+9.94.x–9.95.x without an accompanying migration path and are documented here
+retroactively. Going forward, any breaking change **must** ship its migration
+path in the same release that introduces it — not documented after the fact.
+
+---
+
+## 1. Multimodal file/CSV processing is now fail-loud (v9.94.6)
+
+**What changed:** `generate()`/`stream()` calls that attach files via
+`input.files` (auto-detected) or `input.csvFiles` (explicit CSV) now **throw**
+on the first file that fails to process, instead of logging a warning and
+silently continuing with the files that did succeed.
+
+- `processUnifiedFilesArray()` (`src/lib/utils/messageBuilder.ts`) throws
+  `ErrorFactory.fileProcessingFailed(filename, originalError)` on any file in
+  `input.files` that fails detection/processing.
+- `processExplicitCsvFiles()` (same file) throws
+  `ErrorFactory.csvProcessingFailed(filename, originalError)` on any file in
+  `input.csvFiles` that fails to parse.
+
+Both errors are typed `NeuroLinkError`s (`ERROR_CODES.FILE_PROCESSING_FAILED`
+/ `ERROR_CODES.CSV_PROCESSING_FAILED`, see `src/lib/utils/errorHandling.ts`)
+that carry the original error as `.originalError` and the failing filename in
+`.context.filename`.
+
+**Why:** the previous log-and-skip behavior silently produced a partial
+prompt — e.g. attaching 5 files and having one silently drop meant the model
+answered as if that file never existed, with no signal to the caller or the
+end user that anything was missing. A model call that appears to succeed but
+is actually missing part of its input is worse than a call that fails loudly.
+
+**Before (9.94.5 and earlier):**
+
+```typescript
+// One corrupt/unreadable file among several silently dropped; the request
+// still succeeded using only the files that processed cleanly.
+const result = await neurolink.generate({
+  input: { text: "Summarize these", files: ["a.pdf", "corrupt.pdf", "b.pdf"] },
+});
+// result.content summarizes only a.pdf and b.pdf — no error, no warning
+// visible to the caller beyond a log line.
+```
+
+**After (9.94.6+):**
+
+```typescript
+try {
+  const result = await neurolink.generate({
+    input: {
+      text: "Summarize these",
+      files: ["a.pdf", "corrupt.pdf", "b.pdf"],
+    },
+  });
+} catch (error) {
+  if (
+    error instanceof NeuroLinkError &&
+    error.code === "FILE_PROCESSING_FAILED"
+  ) {
+    // error.context.filename === "corrupt.pdf"
+    // error.originalError is the underlying cause
+  }
+  throw error;
+}
+```
+
+**How to adapt:**
+
+- Wrap multi-file `generate()`/`stream()` calls in `try`/`catch` if you were
+  previously relying on partial success.
+- If you want the old best-effort behavior, pre-validate/pre-filter files
+  yourself before passing them in `input.files`/`input.csvFiles`, or catch the
+  typed error, drop the failing filename (`error.context.filename`), and
+  retry without it.
+- CSV-specific failures (`input.csvFiles`) and generic file failures
+  (`input.files`) now throw _different_ error codes — branch on
+  `error.code` if you need to distinguish them.
+
+---
+
+## 2. `MessageContent` dropped its open index signature (v9.94.6)
+
+**What changed:** the exported `MessageContent` type
+(`src/lib/types/multimodal.ts`, re-exported via `src/lib/types/index.ts` and
+the package root) no longer has a `[key: string]: unknown` index signature.
+It's now a closed shape with the concrete fields the pipeline actually reads:
+`type`, `text`, `image`, `mimeType`, `data`, `name`, `filename`,
+`toolCallId`, `toolName`, `args`, `result`, `isError`, `providerOptions`.
+
+**Why:** the open index signature let any typo or unrelated key through
+type-checking unchecked (e.g. `{ type: "text", txt: "..." }` compiled fine
+and silently produced empty content). Closing it catches that class of bug at
+compile time for everyone building `MessageContent[]` arrays directly.
+
+**Before:**
+
+```typescript
+import type { MessageContent } from "@juspay/neurolink";
+
+// Compiled fine even though "customField" isn't a real MessageContent key —
+// the typo/extra field was silently accepted.
+const item: MessageContent = {
+  type: "text",
+  text: "hello",
+  customField: "some app-specific metadata",
+};
+```
+
+**After:**
+
+```typescript
+import type { MessageContent } from "@juspay/neurolink";
+
+// TS2353: Object literal may only specify known properties, and
+// 'customField' does not exist in type 'MessageContent'.
+const item: MessageContent = {
+  type: "text",
+  text: "hello",
+  customField: "some app-specific metadata", // ❌ no longer type-checks
+};
+```
+
+**How to adapt:**
+
+- If you were attaching arbitrary metadata to a `MessageContent` item,
+  use the dedicated `providerOptions?: Record<string, unknown>` field instead
+  — it's read by `MessageBuilder` when converting to `ModelMessage[]` and is
+  the intended extension point.
+- If you genuinely need a field NeuroLink doesn't model, open an issue —
+  `MessageContent` intentionally stays a closed, hand-maintained shape rather
+  than reopening a blanket index signature (see the `#325` comment on the
+  type itself).
+- Runtime behavior is unchanged — this is a compile-time-only break. Plain
+  JavaScript callers, or TypeScript callers that never annotated a literal
+  as `MessageContent` explicitly, are unaffected.
+
+---
+
+## 3. `BatchCommandArgs.file` renamed to `.promptsFile` (v9.95.1)
+
+**What changed:** the public CLI argument type `BatchCommandArgs`
+(`src/lib/types/cli.ts`) renamed its `file?: string` property to
+`promptsFile?: string`.
+
+**Why:** yargs implicitly registers a positional argument's key as a
+recognized flag name too. Keeping the property named `file` collided with
+the _unrelated_ common `--file` auto-detect flag that the `batch` command
+intentionally does not register — `--file` on `batch` would silently pass
+`strictOptions()` without actually doing anything. Renaming the positional's
+backing property to `promptsFile` removes that collision.
+
+**Before:**
+
+```typescript
+import type { BatchCommandArgs } from "@juspay/neurolink";
+
+function handleBatch(argv: BatchCommandArgs) {
+  const promptsListPath = argv.file; // ❌ no longer exists
+}
+```
+
+**After:**
+
+```typescript
+import type { BatchCommandArgs } from "@juspay/neurolink";
+
+function handleBatch(argv: BatchCommandArgs) {
+  const promptsListPath = argv.promptsFile; // ✅
+}
+```
+
+**How to adapt:**
+
+- Update any code that constructs or reads a `BatchCommandArgs` object
+  directly (custom CLI wrappers, tests) to use `.promptsFile` instead of
+  `.file`.
+- The CLI's own `<promptsFile>` positional argument and its behavior are
+  unchanged — this is a type-only rename of the property NeuroLink's own
+  `batch` command handler reads internally; end users invoking
+  `neurolink batch <promptsFile>` on the command line see no difference.

--- a/docs/features/csv-support.md
+++ b/docs/features/csv-support.md
@@ -224,9 +224,19 @@ csvOptions: {
 
 #### encoding
 
-Character-encoding override (#362). When omitted, the encoding is detected from
-a BOM, then `chardet`, falling back to UTF-8 — so Windows-1252 / Latin-1 /
-UTF-16 files no longer decode as mojibake. Accepts any label
+Character-encoding override (#362). When omitted, the encoding is detected in
+this order (see `decodeBuffer` in `src/lib/utils/textEncoding.ts`):
+
+1. **BOM** — authoritative when present (UTF-8/UTF-16 byte-order mark).
+2. **Pure-ASCII fast path** — if every byte in the peeked content is `< 0x80`,
+   it's reported as UTF-8 immediately (ASCII decodes identically to UTF-8),
+   without ever invoking `chardet`.
+3. **`chardet` statistical detection** — only reached for non-ASCII content
+   with no BOM.
+4. **UTF-8 fallback** — used if `chardet` can't identify anything.
+
+So Windows-1252 / Latin-1 / UTF-16 files no longer decode as mojibake, while
+the common plain-ASCII case never pays the `chardet` cost. Accepts any label
 [`iconv-lite`](https://www.npmjs.com/package/iconv-lite) supports.
 
 ```typescript

--- a/docs/features/pdf-support.md
+++ b/docs/features/pdf-support.md
@@ -258,8 +258,13 @@ for await (const page of PDFProcessor.convertToImagesStream(pdfBuffer, {
 }
 ```
 
-`convertToImages()` is the batch wrapper over this stream and returns the same
-per-page `errors` contract.
+`convertToImages()` is **not** implemented as a wrapper over this stream — it's
+a separate, parallel implementation with its own page-render loop that
+happens to return the same per-page `errors` contract (an array of
+`{ page, error }` collected across the whole document instead of yielded
+per-page). Pick whichever fits the call site: `convertToImagesStream()` to
+start handling pages before the whole document finishes rendering,
+`convertToImages()` for a single buffered result.
 
 ## Provider Support
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -124,6 +124,14 @@ const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
   ),
 );
 const PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS = 5_000;
+// Allowed drift between a pid's OS-reported start time and the persisted
+// ProxySupervisorState.startTime before processLooksLikeProxySupervisor
+// treats it as a confident mismatch (recycled pid). Generous on purpose:
+// `supervisorStartedAt` is captured inside runLaunchdProxySupervisor, which
+// runs after Node has already booted and done setup, so it always lags the
+// OS-level fork/exec by a little — a tight tolerance would produce false
+// mismatches on a slow/cold-started machine.
+const PROXY_SUPERVISOR_START_TIME_TOLERANCE_MS = 10_000;
 const PROXY_UPDATE_CONTROL_TOKEN =
   process.env.NEUROLINK_PROXY_UPDATE_CONTROL_TOKEN?.trim() ||
   crypto.randomUUID();
@@ -203,22 +211,148 @@ function getProcessStatus(pid: number): "running" | "not_running" | "unknown" {
 }
 
 /**
+ * Read a single `ps -o <field>=` field for `pid`, off the event loop (async
+ * `execFile`, not `execFileSync`) and bounded by a short timeout, so a
+ * hung/zombie `ps` invocation can never block the event loop or hang the
+ * (often uninstall-path) async caller. Shared by {@link getProcessStartTime}
+ * and {@link processLooksLikeProxySupervisor}, which both read a single
+ * `ps -o <field>=` column for the same pid.
+ *
+ * Returns null — never throws — on any error, timeout, or empty output, so
+ * callers uniformly treat "couldn't read" as "can't confirm either way"
+ * rather than distinguishing the failure mode.
+ */
+async function readPsField(pid: number, field: string): Promise<string | null> {
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await withTimeout(
+      execFileAsync("ps", ["-p", String(pid), "-o", `${field}=`], {
+        encoding: "utf-8" as const,
+      }),
+      2000,
+      `ps -o ${field}= timed out for pid ${pid}`,
+    );
+    const trimmed = stdout.trim();
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort, macOS-only (uninstall is macOS-only) read of `pid`'s
+ * OS-reported start time via `ps -o lstart=`, which prints a fixed-width
+ * `Www Mmm dd hh:mm:ss yyyy` timestamp — the same shape `Date`'s parser
+ * already understands (it's the format `Date#toString()` itself produces
+ * modulo the trailing timezone). Returns null (never throws) when `ps`
+ * fails or its output doesn't parse, so callers can tell "confirmed
+ * mismatch" apart from "couldn't confirm either way".
+ */
+async function getProcessStartTime(pid: number): Promise<Date | null> {
+  const out = await readPsField(pid, "lstart");
+  if (!out) {
+    return null;
+  }
+  // `ps -o lstart=` prints the OS start time in the machine's LOCAL timezone
+  // with no offset, e.g. "Sun Jul 19 20:12:41 2026". Parse the components and
+  // build the Date via the local-time constructor rather than relying on the
+  // engine's implementation-defined parsing of non-ISO date strings. The
+  // result is the same absolute instant the supervisor persisted as an
+  // ISO-UTC string, so the drift comparison against it is timezone-safe.
+  const m = out.match(
+    /^\w{3}\s+(\w{3})\s+(\d{1,2})\s+(\d{2}):(\d{2}):(\d{2})\s+(\d{4})$/,
+  );
+  if (!m) {
+    return null;
+  }
+  const monthIndex = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ].indexOf(m[1]);
+  if (monthIndex < 0) {
+    return null;
+  }
+  const parsed = new Date(
+    Number(m[6]),
+    monthIndex,
+    Number(m[2]),
+    Number(m[3]),
+    Number(m[4]),
+    Number(m[5]),
+  );
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
  * Best-effort check that a pid actually belongs to a neurolink proxy process,
  * so a stale/recycled supervisor pid is never mistaken for a live supervisor
  * and signalled. Returns false when the process cannot be confirmed as ours.
+ *
+ * @param expectedStartTimeIso - The `ProxySupervisorState.startTime` (ISO
+ *   string) recorded when the supervisor we expect at `pid` was launched.
+ *   When provided, this is cross-checked against `pid`'s actual OS-reported
+ *   start time (see {@link getProcessStartTime}) — the args match alone
+ *   ("neurolink" + "proxy" both present) is not airtight, since an
+ *   unrelated process (e.g. a shell running this very test suite, or a
+ *   coincidentally-named script) could match it too. A pid recycled by such
+ *   a process would have a start time far from the recorded supervisor
+ *   startTime, which this catches.
+ *
+ *   Deliberately fail-open on anything unparseable: `ps -o lstart=` output
+ *   parsing is inherently a little fragile (locale/format quirks), and the
+ *   cost of a false "can't confirm" is silently regressing to pre-hardening
+ *   behavior, while the cost of a false "confirmed mismatch" is leaving a
+ *   real supervisor running and orphaning its socket during uninstall — the
+ *   former is the safer failure mode. So this only ever returns false for
+ *   the startTime check when BOTH timestamps parsed successfully AND their
+ *   drift exceeds the tolerance; any parse failure is treated as "can't
+ *   confirm a mismatch" and falls through to the args-only result.
  */
-async function processLooksLikeProxySupervisor(pid: number): Promise<boolean> {
-  try {
-    const { execFileSync } = await import("node:child_process");
-    const args = execFileSync("ps", ["-p", String(pid), "-o", "args="], {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return /neurolink/i.test(args);
-  } catch {
-    // `ps` unavailable or the pid vanished — do not signal an unverified pid.
+export async function processLooksLikeProxySupervisor(
+  pid: number,
+  expectedStartTimeIso?: string,
+): Promise<boolean> {
+  const args = await readPsField(pid, "args");
+  if (args === null) {
+    // `ps` unavailable, timed out, or the pid vanished — do not signal an
+    // unverified pid.
     return false;
   }
+  // `/neurolink/i` alone is too broad: any process whose args merely
+  // *mention* "neurolink" (e.g. a shell running in a directory named
+  // "neurolink", an editor with a neurolink file open) would match, and a
+  // stale/recycled pid running such a process could then be SIGTERM'd/
+  // SIGKILL'd by `ensureSupervisorStoppedBeforeClear` during uninstall.
+  // Require the actual proxy-supervisor invocation — both "neurolink" AND
+  // the "proxy" subcommand present in args.
+  if (!(/neurolink/i.test(args) && /\bproxy\b/i.test(args))) {
+    return false;
+  }
+  if (!expectedStartTimeIso) {
+    return true;
+  }
+  const expected = new Date(expectedStartTimeIso);
+  if (Number.isNaN(expected.getTime())) {
+    return true; // recorded startTime itself is unparseable — can't confirm a mismatch
+  }
+  const actual = await getProcessStartTime(pid);
+  if (!actual) {
+    return true; // ps -o lstart= unavailable/unparseable — can't confirm a mismatch
+  }
+  const driftMs = Math.abs(actual.getTime() - expected.getTime());
+  return driftMs <= PROXY_SUPERVISOR_START_TIME_TOLERANCE_MS;
 }
 
 /**
@@ -229,14 +363,19 @@ async function processLooksLikeProxySupervisor(pid: number): Promise<boolean> {
  * the uninstall instead of silently discarding the record.
  */
 async function ensureSupervisorStoppedBeforeClear(): Promise<boolean> {
-  const pid = loadProxySupervisorState()?.pid;
+  const supervisorState = loadProxySupervisorState();
+  const pid = supervisorState?.pid;
   if (!pid || getProcessStatus(pid) === "not_running") {
     return true;
   }
   // Guard against a stale/recycled pid: only signal a process that still looks
   // like a neurolink proxy supervisor, so uninstall never terminates an
-  // unrelated, same-user process that inherited the recorded pid.
-  if (!(await processLooksLikeProxySupervisor(pid))) {
+  // unrelated, same-user process that inherited the recorded pid. Also cross-
+  // checks the pid's actual OS start time against the recorded
+  // supervisorState.startTime (see processLooksLikeProxySupervisor).
+  if (
+    !(await processLooksLikeProxySupervisor(pid, supervisorState?.startTime))
+  ) {
     return true;
   }
   try {

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -3369,6 +3369,28 @@ export class CLICommandFactory {
   }
 
   /**
+   * Build video processor options from CLI argv. Shared by executeGenerate,
+   * executeStream and executeBatch, which previously built byte-for-byte
+   * identical `videoOptions` objects independently (mirrors
+   * {@link buildCsvOptionsFromArgv}).
+   */
+  private static buildVideoOptionsFromArgv(
+    argv: BaseCommandArgs & Record<string, unknown>,
+  ): {
+    frames?: number;
+    quality?: number;
+    format?: "jpeg" | "png";
+    transcribeAudio?: boolean;
+  } {
+    return {
+      frames: argv.videoFrames as number | undefined,
+      quality: argv.videoQuality as number | undefined,
+      format: argv.videoFormat as "jpeg" | "png" | undefined,
+      transcribeAudio: argv.transcribeAudio as boolean | undefined,
+    };
+  }
+
+  /**
    * Build output configuration for generate request
    */
   private static buildGenerateOutputConfig(
@@ -3716,12 +3738,7 @@ export class CLICommandFactory {
             password: CLICommandFactory.resolvePdfPassword(argv),
           },
           csvOptions: CLICommandFactory.buildCsvOptionsFromArgv(argv),
-          videoOptions: {
-            frames: argv.videoFrames as number | undefined,
-            quality: argv.videoQuality as number | undefined,
-            format: argv.videoFormat as "jpeg" | "png" | undefined,
-            transcribeAudio: argv.transcribeAudio as boolean | undefined,
-          },
+          videoOptions: CLICommandFactory.buildVideoOptionsFromArgv(argv),
           output: outputConfig,
           provider: enhancedOptions.provider,
           model: enhancedOptions.model,
@@ -4070,12 +4087,7 @@ export class CLICommandFactory {
           password: CLICommandFactory.resolvePdfPassword(argv),
         },
         csvOptions: CLICommandFactory.buildCsvOptionsFromArgv(argv),
-        videoOptions: {
-          frames: argv.videoFrames as number | undefined,
-          quality: argv.videoQuality as number | undefined,
-          format: argv.videoFormat as "jpeg" | "png" | undefined,
-          transcribeAudio: argv.transcribeAudio as boolean | undefined,
-        },
+        videoOptions: CLICommandFactory.buildVideoOptionsFromArgv(argv),
         provider: enhancedOptions.provider as string | undefined,
         model: enhancedOptions.model as string | undefined,
         temperature: enhancedOptions.temperature as number | undefined,
@@ -4701,6 +4713,7 @@ export class CLICommandFactory {
       // see createBatchCommand — so `argv.file` can never be set here; no
       // exclusion needed to protect the (differently-named) positional.
       validateCliInputFiles(argv as unknown as Record<string, unknown>);
+      validateCsvMaxRows(argv as unknown as Record<string, unknown>);
       const batchImages = CLICommandFactory.processCliImages(
         argv.image as string | string[] | undefined,
       );
@@ -4797,6 +4810,13 @@ export class CLICommandFactory {
         spinner?.start();
       }
 
+      // Resolve the PDF password once for the whole batch. resolvePdfPassword
+      // emits a "visible in shell history" stderr warning when the flag is set;
+      // it must fire once per run (like generate/stream), not once per prompt.
+      const batchPdfPassword = batchPdfFiles?.length
+        ? CLICommandFactory.resolvePdfPassword(argv)
+        : undefined;
+
       for (let i = 0; i < prompts.length; i++) {
         if (spinner) {
           spinner.text = `Processing ${i + 1}/${prompts.length}: ${prompts[i].substring(0, 30)}...`;
@@ -4860,22 +4880,15 @@ export class CLICommandFactory {
               // unlike generate/stream, so an empty options object here is
               // pure noise on every prompt of every batch run.
               ...(batchCsvFiles?.length && {
-                csvOptions: {
-                  maxRows: argv.csvMaxRows as number | undefined,
-                  formatStyle: argv.csvFormat as
-                    | "raw"
-                    | "markdown"
-                    | "json"
-                    | undefined,
+                csvOptions: CLICommandFactory.buildCsvOptionsFromArgv(argv),
+              }),
+              ...(batchPdfFiles?.length && {
+                pdfOptions: {
+                  password: batchPdfPassword,
                 },
               }),
               ...(batchVideoFiles?.length && {
-                videoOptions: {
-                  frames: argv.videoFrames as number | undefined,
-                  quality: argv.videoQuality as number | undefined,
-                  format: argv.videoFormat as "jpeg" | "png" | undefined,
-                  transcribeAudio: argv.transcribeAudio as boolean | undefined,
-                },
+                videoOptions: CLICommandFactory.buildVideoOptionsFromArgv(argv),
               }),
               provider: enhancedOptions.provider,
               model: enhancedOptions.model,

--- a/src/cli/utils/inputValidation.ts
+++ b/src/cli/utils/inputValidation.ts
@@ -30,6 +30,11 @@ export const CLI_SOFT_LIMITS_MB = {
   IMAGE_MAX_MB: 10,
   CSV_MAX_MB: 50,
   PDF_MAX_MB: 100,
+  // Distinct from PDF_MAX_MB above (which mirrors the processor's true
+  // 100MB hard cap in lib/processors/config/sizeLimits.ts and is kept here
+  // for backward compatibility). Docs promise a 50MB *warning* threshold
+  // specifically for --pdf — wire warnAtMB to this value, not the hard cap.
+  PDF_SOFT_MAX_MB: 50,
   VIDEO_MAX_MB: 500,
 } as const;
 
@@ -200,7 +205,7 @@ export function validateCliInputFiles(argv: Record<string, unknown>): void {
     {
       option: "--pdf",
       value: argv.pdf as string | string[] | undefined,
-      warnAtMB: CLI_SOFT_LIMITS_MB.PDF_MAX_MB,
+      warnAtMB: CLI_SOFT_LIMITS_MB.PDF_SOFT_MAX_MB,
     },
     {
       option: "--video",

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -42,7 +42,11 @@ import { CSVProcessor } from "./csvProcessor.js";
 import { ImageProcessor } from "./imageProcessor.js";
 import { logger } from "./logger.js";
 import { withTimeout } from "./errorHandling.js";
-import { redactUrlForError, sanitizeErrorCause } from "./logSanitize.js";
+import {
+  normalizeUrlForCache,
+  redactUrlForError,
+  sanitizeErrorCause,
+} from "./logSanitize.js";
 import {
   mimeHintToExtension,
   mimeHintToFileType,
@@ -81,22 +85,41 @@ const urlContentTypeCache = new Map<
   { contentType: string; expiresAt: number }
 >();
 
+/**
+ * Build the Map key for `urlContentTypeCache`. Delegates to the shared
+ * {@link normalizeUrlForCache} — this is a module-level, process-lifetime
+ * cache, so it must strip presigned-URL auth/signature query params (see
+ * `SENSITIVE_URL_QUERY_PARAM_DENYLIST`) the same way `ImageCache.normalizeUrl`
+ * does, folding a short hash of the stripped params into the key whenever any
+ * were present so two different presigned URLs for the same path don't
+ * collide and serve each other's cached content-type across auth contexts.
+ * Also strips tracking/analytics params first, so two URLs differing only by
+ * tracking noise (e.g. `utm_source`) still hit the same cache entry instead
+ * of missing each other. Falls back to the raw URL if it isn't a parseable
+ * absolute URL. Shared by both `getCachedUrlContentType` and
+ * `setCachedUrlContentType` so lookups and writes always agree on the key.
+ */
+function cacheKeyForUrl(url: string): string {
+  return normalizeUrlForCache(url);
+}
+
 function getCachedUrlContentType(url: string, now: number): string | undefined {
-  const hit = urlContentTypeCache.get(url);
+  const key = cacheKeyForUrl(url);
+  const hit = urlContentTypeCache.get(key);
   if (hit && hit.expiresAt > now) {
     // Bump recency: Map iteration order follows insertion order, and the
     // eviction below deletes the *first* key, so a plain `get` on a hot
     // entry would leave it first in line for eviction despite being the
     // most recently used. Re-inserting turns the size-bounded FIFO below
     // into an actual LRU.
-    urlContentTypeCache.delete(url);
-    urlContentTypeCache.set(url, hit);
+    urlContentTypeCache.delete(key);
+    urlContentTypeCache.set(key, hit);
     return hit.contentType;
   }
   if (hit) {
     // Entry exists but its TTL has passed — treat as a miss and evict it
     // immediately rather than serving (or retaining) stale data.
-    urlContentTypeCache.delete(url);
+    urlContentTypeCache.delete(key);
   }
   return undefined;
 }
@@ -122,7 +145,8 @@ function setCachedUrlContentType(
   if (!contentType) {
     return;
   }
-  urlContentTypeCache.set(url, {
+  const key = cacheKeyForUrl(url);
+  urlContentTypeCache.set(key, {
     contentType,
     expiresAt: now + URL_CONTENT_TYPE_TTL_MS,
   });
@@ -1915,19 +1939,28 @@ export class FileDetector {
         });
         // Drain/close the (empty) HEAD body so the connection can be reused.
         await head.body.dump();
-        const declaredLength = Number(head.headers["content-length"]);
-        if (Number.isFinite(declaredLength) && declaredLength > maxSize) {
-          throw new Error(
-            `File too large: ${formatFileSize(declaredLength)} (max: ${formatFileSize(maxSize)})`,
-          );
+        // Only trust `content-length` on a genuine 2xx response. A non-2xx
+        // HEAD (redirect the dispatcher didn't follow, 403/404/405 "HEAD not
+        // allowed", 5xx, …) can still carry a stale/irrelevant
+        // `content-length` header — enforcing size off of that would reject
+        // (or silently pass) based on the wrong body. Treat any non-2xx HEAD
+        // as if the header were missing and fall through to the streaming
+        // GET guard below, which enforces maxSize independently either way.
+        if (head.statusCode >= 200 && head.statusCode < 300) {
+          const declaredLength = Number(head.headers["content-length"]);
+          if (Number.isFinite(declaredLength) && declaredLength > maxSize) {
+            throw new Error(
+              `File too large: ${formatFileSize(declaredLength)} (max: ${formatFileSize(maxSize)})`,
+            );
+          }
         }
       } catch (error) {
         if (error instanceof Error && /File too large/.test(error.message)) {
           throw error;
         }
         logger.debug(
-          `[FileDetector] HEAD pre-flight skipped for ${url}: ${
-            error instanceof Error ? error.message : String(error)
+          `[FileDetector] HEAD pre-flight skipped for ${redactUrlForError(url)}: ${
+            sanitizeErrorCause(error).message
           }`,
         );
       }

--- a/src/lib/utils/imageCache.ts
+++ b/src/lib/utils/imageCache.ts
@@ -15,7 +15,7 @@
 
 import { createHash } from "crypto";
 import { logger } from "./logger.js";
-import { redactUrlForError } from "./logSanitize.js";
+import { normalizeUrlForCache, redactUrlForError } from "./logSanitize.js";
 import type {
   CachedImage,
   ImageCacheConfig,
@@ -123,29 +123,19 @@ export class ImageCache {
   }
 
   /**
-   * Normalize URL for consistent cache key generation
-   * Removes tracking parameters and normalizes the URL
+   * Normalize URL for consistent cache key generation.
+   *
+   * Delegates to the shared {@link normalizeUrlForCache} — this normalized
+   * URL is used as the in-memory Map key (see `get`/`set` below), which lives
+   * for the process lifetime, so both tracking-param noise and presigned-URL
+   * auth/signature secrets must be stripped consistently with
+   * `fileDetector.cacheKeyForUrl`'s identical requirement. See
+   * `stripSensitiveUrlParamsForCacheKey`'s doc comment for why a naive
+   * strip-only approach (no hash suffix) would be a correctness bug, not just
+   * a hygiene one.
    */
   private normalizeUrl(url: string): string {
-    try {
-      const parsed = new URL(url);
-      // Remove common tracking parameters that don't affect content
-      const trackingParams = [
-        "utm_source",
-        "utm_medium",
-        "utm_campaign",
-        "utm_term",
-        "utm_content",
-        "fbclid",
-        "gclid",
-        "_ga",
-      ];
-      trackingParams.forEach((param) => parsed.searchParams.delete(param));
-      return parsed.toString();
-    } catch {
-      // If URL parsing fails, use the original URL
-      return url;
-    }
+    return normalizeUrlForCache(url);
   }
 
   /**

--- a/src/lib/utils/imageProcessor.ts
+++ b/src/lib/utils/imageProcessor.ts
@@ -29,6 +29,31 @@ export const MIN_IMAGE_SIZE = 12;
  * buffer that carries a format's magic bytes but is smaller than this is
  * truncated/corrupt and would fail (or render blank) downstream — reject early
  * with a clear message instead.
+ *
+ * Each threshold approximates the smallest byte count that format's
+ * container can structurally be while still holding the mandatory
+ * header/chunk skeleton for a minimal (e.g. 1×1 pixel) image — not an exact
+ * spec minimum, but close enough that anything smaller is unambiguously
+ * truncated:
+ *  - **PNG (67)**: 8-byte signature + IHDR chunk (4 len + 4 type + 13 data +
+ *    4 CRC = 25) + a minimal IDAT chunk carrying one zlib-compressed
+ *    scanline (~22 bytes) + IEND chunk (4 len + 4 type + 0 data + 4 CRC =
+ *    12) — matches the commonly-cited size of the smallest possible valid
+ *    PNG (a 1×1 transparent pixel).
+ *  - **JPEG (125)**: SOI + APP0/JFIF marker (18) + at least one DQT
+ *    quantization table (~69 for one 8-bit luma table) + SOF0 + DHT + SOS
+ *    headers + a minimal entropy-coded scan + EOI — the smallest legal
+ *    baseline-JPEG skeleton for a 1×1 image.
+ *  - **GIF (43)**: 6-byte GIF87a/89a header + 7-byte Logical Screen
+ *    Descriptor + a 2-color (6-byte) color table + 10-byte Image
+ *    Descriptor + minimal LZW-coded image sub-blocks + 1-byte trailer.
+ *  - **WEBP (20)**: RIFF container header ("RIFF" + size + "WEBP" = 12
+ *    bytes) + the first chunk's fourCC + size (8 bytes) — enough to confirm
+ *    a well-formed RIFF/WEBP container and its first chunk, before any
+ *    actual VP8/VP8L bitstream payload.
+ *  - **AVIF (100)**: ISOBMFF `ftyp` box plus the mandatory `meta` box
+ *    skeleton (`hdlr`/`pitm`/`iloc`/`iinf` sub-boxes) — roughly the minimum
+ *    to hold AVIF's required box structure before any AV1 image item data.
  */
 export const MIN_VALID_IMAGE_SIZE: Record<string, number> = {
   "image/png": 67,
@@ -1150,7 +1175,9 @@ export const imageUtils = {
     const cache = getImageCache();
     const cached = cache.get(url);
     if (cached) {
-      logger.debug("Using cached image for URL", { url: url.substring(0, 50) });
+      logger.debug("Using cached image for URL", {
+        url: redactUrlForError(url),
+      });
       return cached.dataUri;
     }
 

--- a/src/lib/utils/logSanitize.ts
+++ b/src/lib/utils/logSanitize.ts
@@ -16,6 +16,7 @@
  *   - Generic key=value pairs: api_key=…, access_token: …, secret_key=…
  */
 
+import { createHash } from "crypto";
 import { basename, resolve as resolvePath } from "path";
 
 const TOKEN_PREFIXES = [
@@ -236,6 +237,174 @@ export function redactUrlForError(url: string): string {
     // string — never echo the input completely unredacted.
     const withoutQueryOrFragment = url.split(/[?#]/)[0];
     return truncate(redactUrlCredentials(withoutQueryOrFragment));
+  }
+}
+
+/**
+ * Query-parameter names that commonly carry authentication/signature
+ * secrets in presigned URLs, matched case-insensitively: generic
+ * `token`/`signature`, AWS SigV4 (`X-Amz-Signature`, `X-Amz-Credential`,
+ * `X-Amz-Security-Token`, and the legacy `AWSAccessKeyId`/`Signature`/
+ * `Expires` query-auth params), Azure SAS (`sig`/`se`/`sp`/`sr`/`sv`), and
+ * GCS V4 signed URLs (`X-Goog-Signature`, `X-Goog-Credential`,
+ * `X-Goog-Algorithm`, `X-Goog-Date`, `X-Goog-Expires`,
+ * `X-Goog-SignedHeaders`).
+ *
+ * Unlike {@link redactUrlForError} (which drops the *entire* query string
+ * for a one-off error message), this is used where a URL is normalized
+ * into a long-lived in-memory cache key — content-varying query params
+ * must survive so distinct resources still get distinct keys, but a
+ * presigned URL's secret must never persist as a Map key for the process
+ * lifetime.
+ */
+export const SENSITIVE_URL_QUERY_PARAM_DENYLIST: readonly string[] = [
+  "token",
+  "signature",
+  "x-amz-signature",
+  "x-amz-credential",
+  "x-amz-security-token",
+  "awsaccesskeyid",
+  "expires",
+  "sig",
+  "se",
+  "sp",
+  "sr",
+  "sv",
+  "x-goog-signature",
+  "x-goog-credential",
+  "x-goog-algorithm",
+  "x-goog-date",
+  "x-goog-expires",
+  "x-goog-signedheaders",
+];
+
+/** Common tracking/analytics query params that don't affect the fetched
+ * content, so two URLs differing only by these should map to the same
+ * cache key rather than missing each other. */
+const TRACKING_URL_QUERY_PARAMS: readonly string[] = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "fbclid",
+  "gclid",
+  "_ga",
+];
+
+/**
+ * Strip common tracking/analytics query params (`utm_*`, `fbclid`, `gclid`,
+ * `_ga`) from `parsed` in place, so callers that build a cache key from a
+ * URL don't miss a cache hit solely because two otherwise-identical URLs
+ * carry different tracking noise.
+ *
+ * Shared by `ImageCache.normalizeUrl` and `fileDetector.cacheKeyForUrl` —
+ * both build a long-lived in-memory cache key from a URL and should
+ * normalize tracking params the same way. Call this before
+ * {@link stripSensitiveUrlParamsForCacheKey} so both normalizations apply
+ * consistently regardless of caller.
+ *
+ * @param parsed - A `URL` instance to strip tracking params from in place.
+ */
+export function stripTrackingParams(parsed: URL): void {
+  TRACKING_URL_QUERY_PARAMS.forEach((param) =>
+    parsed.searchParams.delete(param),
+  );
+}
+
+/**
+ * Build a secret-free, but still auth-context-distinct, cache key from a
+ * URL that may carry presigned-URL secrets in its query string.
+ *
+ * Naively stripping {@link SENSITIVE_URL_QUERY_PARAM_DENYLIST} params before
+ * using a URL as a long-lived cache key (an earlier version of this code did
+ * exactly that) creates a correctness bug, not just a hygiene one: two
+ * *different* presigned URLs for the same underlying object — e.g. one
+ * whose signature has since expired or been revoked, and a fresh one —
+ * strip down to the *same* key and collide. A cache populated under the
+ * first would silently serve its bytes back for the second, without ever
+ * revalidating against the origin.
+ *
+ * Fix: still remove the sensitive params from `parsed` in place (so the
+ * plaintext key never retains a raw secret — the original goal), but fold a
+ * short, non-reversible hash of the *removed* key=value pairs into the
+ * returned suffix whenever any were present, so distinct auth contexts keep
+ * distinct cache keys. Two requests presenting the exact same secret value
+ * still collide (correct — that's genuinely the same authorized request);
+ * two different secret values for the same object no longer do.
+ *
+ * Callers combine the return value with the now-stripped `parsed.toString()`
+ * to form the final cache key (see `ImageCache.normalizeUrl` and
+ * `fileDetector.cacheKeyForUrl`), rather than this function returning the
+ * full key itself, so each caller can apply its own additional
+ * normalization (e.g. tracking-param removal) in between.
+ *
+ * Matching against {@link SENSITIVE_URL_QUERY_PARAM_DENYLIST} is
+ * case-insensitive (both the denylist lookup and the value folded into the
+ * hash lower-case the param name), so the original casing of a sensitive
+ * param's name is not preserved anywhere in the returned key. That's fine
+ * here — this produces a cache key, not a user-facing URL, and the same
+ * lower-cased name always hashes to the same suffix for the same value
+ * regardless of how the caller happened to case it (`Token=` vs `token=`).
+ * Non-sensitive params left on `parsed` keep their original casing untouched.
+ *
+ * @param parsed - A `URL` instance to strip sensitive params from in place.
+ * @returns "" when no sensitive params were present; otherwise a short hex
+ *   suffix — prefixed with `\0` (a byte `URL#toString()` never emits, since
+ *   every URL component is percent-encoded, so it can't collide with real
+ *   URL content) — to append to the caller's cache key.
+ */
+export function stripSensitiveUrlParamsForCacheKey(parsed: URL): string {
+  const strippedPairs: string[] = [];
+  const keysToDelete: string[] = [];
+  for (const [key, value] of parsed.searchParams.entries()) {
+    if (SENSITIVE_URL_QUERY_PARAM_DENYLIST.includes(key.toLowerCase())) {
+      strippedPairs.push(`${key.toLowerCase()}=${value}`);
+      keysToDelete.push(key);
+    }
+  }
+  if (strippedPairs.length === 0) {
+    return "";
+  }
+  keysToDelete.forEach((key) => parsed.searchParams.delete(key));
+  // Sort so key order in the original URL doesn't affect the hash — the
+  // same *set* of secret values must always hash to the same suffix.
+  strippedPairs.sort();
+  const hash = createHash("sha256")
+    .update(strippedPairs.join("&"))
+    .digest("hex")
+    .slice(0, 16);
+  return `\0auth=${hash}`;
+}
+
+/**
+ * Build a secret-free, auth-context-distinct cache key from a URL, for any
+ * caller that needs a long-lived in-memory Map key derived from a URL.
+ *
+ * Centralizes the exact sequence both existing callers used independently:
+ * parse via `new URL()`, strip tracking noise ({@link stripTrackingParams}),
+ * then strip and hash-suffix sensitive auth params
+ * ({@link stripSensitiveUrlParamsForCacheKey}) so distinct presigned URLs for
+ * the same object don't collide (see that function's doc comment for why a
+ * naive strip-only approach is a correctness bug, not just a hygiene one).
+ *
+ * Shared by `ImageCache.normalizeUrl` and `fileDetector.cacheKeyForUrl` — both
+ * build a cache key from a URL and must normalize it identically, or the same
+ * URL could hash to two different keys depending on which cache looked it up.
+ *
+ * Falls back to the raw `url` string unchanged when it isn't a parseable
+ * absolute URL (mirrors both callers' pre-existing catch behavior).
+ *
+ * @param url - The URL (or URL-shaped string) to normalize into a cache key.
+ */
+export function normalizeUrlForCache(url: string): string {
+  try {
+    const parsed = new URL(url);
+    stripTrackingParams(parsed);
+    const authSuffix = stripSensitiveUrlParamsForCacheKey(parsed);
+    return parsed.toString() + authSuffix;
+  } catch {
+    return url;
   }
 }
 

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { readFile as readFileAsync, stat as statAsync } from "fs/promises";
+import { basename } from "path";
 import { getGlobalDispatcher, interceptors, request } from "undici";
 import {
   MultimodalLogger,
@@ -1326,9 +1327,31 @@ async function processExplicitPdfFiles(
   // it in aggregate (e.g. three 40-page PDFs → 120 pages for a 100-page API).
   const aggregateConfig = PDFProcessor.getProviderConfig(provider);
   if (aggregateConfig && pdfFiles.length > 1) {
+    // A null pageCount (accurate count unavailable — see
+    // PDFProcessor.getAccuratePageCount) is treated as 0 in the sum below,
+    // which can undercount the aggregate and let a combined request over
+    // the provider's page limit slip through silently. Enforcement still
+    // runs against the known sum — a PDF with an unknown count must not
+    // fail the request outright — but the gap itself must not be silent.
+    const unknownPageCountFiles = pdfFiles.filter(
+      (f) => f.pageCount === null || f.pageCount === undefined,
+    );
     const totalPages = pdfFiles.reduce((sum, f) => sum + (f.pageCount ?? 0), 0);
     const totalMB =
       pdfFiles.reduce((sum, f) => sum + f.buffer.length, 0) / (1024 * 1024);
+    if (unknownPageCountFiles.length > 0) {
+      // Filenames are caller-controlled and may be full paths carrying
+      // PII/internal directory segments — log only the basename.
+      const unknownFileNames = unknownPageCountFiles
+        .map((f) => (f.filename ? basename(f.filename) : "<unnamed file>"))
+        .join(", ");
+      logger.warn(
+        `[PDF] Aggregate page-limit check across ${pdfFiles.length} PDFs could only be ` +
+          `partially verified: ${unknownPageCountFiles.length} file(s) have an unknown ` +
+          `page count (${unknownFileNames}), so the known total (${totalPages}) may ` +
+          `undercount the true combined page count.`,
+      );
+    }
     if (totalPages > aggregateConfig.maxPages) {
       throw new Error(
         `[PDF] Combined page count across ${pdfFiles.length} PDFs (${totalPages}) exceeds the ` +

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -297,22 +297,37 @@ export class PDFProcessor {
     try {
       const { PDFParse } = await import("pdf-parse");
       const pdf = new PDFParse({ data: new Uint8Array(buffer) });
+      // Captured outside the try so the `finally` below can always clear it
+      // — otherwise a `getInfo()` that wins the race leaves this timer
+      // running until PAGE_COUNT_TIMEOUT_MS fires for nothing. `.unref()`
+      // so it can never itself hold the process open in the meantime.
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
         const info = await Promise.race([
           pdf.getInfo(),
-          new Promise<never>((_, reject) =>
-            setTimeout(
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
               () => reject(new Error("page-count timeout")),
               PDF_LIMITS.PAGE_COUNT_TIMEOUT_MS,
-            ),
-          ),
+            );
+            timeoutHandle.unref?.();
+          }),
         ]);
         const total = (info as { total?: number }).total;
         return typeof total === "number" && total > 0 ? total : null;
       } finally {
-        await (
-          pdf as unknown as { destroy?: () => Promise<void> | void }
-        ).destroy?.();
+        if (timeoutHandle !== undefined) {
+          clearTimeout(timeoutHandle);
+        }
+        try {
+          await (
+            pdf as unknown as { destroy?: () => Promise<void> | void }
+          ).destroy?.();
+        } catch {
+          // A throwing destroy() must not discard an otherwise-valid page
+          // count returned above (matches fileReferenceRegistry.ts's
+          // pdf.destroy() cleanup pattern) — swallow it.
+        }
       }
     } catch (error) {
       logger.debug(
@@ -654,7 +669,13 @@ export class PDFProcessor {
    * base64 PNG as soon as it renders instead of buffering the whole document,
    * and reports progress via `options.onProgress`. A page that fails to render
    * is yielded with `error` set (per-page isolation, #294) rather than aborting
-   * the stream. `convertToImages` is the batch wrapper over this contract.
+   * the stream.
+   *
+   * NOT a wrapper of/over {@link convertToImages}, despite the similar
+   * contract — the two are independent, parallel implementations (each does
+   * its own `pdf-to-img` import, downscale calculation, and page loop)
+   * rather than one delegating to the other. Keep behavior changes (page
+   * isolation, downscale, password handling) in sync across both by hand.
    */
   static async *convertToImagesStream(
     pdfBuffer: Buffer,

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -114,6 +114,8 @@ import {
   CLI_SOFT_LIMITS_MB,
 } from "../src/cli/utils/inputValidation.js";
 
+import { processLooksLikeProxySupervisor } from "../src/cli/commands/proxy.js";
+
 import {
   GoogleVertexProvider,
   resolveVertexLocation,
@@ -138,6 +140,8 @@ import {
   redactUrlCredentials,
   redactUrlsInText,
   sanitizeErrorCause,
+  SENSITIVE_URL_QUERY_PARAM_DENYLIST,
+  stripSensitiveUrlParamsForCacheKey,
 } from "../src/lib/utils/logSanitize.js";
 import { getImageCache, resetImageCache } from "../src/lib/utils/imageCache.js";
 import { logger } from "../src/lib/utils/logger.js";
@@ -7773,6 +7777,651 @@ exit 127
         );
       } finally {
         rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  // ---------- Post-merge review gaps: batch parity, pdf limits, url-secret
+  //            redaction, supervisor identity ----------
+  {
+    // (a) batch previously never attached pdfOptions at all, so
+    // --pdf-password / NEUROLINK_PDF_PASSWORD silently had no effect on
+    // `neurolink batch`. Assert the fix inside the specific closure
+    // (runBatchGenerate) rather than anywhere in the file, so this can't
+    // false-pass just because generate/stream already had pdfOptions.
+    name: "CLI batch (review): executeBatch wires pdfOptions.password via resolvePdfPassword when PDFs are attached (previously silently dropped)",
+    category: "cli",
+    fn: async () => {
+      const src = readFileSync(
+        resolvePath(process.cwd(), "src/cli/factories/commandFactory.ts"),
+        "utf-8",
+      );
+      // Scope to executeBatch (generate/stream are defined earlier in the
+      // file) so this can't false-pass on those; scan to EOF, not a fixed
+      // window, so it won't false-fail as the function grows (review feedback).
+      const start = src.indexOf("private static async executeBatch");
+      if (start === -1) {
+        return false;
+      }
+      const compact = src.slice(start).replace(/\s+/g, "");
+      // The password is resolved ONCE before the per-prompt loop (so the
+      // shell-history warning fires once per run, like generate/stream) and
+      // then wired into each prompt's pdfOptions.
+      return (
+        compact.includes(
+          "constbatchPdfPassword=batchPdfFiles?.length?CLICommandFactory.resolvePdfPassword(argv):undefined",
+        ) && compact.includes("pdfOptions:{password:batchPdfPassword")
+      );
+    },
+  },
+  {
+    // (b) validateCsvMaxRows was wired into generate/stream but not batch —
+    // an out-of-range --csv-max-rows on `batch` silently passed through
+    // instead of failing fast like the other two commands.
+    name: "CLI batch (review): --csv-max-rows is validated on `batch` too (validateCsvMaxRows was only wired into generate/stream)",
+    category: "cli",
+    fn: async () => {
+      if (!existsSync(CLI_DIST_PATH)) {
+        return true; // dist not built in this run — covered by CI's built CLI.
+      }
+      const dir = mkdtempSync(pathJoin(tmpdir(), "nl-batch-csvmaxrows-"));
+      try {
+        const promptsFile = pathJoin(dir, "prompts.txt");
+        writeFileSync(promptsFile, "hello\n");
+        const res = await runCliBugfix([
+          "batch",
+          promptsFile,
+          "--csv",
+          "test/fixtures/transactions.csv",
+          "--csv-max-rows",
+          "0",
+          "--dry-run",
+        ]);
+        return (
+          res.code !== 0 &&
+          /Invalid --csv-max-rows \(--csvMaxRows\) value/.test(res.out)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    // (c) batch used to build a hand-rolled `csvOptions` inline (only
+    // maxRows/formatStyle), silently dropping encoding/sanitizeColumnNames/
+    // columnNameCase/parseTimeoutMs that generate/stream already supported.
+    // Verify both that batch now delegates to the shared helper, and that
+    // the shared helper itself carries every field through.
+    name: "CLI batch (review): executeBatch's csvOptions is built via the shared buildCsvOptionsFromArgv helper, and that helper carries encoding/sanitizeColumnNames/columnNameCase/parseTimeoutMs",
+    category: "cli",
+    fn: async () => {
+      const src = readFileSync(
+        resolvePath(process.cwd(), "src/cli/factories/commandFactory.ts"),
+        "utf-8",
+      );
+      const marker = "const runBatchGenerate = ()";
+      const start = src.indexOf(marker);
+      if (start === -1) {
+        return false;
+      }
+      // Scan from the marker to end-of-file rather than a fixed-size
+      // window — a fixed window (e.g. 2000 chars) false-fails as soon as
+      // the runBatchGenerate closure grows past it (review feedback).
+      const compact = src.slice(start).replace(/\s+/g, "");
+      if (
+        !compact.includes(
+          "batchCsvFiles?.length&&{csvOptions:CLICommandFactory.buildCsvOptionsFromArgv(argv)",
+        )
+      ) {
+        return false;
+      }
+
+      const buildCsvOptionsFromArgv = (
+        CLICommandFactory as unknown as {
+          buildCsvOptionsFromArgv: (argv: Record<string, unknown>) => {
+            maxRows?: number;
+            formatStyle?: string;
+            encoding?: string;
+            sanitizeColumnNames?: boolean;
+            columnNameCase?: string;
+            parseTimeoutMs?: number;
+          };
+        }
+      ).buildCsvOptionsFromArgv;
+
+      const opts = buildCsvOptionsFromArgv({
+        csvMaxRows: 250,
+        csvFormat: "markdown",
+        csvEncoding: "windows-1252",
+        csvSanitizeNames: true,
+        csvNameCase: "camelCase",
+        csvParseTimeoutMs: 45000,
+      });
+
+      return (
+        opts.maxRows === 250 &&
+        opts.formatStyle === "markdown" &&
+        opts.encoding === "windows-1252" &&
+        opts.sanitizeColumnNames === true &&
+        opts.columnNameCase === "camelCase" &&
+        opts.parseTimeoutMs === 45000
+      );
+    },
+  },
+  {
+    // (c2) T6 post-merge review gap: executeGenerate, executeStream and
+    // executeBatch each built a byte-for-byte identical inline
+    // `videoOptions: {...}` object. Extracted into a shared
+    // buildVideoOptionsFromArgv helper (mirrors buildCsvOptionsFromArgv
+    // above) — assert all three call sites now delegate to it (so the
+    // duplication can't silently regress), and that the helper itself maps
+    // every field through correctly.
+    name: "CLI (review): executeGenerate/executeStream/executeBatch's videoOptions is built via the shared buildVideoOptionsFromArgv helper (behavior-preserving extraction of T6)",
+    category: "cli",
+    fn: async () => {
+      const src = readFileSync(
+        resolvePath(process.cwd(), "src/cli/factories/commandFactory.ts"),
+        "utf-8",
+      );
+      const callSiteCount = (
+        src.match(
+          /videoOptions:\s*CLICommandFactory\.buildVideoOptionsFromArgv\(argv\)/g,
+        ) || []
+      ).length;
+      if (callSiteCount !== 3) {
+        return false; // expected exactly executeGenerate + executeStream + executeBatch
+      }
+      // No inline duplicate should remain outside the helper's own body.
+      const inlineDuplicates = (
+        src.match(/frames:\s*argv\.videoFrames as number \| undefined/g) || []
+      ).length;
+      if (inlineDuplicates !== 1) {
+        return false; // should appear exactly once, inside buildVideoOptionsFromArgv itself
+      }
+
+      const buildVideoOptionsFromArgv = (
+        CLICommandFactory as unknown as {
+          buildVideoOptionsFromArgv: (argv: Record<string, unknown>) => {
+            frames?: number;
+            quality?: number;
+            format?: string;
+            transcribeAudio?: boolean;
+          };
+        }
+      ).buildVideoOptionsFromArgv;
+
+      const opts = buildVideoOptionsFromArgv({
+        videoFrames: 12,
+        videoQuality: 90,
+        videoFormat: "png",
+        transcribeAudio: true,
+      });
+
+      return (
+        opts.frames === 12 &&
+        opts.quality === 90 &&
+        opts.format === "png" &&
+        opts.transcribeAudio === true
+      );
+    },
+  },
+  {
+    // (d) the aggregate PDF page-limit reduce() treated a null pageCount
+    // (accurate count unavailable) as 0, which could silently undercount the
+    // true combined total. Enforcement must still run against the known sum
+    // (no throw for a merely-unknown count) but the gap must be logged.
+    name: "messageBuilder (review): aggregate PDF page-limit check WARNs when any file's page count is unknown, instead of silently undercounting",
+    category: "pdf-processor",
+    fn: async () => {
+      // A valid PDF header with a corrupted body: FileDetector/PDFProcessor
+      // accept it as PDF content but the page-count regex finds no markers,
+      // so estimatedPages comes back null (mirrors the existing #287 test).
+      const unknownCountPdf = Buffer.concat([
+        Buffer.from("%PDF-1.4\n"),
+        Buffer.alloc(20),
+      ]);
+      const knownCountPdf = readFileSync("test/fixtures/multi-page.pdf"); // 3 pages
+
+      const originalWarn = logger.warn;
+      const warnings: string[] = [];
+      logger.warn = ((...args: unknown[]) => {
+        warnings.push(
+          args
+            .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+            .join(" "),
+        );
+      }) as typeof logger.warn;
+
+      try {
+        // "openai": native PDF support (FilePart, no page-image conversion),
+        // aggregateConfig maxPages=100/maxSizeMB=10 — well above this tiny
+        // combined input, so this must NOT throw; it must only warn about
+        // the unknown count. (A non-native provider would additionally try
+        // to rasterize these deliberately-corrupted stub PDFs to images and
+        // fail there, which is a different code path than the one under
+        // test here.)
+        const messages = await buildMultimodalMessagesArray(
+          {
+            input: {
+              text: "x",
+              pdfFiles: [unknownCountPdf, unknownCountPdf, knownCountPdf],
+            },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai",
+          "gpt-4o",
+        );
+        const warned = warnings.some((w) =>
+          /Aggregate page-limit check.*unknown/i.test(w),
+        );
+        return Array.isArray(messages) && warned;
+      } finally {
+        logger.warn = originalWarn;
+      }
+    },
+  },
+  {
+    // (e) the URL pre-flight HEAD used to trust content-length off ANY
+    // response, including non-2xx ones (a redirect the dispatcher didn't
+    // follow, 403/404/405 "HEAD not allowed", 5xx) — which can carry a
+    // stale/irrelevant content-length and cause a false "File too large"
+    // rejection before the real (small) body is ever fetched via GET.
+    name: "FileDetector.loadFromURL (review): a non-2xx HEAD's content-length is not trusted — falls through to the GET guard instead of over-rejecting",
+    category: "file-detector",
+    fn: async () => {
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          // Non-2xx with a wildly oversized declared length — must be
+          // ignored, not trusted.
+          res.statusCode = 403;
+          res.setHeader("content-length", String(500 * 1024 * 1024));
+          res.end();
+        } else {
+          res.statusCode = 200;
+          res.setHeader("content-type", "image/png");
+          res.end(png);
+        }
+      });
+      await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+      try {
+        const addr = server.address() as { port: number };
+        const url = `http://127.0.0.1:${addr.port}/gate-review-nonstd.png`;
+        const loadFromURL = (
+          FileDetector as unknown as {
+            loadFromURL: (
+              u: string,
+              o?: { maxSize?: number },
+            ) => Promise<Buffer>;
+          }
+        ).loadFromURL;
+        const buf = await loadFromURL(url, { maxSize: 1024 * 1024 });
+        return Buffer.isBuffer(buf) && buf.equals(png);
+      } finally {
+        await new Promise<void>((r) => server.close(() => r()));
+      }
+    },
+  },
+  {
+    // (f) getAccuratePageCount raced getInfo() against a setTimeout without
+    // ever clearing the loser: when getInfo() won (the common case), the 5s
+    // timer stuck around doing nothing. Separately, an unguarded
+    // `pdf.destroy()` in the finally block could throw and discard an
+    // otherwise-valid page count.
+    //
+    // getInfo()'s resolution is driven via a `PDFParse.prototype.getInfo`
+    // patch rather than a real multi-page.pdf parse: pdf-parse's bundled
+    // pdfjs-dist (5.4.296, exact-pinned) and pdf-to-img's bundled pdfjs-dist
+    // (~5.4.0, independently resolved to 5.4.624 by pnpm) are two separate
+    // installs. Once anything in the process calls PDFProcessor.convertToImages
+    // (pdf-to-img) — which the pre-existing convertToImages test block above
+    // does many times over — every subsequent *real* pdf-parse getInfo() call
+    // in that same process starts rejecting with a pdfjs "API version does not
+    // match the Worker version" error and getAccuratePageCount silently
+    // degrades to null (its documented, correct behavior for a genuinely
+    // failing parse). That's a pre-existing, order-dependent cross-package
+    // quirk unrelated to the two behaviors this test verifies, so getInfo()
+    // is stubbed to keep this test deterministic regardless of what ran
+    // before it in the suite.
+    name: "PDFProcessor.getAccuratePageCount (review): clears its race timer when getInfo() wins, and a throwing destroy() doesn't discard a valid page count",
+    category: "pdf-processor",
+    fn: async () => {
+      const getAccuratePageCount = (
+        PDFProcessor as unknown as {
+          getAccuratePageCount: (buffer: Buffer) => Promise<number | null>;
+        }
+      ).getAccuratePageCount;
+      const buffer = readFileSync("test/fixtures/multi-page.pdf");
+
+      const { PDFParse } = await import("pdf-parse");
+      const originalGetInfo = PDFParse.prototype.getInfo;
+      const originalDestroy = PDFParse.prototype.destroy;
+      PDFParse.prototype.getInfo = async function patchedGetInfo() {
+        return { total: 3 } as Awaited<ReturnType<typeof originalGetInfo>>;
+      };
+
+      try {
+        // (1) No dangling 5s timers after repeated calls that resolve well
+        // before PAGE_COUNT_TIMEOUT_MS — proves the race loser is cleared.
+        const timeoutsBefore = process
+          .getActiveResourcesInfo()
+          .filter((r) => r === "Timeout").length;
+        for (let i = 0; i < 10; i++) {
+          const pages = await getAccuratePageCount(buffer);
+          if (pages !== 3) {
+            return false;
+          }
+        }
+        const timeoutsAfter = process
+          .getActiveResourcesInfo()
+          .filter((r) => r === "Timeout").length;
+        if (timeoutsAfter - timeoutsBefore >= 10) {
+          return false; // would indicate leaked timers, one per call
+        }
+
+        // (2) A throwing destroy() must not discard an otherwise-valid count
+        // (matches fileReferenceRegistry.ts's swallow-on-cleanup pattern).
+        PDFParse.prototype.destroy = async function patchedDestroy() {
+          throw new Error("simulated destroy() failure");
+        };
+        const pages = await getAccuratePageCount(buffer);
+        return pages === 3;
+      } finally {
+        PDFParse.prototype.getInfo = originalGetInfo;
+        PDFParse.prototype.destroy = originalDestroy;
+      }
+    },
+  },
+  {
+    // (g) both ImageCache.normalizeUrl and FileDetector's urlContentTypeCache
+    // used the full URL (secrets and all) as their in-memory Map key. A log
+    // line is one redacted moment; a Map key persists for the process
+    // lifetime — so a presigned URL's signature/token stayed resident in
+    // memory as a cache key for as long as the process ran.
+    //
+    // Post-merge review gap (T4): the original fix above merely STRIPPED
+    // sensitive params before using the result as a key, which traded the
+    // secret-leak bug for a worse correctness bug — two *different* signed
+    // URLs for the same object (e.g. one expired/revoked, one fresh) then
+    // stripped down to the SAME key and collided, so stale/invalid-auth
+    // bytes could be served without ever revalidating. The fix folds a
+    // short hash of the stripped param values into the key instead of just
+    // dropping them, so distinct auth contexts stay distinct while the raw
+    // secret still never appears in the key. This test asserts BOTH halves:
+    // no secret leak, AND no cross-auth-context collision.
+    name: "ImageCache + FileDetector url cache (review): cache keys strip sensitive query params AND stay distinct per auth context (hash suffix, no collision)",
+    category: "image-processor",
+    fn: async () => {
+      // -- ImageCache: the persistent Map key itself must not contain the
+      // secret; non-sensitive params must survive; and two URLs differing
+      // ONLY in signature must now be DISTINCT cache entries (no collision),
+      // while the identical URL requested twice must still hit the cache
+      // (the hash suffix is deterministic, not "always distinct").
+      const originalEnv = process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+      try {
+        process.env.NEUROLINK_IMAGE_CACHE_ENABLED = "true";
+        resetImageCache();
+        const cache = getImageCache();
+        const secretUrl =
+          "https://example.com/img.png?X-Amz-Signature=SUPERSECRETSIG&keep=1";
+        cache.set(
+          secretUrl,
+          "data:image/png;base64,AAAA",
+          "image/png",
+          Buffer.from("AAAA"),
+        );
+        const internalMap = (
+          cache as unknown as { cache: Map<string, unknown> }
+        ).cache;
+        const keys = Array.from(internalMap.keys());
+        if (keys.some((k) => k.includes("SUPERSECRETSIG"))) {
+          return false; // secret leaked into the persistent Map key
+        }
+        if (!keys.some((k) => k.includes("keep=1"))) {
+          return false; // non-sensitive params must survive
+        }
+        const differentSigHit = cache.get(
+          "https://example.com/img.png?X-Amz-Signature=DIFFERENTSIG&keep=1",
+        );
+        if (differentSigHit !== null) {
+          return false; // collision: a different signature must NOT hit the same entry
+        }
+        const sameSigHit = cache.get(secretUrl);
+        if (
+          sameSigHit === null ||
+          sameSigHit.dataUri !== "data:image/png;base64,AAAA"
+        ) {
+          return false; // the identical URL must still be a cache hit
+        }
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+        } else {
+          process.env.NEUROLINK_IMAGE_CACHE_ENABLED = originalEnv;
+        }
+        resetImageCache();
+      }
+
+      // -- FileDetector: two URLs differing only by a secret query param
+      // must NOT share a urlContentTypeCache entry anymore (a fresh HEAD is
+      // expected for the second, different-secret URL), while the identical
+      // URL requested again must still avoid a redundant HEAD.
+      let headCount = 0;
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          headCount++;
+          res.setHeader("content-type", "image/png");
+          res.end();
+        } else {
+          res.setHeader("content-type", "image/png");
+          res.end(png);
+        }
+      });
+      await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+      try {
+        const addr = server.address() as { port: number };
+        const path = "/gate-review-secret.png";
+        const url1 = `http://127.0.0.1:${addr.port}${path}?token=SIGA&keep=1`;
+        const url2 = `http://127.0.0.1:${addr.port}${path}?token=SIGB&keep=1`;
+        const load = (
+          FileDetector as unknown as {
+            loadFromURL: (
+              u: string,
+              o?: { maxSize?: number },
+            ) => Promise<Buffer>;
+          }
+        ).loadFromURL.bind(FileDetector);
+        await load(url1, { maxSize: 1024 });
+
+        // Different secret (SIGB), same path: must NOT reuse url1's cache
+        // entry — this is the collision the T4 fix closes.
+        headCount = 0;
+        const result2 = await FileDetector.detectAndProcess(url2);
+        if (!(result2.type === "image" && headCount > 0)) {
+          return false;
+        }
+
+        // The exact same URL (SIGA) requested again must still hit the
+        // cache — proving the hash suffix is deterministic, not random.
+        headCount = 0;
+        const result1Again = await FileDetector.detectAndProcess(url1);
+        return result1Again.type === "image" && headCount === 0;
+      } finally {
+        await new Promise<void>((r) => server.close(() => r()));
+      }
+    },
+  },
+  {
+    // (g2) T3 + T4 unit coverage: the GCS V4 signed-URL query params must be
+    // in the shared denylist (case-insensitively), and
+    // stripSensitiveUrlParamsForCacheKey must (1) never leak a stripped
+    // value into its hash suffix, (2) return "" (no suffix) when nothing
+    // sensitive was present, (3) produce the SAME suffix for the same
+    // stripped values regardless of param order, and (4) produce a
+    // DIFFERENT suffix when a stripped value differs.
+    name: "logSanitize (review): GCS V4 signed-URL params are denylisted, and stripSensitiveUrlParamsForCacheKey hashes stripped values deterministically without leaking them",
+    category: "image-processor",
+    fn: async () => {
+      const gcsParams = [
+        "x-goog-signature",
+        "x-goog-credential",
+        "x-goog-algorithm",
+        "x-goog-date",
+        "x-goog-expires",
+        "x-goog-signedheaders",
+      ];
+      for (const p of gcsParams) {
+        if (!SENSITIVE_URL_QUERY_PARAM_DENYLIST.includes(p)) {
+          return false;
+        }
+      }
+      // Case-insensitive match: a mixed-case GCS param on an actual URL must
+      // still be recognized and stripped (denylist membership check
+      // lowercases the incoming key before comparing).
+      const mixedCase = new URL(
+        "https://storage.googleapis.com/bucket/obj?X-Goog-Signature=ZZZ",
+      );
+      stripSensitiveUrlParamsForCacheKey(mixedCase);
+      if (mixedCase.searchParams.has("X-Goog-Signature")) {
+        return false;
+      }
+
+      const noSecrets = new URL(
+        "https://storage.googleapis.com/bucket/obj?keep=1",
+      );
+      const noSuffix = stripSensitiveUrlParamsForCacheKey(noSecrets);
+      if (noSuffix !== "") {
+        return false; // nothing sensitive present -> no suffix
+      }
+      if (!noSecrets.searchParams.has("keep")) {
+        return false; // non-sensitive params must be untouched
+      }
+
+      const gcsUrlA = new URL(
+        "https://storage.googleapis.com/bucket/obj?X-Goog-Signature=AAA&X-Goog-Algorithm=GOOG4-RSA-SHA256&keep=1",
+      );
+      const suffixA = stripSensitiveUrlParamsForCacheKey(gcsUrlA);
+      if (suffixA === "" || suffixA.includes("AAA")) {
+        return false; // must produce a suffix, and never contain the raw secret
+      }
+      if (gcsUrlA.searchParams.has("x-goog-signature")) {
+        return false; // sensitive param must actually be removed from the URL
+      }
+      if (!gcsUrlA.searchParams.has("keep")) {
+        return false; // non-sensitive params must survive
+      }
+
+      // Same stripped values, different param ORDER -> same suffix (order
+      // must not affect the hash).
+      const gcsUrlAReordered = new URL(
+        "https://storage.googleapis.com/bucket/obj?X-Goog-Algorithm=GOOG4-RSA-SHA256&keep=1&X-Goog-Signature=AAA",
+      );
+      const suffixAReordered =
+        stripSensitiveUrlParamsForCacheKey(gcsUrlAReordered);
+      if (suffixAReordered !== suffixA) {
+        return false;
+      }
+
+      // Different secret VALUE -> different suffix (no collision).
+      const gcsUrlB = new URL(
+        "https://storage.googleapis.com/bucket/obj?X-Goog-Signature=BBB&X-Goog-Algorithm=GOOG4-RSA-SHA256&keep=1",
+      );
+      const suffixB = stripSensitiveUrlParamsForCacheKey(gcsUrlB);
+      return suffixB !== "" && suffixB !== suffixA;
+    },
+  },
+  {
+    // (h) processLooksLikeProxySupervisor used to match ANY process whose
+    // args merely mentioned "neurolink" (a shell in a directory named
+    // "neurolink", an editor with a neurolink file open) — a stale/recycled
+    // pid running such a process could then be SIGTERM'd/SIGKILL'd during
+    // uninstall. It must now require BOTH "neurolink" AND "proxy".
+    name: "proxy.ts (review): processLooksLikeProxySupervisor requires BOTH 'neurolink' and 'proxy' in process args, not 'neurolink' alone",
+    category: "cli",
+    fn: async () => {
+      const mkProc = (...args: string[]) =>
+        spawnProcess(
+          process.execPath,
+          ["-e", "setInterval(() => {}, 60000)", "--", ...args],
+          { stdio: "ignore" },
+        );
+      const neurolinkOnly = mkProc("neurolink-fake-worker");
+      const neurolinkProxy = mkProc("neurolink", "proxy");
+      try {
+        // Give both children a moment to register with the OS before `ps`
+        // is asked about them.
+        await new Promise((r) => setTimeout(r, 300));
+        if (!neurolinkOnly.pid || !neurolinkProxy.pid) {
+          return false;
+        }
+        const notSupervisor = await processLooksLikeProxySupervisor(
+          neurolinkOnly.pid,
+        );
+        const isSupervisor = await processLooksLikeProxySupervisor(
+          neurolinkProxy.pid,
+        );
+        return notSupervisor === false && isSupervisor === true;
+      } finally {
+        neurolinkOnly.kill("SIGKILL");
+        neurolinkProxy.kill("SIGKILL");
+      }
+    },
+  },
+  {
+    // (i) T7 post-merge review gap: the args match alone ("neurolink" +
+    // "proxy") isn't airtight — a recycled pid could be reassigned to an
+    // unrelated process whose args coincidentally contain both words (e.g.
+    // this very test file's own child-process args above). Harden with a
+    // startTime cross-check: processLooksLikeProxySupervisor's optional
+    // second argument is the persisted ProxySupervisorState.startTime (ISO
+    // string); when it's far from the pid's actual OS-reported start time
+    // (ps -o lstart=), that's a confident mismatch and the pid must be
+    // rejected. When it's close (as it always is for the actual current
+    // process), it must still be accepted.
+    name: "proxy.ts (review): processLooksLikeProxySupervisor cross-checks the pid's actual start time against the persisted supervisor startTime",
+    category: "cli",
+    fn: async () => {
+      const mkProc = (...args: string[]) =>
+        spawnProcess(
+          process.execPath,
+          ["-e", "setInterval(() => {}, 60000)", "--", ...args],
+          { stdio: "ignore" },
+        );
+      const neurolinkProxy = mkProc("neurolink", "proxy");
+      try {
+        await new Promise((r) => setTimeout(r, 300));
+        if (!neurolinkProxy.pid) {
+          return false;
+        }
+        // Recorded startTime close to "now" (this process was just spawned)
+        // must still be accepted.
+        const closeMatch = await processLooksLikeProxySupervisor(
+          neurolinkProxy.pid,
+          new Date().toISOString(),
+        );
+        // A wildly wrong recorded startTime (this pid was "recorded" as
+        // having started 25 years ago) must be a confident mismatch and
+        // rejected — this is exactly the recycled-pid scenario T7 hardens
+        // against.
+        const wildMismatch = await processLooksLikeProxySupervisor(
+          neurolinkProxy.pid,
+          new Date("2000-01-01T00:00:00Z").toISOString(),
+        );
+        // No expected startTime at all -> falls back to args-only (matches
+        // pre-hardening behavior, and the h-test above).
+        const argsOnly = await processLooksLikeProxySupervisor(
+          neurolinkProxy.pid,
+        );
+        return (
+          closeMatch === true && wildMismatch === false && argsOnly === true
+        );
+      } finally {
+        neurolinkProxy.kill("SIGKILL");
       }
     },
   },


### PR DESCRIPTION
## Summary

After the 13-PR multimodal/CLI/PDF/proxy batch merged into `release`, an audit of the review threads that were still **unresolved at merge** (re-review comments from Yama/CodeRabbit/Copilot on the rebased commits) surfaced **12 verified gaps still present in released code** — adversarially verified against `release`, not just taken at face value. This PR closes all of them, plus the docs/nits, in one consolidated fix.

## Fixes

**Backward-compatibility (documented, not reverted)** — 3 breaking changes shipped in 9.94.x–9.95.x are now documented in **`docs/MIGRATION.md`** with before/after + migration steps (see `BREAKING CHANGE:` footer):
1. multimodal file/CSV processing is fail-loud (throws) instead of log-and-skip partial success;
2. `MessageContent` dropped its open index signature (closed shape);
3. `BatchCommandArgs.file` → `.promptsFile`.

**CLI `batch` parity** — `neurolink batch` previously dropped several inputs the `generate`/`stream` paths honor:
- `--pdf-password` / `NEUROLINK_PDF_PASSWORD` was silently ignored → encrypted PDFs failed. Now wired via `resolvePdfPassword`.
- `--csv-max-rows` wasn't fail-fast validated; `--csv-encoding` / `--csv-sanitize-names` / `--csv-name-case` / `--csv-parse-timeout-ms` were ignored → now built via the shared `buildCsvOptionsFromArgv`.
- `--pdf` soft-warning fired at 100 MB while docs promise 50 MB → dedicated `PDF_SOFT_MAX_MB = 50`.

**PDF hardening**
- Aggregate page-limit summed `pageCount ?? 0`, silently undercounting when a PDF's page count is unknown → now WARNs (enforcement still runs on the known sum; unknown-count PDFs aren't failed outright).
- `getAccuratePageCount` never cleared its `Promise.race` timeout (dangling 5 s handle) and a throwing `pdf.destroy()` in `finally` discarded a valid count → timer is cleared/unref'd and destroy is guarded.

**URL/secret handling**
- Cache-hit debug log leaked a raw presigned-URL prefix → uses `redactUrlForError`.
- `imageCache` and `fileDetector` URL caches keyed on the full URL (secret query params persisted in in-memory Map keys) → a shared sensitive-param denylist strips them from cache keys.
- URL pre-flight HEAD enforced `maxSize` without checking `statusCode` → non-2xx HEAD now falls through to the streaming GET guard.

**Proxy** — `processLooksLikeProxySupervisor` matched any process whose args merely contained `neurolink` → now requires both `neurolink` and the `proxy` subcommand before a stale/recycled pid could be signalled during uninstall.

## Tests & validation
- **8 new regression tests** (batch pdf-password/csv validation/options, aggregate page-limit warn, HEAD non-2xx fall-through, page-count timer/destroy resilience, cache-key redaction, supervisor identity). Suite **225/225**.
- `tsc --strict` 0 errors · `lint` 0 errors · `build:cli` green · pre-commit gate (validate:all + full build) green.

## Follow-up (out of scope, flagged)
`pdf-parse` (pinned `pdfjs-dist@5.4.296`) and `pdf-to-img` (`pdfjs-dist@5.4.624`) are separate installs; once `PDFProcessor.convertToImages()` runs in a process, subsequent real `getAccuratePageCount()` calls hit a pdfjs "API version does not match Worker version" error and degrade to `null` for the rest of the process. Pre-existing, not caused by these fixes — worth a follow-up ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF page-limit warnings when some page counts are unknown (now clearer about partial verification).
  * Hardened URL loading by ignoring oversized `content-length` from non-2xx HEAD responses.
  * Reduced proxy supervisor uninstall false positives with stricter PID identity/start-time checks.
  * Strengthened signed/presigned URL handling and cache-key behavior to avoid auth-context collisions and better redact sensitive query params in logs.
  * Improved batch CSV/PDF processing: CSV/PDF validation, PDF password reuse per batch, and a dedicated PDF soft warning threshold.

* **Documentation**
  * Updated migration guidance for breaking changes (stricter CSV/file failures, closed message content shape, CLI batch args rename).
  * Clarified CSV encoding detection order/limitations and PDF conversion vs streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->