### PR TITLE
feat(context): per-step budget guard compacts the AI-SDK tool loop before overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test:system-messages:vitest": "pnpm exec vitest run test/systemMessages.test.ts",
     "test:tool-routing-semantic:vitest": "pnpm exec vitest run test/toolRoutingSemantic.test.ts",
     "test:tool-routing-semantic": "pnpm run test:tool-routing-semantic:vitest && npx tsx test/continuous-test-suite-tool-routing-semantic.ts",
-    "test:unit": "pnpm run test:envguard && pnpm run test:bugfixes && pnpm run test:file-detector-extension && pnpm run test:mcp:infra && pnpm run test:mcp:bash && pnpm run test:mcp:limits && pnpm run test:mcp:spans && pnpm run test:autoresearch:redis && pnpm run test:unit:vitest && pnpm run test:tool-routing-cli:vitest && pnpm run test:tool-dedup:vitest && pnpm run test:model-pool:vitest && pnpm run test:litellm-context:vitest && pnpm run test:system-messages:vitest && pnpm run test:tool-routing-semantic:vitest && pnpm run test:anthropic-tools-policy && pnpm run test:sagemaker-tools && pnpm run test:anthropic-multimodal && pnpm run test:excel-interop",
+    "test:unit": "pnpm run test:envguard && pnpm run test:bugfixes && pnpm run test:file-detector-extension && pnpm run test:mcp:infra && pnpm run test:mcp:bash && pnpm run test:mcp:limits && pnpm run test:mcp:spans && pnpm run test:autoresearch:redis && pnpm run test:unit:vitest && pnpm run test:tool-routing-cli:vitest && pnpm run test:tool-dedup:vitest && pnpm run test:model-pool:vitest && pnpm run test:litellm-context:vitest && pnpm run test:step-budget-guard:vitest && pnpm run test:system-messages:vitest && pnpm run test:tool-routing-semantic:vitest && pnpm run test:anthropic-tools-policy && pnpm run test:sagemaker-tools && pnpm run test:anthropic-multimodal && pnpm run test:excel-interop",
     "// CI tier — live providers, runs only when API keys are present (test:credentials and test:dynamic make real provider calls when keys are set, so they live here, not in test:unit)": "",
     "test:live": "pnpm run test:providers && pnpm run test:mcp:http && pnpm run test:mcp:sdk && pnpm run test:mcp:cli && pnpm run test:observability && pnpm run test:context && pnpm run test:memory && pnpm run test:tool-reliability && pnpm run test:evaluation && pnpm run test:autoresearch && pnpm run test:credentials && pnpm run test:dynamic",
     "// CI tier — product output (image/video/TTS/PPT) — costs $$ per run": "",
@@ -209,7 +209,8 @@
     "pre-commit": "lint-staged",
     "pre-push": "pnpm run validate:commit && pnpm run validate:env && pnpm run validate && pnpm run test:ci",
     "check:all": "pnpm run lint && pnpm run format --check && pnpm run validate && pnpm run validate:commit",
-    "test:litellm-context:vitest": "pnpm exec vitest run test/litellmContextWindows.test.ts"
+    "test:litellm-context:vitest": "pnpm exec vitest run test/litellmContextWindows.test.ts",
+    "test:step-budget-guard:vitest": "pnpm exec vitest run test/stepBudgetGuard.test.ts"
   },
   "files": [
     "dist",

--- a/src/lib/context/stepBudgetGuard.ts
+++ b/src/lib/context/stepBudgetGuard.ts
@@ -1,0 +1,366 @@
+/**
+ * Per-step context budget guard for the AI-SDK agent loop.
+ *
+ * Pre-call budgeting (`checkContextBudget` + compaction) runs ONCE before
+ * dispatch and only sees the input/session conversation. The AI-SDK tool loop
+ * then appends assistant turns and tool results on every step — growth the
+ * pre-call pipeline never sees, which is how long agentic runs overflow the
+ * model's real context window mid-loop (provider 400s after dozens of tool
+ * calls). The googleVertex native loops already guard this via
+ * `createContextGuard`; this module brings the AI-SDK path (every provider
+ * that delegates to `generateText`) to parity — and goes one step further:
+ * instead of stopping the loop, it deterministically reclaims budget so the
+ * loop can CONTINUE.
+ *
+ * Wired in `GenerationHandler.callGenerateText` through
+ * `experimental_prepareStep`, whose result may replace the step's `messages`.
+ * The guard operates on `ModelMessage[]` natively (no lossy ChatMessage
+ * round-trip) and never makes LLM calls:
+ *
+ *   Stage 1 — truncate OLD tool outputs to head/tail previews
+ *             (`generateToolOutputPreview`), oldest first, outside the
+ *             protected recent tail.
+ *   Stage 2 — drop the oldest complete tool exchanges (assistant tool-call
+ *             message + its following tool-result messages, as a unit, so
+ *             call/result pairing stays intact), replacing them with a single
+ *             elision note.
+ *
+ * The system prompt and tool definitions ride OUTSIDE the step messages (the
+ * handler hoists system into generateText's `system` option), so their cost is
+ * passed in as `fixedOverheadTokens`. The first user message (the task) and
+ * the most recent messages are never touched.
+ */
+
+import type { ModelMessage, StepBudgetGuardConfig } from "../types/index.js";
+import { DEFAULT_CONTEXT_GUARD_RATIO } from "../core/constants.js";
+import { getAvailableInputTokens } from "../constants/contextWindows.js";
+import {
+  estimateTokens,
+  TOKENS_PER_MESSAGE,
+} from "../utils/tokenEstimation.js";
+import { generateToolOutputPreview } from "./toolOutputLimits.js";
+import { logger } from "../utils/logger.js";
+
+/** Estimated tokens for a tool definition that fails to serialize. */
+const TOKENS_PER_TOOL_DEFINITION = 200;
+
+/** Messages at the end of the conversation the guard never modifies. */
+const PROTECTED_TAIL_MESSAGES = 4;
+
+/** Stage-1 preview budget for an old tool output (bytes). */
+const OLD_TOOL_OUTPUT_PREVIEW_BYTES = 2_048;
+
+/** Stage-1 preview budget for an old tool output (lines). */
+const OLD_TOOL_OUTPUT_PREVIEW_LINES = 60;
+
+/**
+ * Serialize any ModelMessage content to text for estimation. Tool-call args
+ * and tool-result outputs are JSON-stringified; unserializable values fall
+ * back to a fixed-size placeholder so estimation never throws.
+ */
+function contentToText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  try {
+    return JSON.stringify(content) ?? "";
+  } catch {
+    return "x".repeat(TOKENS_PER_TOOL_DEFINITION * 4);
+  }
+}
+
+/** Estimate the token cost of a step's message array. */
+export function estimateStepMessagesTokens(
+  messages: readonly ModelMessage[],
+  provider?: string,
+): number {
+  let total = 0;
+  for (const message of messages) {
+    total +=
+      estimateTokens(contentToText(message.content), provider) +
+      TOKENS_PER_MESSAGE;
+  }
+  return total;
+}
+
+/**
+ * Estimate the fixed per-request overhead: hoisted system prompt + tool
+ * definitions. Mirrors `checkContextBudget`'s categories for the pieces that
+ * do not live in the step messages.
+ */
+export function estimateFixedOverheadTokens(
+  system: unknown,
+  tools: Record<string, unknown> | undefined,
+  provider?: string,
+): number {
+  let total = system
+    ? estimateTokens(contentToText(system), provider) + TOKENS_PER_MESSAGE
+    : 0;
+  for (const tool of Object.values(tools ?? {})) {
+    try {
+      total += estimateTokens(JSON.stringify(tool) ?? "", provider);
+    } catch {
+      total += TOKENS_PER_TOOL_DEFINITION;
+    }
+  }
+  return total;
+}
+
+/**
+ * Serialize a ToolResultOutput to the text the MODEL should see in a preview.
+ * Variant-aware: `text`/`error-text` carry their payload in `.value` directly —
+ * stringifying the wrapper would put escaped `{"type":"text","value":…}` JSON
+ * in front of the model instead of the actual output. `json`/`error-json`/
+ * `content` serialize their value; unknown shapes fall back to the wrapper.
+ */
+function toolResultOutputToText(output: unknown): string {
+  const variant = output as { type?: string; value?: unknown } | undefined;
+  if (variant && typeof variant === "object" && "type" in variant) {
+    if (
+      (variant.type === "text" || variant.type === "error-text") &&
+      typeof variant.value === "string"
+    ) {
+      return variant.value;
+    }
+    if (
+      variant.type === "json" ||
+      variant.type === "error-json" ||
+      variant.type === "content"
+    ) {
+      return contentToText(variant.value);
+    }
+  }
+  return contentToText(output);
+}
+
+/** True when the message is an assistant message that issues tool calls. */
+function isToolCallAssistantMessage(message: ModelMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    Array.isArray(message.content) &&
+    message.content.some(
+      (part) => (part as { type?: string })?.type === "tool-call",
+    )
+  );
+}
+
+/**
+ * Stage 1: replace large tool-result outputs outside the protected tail with
+ * head/tail previews. Returns the new array plus how many outputs shrank.
+ */
+function truncateOldToolOutputs(messages: ModelMessage[]): {
+  messages: ModelMessage[];
+  truncated: number;
+} {
+  const cutoff = Math.max(0, messages.length - PROTECTED_TAIL_MESSAGES);
+  let truncated = 0;
+
+  const next = messages.map((message, index) => {
+    if (index >= cutoff || message.role !== "tool") {
+      return message;
+    }
+    if (!Array.isArray(message.content)) {
+      return message;
+    }
+    let changed = false;
+    const content = message.content.map((part) => {
+      const resultPart = part as {
+        type?: string;
+        toolCallId?: string;
+        toolName?: string;
+        output?: unknown;
+      };
+      if (resultPart?.type !== "tool-result") {
+        return part;
+      }
+      const serialized = toolResultOutputToText(resultPart.output);
+      if (serialized.length <= OLD_TOOL_OUTPUT_PREVIEW_BYTES) {
+        return part;
+      }
+      const { preview } = generateToolOutputPreview(serialized, {
+        maxBytes: OLD_TOOL_OUTPUT_PREVIEW_BYTES,
+        maxLines: OLD_TOOL_OUTPUT_PREVIEW_LINES,
+      });
+      changed = true;
+      truncated += 1;
+      return {
+        ...resultPart,
+        output: { type: "text", value: preview },
+      };
+    });
+    return changed ? ({ ...message, content } as ModelMessage) : message;
+  });
+
+  return { messages: next, truncated };
+}
+
+/**
+ * Stage 2: drop the oldest complete tool exchanges — an assistant tool-call
+ * message together with ALL directly-following `tool` messages — until the
+ * estimate fits or only the protected head/tail remains. The first
+ * non-assistant message run (the task) is never dropped. A single elision
+ * note replaces everything removed so the model knows history was elided.
+ */
+function dropOldestToolExchanges(
+  messages: ModelMessage[],
+  budgetTokens: number,
+  fixedOverheadTokens: number,
+  provider?: string,
+): { messages: ModelMessage[]; droppedExchanges: number } {
+  const result = [...messages];
+  let droppedExchanges = 0;
+
+  // Running-total accounting: estimate each message ONCE, keep the estimates
+  // array in lockstep with `result`, and subtract dropped blocks — instead of
+  // re-estimating the whole array on every iteration (O(n²) with many drops).
+  const estimates = result.map(
+    (message) =>
+      estimateTokens(contentToText(message.content), provider) +
+      TOKENS_PER_MESSAGE,
+  );
+  let currentTokens =
+    fixedOverheadTokens + estimates.reduce((sum, tokens) => sum + tokens, 0);
+
+  while (currentTokens > budgetTokens) {
+    // Find the FIRST (oldest) droppable exchange outside the protected tail.
+    const tailStart = Math.max(0, result.length - PROTECTED_TAIL_MESSAGES);
+    let exchangeStart = -1;
+    for (let i = 0; i < tailStart; i++) {
+      if (isToolCallAssistantMessage(result[i])) {
+        exchangeStart = i;
+        break;
+      }
+    }
+    if (exchangeStart === -1) {
+      break; // nothing left the guard is allowed to drop
+    }
+    let exchangeEnd = exchangeStart + 1;
+    while (exchangeEnd < result.length && result[exchangeEnd].role === "tool") {
+      exchangeEnd++;
+    }
+    if (exchangeEnd > tailStart) {
+      // The oldest remaining exchange bleeds into the protected tail. Because
+      // the scan is oldest-first, every exchange after this one STARTS inside
+      // the tail (this one's result chain reaches it), and every exchange
+      // before it was already dropped by earlier iterations — so there is
+      // nothing else the guard may remove. Stop.
+      break;
+    }
+    const dropped = estimates
+      .slice(exchangeStart, exchangeEnd)
+      .reduce((sum, tokens) => sum + tokens, 0);
+    result.splice(exchangeStart, exchangeEnd - exchangeStart);
+    estimates.splice(exchangeStart, exchangeEnd - exchangeStart);
+    currentTokens -= dropped;
+    droppedExchanges++;
+  }
+
+  if (droppedExchanges > 0) {
+    // Insert one elision note where history was removed: after the leading
+    // non-exchange messages (typically the first user/task message), but
+    // never after the protected tail — when every droppable exchange was
+    // removed, an uncapped scan would append the note at the END, where the
+    // "history was removed" cue lands after the content it refers to.
+    let noteIndex = 0;
+    while (
+      noteIndex < result.length &&
+      !isToolCallAssistantMessage(result[noteIndex])
+    ) {
+      noteIndex++;
+    }
+    const tailBoundary = Math.max(0, result.length - PROTECTED_TAIL_MESSAGES);
+    result.splice(Math.min(noteIndex, tailBoundary), 0, {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: `[context truncated: ${droppedExchanges} earlier tool exchange(s) were removed to fit the model's context window. Continue from the remaining context.]`,
+        },
+      ],
+    } as ModelMessage);
+  }
+
+  return { messages: result, droppedExchanges };
+}
+
+/**
+ * Create a per-step budget guard. Returns a function that, given the step's
+ * messages, returns a compacted replacement array when the projected request
+ * exceeds the threshold — or `undefined` when no change is needed.
+ */
+export function createStepBudgetGuard(config: StepBudgetGuardConfig) {
+  const {
+    provider,
+    model,
+    maxTokens,
+    fixedOverheadTokens = 0,
+    getFixedOverheadTokens,
+    thresholdRatio = DEFAULT_CONTEXT_GUARD_RATIO,
+  } = config;
+
+  const availableInput = getAvailableInputTokens(provider, model, maxTokens);
+  const thresholdTokens = Math.floor(availableInput * thresholdRatio);
+
+  return function guardStepMessages(
+    messages: readonly ModelMessage[],
+  ): ModelMessage[] | undefined {
+    // Resolve overhead per invocation: the tool set can GROW mid-loop
+    // (search_tools hydration adds discovered tools between steps), so a
+    // once-captured value would undercount later steps.
+    const overheadTokens = getFixedOverheadTokens?.() ?? fixedOverheadTokens;
+    const estimate =
+      overheadTokens + estimateStepMessagesTokens(messages, provider);
+    // Logger Guard: per-step diagnostics for debugging why a long run does
+    // (or does not) trigger compaction — gated so nothing is serialized when
+    // debug logging is off.
+    if (logger.shouldLog("debug")) {
+      logger.debug("[StepBudgetGuard] step estimate", {
+        provider,
+        model,
+        messageCount: messages.length,
+        estimatedTokens: estimate,
+        thresholdTokens,
+        willCompact: estimate > thresholdTokens,
+      });
+    }
+    if (estimate <= thresholdTokens) {
+      return undefined;
+    }
+
+    // Stage 1: shrink old tool outputs to previews.
+    const stage1 = truncateOldToolOutputs([...messages]);
+    let compacted = stage1.messages;
+    let newEstimate =
+      overheadTokens + estimateStepMessagesTokens(compacted, provider);
+
+    // Stage 2: drop oldest complete tool exchanges if still over.
+    let droppedExchanges = 0;
+    if (newEstimate > thresholdTokens) {
+      const stage2 = dropOldestToolExchanges(
+        compacted,
+        thresholdTokens,
+        overheadTokens,
+        provider,
+      );
+      compacted = stage2.messages;
+      droppedExchanges = stage2.droppedExchanges;
+      newEstimate =
+        overheadTokens + estimateStepMessagesTokens(compacted, provider);
+    }
+
+    if (stage1.truncated === 0 && droppedExchanges === 0) {
+      return undefined; // nothing actionable (already all-protected)
+    }
+
+    logger.info("[StepBudgetGuard] Compacted agent-loop step messages", {
+      provider,
+      model,
+      estimatedTokens: estimate,
+      thresholdTokens,
+      afterTokens: newEstimate,
+      toolOutputsTruncated: stage1.truncated,
+      exchangesDropped: droppedExchanges,
+    });
+    return compacted;
+  };
+}

--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -40,6 +40,10 @@ import {
 } from "../../utils/tokenUtils.js";
 import { DEFAULT_MAX_STEPS } from "../constants.js";
 import {
+  createStepBudgetGuard,
+  estimateFixedOverheadTokens,
+} from "../../context/stepBudgetGuard.js";
+import {
   isTemperatureDeprecatedError,
   isSchemaComplexityError,
   isToolsSchemaConflictError,
@@ -187,6 +191,43 @@ export class GenerationHandler {
     // rejected in v7). See extractSystemMessages for the rationale. (#1024)
     const { system, messages: nonSystemMessages } =
       extractSystemMessages(messages);
+
+    // Per-step context budget guard: the tool loop appends assistant turns and
+    // tool results on every step — growth the pre-call budget check never
+    // sees. Estimate each step's projected request and deterministically
+    // reclaim budget (truncate old tool outputs, then drop oldest exchanges)
+    // so long agentic runs cannot overflow the model's window mid-loop.
+    // Parity with the googleVertex native loops' createContextGuard, upgraded
+    // from stop-only to compact-and-continue. The caller's prepareStep result
+    // wins on conflicts; the guard only contributes `messages`.
+    //
+    // Overhead is resolved PER STEP because `toolsWithCache` is deliberately
+    // mutable (search_tools hydration adds discovered tools mid-loop) — a
+    // once-captured estimate would undercount later steps. Tools are only
+    // ever added, so memoizing on tool count keeps the common step O(1).
+    let cachedOverhead = { toolCount: -1, tokens: 0 };
+    const stepBudgetGuard = createStepBudgetGuard({
+      provider: this.providerName ?? "unknown",
+      model: this.modelName,
+      maxTokens: options.maxTokens,
+      getFixedOverheadTokens: () => {
+        const toolCount = shouldUseTools
+          ? Object.keys(toolsWithCache).length
+          : 0;
+        if (toolCount !== cachedOverhead.toolCount) {
+          cachedOverhead = {
+            toolCount,
+            tokens: estimateFixedOverheadTokens(
+              system,
+              shouldUseTools ? toolsWithCache : undefined,
+              this.providerName,
+            ),
+          };
+        }
+        return cachedOverhead.tokens;
+      },
+    });
+
     return await generateText({
       model,
       ...(system && { system }),
@@ -196,13 +237,32 @@ export class GenerationHandler {
       stopWhen: stepCountIs(options.maxSteps ?? DEFAULT_MAX_STEPS),
       ...(shouldUseTools &&
         options.toolChoice && { toolChoice: options.toolChoice }),
-      ...(prepareStep && {
-        experimental_prepareStep: ((stepOptions) =>
-          prepareStep({
-            ...stepOptions,
-            maxSteps: options.maxSteps ?? DEFAULT_MAX_STEPS,
-          })) satisfies PrepareStepFunction,
-      }),
+      experimental_prepareStep: (async (stepOptions) => {
+        // Public contract preserved: a caller-supplied prepareStep receives
+        // the ORIGINAL AI-SDK step options, exactly as before the guard
+        // existed — callers that inspect message history see the real thing.
+        const callerResult = prepareStep
+          ? await prepareStep({
+              ...stepOptions,
+              maxSteps: options.maxSteps ?? DEFAULT_MAX_STEPS,
+            })
+          : undefined;
+        // The guard runs LAST, on the messages that will actually be sent:
+        // the caller's override when one was returned (out-of-contract for
+        // NeuroLink's public prepareStep type, but possible at runtime), else
+        // the step's own messages. It never replaces a caller's content
+        // choices — it only reclaims budget from whatever was chosen.
+        const callerMessages = (
+          callerResult as { messages?: ModelMessage[] } | undefined
+        )?.messages;
+        const compacted = stepBudgetGuard(
+          callerMessages ?? stepOptions.messages,
+        );
+        if (!compacted) {
+          return callerResult;
+        }
+        return { ...(callerResult ?? {}), messages: compacted };
+      }) satisfies PrepareStepFunction,
       temperature: options.temperature,
       maxOutputTokens: options.maxTokens,
       maxRetries: 0, // NL11: Disable AI SDK's invisible internal retries; we handle retries with OTel instrumentation

--- a/src/lib/types/context.ts
+++ b/src/lib/types/context.ts
@@ -657,6 +657,29 @@ export type BudgetCheckResult = {
   };
 };
 
+/**
+ * Configuration for the per-step context budget guard that compacts the
+ * AI-SDK tool loop's messages before they overflow the model window
+ * (context/stepBudgetGuard.ts).
+ */
+export type StepBudgetGuardConfig = {
+  provider: string;
+  model?: string;
+  /** The caller's requested output budget (reserved out of the window). */
+  maxTokens?: number;
+  /** Static token cost of the hoisted system prompt + tool definitions. */
+  fixedOverheadTokens?: number;
+  /**
+   * Dynamic overhead resolver, re-evaluated on EVERY guard invocation. Takes
+   * precedence over `fixedOverheadTokens`. Use when the tool set can grow
+   * mid-loop (search_tools hydration) so newly added definitions count toward
+   * the budget.
+   */
+  getFixedOverheadTokens?: () => number;
+  /** Override the trigger ratio; defaults to DEFAULT_CONTEXT_GUARD_RATIO. */
+  thresholdRatio?: number;
+};
+
 /** Parameters for budget checking. */
 export type BudgetCheckParams = {
   provider: string;

--- a/test/stepBudgetGuard.test.ts
+++ b/test/stepBudgetGuard.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Vitest tests for the per-step context budget guard (AI-SDK tool loop).
+ *
+ * The guard is the compact-and-continue counterpart of the googleVertex
+ * native loops' createContextGuard: given a step's ModelMessage[] it must
+ * (1) no-op under threshold, (2) truncate OLD tool outputs to previews,
+ * (3) drop oldest complete tool exchanges while preserving the task message,
+ * call/result pairing, and the protected tail, and (4) never make the
+ * conversation structurally invalid.
+ *
+ * Run:
+ *   pnpm exec vitest run test/stepBudgetGuard.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import {
+  createStepBudgetGuard,
+  estimateStepMessagesTokens,
+  estimateFixedOverheadTokens,
+} from "../src/lib/context/stepBudgetGuard.js";
+
+const user = (text: string): ModelMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+const assistantToolCall = (id: string): ModelMessage =>
+  ({
+    role: "assistant",
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: id,
+        toolName: "search",
+        input: { q: id },
+      },
+    ],
+  }) as ModelMessage;
+
+const toolResult = (id: string, payload: string): ModelMessage =>
+  ({
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: id,
+        toolName: "search",
+        output: { type: "text", value: payload },
+      },
+    ],
+  }) as ModelMessage;
+
+const assistantText = (text: string): ModelMessage => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+});
+
+/** A conversation: task + N tool exchanges with `payloadBytes` outputs each. */
+const conversation = (exchanges: number, payloadBytes: number) => {
+  const messages: ModelMessage[] = [user("Review this pull request.")];
+  for (let i = 0; i < exchanges; i++) {
+    messages.push(assistantToolCall(`call-${i}`));
+    messages.push(toolResult(`call-${i}`, "x".repeat(payloadBytes)));
+  }
+  return messages;
+};
+
+describe("estimateStepMessagesTokens", () => {
+  it("scales with content size and never throws on tool parts", () => {
+    const small = estimateStepMessagesTokens(conversation(1, 100));
+    const large = estimateStepMessagesTokens(conversation(1, 100_000));
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+describe("estimateFixedOverheadTokens", () => {
+  it("counts system prompt and tool definitions", () => {
+    const none = estimateFixedOverheadTokens(undefined, undefined);
+    const withSystem = estimateFixedOverheadTokens("You are a reviewer.", {
+      search: { description: "search the code", inputSchema: {} },
+    });
+    expect(none).toBe(0);
+    expect(withSystem).toBeGreaterThan(0);
+  });
+});
+
+describe("createStepBudgetGuard", () => {
+  it("no-ops (returns undefined) when the step fits the budget", () => {
+    // litellm static default window = 128K — a tiny conversation fits.
+    const guard = createStepBudgetGuard({
+      provider: "litellm",
+      model: "glm-private",
+      maxTokens: 4_000,
+    });
+    expect(guard(conversation(2, 200))).toBeUndefined();
+  });
+
+  it("truncates OLD tool outputs to previews and leaves the protected tail intact", () => {
+    const guard = createStepBudgetGuard({
+      provider: "litellm",
+      model: "glm-private",
+      maxTokens: 4_000,
+    });
+    // 10 exchanges × ~80KB outputs ≈ far beyond the ~105K available input.
+    const messages = conversation(10, 80_000);
+    const compacted = guard(messages);
+
+    expect(compacted).toBeDefined();
+    const result = compacted!;
+
+    // The task message survives as the first message.
+    expect(result[0]).toEqual(messages[0]);
+
+    // The final tool result (protected tail) is untouched.
+    const lastTool = result[result.length - 1] as {
+      content: Array<{ output: { value: string } }>;
+    };
+    expect(lastTool.content[0].output.value.length).toBe(80_000);
+
+    // Compaction actually reduced the projected request.
+    expect(estimateStepMessagesTokens(result)).toBeLessThan(
+      estimateStepMessagesTokens(messages),
+    );
+  });
+
+  it("drops oldest complete exchanges (call+result together) when previews aren't enough, with an elision note", () => {
+    // Tiny window forces stage 2: lm-studio static default is 8K.
+    const guard = createStepBudgetGuard({
+      provider: "lm-studio",
+      model: "local-model",
+      maxTokens: 1_000,
+    });
+    const messages = conversation(12, 4_000);
+    const compacted = guard(messages);
+
+    expect(compacted).toBeDefined();
+    const result = compacted!;
+
+    // Task message survives.
+    expect(result[0]).toEqual(messages[0]);
+
+    // An elision note tells the model history was removed.
+    const noteMessage = result.find(
+      (m) =>
+        m.role === "user" &&
+        Array.isArray(m.content) &&
+        JSON.stringify(m.content).includes("context truncated"),
+    );
+    expect(noteMessage).toBeDefined();
+
+    // Pairing integrity: every remaining tool message's toolCallId has a
+    // preceding assistant tool-call with the same id.
+    const callIds = new Set<string>();
+    for (const message of result) {
+      if (!Array.isArray(message.content)) {
+        continue;
+      }
+      for (const part of message.content as Array<{
+        type?: string;
+        toolCallId?: string;
+      }>) {
+        if (part.type === "tool-call" && part.toolCallId) {
+          callIds.add(part.toolCallId);
+        }
+        if (part.type === "tool-result" && part.toolCallId) {
+          expect(callIds.has(part.toolCallId)).toBe(true);
+        }
+      }
+    }
+
+    // It got materially smaller.
+    expect(result.length).toBeLessThan(messages.length);
+  });
+
+  it("previews the tool output VALUE for text results, not the wrapper JSON", () => {
+    const guard = createStepBudgetGuard({
+      provider: "litellm",
+      model: "glm-private",
+      maxTokens: 4_000,
+    });
+    const marker = "REAL_PAYLOAD_HEAD ";
+    // Sizing: 'old' dominates the estimate (~100K+ tokens on the 128K litellm
+    // default → over the ~105K threshold), so stage-1 truncation of 'old'
+    // alone resolves the overage and stage 2 never drops the exchange we
+    // assert on. The later exchanges keep 'old' outside the protected tail.
+    const messages: ModelMessage[] = [
+      user("Task"),
+      assistantToolCall("old"),
+      toolResult("old", marker + "y".repeat(400_000)),
+      assistantToolCall("mid"),
+      toolResult("mid", "z".repeat(60_000)),
+      assistantToolCall("new"),
+      toolResult("new", "w".repeat(60_000)),
+    ];
+    const compacted = guard(messages)!;
+    expect(compacted).toBeDefined();
+
+    const oldResult = compacted.find(
+      (m) =>
+        m.role === "tool" &&
+        Array.isArray(m.content) &&
+        (m.content[0] as { toolCallId?: string }).toolCallId === "old",
+    ) as { content: Array<{ output: { value: string } }> };
+    const previewText = oldResult.content[0].output.value;
+    // The preview must contain the actual payload, not the escaped
+    // {"type":"text","value":... wrapper serialization.
+    expect(previewText).toContain(marker);
+    expect(previewText).not.toContain('{"type":"text"');
+  });
+
+  it("re-resolves overhead per invocation via getFixedOverheadTokens (mid-loop tool growth)", () => {
+    let overhead = 0;
+    const guard = createStepBudgetGuard({
+      provider: "litellm",
+      model: "glm-private",
+      maxTokens: 4_000,
+      getFixedOverheadTokens: () => overhead,
+    });
+    const messages = conversation(6, 10_000);
+
+    // First step: small tool set — fits.
+    expect(guard(messages)).toBeUndefined();
+    // Mid-loop hydration added many tool definitions — same messages must now
+    // trigger compaction because the dynamic overhead is re-read.
+    overhead = 1_000_000;
+    expect(guard(messages)).toBeDefined();
+  });
+
+  it("includes fixedOverheadTokens (system + tools) in the trigger decision", () => {
+    const base = {
+      provider: "litellm",
+      model: "glm-private",
+      maxTokens: 4_000,
+    };
+    const messages = conversation(6, 10_000);
+
+    const withoutOverhead = createStepBudgetGuard(base)(messages);
+    const withHugeOverhead = createStepBudgetGuard({
+      ...base,
+      fixedOverheadTokens: 1_000_000,
+    })(messages);
+
+    // Same messages: overhead alone pushes the step over the threshold.
+    expect(withoutOverhead).toBeUndefined();
+    expect(withHugeOverhead).toBeDefined();
+  });
+
+  it("places the elision note BEFORE the protected tail even when every droppable exchange is removed", () => {
+    const guard = createStepBudgetGuard({
+      provider: "lm-studio",
+      model: "local-model",
+      maxTokens: 1_000,
+    });
+    // Payloads so large that stage 2 must drop every droppable exchange.
+    const messages = conversation(10, 60_000);
+    const compacted = guard(messages);
+
+    expect(compacted).toBeDefined();
+    const result = compacted!;
+    const noteIndex = result.findIndex(
+      (m) =>
+        m.role === "user" &&
+        Array.isArray(m.content) &&
+        JSON.stringify(m.content).includes("context truncated"),
+    );
+    expect(noteIndex).toBeGreaterThanOrEqual(0);
+    // The note must precede the retained context it refers to — never sit at
+    // the very end after the protected tail.
+    expect(noteIndex).toBeLessThan(result.length - 1);
+  });
+
+  it("never drops a trailing exchange that bleeds into the protected tail", () => {
+    const guard = createStepBudgetGuard({
+      provider: "lm-studio",
+      model: "local-model",
+      maxTokens: 1_000,
+    });
+    // One giant exchange inside the protected tail only: guard may truncate
+    // nothing structural — plain assistant/user tail stays untouched.
+    const messages: ModelMessage[] = [
+      user("Task"),
+      assistantText("thinking"),
+      assistantToolCall("only"),
+      toolResult("only", "x".repeat(50_000)),
+    ];
+    const compacted = guard(messages);
+    // The last exchange is within the 4-message protected tail — the guard
+    // must not mutate it, so either nothing changes or nothing structural does.
+    if (compacted) {
+      expect(compacted.length).toBe(messages.length);
+      const lastTool = compacted[compacted.length - 1] as {
+        content: Array<{ output: { value: string } }>;
+      };
+      expect(lastTool.content[0].output.value.length).toBe(50_000);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Pre-call budgeting (`checkContextBudget` + compaction in `neurolink.ts`) runs ONCE before dispatch and only sees the input/session conversation. The AI-SDK agent loop (`GenerationHandler.callGenerateText`, up to `DEFAULT_MAX_STEPS=200` steps) then appends assistant turns and tool results on every step — growth the pre-call pipeline never sees. Long agentic runs overflow the model's real window mid-loop: juspay/yama#61 CI accumulated ~246K input tokens against a 262K window (and double NeuroLink's own 128K litellm default) before the backend 400'd with `ContextWindowExceededError`.

The googleVertex native loops already guard this (`createContextGuard`, checked every iteration, `DEFAULT_CONTEXT_GUARD_RATIO` 0.85) — but as stop-only. The AI-SDK path, anthropic/bedrock native loops, and the chat-completions stream loop have nothing.

## Fix

`context/stepBudgetGuard.ts` + wiring in `callGenerateText` via `experimental_prepareStep` (whose result may replace the step's `messages` — the sanctioned AI-SDK hook). Every step:

1. Estimate the projected request (step messages + hoisted system prompt + tool definitions) against `getAvailableInputTokens() × DEFAULT_CONTEXT_GUARD_RATIO` — same ratio as the Vertex guard.
2. Over threshold → deterministically reclaim budget and **continue** (an upgrade over Vertex's stop-only): Stage 1 truncates OLD tool outputs to head/tail previews (`generateToolOutputPreview`); Stage 2 drops the oldest complete tool exchanges (assistant tool-call + its tool-result messages as a unit, preserving call/result pairing) and inserts one elision note.
3. Never touches: the first user (task) message, the protected recent tail, or anything when under threshold (zero overhead no-op).

Operates on `ModelMessage[]` natively (no lossy ChatMessage round-trip), makes no LLM calls, and composes with a caller-supplied `prepareStep` (caller result wins; the guard only contributes `messages`).

## Tests

`test/stepBudgetGuard.test.ts` (7 tests, wired into `test:unit`): estimation scaling, overhead accounting, no-op under threshold, stage-1 truncation with protected tail, stage-2 pair-integral drops with elision note, fixed-overhead trigger, protected-tail immunity. `test:anthropic-tools-policy` and `test:mcp:limits` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-step context budget guard for AI tool-driven message loops, including deterministic token estimation and safe message compaction.
  * Generation now automatically applies the guard to prevent context overflow while preserving the most recent conversation tail.
* **Bug Fixes**
  * Helps prevent long-running tool workflows from exceeding model context limits by reducing step history before sending.
* **Tests**
  * Added a dedicated Vitest suite covering token estimation, tool-output truncation, history preservation, and overhead/budget decisions.
* **Chores**
  * Expanded unit test scripts to include the new guard test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->