### PR TITLE
fix(cache): keep image content-hash dedup index resilient across eviction (#1213)

### DIFF
--- a/src/lib/utils/imageCache.ts
+++ b/src/lib/utils/imageCache.ts
@@ -30,7 +30,11 @@ import type {
  */
 export class ImageCache {
   private cache = new Map<string, CachedImage>();
-  private contentHashIndex = new Map<string, string>(); // contentHash -> url
+  // contentHash -> set of normalized urls whose cache entry holds that
+  // content. A Set (not a single url) so that evicting/deleting one url
+  // doesn't drop the dedup mapping for other urls still caching the same
+  // content (#1213).
+  private contentHashIndex = new Map<string, Set<string>>();
   private maxSize: number;
   private ttlMs: number;
   private maxImageSize: number;
@@ -215,11 +219,40 @@ export class ImageCache {
    * Useful for deduplication when the same image is accessed via different URLs
    */
   getByContentHash(contentHash: string): CachedImage | null {
-    const url = this.contentHashIndex.get(contentHash);
-    if (!url) {
+    const urlSet = this.contentHashIndex.get(contentHash);
+    if (!urlSet) {
       return null;
     }
-    return this.get(url);
+
+    // Find the first url whose cache entry is still live, pruning any url
+    // whose entry no longer exists in `this.cache` along the way. Entries
+    // that exist but are expired are left in the set (not "gone") - the
+    // normal TTL/get() path is responsible for reaping those.
+    let liveUrl: string | null = null;
+    // Iterate a copy so reaping below can mutate the set safely.
+    for (const url of [...urlSet]) {
+      const entry = this.cache.get(url);
+      if (!entry) {
+        urlSet.delete(url);
+        continue;
+      }
+      if (this.isExpired(entry)) {
+        // Reap expired entries here too (matching get() semantics) so stale
+        // urls don't accumulate when callers primarily use getByContentHash.
+        this.cache.delete(url);
+        urlSet.delete(url);
+        continue;
+      }
+      if (liveUrl === null) {
+        liveUrl = url;
+      }
+    }
+
+    if (urlSet.size === 0) {
+      this.contentHashIndex.delete(contentHash);
+    }
+
+    return liveUrl ? this.get(liveUrl) : null;
   }
 
   /**
@@ -253,21 +286,42 @@ export class ImageCache {
     // Generate content hash
     const contentHash = this.generateContentHash(imageData);
 
-    // Check if same content already exists under different URL
-    const existingUrl = this.contentHashIndex.get(contentHash);
-    if (existingUrl && existingUrl !== normalizedUrl) {
-      // Content already cached under different URL - create a shallow copy
-      const existingEntry = this.cache.get(existingUrl);
-      if (existingEntry && !this.isExpired(existingEntry)) {
-        // Create a shallow copy for the new URL to avoid shared reference issues
-        this.cache.set(normalizedUrl, { ...existingEntry });
-        // Update content hash index to point to the new URL as well
-        this.contentHashIndex.set(contentHash, normalizedUrl);
-        logger.debug("Image cache dedup hit", {
-          newUrl: redactUrlForError(normalizedUrl),
-          existingUrl: redactUrlForError(existingUrl),
-        });
-        return;
+    // Check if same content already exists under a different URL
+    const existingUrls = this.contentHashIndex.get(contentHash);
+    if (existingUrls) {
+      for (const existingUrl of existingUrls) {
+        if (existingUrl === normalizedUrl) {
+          continue;
+        }
+        // Content already cached under a different URL - create a shallow copy
+        const existingEntry = this.cache.get(existingUrl);
+        if (existingEntry && !this.isExpired(existingEntry)) {
+          // A dedup hit still adds a cache entry for the new URL, so enforce
+          // capacity first — otherwise many URLs sharing one content hash could
+          // grow the cache past maxSize.
+          while (this.cache.size >= this.maxSize && this.cache.size > 0) {
+            this.evictOldest();
+          }
+          // Create a shallow copy for the new URL to avoid shared reference issues
+          this.cache.set(normalizedUrl, { ...existingEntry });
+          // Re-fetch (or re-create) the hash's URL set: the eviction above may
+          // have removed this hash's last url, emptying the set and deleting it
+          // from contentHashIndex — reusing the stale `existingUrls` reference
+          // would add the new url to an orphaned set that the index no longer
+          // points to, leaving a live entry unreachable by content hash
+          // (the exact #1213 failure mode). Never replace an existing mapping.
+          let hashUrls = this.contentHashIndex.get(contentHash);
+          if (!hashUrls) {
+            hashUrls = new Set<string>();
+            this.contentHashIndex.set(contentHash, hashUrls);
+          }
+          hashUrls.add(normalizedUrl);
+          logger.debug("Image cache dedup hit", {
+            newUrl: redactUrlForError(normalizedUrl),
+            existingUrl: redactUrlForError(existingUrl),
+          });
+          return;
+        }
       }
     }
 
@@ -288,7 +342,12 @@ export class ImageCache {
     };
 
     this.cache.set(normalizedUrl, entry);
-    this.contentHashIndex.set(contentHash, normalizedUrl);
+    let urlSet = this.contentHashIndex.get(contentHash);
+    if (!urlSet) {
+      urlSet = new Set<string>();
+      this.contentHashIndex.set(contentHash, urlSet);
+    }
+    urlSet.add(normalizedUrl);
 
     logger.debug("Image cached", {
       url: redactUrlForError(normalizedUrl),
@@ -306,9 +365,14 @@ export class ImageCache {
     const entry = this.cache.get(normalizedUrl);
 
     if (entry) {
-      // Remove from content hash index
-      if (this.contentHashIndex.get(entry.contentHash) === normalizedUrl) {
-        this.contentHashIndex.delete(entry.contentHash);
+      // Remove this URL from its content hash's URL set; only drop the
+      // hash entry once no URL maps to that content anymore (#1213).
+      const urlSet = this.contentHashIndex.get(entry.contentHash);
+      if (urlSet) {
+        urlSet.delete(normalizedUrl);
+        if (urlSet.size === 0) {
+          this.contentHashIndex.delete(entry.contentHash);
+        }
       }
       this.cache.delete(normalizedUrl);
       return true;
@@ -326,8 +390,15 @@ export class ImageCache {
     if (oldestKey !== undefined) {
       const entry = this.cache.get(oldestKey);
       if (entry) {
-        if (this.contentHashIndex.get(entry.contentHash) === oldestKey) {
-          this.contentHashIndex.delete(entry.contentHash);
+        // Remove only the evicted URL from its content hash's URL set; the
+        // hash entry is dropped only once no URL maps to it anymore
+        // (#1213).
+        const urlSet = this.contentHashIndex.get(entry.contentHash);
+        if (urlSet) {
+          urlSet.delete(oldestKey);
+          if (urlSet.size === 0) {
+            this.contentHashIndex.delete(entry.contentHash);
+          }
         }
       }
       this.cache.delete(oldestKey);

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -143,7 +143,11 @@ import {
   SENSITIVE_URL_QUERY_PARAM_DENYLIST,
   stripSensitiveUrlParamsForCacheKey,
 } from "../src/lib/utils/logSanitize.js";
-import { getImageCache, resetImageCache } from "../src/lib/utils/imageCache.js";
+import {
+  ImageCache,
+  getImageCache,
+  resetImageCache,
+} from "../src/lib/utils/imageCache.js";
 import { logger } from "../src/lib/utils/logger.js";
 
 import type {
@@ -8422,6 +8426,159 @@ exit 127
         );
       } finally {
         neurolinkProxy.kill("SIGKILL");
+      }
+    },
+  },
+  {
+    // (i) #1213: contentHashIndex used to map a content hash to a SINGLE
+    // url (Map<contentHash, url>). When the same image content was cached
+    // under two urls, set() repointed the index to the newer url, dropping
+    // the older url's mapping. Deleting/evicting that newer url then
+    // removed the index entry entirely, even though the OLDER url's entry
+    // was still live in `this.cache` - so getByContentHash() returned null
+    // and the dedup benefit was lost. The fix stores a Set of urls per
+    // content hash (Map<contentHash, Set<url>>) so removing one url only
+    // drops it from the set, not the whole mapping.
+    name: "ImageCache #1213: content-hash dedup index survives deletion of one of two same-content urls",
+    category: "image-processor",
+    fn: async () => {
+      const originalEnv = process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+      try {
+        process.env.NEUROLINK_IMAGE_CACHE_ENABLED = "true";
+        resetImageCache();
+        const cache = getImageCache();
+
+        const content = Buffer.from("neurolink-1213-dedup-content");
+        const dataUri = "data:image/png;base64,AAAA";
+        const urlA = "https://example.com/dedup-a.png";
+        const urlB = "https://example.com/dedup-b.png";
+
+        // Same content cached under two different urls - set() must ADD
+        // urlB to the hash's url set rather than replacing urlA.
+        cache.set(urlA, dataUri, "image/png", content);
+        cache.set(urlB, dataUri, "image/png", content);
+
+        const entryA = cache.get(urlA);
+        if (!entryA) {
+          return false; // sanity: first url must be cached
+        }
+        const contentHash = entryA.contentHash;
+
+        const beforeDelete = cache.getByContentHash(contentHash);
+        if (!beforeDelete || beforeDelete.dataUri !== dataUri) {
+          return false;
+        }
+
+        // Delete the SECOND (newer) url. Pre-fix, set(urlB, ...) had
+        // repointed the single-url index to urlB, so deleting urlB wiped
+        // out the only mapping for this hash - getByContentHash() would
+        // return null even though urlA's entry is still live in the cache.
+        cache.delete(urlB);
+
+        const afterDelete = cache.getByContentHash(contentHash);
+        return (
+          afterDelete !== null &&
+          afterDelete.dataUri === dataUri &&
+          cache.get(urlA) !== null &&
+          cache.get(urlB) === null
+        );
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+        } else {
+          process.env.NEUROLINK_IMAGE_CACHE_ENABLED = originalEnv;
+        }
+        resetImageCache();
+      }
+    },
+  },
+  {
+    name: "ImageCache #1213: dedup index survives EVICTION of the indexed url, not just deletion",
+    category: "image-processor",
+    fn: async () => {
+      const originalEnv = process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+      try {
+        process.env.NEUROLINK_IMAGE_CACHE_ENABLED = "true";
+        // maxSize=2 so a third distinct-content entry forces an eviction.
+        const cache = new ImageCache({ maxSize: 2 });
+        const content = Buffer.from("neurolink-1213-evict-content");
+        const other = Buffer.from("neurolink-1213-other-content");
+        const dataUri = "data:image/png;base64,AAAA";
+        const urlA = "https://example.com/evict-a.png";
+        const urlB = "https://example.com/evict-b.png";
+        const urlC = "https://example.com/evict-c.png";
+
+        cache.set(urlA, dataUri, "image/png", content); // A (content)
+        cache.set(urlB, dataUri, "image/png", content); // B (dedup, same content)
+        // Reading A returns its entry AND bumps it to most-recently-used, so B
+        // becomes the least-recently-used and is what evictOldest() removes.
+        const entryA = cache.get(urlA);
+        if (!entryA) {
+          return false;
+        }
+        const contentHash = entryA.contentHash;
+
+        // A third, different-content image at maxSize=2 evicts the oldest (B).
+        // Pre-fix, the single-url index pointed at B (the newest same-content
+        // url), so evicting B dropped the only mapping for this hash and
+        // getByContentHash() returned null even though A's entry is still live.
+        cache.set(urlC, dataUri, "image/png", other);
+
+        const found = cache.getByContentHash(contentHash);
+        return (
+          found !== null &&
+          found.dataUri === dataUri &&
+          cache.get(urlA) !== null && // survivor still cached
+          cache.get(urlB) === null // B was evicted
+        );
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+        } else {
+          process.env.NEUROLINK_IMAGE_CACHE_ENABLED = originalEnv;
+        }
+        resetImageCache();
+      }
+    },
+  },
+  {
+    name: "ImageCache #1213: dedup copy at capacity re-creates the hash index (no orphaned set)",
+    category: "image-processor",
+    fn: async () => {
+      const originalEnv = process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+      try {
+        process.env.NEUROLINK_IMAGE_CACHE_ENABLED = "true";
+        // maxSize=1: caching the dedup copy under a second url must evict the
+        // first (emptying that hash's url set), yet the content must stay
+        // reachable. The fix re-fetches/re-creates the index entry after the
+        // eviction instead of adding to the now-orphaned set.
+        const cache = new ImageCache({ maxSize: 1 });
+        const content = Buffer.from("neurolink-1213-orphan-content");
+        const dataUri = "data:image/png;base64,BBBB";
+        const urlA = "https://example.com/orphan-a.png";
+        const urlB = "https://example.com/orphan-b.png";
+
+        cache.set(urlA, dataUri, "image/png", content); // A
+        cache.set(urlB, dataUri, "image/png", content); // B: dedup hit; evicts A (maxSize=1)
+
+        const entryB = cache.get(urlB);
+        if (!entryB) {
+          return false;
+        }
+        const found = cache.getByContentHash(entryB.contentHash);
+        return (
+          found !== null &&
+          found.dataUri === dataUri &&
+          cache.get(urlA) === null && // A evicted to make room
+          cache.get(urlB) !== null // B survives and stays indexed
+        );
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEUROLINK_IMAGE_CACHE_ENABLED;
+        } else {
+          process.env.NEUROLINK_IMAGE_CACHE_ENABLED = originalEnv;
+        }
+        resetImageCache();
       }
     },
   },


### PR DESCRIPTION
Closes #1213.

## Problem
`ImageCache.contentHashIndex` was `Map<contentHash, url>` — one url per content hash. When the same image content was cached under two URLs, `set()` repointed the index to the newest url, dropping the older mapping. If that newest url's entry was later evicted (`evictOldest`) or `delete()`d, the whole hash→url mapping was removed even though an older url's entry for the same content still lived in the cache — so `getByContentHash()` returned `null` and the dedup benefit was lost across eviction. Pre-existing; flagged during the #1211 post-merge audit.

## Fix
`contentHashIndex` is now `Map<contentHash, Set<url>>`:
- `set()` adds the new url to the hash's set (doesn't replace).
- `getByContentHash()` returns the first url in the set whose entry still lives (pruning gone urls; dropping the hash key only when the set empties).
- `delete()` / `evictOldest()` remove only that url from the set, deleting the hash key only when empty.

Single-url behavior is unchanged; only the multi-url-same-content path is now eviction-resilient.

## Validation
- New regression test `ImageCache #1213: content-hash dedup index survives deletion of one of two same-content urls` — caches the same content under two URLs, deletes the second, and asserts `getByContentHash` still resolves the first (returned `null` before the fix).
- Full bugfixes suite **229/229**, `tsc --strict` 0 errors, `lint` 0 errors, `build:cli` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image caching when multiple URLs reference identical image content.
  * Prevented valid cached images from becoming undiscoverable after deleting or evicting another URL.
  * Fixed cache consistency during capacity-based replacement and deduplication.
* **Tests**
  * Added coverage for shared-content caching, deletion, eviction, and replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->