### PR TITLE
fix(pdf): pin pdfjs-dist to one version so page counting survives image conversion (#1212)

### DIFF
--- a/package.json
+++ b/package.json
@@ -621,7 +621,8 @@
       "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
       "shell-quote@<1.8.4": ">=1.8.4",
-      "undici@>=8.0.0": ">=7.24.0 <8.0.0"
+      "undici@>=8.0.0": ">=7.24.0 <8.0.0",
+      "pdfjs-dist": "5.4.624"
     },
     "patchedDependencies": {
       "mammoth@1.12.0": "patches/mammoth@1.12.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   shell-quote@<1.8.4: '>=1.8.4'
   undici@>=8.0.0: '>=7.24.0 <8.0.0'
+  pdfjs-dist: 5.4.624
 
 pnpmfileChecksum: sha256-qFFlrDVMxTAG02VWf3xBAHmYpquoAuUauBBYPNQv57g=
 
@@ -7023,10 +7024,6 @@ packages:
     resolution: {integrity: sha512-QJy7P2Qbk86lntPPIC3HVZAyw/CvM+CP592UbO7grborOJ74Icspb8A2sdHO33MDb/WHwHZpSJxd771rQTlZKA==}
     engines: {node: '>=20'}
     hasBin: true
-
-  pdfjs-dist@5.4.296:
-    resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
-    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   pdfjs-dist@5.4.624:
     resolution: {integrity: sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==}
@@ -16622,15 +16619,11 @@ snapshots:
   pdf-parse@2.4.5:
     dependencies:
       '@napi-rs/canvas': 0.1.80
-      pdfjs-dist: 5.4.296
+      pdfjs-dist: 5.4.624
 
   pdf-to-img@5.0.0:
     dependencies:
       pdfjs-dist: 5.4.624
-
-  pdfjs-dist@5.4.296:
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.80
 
   pdfjs-dist@5.4.624:
     optionalDependencies:

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -1367,6 +1367,30 @@ const tests: TestFunction[] = [
     },
   },
   {
+    name: "PDFProcessor #1212: getAccuratePageCount stays accurate after convertToImages (single pdfjs-dist version)",
+    category: "pdf-processor",
+    fn: async () => {
+      // Regression guard for the pdf-parse (pdfjs-dist@5.4.296) vs pdf-to-img
+      // version skew: once convertToImages() had loaded a *different* pdfjs
+      // worker version, every later getAccuratePageCount() failed pdfjs's
+      // API-vs-Worker equality check and silently degraded to null for the rest
+      // of the process. With both libraries pinned to one pdfjs-dist version
+      // (pnpm.overrides), counting must survive an image conversion in the same
+      // process.
+      const pdf = readFileSync("test/fixtures/valid-sample.pdf");
+      // Baseline count BEFORE any image conversion loads a pdfjs worker.
+      const before = await PDFProcessor.getAccuratePageCount(pdf);
+      // Do NOT swallow: a conversion failure here (e.g. the very version skew
+      // this guards against) must fail the test, not be hidden — nearby tests
+      // already rely on convertToImages succeeding in this environment.
+      await PDFProcessor.convertToImages(pdf, { maxPages: 1 });
+      const after = await PDFProcessor.getAccuratePageCount(pdf);
+      // The count must survive the conversion (the skew made `after` null) and
+      // stay identical to the pre-conversion count — not merely be positive.
+      return before !== null && after !== null && after === before;
+    },
+  },
+  {
     name: "PDFProcessor #260: oversized page auto-downscales; normal page unaffected",
     category: "pdf-processor",
     fn: async () => {


### PR DESCRIPTION
Closes #1212.

## Problem
`pdf-parse` pins `pdfjs-dist@5.4.296` while `pdf-to-img` resolved `pdfjs-dist@5.4.624`, so two copies loaded into the same process. `pdfjs-dist` enforces a global API-vs-Worker version equality check, so once `PDFProcessor.convertToImages()` (pdf-to-img) ran, **every subsequent** `PDFProcessor.getAccuratePageCount()` (pdf-parse) failed the check and silently degraded to its `null` fallback for the rest of the process — under-counting the single-file and aggregate PDF page-limit guards. Found during the #1211 post-merge audit.

## Fix
Add a `pnpm.overrides` entry pinning `pdfjs-dist` to a single version (`5.4.624` — pdf-to-img's own resolved version, and within pdf-parse's compatibility). Both libraries now load the same pdfjs worker, so there's no version skew.

Chose `5.4.624` (pin *up*) over `5.4.296` (pin *down*) because it's pdf-to-img's native version (no downgrade risk) and pdf-parse works cleanly on it — verified by the full suite.

## Validation
- New regression test `PDFProcessor #1212: getAccuratePageCount stays accurate after convertToImages` — runs the exact failing order (`convertToImages` → `getAccuratePageCount`) and asserts a real count, not `null`.
- Full bugfixes suite **229/229** (all PDF + CLI tests), `tsc --strict` 0 errors, `lint` 0 errors, `build:cli` green.
- Both consumers now resolve to a single `pdfjs-dist@5.4.624`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing reliability when determining page counts after converting PDFs to images.
  * Updated PDF compatibility to help prevent processing failures caused by mismatched PDF library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->