### PR TITLE
fix(timeout): add missing litellm entry to DEFAULT_TIMEOUTS.providers

### DIFF
--- a/src/lib/utils/timeout.ts
+++ b/src/lib/utils/timeout.ts
@@ -102,6 +102,7 @@ export const DEFAULT_TIMEOUTS = {
     huggingface: "2m", // Open source models vary significantly
     ollama: "5m", // Local models need more time, especially large ones
     mistral: "45s", // Mistral AI moderate speed
+    litellm: "5m", // Self-hosted proxy over arbitrary backends, same variable-latency profile as ollama
   },
   tools: {
     default: "10s", // Default timeout for MCP tool execution


### PR DESCRIPTION
## Root cause

`DEFAULT_TIMEOUTS.providers` (`src/lib/utils/timeout.ts`) has an entry for
every AI provider **except `litellm`**:

```ts
providers: {
  openai: "30s",
  bedrock: "45s",
  vertex: "60s",
  anthropic: "60s",
  azure: "30s",
  "google-ai": "30s",
  huggingface: "2m",
  ollama: "5m",
  mistral: "45s",
  // litellm: missing
},
```

`getDefaultTimeout(provider, operation)` falls back to `DEFAULT_TIMEOUTS.global`
("30s") whenever `providers[provider]` is undefined. Since `LiteLLMProvider`
registers itself with `providerName = "litellm"`
(`src/lib/providers/litellm.ts:78`, `super("litellm" as AIProviderName, ...)`),
every litellm call that reaches this fallback (i.e. any internal turn that
doesn't carry an explicit per-call `options.timeout`) gets exactly 30000ms —
which is the literal string in every failure:

```
TimeoutError: litellm generate operation timed out after 30000
```

## Where this breaks in production

`juspay/clairvoyance`'s "Yama PR Review" CI job (`juspay/yama@v2.7.1`, which
locks `@juspay/neurolink@9.70.7` in its `pnpm-lock.yaml`) has been failing on
every PR since 2026-07-17 with this exact error, e.g.:

- https://github.com/juspay/clairvoyance/actions/runs/29599877585/job/87949143548
- https://github.com/juspay/clairvoyance/actions/runs/29732876602/job/88321309413

Real wall-clock response times logged alongside these failures (`responseTime`
in the error payload) ranged **55–203 seconds** — the LiteLLM proxy backend
(`private-large` model) is genuinely slower than 30s, it's just never being
told it's allowed to be. I confirmed this bug is **not** fixed in any released
version up to and including `v10.0.1` (published today) by diffing
`timeout.ts`, `Utilities.ts`, and `proxyFetch.ts` between `v9.70.7` and
`v10.0.1` — byte-for-byte identical in all three files.

## The fix

Add a `litellm` entry to `DEFAULT_TIMEOUTS.providers`, set to `"5m"` —
matching `ollama`'s existing convention for self-hosted/proxied backends with
variable latency, and comfortably exceeding the 203s worst case actually
observed in production (5m gives ~48% headroom over the worst logged
attempt).

This is deliberately the minimal, targeted fix: a missing table entry for a
supported provider. It does not touch retry logic, context-window scaling, or
option-forwarding.

## What this does NOT fix (follow-ups, not in scope here)

1. **`Utilities.getContextAwareTimeout()`** (`src/lib/core/modules/Utilities.ts`)
   scales the timeout up for large contexts (>100K tokens) but has **zero call
   sites** anywhere in the codebase — dead code. Worth wiring up or removing
   in a separate change.
2. **Internal agentic/tool-loop turns may not inherit the parent call's
   `options.timeout`.** Yama's "explore" step (a multi-turn MCP tool loop) and
   its outer `generateWithRetry` both explicitly pass `timeout: "15m"` /
   `"5m"` from `yama.config.yaml`, and I traced `options.timeout` being
   correctly threaded through `generate()` → `buildGenerateTextOptions()` →
   `generateTextInternal()` → `directProviderGeneration()` →
   `provider.generate({...options})`. Despite that, production failures show
   the flat 30000ms default on the very first attempt, not 900000 or 300000 —
   suggesting some internal turn within the agentic loop (`neurolink.ts`'s
   `performMCPGenerationRetries`/`attemptMCPGeneration` machinery) isn't
   inheriting the caller's timeout. I did not have time/access to fully trace
   this through the 14k-line `neurolink.ts`; flagging it here as a real,
   separate bug this PR does not claim to fix.
3. **Ops note:** independent of any client bug, 55–203s per attempt for a
   single LLM call is slow. Worth an ops look at the `private-large` LiteLLM
   backend's health/load, since this fix only raises the ceiling — it doesn't
   make the backend faster.

## Verification performed

- `npx prettier --check` (scoped + full repo) — pass
- `npx eslint src/lib/utils/timeout.ts` and full `eslint src/` (matches CI's
  `test` job, `--max-warnings=300`) — 0 errors, 42 pre-existing warnings, none
  in the touched file
- `npx tsc --noEmit --strict --project tsconfig.json` (matches CI's
  `quality-gate` job) — pass
- `pnpm run build` (full `prepack`: svelte-package, CLI build, browser bundle,
  `publint`) — pass; verified `dist/lib/utils/timeout.js` contains the new
  entry
- `pnpm exec vitest run` across the vitest-based unit suites
  (`toolRoutingCli`, `toolDedup`, `modelPool`, `toolRouting`,
  `systemMessages`, `toolRoutingSemantic`, `providers/dedupExecuteMap`) — 158
  passed. 2 tests timed out (`toolDedup` "getToolDedupConfig...", `modelPool`
  "falls back to member#2..."); confirmed both are **pre-existing flakiness**
  unrelated to this change by re-running against unmodified `release` HEAD,
  where `modelPool`'s test fails identically and `toolDedup`'s passes in
  isolation (timing-dependent, not this PR)
- No dedicated test file exists for `timeout.ts` / `DEFAULT_TIMEOUTS`, and the
  repo's vitest suites are scoped per-feature (tool-routing, model-pool,
  etc.) rather than generic-utils — skipped adding a new test rather than
  inventing test infra for this one table entry, per this PR's scope.

## Downstream chain to actually unblock clairvoyance's CI

This alone doesn't fix `juspay/clairvoyance`'s Yama check — that requires,
after this merges and releases:
1. This PR merges to `release` and `semantic-release` cuts a new
   `@juspay/neurolink` version.
2. `juspay/yama` bumps its `@juspay/neurolink` dependency to that version
   (its `pnpm-lock.yaml` currently pins `9.70.7`) and cuts a new tag.
3. `juspay/clairvoyance`'s `.github/workflows/yama-review.yml` bumps
   `uses: juspay/yama@v2.7.1` to the new tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default timeout support for the LiteLLM provider, allowing requests up to five minutes by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->