### PR TITLE
fix(litellm): discover real model context windows from the proxy /model/info

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test:system-messages:vitest": "pnpm exec vitest run test/systemMessages.test.ts",
     "test:tool-routing-semantic:vitest": "pnpm exec vitest run test/toolRoutingSemantic.test.ts",
     "test:tool-routing-semantic": "pnpm run test:tool-routing-semantic:vitest && npx tsx test/continuous-test-suite-tool-routing-semantic.ts",
-    "test:unit": "pnpm run test:envguard && pnpm run test:bugfixes && pnpm run test:file-detector-extension && pnpm run test:mcp:infra && pnpm run test:mcp:bash && pnpm run test:mcp:limits && pnpm run test:mcp:spans && pnpm run test:autoresearch:redis && pnpm run test:unit:vitest && pnpm run test:tool-routing-cli:vitest && pnpm run test:tool-dedup:vitest && pnpm run test:model-pool:vitest && pnpm run test:system-messages:vitest && pnpm run test:tool-routing-semantic:vitest && pnpm run test:anthropic-tools-policy && pnpm run test:sagemaker-tools && pnpm run test:anthropic-multimodal && pnpm run test:excel-interop",
+    "test:unit": "pnpm run test:envguard && pnpm run test:bugfixes && pnpm run test:file-detector-extension && pnpm run test:mcp:infra && pnpm run test:mcp:bash && pnpm run test:mcp:limits && pnpm run test:mcp:spans && pnpm run test:autoresearch:redis && pnpm run test:unit:vitest && pnpm run test:tool-routing-cli:vitest && pnpm run test:tool-dedup:vitest && pnpm run test:model-pool:vitest && pnpm run test:litellm-context:vitest && pnpm run test:system-messages:vitest && pnpm run test:tool-routing-semantic:vitest && pnpm run test:anthropic-tools-policy && pnpm run test:sagemaker-tools && pnpm run test:anthropic-multimodal && pnpm run test:excel-interop",
     "// CI tier — live providers, runs only when API keys are present (test:credentials and test:dynamic make real provider calls when keys are set, so they live here, not in test:unit)": "",
     "test:live": "pnpm run test:providers && pnpm run test:mcp:http && pnpm run test:mcp:sdk && pnpm run test:mcp:cli && pnpm run test:observability && pnpm run test:context && pnpm run test:memory && pnpm run test:tool-reliability && pnpm run test:evaluation && pnpm run test:autoresearch && pnpm run test:credentials && pnpm run test:dynamic",
     "// CI tier — product output (image/video/TTS/PPT) — costs $$ per run": "",
@@ -208,7 +208,8 @@
     "quality:report": "pnpm run quality:metrics && echo 'Quality metrics saved to quality-metrics.json'",
     "pre-commit": "lint-staged",
     "pre-push": "pnpm run validate:commit && pnpm run validate:env && pnpm run validate && pnpm run test:ci",
-    "check:all": "pnpm run lint && pnpm run format --check && pnpm run validate && pnpm run validate:commit"
+    "check:all": "pnpm run lint && pnpm run format --check && pnpm run validate && pnpm run validate:commit",
+    "test:litellm-context:vitest": "pnpm exec vitest run test/litellmContextWindows.test.ts"
   },
   "files": [
     "dist",

--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -401,11 +401,49 @@ function normalizeProviderForLookup(provider: string): string {
 }
 
 /**
+ * Runtime-discovered context windows, keyed `${provider}:${model}`.
+ *
+ * Populated asynchronously by providers that can discover real per-model
+ * limits at runtime (e.g. the LiteLLM provider reads `max_input_tokens` from
+ * the proxy's `/model/info`), and read synchronously by
+ * {@link getContextWindowSize} — the same async-populate/sync-read contract as
+ * the DynamicModelProvider registry. Keys use the RAW provider string callers
+ * pass into budget calculations (see the alias-map comment above: normalized
+ * provider names never reach these lookups).
+ */
+const RUNTIME_CONTEXT_WINDOWS = new Map<string, number>();
+
+/**
+ * Register a runtime-discovered context window for a provider/model pair.
+ * Later registrations overwrite earlier ones (rediscovery refreshes values).
+ * Non-positive/non-finite windows are ignored so a malformed discovery source
+ * can never shrink a budget to zero.
+ */
+export function registerRuntimeContextWindow(
+  provider: string,
+  model: string,
+  contextWindow: number,
+): void {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return;
+  }
+  RUNTIME_CONTEXT_WINDOWS.set(`${provider}:${model}`, contextWindow);
+}
+
+/** Test hook: clear runtime-discovered windows (state is module-global). */
+export function clearRuntimeContextWindows(): void {
+  RUNTIME_CONTEXT_WINDOWS.clear();
+}
+
+/**
  * Resolve context window size for a provider/model combination.
  *
  * Priority:
  *  0. Dynamic model registry (DynamicModelProvider) — resolves cross-provider
  *     models (e.g. Claude on Vertex) that the static table cannot handle
+ *  0.5 Runtime-discovered windows (registerRuntimeContextWindow) — real
+ *      per-model limits fetched from the serving infrastructure (LiteLLM
+ *      `/model/info`)
  *  1. Exact model match under provider in static registry
  *  2. Prefix match under provider in static registry
  *  3. Provider's _default in static registry
@@ -428,6 +466,14 @@ export function getContextWindowSize(provider: string, model?: string): number {
       }
     } catch {
       // Dynamic registry not initialized yet — fall through to static lookup
+    }
+  }
+
+  // Step 0.5: Runtime-discovered window for this exact provider/model.
+  if (model) {
+    const discovered = RUNTIME_CONTEXT_WINDOWS.get(`${provider}:${model}`);
+    if (discovered !== undefined) {
+      return discovered;
     }
   }
 

--- a/src/lib/providers/litellm.ts
+++ b/src/lib/providers/litellm.ts
@@ -1,5 +1,6 @@
 import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { AIProviderName } from "../constants/enums.js";
+import { registerRuntimeContextWindow } from "../constants/contextWindows.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type {
   OpenAICompatBuildBodyArgs,
@@ -67,6 +68,12 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
   private static modelsCache: string[] = [];
   private static modelsCacheTime = 0;
   private static readonly MODELS_CACHE_DURATION = 10 * 60 * 1000; // 10 minutes
+  /**
+   * Dedupes the fire-and-forget `/model/info` discovery per base URL, so a
+   * process constructing many LiteLLM providers fetches each proxy's limits
+   * once per cache period.
+   */
+  private static modelInfoFetchTime = new Map<string, number>();
 
   constructor(
     modelName?: string,
@@ -79,6 +86,13 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
       baseURL: credentials?.baseURL ?? envConfig.baseURL,
       apiKey: credentials?.apiKey ?? envConfig.apiKey,
     });
+
+    // Fire-and-forget: discover real per-model context windows from the
+    // proxy's /model/info. The static table only has a one-size litellm
+    // `_default` (128K), while proxied models range from 8K to 2M — budget
+    // checks and compaction need the real window. Failures degrade cleanly
+    // to the static default.
+    this.discoverModelContextWindows();
 
     logger.debug("LiteLLM Provider initialized", {
       modelName: this.modelName,
@@ -297,6 +311,105 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
     }
 
     return this.getFallbackModels();
+  }
+
+  /**
+   * Discover real per-model context windows from the LiteLLM proxy's
+   * `GET /model/info` (`data[].model_info.max_input_tokens`) and register
+   * them with the context-window resolver. Fire-and-forget with the same
+   * cache period as the models list; any failure (endpoint absent, auth,
+   * timeout) is logged at debug and leaves the static `_default` in force.
+   */
+  private discoverModelContextWindows(): void {
+    const baseURL = stripTrailingSlash(this.config.baseURL);
+    const now = Date.now();
+    const lastFetch = LiteLLMProvider.modelInfoFetchTime.get(baseURL) ?? 0;
+    if (now - lastFetch < LiteLLMProvider.MODELS_CACHE_DURATION) {
+      return;
+    }
+    LiteLLMProvider.modelInfoFetchTime.set(baseURL, now);
+
+    void this.fetchModelInfoFromAPI()
+      .then((windows) => {
+        for (const [model, contextWindow] of windows) {
+          registerRuntimeContextWindow("litellm", model, contextWindow);
+        }
+        if (windows.size > 0) {
+          logger.debug(
+            "[LiteLLMProvider] Registered runtime context windows from /model/info",
+            { baseURL: redactUrlCredentials(baseURL), models: windows.size },
+          );
+        }
+      })
+      .catch((error) => {
+        // Allow a retry before the cache period when discovery failed.
+        LiteLLMProvider.modelInfoFetchTime.delete(baseURL);
+        logger.debug(
+          "[LiteLLMProvider] /model/info discovery failed; static context-window defaults remain in force",
+          { error: error instanceof Error ? error.message : String(error) },
+        );
+      });
+  }
+
+  /**
+   * Fetch `GET /model/info` and map model group name → max_input_tokens.
+   * Same fetch/auth/abort scaffolding as {@link fetchModelsFromAPI}.
+   */
+  private async fetchModelInfoFromAPI(): Promise<Map<string, number>> {
+    const infoUrl = `${stripTrailingSlash(this.config.baseURL)}/model/info`;
+    const proxyFetch = createProxyFetch();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await proxyFetch(infoUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const data = (await response.json()) as {
+        data?: Array<{
+          model_name?: string;
+          model_info?: { max_input_tokens?: number };
+        }>;
+      };
+      const windows = new Map<string, number>();
+      for (const entry of data.data ?? []) {
+        const model = entry?.model_name;
+        const maxInput = entry?.model_info?.max_input_tokens;
+        if (
+          typeof model === "string" &&
+          model.length > 0 &&
+          typeof maxInput === "number" &&
+          Number.isFinite(maxInput) &&
+          maxInput > 0
+        ) {
+          // A model group can appear once per underlying deployment; keep the
+          // smallest advertised window so budgets are safe for every replica.
+          const existing = windows.get(model);
+          windows.set(
+            model,
+            existing === undefined ? maxInput : Math.min(existing, maxInput),
+          );
+        }
+      }
+      return windows;
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new NetworkError(
+          "Request timed out after 5 seconds",
+          this.providerName,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   private async fetchModelsFromAPI(): Promise<string[]> {

--- a/test/litellmContextWindows.test.ts
+++ b/test/litellmContextWindows.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Vitest tests for LiteLLM runtime context-window discovery.
+ *
+ * Covers the runtime override registry in constants/contextWindows.ts and the
+ * LiteLLM provider's fire-and-forget `/model/info` discovery that populates it
+ * (real per-model `max_input_tokens` instead of the one-size litellm
+ * `_default`).
+ *
+ * Run:
+ *   pnpm exec vitest run test/litellmContextWindows.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getContextWindowSize,
+  getAvailableInputTokens,
+  registerRuntimeContextWindow,
+  clearRuntimeContextWindows,
+} from "../src/lib/constants/contextWindows.js";
+import { LiteLLMProvider } from "../src/lib/providers/litellm.js";
+
+/** Wait until the fire-and-forget discovery promise chain has settled. */
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const modelInfoResponse = (
+  entries: Array<{ model_name?: string; max_input_tokens?: unknown }>,
+) =>
+  new Response(
+    JSON.stringify({
+      data: entries.map((e) => ({
+        model_name: e.model_name,
+        model_info: { max_input_tokens: e.max_input_tokens },
+      })),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+
+describe("runtime context-window registry", () => {
+  beforeEach(() => clearRuntimeContextWindows());
+  afterEach(() => clearRuntimeContextWindows());
+
+  it("falls back to the static litellm _default when nothing is registered", () => {
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(128_000);
+  });
+
+  it("prefers a runtime-registered window over the static default", () => {
+    registerRuntimeContextWindow("litellm", "glm-private", 262_144);
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(262_144);
+    // Other models on the same provider still use the static default.
+    expect(getContextWindowSize("litellm", "other-model")).toBe(128_000);
+  });
+
+  it("feeds discovered windows into available-input budgeting", () => {
+    registerRuntimeContextWindow("litellm", "glm-private", 262_144);
+    const available = getAvailableInputTokens("litellm", "glm-private", 16_000);
+    expect(available).toBe(262_144 - 16_000);
+  });
+
+  it("ignores non-positive and non-finite windows", () => {
+    registerRuntimeContextWindow("litellm", "glm-private", 0);
+    registerRuntimeContextWindow("litellm", "glm-private", -5);
+    registerRuntimeContextWindow("litellm", "glm-private", Number.NaN);
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(128_000);
+  });
+
+  it("lets a later registration refresh an earlier one", () => {
+    registerRuntimeContextWindow("litellm", "glm-private", 100_000);
+    registerRuntimeContextWindow("litellm", "glm-private", 262_144);
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(262_144);
+  });
+});
+
+describe("LiteLLMProvider /model/info discovery", () => {
+  const originalFetch = globalThis.fetch;
+  let baseUrlCounter = 0;
+
+  // Each test uses a unique baseURL so the provider's per-URL fetch dedupe
+  // never suppresses a later test's discovery.
+  const uniqueBaseURL = () =>
+    `http://litellm-test-${++baseUrlCounter}.local:4000`;
+
+  beforeEach(() => clearRuntimeContextWindows());
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearRuntimeContextWindows();
+    vi.restoreAllMocks();
+  });
+
+  it("registers max_input_tokens per model group from /model/info", async () => {
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url.endsWith("/model/info")).toBe(true);
+      return modelInfoResponse([
+        { model_name: "glm-private", max_input_tokens: 262_144 },
+        { model_name: "private-large", max_input_tokens: 1_000_000 },
+      ]);
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    new LiteLLMProvider("glm-private", undefined, undefined, {
+      apiKey: "k",
+      baseURL: uniqueBaseURL(),
+    });
+    await flushAsync();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(262_144);
+    expect(getContextWindowSize("litellm", "private-large")).toBe(1_000_000);
+  });
+
+  it("keeps the SMALLEST advertised window when a model group has several deployments", async () => {
+    globalThis.fetch = (async () =>
+      modelInfoResponse([
+        { model_name: "glm-private", max_input_tokens: 262_144 },
+        { model_name: "glm-private", max_input_tokens: 131_072 },
+      ])) as typeof fetch;
+
+    new LiteLLMProvider("glm-private", undefined, undefined, {
+      apiKey: "k",
+      baseURL: uniqueBaseURL(),
+    });
+    await flushAsync();
+
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(131_072);
+  });
+
+  it("skips malformed entries and keeps valid ones", async () => {
+    globalThis.fetch = (async () =>
+      modelInfoResponse([
+        { model_name: "glm-private", max_input_tokens: 262_144 },
+        { model_name: "bad-model", max_input_tokens: "not-a-number" },
+        { model_name: "", max_input_tokens: 9000 },
+        { max_input_tokens: 9000 },
+      ])) as typeof fetch;
+
+    new LiteLLMProvider("glm-private", undefined, undefined, {
+      apiKey: "k",
+      baseURL: uniqueBaseURL(),
+    });
+    await flushAsync();
+
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(262_144);
+    expect(getContextWindowSize("litellm", "bad-model")).toBe(128_000);
+  });
+
+  it("degrades cleanly to the static default when /model/info fails", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 404 })) as typeof fetch;
+
+    new LiteLLMProvider("glm-private", undefined, undefined, {
+      apiKey: "k",
+      baseURL: uniqueBaseURL(),
+    });
+    await flushAsync();
+
+    expect(getContextWindowSize("litellm", "glm-private")).toBe(128_000);
+  });
+
+  it("dedupes discovery per base URL within the cache period", async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        modelInfoResponse([
+          { model_name: "glm-private", max_input_tokens: 262_144 },
+        ]) as Response,
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const baseURL = uniqueBaseURL();
+    new LiteLLMProvider("glm-private", undefined, undefined, {
+      apiKey: "k",
+      baseURL,
+    });
+    new LiteLLMProvider("private-large", undefined, undefined, {
+      apiKey: "k",
+      baseURL,
+    });
+    await flushAsync();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

`MODEL_CONTEXT_WINDOWS.litellm` is a single static `_default: 128_000`, but a LiteLLM proxy serves arbitrary models with real windows from 8K to 2M. Budget checks (`checkContextBudget`), compaction thresholds, and the new per-step loop guard all key off `getAvailableInputTokens()` — with a wrong window they either over-compact small models or let big conversations sail into provider 400s (`ContextWindowExceededError`, observed on juspay/yama#61 CI against `glm-private`, real window 262,144).

## Fix

Runtime window discovery, mirroring the existing async-populate/sync-read precedent (`DynamicModelProvider` Step 0 in `getContextWindowSize`):

- `contextWindows.ts`: a runtime override table + `registerRuntimeContextWindow(provider, model, window)`, consulted as Step 0.5 of the resolution chain (after the dynamic registry, before static lookup). Keyed on the raw provider string, matching how budget callers pass it. Invalid (non-positive/non-finite) registrations are ignored.
- `litellm.ts`: fire-and-forget `GET /model/info` on construction (same fetch/auth/5s-abort scaffolding and 10-minute cache period as the existing `/v1/models` fetch, deduped per base URL), registering `model_info.max_input_tokens` per model group. When a group has multiple deployments, the smallest advertised window wins so budgets are safe for every replica. Any failure (endpoint absent, auth, timeout) degrades cleanly to the static `_default`.

## Tests

`test/litellmContextWindows.test.ts` (10 tests, wired into `test:unit`): static fallback, runtime-override precedence, budgeting integration, invalid-value rejection, refresh semantics, `/model/info` parsing, min-window-per-group, malformed-entry tolerance, failure degradation, per-URL fetch dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-discovered, per-model context window limits for LiteLLM using `/model/info`.
  * Applies discovered limits with preference for exact provider/model matches.
  * When multiple deployments are available, uses the smallest advertised limit.
* **Bug Fixes**
  * Ignores invalid/non-finite context window values.
  * If discovery fails, automatically falls back to existing default context behavior and can retry later.
* **Tests**
  * Added a new Vitest suite covering discovery, registry behavior, malformed responses, and request deduplication.
  * Updated unit test chaining to include this new suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->