### PR TITLE
fix(providers): suppress response_format on chat-completions requests that carry tools

### DIFF
--- a/src/lib/providers/azureOpenai.ts
+++ b/src/lib/providers/azureOpenai.ts
@@ -184,6 +184,15 @@ export class AzureOpenAIProvider extends OpenAIChatCompletionsProvider {
   // Abstract-hook implementations
   // ===========================================================================
 
+  /**
+   * Azure OpenAI natively supports `response_format: json_schema` together
+   * with tool calling in one request, so structured output stays
+   * wire-enforced mid-loop instead of deferring to post-hoc coercion.
+   */
+  protected override suppressResponseFormatWithTools(): boolean {
+    return false;
+  }
+
   protected getProviderName(): AIProviderName {
     return "azure" as AIProviderName;
   }

--- a/src/lib/providers/openAI.ts
+++ b/src/lib/providers/openAI.ts
@@ -115,6 +115,15 @@ export class OpenAIProvider extends OpenAIChatCompletionsProvider {
   // Abstract hook implementations
   // ===========================================================================
 
+  /**
+   * OpenAI natively supports `response_format: json_schema` together with
+   * tool calling in one request, so structured output stays wire-enforced
+   * mid-loop instead of deferring to post-hoc coercion.
+   */
+  protected override suppressResponseFormatWithTools(): boolean {
+    return false;
+  }
+
   protected getProviderName(): AIProviderName {
     return AIProviderNameEnum.OPENAI;
   }

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -156,6 +156,24 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   }
 
   /**
+   * When true (default), `response_format` is NOT sent on requests that carry
+   * tools. The AI SDK sets responseFormat on EVERY step of a tool loop, and
+   * generic/proxy backends (LiteLLM→vllm/GLM, openai-compatible, local
+   * servers) may silently honor it over tool calling — answering with
+   * final-shape JSON on step 1 instead of running the agentic loop. No error
+   * is raised, so the runtime tools↔schema conflict detector cannot catch it.
+   * The schema is still enforced post-hoc (GenerationHandler coerces the final
+   * text against it) — the same contract as the Gemini tools↔schema exclusion.
+   * Mirrors the streaming path, which never sends response_format.
+   *
+   * Backends with first-party support for tools + json_schema in one request
+   * (OpenAI, Azure OpenAI) override this to false.
+   */
+  protected suppressResponseFormatWithTools(): boolean {
+    return true;
+  }
+
+  /**
    * Hook to adjust the fully-built wire request body before it is sent, on
    * both the streaming and non-streaming paths. Default identity. Override for
    * provider/model quirks that can't be expressed through buildBody options —
@@ -323,6 +341,8 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     const adjustResponseFormat = this.adjustResponseFormat.bind(this);
     const adjustRequestBody = this.adjustRequestBody.bind(this);
     const adjustBodyAfter400 = this.adjustBodyAfter400.bind(this);
+    const suppressResponseFormatWithTools =
+      this.suppressResponseFormatWithTools.bind(this);
     const getTimeoutForOptions = (
       opts: Record<string, unknown> | undefined,
     ): number => this.getTimeout((opts ?? {}) as never);
@@ -356,12 +376,16 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         const baseMessages = messageBuilderToOpenAI(
           options.prompt as OpenAICompatMessage[],
         );
-        const responseFormat = options.responseFormat
-          ? adjustResponseFormat(
-              v3ResponseFormatToOpenAI(options.responseFormat),
-              modelId,
-            )
-          : undefined;
+        const hasTools =
+          Array.isArray(options.tools) && options.tools.length > 0;
+        const responseFormat =
+          options.responseFormat &&
+          !(hasTools && suppressResponseFormatWithTools())
+            ? adjustResponseFormat(
+                v3ResponseFormatToOpenAI(options.responseFormat),
+                modelId,
+              )
+            : undefined;
         // ensureJsonWordInBody runs LAST — on the body after adjustRequestBody —
         // so the json_object word guard reflects whatever a subclass left on
         // the wire (it may rewrite response_format/messages), not an

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -127,6 +127,7 @@ import {
 } from "../src/lib/providers/googleNativeGemini3.js";
 
 import { OpenAICompatibleProvider } from "../src/lib/providers/openaiCompatible.js";
+import { OpenAIProvider } from "../src/lib/providers/openAI.js";
 import { LiteLLMProvider } from "../src/lib/providers/litellm.js";
 import { ModelAccessDeniedError } from "../src/lib/types/index.js";
 
@@ -3172,7 +3173,7 @@ exit 127
   //   P2.1 streaming analytics saw stale 0/0/0 usage
   //   P2.2 getAvailableModels stripped pathful base URLs
   {
-    name: "openai-compatible.doGenerate forwards maxTokens/temperature/tools/responseFormat to the wire body",
+    name: "openai-compatible.doGenerate forwards maxTokens/temperature/tools and SUPPRESSES response_format while tools are present",
     category: "openai-compatible",
     fn: async () => {
       const originalFetch = globalThis.fetch;
@@ -3245,9 +3246,133 @@ exit 127
           tools.length === 1 &&
           tools[0].function.name === "echo" &&
           capturedBody?.tool_choice === "auto" &&
+          // response_format must NOT ride alongside tools on generic backends:
+          // proxied models (LiteLLM→vllm/GLM) can silently honor it over tool
+          // calling, answering with final JSON on step 1 and killing the loop.
+          capturedBody?.response_format === undefined
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  },
+  {
+    name: "openai-compatible.doGenerate keeps response_format json_schema on single-shot calls WITHOUT tools",
+    category: "openai-compatible",
+    fn: async () => {
+      const originalFetch = globalThis.fetch;
+      let capturedBody: Record<string, unknown> | undefined;
+      try {
+        globalThis.fetch = (async (
+          _input: RequestInfo | URL,
+          init?: RequestInit,
+        ) => {
+          capturedBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return new Response(
+            JSON.stringify({
+              id: "chatcmpl-x",
+              model: "test-model",
+              choices: [
+                {
+                  index: 0,
+                  message: { role: "assistant", content: "{}" },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }) as typeof fetch;
+
+        const provider = new OpenAICompatibleProvider(
+          "test-model",
+          undefined,
+          undefined,
+          { apiKey: "k", baseURL: "http://fake.local/v1" },
+        );
+        const model = (await provider.getAISDKModel()) as unknown as {
+          doGenerate: (opts: Record<string, unknown>) => Promise<unknown>;
+        };
+        await model.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+          responseFormat: { type: "json", schema: { type: "object" } },
+        });
+
+        return (
           typeof capturedBody?.response_format === "object" &&
           (capturedBody.response_format as { type: string }).type ===
             "json_schema"
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  },
+  {
+    name: "openai.doGenerate keeps response_format alongside tools (first-party json_schema+tools support)",
+    category: "openai-compatible",
+    fn: async () => {
+      const originalFetch = globalThis.fetch;
+      let capturedBody: Record<string, unknown> | undefined;
+      try {
+        globalThis.fetch = (async (
+          _input: RequestInfo | URL,
+          init?: RequestInit,
+        ) => {
+          capturedBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return new Response(
+            JSON.stringify({
+              id: "chatcmpl-x",
+              model: "gpt-4o",
+              choices: [
+                {
+                  index: 0,
+                  message: { role: "assistant", content: "hi" },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }) as typeof fetch;
+
+        const provider = new OpenAIProvider("gpt-4o", undefined, undefined, {
+          apiKey: "k",
+        });
+        const model = (await provider.getAISDKModel()) as unknown as {
+          doGenerate: (opts: Record<string, unknown>) => Promise<unknown>;
+        };
+        await model.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+          tools: [
+            {
+              type: "function",
+              name: "echo",
+              description: "echo back",
+              inputSchema: {
+                type: "object",
+                properties: { msg: { type: "string" } },
+                required: ["msg"],
+              },
+            },
+          ],
+          toolChoice: { type: "auto" },
+          responseFormat: { type: "json", schema: { type: "object" } },
+        });
+
+        return (
+          typeof capturedBody?.response_format === "object" &&
+          (capturedBody.response_format as { type: string }).type ===
+            "json_schema" &&
+          Array.isArray(capturedBody?.tools)
         );
       } finally {
         globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Problem

When a caller passes `schema` to `generate()` with tools active on a chat-completions provider, the AI SDK sets `responseFormat` on EVERY step of the agent loop, and `openaiChatCompletionsBase.doGenerate` sends it as OpenAI `response_format: json_schema` alongside `tools`. Generic/proxy backends (LiteLLM→vllm/GLM, openai-compatible, local servers) may **silently obey** `response_format` over tool calling — the model emits final-shape JSON on step 1, never calls a tool, and the agentic loop dies after one step. No error is raised, so `isToolsSchemaConflictError` (the runtime detector that catches Groq-style rejections) never fires.

Real-world reproduction: juspay/yama#61 self-review on `litellm`/`glm-private` — the review "completed" in 6 seconds with a fabricated finding.

## Fix

New overridable hook `suppressResponseFormatWithTools()` (default `true`) on `OpenAIChatCompletionsProvider`, following the existing `adjustResponseFormat`/`adjustBodyAfter400` hook idiom: `doGenerate` omits `response_format` when the request carries tools. OpenAI and Azure OpenAI override to `false` (first-party `json_schema`+tools support).

- **Lossless**: the schema is still enforced post-hoc — `GenerationHandler.formatEnhancedResult` routes no-`experimental_output` results through `coerceTextMode`/`coerceJsonToSchema`, the same tested contract as the Gemini tools↔schema exclusion path.
- **Single-shot schema calls WITHOUT tools are unchanged** (wire-level `json_schema` preserved, including DeepSeek's `json_object` downgrade via `adjustResponseFormat`).
- **Aligns `doGenerate` with the streaming path**, which already never sends `response_format`.
- Per-step gating inside the AI SDK was ruled out on evidence: `responseFormat` reads a fixed closure every step and `PrepareStepResult` has no responseFormat field.

## Tests

- Flipped the existing wire-body assertion: with tools present, `response_format` must be absent (openai-compatible).
- New: single-shot without tools keeps `json_schema`.
- New: `OpenAIProvider` keeps `response_format` alongside tools via the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured JSON Schema responses when tool calling is enabled, ensuring request formatting works correctly for both OpenAI and Azure OpenAI in the same interaction.

* **Tests**
  * Added/expanded coverage to validate when `response_format` is included or omitted in outbound requests, including scenarios with and without tools, while preserving other request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->