### PR TITLE
fix(context): end the derived turn deadline one wrap-up lead before the hard abort

### DIFF
--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -104,7 +104,7 @@ function safePreview(v: unknown): string {
  * and a deadline computed from Date.now() per attempt would hand each retry
  * a fresh budget — multiplying the caller's wall-clock cap.
  */
-function resolveTurnBudget(
+export function resolveTurnBudget(
   options: TextGenerationOptions,
   turnStartMs: number,
 ): {
@@ -124,15 +124,30 @@ function resolveTurnBudget(
       { turnTimeoutMs: options.turnTimeoutMs },
     );
   }
-  const turnBudgetMs = hasValidTurnTimeout
+  let turnBudgetMs = hasValidTurnTimeout
     ? options.turnTimeoutMs
     : callerTimeoutMs;
-  const wrapupLeadMs = turnBudgetMs
+  let wrapupLeadMs = turnBudgetMs
     ? Math.min(
         options.wrapupTimeLeadMs ?? DEFAULT_WRAPUP_TIME_LEAD_MS,
         Math.floor(turnBudgetMs / 4),
       )
     : 0;
+  // When the budget is DERIVED from the generate `timeout`, the hard abort in
+  // executeStandardGenerateFlow fires at exactly callerTimeoutMs — the same
+  // instant as the turn deadline. Wrap-up would engage at (deadline − lead)
+  // but its final, tools-off generation then RACES the abort and loses on
+  // slow models (observed: wrap-up engaged at T−lead, final answer killed at
+  // exactly T → TimeoutError, all work discarded). Pull the turn deadline one
+  // wrap-up lead earlier so the final generation runs in EXCLUSIVE margin
+  // before the abort. An explicit turnTimeoutMs is left untouched — the
+  // caller separated the two deadlines deliberately.
+  if (!hasValidTurnTimeout && turnBudgetMs !== undefined && wrapupLeadMs > 0) {
+    turnBudgetMs = turnBudgetMs - wrapupLeadMs;
+    // Keep the quarter-budget clamp invariant against the reduced budget so
+    // short timeouts still don't wrap up on the very first step.
+    wrapupLeadMs = Math.min(wrapupLeadMs, Math.floor(turnBudgetMs / 4));
+  }
   const turnDeadline = turnBudgetMs ? turnStartMs + turnBudgetMs : undefined;
   return { callerTimeoutMs, turnBudgetMs, wrapupLeadMs, turnDeadline };
 }

--- a/test/continuous-test-suite-litellm-parity.ts
+++ b/test/continuous-test-suite-litellm-parity.ts
@@ -35,7 +35,10 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { defineSuite, assertEqual, assert } from "./helpers/harness.js";
 import { coerceType } from "../src/lib/utils/toolCallRepair.js";
 import { buildMCPSchemaValidator } from "../src/lib/core/modules/ToolsManager.js";
-import { GenerationHandler } from "../src/lib/core/modules/GenerationHandler.js";
+import {
+  GenerationHandler,
+  resolveTurnBudget,
+} from "../src/lib/core/modules/GenerationHandler.js";
 import { ToolDiscoveryService } from "../src/lib/mcp/toolDiscoveryService.js";
 import { isTransientNetworkError } from "../src/lib/proxy/proxyFetch.js";
 import {
@@ -683,6 +686,66 @@ await test("overflow 400 self-heals the window registry and re-fits max_tokens",
     "re-fit bound derives from requestedOutputTokens when max_tokens was unset",
   );
   clearRuntimeContextWindows();
+});
+
+// ---------------------------------------------------------------------------
+// Part 4 — Turn budget vs hard abort separation
+// ---------------------------------------------------------------------------
+// The hard abort in executeStandardGenerateFlow fires at exactly the generate
+// `timeout`. When the turn budget is DERIVED from that same timeout, the turn
+// deadline must sit one wrap-up lead EARLIER so the wrap-up's final,
+// tools-off generation runs in exclusive margin instead of racing the abort
+// (observed on litellm/private-large: wrap-up engaged at T−lead, final answer
+// killed at exactly T → TimeoutError with the whole turn discarded).
+
+await test("derived-from-timeout turn deadline ends one wrap-up lead before the hard abort", () => {
+  const start = 1_000_000;
+  const { callerTimeoutMs, turnBudgetMs, wrapupLeadMs, turnDeadline } =
+    resolveTurnBudget({ timeout: "15m" } as never, start);
+  assertEqual(callerTimeoutMs, 900_000, "15m parses to 900000ms");
+  assertEqual(turnBudgetMs, 780_000, "budget = 15m − 120s default lead");
+  assertEqual(wrapupLeadMs, 120_000, "default lead preserved");
+  assert(
+    (turnDeadline ?? 0) + 120_000 <= start + 900_000,
+    "final generation gets a full lead of exclusive margin before the abort",
+  );
+});
+
+await test("short derived timeouts keep the quarter-budget lead clamp", () => {
+  const { turnBudgetMs, wrapupLeadMs } = resolveTurnBudget(
+    { timeout: "5m" } as never,
+    0,
+  );
+  // lead clamps to 300s/4 = 75s, budget shrinks to 225s, lead re-clamps to 56s.
+  assertEqual(turnBudgetMs, 225_000, "5m budget shrinks by its clamped lead");
+  assertEqual(
+    wrapupLeadMs,
+    56_250,
+    "lead re-clamped to a quarter of the reduced budget",
+  );
+});
+
+await test("an explicit turnTimeoutMs is honored verbatim (caller separated the deadlines)", () => {
+  const { turnBudgetMs, wrapupLeadMs } = resolveTurnBudget(
+    { timeout: "15m", turnTimeoutMs: 600_000 } as never,
+    0,
+  );
+  assertEqual(turnBudgetMs, 600_000, "explicit turn budget untouched");
+  assertEqual(
+    wrapupLeadMs,
+    120_000,
+    "default lead against the explicit budget",
+  );
+});
+
+await test("no timeout and no turnTimeoutMs → no turn deadline (pre-existing behaviour)", () => {
+  const { turnBudgetMs, turnDeadline, wrapupLeadMs } = resolveTurnBudget(
+    {} as never,
+    0,
+  );
+  assertEqual(turnBudgetMs, undefined, "no budget without a caller deadline");
+  assertEqual(turnDeadline, undefined, "no deadline engaged");
+  assertEqual(wrapupLeadMs, 0, "no lead without a budget");
 });
 
 await runSuite();


### PR DESCRIPTION
## Problem

When the agent-loop turn budget is DERIVED from the generate `timeout` (`turnTimeoutMs` unset), the turn deadline and the hard abort in `executeStandardGenerateFlow` land on the SAME instant. Wrap-up engages at `deadline − lead`, but its final, tools-off generation then races the abort — and loses on slow models.

Observed live (Yama self-review on litellm/`private-large`, `timeout: "5m"`):
- 10:13:28 generate starts
- 10:17:30 `Turn budget nearly exhausted — forcing wrap-up (toolChoice: none)`
- 10:18:28.1 — exactly 5m: hard abort kills the wrap-up generation mid-flight → `TimeoutError`, whole turn discarded

Same pattern killed two consecutive 15-minute review attempts in juspay/yama#61 CI (76-minute failed job). The wrap-up warn is invisible in CI (warn-level logs require `NEUROLINK_DEBUG`), which masked this.

## Fix

In `resolveTurnBudget`: when the budget comes from `timeout`, pull the turn deadline one wrap-up lead earlier (`budget = callerTimeout − lead`, lead re-clamped to the quarter-budget invariant). The wrap-up's final generation now runs in EXCLUSIVE margin before the abort — e.g. `timeout: 15m` → wrap-up at 11m, turn ends 13m, abort 15m. An explicit `turnTimeoutMs` is honored verbatim (the caller separated the deadlines deliberately).

`resolveTurnBudget` is exported for direct unit coverage.

## Tests

Four new cases in `test:litellm-parity` (Part 4): derived-deadline margin property, quarter-clamp on short timeouts, explicit `turnTimeoutMs` untouched, no-deadline pre-existing behaviour. Suite 23/23 passing; `test:anthropic-tools-policy` and the step-budget-guard suite pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation timeout handling so wrap-up time is reserved correctly before a hard abort.
  * Prevented short timeout settings from triggering wrap-up too early.
  * Preserved explicit turn timeout settings while maintaining consistent wrap-up behavior.

* **Tests**
  * Added coverage for timeout parsing, deadline calculation, short timeouts, explicit turn limits, and unset timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->