### PR TITLE
fix(proxy): close restartless observability gaps

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -308,7 +308,7 @@ async function getProcessStartTime(pid: number): Promise<Date | null> {
  *   string) recorded when the supervisor we expect at `pid` was launched.
  *   When provided, this is cross-checked against `pid`'s actual OS-reported
  *   start time (see {@link getProcessStartTime}) — the args match alone
- *   ("neurolink" + "proxy" both present) is not airtight, since an
+ *   (the `neurolink proxy start` command is present) is not airtight, since an
  *   unrelated process (e.g. a shell running this very test suite, or a
  *   coincidentally-named script) could match it too. A pid recycled by such
  *   a process would have a start time far from the recorded supervisor
@@ -339,9 +339,9 @@ export async function processLooksLikeProxySupervisor(
   // "neurolink", an editor with a neurolink file open) would match, and a
   // stale/recycled pid running such a process could then be SIGTERM'd/
   // SIGKILL'd by `ensureSupervisorStoppedBeforeClear` during uninstall.
-  // Require the actual proxy-supervisor invocation — both "neurolink" AND
-  // the "proxy" subcommand present in args.
-  if (!(/neurolink/i.test(args) && /\bproxy\b/i.test(args))) {
+  // Require the actual proxy-supervisor invocation. Commands such as
+  // `neurolink proxy status` must never be mistaken for the listener owner.
+  if (!/\bneurolink(?:-proxy)?\b.*\bproxy\s+start\b/i.test(args)) {
     return false;
   }
   if (!expectedStartTimeIso) {
@@ -1990,6 +1990,96 @@ export async function createProxyStartApp(params: {
     const primaryAccount = await resolveStatusPrimaryAccount(activeProxyConfig);
     const activeUpdaterPid =
       supervisorState?.updaterPid ?? runtimeState?.updaterPid;
+    const accountRows: NonNullable<StatusStats["accounts"]> = Object.values(
+      stats.accounts,
+    ).map((account) => {
+      const normalizedKey = normalizeAnthropicAccountKey(account.label);
+      const isLegacyAccount =
+        account.type === "oauth" && account.label === legacyAccountLabel;
+      const accountKey = storedAccountKeys.has(normalizedKey)
+        ? normalizedKey
+        : isLegacyAccount
+          ? LEGACY_ANTHROPIC_ACCOUNT_KEY
+          : account.label === "env"
+            ? ENV_ANTHROPIC_ACCOUNT_KEY
+            : normalizedKey;
+      const isStored = storedAccountKeys.has(accountKey) || isLegacyAccount;
+      const cooling = (cooldowns[accountKey]?.coolingUntil ?? 0) > now;
+      const accountStatus = disabledAccountKeys.has(accountKey)
+        ? "disabled"
+        : !isAccountAllowed(accountKey, activeAccountAllowlist)
+          ? "excluded"
+          : accountInventoryLoaded && account.type === "oauth" && !isStored
+            ? "removed"
+            : cooling
+              ? "cooling"
+              : "active";
+      return {
+        label: account.label,
+        type: account.type,
+        attempts: account.attemptCount,
+        requests: account.successCount + account.errorCount,
+        success: account.successCount,
+        errors: account.errorCount,
+        attemptErrors: account.attemptErrorCount,
+        rateLimits: account.rateLimitCount,
+        transientRateLimits: account.transientRateLimitCount,
+        quotaRateLimits: account.quotaRateLimitCount,
+        cooling,
+        status: accountStatus,
+      };
+    });
+    const attributed = accountRows.reduce(
+      (total, account) => ({
+        attempts: total.attempts + (account.attempts ?? 0),
+        requests: total.requests + (account.requests ?? 0),
+        success: total.success + (account.success ?? 0),
+        errors: total.errors + (account.errors ?? 0),
+        attemptErrors: total.attemptErrors + (account.attemptErrors ?? 0),
+        rateLimits: total.rateLimits + (account.rateLimits ?? 0),
+        transientRateLimits:
+          total.transientRateLimits + (account.transientRateLimits ?? 0),
+        quotaRateLimits: total.quotaRateLimits + (account.quotaRateLimits ?? 0),
+      }),
+      {
+        attempts: 0,
+        requests: 0,
+        success: 0,
+        errors: 0,
+        attemptErrors: 0,
+        rateLimits: 0,
+        transientRateLimits: 0,
+        quotaRateLimits: 0,
+      },
+    );
+    const unattributed = {
+      attempts: Math.max(0, stats.totalAttempts - attributed.attempts),
+      requests: Math.max(0, stats.totalRequests - attributed.requests),
+      success: Math.max(0, stats.totalSuccess - attributed.success),
+      errors: Math.max(0, stats.totalErrors - attributed.errors),
+      attemptErrors: Math.max(
+        0,
+        stats.totalAttemptErrors - attributed.attemptErrors,
+      ),
+      rateLimits: Math.max(0, stats.totalRateLimits - attributed.rateLimits),
+      transientRateLimits: Math.max(
+        0,
+        stats.totalTransientRateLimits - attributed.transientRateLimits,
+      ),
+      quotaRateLimits: Math.max(
+        0,
+        stats.totalQuotaRateLimits - attributed.quotaRateLimits,
+      ),
+    };
+    if (Object.values(unattributed).some((count) => count > 0)) {
+      accountRows.push({
+        label: "unattributed",
+        type: "internal",
+        ...unattributed,
+        cooling: false,
+        status: "unattributed",
+      });
+    }
     return c.json({
       status: "running",
       ready: health.ready,
@@ -2012,43 +2102,7 @@ export async function createProxyStartApp(params: {
         totalRateLimits: stats.totalRateLimits,
         totalTransientRateLimits: stats.totalTransientRateLimits,
         totalQuotaRateLimits: stats.totalQuotaRateLimits,
-        accounts: Object.values(stats.accounts).map((account) => {
-          const normalizedKey = normalizeAnthropicAccountKey(account.label);
-          const isLegacyAccount =
-            account.type === "oauth" && account.label === legacyAccountLabel;
-          const accountKey = storedAccountKeys.has(normalizedKey)
-            ? normalizedKey
-            : isLegacyAccount
-              ? LEGACY_ANTHROPIC_ACCOUNT_KEY
-              : account.label === "env"
-                ? ENV_ANTHROPIC_ACCOUNT_KEY
-                : normalizedKey;
-          const isStored = storedAccountKeys.has(accountKey) || isLegacyAccount;
-          const cooling = (cooldowns[accountKey]?.coolingUntil ?? 0) > now;
-          const accountStatus = disabledAccountKeys.has(accountKey)
-            ? "disabled"
-            : !isAccountAllowed(accountKey, activeAccountAllowlist)
-              ? "excluded"
-              : accountInventoryLoaded && account.type === "oauth" && !isStored
-                ? "removed"
-                : cooling
-                  ? "cooling"
-                  : "active";
-          return {
-            label: account.label,
-            type: account.type,
-            attempts: account.attemptCount,
-            requests: account.successCount + account.errorCount,
-            success: account.successCount,
-            errors: account.errorCount,
-            attemptErrors: account.attemptErrorCount,
-            rateLimits: account.rateLimitCount,
-            transientRateLimits: account.transientRateLimitCount,
-            quotaRateLimits: account.quotaRateLimitCount,
-            cooling,
-            status: accountStatus,
-          };
-        }),
+        accounts: accountRows,
         primaryAccount,
         persistence: getUsageStatsPersistenceStatus(),
       },
@@ -2452,19 +2506,30 @@ function registerProxyShutdownHandlers(params: {
     const usageStatsFlush = import("../../lib/proxy/usageStats.js").then(
       ({ flushUsageStats }) => flushUsageStats(),
     );
-    const [usageStatsFlushResult, lifecycleFlushResult] =
-      await Promise.allSettled([
-        withTimeout(
-          usageStatsFlush,
-          PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS,
-          "Timed out flushing proxy usage statistics during shutdown",
-        ),
-        withTimeout(
-          flushProxyLifecycleEvents(),
-          PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS,
-          "Timed out flushing proxy lifecycle metadata during shutdown",
-        ),
-      ]);
+    const requestLogsFlush = import("../../lib/proxy/requestLogger.js").then(
+      ({ flushRequestLogs }) => flushRequestLogs(),
+    );
+    const [
+      usageStatsFlushResult,
+      lifecycleFlushResult,
+      requestLogsFlushResult,
+    ] = await Promise.allSettled([
+      withTimeout(
+        usageStatsFlush,
+        PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS,
+        "Timed out flushing proxy usage statistics during shutdown",
+      ),
+      withTimeout(
+        flushProxyLifecycleEvents(),
+        PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS,
+        "Timed out flushing proxy lifecycle metadata during shutdown",
+      ),
+      withTimeout(
+        requestLogsFlush,
+        PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS,
+        "Timed out flushing proxy request logs during shutdown",
+      ),
+    ]);
     if (usageStatsFlushResult.status === "rejected") {
       const error = usageStatsFlushResult.reason;
       logger.warn(
@@ -2475,6 +2540,12 @@ function registerProxyShutdownHandlers(params: {
       const error = lifecycleFlushResult.reason;
       logger.debug(
         `[proxy] lifecycle metadata flush failed during shutdown: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (requestLogsFlushResult.status === "rejected") {
+      const error = requestLogsFlushResult.reason;
+      logger.warn(
+        `[proxy] request log flush failed during shutdown: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
@@ -2643,7 +2714,6 @@ async function startProxyRuntime(params: {
       model: entry.model as string,
     }));
   const initialConfigStatus = params.runtimeConfigStore?.getStatus();
-
   const persistInitialProxyState = (): void => {
     const supervisorState = socketWorker ? loadProxySupervisorState() : null;
     saveProxyState({
@@ -2707,8 +2777,30 @@ async function startProxyRuntime(params: {
   let stopRuntimeConfig: (() => void) | undefined;
   if (params.runtimeConfigStore) {
     const runtimeConfigStore = params.runtimeConfigStore;
-    const unsubscribeReload = runtimeConfigStore.subscribeReload(() => {
-      persistRuntimeConfig(runtimeConfigStore.getSnapshot());
+    const unsubscribeReload = runtimeConfigStore.subscribeReload((result) => {
+      const snapshot = runtimeConfigStore.getSnapshot();
+      persistRuntimeConfig(snapshot);
+      if (
+        socketWorker &&
+        result.applied &&
+        result.changed &&
+        result.environmentChanged &&
+        process.connected &&
+        process.send
+      ) {
+        try {
+          process.send({
+            type: "proxy-worker:replacement-requested",
+            generation: getProxyWorkerGeneration(),
+            pid: process.pid,
+            reason: "environment",
+          });
+        } catch (error) {
+          logger.warn(
+            `[proxy] failed to request environment replacement: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
     });
     const reloadOnSighup = (): void => {
       void runtimeConfigStore.reload("sighup");
@@ -3345,20 +3437,23 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
               supervisorState.rolling.active?.pid === state?.pid)
           : true);
       if ((state || supervisorState) && (servingWorker || supervisorRunning)) {
-        const activeHost = state?.host ?? supervisorState?.host ?? null;
-        const activePort = state?.port ?? supervisorState?.port ?? null;
+        const servingState = servingWorker ? state : null;
+        const activeHost = servingState?.host ?? supervisorState?.host ?? null;
+        const activePort = servingState?.port ?? supervisorState?.port ?? null;
         status.running = true;
         status.pid = servingWorker && state ? state.pid : null;
         status.port = activePort;
         status.host = activeHost;
-        status.mode = state
-          ? state.passthrough
+        status.mode = servingState
+          ? servingState.passthrough
             ? "passthrough"
             : "full"
           : null;
-        status.strategy = state?.strategy ?? null;
+        status.strategy = servingState?.strategy ?? null;
         status.startTime =
-          state?.startTime ?? supervisorState?.startTime ?? null;
+          (supervisorRunning ? supervisorState?.startTime : null) ??
+          servingState?.startTime ??
+          null;
         status.uptime = status.startTime
           ? Date.now() - new Date(status.startTime).getTime()
           : null;
@@ -3366,17 +3461,18 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
           activeHost && activePort
             ? `http://${activeHost === "0.0.0.0" ? "localhost" : activeHost}:${activePort}`
             : null;
-        status.envFile = state?.envFile ?? null;
-        status.fallbackChain = state?.fallbackChain ?? null;
-        status.accountAllowlist = state?.accountAllowlist ?? null;
-        status.configGeneration = state?.configGeneration ?? null;
-        status.configLoadedAt = state?.configLoadedAt ?? null;
-        status.lastConfigReloadError = state?.lastConfigReloadError ?? null;
+        status.envFile = servingState?.envFile ?? null;
+        status.fallbackChain = servingState?.fallbackChain ?? null;
+        status.accountAllowlist = servingState?.accountAllowlist ?? null;
+        status.configGeneration = servingState?.configGeneration ?? null;
+        status.configLoadedAt = servingState?.configLoadedAt ?? null;
+        status.lastConfigReloadError =
+          servingState?.lastConfigReloadError ?? null;
         status.supervisorPid = supervisorPid ?? null;
         status.supervisorRunning = supervisorRunning;
         status.rolling = supervisorState?.rolling ?? null;
         status.updaterPid =
-          supervisorState?.updaterPid ?? state?.updaterPid ?? null;
+          supervisorState?.updaterPid ?? servingState?.updaterPid ?? null;
         status.updaterRunning = status.updaterPid
           ? isProcessRunning(status.updaterPid)
           : false;
@@ -3574,29 +3670,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
           });
           if (statusResp.ok) {
             const statusData = (await statusResp.json()) as {
-              stats?: {
-                totalAttempts?: number;
-                totalAttemptErrors?: number;
-                totalRequests: number;
-                totalSuccess: number;
-                totalErrors: number;
-                totalRateLimits: number;
-                totalTransientRateLimits?: number;
-                totalQuotaRateLimits?: number;
-                accounts?: {
-                  label: string;
-                  type: string;
-                  attempts?: number;
-                  requests?: number;
-                  success?: number;
-                  errors?: number;
-                  attemptErrors?: number;
-                  rateLimits?: number;
-                  transientRateLimits?: number;
-                  quotaRateLimits?: number;
-                  cooling: boolean;
-                }[];
-              };
+              stats?: StatusStats;
             };
             if (statusData.stats) {
               printStatusStats(statusData.stats);

--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -22,7 +22,7 @@ function printAnalysis(
   logger.always(`  Since:       ${chalk.cyan(report.since)}`);
   logger.always(`  Logs:        ${chalk.cyan(report.logsDir)}`);
   logger.always(
-    `  Files:       ${report.files.requests} request, ${report.files.attempts} attempt, ${report.files.lifecycle} lifecycle`,
+    `  Files:       ${report.files.requests} request, ${report.files.attempts} attempt, ${report.files.lifecycle} lifecycle, ${report.files.debug} debug`,
   );
   logger.always("");
   logger.always(chalk.bold("  Reliability"));
@@ -99,6 +99,19 @@ function printAnalysis(
   logger.always(
     `    ${report.dataQuality.linesRead} lines scanned, ${report.dataQuality.malformedLines} malformed, ${report.dataQuality.unsupportedLifecycleLines} unsupported lifecycle, ${report.dataQuality.lifecycleSequenceGaps} sequence gaps, ${report.dataQuality.lifecycleSequenceDuplicates} duplicates`,
   );
+  for (const [stream, range] of Object.entries(report.dataQuality.streams)) {
+    if (range.observedFrom) {
+      logger.always(
+        `    ${stream}: ${range.observedFrom} to ${range.observedTo}${range.startsAtOrBeforeRequestedWindow ? "" : chalk.yellow(" (starts after requested window)")}`,
+      );
+    }
+  }
+  const artifacts = report.dataQuality.bodyArtifacts;
+  if (artifacts.capturesIndexed > 0) {
+    logger.always(
+      `    Body artifacts: ${artifacts.artifactsPresent}/${artifacts.artifactsReferenced} present, ${artifacts.artifactsMissing} missing, ${artifacts.writeFailures} write failures, ${artifacts.invalidPaths} invalid paths, ${artifacts.truncatedCaptures} truncated captures`,
+    );
+  }
   if (report.accounts.length > 0) {
     logger.always("");
     logger.always(chalk.bold("  Accounts"));

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -1,26 +1,57 @@
 import { createReadStream } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { lstat, readdir, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { createInterface } from "node:readline";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import type {
   ProxyAnalysisAccount,
   ProxyAnalysisAttemptRecord,
   ProxyAnalysisFinalRequestRecord,
   ProxyAnalysisOptions,
   ProxyAnalysisReport,
+  ProxyAnalysisStreamName,
   ProxyLatencySummary,
 } from "../types/index.js";
 
 const LIFECYCLE_FILE_PATTERN = /^proxy-lifecycle-\d{4}-\d{2}-\d{2}\.jsonl$/;
 const REQUEST_FILE_PATTERN = /^proxy-\d{4}-\d{2}-\d{2}\.jsonl$/;
 const ATTEMPT_FILE_PATTERN = /^proxy-attempts-\d{4}-\d{2}-\d{2}\.jsonl$/;
+const DEBUG_FILE_PATTERN = /^proxy-debug-\d{4}-\d{2}-\d{2}\.jsonl$/;
+const ARTIFACT_STAT_CONCURRENCY = 64;
 const LIFECYCLE_EVENTS = new Set([
   "request_accepted",
   "response_headers",
   "response_first_chunk",
   "request_terminal",
 ]);
+
+function isContainedPath(root: string, candidate: string): boolean {
+  const candidateRelative = relative(root, candidate);
+  return (
+    candidateRelative.length > 0 &&
+    !isAbsolute(candidateRelative) &&
+    candidateRelative !== ".." &&
+    !candidateRelative.startsWith(`..${sep}`)
+  );
+}
+
+async function inspectBodyArtifact(
+  artifactPath: string,
+  canonicalBodiesRoot: string | null,
+): Promise<"invalid" | "missing" | "present"> {
+  if (!canonicalBodiesRoot) {
+    return "missing";
+  }
+  try {
+    const canonicalArtifactPath = await realpath(artifactPath);
+    if (!isContainedPath(canonicalBodiesRoot, canonicalArtifactPath)) {
+      return "invalid";
+    }
+    return (await stat(canonicalArtifactPath)).isFile() ? "present" : "missing";
+  } catch {
+    return "missing";
+  }
+}
 
 function increment(counter: Record<string, number>, key: string): void {
   counter[key] = (counter[key] ?? 0) + 1;
@@ -245,6 +276,7 @@ async function discoverLogFiles(logsDir: string) {
     lifecycleFiles: matching(LIFECYCLE_FILE_PATTERN),
     requestFiles: matching(REQUEST_FILE_PATTERN),
     attemptFiles: matching(ATTEMPT_FILE_PATTERN),
+    debugFiles: matching(DEBUG_FILE_PATTERN),
   };
 }
 
@@ -257,8 +289,32 @@ export async function analyzeProxyLogs(
   const logsDir = resolve(
     options?.logsDir ?? join(homedir(), ".neurolink", "logs"),
   );
-  const { lifecycleFiles, requestFiles, attemptFiles } =
+  const { lifecycleFiles, requestFiles, attemptFiles, debugFiles } =
     await discoverLogFiles(logsDir);
+
+  const observedRanges: Record<
+    ProxyAnalysisStreamName,
+    { from: number | null; to: number | null }
+  > = {
+    lifecycle: { from: null, to: null },
+    requests: { from: null, to: null },
+    attempts: { from: null, to: null },
+    debug: { from: null, to: null },
+  };
+  const observeTimestamp = (
+    stream: ProxyAnalysisStreamName,
+    record: Record<string, unknown>,
+  ): number | null => {
+    const timestamp = Date.parse(String(record.timestamp ?? ""));
+    if (!Number.isFinite(timestamp)) {
+      return null;
+    }
+    const range = observedRanges[stream];
+    range.from =
+      range.from === null ? timestamp : Math.min(range.from, timestamp);
+    range.to = range.to === null ? timestamp : Math.max(range.to, timestamp);
+    return timestamp;
+  };
 
   let linesRead = 0;
   let malformedLines = 0;
@@ -279,8 +335,8 @@ export async function analyzeProxyLogs(
     linesRead += await readJsonLines(
       filePath,
       (record) => {
-        const timestamp = Date.parse(String(record.timestamp ?? ""));
-        if (!Number.isFinite(timestamp) || timestamp < sinceMs) {
+        const timestamp = observeTimestamp("lifecycle", record);
+        if (timestamp === null || timestamp < sinceMs) {
           return;
         }
         const event = stringValue(record.event);
@@ -369,8 +425,8 @@ export async function analyzeProxyLogs(
     linesRead += await readJsonLines(
       filePath,
       (record) => {
-        const timestamp = Date.parse(String(record.timestamp ?? ""));
-        if (!Number.isFinite(timestamp) || timestamp < sinceMs) {
+        const timestamp = observeTimestamp("attempts", record);
+        if (timestamp === null || timestamp < sinceMs) {
           return;
         }
         const requestId = stringValue(record.requestId);
@@ -437,8 +493,8 @@ export async function analyzeProxyLogs(
     linesRead += await readJsonLines(
       filePath,
       (record) => {
-        const timestamp = Date.parse(String(record.timestamp ?? ""));
-        if (!Number.isFinite(timestamp) || timestamp < sinceMs) {
+        const timestamp = observeTimestamp("requests", record);
+        if (timestamp === null || timestamp < sinceMs) {
           return;
         }
         const requestId = stringValue(record.requestId);
@@ -471,6 +527,81 @@ export async function analyzeProxyLogs(
     );
   }
 
+  let capturesIndexed = 0;
+  let truncatedCaptures = 0;
+  let writeFailures = 0;
+  let invalidPaths = 0;
+  const referencedArtifacts = new Set<string>();
+  const bodiesRoot = resolve(logsDir, "bodies");
+  for (const filePath of debugFiles) {
+    linesRead += await readJsonLines(
+      filePath,
+      (record) => {
+        const timestamp = observeTimestamp("debug", record);
+        if (timestamp === null || timestamp < sinceMs) {
+          return;
+        }
+        if (record.type !== "body_capture") {
+          return;
+        }
+        capturesIndexed += 1;
+        truncatedCaptures += record.bodyTruncated === true ? 1 : 0;
+        writeFailures += record.bodyWriteFailed === true ? 1 : 0;
+        const bodyPath = stringValue(record.bodyPath);
+        if (!bodyPath) {
+          return;
+        }
+        if (bodyPath.includes("\0") || bodyPath.split(/[\\/]/).includes("..")) {
+          invalidPaths += 1;
+          return;
+        }
+        const resolvedBodyPath = resolve(logsDir, bodyPath);
+        if (!isContainedPath(bodiesRoot, resolvedBodyPath)) {
+          invalidPaths += 1;
+          return;
+        }
+        referencedArtifacts.add(resolvedBodyPath);
+      },
+      () => {
+        malformedLines += 1;
+      },
+    );
+  }
+  const artifactPaths = [...referencedArtifacts];
+  let canonicalBodiesRoot: string | null = null;
+  let bodiesRootUnsafe = false;
+  try {
+    const bodiesRootStat = await lstat(bodiesRoot);
+    if (bodiesRootStat.isDirectory() && !bodiesRootStat.isSymbolicLink()) {
+      canonicalBodiesRoot = await realpath(bodiesRoot);
+    } else {
+      bodiesRootUnsafe = true;
+    }
+  } catch {
+    // A missing body directory means every lexically valid reference is absent.
+  }
+  let artifactsPresent = 0;
+  let artifactsMissing = 0;
+  for (
+    let offset = 0;
+    offset < artifactPaths.length;
+    offset += ARTIFACT_STAT_CONCURRENCY
+  ) {
+    const presence = await Promise.all(
+      artifactPaths
+        .slice(offset, offset + ARTIFACT_STAT_CONCURRENCY)
+        .map((artifactPath) =>
+          bodiesRootUnsafe
+            ? Promise.resolve<"invalid" | "missing" | "present">("invalid")
+            : inspectBodyArtifact(artifactPath, canonicalBodiesRoot),
+        ),
+    );
+    artifactsPresent += presence.filter((value) => value === "present").length;
+    artifactsMissing += presence.filter((value) => value === "missing").length;
+    invalidPaths += presence.filter((value) => value === "invalid").length;
+  }
+  const artifactsReferenced = artifactsPresent + artifactsMissing;
+
   const finalSummary = summarizeFinalRequests(
     finalRequests,
     terminalStreamErrors,
@@ -486,11 +617,13 @@ export async function analyzeProxyLogs(
       lifecycle: lifecycleFiles.length,
       requests: requestFiles.length,
       attempts: attemptFiles.length,
+      debug: debugFiles.length,
     },
     coverage: {
-      lifecycle: lifecycleFiles.length > 0,
-      finalRequests: requestFiles.length > 0,
-      attempts: attemptFiles.length > 0,
+      lifecycle:
+        accepted.size + headers.size + firstChunks.size + terminal.size > 0,
+      finalRequests: finalRequests.size > 0 || terminalStreamErrors.size > 0,
+      attempts: totalAttempts > 0,
       attemptLatency: attemptLatency.length > 0,
       cacheUsage: finalSummary.cache.requestsWithUsage > 0,
     },
@@ -500,6 +633,28 @@ export async function analyzeProxyLogs(
       unsupportedLifecycleLines,
       lifecycleSequenceGaps,
       lifecycleSequenceDuplicates,
+      streams: Object.fromEntries(
+        Object.entries(observedRanges).map(([stream, range]) => [
+          stream,
+          {
+            observedFrom:
+              range.from === null ? null : new Date(range.from).toISOString(),
+            observedTo:
+              range.to === null ? null : new Date(range.to).toISOString(),
+            startsAtOrBeforeRequestedWindow:
+              range.from !== null && range.from <= sinceMs,
+          },
+        ]),
+      ) as ProxyAnalysisReport["dataQuality"]["streams"],
+      bodyArtifacts: {
+        capturesIndexed,
+        artifactsReferenced,
+        artifactsPresent,
+        artifactsMissing,
+        invalidPaths,
+        writeFailures,
+        truncatedCaptures,
+      },
     },
     lifecycle: {
       accepted: accepted.size,

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -18,7 +18,7 @@ import {
   statSync,
   unlinkSync,
 } from "fs";
-import { appendFile, writeFile } from "fs/promises";
+import { writeFile } from "fs/promises";
 import { createHash } from "crypto";
 import { promisify } from "util";
 import { gzip as gzipCallback } from "zlib";
@@ -33,9 +33,56 @@ import { OtelBridge } from "../observability/otelBridge.js";
 import { SeverityNumber } from "@opentelemetry/api-logs";
 import type { LoggerProvider } from "@opentelemetry/sdk-logs";
 import { configureProxyLifecycleLogger } from "./proxyLifecycle.js";
+import { withTimeout } from "../utils/async/withTimeout.js";
 
 let logDir: string | null = null;
 let logEnabled = false;
+const pendingLogOperations = new Set<Promise<unknown>>();
+const REQUEST_LOG_IO_TIMEOUT_MS = 5_000;
+
+function trackLogOperation<T>(operation: Promise<T>): Promise<T> {
+  pendingLogOperations.add(operation);
+  void operation.then(
+    () => pendingLogOperations.delete(operation),
+    () => pendingLogOperations.delete(operation),
+  );
+  return operation;
+}
+
+/** Wait, up to a bounded deadline, for admitted request/body writes to settle. */
+export async function flushRequestLogs(
+  timeoutMs: number = REQUEST_LOG_IO_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + Math.max(1, timeoutMs);
+  while (pendingLogOperations.size > 0) {
+    const admitted = [...pendingLogOperations];
+    const remainingMs = Math.max(1, deadline - Date.now());
+    try {
+      await withTimeout(
+        Promise.allSettled(admitted),
+        remainingMs,
+        `Timed out flushing ${admitted.length} proxy request log operation(s)`,
+      );
+    } catch (error) {
+      for (const operation of admitted) {
+        pendingLogOperations.delete(operation);
+      }
+      throw error;
+    }
+    if (Date.now() >= deadline && pendingLogOperations.size > 0) {
+      const remaining = pendingLogOperations.size;
+      throw new Error(
+        `Timed out flushing ${remaining} proxy request log operation(s)`,
+      );
+    }
+  }
+}
+
+/** @internal Test-only hook for exercising shutdown behavior without real I/O. */
+export const __requestLoggerTestHooks = {
+  pendingOperationCount: () => pendingLogOperations.size,
+  trackLogOperation,
+};
 
 /**
  * Lazily-resolved LoggerProvider from OTel instrumentation.
@@ -124,7 +171,13 @@ export async function logRequest(entry: RequestLogEntry): Promise<void> {
   const line = JSON.stringify(entry) + "\n";
 
   try {
-    await appendFile(logFile, line, { mode: 0o600 });
+    await trackLogOperation(
+      writeFile(logFile, line, {
+        mode: 0o600,
+        flag: "a",
+        signal: AbortSignal.timeout(REQUEST_LOG_IO_TIMEOUT_MS),
+      }),
+    );
   } catch {
     // Non-fatal — don't crash proxy for logging failures
   }
@@ -161,7 +214,13 @@ export async function logRequestAttempt(
   const line = JSON.stringify(entry) + "\n";
 
   try {
-    await appendFile(logFile, line, { mode: 0o600 });
+    await trackLogOperation(
+      writeFile(logFile, line, {
+        mode: 0o600,
+        flag: "a",
+        signal: AbortSignal.timeout(REQUEST_LOG_IO_TIMEOUT_MS),
+      }),
+    );
   } catch {
     // Non-fatal — don't crash proxy for logging failures
   }
@@ -452,7 +511,7 @@ function collectManagedLogFiles(rootDir: string): ManagedLogFile[] {
 
       const isTopLevelProxyLog =
         directory === rootDir &&
-        /^proxy(?:-attempts|-debug)?-.*\.jsonl$/.test(entry.name);
+        /^proxy(?:-attempts|-debug|-lifecycle)?-.*\.jsonl$/.test(entry.name);
       const isBodyArtifact =
         entry.name.endsWith(".json.gz") &&
         entryPath.includes(`${join(rootDir, "bodies")}`);
@@ -540,7 +599,10 @@ async function writeBodyArtifact(
     metadata: entry.metadata,
   });
   const compressed = await gzip(payload);
-  await writeFile(bodyPath, compressed, { mode: 0o600 });
+  await writeFile(bodyPath, compressed, {
+    mode: 0o600,
+    signal: AbortSignal.timeout(REQUEST_LOG_IO_TIMEOUT_MS),
+  });
 
   return {
     bodyPath,
@@ -641,11 +703,13 @@ export async function logBodyCapture(
 
   let stored: StoredBodyArtifact;
   try {
-    stored = await writeBodyArtifact(
-      entry,
-      redactedHeaders,
-      preparedBody.value,
-      preparedBody.truncated,
+    stored = await trackLogOperation(
+      writeBodyArtifact(
+        entry,
+        redactedHeaders,
+        preparedBody.value,
+        preparedBody.truncated,
+      ),
     );
   } catch (writeError) {
     logger.warn(
@@ -656,6 +720,7 @@ export async function logBodyCapture(
       redactedBody: preparedBody.value,
       redactedBodyBytes: preparedBody.bytes,
       bodyTruncated: preparedBody.truncated,
+      bodyWriteFailed: true,
     };
   }
 
@@ -681,6 +746,7 @@ export async function logBodyCapture(
     redactedBodyBytes: stored.redactedBodyBytes ?? preparedBody.bytes,
     storedFileBytes: stored.storedFileBytes,
     bodyTruncated: stored.bodyTruncated ?? preparedBody.truncated,
+    bodyWriteFailed: stored.bodyWriteFailed,
     metadata: entry.metadata,
   };
 
@@ -690,9 +756,13 @@ export async function logBodyCapture(
   }
 
   try {
-    await appendFile(logFile, JSON.stringify(indexEntry) + "\n", {
-      mode: 0o600,
-    });
+    await trackLogOperation(
+      writeFile(logFile, JSON.stringify(indexEntry) + "\n", {
+        mode: 0o600,
+        flag: "a",
+        signal: AbortSignal.timeout(REQUEST_LOG_IO_TIMEOUT_MS),
+      }),
+    );
   } catch {
     // Non-fatal
   }
@@ -797,9 +867,13 @@ export async function logStreamError(entry: {
   }
 
   try {
-    await appendFile(logFile, JSON.stringify(logEntry) + "\n", {
-      mode: 0o600,
-    });
+    await trackLogOperation(
+      writeFile(logFile, JSON.stringify(logEntry) + "\n", {
+        mode: 0o600,
+        flag: "a",
+        signal: AbortSignal.timeout(REQUEST_LOG_IO_TIMEOUT_MS),
+      }),
+    );
   } catch {
     // Non-fatal — don't crash proxy for logging failures
   }
@@ -824,6 +898,14 @@ export function cleanupLogs(
     const files = collectManagedLogFiles(activeLogDir).sort(
       (a, b) => a.mtime - b.mtime,
     ); // oldest first
+    const currentDate = new Date().toISOString().split("T")[0];
+    const currentMetadataLogs = new Set(
+      ["proxy", "proxy-attempts", "proxy-debug", "proxy-lifecycle"].map(
+        (prefix) => join(activeLogDir, `${prefix}-${currentDate}.jsonl`),
+      ),
+    );
+    const canDelete = (file: ManagedLogFile) =>
+      !currentMetadataLogs.has(file.path);
 
     const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
     let deletedCount = 0;
@@ -832,7 +914,7 @@ export function cleanupLogs(
     // Pass 1: delete files older than maxAgeDays
     const remaining = [];
     for (const file of files) {
-      if (file.mtime < cutoff) {
+      if (file.mtime < cutoff && canDelete(file)) {
         unlinkSync(file.path);
         deletedCount++;
         freedBytes += file.size;
@@ -849,9 +931,14 @@ export function cleanupLogs(
     // Pass 2: if total size exceeds maxSizeMb, delete oldest until under limit
     const maxBytes = maxSizeMb * 1024 * 1024;
     let totalSize = remaining.reduce((sum, f) => sum + f.size, 0);
+    const deletionCandidates = remaining.filter(canDelete);
 
-    while (totalSize > maxBytes && remaining.length > 0) {
-      const oldest = remaining.shift();
+    // Current-day metadata is the only reliable source for final-request,
+    // attempt, lifecycle, and body-index reconciliation. Keep those indexes
+    // intact during size cleanup; body artifacts and older indexes remain
+    // eligible for eviction.
+    while (totalSize > maxBytes && deletionCandidates.length > 0) {
+      const oldest = deletionCandidates.shift();
       if (!oldest) {
         break;
       }

--- a/src/lib/proxy/rollingProxyServer.ts
+++ b/src/lib/proxy/rollingProxyServer.ts
@@ -19,6 +19,10 @@ export async function startRollingProxyServer(
   let listening = false;
   let recoveryFailures = 0;
   let recoveryTimer: NodeJS.Timeout | undefined;
+  let requestedReplacementTimer: NodeJS.Timeout | undefined;
+  let requestedReplacementSchedule = 0;
+  let requestedReplacementPending = false;
+  let replacementQueueTail: Promise<void> | null = null;
 
   const recoveryDelayMs = Math.max(
     1,
@@ -28,6 +32,26 @@ export async function startRollingProxyServer(
     recoveryDelayMs,
     options.maxRecoveryDelayMs ?? DEFAULT_MAX_RECOVERY_DELAY_MS,
   );
+
+  const queueReplacement = <T>(operation: () => Promise<T>): Promise<T> => {
+    const predecessor = replacementQueueTail;
+    const result = (predecessor ?? Promise.resolve()).then(operation);
+    const completion = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    replacementQueueTail = completion;
+    void completion.finally(() => {
+      if (replacementQueueTail !== completion) {
+        return;
+      }
+      replacementQueueTail = null;
+      if (requestedReplacementPending) {
+        scheduleRequestedReplacement();
+      }
+    });
+    return result;
+  };
 
   const scheduleRecovery = (): void => {
     if (closing || !listening || recoveryTimer) {
@@ -45,11 +69,13 @@ export async function startRollingProxyServer(
       // An explicit replace() may have started (or completed) a generation
       // while this timer was pending. Re-validate before recovering so we never
       // launch a duplicate generation that conflicts with the requested worker.
-      const snapshot = supervisor.snapshot();
-      if (closing || snapshot.active || snapshot.candidate) {
-        return;
-      }
-      void supervisor.replace(desiredVersion).then(
+      void queueReplacement(async () => {
+        const snapshot = supervisor.snapshot();
+        if (closing || snapshot.active || snapshot.candidate) {
+          return;
+        }
+        await supervisor.replace(desiredVersion);
+      }).then(
         () => {
           recoveryFailures = 0;
         },
@@ -77,6 +103,45 @@ export async function startRollingProxyServer(
       scheduleRecovery();
     }
   };
+
+  function scheduleRequestedReplacement(): void {
+    if (closing) {
+      return;
+    }
+    requestedReplacementPending = true;
+    if (requestedReplacementTimer || replacementQueueTail) {
+      return;
+    }
+    const schedule = ++requestedReplacementSchedule;
+    requestedReplacementTimer = setTimeout(() => {
+      requestedReplacementTimer = undefined;
+      if (schedule !== requestedReplacementSchedule) {
+        return;
+      }
+      if (closing || !supervisor.snapshot().active) {
+        return;
+      }
+      requestedReplacementPending = false;
+      const replacementVersion = desiredVersion;
+      void queueReplacement(async () => {
+        if (closing || !supervisor.snapshot().active) {
+          return;
+        }
+        options.log?.(
+          `[proxy-supervisor] preparing same-version worker replacement version=${replacementVersion} reason=environment`,
+        );
+        await supervisor.replace(replacementVersion);
+        options.log?.(
+          `[proxy-supervisor] same-version worker replacement complete version=${replacementVersion} reason=environment`,
+        );
+      }).catch((error) => {
+        options.log?.(
+          `[proxy-supervisor] same-version worker replacement failed version=${replacementVersion} reason=environment: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }, 50);
+    requestedReplacementTimer.unref?.();
+  }
   const supervisor = new RollingWorkerSupervisor({
     spawnWorker: options.spawnWorker,
     readyTimeoutMs: options.readyTimeoutMs,
@@ -84,9 +149,14 @@ export async function startRollingProxyServer(
     socketQueueTimeoutMs: options.socketQueueTimeoutMs,
     shutdownTimeoutMs: options.shutdownTimeoutMs,
     onStateChange: stateChanged,
+    onReplacementRequested: scheduleRequestedReplacement,
     log: options.log,
   });
   const listener = createServer({ pauseOnConnect: true }, (socket) => {
+    // The parent keeps its descriptor until the worker commits the IPC
+    // transfer. Consume client resets during that interval so they cannot
+    // terminate the long-lived supervisor process.
+    socket.once("error", () => socket.destroy());
     supervisor.acceptSocket(socket);
   });
   await new Promise<void>((resolve, reject) => {
@@ -119,8 +189,8 @@ export async function startRollingProxyServer(
   }
   const address = listener.address();
   if (!address || typeof address === "string") {
-    listener.close();
-    void supervisor.close();
+    await new Promise<void>((resolve) => listener.close(() => resolve()));
+    await supervisor.close().catch(() => undefined);
     throw ErrorFactory.proxyWorkerLifecycle(
       "rolling proxy listener did not expose a TCP address",
     );
@@ -144,8 +214,16 @@ export async function startRollingProxyServer(
         clearTimeout(recoveryTimer);
         recoveryTimer = undefined;
       }
+      if (requestedReplacementTimer) {
+        clearTimeout(requestedReplacementTimer);
+        requestedReplacementTimer = undefined;
+      }
+      requestedReplacementSchedule += 1;
+      requestedReplacementPending = false;
       try {
-        const snapshot = await supervisor.replace(expectedVersion);
+        const snapshot = await queueReplacement(() =>
+          supervisor.replace(expectedVersion),
+        );
         recoveryFailures = 0;
         return snapshot;
       } catch (error) {
@@ -171,6 +249,12 @@ export async function startRollingProxyServer(
         clearTimeout(recoveryTimer);
         recoveryTimer = undefined;
       }
+      if (requestedReplacementTimer) {
+        clearTimeout(requestedReplacementTimer);
+        requestedReplacementTimer = undefined;
+      }
+      requestedReplacementSchedule += 1;
+      requestedReplacementPending = false;
       const listenerClosed = new Promise<void>((resolve, reject) => {
         listener.close((error) => (error ? reject(error) : resolve()));
       });

--- a/src/lib/proxy/rollingWorkerProcess.ts
+++ b/src/lib/proxy/rollingWorkerProcess.ts
@@ -16,7 +16,7 @@ import {
 export function spawnProxySocketWorker(
   options: SpawnProxySocketWorkerOptions,
 ): RollingWorkerHandle {
-  const socketAckTimeoutMs = Math.max(1, options.socketAckTimeoutMs ?? 5_000);
+  const socketAckTimeoutMs = Math.max(1, options.socketAckTimeoutMs ?? 30_000);
   let nextSocketId = 0;
   const pendingSockets = new Map<
     string,
@@ -86,6 +86,20 @@ export function spawnProxySocketWorker(
     }
     pendingSockets.delete(socketId);
     clearTimeout(pending.timeout);
+    if (error && child.connected && !pending.accepted) {
+      try {
+        child.send(
+          {
+            type: "proxy-worker:socket-cancel",
+            generation: options.generation,
+            socketId,
+          },
+          () => undefined,
+        );
+      } catch {
+        // The supervisor will quarantine the worker after the failed transfer.
+      }
+    }
     if (!error) {
       pending.socket.destroy();
     }
@@ -126,11 +140,19 @@ export function spawnProxySocketWorker(
       publishStatus(message);
     }
   });
-  child.once("exit", () => {
+  child.once("exit", (code, signal) => {
     for (const socketId of [...pendingSockets.keys()]) {
       settleSocket(
         socketId,
-        new Error(`proxy worker ${childPid} exited before accepting socket`),
+        ErrorFactory.proxyWorkerLifecycle(
+          `proxy worker ${childPid} exited before socket transfer committed (code=${code ?? "none"}, signal=${signal ?? "none"})`,
+          {
+            workerPid: childPid,
+            generation: options.generation,
+            exitCode: code,
+            signal,
+          },
+        ),
       );
     }
   });
@@ -156,17 +178,6 @@ export function spawnProxySocketWorker(
       }
       const socketId = `${generation}:${++nextSocketId}`;
       const timeout = setTimeout(() => {
-        if (child.connected) {
-          try {
-            child.send({
-              type: "proxy-worker:socket-cancel",
-              generation,
-              socketId,
-            });
-          } catch {
-            // The worker is terminated after the failed transfer is reported.
-          }
-        }
         settleSocket(
           socketId,
           new Error(

--- a/src/lib/proxy/rollingWorkerProtocol.ts
+++ b/src/lib/proxy/rollingWorkerProtocol.ts
@@ -50,6 +50,7 @@ export function isProxyWorkerStatusMessage(
     version?: unknown;
     message?: unknown;
     socketId?: unknown;
+    reason?: unknown;
   };
   if (
     !Number.isSafeInteger(message.generation) ||
@@ -70,6 +71,9 @@ export function isProxyWorkerStatusMessage(
   }
   if (message.type === "proxy-worker:socket-accepted") {
     return typeof message.socketId === "string" && message.socketId.length > 0;
+  }
+  if (message.type === "proxy-worker:replacement-requested") {
+    return message.reason === "environment";
   }
   return (
     message.type === "proxy-worker:fatal" && typeof message.message === "string"

--- a/src/lib/proxy/rollingWorkerSupervisor.ts
+++ b/src/lib/proxy/rollingWorkerSupervisor.ts
@@ -120,7 +120,6 @@ export class RollingWorkerSupervisor {
           );
     }
 
-    this.lastFailure = null;
     this.replacement = this.spawnCandidate(expectedVersion).finally(() => {
       this.replacement = null;
     });
@@ -319,6 +318,16 @@ export class RollingWorkerSupervisor {
           }
           return;
         }
+        if (message.type === "proxy-worker:replacement-requested") {
+          if (this.active?.generation === generation) {
+            this.options.onReplacementRequested?.({
+              generation,
+              pid: handle.pid,
+              reason: message.reason,
+            });
+          }
+          return;
+        }
         if (message.type === "proxy-worker:ready") {
           if (message.version !== expectedVersion) {
             finish(
@@ -409,7 +418,7 @@ export class RollingWorkerSupervisor {
             );
           }
           this.options.log?.(
-            `[proxy-supervisor] active worker exited generation=${generation} pid=${handle.pid}`,
+            `[proxy-supervisor] active worker exited generation=${generation} pid=${handle.pid} code=${code ?? "none"} signal=${signal ?? "none"}`,
           );
         }
         const drained = this.draining.get(generation);
@@ -467,31 +476,38 @@ export class RollingWorkerSupervisor {
     try {
       worker.handle.sendSocket(worker.generation, socket, (error) => {
         if (error) {
-          this.handleTransferFailure(worker, socket);
+          this.handleTransferFailure(worker, socket, error);
         }
       });
-    } catch {
-      this.handleTransferFailure(worker, socket);
+    } catch (error) {
+      this.handleTransferFailure(worker, socket, error);
     }
   }
 
   private handleTransferFailure(
     worker: RollingManagedWorker,
     socket: TransferableProxySocket,
+    error: unknown,
   ): void {
     this.failedTransfers += 1;
+    const detail = this.describeTransferError(error);
     this.recordFailure(
       worker.generation,
       worker.version,
       "transfer",
-      `worker ${worker.handle.pid} failed to accept a transferred socket`,
+      `worker ${worker.handle.pid} failed to accept a transferred socket: ${detail}`,
+    );
+    this.options.log?.(
+      `[proxy-supervisor] socket transfer failed generation=${worker.generation} pid=${worker.handle.pid}: ${detail}`,
     );
     if (this.active?.generation === worker.generation && !this.closed) {
-      // Do not let worker-side graceful shutdown call shutdown(2) on an
-      // offered-but-uncommitted duplicate descriptor.
-      worker.dispose();
-      worker.handle.terminate("SIGKILL");
       this.active = null;
+      this.draining.set(worker.generation, worker);
+      // The child may own a duplicate of an incompletely transferred socket.
+      // SIGKILL closes its descriptor without worker-side shutdown(2), after
+      // which the parent rejects its copy rather than attempting unsafe replay.
+      worker.handle.terminate("SIGKILL");
+      this.publishState();
     }
     this.rejectSocket(socket);
   }
@@ -500,6 +516,14 @@ export class RollingWorkerSupervisor {
     this.rejectedSockets += 1;
     socket.destroy();
     this.publishState();
+  }
+
+  private describeTransferError(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return String(error ?? "unknown transfer failure");
+    }
+    const code = (error as NodeJS.ErrnoException).code;
+    return code ? `${code}: ${error.message}` : error.message;
   }
 
   private recordFailure(

--- a/src/lib/proxy/runtimeConfig.ts
+++ b/src/lib/proxy/runtimeConfig.ts
@@ -243,14 +243,17 @@ async function buildCandidate(
   snapshot: ProxyRuntimeConfigSnapshot;
   configFilePresent: boolean;
   envFilePresent: boolean;
+  envFileHash: string;
 }> {
   const effectiveEnv = { ...options.baseEnv };
   let envFilePresent = false;
+  let envFileValues: Record<string, string> = {};
   if (options.envFilePath) {
     try {
-      const envContent = await readFile(options.envFilePath, "utf8");
+      const envFileContent = await readFile(options.envFilePath, "utf8");
       const { parse } = await import("dotenv");
-      Object.assign(effectiveEnv, parse(envContent));
+      envFileValues = parse(envFileContent);
+      Object.assign(effectiveEnv, envFileValues);
       envFilePresent = true;
     } catch (error) {
       if (
@@ -332,6 +335,18 @@ async function buildCandidate(
         accountAllowlist: routing.accountAllowlist,
       })
     : undefined;
+  const envFileHash = createHash("sha256")
+    .update(
+      envFilePresent
+        ? JSON.stringify(
+            Object.entries(envFileValues).sort(([left], [right]) =>
+              left < right ? -1 : left > right ? 1 : 0,
+            ),
+          )
+        : "[missing]",
+    )
+    .digest("hex")
+    .slice(0, 16);
   const fingerprintSource = JSON.stringify({
     strategy,
     passthrough: options.passthrough,
@@ -364,6 +379,7 @@ async function buildCandidate(
     }),
     configFilePresent,
     envFilePresent,
+    envFileHash,
   };
 }
 
@@ -379,6 +395,7 @@ export class ProxyRuntimeConfigStore {
   private reloadTimer: ReturnType<typeof setTimeout> | undefined;
   private configFileObserved: boolean;
   private envFileObserved: boolean;
+  private currentEnvFileHash: string;
   private readonly watchListener = (current: Stats, previous: Stats): void => {
     if (
       current.mtimeMs === previous.mtimeMs &&
@@ -395,11 +412,13 @@ export class ProxyRuntimeConfigStore {
     snapshot: ProxyRuntimeConfigSnapshot,
     configFileObserved: boolean,
     envFileObserved: boolean,
+    envFileHash: string,
   ) {
     this.options = { ...options, baseEnv: { ...options.baseEnv } };
     this.currentSnapshot = snapshot;
     this.configFileObserved = configFileObserved;
     this.envFileObserved = envFileObserved;
+    this.currentEnvFileHash = envFileHash;
     this.status = {
       configPath: options.configPath,
       ...(options.envFilePath ? { envFilePath: options.envFilePath } : {}),
@@ -420,6 +439,7 @@ export class ProxyRuntimeConfigStore {
       candidate.snapshot,
       candidate.configFilePresent,
       candidate.envFilePresent,
+      candidate.envFileHash,
     );
   }
 
@@ -526,7 +546,10 @@ export class ProxyRuntimeConfigStore {
       );
       this.configFileObserved ||= candidate.configFilePresent;
       this.envFileObserved ||= candidate.envFilePresent;
-      if (candidate.snapshot.configHash === this.currentSnapshot.configHash) {
+      if (
+        candidate.snapshot.configHash === this.currentSnapshot.configHash &&
+        candidate.envFileHash === this.currentEnvFileHash
+      ) {
         this.status = {
           ...this.status,
           lastReloadAt: attemptedAt,
@@ -542,7 +565,10 @@ export class ProxyRuntimeConfigStore {
         return result;
       }
 
+      const environmentChanged =
+        candidate.envFileHash !== this.currentEnvFileHash;
       this.currentSnapshot = candidate.snapshot;
+      this.currentEnvFileHash = candidate.envFileHash;
       this.status = {
         ...this.status,
         generation: candidate.snapshot.generation,
@@ -568,6 +594,7 @@ export class ProxyRuntimeConfigStore {
         applied: true,
         changed: true,
         generation: candidate.snapshot.generation,
+        ...(environmentChanged ? { environmentChanged: true } : {}),
       };
       this.notifyReloadListeners(result);
       return result;

--- a/src/lib/proxy/socketWorkerRuntime.ts
+++ b/src/lib/proxy/socketWorkerRuntime.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import type {
+  DetachableTransferableProxySocket,
   ProxyWorkerStatusMessage,
   SocketWorkerRuntime,
   SocketWorkerRuntimeOptions,
@@ -10,7 +11,7 @@ import { isProxyWorkerControlMessage } from "./rollingWorkerProtocol.js";
 
 function isTransferableProxySocket(
   handle: unknown,
-): handle is TransferableProxySocket {
+): handle is DetachableTransferableProxySocket {
   if (!handle || typeof handle !== "object") {
     return false;
   }
@@ -20,6 +21,7 @@ function isTransferableProxySocket(
     typeof candidate.resume === "function" &&
     typeof candidate.destroy === "function" &&
     typeof candidate.end === "function" &&
+    typeof candidate.off === "function" &&
     typeof candidate.once === "function"
   );
 }
@@ -160,7 +162,14 @@ export function attachSocketWorkerProcess(
 ): SocketWorkerRuntime {
   let activated = false;
   let gracefulDrain = false;
-  const pendingSockets = new Map<string, TransferableProxySocket>();
+  const pendingSockets = new Map<
+    string,
+    {
+      socket: DetachableTransferableProxySocket;
+      onError: () => void;
+      onClose: () => void;
+    }
+  >();
   const send = (message: ProxyWorkerStatusMessage): void => {
     if (!process.connected || !process.send) {
       return;
@@ -190,6 +199,18 @@ export function attachSocketWorkerProcess(
     // synchronously here would truncate that in-flight request.
     setImmediate(() => runtime.drain());
   };
+  const takePendingSocket = (
+    socketId: string,
+  ): DetachableTransferableProxySocket | undefined => {
+    const pending = pendingSockets.get(socketId);
+    if (!pending) {
+      return undefined;
+    }
+    pendingSockets.delete(socketId);
+    pending.socket.off("error", pending.onError);
+    pending.socket.off("close", pending.onClose);
+    return pending.socket;
+  };
   const onMessage = (message: unknown, handle: unknown): void => {
     if (
       message &&
@@ -204,7 +225,7 @@ export function attachSocketWorkerProcess(
         isTransferableProxySocket(handle)
       ) {
         const socketId = (message as { socketId: string }).socketId;
-        const socket = handle as TransferableProxySocket;
+        const socket = handle;
         socket.pause();
         if (
           !activated ||
@@ -219,7 +240,27 @@ export function attachSocketWorkerProcess(
           socket.destroy();
           return;
         }
-        pendingSockets.set(socketId, socket);
+        // A client can reset while the transferred handle is paused between
+        // acceptance and commit. The HTTP server has not seen the socket yet,
+        // so it cannot install its normal transport-error handler for us.
+        const onError = (): void => {
+          if (pendingSockets.get(socketId)?.socket !== socket) {
+            return;
+          }
+          takePendingSocket(socketId);
+          socket.destroy();
+          drainWhenPendingSettled();
+        };
+        const onClose = (): void => {
+          if (pendingSockets.get(socketId)?.socket !== socket) {
+            return;
+          }
+          takePendingSocket(socketId);
+          drainWhenPendingSettled();
+        };
+        pendingSockets.set(socketId, { socket, onError, onClose });
+        socket.once("error", onError);
+        socket.once("close", onClose);
         try {
           process.send(
             {
@@ -230,14 +271,14 @@ export function attachSocketWorkerProcess(
             },
             (error) => {
               if (error) {
-                pendingSockets.delete(socketId);
-                socket.destroy();
+                takePendingSocket(socketId)?.destroy();
+                drainWhenPendingSettled();
               }
             },
           );
         } catch {
-          pendingSockets.delete(socketId);
-          socket.destroy();
+          takePendingSocket(socketId)?.destroy();
+          drainWhenPendingSettled();
         }
       } else {
         destroyTransferredHandle(handle);
@@ -275,11 +316,10 @@ export function attachSocketWorkerProcess(
         message.type === "proxy-worker:socket-commit" ||
         message.type === "proxy-worker:socket-cancel"
       ) {
-        const socket = pendingSockets.get(message.socketId);
+        const socket = takePendingSocket(message.socketId);
         if (!socket) {
           return;
         }
-        pendingSockets.delete(message.socketId);
         if (message.type === "proxy-worker:socket-commit") {
           runtime.acceptSocket(socket);
         } else {
@@ -303,10 +343,9 @@ export function attachSocketWorkerProcess(
   // is exiting. The zero-downtime guarantee applies to the rolling handoff
   // (control-message) path, not to process termination.
   const drain = (): void => {
-    for (const socket of pendingSockets.values()) {
-      socket.destroy();
+    for (const socketId of [...pendingSockets.keys()]) {
+      takePendingSocket(socketId)?.destroy();
     }
-    pendingSockets.clear();
     runtime.drain();
   };
   const onTerminationSignal = (): void => drain();
@@ -327,10 +366,9 @@ export function attachSocketWorkerProcess(
       process.off("disconnect", drain);
       process.off("SIGTERM", onTerminationSignal);
       process.off("SIGINT", onTerminationSignal);
-      for (const socket of pendingSockets.values()) {
-        socket.destroy();
+      for (const socketId of [...pendingSockets.keys()]) {
+        takePendingSocket(socketId)?.destroy();
       }
-      pendingSockets.clear();
       runtime.close();
     },
   };

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -3150,6 +3150,7 @@ async function handleAnthropicSuccessfulResponse(args: {
     attemptNumber,
     finalBodyStr,
     upstreamSpan,
+    logAttempt,
     logProxyBody,
     logFinalRequest,
   });
@@ -3200,6 +3201,8 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     logFinalRequest,
   } = args;
   if (!response.body) {
+    recordAttemptError(account.label, account.type, 502);
+    logAttempt(502, "stream_error", "No response body from upstream");
     upstreamSpan?.end();
     tracer?.setError("stream_error", "No response body from upstream");
     tracer?.end(502, Date.now() - requestStartTime);
@@ -3370,6 +3373,9 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     };
   }
 
+  logAttempt(response.status, undefined, undefined, {
+    attemptDurationMs: Date.now() - fetchStartMs,
+  });
   const streamOutcomeTracker = createStreamTerminalOutcomeTracker();
   let mainStreamClosed = false;
   const remainingStream = new ReadableStream({
@@ -3812,6 +3818,7 @@ async function handleAnthropicJsonSuccessResponse(args: {
   attemptNumber: number;
   finalBodyStr: string;
   upstreamSpan?: import("@opentelemetry/api").Span;
+  logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: (
     status: number,
@@ -3837,10 +3844,14 @@ async function handleAnthropicJsonSuccessResponse(args: {
     attemptNumber,
     finalBodyStr,
     upstreamSpan,
+    logAttempt,
     logProxyBody,
     logFinalRequest,
   } = args;
   const responseText = await response.text();
+  logAttempt(response.status, undefined, undefined, {
+    attemptDurationMs: Date.now() - fetchStartMs,
+  });
   tracer?.logUpstreamResponseBody(responseText);
   logProxyBody({
     phase: "upstream_response",
@@ -3951,9 +3962,7 @@ async function handleAnthropicJsonSuccessResponse(args: {
   return { response: responseJson };
 }
 
-async function handleAnthropicSuccessfulRetryResponse(args: {
-  ctx: ServerContext;
-  body: ClaudeRequest;
+async function handleAnthropicSuccessfulNonStreamRetryResponse(args: {
   account: ProxyPassthroughAccount;
   accountState: RuntimeAccountState;
   retryResp: Response;
@@ -3963,6 +3972,7 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
   attemptNumber: number;
   finalBodyStr: string;
   upstreamSpan?: import("@opentelemetry/api").Span;
+  logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: (
     status: number,
@@ -3979,7 +3989,6 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
   ) => void;
 }): Promise<Response | unknown> {
   const {
-    body,
     account,
     accountState,
     retryResp,
@@ -3989,6 +3998,7 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
     attemptNumber,
     finalBodyStr,
     upstreamSpan,
+    logAttempt,
     logProxyBody,
     logFinalRequest,
   } = args;
@@ -4016,66 +4026,11 @@ async function handleAnthropicSuccessfulRetryResponse(args: {
     });
   }
 
-  if (body.stream && retryResp.body) {
-    const retryReader = retryResp.body.getReader();
-    const streamOutcomeTracker = createStreamTerminalOutcomeTracker();
-    let retryStreamClosed = false;
-    const retryStream = new ReadableStream({
-      async pull(controller) {
-        if (retryStreamClosed) {
-          return;
-        }
-        try {
-          const { done, value } = await retryReader.read();
-          if (retryStreamClosed) {
-            return;
-          }
-          if (done) {
-            retryStreamClosed = true;
-            streamOutcomeTracker.complete();
-            controller.close();
-            return;
-          }
-          controller.enqueue(value);
-        } catch (streamErr) {
-          const errMsg = describeTransportError(streamErr);
-          logger.always(
-            `[proxy] mid-stream error (auth-retry) account=${account.label}: ${errMsg}`,
-          );
-          streamOutcomeTracker.fail(errMsg);
-          if (!retryStreamClosed) {
-            retryStreamClosed = true;
-            const errorEvent = `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: `Upstream stream interrupted: ${errMsg}` } })}\n\n`;
-            controller.enqueue(new TextEncoder().encode(errorEvent));
-            controller.close();
-          }
-        }
-      },
-      cancel() {
-        retryStreamClosed = true;
-        streamOutcomeTracker.cancel();
-        return retryReader.cancel();
-      },
-    });
-
-    return attachAnthropicSuccessStreamTelemetry({
-      account,
-      response: retryResp,
-      responseHeaders: Object.fromEntries([...retryResp.headers.entries()]),
-      remainingStream: retryStream,
-      streamOutcome: streamOutcomeTracker.outcome,
-      tracer,
-      requestStartTime,
-      attemptNumber,
-      finalBodyStr,
-      upstreamSpan,
-      logProxyBody,
-      logFinalRequest,
-    });
-  }
-
   const retryRespHeaders = Object.fromEntries([...retryResp.headers.entries()]);
   const retryText = await retryResp.text();
+  logAttempt(retryResp.status, undefined, undefined, {
+    attemptDurationMs: Date.now() - fetchStartMs,
+  });
   tracer?.logUpstreamResponseHeaders(retryRespHeaders);
   tracer?.logUpstreamResponseBody(retryText);
   logProxyBody({
@@ -4264,7 +4219,8 @@ async function handleAnthropicAuthRetry(args: {
       logAttempt(status, errorType, errorMessage, {
         ...extra,
         attempt: retryAttemptNumber,
-        attemptDurationMs: Date.now() - retryAttemptStartedAt,
+        attemptDurationMs:
+          extra?.attemptDurationMs ?? Date.now() - retryAttemptStartedAt,
       });
     const retryBodyStr = buildUpstreamBody(account.token).bodyStr;
     const retryFetchStartMs = Date.now();
@@ -4293,23 +4249,55 @@ async function handleAnthropicAuthRetry(args: {
         logger.always(
           `[proxy] ← 200 account=${account.label} (after ${authRetry + 1} refresh(es))`,
         );
-        const successResponse = await handleAnthropicSuccessfulRetryResponse({
-          ctx,
-          body,
-          account,
-          accountState,
-          retryResp,
-          tracer,
-          requestStartTime,
-          fetchStartMs: retryFetchStartMs,
-          attemptNumber: retryAttemptNumber,
-          finalBodyStr: retryBodyStr,
-          upstreamSpan: currentUpstreamSpan,
-          logProxyBody,
-          logFinalRequest,
-        });
+        const successResult = body.stream
+          ? await handleAnthropicSuccessfulResponse({
+              ctx,
+              body,
+              account,
+              accountState,
+              response: retryResp,
+              tracer,
+              requestStartTime,
+              fetchStartMs: retryFetchStartMs,
+              attemptNumber: retryAttemptNumber,
+              finalBodyStr: retryBodyStr,
+              upstreamSpan: currentUpstreamSpan,
+              logAttempt: retryLogAttempt,
+              logProxyBody,
+              logFinalRequest,
+            })
+          : {
+              response: await handleAnthropicSuccessfulNonStreamRetryResponse({
+                account,
+                accountState,
+                retryResp,
+                tracer,
+                requestStartTime,
+                fetchStartMs: retryFetchStartMs,
+                attemptNumber: retryAttemptNumber,
+                finalBodyStr: retryBodyStr,
+                upstreamSpan: currentUpstreamSpan,
+                logAttempt: retryLogAttempt,
+                logProxyBody,
+                logFinalRequest,
+              }),
+            };
+        if ("retryNextAccount" in successResult) {
+          const failure = successResult.failure;
+          return {
+            continueLoop: true,
+            lastError: failure?.message ?? currentLastError,
+            authFailureMessage: currentAuthFailureMessage,
+            sawRateLimit: currentSawRateLimit || Boolean(failure?.rateLimit),
+            sawTransientFailure:
+              currentSawTransientFailure ||
+              Boolean(failure && !failure.rateLimit),
+            sawNetworkError: currentSawNetworkError,
+            upstreamSpan: undefined,
+          };
+        }
         return {
-          response: successResponse,
+          response: successResult.response,
           continueLoop: false,
           lastError: currentLastError,
           authFailureMessage: currentAuthFailureMessage,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1342,6 +1342,12 @@ export type ProxyAnalysisAccount = {
 };
 
 /** Offline report generated from proxy request, attempt, and lifecycle logs. */
+export type ProxyAnalysisStreamName =
+  | "lifecycle"
+  | "requests"
+  | "attempts"
+  | "debug";
+
 export type ProxyAnalysisReport = {
   generatedAt: string;
   since: string;
@@ -1350,6 +1356,7 @@ export type ProxyAnalysisReport = {
     lifecycle: number;
     requests: number;
     attempts: number;
+    debug: number;
   };
   coverage: {
     lifecycle: boolean;
@@ -1364,6 +1371,23 @@ export type ProxyAnalysisReport = {
     unsupportedLifecycleLines: number;
     lifecycleSequenceGaps: number;
     lifecycleSequenceDuplicates: number;
+    streams: Record<
+      ProxyAnalysisStreamName,
+      {
+        observedFrom: string | null;
+        observedTo: string | null;
+        startsAtOrBeforeRequestedWindow: boolean;
+      }
+    >;
+    bodyArtifacts: {
+      capturesIndexed: number;
+      artifactsReferenced: number;
+      artifactsPresent: number;
+      artifactsMissing: number;
+      invalidPaths: number;
+      writeFailures: number;
+      truncatedCaptures: number;
+    };
   };
   lifecycle: {
     accepted: number;
@@ -1635,6 +1659,7 @@ export type StoredBodyArtifact = {
   storedFileBytes?: number;
   redactedBody?: string;
   bodyTruncated?: boolean;
+  bodyWriteFailed?: boolean;
 };
 
 /** File the proxy logger tracks for rotation and cleanup. */
@@ -1931,6 +1956,12 @@ export type ProxyWorkerStatusMessage =
       generation: number;
       pid: number;
       socketId: string;
+    }
+  | {
+      type: "proxy-worker:replacement-requested";
+      generation: number;
+      pid: number;
+      reason: "environment";
     };
 
 export type ProxyWorkerSocketMessage = {
@@ -1948,6 +1979,10 @@ export type TransferableProxySocket = Pick<
   import("node:net").Socket,
   "destroy" | "end" | "pause" | "resume" | "once"
 >;
+
+/** A transferred socket whose temporary handoff listeners can be detached. */
+export type DetachableTransferableProxySocket = TransferableProxySocket &
+  Pick<import("node:net").Socket, "off">;
 
 export type RollingWorkerHandle = {
   pid: number;
@@ -2008,6 +2043,11 @@ export type RollingWorkerSupervisorOptions = {
   socketQueueTimeoutMs?: number;
   shutdownTimeoutMs?: number;
   onStateChange?: (snapshot: RollingWorkerSupervisorSnapshot) => void;
+  onReplacementRequested?: (request: {
+    generation: number;
+    pid: number;
+    reason: "environment";
+  }) => void;
   log?: (message: string) => void;
 };
 
@@ -2187,6 +2227,7 @@ export type ProxyRuntimeConfigReloadResult = {
   applied: boolean;
   changed: boolean;
   generation: number;
+  environmentChanged?: boolean;
   error?: string;
 };
 
@@ -2280,7 +2321,13 @@ export type StatusStats = {
     transientRateLimits?: number;
     quotaRateLimits?: number;
     cooling: boolean;
-    status?: "active" | "cooling" | "disabled" | "excluded" | "removed";
+    status?:
+      | "active"
+      | "cooling"
+      | "disabled"
+      | "excluded"
+      | "removed"
+      | "unattributed";
   }[];
   persistence?: ProxyStatsPersistenceStatus;
 };

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -8493,8 +8493,8 @@ exit 127
     // args merely mentioned "neurolink" (a shell in a directory named
     // "neurolink", an editor with a neurolink file open) — a stale/recycled
     // pid running such a process could then be SIGTERM'd/SIGKILL'd during
-    // uninstall. It must now require BOTH "neurolink" AND "proxy".
-    name: "proxy.ts (review): processLooksLikeProxySupervisor requires BOTH 'neurolink' and 'proxy' in process args, not 'neurolink' alone",
+    // uninstall. It must require the exact `neurolink proxy start` command.
+    name: "proxy.ts (review): processLooksLikeProxySupervisor requires the proxy start command",
     category: "cli",
     fn: async () => {
       const mkProc = (...args: string[]) =>
@@ -8504,24 +8504,37 @@ exit 127
           { stdio: "ignore" },
         );
       const neurolinkOnly = mkProc("neurolink-fake-worker");
-      const neurolinkProxy = mkProc("neurolink", "proxy");
+      const neurolinkProxyStatus = mkProc("neurolink", "proxy", "status");
+      const neurolinkProxyStart = mkProc("neurolink", "proxy", "start");
       try {
-        // Give both children a moment to register with the OS before `ps`
+        // Give all children a moment to register with the OS before `ps`
         // is asked about them.
         await new Promise((r) => setTimeout(r, 300));
-        if (!neurolinkOnly.pid || !neurolinkProxy.pid) {
+        if (
+          !neurolinkOnly.pid ||
+          !neurolinkProxyStatus.pid ||
+          !neurolinkProxyStart.pid
+        ) {
           return false;
         }
         const notSupervisor = await processLooksLikeProxySupervisor(
           neurolinkOnly.pid,
         );
-        const isSupervisor = await processLooksLikeProxySupervisor(
-          neurolinkProxy.pid,
+        const statusIsNotSupervisor = await processLooksLikeProxySupervisor(
+          neurolinkProxyStatus.pid,
         );
-        return notSupervisor === false && isSupervisor === true;
+        const isSupervisor = await processLooksLikeProxySupervisor(
+          neurolinkProxyStart.pid,
+        );
+        return (
+          notSupervisor === false &&
+          statusIsNotSupervisor === false &&
+          isSupervisor === true
+        );
       } finally {
         neurolinkOnly.kill("SIGKILL");
-        neurolinkProxy.kill("SIGKILL");
+        neurolinkProxyStatus.kill("SIGKILL");
+        neurolinkProxyStart.kill("SIGKILL");
       }
     },
   },
@@ -8545,7 +8558,7 @@ exit 127
           ["-e", "setInterval(() => {}, 60000)", "--", ...args],
           { stdio: "ignore" },
         );
-      const neurolinkProxy = mkProc("neurolink", "proxy");
+      const neurolinkProxy = mkProc("neurolink", "proxy", "start");
       try {
         await new Promise((r) => setTimeout(r, 300));
         if (!neurolinkProxy.pid) {

--- a/test/fixtures/proxySocketWorker.cjs
+++ b/test/fixtures/proxySocketWorker.cjs
@@ -1,4 +1,4 @@
-/* global process, Buffer, setInterval, clearInterval */
+/* global process, Buffer, setInterval, clearInterval, setTimeout */
 
 const http = require("node:http");
 
@@ -7,6 +7,9 @@ const version = process.env.NEUROLINK_PROXY_WORKER_EXPECTED_VERSION;
 const sockets = new Set();
 const activeBySocket = new Map();
 const pendingSockets = new Map();
+const socketAcceptDelayMs = Number(
+  process.env.NEUROLINK_PROXY_WORKER_SOCKET_ACCEPT_DELAY_MS ?? 0,
+);
 let draining = false;
 
 // When the rolling handoff benchmark asks for it, flush this worker's exit-time
@@ -110,20 +113,42 @@ process.on("message", (message, socket) => {
     }
     socket.pause();
     pendingSockets.set(message.socketId, socket);
-    process.send?.(
-      {
-        type: "proxy-worker:socket-accepted",
-        generation,
-        pid: process.pid,
-        socketId: message.socketId,
-      },
-      (error) => {
-        if (error) {
-          pendingSockets.delete(message.socketId);
-          socket.destroy();
-        }
-      },
-    );
+    socket.once("error", () => {
+      if (pendingSockets.get(message.socketId) !== socket) {
+        return;
+      }
+      pendingSockets.delete(message.socketId);
+      socket.destroy();
+      reportDrained();
+    });
+    socket.once("close", () => {
+      if (pendingSockets.get(message.socketId) !== socket) {
+        return;
+      }
+      pendingSockets.delete(message.socketId);
+      reportDrained();
+    });
+    const acknowledge = () => {
+      process.send?.(
+        {
+          type: "proxy-worker:socket-accepted",
+          generation,
+          pid: process.pid,
+          socketId: message.socketId,
+        },
+        (error) => {
+          if (error) {
+            pendingSockets.delete(message.socketId);
+            socket.destroy();
+          }
+        },
+      );
+    };
+    if (socketAcceptDelayMs > 0) {
+      setTimeout(acknowledge, socketAcceptDelayMs);
+    } else {
+      acknowledge();
+    }
     return;
   }
   if (

--- a/test/proxyAnalysis.test.ts
+++ b/test/proxyAnalysis.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -269,6 +269,75 @@ describe("offline proxy log analysis", () => {
     });
   });
 
+  it("reports per-stream coverage and missing body artifacts without reading bodies", async () => {
+    const logDir = await mkdtemp(join(tmpdir(), "neurolink-analysis-"));
+    tempDirs.push(logDir);
+    const bodyDir = join(logDir, "bodies", "2026-07-18", "request-1");
+    const presentBody = join(bodyDir, "present.json.gz");
+    const missingBody = join(bodyDir, "missing.json.gz");
+    const escapedBody = join(bodyDir, "escaped.json.gz");
+    const outsideBody = join(logDir, "outside-body.json.gz");
+    await mkdir(bodyDir, { recursive: true });
+    await writeFile(presentBody, "not-read-by-the-analyzer");
+    await writeFile(outsideBody, "outside-the-body-sandbox");
+    await symlink(outsideBody, escapedBody);
+    await writeJsonLines(logDir, "proxy-debug-2026-07-18.jsonl", [
+      {
+        timestamp: "2026-07-18T10:00:00.000Z",
+        type: "body_capture",
+        bodyPath: presentBody,
+        bodyTruncated: true,
+      },
+      {
+        timestamp: "2026-07-18T11:00:00.000Z",
+        type: "body_capture",
+        bodyPath: missingBody,
+      },
+      {
+        timestamp: "2026-07-18T11:30:00.000Z",
+        type: "body_capture",
+        bodyWriteFailed: true,
+      },
+      {
+        timestamp: "2026-07-18T11:45:00.000Z",
+        type: "body_capture",
+        bodyPath: join(logDir, "outside.json.gz"),
+      },
+      {
+        timestamp: "2026-07-18T11:46:00.000Z",
+        type: "body_capture",
+        bodyPath: escapedBody,
+      },
+      {
+        timestamp: "2026-07-18T11:47:00.000Z",
+        type: "body_capture",
+        bodyPath: "bodies/unsafe\0artifact.json.gz",
+      },
+    ]);
+
+    const report = await analyzeProxyLogs({
+      logsDir: logDir,
+      since: "2h",
+      nowMs,
+    });
+
+    expect(report.files.debug).toBe(1);
+    expect(report.dataQuality.streams.debug).toEqual({
+      observedFrom: "2026-07-18T10:00:00.000Z",
+      observedTo: "2026-07-18T11:47:00.000Z",
+      startsAtOrBeforeRequestedWindow: true,
+    });
+    expect(report.dataQuality.bodyArtifacts).toEqual({
+      capturesIndexed: 6,
+      artifactsReferenced: 2,
+      artifactsPresent: 1,
+      artifactsMissing: 1,
+      invalidPaths: 3,
+      writeFailures: 1,
+      truncatedCaptures: 1,
+    });
+  });
+
   it("marks absent telemetry as unavailable instead of treating it as zero", async () => {
     const logDir = await mkdtemp(join(tmpdir(), "neurolink-analysis-"));
     tempDirs.push(logDir);
@@ -288,5 +357,33 @@ describe("offline proxy log analysis", () => {
     });
     expect(report.requests.completed).toBe(0);
     expect(report.lifecycle.unsettled).toBe(0);
+  });
+
+  it("does not claim attempt coverage from a file with no records in the requested window", async () => {
+    const logDir = await mkdtemp(join(tmpdir(), "neurolink-analysis-"));
+    tempDirs.push(logDir);
+    await writeJsonLines(logDir, "proxy-attempts-2026-07-18.jsonl", [
+      {
+        timestamp: "2026-07-18T08:00:00.000Z",
+        requestId: "old-attempt",
+        account: "old@example.com",
+        accountType: "oauth",
+        responseStatus: 200,
+        attemptDurationMs: 10,
+      },
+    ]);
+
+    const report = await analyzeProxyLogs({
+      logsDir: logDir,
+      since: "2h",
+      nowMs,
+    });
+
+    expect(report.files.attempts).toBe(1);
+    expect(report.coverage.attempts).toBe(false);
+    expect(report.attempts.total).toBe(0);
+    expect(report.dataQuality.streams.attempts.observedTo).toBe(
+      "2026-07-18T08:00:00.000Z",
+    );
   });
 });

--- a/test/proxyConfigHotReload.test.ts
+++ b/test/proxyConfigHotReload.test.ts
@@ -336,6 +336,47 @@ routing:
     expect(store.getSnapshot()).toBe(stable);
   });
 
+  it("publishes non-routing env changes so a supervised worker can be replaced", async () => {
+    const directory = await createTempDir();
+    const configPath = join(directory, "proxy-config.yaml");
+    const envFilePath = join(directory, ".env");
+    await writeFile(configPath, "routing:\n  strategy: fill-first\n");
+    await writeFile(envFilePath, "OTEL_EXPORTER_OTLP_ENDPOINT=http://one\n");
+    const store = await ProxyRuntimeConfigStore.create({
+      configPath,
+      configRequired: true,
+      envFilePath,
+      envFileRequired: true,
+      baseEnv: {},
+      passthrough: false,
+    });
+    const initial = store.getSnapshot();
+
+    await writeFile(
+      envFilePath,
+      "# Cosmetic edits must not roll the worker.\nOTEL_EXPORTER_OTLP_ENDPOINT = http://one\n",
+    );
+    await expect(store.reload("manual")).resolves.toEqual({
+      applied: true,
+      changed: false,
+      generation: 1,
+    });
+    expect(store.getSnapshot()).toBe(initial);
+
+    await writeFile(envFilePath, "OTEL_EXPORTER_OTLP_ENDPOINT=http://two\n");
+    await expect(store.reload("manual")).resolves.toEqual({
+      applied: true,
+      changed: true,
+      generation: 2,
+      environmentChanged: true,
+    });
+
+    const reloaded = store.getSnapshot();
+    expect(reloaded.configHash).toBe(initial.configHash);
+    expect(reloaded.strategy).toBe(initial.strategy);
+    expect(reloaded).not.toHaveProperty("envFileHash");
+  });
+
   it("serializes concurrent reload attempts and notifies rejected reloads", async () => {
     const dir = await createTempDir();
     const configPath = join(dir, "proxy-config.json");

--- a/test/proxyObservabilityFoundation.test.ts
+++ b/test/proxyObservabilityFoundation.test.ts
@@ -1,16 +1,18 @@
 import {
+  mkdir,
   mkdtemp,
   readFile,
   readdir,
   rm,
   stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { gunzip } from "node:zlib";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProxyStartApp } from "../src/cli/commands/proxy.js";
 import {
   beginProxyRequest,
@@ -26,8 +28,12 @@ import {
   resetProxyLifecycleLoggerForTests,
 } from "../src/lib/proxy/proxyLifecycle.js";
 import {
+  __requestLoggerTestHooks,
+  cleanupLogs,
+  flushRequestLogs,
   initRequestLogger,
   logBodyCapture,
+  logRequestAttempt,
 } from "../src/lib/proxy/requestLogger.js";
 import type { ProxyResponseTerminalOutcome } from "../src/lib/types/index.js";
 import compatibilityFixture from "./fixtures/proxy-compatibility-v9.88.12.json";
@@ -65,6 +71,7 @@ function permissionBits(mode: number): string {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   await flushProxyLifecycleEvents();
   initRequestLogger(false);
   resetProxyLifecycleLoggerForTests();
@@ -164,6 +171,123 @@ describe("proxy 9.88.12 compatibility contract", () => {
         ),
       ).toBe(true);
     }
+  });
+
+  it("preserves current-day metadata while evicting older logs and body artifacts", async () => {
+    const logDir = await makeTempDir();
+    initRequestLogger(true, logDir);
+    const now = Date.now();
+    const currentDate = new Date(now).toISOString().split("T")[0];
+    const previousDate = new Date(now - 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+    const currentMetadata = [
+      `proxy-${currentDate}.jsonl`,
+      `proxy-attempts-${currentDate}.jsonl`,
+      `proxy-debug-${currentDate}.jsonl`,
+      `proxy-lifecycle-${currentDate}.jsonl`,
+    ].map((name) => join(logDir, name));
+    const previousLog = join(logDir, `proxy-${previousDate}.jsonl`);
+    const previousLifecycleLog = join(
+      logDir,
+      `proxy-lifecycle-${previousDate}.jsonl`,
+    );
+    const bodyDir = join(logDir, "bodies", currentDate, "request-1");
+    const bodyArtifact = join(bodyDir, "response.json.gz");
+
+    await mkdir(bodyDir, { recursive: true });
+    await Promise.all([
+      ...currentMetadata.map((path) => writeFile(path, "x".repeat(4096))),
+      writeFile(previousLog, "x".repeat(4096)),
+      writeFile(previousLifecycleLog, "x".repeat(4096)),
+      writeFile(bodyArtifact, "x".repeat(4096)),
+    ]);
+    const older = new Date(now - 60_000);
+    await Promise.all([
+      utimes(previousLog, older, older),
+      utimes(previousLifecycleLog, older, older),
+      utimes(bodyArtifact, older, older),
+    ]);
+
+    cleanupLogs(7, 0.001);
+
+    await Promise.all(
+      currentMetadata.map((path) => expect(stat(path)).resolves.toBeDefined()),
+    );
+    await expect(stat(previousLog)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(previousLifecycleLog)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(stat(bodyArtifact)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("flushes admitted attempt writes before a rolling worker exits", async () => {
+    const logDir = await makeTempDir();
+    initRequestLogger(true, logDir);
+    const timestamp = new Date().toISOString();
+
+    void logRequestAttempt({
+      timestamp,
+      requestId: "draining-attempt",
+      attempt: 1,
+      method: "POST",
+      path: "/v1/messages",
+      model: "claude-sonnet-5",
+      stream: true,
+      toolCount: 0,
+      account: "primary@example.com",
+      accountType: "oauth",
+      responseStatus: 200,
+      responseTimeMs: 25,
+      attemptDurationMs: 20,
+    });
+    await flushRequestLogs();
+
+    const date = timestamp.split("T")[0];
+    await expect(
+      readJsonLines(join(logDir, `proxy-attempts-${date}.jsonl`)),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        requestId: "draining-attempt",
+        responseStatus: 200,
+      }),
+    ]);
+  });
+
+  it("bounds request-log flushing when an admitted operation never settles", async () => {
+    const neverSettles = new Promise<void>(() => undefined);
+    void __requestLoggerTestHooks.trackLogOperation(neverSettles);
+
+    await expect(flushRequestLogs(10)).rejects.toThrow(
+      "Timed out flushing 1 proxy request log operation(s)",
+    );
+    await expect(flushRequestLogs(10)).resolves.toBeUndefined();
+  });
+
+  it("retains operations admitted while a flush batch reaches its deadline", async () => {
+    vi.useFakeTimers();
+    let resolveLateOperation: (() => void) | undefined;
+    const lateOperation = new Promise<void>((resolve) => {
+      resolveLateOperation = resolve;
+    });
+    const firstOperation = new Promise<void>((resolve) =>
+      setTimeout(resolve, 10),
+    ).then(() => {
+      void __requestLoggerTestHooks.trackLogOperation(lateOperation);
+    });
+    void __requestLoggerTestHooks.trackLogOperation(firstOperation);
+
+    const flushing = flushRequestLogs(10);
+    const flushExpectation = expect(flushing).rejects.toThrow(
+      "Timed out flushing 1 proxy request log operation(s)",
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    await flushExpectation;
+    expect(__requestLoggerTestHooks.pendingOperationCount()).toBe(1);
+
+    resolveLateOperation?.();
+    await Promise.resolve();
+    await expect(flushRequestLogs(10)).resolves.toBeUndefined();
   });
 });
 

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -709,6 +709,77 @@ describe("upstream attempt classification and retry amplification", () => {
     );
   });
 
+  it("records duration for a successful non-stream OAuth retry", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: "refreshed-access",
+            refresh_token: "refreshed-refresh",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            type: "message",
+            usage: { input_tokens: 7, output_tokens: 3 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "expired-access",
+      refreshToken: "valid-refresh",
+      type: "oauth" as const,
+    };
+    const logAttempt = vi.fn();
+    const logFinalRequest = vi.fn();
+    recordAttempt(account.label, account.type);
+
+    const result = await __testHooks.handleAnthropicAuthRetry({
+      ctx: {} as never,
+      body: { model: "claude-sonnet-5", messages: [], stream: false },
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      headers: { "content-type": "application/json" },
+      buildUpstreamBody: () => ({ bodyStr: "{}" }),
+      enabledAccounts: [account],
+      orderedAccounts: [account],
+      requestStartTime: Date.now(),
+      allocateAttemptNumber: () => 3,
+      logAttempt,
+      logProxyBody: vi.fn(),
+      logFinalRequest,
+      lastError: undefined,
+      authFailureMessage: null,
+      sawRateLimit: false,
+      sawTransientFailure: false,
+      sawNetworkError: false,
+    });
+
+    expect(result).toMatchObject({
+      continueLoop: false,
+      response: { type: "message" },
+    });
+    expect(logAttempt).toHaveBeenNthCalledWith(2, 200, undefined, undefined, {
+      attempt: 3,
+      attemptDurationMs: expect.any(Number),
+    });
+    expect(logFinalRequest).toHaveBeenCalledWith(
+      200,
+      account.label,
+      account.type,
+    );
+  });
+
   it("classifies terminal OAuth retry transport failures as non-retryable", async () => {
     const retryError = Object.assign(new TypeError("invalid URL"), {
       cause: { code: "ERR_INVALID_URL" },
@@ -775,6 +846,90 @@ describe("upstream attempt classification and retry amplification", () => {
         attemptDurationMs: expect.any(Number),
       },
     );
+  });
+
+  it("preflights immediate SSE rate limits after OAuth refresh before client commit", async () => {
+    const streamError =
+      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"rate limited after refresh"}}\n\n';
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: "refreshed-access",
+            refresh_token: "refreshed-refresh",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(streamError, {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+            "retry-after": "1",
+            "anthropic-ratelimit-unified-status": "allowed",
+          },
+        }),
+      );
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "expired-access",
+      refreshToken: "valid-refresh",
+      type: "oauth" as const,
+    };
+    const logAttempt = vi.fn();
+    recordAttempt(account.label, account.type);
+
+    const result = await __testHooks.handleAnthropicAuthRetry({
+      ctx: {} as never,
+      body: { model: "claude-sonnet-5", messages: [], stream: true },
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      headers: { "content-type": "application/json" },
+      buildUpstreamBody: () => ({ bodyStr: "{}" }),
+      enabledAccounts: [account],
+      orderedAccounts: [account],
+      requestStartTime: Date.now(),
+      allocateAttemptNumber: () => 2,
+      logAttempt,
+      logProxyBody: vi.fn(),
+      logFinalRequest: vi.fn(),
+      lastError: undefined,
+      authFailureMessage: null,
+      sawRateLimit: false,
+      sawTransientFailure: false,
+      sawNetworkError: false,
+    });
+
+    expect(result).toMatchObject({
+      continueLoop: true,
+      sawRateLimit: true,
+      sawTransientFailure: false,
+      lastError: "rate limited after refresh",
+    });
+    expect(result.response).toBeUndefined();
+    expect(logAttempt).toHaveBeenNthCalledWith(
+      2,
+      429,
+      "rate_limit_error",
+      "rate limited after refresh",
+      expect.objectContaining({
+        attempt: 2,
+        retryable: true,
+        rateLimitKind: "transient",
+      }),
+    );
+    expect(getStats()).toMatchObject({
+      totalAttempts: 2,
+      totalAttemptErrors: 2,
+      totalRateLimits: 1,
+      totalRequests: 0,
+    });
   });
 
   it("still counts and plans cooldown for a genuine transient 429", async () => {
@@ -1650,6 +1805,7 @@ describe("stream terminal outcomes", () => {
       type: "oauth" as const,
     };
     const logFinalRequest = vi.fn();
+    const logAttempt = vi.fn();
     const logProxyBody = vi.fn();
     const upstreamSpan = { end: vi.fn() };
     const tracer = {
@@ -1682,7 +1838,7 @@ describe("stream terminal outcomes", () => {
       attemptNumber: 1,
       finalBodyStr: "{}",
       upstreamSpan: upstreamSpan as never,
-      logAttempt: vi.fn(),
+      logAttempt,
       logProxyBody,
       logFinalRequest,
     });
@@ -1690,6 +1846,10 @@ describe("stream terminal outcomes", () => {
     expect(result).not.toHaveProperty("retryNextAccount");
     await (result.response as Response).text();
     await vi.waitFor(() => expect(logFinalRequest).toHaveBeenCalledTimes(1));
+
+    expect(logAttempt).toHaveBeenCalledWith(200, undefined, undefined, {
+      attemptDurationMs: expect.any(Number),
+    });
 
     expect(logFinalRequest).toHaveBeenCalledWith(
       502,
@@ -1742,6 +1902,14 @@ describe("launchd lifecycle source invariants", () => {
     expect(source).toContain('"proxy-supervisor-state.json"');
     expect(source).toContain("const servingWorker =");
     expect(source).toContain(
+      "const servingState = servingWorker ? state : null",
+    );
+    expect(source).toContain('type: "proxy-worker:replacement-requested"');
+    expect(source).toContain(
+      "status.strategy = servingState?.strategy ?? null",
+    );
+    expect(source).not.toContain("status.strategy = state?.strategy ?? null");
+    expect(source).toContain(
       "rolling activation failed; restoring @juspay/neurolink@",
     );
     expect(source).toContain("package rollback complete");
@@ -1770,7 +1938,6 @@ describe("launchd lifecycle source invariants", () => {
     expect(source).not.toContain("tokenChanged || legacyTransientDisable");
     expect(source).toContain("initAccountCooldown(devPaths.cooldownFile)");
     expect(source).not.toContain("Ignoring default config");
-    expect(source).not.toContain("cooling: false");
     expect(source).toContain("catch(forceExitAfterShutdownFailure)");
     expect(source).toContain("Timed out draining the proxy server");
     expect(source).toContain("await Promise.allSettled([");
@@ -1779,6 +1946,19 @@ describe("launchd lifecycle source invariants", () => {
     );
     expect(source).toContain(
       "Timed out flushing proxy lifecycle metadata during shutdown",
+    );
+    expect(source).toContain(
+      "Timed out flushing proxy request logs during shutdown",
+    );
+    const rollingServer = await readFile(
+      new URL("../src/lib/proxy/rollingProxyServer.ts", import.meta.url),
+      "utf8",
+    );
+    expect(rollingServer).toContain(
+      "await new Promise<void>((resolve) => listener.close(() => resolve()))",
+    );
+    expect(rollingServer).toContain(
+      "await supervisor.close().catch(() => undefined)",
     );
     const startAllowedIndex = startHandler.indexOf(
       "await ensureProxyStartAllowed(spinner)",

--- a/test/proxyRollingWorkerHandoff.test.ts
+++ b/test/proxyRollingWorkerHandoff.test.ts
@@ -123,6 +123,17 @@ class FakeWorker implements RollingWorkerHandle {
     }
   }
 
+  requestReplacement(generation: number): void {
+    for (const listener of this.messages) {
+      listener({
+        type: "proxy-worker:replacement-requested",
+        generation,
+        pid: this.pid,
+        reason: "environment",
+      });
+    }
+  }
+
   activated(generation: number): void {
     for (const listener of this.messages) {
       listener({ type: "proxy-worker:activated", generation, pid: this.pid });
@@ -497,12 +508,14 @@ describe("rolling proxy worker supervisor", () => {
 
   it("fails every uncommitted socket without replaying after a worker transfer failure", async () => {
     const workers: FakeWorker[] = [];
+    const logs: string[] = [];
     const supervisor = new RollingWorkerSupervisor({
       spawnWorker: () => {
         const worker = new FakeWorker(475 + workers.length);
         workers.push(worker);
         return worker;
       },
+      log: (message) => logs.push(message),
     });
     const initial = supervisor.start("9.93.1");
     workers[0].ready(1, "9.93.1");
@@ -516,12 +529,32 @@ describe("rolling proxy worker supervisor", () => {
     workers[0].failPendingSockets("worker IPC failed");
     expect(supervisor.snapshot()).toMatchObject({
       active: null,
+      draining: [{ pid: 475 }],
       queuedSockets: 0,
       failedTransfers: 3,
       rejectedSockets: 3,
+      lastFailure: {
+        phase: "transfer",
+        message: expect.stringContaining("worker IPC failed"),
+      },
     });
-    expect(sockets.every((socket) => socket.destroyed)).toBe(true);
     expect(workers[0].terminated).toContain("SIGKILL");
+    expect(sockets.every((socket) => socket.destroyed)).toBe(true);
+    expect(logs).toContainEqual(expect.stringContaining("worker IPC failed"));
+
+    workers[0].exit(null, "SIGKILL");
+    const replacement = supervisor.replace("9.93.1");
+    workers[1].ready(2, "9.93.1");
+    await replacement;
+    expect(supervisor.snapshot()).toMatchObject({
+      active: { pid: 476 },
+      queuedSockets: 0,
+      rejectedSockets: 3,
+      lastFailure: {
+        phase: "transfer",
+        message: expect.stringContaining("worker IPC failed"),
+      },
+    });
     void supervisor.close();
   });
 });
@@ -690,6 +723,8 @@ describe("socket worker runtime", () => {
       expect(sent.some((m) => m?.type === "proxy-worker:socket-accepted")).toBe(
         true,
       );
+      const pendingErrorListeners = socket.listeners("error");
+      const pendingCloseListeners = socket.listeners("close");
 
       // Drain arrives before the commit: the acknowledged socket must survive.
       process.emit("message", { type: "proxy-worker:drain", generation: 91 });
@@ -704,6 +739,85 @@ describe("socket worker runtime", () => {
       });
       expect(socket.destroyed).toBe(false);
       expect(socket.resumed).toBe(true);
+      for (const listener of pendingErrorListeners) {
+        expect(socket.listeners("error")).not.toContain(listener);
+      }
+      for (const listener of pendingCloseListeners) {
+        expect(socket.listeners("close")).not.toContain(listener);
+      }
+    } finally {
+      if (originalConnected) {
+        Object.defineProperty(process, "connected", originalConnected);
+      } else {
+        delete (process as { connected?: boolean }).connected;
+      }
+      if (originalSend) {
+        process.send = originalSend;
+      } else {
+        delete (process as { send?: unknown }).send;
+      }
+    }
+  });
+
+  it("survives a client reset while a transferred socket awaits commit", () => {
+    const httpServer = createHttpServer();
+    const runtime = attachSocketWorkerProcess(httpServer, {
+      generation: 92,
+      version: "9.93.1",
+    });
+    trackCleanup(() => runtime.close());
+
+    const originalSend = process.send;
+    const originalConnected = Object.getOwnPropertyDescriptor(
+      process,
+      "connected",
+    );
+    (process as { send?: unknown }).send = (
+      _message: unknown,
+      handleOrCallback?: unknown,
+      _options?: unknown,
+      maybeCallback?: unknown,
+    ): boolean => {
+      const ack =
+        typeof handleOrCallback === "function"
+          ? handleOrCallback
+          : maybeCallback;
+      if (typeof ack === "function") {
+        (ack as (error: Error | null) => void)(null);
+      }
+      return true;
+    };
+    Object.defineProperty(process, "connected", {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      process.emit("message", {
+        type: "proxy-worker:activate",
+        generation: 92,
+      });
+      const socket = new FakeSocket();
+      process.emit(
+        "message",
+        { type: "proxy-worker:socket", generation: 92, socketId: "reset" },
+        socket,
+      );
+
+      expect(() =>
+        socket.emit(
+          "error",
+          Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+        ),
+      ).not.toThrow();
+      expect(socket.destroyed).toBe(true);
+
+      process.emit("message", {
+        type: "proxy-worker:socket-commit",
+        generation: 92,
+        socketId: "reset",
+      });
+      expect(socket.resumed).toBe(false);
     } finally {
       if (originalConnected) {
         Object.defineProperty(process, "connected", originalConnected);
@@ -819,6 +933,49 @@ describe("cross-process socket handoff", () => {
     await closing;
   });
 
+  it("keeps the worker alive when a client resets before socket commit", async () => {
+    const rollingServer = await startTrackedRollingServer({
+      host: "127.0.0.1",
+      port: 0,
+      initialVersion: "9.93.1",
+      spawnWorker: (generation, expectedVersion) =>
+        spawnProxySocketWorker({
+          generation,
+          expectedVersion,
+          command: process.execPath,
+          args: [IPC_HTTP_WORKER],
+          stdout: "ignore",
+          stderr: "ignore",
+          env: { NEUROLINK_PROXY_WORKER_SOCKET_ACCEPT_DELAY_MS: "100" },
+        }),
+    });
+    const initialWorker = rollingServer.snapshot().active;
+    expect(initialWorker).not.toBeNull();
+
+    const client = createConnection({
+      host: "127.0.0.1",
+      port: rollingServer.address.port,
+    });
+    trackConnection(client);
+    await new Promise<void>((resolve, reject) => {
+      client.once("connect", resolve);
+      client.once("error", reject);
+    });
+    client.resetAndDestroy();
+    await new Promise<void>((resolve) => setTimeout(resolve, 150));
+
+    expect(rollingServer.snapshot()).toMatchObject({
+      active: initialWorker,
+      failedTransfers: 0,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${rollingServer.address.port}/health`,
+      { headers: { connection: "close" } },
+    );
+    expect(await response.text()).toBe("worker-9.93.1");
+    await rollingServer.close();
+  });
+
   it("keeps the listener alive and recovers after initial worker startup fails", async () => {
     let spawnCount = 0;
     const rollingServer = await startTrackedRollingServer({
@@ -854,6 +1011,116 @@ describe("cross-process socket handoff", () => {
       rejectedSockets: 0,
     });
     await rollingServer.close();
+  });
+
+  it("rolls to a same-version worker when the active worker reports an environment change", async () => {
+    const workers: FakeWorker[] = [];
+    const rollingServer = await startTrackedRollingServer({
+      host: "127.0.0.1",
+      port: 0,
+      initialVersion: "9.93.1",
+      spawnWorker: (generation, expectedVersion) => {
+        const worker = new FakeWorker(500 + generation);
+        workers.push(worker);
+        queueMicrotask(() => worker.ready(generation, expectedVersion));
+        return worker;
+      },
+    });
+
+    workers[0].requestReplacement(1);
+
+    await vi.waitFor(() =>
+      expect(rollingServer.snapshot().active).toMatchObject({
+        generation: 2,
+        version: "9.93.1",
+      }),
+    );
+    expect(workers).toHaveLength(2);
+    expect(workers[0].controls).toContainEqual({
+      type: "proxy-worker:drain",
+      generation: 1,
+    });
+    const closing = rollingServer.close();
+    workers[0].exit(0, null);
+    workers[1].exit(0, null);
+    await closing;
+  });
+
+  it("serializes an explicit replacement behind an environment replacement", async () => {
+    const workers: FakeWorker[] = [];
+    const rollingServer = await startTrackedRollingServer({
+      host: "127.0.0.1",
+      port: 0,
+      initialVersion: "9.93.1",
+      spawnWorker: (generation, expectedVersion) => {
+        const worker = new FakeWorker(520 + generation);
+        workers.push(worker);
+        if (generation !== 2) {
+          queueMicrotask(() => worker.ready(generation, expectedVersion));
+        }
+        return worker;
+      },
+    });
+
+    workers[0].requestReplacement(1);
+    await vi.waitFor(() => expect(workers).toHaveLength(2));
+
+    const explicitReplacement = rollingServer.replace("9.94.0");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(workers).toHaveLength(2);
+
+    workers[1].ready(2, "9.93.1");
+    await explicitReplacement;
+
+    expect(workers).toHaveLength(3);
+    expect(rollingServer.snapshot().active).toMatchObject({
+      generation: 3,
+      version: "9.94.0",
+    });
+    const closing = rollingServer.close();
+    for (const worker of workers) {
+      worker.exit(0, null);
+    }
+    await closing;
+  });
+
+  it("preserves an environment replacement when the active worker exits during debounce", async () => {
+    const workers: FakeWorker[] = [];
+    const rollingServer = await startTrackedRollingServer({
+      host: "127.0.0.1",
+      port: 0,
+      initialVersion: "9.93.1",
+      recoveryDelayMs: 100,
+      maxRecoveryDelayMs: 100,
+      spawnWorker: (generation, expectedVersion) => {
+        const worker = new FakeWorker(540 + generation);
+        workers.push(worker);
+        queueMicrotask(() => worker.ready(generation, expectedVersion));
+        return worker;
+      },
+    });
+
+    workers[0].requestReplacement(1);
+    workers[0].exit(1, null);
+
+    await vi.waitFor(
+      () =>
+        expect(rollingServer.snapshot().active).toMatchObject({
+          generation: 3,
+          version: "9.93.1",
+        }),
+      { timeout: 1_000 },
+    );
+    expect(workers).toHaveLength(3);
+    expect(workers[1].controls).toContainEqual({
+      type: "proxy-worker:drain",
+      generation: 2,
+    });
+    const closing = rollingServer.close();
+    for (const worker of workers) {
+      worker.exit(0, null);
+    }
+    await closing;
   });
 
   it("atomically routes new TCP connections to a replacement process", async () => {

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -179,6 +179,19 @@ describe("proxy runtime error finalization", () => {
     expect(response.status).toBe(400);
     await response.text();
     expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    const status = await (await app.request("/status")).json();
+    expect(status.stats.accounts).toEqual([
+      expect.objectContaining({
+        label: "unattributed",
+        type: "internal",
+        attempts: 0,
+        requests: 1,
+        success: 0,
+        errors: 1,
+        cooling: false,
+        status: "unattributed",
+      }),
+    ]);
     expect(getProxyActivitySnapshot().activeRequests).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- replace the active rolling worker on `.env` changes while preserving the public listener and draining existing streams
- serialize environment, explicit, and crash-recovery replacements; invalidate stale timer callbacks; and harden listener cleanup, supervisor PID validation, and stale status metadata handling
- extend socket-transfer acknowledgement to 30 seconds, retain exact worker exit/transfer failures after recovery, and keep unsafe descriptors non-replayable
- guard parent and worker copies of pre-commit transferred sockets so client `ECONNRESET` cannot crash the supervisor or worker
- preserve pending environment replacements across worker recovery and ignore comment/whitespace-only `.env` rewrites
- persist successful upstream attempts, bound and abort request/body log I/O during shutdown, and preflight immediate SSE errors after OAuth refresh
- retain current-day metadata indexes, report unattributed persisted counters, and expose per-stream/body-artifact data quality in `proxy analyze`

## Validation

- `pnpm exec vitest run test/proxyAnalysis.test.ts test/proxyConfigHotReload.test.ts test/proxyObservabilityFoundation.test.ts test/proxyReliabilityHardening.test.ts test/proxyReplay.test.ts test/proxyRollingWorkerHandoff.test.ts test/proxyUpdaterFallback.test.ts test/proxyUsageStatsPersistence.test.ts` (181 passed)
- `pnpm run test:bugfixes` (234 passed)
- `pnpm run typecheck`
- changed-file ESLint (0 errors)
- `pnpm run build:cli`
- full pre-commit pipeline: check, format, lint, validate/security, package build, browser build, publint
- `pnpm run proxy:performance` (all budgets passed; 0 dropped handoff requests; active stream preserved)
- built CLI `proxy analyze --help` smoke test

## Live safety

No repository test sent model traffic or used the live proxy as a development target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded offline proxy log analysis to include debug time windows and body-artifact quality (indexed, present/missing, invalid paths, truncation, write failures).
  * Runtime reload now better detects environment-only changes and reports `environmentChanged`.
  * Proxy `/status` now improves serving-state details and per-account attribution, including an “unattributed” entry.
* **Bug Fixes**
  * Standardized attempt/telemetry completion logging across JSON, streaming, and auth-retry flows.
  * Improved shutdown/reload reliability by coordinating request-log flushing and strengthening log cleanup/retention safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->