### PR TITLE
fix(tools): resolve tool discovery failures in native agent loops

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -60,6 +60,7 @@ import {
 } from "../utils/anthropicCacheBreakpoints.js";
 import type { VertexAnthropicMessage } from "../types/index.js";
 import { calculateCost } from "../utils/pricing.js";
+import { resolveDeferredTool } from "../tools/toolDiscovery.js";
 import {
   createAnthropicConfig,
   getProviderModel,
@@ -1814,6 +1815,22 @@ export class AnthropicProvider extends BaseProvider {
       let lastStop: string | null = null;
 
       for (let step = 0; step < maxSteps; step++) {
+        // Mid-turn discovery sync: search_tools (tools.discovery) hydrates
+        // new tools into toolsRecord between steps; Claude only calls tools
+        // declared in the request, so advertise them now (`params` below
+        // rebuilds from anthropicTools every step).
+        if (anthropicTools) {
+          const declared = new Set(anthropicTools.map((t) => t.name));
+          const hydrated = Object.fromEntries(
+            Object.entries(toolsRecord).filter(([name]) => !declared.has(name)),
+          );
+          if (Object.keys(hydrated).length > 0) {
+            anthropicTools.push(...(toolsToAnthropic(hydrated) ?? []));
+            logger.info(
+              `[Anthropic] ${Object.keys(hydrated).length} tool(s) hydrated mid-turn via discovery: ${Object.keys(hydrated).join(", ")}`,
+            );
+          }
+        }
         // Prompt-cache parity with the native Vertex+Claude path — rolling
         // history breakpoints, re-applied per step so the stable prefix
         // stays byte-identical while the breakpoint follows the growing
@@ -2000,7 +2017,11 @@ export class AnthropicProvider extends BaseProvider {
           });
           toolsUsed.push(acc.name);
 
-          const tool = toolsRecord[acc.name] as
+          // Live record lookup, then deferred-catalog auto-hydration: with
+          // tools.discovery on, the model may call a cataloged tool it never
+          // loaded via search_tools — a real tool, not a hallucination.
+          const tool = (toolsRecord[acc.name] ??
+            resolveDeferredTool(toolsRecord, acc.name)) as
             | {
                 execute?: (
                   input: Record<string, unknown>,

--- a/src/lib/providers/googleAiStudio.ts
+++ b/src/lib/providers/googleAiStudio.ts
@@ -29,6 +29,7 @@ import type {
   GoogleLiveAudioQueueItem,
   LiveServerMessage,
   AudioChunk,
+  NativeToolDeclarationsResult,
   NativeToolsConfig,
   StreamOptions,
   StreamResult,
@@ -66,6 +67,7 @@ import {
   handleMaxStepsTermination,
   prependConversationMessages,
   pushModelResponseToHistory,
+  refreshNativeToolDeclarations,
   DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
@@ -738,6 +740,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
           let toolsConfig: NativeToolsConfig | undefined;
           let executeMap: Map<string, Tool["execute"]> = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
+          let declarationsResult: NativeToolDeclarationsResult | undefined;
 
           if (
             options.tools &&
@@ -745,6 +748,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
             !options.disableTools
           ) {
             const result = buildNativeToolDeclarations(options.tools);
+            declarationsResult = result;
             toolsConfig = result.toolsConfig;
             executeMap = result.executeMap;
             originalNameMap = result.originalNameMap;
@@ -843,6 +847,14 @@ export class GoogleAIStudioProvider extends BaseProvider {
                     : new Error("Request aborted");
                 }
                 step++;
+                // Mid-turn discovery sync: advertise tools hydrated into the
+                // live record by search_tools during the previous step.
+                if (declarationsResult) {
+                  refreshNativeToolDeclarations(
+                    options.tools,
+                    declarationsResult,
+                  );
+                }
                 logger.debug(
                   `[GoogleAIStudio] Native SDK step ${step}/${maxSteps}`,
                 );
@@ -914,6 +926,8 @@ export class GoogleAIStudioProvider extends BaseProvider {
                       abortSignal: composedSignal,
                       originalNameMap,
                       toolExecutions,
+                      liveTools: options.tools,
+                      declarations: declarationsResult,
                     },
                   );
 
@@ -1153,6 +1167,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
           let toolsConfig: NativeToolsConfig | undefined;
           let executeMap: Map<string, Tool["execute"]> = new DedupExecuteMap();
           let originalNameMap = new Map<string, string>();
+          let declarationsResult: NativeToolDeclarationsResult | undefined;
 
           const shouldUseTools = !options.disableTools;
           if (shouldUseTools) {
@@ -1160,6 +1175,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
             if (Object.keys(tools).length > 0) {
               const result = buildNativeToolDeclarations(tools);
+              declarationsResult = result;
               toolsConfig = result.toolsConfig;
               executeMap = result.executeMap;
               originalNameMap = result.originalNameMap;
@@ -1230,6 +1246,10 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 : new Error("Request aborted");
             }
             step++;
+            // Mid-turn discovery sync — see the stream twin.
+            if (declarationsResult) {
+              refreshNativeToolDeclarations(options.tools, declarationsResult);
+            }
             logger.debug(
               `[GoogleAIStudio] Native SDK generate step ${step}/${maxSteps}`,
             );
@@ -1293,6 +1313,8 @@ export class GoogleAIStudioProvider extends BaseProvider {
                   toolExecutions,
                   abortSignal: composedSignal,
                   originalNameMap,
+                  liveTools: options.tools,
+                  declarations: declarationsResult,
                 },
               );
 

--- a/src/lib/providers/googleNativeGemini3.ts
+++ b/src/lib/providers/googleNativeGemini3.ts
@@ -47,6 +47,7 @@ import {
 } from "../utils/schemaConversion.js";
 
 import { createNativeThinkingConfig } from "../utils/thinkingConfig.js";
+import { resolveLiveTool } from "../tools/toolDiscovery.js";
 import type { ToolExecuteFunction, Tool } from "../types/index.js";
 import {
   jsonSchema as aiJsonSchema,
@@ -495,6 +496,7 @@ export function normalizeToolsForJsonSchemaProvider(
  */
 export function buildNativeToolDeclarations(
   tools: Record<string, Tool>,
+  reservedNames?: ReadonlySet<string>,
 ): NativeToolDeclarationsResult {
   const functionDeclarations: NativeFunctionDeclaration[] = [];
   const executeMap = new DedupExecuteMap();
@@ -510,8 +512,10 @@ export function buildNativeToolDeclarations(
   // execute are still pushed to functionDeclarations). The originalNameMap
   // lets the calling stream loop translate Google-returned function-call
   // names back to the consumer-facing identifier so the sanitization is
-  // transport-only.
-  const usedNames = new Set<string>();
+  // transport-only. `reservedNames` seeds the collision set so a mid-turn
+  // refresh (see refreshNativeToolDeclarations) never re-issues a safe name
+  // already assigned by the pre-loop snapshot.
+  const usedNames = new Set<string>(reservedNames ?? []);
   const originalNameMap = new Map<string, string>();
 
   for (const [name, tool] of Object.entries(tools)) {
@@ -594,6 +598,49 @@ export function buildNativeToolDeclarations(
     executeMap,
     originalNameMap,
   };
+}
+
+/**
+ * Mid-turn tool sync for the native Gemini loops that build their snapshot
+ * via buildNativeToolDeclarations. `search_tools` (tools.discovery) hydrates
+ * discovered tools into the live record between steps; without this refresh
+ * they stay invisible to the rest of the turn and every call dies as
+ * TOOL_NOT_FOUND. Mutates the snapshot in place — the request config holds
+ * `toolsConfig` by reference — and returns true when anything was added.
+ */
+export function refreshNativeToolDeclarations(
+  liveTools: Record<string, Tool> | undefined,
+  current: NativeToolDeclarationsResult,
+): boolean {
+  if (!liveTools) {
+    return false;
+  }
+  const declaredOriginals = new Set(current.originalNameMap.values());
+  const missing = Object.entries(liveTools).filter(
+    ([name]) => !declaredOriginals.has(name),
+  );
+  if (missing.length === 0) {
+    return false;
+  }
+  const built = buildNativeToolDeclarations(
+    Object.fromEntries(missing),
+    new Set(current.originalNameMap.keys()),
+  );
+  current.toolsConfig[0].functionDeclarations.push(
+    ...built.toolsConfig[0].functionDeclarations,
+  );
+  for (const [safeName, originalName] of built.originalNameMap) {
+    current.originalNameMap.set(safeName, originalName);
+  }
+  for (const [safeName, execute] of built.executeMap) {
+    current.executeMap.set(safeName, execute);
+  }
+  logger.info(
+    `[buildNativeToolDeclarations] ${missing.length} tool(s) hydrated mid-turn via discovery: ${missing
+      .map(([name]) => name)
+      .join(", ")}`,
+  );
+  return true;
 }
 
 /**
@@ -1019,6 +1066,15 @@ export async function executeNativeToolCalls(
     }>;
     abortSignal?: AbortSignal;
     originalNameMap?: Map<string, string>;
+    /**
+     * Live tool record + declaration snapshot for mid-turn discovery: on a
+     * dispatch miss the executor re-resolves against `liveTools` (hydrated
+     * by search_tools, or auto-hydrated from the deferred catalog) and syncs
+     * `declarations` in place. `declarations.executeMap` must be the same
+     * map passed as the `executeMap` argument (true at every call site).
+     */
+    liveTools?: Record<string, Tool>;
+    declarations?: NativeToolDeclarationsResult;
   },
 ): Promise<NativeFunctionResponse[]> {
   const functionResponses: NativeFunctionResponse[] = [];
@@ -1065,7 +1121,33 @@ export async function executeNativeToolCalls(
       continue;
     }
 
-    const execute = executeMap.get(call.name);
+    let execute = executeMap.get(call.name);
+    if (!execute && options?.declarations) {
+      // Snapshot miss: the tool may have been hydrated into the live record
+      // by search_tools within this very step batch, or the model called a
+      // deferred catalog tool directly by its advertised name.
+      const liveTool = resolveLiveTool(options.liveTools, exposedName);
+      if (liveTool?.execute) {
+        refreshNativeToolDeclarations(options.liveTools, options.declarations);
+        // NOT_FOUND strikes accrued while the tool was deferred are snapshot
+        // artifacts, not real failures — reset so the breaker starts clean.
+        failedTools.delete(call.name);
+        // The refresh registered the executor under its Google-safe name —
+        // resolve it for this dispatch (later calls use the declared name).
+        for (const [safeName, originalName] of options.declarations
+          .originalNameMap) {
+          if (originalName === exposedName) {
+            execute = executeMap.get(safeName);
+            break;
+          }
+        }
+        if (execute) {
+          logger.info(
+            `${logLabel} Tool "${exposedName}" resolved mid-turn via discovery — executing.`,
+          );
+        }
+      }
+    }
     if (execute) {
       try {
         // AI SDK Tool execute requires (args, options) - provide minimal options

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -37,6 +37,7 @@ import type {
   AnthropicVertexSettings,
   StreamOptions,
   StreamResult,
+  Tool,
   ToolWithLegacyParams,
   VertexNativePart,
   VertexGenaiFunctionDeclaration,
@@ -103,6 +104,7 @@ import {
   DedupExecuteMap,
 } from "./googleNativeGemini3.js";
 import { getContextWindowSize } from "../constants/contextWindows.js";
+import { resolveLiveTool } from "../tools/toolDiscovery.js";
 import {
   ATTR,
   LANGFUSE_ATTR,
@@ -1382,6 +1384,217 @@ export class GoogleVertexProvider extends BaseProvider {
   }
 
   /**
+   * Convert one AI-SDK tool into a Vertex Gemini function declaration.
+   * Single source for the pre-loop snapshot AND the mid-turn discovery
+   * refresh, so tools hydrated by search_tools get the exact same schema
+   * treatment (inline, typed, additionalProperties stripped).
+   */
+  private buildGeminiFunctionDeclaration(
+    name: string,
+    tool: Tool,
+  ): VertexGenaiFunctionDeclaration {
+    const decl: VertexGenaiFunctionDeclaration = {
+      name,
+      description: tool.description || `Tool: ${name}`,
+    };
+
+    // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
+    const legacyTool = tool as ToolWithLegacyParams;
+    const toolParams = legacyTool.parameters || tool.inputSchema;
+    if (toolParams) {
+      // Convert and inline schema to resolve $ref/definitions
+      const rawSchema = convertZodToJsonSchema(
+        toolParams as ZodUnknownSchema,
+        "openApi3",
+      ) as Record<string, unknown>;
+      const inlinedSchema = inlineJsonSchema(rawSchema);
+      // Remove $schema if present - @google/genai doesn't need it
+      if (inlinedSchema.$schema) {
+        delete inlinedSchema.$schema;
+      }
+      // CRITICAL: Google Vertex AI requires ALL nested schemas to have a type field
+      // ensureNestedSchemaTypes recursively adds missing type fields to tool schemas
+      // Note: convertZodToJsonSchema now uses openApi3 target which produces nullable: true
+      const typedSchema = ensureNestedSchemaTypes(inlinedSchema);
+      // Strip `additionalProperties` recursively — Vertex Gemini's
+      // function-call validator rejects it on object schemas (returns
+      // 400 INVALID_ARGUMENT) even though it's valid OpenAPI 3. The
+      // field has no semantic meaning to the model, so dropping it
+      // before send is safe for every caller.
+      stripAdditionalPropertiesDeep(typedSchema);
+      decl.parametersJsonSchema = typedSchema;
+    }
+    return decl;
+  }
+
+  /**
+   * Mid-turn tool sync for the native Gemini loops. `search_tools` hydrates
+   * discovered tools into the live `options.tools` record between steps, but
+   * the loop's declarations + executeMap are a pre-loop snapshot — without
+   * this refresh, a tool discovered this turn stays invisible to the rest of
+   * the turn and every call to it dies as TOOL_NOT_FOUND. Mutates the
+   * declaration array in place (the request config holds it by reference)
+   * and clears breaker strikes accrued while the tool was still deferred.
+   */
+  private refreshGeminiToolDeclarations(
+    liveTools: Record<string, Tool> | undefined,
+    declarations: VertexGenaiFunctionDeclaration[] | undefined,
+    executeMap: DedupExecuteMap,
+    failedTools: Map<string, { count: number; lastError: string }>,
+  ): void {
+    if (!liveTools || !declarations) {
+      return;
+    }
+    const declared = new Set(declarations.map((d) => d.name));
+    for (const [name, tool] of Object.entries(liveTools)) {
+      if (declared.has(name)) {
+        continue;
+      }
+      declarations.push(this.buildGeminiFunctionDeclaration(name, tool));
+      if (tool.execute) {
+        executeMap.set(name, tool.execute);
+      }
+      failedTools.delete(name);
+      logger.info(
+        `[GoogleVertex] Tool "${name}" hydrated mid-turn via discovery — added to Gemini declarations.`,
+      );
+    }
+  }
+
+  /**
+   * Dispatch-miss recovery for the native Gemini loops: the model called a
+   * name missing from the executeMap snapshot. Re-read the live record (a
+   * tool hydrated by search_tools in this very step batch) or auto-hydrate a
+   * deferred catalog tool the model called directly by its advertised name.
+   * Returns the dedup-wrapped executor, or undefined when the name is
+   * genuinely unknown — callers keep TOOL_NOT_FOUND for that case.
+   */
+  private resolveGeminiToolOnMiss(
+    name: string,
+    liveTools: Record<string, Tool> | undefined,
+    declarations: VertexGenaiFunctionDeclaration[] | undefined,
+    executeMap: DedupExecuteMap,
+    failedTools: Map<string, { count: number; lastError: string }>,
+  ): Tool["execute"] | undefined {
+    if (!declarations) {
+      return undefined;
+    }
+    const tool = resolveLiveTool(liveTools, name);
+    if (!tool?.execute) {
+      return undefined;
+    }
+    if (!declarations.some((d) => d.name === name)) {
+      declarations.push(this.buildGeminiFunctionDeclaration(name, tool));
+    }
+    executeMap.set(name, tool.execute);
+    // NOT_FOUND strikes accrued while the tool was deferred are snapshot
+    // artifacts, not real failures — reset so the breaker starts clean.
+    failedTools.delete(name);
+    logger.info(
+      `[GoogleVertex] Tool "${name}" resolved mid-turn via discovery — executing.`,
+    );
+    return executeMap.get(name);
+  }
+
+  /**
+   * Convert one AI-SDK tool into an Anthropic (Claude-on-Vertex) tool
+   * declaration. Single source for the pre-loop snapshot AND the mid-turn
+   * discovery refresh — Anthropic validates input_schema as JSON Schema
+   * draft 2020-12 and rejects OpenAPI-3 dialect (`nullable: true`), so this
+   * uses the default JSON Schema target, matching the direct anthropic
+   * provider. The Gemini paths keep "openApi3".
+   */
+  private buildAnthropicToolDeclaration(
+    name: string,
+    tool: Tool,
+  ): VertexAnthropicTool {
+    const anthropicTool: VertexAnthropicTool = {
+      name,
+      description: tool.description || `Tool: ${name}`,
+      input_schema: {
+        type: "object",
+      },
+    };
+
+    // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
+    const legacyTool = tool as ToolWithLegacyParams;
+    const toolParams = legacyTool.parameters || tool.inputSchema;
+    if (toolParams) {
+      const jsonSchema = convertZodToJsonSchema(
+        toolParams as ZodUnknownSchema,
+      ) as Record<string, unknown>;
+      const inlined = inlineJsonSchema(jsonSchema);
+      anthropicTool.input_schema = {
+        type: "object",
+        properties: (inlined.properties as Record<string, unknown>) || {},
+        required: (inlined.required as string[]) || [],
+      };
+    }
+    return anthropicTool;
+  }
+
+  /**
+   * Mid-turn tool sync for the Claude-on-Vertex loops — the Anthropic
+   * counterpart of refreshGeminiToolDeclarations. Claude only calls tools
+   * present in the request's `tools` array, so without this per-step refresh
+   * a tool discovered via search_tools is unreachable for the rest of the
+   * turn. Mutates the array in place (requestParams holds it by reference).
+   */
+  private refreshAnthropicToolDeclarations(
+    liveTools: Record<string, Tool> | undefined,
+    declarations: VertexAnthropicTool[] | undefined,
+    executeMap: DedupExecuteMap,
+    failedTools: Map<string, { count: number; lastError: string }>,
+  ): void {
+    if (!liveTools || !declarations) {
+      return;
+    }
+    const declared = new Set(declarations.map((d) => d.name));
+    for (const [name, tool] of Object.entries(liveTools)) {
+      if (declared.has(name)) {
+        continue;
+      }
+      declarations.push(this.buildAnthropicToolDeclaration(name, tool));
+      if (tool.execute) {
+        executeMap.set(name, tool.execute);
+      }
+      failedTools.delete(name);
+      logger.info(
+        `[GoogleVertex] Tool "${name}" hydrated mid-turn via discovery — added to Anthropic declarations.`,
+      );
+    }
+  }
+
+  /**
+   * Dispatch-miss recovery for the Claude-on-Vertex loops — the Anthropic
+   * counterpart of resolveGeminiToolOnMiss.
+   */
+  private resolveAnthropicToolOnMiss(
+    name: string,
+    liveTools: Record<string, Tool> | undefined,
+    declarations: VertexAnthropicTool[] | undefined,
+    executeMap: DedupExecuteMap,
+    failedTools: Map<string, { count: number; lastError: string }>,
+  ): Tool["execute"] | undefined {
+    if (!declarations) {
+      return undefined;
+    }
+    const tool = resolveLiveTool(liveTools, name);
+    if (!tool?.execute) {
+      return undefined;
+    }
+    if (!declarations.some((d) => d.name === name)) {
+      declarations.push(this.buildAnthropicToolDeclaration(name, tool));
+    }
+    executeMap.set(name, tool.execute);
+    failedTools.delete(name);
+    logger.info(
+      `[GoogleVertex] Tool "${name}" resolved mid-turn via discovery — executing.`,
+    );
+    return executeMap.get(name);
+  }
+
+  /**
    * Execute stream using native @google/genai SDK for Gemini 3 models on Vertex AI
    * This bypasses @ai-sdk/google-vertex to properly handle thought_signature
    */
@@ -1567,40 +1780,9 @@ export class GoogleVertexProvider extends BaseProvider {
       const functionDeclarations: VertexGenaiFunctionDeclaration[] = [];
 
       for (const [name, tool] of Object.entries(options.tools)) {
-        const decl: VertexGenaiFunctionDeclaration = {
-          name,
-          description: tool.description || `Tool: ${name}`,
-        };
-
-        // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
-        const legacyTool = tool as ToolWithLegacyParams;
-        const toolParams = legacyTool.parameters || tool.inputSchema;
-        if (toolParams) {
-          // Convert and inline schema to resolve $ref/definitions
-          const rawSchema = convertZodToJsonSchema(
-            toolParams as ZodUnknownSchema,
-            "openApi3",
-          ) as Record<string, unknown>;
-          const inlinedSchema = inlineJsonSchema(rawSchema);
-          // Remove $schema if present - @google/genai doesn't need it
-          if (inlinedSchema.$schema) {
-            delete inlinedSchema.$schema;
-          }
-          // CRITICAL: Google Vertex AI requires ALL nested schemas to have a type field
-          // ensureNestedSchemaTypes recursively adds missing type fields to tool schemas
-          // Note: convertZodToJsonSchema now uses openApi3 target which produces nullable: true
-          const typedSchema = ensureNestedSchemaTypes(inlinedSchema);
-          // Strip `additionalProperties` recursively — Vertex Gemini's
-          // function-call validator rejects it on object schemas (returns
-          // 400 INVALID_ARGUMENT) even though it's valid OpenAPI 3. The
-          // field has no semantic meaning to the model, so dropping it
-          // before send is safe for every caller.
-          stripAdditionalPropertiesDeep(typedSchema);
-          decl.parametersJsonSchema = typedSchema;
-        }
-
-        functionDeclarations.push(decl);
-
+        functionDeclarations.push(
+          this.buildGeminiFunctionDeclaration(name, tool),
+        );
         if (tool.execute) {
           executeMap.set(name, tool.execute);
         }
@@ -1882,6 +2064,16 @@ export class GoogleVertexProvider extends BaseProvider {
         }
         step++;
         turnClock.noteProgress();
+        // Mid-turn discovery sync: search_tools may have hydrated new tools
+        // into the live record during the previous step — advertise them in
+        // this step's request instead of leaving them invisible until the
+        // next turn (TOOL_NOT_FOUND).
+        this.refreshGeminiToolDeclarations(
+          options.tools,
+          tools?.[0]?.functionDeclarations,
+          executeMap,
+          failedTools,
+        );
         logger.debug(`[GoogleVertex] Native SDK step ${step}/${maxSteps}`);
 
         try {
@@ -2127,7 +2319,19 @@ export class GoogleVertexProvider extends BaseProvider {
               continue;
             }
 
-            const execute = executeMap.get(call.name);
+            let execute = executeMap.get(call.name);
+            if (!execute) {
+              // Snapshot miss: the tool may have been hydrated into the live
+              // record by search_tools within this very step batch, or the
+              // model called a deferred catalog tool directly by name.
+              execute = this.resolveGeminiToolOnMiss(
+                call.name,
+                options.tools,
+                tools?.[0]?.functionDeclarations,
+                executeMap,
+                failedTools,
+              );
+            }
             if (execute) {
               try {
                 // AI SDK Tool execute requires (args, options) - provide minimal options
@@ -2761,40 +2965,9 @@ export class GoogleVertexProvider extends BaseProvider {
       const functionDeclarations: VertexGenaiFunctionDeclaration[] = [];
 
       for (const [name, tool] of Object.entries(combinedTools)) {
-        const decl: VertexGenaiFunctionDeclaration = {
-          name,
-          description: tool.description || `Tool: ${name}`,
-        };
-
-        // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
-        const legacyTool = tool as ToolWithLegacyParams;
-        const toolParams = legacyTool.parameters || tool.inputSchema;
-        if (toolParams) {
-          // Convert and inline schema to resolve $ref/definitions
-          const rawSchema = convertZodToJsonSchema(
-            toolParams as ZodUnknownSchema,
-            "openApi3",
-          ) as Record<string, unknown>;
-          const inlinedSchema = inlineJsonSchema(rawSchema);
-          // Remove $schema if present - @google/genai doesn't need it
-          if (inlinedSchema.$schema) {
-            delete inlinedSchema.$schema;
-          }
-          // CRITICAL: Google Vertex AI requires ALL nested schemas to have a type field
-          // ensureNestedSchemaTypes recursively adds missing type fields to tool schemas
-          // Note: convertZodToJsonSchema now uses openApi3 target which produces nullable: true
-          const typedSchema = ensureNestedSchemaTypes(inlinedSchema);
-          // Strip `additionalProperties` recursively — Vertex Gemini's
-          // function-call validator rejects it on object schemas (returns
-          // 400 INVALID_ARGUMENT) even though it's valid OpenAPI 3. The
-          // field has no semantic meaning to the model, so dropping it
-          // before send is safe for every caller.
-          stripAdditionalPropertiesDeep(typedSchema);
-          decl.parametersJsonSchema = typedSchema;
-        }
-
-        functionDeclarations.push(decl);
-
+        functionDeclarations.push(
+          this.buildGeminiFunctionDeclaration(name, tool),
+        );
         if (tool.execute) {
           executeMap.set(name, tool.execute);
         }
@@ -3064,6 +3237,13 @@ export class GoogleVertexProvider extends BaseProvider {
         }
         step++;
         turnClock.noteProgress();
+        // Mid-turn discovery sync — see the stream twin.
+        this.refreshGeminiToolDeclarations(
+          combinedTools,
+          tools?.[0]?.functionDeclarations,
+          executeMap,
+          failedTools,
+        );
         logger.debug(
           `[GoogleVertex] Native SDK generate step ${step}/${maxSteps}`,
         );
@@ -3303,7 +3483,17 @@ export class GoogleVertexProvider extends BaseProvider {
               continue;
             }
 
-            const execute = executeMap.get(call.name);
+            let execute = executeMap.get(call.name);
+            if (!execute) {
+              // Snapshot miss — see the stream twin.
+              execute = this.resolveGeminiToolOnMiss(
+                call.name,
+                combinedTools,
+                tools?.[0]?.functionDeclarations,
+                executeMap,
+                failedTools,
+              );
+            }
             if (execute) {
               try {
                 // AI SDK Tool execute requires (args, options) - provide minimal options
@@ -4093,35 +4283,7 @@ export class GoogleVertexProvider extends BaseProvider {
       tools = [];
 
       for (const [name, tool] of Object.entries(options.tools)) {
-        const anthropicTool: VertexAnthropicTool = {
-          name,
-          description: tool.description || `Tool: ${name}`,
-          input_schema: {
-            type: "object",
-          },
-        };
-
-        // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
-        const legacyTool = tool as ToolWithLegacyParams;
-        const toolParams = legacyTool.parameters || tool.inputSchema;
-        if (toolParams) {
-          // Anthropic validates input_schema as JSON Schema draft 2020-12 and
-          // rejects OpenAPI-3 dialect output (e.g. `nullable: true`) with a
-          // 400 — use the default JSON Schema target, matching the direct
-          // anthropic provider. The Gemini paths keep "openApi3".
-          const jsonSchema = convertZodToJsonSchema(
-            toolParams as ZodUnknownSchema,
-          ) as Record<string, unknown>;
-          const inlined = inlineJsonSchema(jsonSchema);
-          anthropicTool.input_schema = {
-            type: "object",
-            properties: (inlined.properties as Record<string, unknown>) || {},
-            required: (inlined.required as string[]) || [],
-          };
-        }
-
-        tools.push(anthropicTool);
-
+        tools.push(this.buildAnthropicToolDeclaration(name, tool));
         if (tool.execute) {
           executeMap.set(name, tool.execute);
         }
@@ -4431,6 +4593,16 @@ export class GoogleVertexProvider extends BaseProvider {
           }
           step++;
           turnClock.noteProgress();
+          // Mid-turn discovery sync: Claude only calls tools declared in the
+          // request, so tools hydrated by search_tools last step must be
+          // advertised now (requestParams.tools holds this array by
+          // reference).
+          this.refreshAnthropicToolDeclarations(
+            options.tools,
+            tools,
+            executeMap,
+            failedTools,
+          );
 
           // One generation observation per API call: request in, content + usage out.
           const generationSpan = tracers.generation.startSpan(
@@ -4789,7 +4961,18 @@ export class GoogleVertexProvider extends BaseProvider {
               toolSpan.end();
             };
 
-            const execute = executeMap.get(toolUse.name);
+            let execute = executeMap.get(toolUse.name);
+            if (!execute) {
+              // Snapshot miss: hydrated by search_tools this step batch, or
+              // a deferred catalog tool called directly by name.
+              execute = this.resolveAnthropicToolOnMiss(
+                toolUse.name,
+                options.tools,
+                tools,
+                executeMap,
+                failedTools,
+              );
+            }
             if (execute) {
               try {
                 const toolOptions = {
@@ -5755,35 +5938,7 @@ export class GoogleVertexProvider extends BaseProvider {
       tools = [];
 
       for (const [name, tool] of Object.entries(options.tools)) {
-        const anthropicTool: VertexAnthropicTool = {
-          name,
-          description: tool.description || `Tool: ${name}`,
-          input_schema: {
-            type: "object",
-          },
-        };
-
-        // Access legacy `parameters` (AI SDK v3/v4) or current `inputSchema` (v6)
-        const legacyTool = tool as ToolWithLegacyParams;
-        const toolParams = legacyTool.parameters || tool.inputSchema;
-        if (toolParams) {
-          // Anthropic validates input_schema as JSON Schema draft 2020-12 and
-          // rejects OpenAPI-3 dialect output (e.g. `nullable: true`) with a
-          // 400 — use the default JSON Schema target, matching the direct
-          // anthropic provider. The Gemini paths keep "openApi3".
-          const jsonSchema = convertZodToJsonSchema(
-            toolParams as ZodUnknownSchema,
-          ) as Record<string, unknown>;
-          const inlined = inlineJsonSchema(jsonSchema);
-          anthropicTool.input_schema = {
-            type: "object",
-            properties: (inlined.properties as Record<string, unknown>) || {},
-            required: (inlined.required as string[]) || [],
-          };
-        }
-
-        tools.push(anthropicTool);
-
+        tools.push(this.buildAnthropicToolDeclaration(name, tool));
         if (tool.execute) {
           executeMap.set(name, tool.execute);
         }
@@ -5981,6 +6136,13 @@ export class GoogleVertexProvider extends BaseProvider {
       }
       step++;
       turnClock.noteProgress();
+      // Mid-turn discovery sync — see the stream twin.
+      this.refreshAnthropicToolDeclarations(
+        options.tools,
+        tools,
+        executeMap,
+        failedTools,
+      );
 
       try {
         // Bound the SDK wait so a stalled Vertex/Anthropic call can't hang
@@ -6166,7 +6328,17 @@ export class GoogleVertexProvider extends BaseProvider {
             continue;
           }
 
-          const execute = executeMap.get(toolUse.name);
+          let execute = executeMap.get(toolUse.name);
+          if (!execute) {
+            // Snapshot miss — see the stream twin.
+            execute = this.resolveAnthropicToolOnMiss(
+              toolUse.name,
+              options.tools,
+              tools,
+              executeMap,
+              failedTools,
+            );
+          }
           if (execute) {
             try {
               const toolOptions = {

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -74,6 +74,7 @@ import {
 import { emitToolEndFromStepFinish } from "../utils/toolEndEmitter.js";
 import { resolveToolChoice } from "../utils/toolChoice.js";
 import { transformToolExecutions } from "../utils/transformationUtils.js";
+import { resolveDeferredTool } from "../tools/toolDiscovery.js";
 import {
   buildAPIError,
   buildBody,
@@ -1035,8 +1036,49 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     try {
       let stepFinish: OpenAICompatChatChoice["finish_reason"] = null;
       let stepUsage: OpenAICompatChatResponse["usage"] | undefined;
+      // May grow mid-turn: hydrated tools with wire-unsafe names need
+      // reverse-mapping even when the initial name set required none.
+      let effectiveToolNameFromWire = toolNameFromWire;
 
       for (let step = 0; step < maxSteps; step++) {
+        // Mid-turn discovery sync: search_tools (tools.discovery) hydrates
+        // new tools into toolsRecord between steps. Dispatch already re-reads
+        // the record — this block makes the request DECLARE them so the model
+        // can call them, keeping the wire-name round-trip intact.
+        if (openAITools) {
+          const declared = new Set(
+            openAITools.map(
+              (t) =>
+                effectiveToolNameFromWire?.get(t.function.name) ??
+                t.function.name,
+            ),
+          );
+          const hydrated = Object.fromEntries(
+            Object.entries(toolsRecord).filter(([name]) => !declared.has(name)),
+          );
+          if (Object.keys(hydrated).length > 0) {
+            // Seed with the wire names already declared this turn — mapping
+            // only the hydrated subset could otherwise re-issue a wire name
+            // an earlier tool claimed (sanitized or literal), making the
+            // reverse mapping ambiguous.
+            const extraMaps = buildWireToolNameMaps(
+              Object.keys(hydrated),
+              new Set(openAITools.map((t) => t.function.name)),
+            );
+            if (extraMaps) {
+              effectiveToolNameFromWire ??= new Map<string, string>();
+              for (const [wireName, registryName] of extraMaps.fromWire) {
+                effectiveToolNameFromWire.set(wireName, registryName);
+              }
+            }
+            openAITools.push(
+              ...(buildToolsForOpenAI(hydrated, extraMaps?.toWire) ?? []),
+            );
+            logger.info(
+              `${this.providerName}: ${Object.keys(hydrated).length} tool(s) hydrated mid-turn via discovery: ${Object.keys(hydrated).join(", ")}`,
+            );
+          }
+        }
         const stepResult = await this.streamOneStep({
           modelId,
           url,
@@ -1061,7 +1103,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
           stepResult,
           conversation,
           toolsRecord,
-          toolNameFromWire,
+          toolNameFromWire: effectiveToolNameFromWire,
           emitter,
           toolsUsed,
           toolExecutionSummaries,
@@ -1237,7 +1279,12 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       // reporting use the registered names (reverse-mapped when a wire-name
       // map is in effect — see buildWireToolNameMaps).
       const registryName = toolNameFromWire?.get(t.name) ?? t.name;
-      const toolDef = toolsRecord[registryName];
+      // Live record lookup, then deferred-catalog auto-hydration: with
+      // tools.discovery on, the model may call a cataloged tool it never
+      // loaded via search_tools — that's a real tool, not a hallucination.
+      const toolDef =
+        toolsRecord[registryName] ??
+        resolveDeferredTool(toolsRecord, registryName);
       emitter?.emit("tool:start", {
         toolName: registryName,
         toolCallId: t.id,

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -57,31 +57,42 @@ const WIRE_TOOL_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$/;
 
 /**
  * Build a bijective original ↔ wire tool-name map. Returns undefined when
- * every name is already wire-valid (the common case — the wire then uses
- * original names untouched and callers skip all mapping). Sanitized names
- * that collide get a deterministic numeric suffix so the map stays
- * invertible.
+ * every name is already wire-valid and unreserved (the common case — the
+ * wire then uses original names untouched and callers skip all mapping).
+ * Sanitized names that collide get a deterministic numeric suffix so the
+ * map stays invertible.
+ *
+ * `reservedWireNames` seeds the collision set with wire names already
+ * declared in the request — a mid-turn discovery refresh maps only the
+ * newly hydrated subset, and without seeding a hydrated name (sanitized OR
+ * wire-valid) could reuse a wire name an earlier tool already claimed,
+ * making the reverse mapping ambiguous.
  */
 export const buildWireToolNameMaps = (
   names: readonly string[],
+  reservedWireNames?: ReadonlySet<string>,
 ):
   | { toWire: Map<string, string>; fromWire: Map<string, string> }
   | undefined => {
-  if (names.every((name) => WIRE_TOOL_NAME_RE.test(name))) {
+  if (
+    names.every(
+      (name) => WIRE_TOOL_NAME_RE.test(name) && !reservedWireNames?.has(name),
+    )
+  ) {
     return undefined;
   }
   const toWire = new Map<string, string>();
   const fromWire = new Map<string, string>();
   for (const name of names) {
     let wire = WIRE_TOOL_NAME_RE.test(name) ? name : sanitizeToolName(name);
-    if (fromWire.has(wire)) {
+    if (fromWire.has(wire) || reservedWireNames?.has(wire)) {
       let suffix = 2;
       let candidate: string;
       do {
         const tail = `_${suffix}`;
         candidate = `${wire.slice(0, 64 - tail.length)}${tail}`;
         suffix++;
-      } while (fromWire.has(candidate));
+      } while (fromWire.has(candidate) || reservedWireNames?.has(candidate));
       wire = candidate;
     }
     toWire.set(name, wire);

--- a/src/lib/tools/toolDiscovery.ts
+++ b/src/lib/tools/toolDiscovery.ts
@@ -6,11 +6,18 @@
  * requested tools, and previously discovered tools) plus ONE `search_tools`
  * meta-tool whose description embeds a compact name+summary catalog of the
  * deferred tools. Calling `search_tools` loads matching tools:
- *  - immediately into the live tool record (providers that re-read the tools
- *    record between agent-loop steps — the AI SDK path — can call them on the
- *    very next step), and
+ *  - immediately into the live tool record — the AI SDK path re-reads the
+ *    record between agent-loop steps, and the native loops (Vertex
+ *    Gemini/Claude, AI Studio, chat-completions, direct Anthropic) re-resolve
+ *    against it on a dispatch miss and refresh their wire declarations per
+ *    step — so discovered tools are callable on the very next step, and
  *  - into the session pin set (all providers include them in full on every
  *    subsequent call of the session).
+ *
+ * The record additionally carries a symbol-keyed {@link DeferredToolResolver}
+ * (see `resolveDeferredTool`) so a loop can hydrate a cataloged tool the
+ * model called directly by name WITHOUT a prior search_tools call — the
+ * catalog advertises exact names, so models legitimately do this.
  *
  * Evidence for this design: catalogs past ~30-50 tools measurably degrade
  * tool-selection accuracy, and deferral+search both cuts definition tokens by
@@ -22,9 +29,22 @@
 
 import { z } from "zod";
 import { tool as createAISDKTool } from "../utils/tool.js";
-import type { DeferredToolIndexEntry, Tool } from "../types/index.js";
+import type {
+  DeferredToolIndexEntry,
+  DeferredToolResolver,
+  Tool,
+} from "../types/index.js";
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
 import { logger } from "../utils/logger.js";
+
+/**
+ * Symbol key under which the hot record carries its deferred-tool resolver.
+ * Symbol-keyed properties are skipped by Object.keys/entries, for-in, and
+ * JSON.stringify, so no declaration builder (or the AI SDK) ever sees the
+ * resolver as a tool. `Symbol.for` (global registry) keeps the key stable
+ * even if this module is loaded twice (ESM/CJS dual load of the bundle).
+ */
+const DEFERRED_TOOL_RESOLVER_KEY = Symbol.for("neurolink.deferredToolResolver");
 
 /**
  * Above this many tools, a WARN suggests enabling `tools.discovery` when it
@@ -200,6 +220,36 @@ export function partitionToolsForDiscovery(
 
   hot["search_tools"] = buildSearchTool(entries, tools, hot, args.onHydrate);
 
+  // Dispatch-miss escape hatch for the native agent loops: hydrate a
+  // deferred tool the model called directly by its cataloged name (the
+  // catalog advertises exact names, so this is legitimate model behavior,
+  // not hallucination). Hydration mutates the hot record and persists the
+  // session pin — identical side effects to a search_tools hit.
+  const resolver: DeferredToolResolver = (name) => {
+    if (name in hot) {
+      return hot[name];
+    }
+    if (!deferredSet.has(name)) {
+      return undefined;
+    }
+    const toolDef = tools[name];
+    if (!toolDef) {
+      return undefined;
+    }
+    hot[name] = toolDef;
+    args.onHydrate([name]);
+    logger.debug("[ToolDiscovery] Auto-hydrated deferred tool on direct call", {
+      name,
+    });
+    return toolDef;
+  };
+  Object.defineProperty(hot, DEFERRED_TOOL_RESOLVER_KEY, {
+    value: resolver,
+    enumerable: false,
+    writable: false,
+    configurable: true,
+  });
+
   logger.debug("[ToolDiscovery] Deferred external tools behind search_tools", {
     hotCount: Object.keys(hot).length - 1,
     deferredCount: deferredNames.length,
@@ -207,6 +257,44 @@ export function partitionToolsForDiscovery(
   });
 
   return hot;
+}
+
+/**
+ * Hydrate-and-return a deferred tool by name, when `record` was produced by
+ * `partitionToolsForDiscovery` and `name` is in its deferred catalog.
+ * Returns `undefined` for records without a resolver (discovery off) and for
+ * names that are genuinely unknown — callers keep their hallucinated-name
+ * handling for that case.
+ */
+export function resolveDeferredTool(
+  record: Record<string, Tool> | undefined,
+  name: string,
+): Tool | undefined {
+  if (!record) {
+    return undefined;
+  }
+  const resolver = (record as Record<symbol, unknown>)[
+    DEFERRED_TOOL_RESOLVER_KEY
+  ];
+  return typeof resolver === "function"
+    ? (resolver as DeferredToolResolver)(name)
+    : undefined;
+}
+
+/**
+ * Live tool lookup for native agent loops on a dispatch miss: first re-reads
+ * the record (a tool hydrated by search_tools after the loop built its
+ * pre-step snapshot), then falls back to auto-hydrating from the deferred
+ * catalog. Returns `undefined` only when the name is genuinely unknown.
+ */
+export function resolveLiveTool(
+  record: Record<string, Tool> | undefined,
+  name: string,
+): Tool | undefined {
+  if (!record) {
+    return undefined;
+  }
+  return record[name] ?? resolveDeferredTool(record, name);
 }
 
 function buildSearchTool(
@@ -285,7 +373,7 @@ function buildSearchTool(
         found: loaded.length,
         tools: loaded,
         message:
-          "These tools are now loaded for this session. Call them directly by name with arguments matching their inputSchema. If a call reports the tool as unavailable, it will be available from the next message onward.",
+          "These tools are now loaded for this session. Call them directly by name with arguments matching their inputSchema.",
       };
     },
   }) as Tool;

--- a/src/lib/types/toolResolution.ts
+++ b/src/lib/types/toolResolution.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ToolConfig } from "./config.js";
+import type { Tool } from "./tools.js";
 
 /**
  * The resolved, merged tool policy for one request. Produced by
@@ -75,3 +76,13 @@ export type DeferredToolIndexEntry = {
   /** Originating MCP server id, when known. */
   serverId?: string;
 };
+
+/**
+ * Resolver attached (under a symbol key, invisible to enumeration) to the
+ * hot tool record by `partitionToolsForDiscovery`. Given a deferred tool's
+ * name it hydrates that tool into the record, persists the session pin, and
+ * returns it — `undefined` when the name is not in the deferred catalog.
+ * Native agent loops call it on a dispatch miss so a model that calls a
+ * cataloged tool directly (without `search_tools` first) still succeeds.
+ */
+export type DeferredToolResolver = (name: string) => Tool | undefined;

--- a/test/continuous-test-suite-tool-resolution.ts
+++ b/test/continuous-test-suite-tool-resolution.ts
@@ -18,6 +18,10 @@ import "dotenv/config";
  *   Part 4 — Discovery (tools.discovery): partition behind search_tools,
  *     catalog rendering + degradation ladder, lexical search, live
  *     hydration, session pinning, miss handling.
+ *   Part 5 — Mid-turn hydration parity (native loops): the deferred-tool
+ *     resolver on the hot record, resolveLiveTool/resolveDeferredTool,
+ *     refreshNativeToolDeclarations, and the shared native executor's
+ *     dispatch-miss recovery (the curator T1/T7 regression shapes).
  *
  * Run: npx tsx test/continuous-test-suite-tool-resolution.ts
  *      pnpm run test:tool-resolution
@@ -33,7 +37,15 @@ import { applyToolGate } from "../src/lib/tools/toolGate.js";
 import {
   partitionToolsForDiscovery,
   isDiscoveryMetaTool,
+  resolveDeferredTool,
+  resolveLiveTool,
 } from "../src/lib/tools/toolDiscovery.js";
+import {
+  buildNativeToolDeclarations,
+  executeNativeToolCalls,
+  refreshNativeToolDeclarations,
+} from "../src/lib/providers/googleNativeGemini3.js";
+import { buildWireToolNameMaps } from "../src/lib/providers/openaiChatCompletionsClient.js";
 import { MCPToolRegistry } from "../src/lib/mcp/toolRegistry.js";
 import { NeuroLink } from "../src/lib/neurolink.js";
 import type { Tool, ToolInfo } from "../src/lib/types/index.js";
@@ -543,6 +555,303 @@ async function main() {
     nl.pinDiscoveredTools("s-overflow", ["t"]);
     assertEqual([...nl.getDiscoveryPins("s-0")], ["t"], "touched survives");
     assertEqual([...nl.getDiscoveryPins("s-1")], [], "untouched LRU evicted");
+  });
+
+  logSection("Part 5 — Mid-turn hydration parity (native loops)");
+
+  await test("resolveDeferredTool auto-hydrates a cataloged tool and pins it", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      jira_create: fakeTool("Create a Jira ticket in a project"),
+    };
+    const pinned: string[] = [];
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["jira_create"],
+      pinnedNames: new Set(),
+      onHydrate: (names) => pinned.push(...names),
+    });
+    const resolved = resolveDeferredTool(hot, "jira_create");
+    if (!resolved || resolved !== tools["jira_create"]) {
+      throw new Error("resolver did not return the deferred tool");
+    }
+    if (!("jira_create" in hot)) {
+      throw new Error("resolver did not hydrate the live record");
+    }
+    if (!pinned.includes("jira_create")) {
+      throw new Error("auto-hydration must persist the session pin");
+    }
+    // Idempotent: a second resolve returns the same tool without re-pinning.
+    resolveDeferredTool(hot, "jira_create");
+    assertEqual(pinned, ["jira_create"], "no duplicate pin");
+    // Genuinely unknown names stay unknown — the hallucinated-name defense
+    // in the native loops must keep firing for these.
+    assertEqual(
+      resolveDeferredTool(hot, "not_a_tool"),
+      undefined,
+      "unknown name",
+    );
+    // Records without a resolver (discovery off) are a clean no-op.
+    assertEqual(
+      resolveDeferredTool({ a: fakeTool("A") }, "a"),
+      undefined,
+      "plain record",
+    );
+  });
+
+  await test("deferred resolver rides a symbol key — invisible to enumeration", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      jira_create: fakeTool("Create a Jira ticket"),
+    };
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["jira_create"],
+      pinnedNames: new Set(),
+      onHydrate: () => {},
+    });
+    // Declaration builders iterate string keys — the resolver must never
+    // surface there or it would be sent to providers as a "tool".
+    assertEqual(
+      Object.keys(hot).sort(),
+      ["readFile", "search_tools"],
+      "string keys",
+    );
+    if (Object.getOwnPropertySymbols(hot).length === 0) {
+      throw new Error("resolver symbol missing from the hot record");
+    }
+  });
+
+  await test("resolveLiveTool: hot record first, deferred catalog second", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      jira_create: fakeTool("Create a Jira ticket"),
+    };
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["jira_create"],
+      pinnedNames: new Set(),
+      onHydrate: () => {},
+    });
+    if (resolveLiveTool(hot, "readFile") !== tools["readFile"]) {
+      throw new Error("hot tool must resolve from the record directly");
+    }
+    if (resolveLiveTool(hot, "jira_create") !== tools["jira_create"]) {
+      throw new Error("deferred tool must resolve via the catalog");
+    }
+    assertEqual(resolveLiveTool(hot, "ghost"), undefined, "unknown name");
+    assertEqual(resolveLiveTool(undefined, "a"), undefined, "no record");
+  });
+
+  await test("refreshNativeToolDeclarations syncs snapshot with hydrated record", async () => {
+    const initial: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+    };
+    const snapshot = buildNativeToolDeclarations(initial);
+    // Simulate search_tools hydrating a tool into the live record mid-turn.
+    const live: Record<string, Tool> = {
+      ...initial,
+      jira_create: fakeTool("Create a Jira ticket"),
+    };
+    if (!refreshNativeToolDeclarations(live, snapshot)) {
+      throw new Error("refresh must report additions");
+    }
+    assertEqual(
+      snapshot.toolsConfig[0].functionDeclarations.map((d) => d.name).sort(),
+      ["jira_create", "readFile"],
+      "declarations after refresh",
+    );
+    if (typeof snapshot.executeMap.get("jira_create") !== "function") {
+      throw new Error("executeMap missing hydrated tool");
+    }
+    assertEqual(
+      snapshot.originalNameMap.get("jira_create"),
+      "jira_create",
+      "name map after refresh",
+    );
+    // Second refresh with an unchanged record is a no-op.
+    assertEqual(
+      refreshNativeToolDeclarations(live, snapshot),
+      false,
+      "idempotent refresh",
+    );
+  });
+
+  await test("refresh disambiguates sanitized names against the snapshot", async () => {
+    // "my/tool" sanitizes to "my_tool" in the pre-loop snapshot; a tool
+    // hydrated later that literally claims "my_tool" must be suffixed, not
+    // silently collide (reservedNames seeding).
+    const initial: Record<string, Tool> = {
+      "my/tool": fakeTool("Slashed name"),
+    };
+    const snapshot = buildNativeToolDeclarations(initial);
+    assertEqual(
+      snapshot.toolsConfig[0].functionDeclarations.map((d) => d.name),
+      ["my_tool"],
+      "sanitized snapshot",
+    );
+    const live: Record<string, Tool> = {
+      ...initial,
+      my_tool: fakeTool("Claims the sanitized name"),
+    };
+    refreshNativeToolDeclarations(live, snapshot);
+    assertEqual(
+      snapshot.toolsConfig[0].functionDeclarations.map((d) => d.name).sort(),
+      ["my_tool", "my_tool_2"],
+      "collision suffixed",
+    );
+    assertEqual(
+      snapshot.originalNameMap.get("my_tool_2"),
+      "my_tool",
+      "round-trip mapping for the suffixed name",
+    );
+  });
+
+  await test("native executor: tool loaded by search_tools runs in the same batch (T1 shape)", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      jira_create: fakeTool("Create a Jira ticket in a project"),
+    };
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["jira_create"],
+      pinnedNames: new Set(),
+      onHydrate: () => {},
+    });
+    const snapshot = buildNativeToolDeclarations(hot);
+    const failedTools = new Map<string, { count: number; lastError: string }>();
+    const responses = await executeNativeToolCalls(
+      "[Test]",
+      [
+        { name: "search_tools", args: { query: "jira_create" } },
+        { name: "jira_create", args: { x: "1" } },
+      ],
+      snapshot.executeMap,
+      failedTools,
+      [],
+      {
+        originalNameMap: snapshot.originalNameMap,
+        liveTools: hot,
+        declarations: snapshot,
+      },
+    );
+    const second = JSON.stringify(responses[1]);
+    if (second.includes("TOOL_NOT_FOUND")) {
+      throw new Error(`same-batch call died as TOOL_NOT_FOUND: ${second}`);
+    }
+    if (!second.includes('"ok"')) {
+      throw new Error(`expected the tool's real result, got: ${second}`);
+    }
+    if (failedTools.has("jira_create")) {
+      throw new Error("hydrated tool must not carry breaker strikes");
+    }
+  });
+
+  await test("native executor: direct call to a deferred tool auto-hydrates (T7 shape)", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      slack_channels_list: fakeTool("List Slack channels in the workspace"),
+    };
+    const pinned: string[] = [];
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["slack_channels_list"],
+      pinnedNames: new Set(),
+      onHydrate: (names) => pinned.push(...names),
+    });
+    const snapshot = buildNativeToolDeclarations(hot);
+    const failedTools = new Map<string, { count: number; lastError: string }>();
+    // No search_tools call at all — the model read the exact name from the
+    // catalog and called it directly (the curator T7 failure).
+    const responses = await executeNativeToolCalls(
+      "[Test]",
+      [{ name: "slack_channels_list", args: { x: "1" } }],
+      snapshot.executeMap,
+      failedTools,
+      [],
+      {
+        originalNameMap: snapshot.originalNameMap,
+        liveTools: hot,
+        declarations: snapshot,
+      },
+    );
+    const payload = JSON.stringify(responses[0]);
+    if (payload.includes("TOOL_NOT_FOUND")) {
+      throw new Error(
+        `direct deferred call died as TOOL_NOT_FOUND: ${payload}`,
+      );
+    }
+    if (!payload.includes('"ok"')) {
+      throw new Error(`expected the tool's real result, got: ${payload}`);
+    }
+    if (!pinned.includes("slack_channels_list")) {
+      throw new Error("auto-hydration must persist the session pin");
+    }
+    if (
+      !snapshot.toolsConfig[0].functionDeclarations.some(
+        (d) => d.name === "slack_channels_list",
+      )
+    ) {
+      throw new Error("hydrated tool missing from refreshed declarations");
+    }
+  });
+
+  await test("native executor: genuinely unknown names still die as TOOL_NOT_FOUND", async () => {
+    const tools: Record<string, Tool> = {
+      readFile: fakeTool("Read a file"),
+      jira_create: fakeTool("Create a Jira ticket"),
+    };
+    const hot = partitionToolsForDiscovery(tools, {
+      deferrableNames: ["jira_create"],
+      pinnedNames: new Set(),
+      onHydrate: () => {},
+    });
+    const snapshot = buildNativeToolDeclarations(hot);
+    const responses = await executeNativeToolCalls(
+      "[Test]",
+      [{ name: "hallucinated_tool", args: {} }],
+      snapshot.executeMap,
+      new Map(),
+      [],
+      {
+        originalNameMap: snapshot.originalNameMap,
+        liveTools: hot,
+        declarations: snapshot,
+      },
+    );
+    if (!JSON.stringify(responses[0]).includes("TOOL_NOT_FOUND")) {
+      throw new Error("hallucinated-name defense must keep firing");
+    }
+  });
+
+  await test("wire-name maps seed reserved names so hydration refresh cannot collide", async () => {
+    // Chat-completions mid-turn refresh maps only the hydrated subset; the
+    // reserved seed must keep it from re-issuing a wire name an earlier
+    // tool already claimed.
+    // Sanitized hydrated name lands on an already-declared wire name.
+    const sanitized = buildWireToolNameMaps(["my/tool"], new Set(["my_tool"]));
+    if (!sanitized) {
+      throw new Error("reserved collision must materialize maps");
+    }
+    assertEqual(
+      sanitized.toWire.get("my/tool"),
+      "my_tool_2",
+      "sanitized collision suffixed",
+    );
+    // Even a wire-VALID hydrated name must be remapped when reserved.
+    const literal = buildWireToolNameMaps(
+      ["github_search"],
+      new Set(["github_search"]),
+    );
+    if (!literal) {
+      throw new Error("literal reserved collision must materialize maps");
+    }
+    assertEqual(
+      literal.toWire.get("github_search"),
+      "github_search_2",
+      "literal collision suffixed",
+    );
+    // All-valid, unreserved names keep the no-mapping fast path.
+    assertEqual(
+      buildWireToolNameMaps(["a_tool"], new Set(["other_tool"])),
+      undefined,
+      "fast path intact",
+    );
   });
 
   await runSuite();


### PR DESCRIPTION
## Problem

Tool discovery (`tools.discovery` / `search_tools`) failed same-turn on every native agent loop (Vertex Gemini/Claude, AI Studio, chat-completions, direct Anthropic). The loops snapshot their `functionDeclarations` + `executeMap` **before** the step loop, so a tool loaded mid-turn stayed invisible for the rest of the turn:

- Calling a tool right after loading it via `search_tools` died as `TOOL_NOT_FOUND` (`do_not_retry: true`), and the 2-strike breaker escalated to `TOOL_PERMANENTLY_FAILED` — the user gets "tool isn't responding" on a first-turn ask.
- The `search_tools` catalog advertises exact tool names, so models legitimately call a deferred tool directly without loading it first — the loop treated every such call as a hallucinated name.
- The two features actively contradicted each other: `search_tools` replies "these tools are now loaded, call them directly" while the loop replies "does not exist, do not attempt to call this tool again".

## Fix (parity across all native loops)

- **`toolDiscovery.ts`**: the hot record now carries a symbol-keyed deferred-tool resolver (invisible to `Object.keys`/`entries`/JSON, so it can never leak into a provider payload). New `resolveLiveTool` / `resolveDeferredTool` helpers re-read the live record on a dispatch miss and load a cataloged tool called directly by name (persisting the session pin — same side effects as a `search_tools` hit). Removed the contradictory hedge from the `search_tools` result message.
- **`googleVertex.ts`** (4 loops: Gemini/Claude × generate/stream): per-step declaration refresh + dispatch-miss re-resolve; the four duplicated inline tool-conversion blocks are deduplicated into shared builders so snapshot and refresh can't drift.
- **`googleNativeGemini3.ts`**: new `refreshNativeToolDeclarations`; `buildNativeToolDeclarations` gains `reservedNames` seeding so mid-turn refreshes never collide with sanitized snapshot names; the shared `executeNativeToolCalls` does miss-recovery (covers both `googleAiStudio.ts` loops).
- **`openaiChatCompletionsBase.ts`**: per-step refresh of `openAITools` + wire-name maps, deferred fallback in dispatch — inherited by all chat-completions providers (LiteLLM, Ollama, Groq, Mistral, DeepSeek, …).
- **`anthropic.ts`**: same treatment for the direct-Anthropic stream loop.
- Breaker strikes accrued while a tool was still deferred are cleared on load; genuinely unknown names keep the hard `TOOL_NOT_FOUND` defense.

## Verification

- `test/continuous-test-suite-tool-resolution.ts` Part 5 (8 new no-API tests) reproduces both failure shapes against the shared executor — 37/37 pass.
- `tsc --strict`, `pnpm run lint`, full `pnpm run build` + publint clean; MCP no-API suites pass.
- Live runs (local stdio MCP server + `tools: { discovery: true }`): Vertex Claude generate + stream, Vertex Gemini generate + stream, LiteLLM stream — all answered correctly with zero `TOOL_NOT_FOUND` and emitted the discovery proof logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled mid-turn tool discovery and hydration across Anthropic, Gemini, Vertex, and OpenAI.
  * Newly discovered tools can be invoked immediately within the same interaction.
  * Added deeper support for deferred/live tool resolution and mid-turn tool declaration refresh.
* **Bug Fixes**
  * Improved tool execution when a tool becomes available after streaming/generation starts.
  * Reduced tool-name remapping collisions via reserved-name handling.
* **Tests**
  * Expanded suite for mid-turn hydration parity, deferred/live resolution, declaration refresh behavior, and unknown-tool error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->