### PR TITLE
fix(proxy): persist explainable terminal failures

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -14,6 +14,7 @@ import type { CommandModule, Argv } from "yargs";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import chalk from "chalk";
 import ora from "ora";
 import type { Hono } from "hono";
@@ -26,7 +27,10 @@ import {
   waitForProxyReadiness,
 } from "../../lib/proxy/proxyHealth.js";
 import { logger } from "../../lib/utils/logger.js";
-import { sanitizeForLog } from "../../lib/utils/logSanitize.js";
+import {
+  redactUrlsInText,
+  sanitizeForLog,
+} from "../../lib/utils/logSanitize.js";
 import { withTimeout } from "../../lib/utils/async/withTimeout.js";
 import {
   formatUptime,
@@ -38,6 +42,7 @@ import type {
   FallbackInfo,
   LoadedProxyConfig,
   ModelRouterInterface,
+  PersistedAccountCooldown,
   ProxyGuardArgs,
   ProxyNeurolinkRuntime,
   ProxySpinner,
@@ -116,6 +121,7 @@ import packageJson from "../../../package.json" with { type: "json" };
 
 const _require = createRequire(import.meta.url);
 const PROXY_VERSION = packageJson.version;
+const PROXY_INTERNAL_ACCOUNT_LABEL = "proxy/internal";
 
 const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
   new URL(
@@ -125,6 +131,7 @@ const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
 );
 const PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LEGACY_STATUS_ACCOUNT_CACHE_TTL_MS = 5_000;
+const PROXY_STATUS_TOKEN_READ_TIMEOUT_MS = 2_000;
 let legacyStatusAccountCache:
   | { credentialsPath: string; expiresAt: number; label: string | null }
   | undefined;
@@ -500,6 +507,22 @@ async function resolveLegacyStatusAccountLabel(
     label,
   };
   return label;
+}
+
+function deriveAccountAllowance(
+  accountKey: string,
+  now: number,
+  allowlist: AccountAllowlist | undefined,
+  expirations: ReadonlyMap<string, number>,
+  cooldowns: Readonly<Record<string, PersistedAccountCooldown>>,
+): { allowed: boolean; expired: boolean; cooling: boolean } {
+  const allowed = isAccountAllowed(accountKey, allowlist);
+  const expiresAt = expirations.get(accountKey);
+  return {
+    allowed,
+    expired: expiresAt !== undefined && expiresAt <= now,
+    cooling: (cooldowns[accountKey]?.coolingUntil ?? 0) > now,
+  };
 }
 
 /**
@@ -1617,7 +1640,13 @@ export async function createProxyStartApp(params: {
   ): Promise<void> => {
     const clientMessage = options?.clientMessage ?? errorMessage;
     const clientErrorType = options?.clientErrorType ?? errorType;
-    recordFinalError(status);
+    recordFinalError(status, undefined, undefined, {
+      requestId: metadata.requestId,
+      errorType,
+      errorCode: options?.errorCode,
+      terminalOutcome: "handler_error",
+      message: errorMessage,
+    });
     await Promise.all([
       logRequest({
         timestamp: new Date().toISOString(),
@@ -1950,23 +1979,57 @@ export async function createProxyStartApp(params: {
     const activeAccountAllowlist = runtimeConfig
       ? runtimeConfig.accountAllowlist
       : params.accountAllowlist;
-    const { getReconciledStats, getUsageStatsPersistenceStatus } =
+    const { getReconciledUsageSnapshot, getUsageStatsPersistenceStatus } =
       await import("../../lib/proxy/usageStats.js");
     const { loadAccountCooldowns } =
       await import("../../lib/proxy/accountCooldown.js");
-    const stats = await getReconciledStats();
+    const usageSnapshot = await getReconciledUsageSnapshot();
+    const { stats, terminalErrors } = usageSnapshot;
+    const terminalErrorDetailsComparable =
+      usageSnapshot.statsVersion === usageSnapshot.terminalErrorsVersion;
+    const lastTerminalError = terminalErrors.recent.at(-1) ?? null;
+    const terminalErrorDetailsMissing = terminalErrorDetailsComparable
+      ? Math.max(0, stats.totalErrors - terminalErrors.totalErrors)
+      : undefined;
+    const terminalErrorDetailsExcess = terminalErrorDetailsComparable
+      ? Math.max(0, terminalErrors.totalErrors - stats.totalErrors)
+      : undefined;
     const runtimeState = loadProxyState();
     const supervisorState = loadProxySupervisorState();
     const updateState = loadUpdateState();
     const cooldowns = await loadAccountCooldowns();
     const storedAccountKeys = new Set<string>();
+    const storedAccountExpirations = new Map<string, number>();
     const disabledAccountKeys = new Set<string>();
     let accountInventoryLoaded = false;
     try {
       const { tokenStore } = await import("../../lib/auth/tokenStore.js");
-      for (const key of await tokenStore.listByPrefix("anthropic:")) {
-        storedAccountKeys.add(normalizeAnthropicAccountKey(key));
+      const storedKeys = await tokenStore.listByPrefix("anthropic:");
+      for (const key of storedKeys) {
+        const normalizedKey = normalizeAnthropicAccountKey(key);
+        storedAccountKeys.add(normalizedKey);
       }
+      await Promise.all(
+        storedKeys.map(async (key) => {
+          const normalizedKey = normalizeAnthropicAccountKey(key);
+          try {
+            const tokens = await withTimeout(
+              tokenStore.peekTokens(key),
+              PROXY_STATUS_TOKEN_READ_TIMEOUT_MS,
+              "[proxy] /status token inspection timed out",
+            );
+            if (tokens) {
+              storedAccountExpirations.set(normalizedKey, tokens.expiresAt);
+            }
+          } catch (err) {
+            logger.debug(
+              `[proxy] /status: failed to inspect token metadata for ${normalizedKey}: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+        }),
+      );
       for (const key of await tokenStore.listDisabled()) {
         disabledAccountKeys.add(normalizeAnthropicAccountKey(key));
       }
@@ -2004,16 +2067,29 @@ export async function createProxyStartApp(params: {
             ? ENV_ANTHROPIC_ACCOUNT_KEY
             : normalizedKey;
       const isStored = storedAccountKeys.has(accountKey) || isLegacyAccount;
-      const cooling = (cooldowns[accountKey]?.coolingUntil ?? 0) > now;
-      const accountStatus = disabledAccountKeys.has(accountKey)
-        ? "disabled"
-        : !isAccountAllowed(accountKey, activeAccountAllowlist)
-          ? "excluded"
-          : accountInventoryLoaded && account.type === "oauth" && !isStored
-            ? "removed"
-            : cooling
-              ? "cooling"
-              : "active";
+      const { allowed, expired, cooling } = deriveAccountAllowance(
+        accountKey,
+        now,
+        activeAccountAllowlist,
+        storedAccountExpirations,
+        cooldowns,
+      );
+      const accountStatus =
+        account.type === "internal"
+          ? "internal"
+          : disabledAccountKeys.has(accountKey)
+            ? "disabled"
+            : expired
+              ? "expired"
+              : !allowed
+                ? "excluded"
+                : accountInventoryLoaded &&
+                    account.type === "oauth" &&
+                    !isStored
+                  ? "removed"
+                  : cooling
+                    ? "cooling"
+                    : "active";
       return {
         label: account.label,
         type: account.type,
@@ -2027,8 +2103,51 @@ export async function createProxyStartApp(params: {
         quotaRateLimits: account.quotaRateLimitCount,
         cooling,
         status: accountStatus,
+        allowed: account.type === "internal" ? undefined : allowed,
+        expired: account.type === "oauth" ? expired : undefined,
       };
     });
+    const representedAccountKeys = new Set(
+      accountRows
+        .filter((account) => account.type === "oauth")
+        .map((account) => normalizeAnthropicAccountKey(account.label)),
+    );
+    for (const accountKey of storedAccountKeys) {
+      if (representedAccountKeys.has(accountKey)) {
+        continue;
+      }
+      const { allowed, expired, cooling } = deriveAccountAllowance(
+        accountKey,
+        now,
+        activeAccountAllowlist,
+        storedAccountExpirations,
+        cooldowns,
+      );
+      accountRows.push({
+        label: accountKey.slice("anthropic:".length),
+        type: "oauth",
+        attempts: 0,
+        requests: 0,
+        success: 0,
+        errors: 0,
+        attemptErrors: 0,
+        rateLimits: 0,
+        transientRateLimits: 0,
+        quotaRateLimits: 0,
+        cooling,
+        status: disabledAccountKeys.has(accountKey)
+          ? "disabled"
+          : expired
+            ? "expired"
+            : !allowed
+              ? "excluded"
+              : cooling
+                ? "cooling"
+                : "active",
+        allowed,
+        expired,
+      });
+    }
     const attributed = accountRows.reduce(
       (total, account) => ({
         attempts: total.attempts + (account.attempts ?? 0),
@@ -2072,13 +2191,34 @@ export async function createProxyStartApp(params: {
       ),
     };
     if (Object.values(unattributed).some((count) => count > 0)) {
-      accountRows.push({
-        label: "unattributed",
-        type: "internal",
-        ...unattributed,
-        cooling: false,
-        status: "unattributed",
-      });
+      const internalRow = accountRows.find(
+        (account) => account.label === PROXY_INTERNAL_ACCOUNT_LABEL,
+      );
+      if (internalRow) {
+        internalRow.attempts =
+          (internalRow.attempts ?? 0) + unattributed.attempts;
+        internalRow.requests =
+          (internalRow.requests ?? 0) + unattributed.requests;
+        internalRow.success = (internalRow.success ?? 0) + unattributed.success;
+        internalRow.errors = (internalRow.errors ?? 0) + unattributed.errors;
+        internalRow.attemptErrors =
+          (internalRow.attemptErrors ?? 0) + unattributed.attemptErrors;
+        internalRow.rateLimits =
+          (internalRow.rateLimits ?? 0) + unattributed.rateLimits;
+        internalRow.transientRateLimits =
+          (internalRow.transientRateLimits ?? 0) +
+          unattributed.transientRateLimits;
+        internalRow.quotaRateLimits =
+          (internalRow.quotaRateLimits ?? 0) + unattributed.quotaRateLimits;
+      } else {
+        accountRows.push({
+          label: PROXY_INTERNAL_ACCOUNT_LABEL,
+          type: "internal",
+          ...unattributed,
+          cooling: false,
+          status: "internal",
+        });
+      }
     }
     return c.json({
       status: "running",
@@ -2102,6 +2242,11 @@ export async function createProxyStartApp(params: {
         totalRateLimits: stats.totalRateLimits,
         totalTransientRateLimits: stats.totalTransientRateLimits,
         totalQuotaRateLimits: stats.totalQuotaRateLimits,
+        terminalErrors,
+        lastTerminalError,
+        terminalErrorDetailsComparable,
+        terminalErrorDetailsMissing,
+        terminalErrorDetailsExcess,
         accounts: accountRows,
         primaryAccount,
         persistence: getUsageStatsPersistenceStatus(),
@@ -3104,6 +3249,15 @@ async function startProxyCommandHandler(argv: ProxyStartArgs): Promise<void> {
         `[proxy] recovered corrupt usage statistics state at ${new Date(usageStatsPersistence.lastRecoveryAt).toISOString()}`,
       );
     }
+    if (usageStatsPersistence.terminalErrorsLastError) {
+      logger.warn(
+        `[proxy] terminal-error persistence unavailable: ${usageStatsPersistence.terminalErrorsLastError}`,
+      );
+    } else if (usageStatsPersistence.terminalErrorsLastRecoveryAt) {
+      logger.warn(
+        `[proxy] recovered corrupt terminal-error state at ${new Date(usageStatsPersistence.terminalErrorsLastRecoveryAt).toISOString()}`,
+      );
+    }
 
     const baseEnv = { ...process.env };
     const envResolution = resolveProxyEnvFile({
@@ -3293,8 +3447,22 @@ export const proxyStartCommand: CommandModule<object, ProxyStartArgs> = {
 // STATUS DISPLAY HELPERS
 // =============================================================================
 
+export function sanitizeProxyStatusTerminalErrorMessage(
+  message: string,
+): string {
+  return stripVTControlCharacters(
+    sanitizeForLog(redactUrlsInText(message), 700),
+  )
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
 function printStatusStats(stats: StatusStats): void {
   console.info(`\n  Stats:`);
+  if (stats.startedAt !== undefined) {
+    console.info(`    Since:       ${new Date(stats.startedAt).toISOString()}`);
+  }
   if (stats.totalAttempts !== undefined) {
     console.info(`    Attempts:    ${stats.totalAttempts}`);
   }
@@ -3311,6 +3479,46 @@ function printStatusStats(stats: StatusStats): void {
         ? ` (${stats.totalTransientRateLimits} transient, ${stats.totalQuotaRateLimits} quota)`
         : ""),
   );
+  if (stats.terminalErrors) {
+    const causes = Object.entries(stats.terminalErrors.counts)
+      .filter(([, count]) => count > 0)
+      .map(([category, count]) => `${category}=${count}`)
+      .join(", ");
+    console.info(
+      `    Error details: ${stats.terminalErrors.totalErrors}/${stats.totalErrors}` +
+        (causes ? ` (${causes})` : ""),
+    );
+    console.info(
+      `    Detail since: ${new Date(stats.terminalErrors.startedAt).toISOString()}`,
+    );
+    if (
+      (stats.terminalErrorDetailsMissing ?? 0) > 0 ||
+      (stats.terminalErrorDetailsExcess ?? 0) > 0
+    ) {
+      console.info(
+        `    Detail gap:  ${stats.terminalErrorDetailsMissing ?? 0} missing, ${stats.terminalErrorDetailsExcess ?? 0} awaiting counter reconciliation`,
+      );
+    } else if (stats.terminalErrorDetailsComparable === false) {
+      console.info(
+        "    Detail gap:  unavailable during snapshot reconciliation",
+      );
+    }
+    const lastError =
+      stats.lastTerminalError ?? stats.terminalErrors.recent.at(-1);
+    if (lastError) {
+      const cause = lastError.errorType ?? lastError.category;
+      const code = lastError.errorCode ? `/${lastError.errorCode}` : "";
+      const account = lastError.account ? ` account=${lastError.account}` : "";
+      console.info(
+        `    Last error:  ${new Date(lastError.at).toISOString()} ${cause}${code} status=${lastError.status}${account}`,
+      );
+      if (lastError.message) {
+        console.info(
+          `    Last cause:  ${sanitizeProxyStatusTerminalErrorMessage(lastError.message)}`,
+        );
+      }
+    }
+  }
   if (stats.accounts?.length) {
     console.info(`\n  Accounts:`);
     const headers = [
@@ -3329,7 +3537,18 @@ function printStatusStats(stats: StatusStats): void {
       String(account.success ?? 0),
       String(account.errors ?? 0),
       String(account.rateLimits ?? 0),
-      account.status ?? (account.cooling ? "cooling" : "active"),
+      (() => {
+        const status =
+          account.status ?? (account.cooling ? "cooling" : "active");
+        const states = [status];
+        if (account.expired && status !== "expired") {
+          states.push("expired");
+        }
+        if (account.allowed === false && status !== "excluded") {
+          states.push("excluded");
+        }
+        return states.join(", ");
+      })(),
     ]);
     const widths = headers.map((header, index) =>
       Math.max(header.length, ...rows.map((row) => row[index].length)),

--- a/src/lib/auth/tokenStore.ts
+++ b/src/lib/auth/tokenStore.ts
@@ -262,6 +262,22 @@ export class TokenStore {
     );
   }
 
+  /** Reads tokens without updating access metadata or rewriting the store. */
+  async peekTokens(provider: string): Promise<StoredOAuthTokens | null> {
+    return this._mutex.runExclusive(async () => {
+      try {
+        const storageData = await this.loadStorageData();
+        const tokens = storageData.providers[provider]?.tokens;
+        return tokens ? { ...tokens } : null;
+      } catch (error) {
+        if (error instanceof TokenStoreError && error.code === "NOT_FOUND") {
+          return null;
+        }
+        throw error;
+      }
+    });
+  }
+
   /**
    * Internal load without mutex — callers must already hold the mutex.
    */
@@ -645,6 +661,55 @@ export class TokenStore {
         provider,
         reason: reason ?? "unspecified",
       });
+    });
+  }
+
+  /**
+   * Disables an account only when the persisted credentials still match the
+   * request that observed the authentication failure.
+   */
+  async markDisabledIfCurrent(
+    provider: string,
+    expectedTokens: Pick<
+      StoredOAuthTokens,
+      "accessToken" | "refreshToken" | "expiresAt"
+    >,
+    reason?: string,
+  ): Promise<boolean> {
+    return this._mutex.runExclusive(async () => {
+      let storageData: TokenStorageData;
+      try {
+        storageData = await this.loadStorageData();
+      } catch (error) {
+        if (error instanceof TokenStoreError && error.code === "NOT_FOUND") {
+          return false;
+        }
+        throw error;
+      }
+
+      const providerData = storageData.providers[provider];
+      if (!providerData) {
+        return false;
+      }
+      const current = providerData.tokens;
+      if (
+        current.accessToken !== expectedTokens.accessToken ||
+        current.refreshToken !== expectedTokens.refreshToken ||
+        current.expiresAt !== expectedTokens.expiresAt
+      ) {
+        return false;
+      }
+
+      providerData.disabled = true;
+      providerData.disabledAt = Date.now();
+      providerData.disabledReason = reason;
+      storageData.lastModified = Date.now();
+      await this.saveStorageData(storageData);
+      logger.info("Provider marked as disabled", {
+        provider,
+        reason: reason ?? "unspecified",
+      });
+      return true;
     });
   }
 

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -341,6 +341,7 @@ export async function handleTranslatedStreamRequest(args: {
   let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
   let cancelled = false;
   let succeeded = false;
+  let streamInterruptedAfterOutput = false;
   let translatedModel: string | undefined;
   let finalStreamError = "No translation providers succeeded";
   let upstreamIterator: AsyncIterator<unknown> | undefined;
@@ -367,6 +368,9 @@ export async function handleTranslatedStreamRequest(args: {
           attemptIndex < attempts.length;
           attemptIndex++
         ) {
+          if (cancelled) {
+            break;
+          }
           const attempt = attempts[attemptIndex];
           lastAttemptLabel = attempt.label ?? "translation";
           logger.always(
@@ -409,15 +413,19 @@ export async function handleTranslatedStreamRequest(args: {
               }
             }
 
+            if (cancelled) {
+              return;
+            }
+
             const toolCalls = streamResult.toolCalls ?? [];
             if (!hasTranslatedOutput(collectedText, toolCalls)) {
               finalStreamError = `Translated provider ${attempt.label} returned no content or tool calls`;
               logger.debug(
                 `${tag} translation attempt ${attempt.label} returned no content or tool calls`,
               );
+              recordAttemptError(lastAttemptLabel, "translation", 502);
               continue;
             }
-
             if (!cancelled && toolCalls.length) {
               for (const toolCall of toolCalls) {
                 const toolName =
@@ -462,7 +470,6 @@ export async function handleTranslatedStreamRequest(args: {
 
             translatedModel = streamResult.model;
             succeeded = true;
-            recordFinalSuccess(lastAttemptLabel, "translation");
             return;
           } catch (streamErr) {
             if (cancelled) {
@@ -473,6 +480,8 @@ export async function handleTranslatedStreamRequest(args: {
                 ? streamErr.message
                 : String(streamErr);
             if (collectedText.trim().length > 0) {
+              streamInterruptedAfterOutput = true;
+              recordAttemptError(lastAttemptLabel, "translation", 502);
               logger.always(`${tag} mid-stream error: ${finalStreamError}`);
               for (const frame of serializer.emitError(
                 `Upstream stream interrupted: ${finalStreamError}`,
@@ -489,7 +498,6 @@ export async function handleTranslatedStreamRequest(args: {
         }
 
         // All attempts exhausted
-        recordFinalError(500, lastAttemptLabel, "translation");
         if (!cancelled) {
           logger.always(
             `${tag} all translation attempts failed: ${finalStreamError}`,
@@ -508,12 +516,40 @@ export async function handleTranslatedStreamRequest(args: {
         if (tracer && translatedModel && translatedModel !== requestModel) {
           tracer.setModelSubstitution(requestModel, translatedModel);
         }
-        if (!succeeded) {
-          tracer?.setError("generation_error", finalStreamError.slice(0, 500));
+        const terminalStatus = cancelled
+          ? 499
+          : succeeded
+            ? 200
+            : streamInterruptedAfterOutput
+              ? 502
+              : 500;
+        const terminalErrorType = cancelled
+          ? "client_cancelled"
+          : streamInterruptedAfterOutput
+            ? "stream_error"
+            : succeeded
+              ? undefined
+              : "generation_error";
+        const terminalErrorMessage = cancelled
+          ? "Client cancelled the streaming response"
+          : succeeded
+            ? undefined
+            : finalStreamError;
+        if (terminalErrorType && terminalErrorMessage) {
+          tracer?.setError(
+            terminalErrorType,
+            terminalErrorMessage.slice(0, 500),
+          );
+          recordFinalError(terminalStatus, lastAttemptLabel, "translation", {
+            requestId: ctx.requestId,
+            errorType: terminalErrorType,
+            terminalOutcome: terminalErrorType,
+            message: terminalErrorMessage,
+          });
+        } else {
+          recordFinalSuccess(lastAttemptLabel, "translation");
         }
-        // Use the real outcome status so trace data matches the logged
-        // responseStatus below (success path is 200, exhausted-attempts path is 500).
-        tracer?.end(succeeded ? 200 : 500, Date.now() - requestStartTime);
+        tracer?.end(terminalStatus, Date.now() - requestStartTime);
 
         const traceCtx = tracer?.getTraceContext();
         logRequest({
@@ -526,8 +562,12 @@ export async function handleTranslatedStreamRequest(args: {
           toolCount: Object.keys(parsed.tools).length,
           account: "translation",
           accountType: "translation",
-          responseStatus: succeeded ? 200 : 500,
+          responseStatus: terminalStatus,
           responseTimeMs: Date.now() - requestStartTime,
+          ...(terminalErrorType ? { errorType: terminalErrorType } : {}),
+          ...(terminalErrorMessage
+            ? { errorMessage: terminalErrorMessage.slice(0, 500) }
+            : {}),
           ...(traceCtx?.traceId ? { traceId: traceCtx.traceId } : {}),
           ...(traceCtx?.spanId ? { spanId: traceCtx.spanId } : {}),
         });
@@ -573,6 +613,7 @@ export async function handleTranslatedJsonRequest(args: {
   attempts: ProxyTranslationAttempt[];
   tracer?: ProxyTracer;
   requestStartTime: number;
+  terminalFailureStatus?: number;
 }): Promise<unknown> {
   const {
     ctx,
@@ -582,6 +623,7 @@ export async function handleTranslatedJsonRequest(args: {
     attempts,
     tracer,
     requestStartTime,
+    terminalFailureStatus = 500,
   } = args;
   const tag = logTag(format);
   let lastAttemptError = "No translation providers succeeded";
@@ -622,6 +664,7 @@ export async function handleTranslatedJsonRequest(args: {
         logger.debug(
           `${tag} translation attempt ${attempt.label} returned no content or tool calls`,
         );
+        recordAttemptError(lastAttemptLabel, "translation", 502);
         continue;
       }
 
@@ -687,10 +730,15 @@ export async function handleTranslatedJsonRequest(args: {
     }
   }
 
-  recordFinalError(500, lastAttemptLabel, "translation");
+  recordFinalError(terminalFailureStatus, lastAttemptLabel, "translation", {
+    requestId: ctx.requestId,
+    errorType: "generation_error",
+    terminalOutcome: "handler_error",
+    message: lastAttemptError,
+  });
 
   tracer?.setError("generation_error", lastAttemptError.slice(0, 500));
-  tracer?.end(500, Date.now() - requestStartTime);
+  tracer?.end(terminalFailureStatus, Date.now() - requestStartTime);
 
   const traceCtx = tracer?.getTraceContext();
   logRequest({
@@ -703,7 +751,7 @@ export async function handleTranslatedJsonRequest(args: {
     toolCount: Object.keys(parsed.tools).length,
     account: "translation",
     accountType: "translation",
-    responseStatus: 500,
+    responseStatus: terminalFailureStatus,
     responseTimeMs: Date.now() - requestStartTime,
     errorType: "generation_error",
     errorMessage: lastAttemptError.slice(0, 500),

--- a/src/lib/proxy/rawStreamCapture.ts
+++ b/src/lib/proxy/rawStreamCapture.ts
@@ -68,8 +68,12 @@ export function createRawStreamCapture(): RawStreamCaptureResult {
   });
 
   const innerWriter = transform.writable.getWriter();
+  let writableController: WritableStreamDefaultController;
 
   const writable = new WritableStream<Uint8Array>({
+    start(controller) {
+      writableController = controller;
+    },
     write(chunk) {
       return innerWriter.write(chunk);
     },
@@ -82,9 +86,49 @@ export function createRawStreamCapture(): RawStreamCaptureResult {
     },
   });
 
+  // A downstream reader cancellation errors the TransformStream's writable
+  // side, but this wrapper otherwise hides that state from the upstream pipe.
+  // Mirror it onto the wrapper so cancellation reaches the source reader.
+  void innerWriter.closed.catch((reason) => {
+    settle();
+    try {
+      writableController.error(reason);
+    } catch {
+      // The wrapper may already be closing or aborted.
+    }
+  });
+
+  const innerReader = transform.readable.getReader();
+  const readable = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await innerReader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      settle();
+      try {
+        writableController.error(reason);
+      } catch {
+        // The wrapper may already be closing or aborted.
+      }
+      await Promise.allSettled([
+        innerReader.cancel(reason),
+        innerWriter.abort(reason),
+      ]);
+    },
+  });
+
   return {
     stream: {
-      readable: transform.readable,
+      readable,
       writable,
     },
     capture,

--- a/src/lib/proxy/sseInterceptor.ts
+++ b/src/lib/proxy/sseInterceptor.ts
@@ -530,8 +530,12 @@ export function createSSEInterceptor(
   // Wrap the writable side so we can intercept abort() — which does NOT
   // trigger the TransformStream's flush() or cancel() callbacks.
   const innerWriter = transform.writable.getWriter();
+  let writableController: WritableStreamDefaultController;
 
   const writable = new WritableStream<Uint8Array>({
+    start(controller) {
+      writableController = controller;
+    },
     write(chunk) {
       return innerWriter.write(chunk);
     },
@@ -546,8 +550,48 @@ export function createSSEInterceptor(
     },
   });
 
+  // Preserve downstream cancellation across the wrapped writable. Without
+  // this bridge, client disconnects leave the upstream source and telemetry
+  // promise open indefinitely after the readable side is cancelled.
+  void innerWriter.closed.catch((reason) => {
+    settle();
+    try {
+      writableController.error(reason);
+    } catch {
+      // The wrapper may already be closing or aborted.
+    }
+  });
+
+  const innerReader = transform.readable.getReader();
+  const readable = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await innerReader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      settle();
+      try {
+        writableController.error(reason);
+      } catch {
+        // The wrapper may already be closing or aborted.
+      }
+      await Promise.allSettled([
+        innerReader.cancel(reason),
+        innerWriter.abort(reason),
+      ]);
+    },
+  });
+
   const stream: TransformStream<Uint8Array, Uint8Array> = {
-    readable: transform.readable,
+    readable,
     writable,
   };
 

--- a/src/lib/proxy/tokenRefresh.ts
+++ b/src/lib/proxy/tokenRefresh.ts
@@ -1,6 +1,14 @@
 import { logger } from "../utils/logger.js";
 import { tokenStore } from "../auth/tokenStore.js";
+import {
+  ANTHROPIC_TOKEN_URL,
+  ANTHROPIC_TOKEN_URL_FALLBACK,
+  CLAUDE_CLI_USER_AGENT,
+  CLAUDE_CODE_CLIENT_ID,
+} from "../auth/anthropicOAuth.js";
 import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
+import { withTimeout } from "../utils/async/withTimeout.js";
+import { redactUrlForError } from "../utils/logSanitize.js";
 import type {
   RefreshableAccount,
   RefreshResult,
@@ -9,12 +17,11 @@ import type {
   TokenPersistTarget,
 } from "../types/index.js";
 
-const REFRESH_URL = "https://api.anthropic.com/v1/oauth/token";
-const REFRESH_URL_FALLBACK = "https://console.anthropic.com/v1/oauth/token";
-const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const BUFFER_MS = 5 * 60 * 1000;
 const SUCCESS_CACHE_MS = 60_000;
-const USER_AGENT = "claude-cli/2.1.80 (external, cli)";
+// Bound the best-effort persisted-credential reconciliation read so a hung or
+// slow token-store decrypt can never stall (or abort) a live token refresh.
+const PEEK_TOKENS_TIMEOUT_MS = 2_000;
 
 const refreshesInFlight = new Map<string, Promise<SharedRefreshResult>>();
 
@@ -41,18 +48,23 @@ async function performTokenRefresh(
     return { success: false, error: "No refresh token available" };
   }
 
-  const formBody = new URLSearchParams({
+  // OAuth 2.0 token endpoints require an `application/x-www-form-urlencoded`
+  // request body (RFC 6749 §6); a JSON body is nonstandard for this grant and
+  // is rejected by RFC-compliant endpoints. Mirror the interactive auth flow
+  // in `anthropicOAuth.ts::_refreshAccessToken`.
+  const requestBody = new URLSearchParams({
     grant_type: "refresh_token",
     refresh_token: account.refreshToken,
-    client_id: CLIENT_ID,
+    client_id: CLAUDE_CODE_CLIENT_ID,
   }).toString();
 
   const headers = {
     "Content-Type": "application/x-www-form-urlencoded",
-    "User-Agent": USER_AGENT,
+    Accept: "application/json",
+    "User-Agent": CLAUDE_CLI_USER_AGENT,
   };
 
-  const urls = [REFRESH_URL, REFRESH_URL_FALLBACK];
+  const urls = [ANTHROPIC_TOKEN_URL, ANTHROPIC_TOKEN_URL_FALLBACK];
   let terminalFailure: RefreshResult | undefined;
 
   for (const url of urls) {
@@ -60,16 +72,19 @@ async function performTokenRefresh(
       const resp = await fetch(url, {
         method: "POST",
         headers,
-        body: formBody,
+        body: requestBody,
         signal: AbortSignal.timeout(10_000),
       });
 
       if (!resp.ok) {
         const errorBody = await resp.text();
-        logger.warn(`[token-refresh] failed for ${account.label} at ${url}`, {
-          status: resp.status,
-          error: errorBody.slice(0, 500),
-        });
+        logger.warn(
+          `[token-refresh] failed for ${account.label} at ${redactUrlForError(url)}`,
+          {
+            status: resp.status,
+            error: errorBody.slice(0, 500),
+          },
+        );
         const failure = {
           success: false,
           error: errorBody,
@@ -79,7 +94,7 @@ async function performTokenRefresh(
           terminalFailure = failure;
         }
         // If primary URL returned a non-ok status, try fallback.
-        if (url === REFRESH_URL) {
+        if (url === ANTHROPIC_TOKEN_URL) {
           continue;
         }
         return terminalFailure ?? failure;
@@ -101,11 +116,14 @@ async function performTokenRefresh(
       logger.debug(`[token-refresh] refreshed for ${account.label}`);
       return { success: true };
     } catch (e) {
-      logger.warn(`[token-refresh] exception for ${account.label} at ${url}`, {
-        error: String(e),
-      });
+      logger.warn(
+        `[token-refresh] exception for ${account.label} at ${redactUrlForError(url)}`,
+        {
+          error: String(e),
+        },
+      );
       // If primary URL threw, try fallback
-      if (url === REFRESH_URL) {
+      if (url === ANTHROPIC_TOKEN_URL) {
         continue;
       }
       return terminalFailure ?? { success: false, error: String(e) };
@@ -190,6 +208,74 @@ export async function refreshToken(
   return shared.result;
 }
 
+async function reloadPersistedTokenStoreAccount(
+  account: RefreshableAccount,
+  target: TokenPersistTarget | undefined,
+): Promise<boolean> {
+  if (!target || typeof target === "string" || !("providerKey" in target)) {
+    return false;
+  }
+  // Best-effort, bounded reconciliation: this only adopts a newer persisted
+  // credential generation if one exists. A decryption/IO failure — or a hung
+  // read — must NOT abort the caller, which can still refresh with the
+  // already-loaded token. Swallow the failure and treat it as "no newer
+  // persisted generation found" so refresh proceeds instead of the account
+  // being spuriously disabled.
+  let stored: StoredOAuthTokens | null;
+  try {
+    stored = await withTimeout(
+      tokenStore.peekTokens(target.providerKey),
+      PEEK_TOKENS_TIMEOUT_MS,
+      "[token-refresh] peekTokens reconciliation timed out",
+    );
+  } catch (err) {
+    logger.debug(
+      "[token-refresh] skipping persisted-state reconciliation (peek failed)",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    return false;
+  }
+  if (
+    !stored ||
+    stored.expiresAt <= (account.expiresAt ?? 0) ||
+    (stored.accessToken === account.token &&
+      stored.refreshToken === account.refreshToken &&
+      stored.expiresAt === account.expiresAt)
+  ) {
+    return false;
+  }
+  account.token = stored.accessToken;
+  account.refreshToken = stored.refreshToken;
+  account.expiresAt = stored.expiresAt;
+  return true;
+}
+
+/**
+ * Refreshes against the latest persisted credential generation. Queued
+ * requests can otherwise reject a rotated refresh token and disable a newer
+ * login that was saved while they were waiting.
+ */
+export async function refreshTokenFromLatest(
+  account: RefreshableAccount,
+  target?: TokenPersistTarget,
+): Promise<RefreshResult> {
+  const reloadedBeforeRefresh = await reloadPersistedTokenStoreAccount(
+    account,
+    target,
+  );
+  if (reloadedBeforeRefresh && !needsRefresh(account)) {
+    return { success: true };
+  }
+
+  const result = await refreshToken(account);
+  if (result.success) {
+    return result;
+  }
+  return (await reloadPersistedTokenStoreAccount(account, target))
+    ? { success: true }
+    : result;
+}
+
 export function clearRefreshStateForTests(): void {
   refreshesInFlight.clear();
 }
@@ -234,7 +320,11 @@ async function persistTokenStoreAccount(
   account: RefreshableAccount,
 ): Promise<void> {
   try {
-    const existing = await tokenStore.loadTokens(providerKey);
+    const existing = await withTimeout(
+      tokenStore.peekTokens(providerKey),
+      PEEK_TOKENS_TIMEOUT_MS,
+      "[token-refresh] peekTokens for persistence timed out",
+    );
     const merged: StoredOAuthTokens = {
       accessToken: account.token,
       refreshToken: account.refreshToken ?? existing?.refreshToken,
@@ -243,7 +333,11 @@ async function persistTokenStoreAccount(
       tokenType: existing?.tokenType ?? "Bearer",
       ...(existing?.scope ? { scope: existing.scope } : {}),
     };
-    await tokenStore.saveTokens(providerKey, merged);
+    await withTimeout(
+      tokenStore.saveTokens(providerKey, merged),
+      PEEK_TOKENS_TIMEOUT_MS,
+      "[token-refresh] saveTokens timed out",
+    );
   } catch (err) {
     logger.warn("[token-refresh] Failed to persist TokenStore credentials", {
       error: err instanceof Error ? err.message : String(err),

--- a/src/lib/proxy/usageStats.ts
+++ b/src/lib/proxy/usageStats.ts
@@ -19,13 +19,20 @@ import {
 import { basename, dirname, join } from "node:path";
 import type {
   AccountStats,
+  PersistedProxyTerminalErrorSnapshot,
   PersistedProxyStatsSnapshot,
+  ProxyTerminalErrorCategory,
+  ProxyTerminalErrorDetails,
+  ProxyTerminalErrorJournal,
+  ProxyTerminalErrorSummary,
   ProxyStatsLockOwner,
   ProxyStats,
   ProxyStatsPersistenceStatus,
+  ProxyUsageStatsSnapshot,
   ProxyUsageStatsStoreOptions,
 } from "../types/index.js";
 import { AsyncMutex } from "../utils/asyncMutex.js";
+import { redactUrlsInText, sanitizeForLog } from "../utils/logSanitize.js";
 import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
 
 const SNAPSHOT_SCHEMA_VERSION = 1;
@@ -34,6 +41,31 @@ const DEFAULT_LOCK_TIMEOUT_MS = 2_000;
 const DEFAULT_STALE_LOCK_MS = 30_000;
 const LOCK_RETRY_MS = 25;
 const MAX_CORRUPT_SNAPSHOTS = 3;
+const MAX_RECENT_TERMINAL_ERRORS = 20;
+const MAX_TERMINAL_ERROR_FIELD_LENGTH = 128;
+const MAX_TERMINAL_ERROR_MESSAGE_LENGTH = 500;
+const TERMINAL_ERROR_ESCAPE = String.fromCharCode(27);
+const TERMINAL_ERROR_BELL = String.fromCharCode(7);
+const TERMINAL_ERROR_OSC_PATTERN = new RegExp(
+  `${TERMINAL_ERROR_ESCAPE}\\][\\s\\S]*?(?:${TERMINAL_ERROR_BELL}|${TERMINAL_ERROR_ESCAPE}\\\\)`,
+  "g",
+);
+const TERMINAL_ERROR_ANSI_PATTERN = new RegExp(
+  `${TERMINAL_ERROR_ESCAPE}\\[[0-?]*[ -/]*[@-~]`,
+  "g",
+);
+const TERMINAL_ERROR_CATEGORIES = [
+  "authentication",
+  "client_cancelled",
+  "fallback_exhausted",
+  "invalid_request",
+  "proxy_error",
+  "rate_limit",
+  "stream_error",
+  "unclassified",
+  "upstream_error",
+  "other",
+] as const satisfies readonly ProxyTerminalErrorCategory[];
 
 class InvalidProxyStatsSnapshotError extends Error {}
 
@@ -49,6 +81,183 @@ function emptyStats(startedAt: number): ProxyStats {
     totalTransientRateLimits: 0,
     totalQuotaRateLimits: 0,
     accounts: {},
+  };
+}
+
+function emptyTerminalErrorCounts(): Record<
+  ProxyTerminalErrorCategory,
+  number
+> {
+  return Object.fromEntries(
+    TERMINAL_ERROR_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<ProxyTerminalErrorCategory, number>;
+}
+
+function emptyTerminalErrorJournal(
+  startedAt: number,
+): ProxyTerminalErrorJournal {
+  return {
+    startedAt,
+    totalErrors: 0,
+    counts: emptyTerminalErrorCounts(),
+    recent: [],
+  };
+}
+
+function cloneTerminalErrorSummary(
+  summary: ProxyTerminalErrorSummary,
+): ProxyTerminalErrorSummary {
+  return { ...summary };
+}
+
+function cloneTerminalErrorJournal(
+  journal: ProxyTerminalErrorJournal,
+): ProxyTerminalErrorJournal {
+  return {
+    ...journal,
+    counts: { ...journal.counts },
+    recent: journal.recent.map(cloneTerminalErrorSummary),
+  };
+}
+
+function mergeTerminalErrorJournals(
+  left: ProxyTerminalErrorJournal,
+  right: ProxyTerminalErrorJournal,
+): ProxyTerminalErrorJournal {
+  const counts = emptyTerminalErrorCounts();
+  for (const category of TERMINAL_ERROR_CATEGORIES) {
+    counts[category] = left.counts[category] + right.counts[category];
+  }
+  const byId = new Map<string, ProxyTerminalErrorSummary>();
+  for (const summary of [...left.recent, ...right.recent]) {
+    byId.set(summary.id, cloneTerminalErrorSummary(summary));
+  }
+  const recent = [...byId.values()]
+    .sort((a, b) => a.at - b.at || a.id.localeCompare(b.id))
+    .slice(-MAX_RECENT_TERMINAL_ERRORS);
+  return {
+    startedAt: Math.min(left.startedAt, right.startedAt),
+    totalErrors: left.totalErrors + right.totalErrors,
+    counts,
+    recent,
+  };
+}
+
+function terminalErrorsPathForStats(filePath: string): string {
+  return join(dirname(filePath), "proxy-terminal-errors.json");
+}
+
+function clipTerminalErrorField(value: string | undefined): string | undefined {
+  const clipped = value?.slice(0, MAX_TERMINAL_ERROR_FIELD_LENGTH);
+  return clipped ? clipped : undefined;
+}
+
+function stripTerminalErrorControlCharacters(value: string): string {
+  const withoutAnsi = value
+    .replace(TERMINAL_ERROR_OSC_PATTERN, "")
+    .replace(TERMINAL_ERROR_ANSI_PATTERN, "");
+  return Array.from(withoutAnsi, (character) => {
+    const code = character.charCodeAt(0);
+    return code < 32 || (code >= 127 && code <= 159) ? " " : character;
+  }).join("");
+}
+
+function terminalErrorCategory(
+  status: number,
+  errorType: string | undefined,
+): ProxyTerminalErrorCategory {
+  const normalized = errorType?.toLowerCase() ?? "";
+  if (status === 499 || normalized.includes("client_cancel")) {
+    return "client_cancelled";
+  }
+  if (normalized.includes("stream_telemetry")) {
+    return "proxy_error";
+  }
+  if (normalized.includes("stream")) {
+    return "stream_error";
+  }
+  if (status === 429 || normalized.includes("rate_limit")) {
+    return "rate_limit";
+  }
+  if (normalized.includes("auth") || normalized.includes("token_refresh")) {
+    return "authentication";
+  }
+  if (
+    status === 404 ||
+    normalized.includes("invalid_request") ||
+    normalized.includes("not_found") ||
+    normalized.includes("construction_rejection")
+  ) {
+    return "invalid_request";
+  }
+  if (normalized.includes("fallback_exhausted")) {
+    return "fallback_exhausted";
+  }
+  if (
+    normalized.includes("proxy") ||
+    normalized.includes("handler_error") ||
+    normalized.includes("runtime")
+  ) {
+    return "proxy_error";
+  }
+  if (
+    normalized.includes("upstream") ||
+    normalized.includes("network") ||
+    normalized.includes("transient") ||
+    normalized.includes("generation") ||
+    normalized.includes("all_accounts") ||
+    normalized === "api_error" ||
+    status >= 500
+  ) {
+    return "upstream_error";
+  }
+  return normalized ? "other" : "unclassified";
+}
+
+function createTerminalErrorSummary(args: {
+  now: number;
+  status: number;
+  accountLabel?: string;
+  accountType?: string;
+  details?: ProxyTerminalErrorDetails;
+}): ProxyTerminalErrorSummary {
+  const { now, status, accountLabel, accountType, details } = args;
+  const errorType = clipTerminalErrorField(details?.errorType);
+  const message = details?.message
+    ? stripTerminalErrorControlCharacters(
+        sanitizeForLog(
+          redactUrlsInText(details.message),
+          MAX_TERMINAL_ERROR_MESSAGE_LENGTH + MAX_TERMINAL_ERROR_FIELD_LENGTH,
+        ),
+      )
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, MAX_TERMINAL_ERROR_MESSAGE_LENGTH)
+    : undefined;
+  return {
+    id: randomUUID(),
+    at: now,
+    status,
+    category: terminalErrorCategory(status, errorType),
+    ...(clipTerminalErrorField(details?.requestId)
+      ? { requestId: clipTerminalErrorField(details?.requestId) }
+      : {}),
+    ...(clipTerminalErrorField(accountLabel)
+      ? { account: clipTerminalErrorField(accountLabel) }
+      : {}),
+    ...(clipTerminalErrorField(accountType)
+      ? { accountType: clipTerminalErrorField(accountType) }
+      : {}),
+    ...(errorType ? { errorType } : {}),
+    ...(clipTerminalErrorField(details?.errorCode)
+      ? { errorCode: clipTerminalErrorField(details?.errorCode) }
+      : {}),
+    ...(clipTerminalErrorField(details?.terminalOutcome)
+      ? {
+          terminalOutcome: clipTerminalErrorField(details?.terminalOutcome),
+        }
+      : {}),
+    ...(message ? { message } : {}),
   };
 }
 
@@ -174,6 +383,76 @@ function validStats(value: unknown): value is ProxyStats {
   );
 }
 
+function validOptionalString(value: unknown, maxLength: number): boolean {
+  return (
+    value === undefined ||
+    (typeof value === "string" && value.length <= maxLength)
+  );
+}
+
+function validTerminalErrorSummary(
+  value: unknown,
+): value is ProxyTerminalErrorSummary {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<ProxyTerminalErrorSummary>;
+  return (
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    candidate.id.length <= MAX_TERMINAL_ERROR_FIELD_LENGTH &&
+    finiteNonNegativeInteger(candidate.at) &&
+    finiteNonNegativeInteger(candidate.status) &&
+    typeof candidate.category === "string" &&
+    TERMINAL_ERROR_CATEGORIES.includes(candidate.category) &&
+    validOptionalString(candidate.requestId, MAX_TERMINAL_ERROR_FIELD_LENGTH) &&
+    validOptionalString(candidate.account, MAX_TERMINAL_ERROR_FIELD_LENGTH) &&
+    validOptionalString(
+      candidate.accountType,
+      MAX_TERMINAL_ERROR_FIELD_LENGTH,
+    ) &&
+    validOptionalString(candidate.errorType, MAX_TERMINAL_ERROR_FIELD_LENGTH) &&
+    validOptionalString(candidate.errorCode, MAX_TERMINAL_ERROR_FIELD_LENGTH) &&
+    validOptionalString(
+      candidate.terminalOutcome,
+      MAX_TERMINAL_ERROR_FIELD_LENGTH,
+    ) &&
+    validOptionalString(candidate.message, MAX_TERMINAL_ERROR_MESSAGE_LENGTH)
+  );
+}
+
+function validTerminalErrorJournal(
+  value: unknown,
+): value is ProxyTerminalErrorJournal {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<ProxyTerminalErrorJournal>;
+  if (
+    !finiteNonNegativeInteger(candidate.startedAt) ||
+    !finiteNonNegativeInteger(candidate.totalErrors) ||
+    !candidate.counts ||
+    typeof candidate.counts !== "object" ||
+    !Array.isArray(candidate.recent) ||
+    candidate.recent.length > MAX_RECENT_TERMINAL_ERRORS ||
+    !candidate.recent.every(validTerminalErrorSummary)
+  ) {
+    return false;
+  }
+  const countEntries = Object.entries(candidate.counts);
+  return (
+    countEntries.length === TERMINAL_ERROR_CATEGORIES.length &&
+    countEntries.every(
+      ([category, count]) =>
+        TERMINAL_ERROR_CATEGORIES.includes(
+          category as ProxyTerminalErrorCategory,
+        ) && finiteNonNegativeInteger(count),
+    ) &&
+    countEntries.reduce((total, [, count]) => total + Number(count), 0) ===
+      candidate.totalErrors
+  );
+}
+
 function validSnapshot(value: unknown): value is PersistedProxyStatsSnapshot {
   if (!value || typeof value !== "object") {
     return false;
@@ -184,6 +463,21 @@ function validSnapshot(value: unknown): value is PersistedProxyStatsSnapshot {
     finiteNonNegativeInteger(candidate.revision) &&
     finiteNonNegativeInteger(candidate.updatedAt) &&
     validStats(candidate.stats)
+  );
+}
+
+function validTerminalErrorSnapshot(
+  value: unknown,
+): value is PersistedProxyTerminalErrorSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PersistedProxyTerminalErrorSnapshot>;
+  return (
+    candidate.schemaVersion === SNAPSHOT_SCHEMA_VERSION &&
+    finiteNonNegativeInteger(candidate.revision) &&
+    finiteNonNegativeInteger(candidate.updatedAt) &&
+    validTerminalErrorJournal(candidate.journal)
   );
 }
 
@@ -309,17 +603,27 @@ export class ProxyUsageStatsStore {
   private readonly lockTimeoutMs: number;
   private readonly staleLockMs: number;
   private filePath?: string;
+  private terminalErrorsFilePath?: string;
   private stats: ProxyStats;
   private pending: ProxyStats;
+  private terminalErrors: ProxyTerminalErrorJournal;
+  private pendingTerminalErrors: ProxyTerminalErrorJournal;
   private pendingMutations = 0;
   private inFlightMutations = 0;
+  private pendingTerminalErrorMutations = 0;
+  private inFlightTerminalErrorMutations = 0;
   private revision = 0;
+  private terminalErrorsRevision = 0;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly flushMutex = new AsyncMutex();
   private lastFlushedAt?: number;
   private lastReconciledAt?: number;
   private lastRecoveryAt?: number;
   private lastError?: string;
+  private terminalErrorsLastFlushedAt?: number;
+  private terminalErrorsLastRecoveryAt?: number;
+  private terminalErrorsLastError?: string;
+  private snapshotVersion = 0;
 
   constructor(options: ProxyUsageStatsStoreOptions = {}) {
     this.now = options.now ?? Date.now;
@@ -327,24 +631,50 @@ export class ProxyUsageStatsStore {
     this.lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
     this.staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
     this.filePath = options.filePath;
+    this.terminalErrorsFilePath =
+      options.terminalErrorsFilePath ??
+      (options.filePath
+        ? terminalErrorsPathForStats(options.filePath)
+        : undefined);
     const startedAt = this.now();
     this.stats = emptyStats(startedAt);
     this.pending = emptyStats(startedAt);
+    this.terminalErrors = emptyTerminalErrorJournal(startedAt);
+    this.pendingTerminalErrors = emptyTerminalErrorJournal(startedAt);
   }
 
   async initialize(filePath: string = this.filePath ?? ""): Promise<void> {
     this.cancelFlushTimer();
+    const configuredStatsPath = this.filePath;
+    const configuredTerminalErrorsPath = this.terminalErrorsFilePath;
     this.filePath = filePath || undefined;
+    this.terminalErrorsFilePath =
+      this.filePath &&
+      configuredStatsPath === this.filePath &&
+      configuredTerminalErrorsPath
+        ? configuredTerminalErrorsPath
+        : this.filePath
+          ? terminalErrorsPathForStats(this.filePath)
+          : undefined;
     const startedAt = this.now();
     this.stats = emptyStats(startedAt);
     this.pending = emptyStats(startedAt);
+    this.terminalErrors = emptyTerminalErrorJournal(startedAt);
+    this.pendingTerminalErrors = emptyTerminalErrorJournal(startedAt);
     this.pendingMutations = 0;
     this.inFlightMutations = 0;
+    this.pendingTerminalErrorMutations = 0;
+    this.inFlightTerminalErrorMutations = 0;
     this.revision = 0;
+    this.terminalErrorsRevision = 0;
     this.lastFlushedAt = undefined;
     this.lastReconciledAt = undefined;
     this.lastRecoveryAt = undefined;
     this.lastError = undefined;
+    this.terminalErrorsLastFlushedAt = undefined;
+    this.terminalErrorsLastRecoveryAt = undefined;
+    this.terminalErrorsLastError = undefined;
+    this.snapshotVersion = 0;
     if (!this.filePath) {
       return;
     }
@@ -370,6 +700,29 @@ export class ProxyUsageStatsStore {
         }
       } else {
         this.lastError = this.describeError(error);
+      }
+    }
+    if (!this.terminalErrorsFilePath) {
+      return;
+    }
+    try {
+      const snapshot = await this.readTerminalErrorSnapshot();
+      if (snapshot) {
+        this.applyTerminalErrorSnapshot(snapshot);
+      }
+    } catch (error) {
+      if (isCorruptSnapshotError(error)) {
+        try {
+          const recoveredSnapshot =
+            await this.recoverCorruptTerminalErrorSnapshot();
+          if (recoveredSnapshot) {
+            this.applyTerminalErrorSnapshot(recoveredSnapshot);
+          }
+        } catch (recoveryError) {
+          this.terminalErrorsLastError = this.describeError(recoveryError);
+        }
+      } else {
+        this.terminalErrorsLastError = this.describeError(error);
       }
     }
   }
@@ -414,13 +767,26 @@ export class ProxyUsageStatsStore {
   }
 
   recordFinalError(
-    _status: number,
+    status: number,
     accountLabel?: string,
     accountType?: string,
+    details?: ProxyTerminalErrorDetails,
   ): void {
     const failedAt = this.now();
+    const summary = createTerminalErrorSummary({
+      now: failedAt,
+      status,
+      accountLabel,
+      accountType,
+      details,
+    });
     this.applyFinalError(this.stats, accountLabel, accountType, failedAt);
     this.applyFinalError(this.pending, accountLabel, accountType, failedAt);
+    this.applyTerminalError(this.terminalErrors, summary);
+    if (this.terminalErrorsFilePath) {
+      this.applyTerminalError(this.pendingTerminalErrors, summary);
+      this.pendingTerminalErrorMutations += 1;
+    }
     this.markMutation();
   }
 
@@ -431,6 +797,20 @@ export class ProxyUsageStatsStore {
   getAccountStats(label: string): AccountStats | undefined {
     const account = this.stats.accounts[label];
     return account ? cloneAccount(account) : undefined;
+  }
+
+  getTerminalErrors(): ProxyTerminalErrorJournal {
+    return cloneTerminalErrorJournal(this.terminalErrors);
+  }
+
+  getUsageSnapshot(): ProxyUsageStatsSnapshot {
+    const version = this.snapshotVersion;
+    return {
+      stats: this.getStats(),
+      statsVersion: version,
+      terminalErrors: this.getTerminalErrors(),
+      terminalErrorsVersion: version,
+    };
   }
 
   getPersistenceStatus(): ProxyStatsPersistenceStatus {
@@ -445,80 +825,205 @@ export class ProxyUsageStatsStore {
       lastReconciledAt: this.lastReconciledAt ?? null,
       lastRecoveryAt: this.lastRecoveryAt ?? null,
       lastError: this.lastError ?? null,
+      terminalErrorsFilePath: this.terminalErrorsFilePath ?? null,
+      terminalErrorsRevision: this.terminalErrorsRevision,
+      terminalErrorsPending: this.pendingTerminalErrorMutations,
+      terminalErrorsInFlight: this.inFlightTerminalErrorMutations,
+      terminalErrorsUnpersisted:
+        this.pendingTerminalErrorMutations +
+        this.inFlightTerminalErrorMutations,
+      terminalErrorsLastFlushedAt: this.terminalErrorsLastFlushedAt ?? null,
+      terminalErrorsLastRecoveryAt: this.terminalErrorsLastRecoveryAt ?? null,
+      terminalErrorsLastError: this.terminalErrorsLastError ?? null,
     };
   }
 
   async flush(): Promise<void> {
     if (
       !this.filePath ||
-      (this.pendingMutations === 0 && this.inFlightMutations === 0)
+      (this.pendingMutations === 0 &&
+        this.inFlightMutations === 0 &&
+        this.pendingTerminalErrorMutations === 0 &&
+        this.inFlightTerminalErrorMutations === 0)
     ) {
       return;
     }
     this.cancelFlushTimer();
     await this.flushMutex.runExclusive(async () => {
-      if (!this.filePath || this.pendingMutations === 0) {
+      if (!this.filePath) {
         return;
       }
-      const delta = this.pending;
-      const deltaMutations = this.pendingMutations;
-      this.pending = emptyStats(this.now());
-      this.pendingMutations = 0;
-      this.inFlightMutations = deltaMutations;
-      const lockPath = `${this.filePath}.lock`;
-      let releaseLock: (() => Promise<void>) | undefined;
-      try {
-        releaseLock = await acquireFileLock(
-          lockPath,
-          this.lockTimeoutMs,
-          this.staleLockMs,
-          this.now,
-        );
-        let existing: PersistedProxyStatsSnapshot | null;
-        try {
-          existing = await this.readSnapshot();
-        } catch (error) {
-          if (!isCorruptSnapshotError(error)) {
-            throw error;
-          }
-          await this.quarantineCorruptSnapshot();
-          existing = null;
+      let statsDelta: { value: ProxyStats; mutations: number } | undefined;
+      let terminalErrorDelta:
+        | { value: ProxyTerminalErrorJournal; mutations: number }
+        | undefined;
+      if (this.pendingMutations > 0) {
+        statsDelta = {
+          value: this.pending,
+          mutations: this.pendingMutations,
+        };
+        this.pending = emptyStats(this.now());
+        this.pendingMutations = 0;
+        this.inFlightMutations = statsDelta.mutations;
+      }
+      if (
+        this.terminalErrorsFilePath &&
+        this.pendingTerminalErrorMutations > 0
+      ) {
+        terminalErrorDelta = {
+          value: this.pendingTerminalErrors,
+          mutations: this.pendingTerminalErrorMutations,
+        };
+        this.pendingTerminalErrors = emptyTerminalErrorJournal(this.now());
+        this.pendingTerminalErrorMutations = 0;
+        this.inFlightTerminalErrorMutations = terminalErrorDelta.mutations;
+      }
+
+      const countersPersisted = statsDelta
+        ? await this.persistStatsDelta(statsDelta.value, statsDelta.mutations)
+        : true;
+      if (terminalErrorDelta) {
+        if (countersPersisted) {
+          await this.persistTerminalErrorDelta(
+            terminalErrorDelta.value,
+            terminalErrorDelta.mutations,
+          );
+        } else {
+          this.pendingTerminalErrors = mergeTerminalErrorJournals(
+            terminalErrorDelta.value,
+            this.pendingTerminalErrors,
+          );
+          this.pendingTerminalErrorMutations += terminalErrorDelta.mutations;
+          this.inFlightTerminalErrorMutations = 0;
         }
-        const persisted = existing?.stats ?? emptyStats(delta.startedAt);
-        const merged = mergeStats(persisted, delta);
-        const revision = (existing?.revision ?? 0) + 1;
-        const updatedAt = this.now();
-        await writeJsonSnapshotAtomically(
-          this.filePath,
-          {
-            schemaVersion: SNAPSHOT_SCHEMA_VERSION,
-            revision,
-            updatedAt,
-            stats: merged,
-          } satisfies PersistedProxyStatsSnapshot,
-          0o600,
-        );
-        this.revision = revision;
-        this.lastFlushedAt = updatedAt;
-        this.lastReconciledAt = updatedAt;
-        this.lastError = undefined;
-        this.stats = mergeStats(merged, this.pending);
-        this.inFlightMutations = 0;
-      } catch (error) {
-        this.pending = mergeStats(delta, this.pending);
-        this.pendingMutations += deltaMutations;
-        this.inFlightMutations = 0;
-        this.lastError = this.describeError(error);
+      }
+      if (this.pendingMutations > 0 || this.pendingTerminalErrorMutations > 0) {
         this.scheduleFlush();
-      } finally {
-        await releaseLock?.();
       }
     });
   }
 
-  async reconcile(): Promise<ProxyStats> {
+  private async persistStatsDelta(
+    delta: ProxyStats,
+    deltaMutations: number,
+  ): Promise<boolean> {
     if (!this.filePath) {
-      return this.getStats();
+      return false;
+    }
+    let releaseLock: (() => Promise<void>) | undefined;
+    try {
+      releaseLock = await acquireFileLock(
+        `${this.filePath}.lock`,
+        this.lockTimeoutMs,
+        this.staleLockMs,
+        this.now,
+      );
+      let existing: PersistedProxyStatsSnapshot | null;
+      try {
+        existing = await this.readSnapshot();
+      } catch (error) {
+        if (!isCorruptSnapshotError(error)) {
+          throw error;
+        }
+        await this.quarantineCorruptSnapshot();
+        existing = null;
+      }
+      const persisted = existing?.stats ?? emptyStats(delta.startedAt);
+      const merged = mergeStats(persisted, delta);
+      const revision = (existing?.revision ?? 0) + 1;
+      const updatedAt = this.now();
+      await writeJsonSnapshotAtomically(
+        this.filePath,
+        {
+          schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+          revision,
+          updatedAt,
+          stats: merged,
+        } satisfies PersistedProxyStatsSnapshot,
+        0o600,
+      );
+      this.revision = revision;
+      this.lastFlushedAt = updatedAt;
+      this.lastReconciledAt = updatedAt;
+      this.lastError = undefined;
+      this.stats = mergeStats(merged, this.pending);
+      this.inFlightMutations = 0;
+      return true;
+    } catch (error) {
+      this.pending = mergeStats(delta, this.pending);
+      this.pendingMutations += deltaMutations;
+      this.inFlightMutations = 0;
+      this.lastError = this.describeError(error);
+      return false;
+    } finally {
+      await releaseLock?.();
+    }
+  }
+
+  private async persistTerminalErrorDelta(
+    delta: ProxyTerminalErrorJournal,
+    deltaMutations: number,
+  ): Promise<void> {
+    if (!this.terminalErrorsFilePath) {
+      return;
+    }
+    let releaseLock: (() => Promise<void>) | undefined;
+    try {
+      releaseLock = await acquireFileLock(
+        `${this.terminalErrorsFilePath}.lock`,
+        this.lockTimeoutMs,
+        this.staleLockMs,
+        this.now,
+      );
+      let existing: PersistedProxyTerminalErrorSnapshot | null;
+      try {
+        existing = await this.readTerminalErrorSnapshot();
+      } catch (error) {
+        if (!isCorruptSnapshotError(error)) {
+          throw error;
+        }
+        await this.quarantineCorruptTerminalErrorSnapshot();
+        existing = null;
+      }
+      const persisted =
+        existing?.journal ?? emptyTerminalErrorJournal(delta.startedAt);
+      const merged = mergeTerminalErrorJournals(persisted, delta);
+      const revision = (existing?.revision ?? 0) + 1;
+      const updatedAt = this.now();
+      await writeJsonSnapshotAtomically(
+        this.terminalErrorsFilePath,
+        {
+          schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+          revision,
+          updatedAt,
+          journal: merged,
+        } satisfies PersistedProxyTerminalErrorSnapshot,
+        0o600,
+      );
+      this.terminalErrorsRevision = revision;
+      this.terminalErrorsLastFlushedAt = updatedAt;
+      this.terminalErrorsLastError = undefined;
+      this.terminalErrors = mergeTerminalErrorJournals(
+        merged,
+        this.pendingTerminalErrors,
+      );
+      this.inFlightTerminalErrorMutations = 0;
+    } catch (error) {
+      this.pendingTerminalErrors = mergeTerminalErrorJournals(
+        delta,
+        this.pendingTerminalErrors,
+      );
+      this.pendingTerminalErrorMutations += deltaMutations;
+      this.inFlightTerminalErrorMutations = 0;
+      this.terminalErrorsLastError = this.describeError(error);
+    } finally {
+      await releaseLock?.();
+    }
+  }
+
+  async reconcileUsageSnapshot(): Promise<ProxyUsageStatsSnapshot> {
+    if (!this.filePath) {
+      return this.getUsageSnapshot();
     }
 
     return this.flushMutex.runExclusive(async () => {
@@ -534,8 +1039,29 @@ export class ProxyUsageStatsStore {
       } catch (error) {
         this.lastError = this.describeError(error);
       }
-      return this.getStats();
+      if (this.terminalErrorsFilePath) {
+        try {
+          const snapshot = await this.readTerminalErrorSnapshot();
+          if (snapshot) {
+            this.terminalErrors = mergeTerminalErrorJournals(
+              snapshot.journal,
+              this.pendingTerminalErrors,
+            );
+            this.terminalErrorsRevision = snapshot.revision;
+            this.terminalErrorsLastFlushedAt = snapshot.updatedAt;
+          }
+          this.terminalErrorsLastError = undefined;
+        } catch (error) {
+          this.terminalErrorsLastError = this.describeError(error);
+        }
+      }
+      this.snapshotVersion += 1;
+      return this.getUsageSnapshot();
     });
+  }
+
+  async reconcile(): Promise<ProxyStats> {
+    return (await this.reconcileUsageSnapshot()).stats;
   }
 
   resetMemory(): void {
@@ -543,24 +1069,35 @@ export class ProxyUsageStatsStore {
     const startedAt = this.now();
     this.stats = emptyStats(startedAt);
     this.pending = emptyStats(startedAt);
+    this.terminalErrors = emptyTerminalErrorJournal(startedAt);
+    this.pendingTerminalErrors = emptyTerminalErrorJournal(startedAt);
     this.pendingMutations = 0;
     this.inFlightMutations = 0;
+    this.pendingTerminalErrorMutations = 0;
+    this.inFlightTerminalErrorMutations = 0;
     this.revision = 0;
+    this.terminalErrorsRevision = 0;
     this.lastFlushedAt = undefined;
     this.lastReconciledAt = undefined;
     this.lastRecoveryAt = undefined;
     this.lastError = undefined;
+    this.terminalErrorsLastFlushedAt = undefined;
+    this.terminalErrorsLastRecoveryAt = undefined;
+    this.terminalErrorsLastError = undefined;
+    this.snapshotVersion = 0;
   }
 
   async resetForTests(): Promise<void> {
     await this.flushMutex.runExclusive(async () => {
       this.resetMemory();
       this.filePath = undefined;
+      this.terminalErrorsFilePath = undefined;
     });
   }
 
   private markMutation(): void {
     this.pendingMutations += 1;
+    this.snapshotVersion += 1;
     this.scheduleFlush();
   }
 
@@ -629,6 +1166,21 @@ export class ProxyUsageStatsStore {
     }
   }
 
+  private applyTerminalError(
+    target: ProxyTerminalErrorJournal,
+    summary: ProxyTerminalErrorSummary,
+  ): void {
+    target.totalErrors += 1;
+    target.counts[summary.category] += 1;
+    target.recent.push(cloneTerminalErrorSummary(summary));
+    if (target.recent.length > MAX_RECENT_TERMINAL_ERRORS) {
+      target.recent.splice(
+        0,
+        target.recent.length - MAX_RECENT_TERMINAL_ERRORS,
+      );
+    }
+  }
+
   private ensureAccount(
     target: ProxyStats,
     label: string,
@@ -694,11 +1246,42 @@ export class ProxyUsageStatsStore {
     return parsed;
   }
 
+  private async readTerminalErrorSnapshot(): Promise<PersistedProxyTerminalErrorSnapshot | null> {
+    if (!this.terminalErrorsFilePath) {
+      return null;
+    }
+    let raw: string;
+    try {
+      raw = await readFile(this.terminalErrorsFilePath, "utf8");
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        return null;
+      }
+      throw error;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!validTerminalErrorSnapshot(parsed)) {
+      throw new InvalidProxyStatsSnapshotError(
+        `Invalid proxy terminal-error snapshot ${this.terminalErrorsFilePath}`,
+      );
+    }
+    return parsed;
+  }
+
   private applySnapshot(snapshot: PersistedProxyStatsSnapshot): void {
     this.stats = cloneStats(snapshot.stats);
     this.pending = emptyStats(this.now());
     this.revision = snapshot.revision;
     this.lastFlushedAt = snapshot.updatedAt;
+  }
+
+  private applyTerminalErrorSnapshot(
+    snapshot: PersistedProxyTerminalErrorSnapshot,
+  ): void {
+    this.terminalErrors = cloneTerminalErrorJournal(snapshot.journal);
+    this.pendingTerminalErrors = emptyTerminalErrorJournal(this.now());
+    this.terminalErrorsRevision = snapshot.revision;
+    this.terminalErrorsLastFlushedAt = snapshot.updatedAt;
   }
 
   private async recoverCorruptSnapshot(): Promise<PersistedProxyStatsSnapshot | null> {
@@ -726,6 +1309,31 @@ export class ProxyUsageStatsStore {
     }
   }
 
+  private async recoverCorruptTerminalErrorSnapshot(): Promise<PersistedProxyTerminalErrorSnapshot | null> {
+    if (!this.terminalErrorsFilePath) {
+      return null;
+    }
+    const releaseLock = await acquireFileLock(
+      `${this.terminalErrorsFilePath}.lock`,
+      this.lockTimeoutMs,
+      this.staleLockMs,
+      this.now,
+    );
+    try {
+      try {
+        return await this.readTerminalErrorSnapshot();
+      } catch (error) {
+        if (!isCorruptSnapshotError(error)) {
+          throw error;
+        }
+        await this.quarantineCorruptTerminalErrorSnapshot();
+        return null;
+      }
+    } finally {
+      await releaseLock();
+    }
+  }
+
   private async quarantineCorruptSnapshot(): Promise<void> {
     if (!this.filePath) {
       return;
@@ -742,15 +1350,31 @@ export class ProxyUsageStatsStore {
     }
     this.lastRecoveryAt = recoveredAt;
     this.lastError = undefined;
-    await this.pruneCorruptSnapshots();
+    await this.pruneCorruptSnapshots(this.filePath);
   }
 
-  private async pruneCorruptSnapshots(): Promise<void> {
-    if (!this.filePath) {
+  private async quarantineCorruptTerminalErrorSnapshot(): Promise<void> {
+    if (!this.terminalErrorsFilePath) {
       return;
     }
-    const directory = dirname(this.filePath);
-    const prefix = `${basename(this.filePath)}.corrupt.`;
+    const recoveredAt = this.now();
+    const quarantinePath = `${this.terminalErrorsFilePath}.corrupt.${recoveredAt}.${randomUUID()}`;
+    try {
+      await rename(this.terminalErrorsFilePath, quarantinePath);
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+      return;
+    }
+    this.terminalErrorsLastRecoveryAt = recoveredAt;
+    this.terminalErrorsLastError = undefined;
+    await this.pruneCorruptSnapshots(this.terminalErrorsFilePath);
+  }
+
+  private async pruneCorruptSnapshots(filePath: string): Promise<void> {
+    const directory = dirname(filePath);
+    const prefix = `${basename(filePath)}.corrupt.`;
     const quarantined = (await readdir(directory))
       .filter((entry) => entry.startsWith(prefix))
       .sort()
@@ -802,11 +1426,12 @@ export function recordAttemptError(
 }
 
 export function recordFinalError(
-  _status: number,
+  status: number,
   accountLabel?: string,
   accountType?: string,
+  details?: ProxyTerminalErrorDetails,
 ): void {
-  defaultStore.recordFinalError(_status, accountLabel, accountType);
+  defaultStore.recordFinalError(status, accountLabel, accountType, details);
 }
 
 export function getStats(): ProxyStats {
@@ -817,8 +1442,16 @@ export async function getReconciledStats(): Promise<ProxyStats> {
   return defaultStore.reconcile();
 }
 
+export async function getReconciledUsageSnapshot(): Promise<ProxyUsageStatsSnapshot> {
+  return defaultStore.reconcileUsageSnapshot();
+}
+
 export function getAccountStats(label: string): AccountStats | undefined {
   return defaultStore.getAccountStats(label);
+}
+
+export function getTerminalErrors(): ProxyTerminalErrorJournal {
+  return defaultStore.getTerminalErrors();
 }
 
 export function getUsageStatsPersistenceStatus(): ProxyStatsPersistenceStatus {

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -76,6 +76,7 @@ import {
   needsRefresh,
   persistTokens,
   refreshToken,
+  refreshTokenFromLatest,
 } from "../../proxy/tokenRefresh.js";
 import {
   buildProxyTranslationPlan,
@@ -139,6 +140,8 @@ const BLOCKED_UPSTREAM_HEADERS = new Set([
   "content-length",
   "transfer-encoding",
 ]);
+const PROXY_INTERNAL_ACCOUNT_LABEL = "proxy/internal";
+const PROXY_INTERNAL_ACCOUNT_TYPE = "internal";
 
 // ---------------------------------------------------------------------------
 // Module-level state
@@ -1344,15 +1347,37 @@ async function handleTranslatedClaudeRequest(args: {
     });
   }
 
-  return handleTranslatedJsonRequest({
-    ctx,
-    format: "claude",
-    requestModel: body.model,
-    parsed,
-    attempts,
-    tracer,
-    requestStartTime,
-  });
+  try {
+    return await handleTranslatedJsonRequest({
+      ctx,
+      format: "claude",
+      requestModel: body.model,
+      parsed,
+      attempts,
+      tracer,
+      requestStartTime,
+      terminalFailureStatus: 502,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    logger.error(
+      `[claude-proxy] Translated generation failed for ${body.model}: ${message}`,
+    );
+    const clientError = buildClaudeError(502, `Generation failed: ${message}`);
+    const clientErrorBody = JSON.stringify(clientError);
+    logProxyBody({
+      phase: "client_response",
+      headers: { "content-type": "application/json" },
+      body: clientErrorBody,
+      bodySize: Buffer.byteLength(clientErrorBody, "utf8"),
+      contentType: "application/json",
+      account: "translation",
+      accountType: "translation",
+      responseStatus: 502,
+      durationMs: Date.now() - requestStartTime,
+    });
+    return clientError;
+  }
 }
 
 function logProxyRoutingPlan(
@@ -1377,6 +1402,7 @@ async function handleClaudePassthroughRequest(args: {
   tracer?: ProxyTracer;
   requestStartTime: number;
   logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
 }): Promise<unknown> {
   const {
     ctx,
@@ -1385,6 +1411,7 @@ async function handleClaudePassthroughRequest(args: {
     tracer,
     requestStartTime,
     logProxyBody,
+    logFinalRequest,
   } = args;
   tracer?.setMode("passthrough-cli");
   const bodyStr = clientRequestBody;
@@ -1422,6 +1449,7 @@ async function handleClaudePassthroughRequest(args: {
       upstreamUrl: "https://api.anthropic.com/v1/messages?beta=true",
     },
   });
+  recordAttempt("passthrough", "passthrough");
 
   let response: Response;
   try {
@@ -1434,24 +1462,11 @@ async function handleClaudePassthroughRequest(args: {
   } catch (fetchErr) {
     const errMsg =
       fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+    recordAttemptError("passthrough", "passthrough", 502);
     tracer?.setError("network_error", errMsg);
     upstreamSpan?.end();
     tracer?.end(502, Date.now() - requestStartTime);
-    logRequest({
-      timestamp: new Date().toISOString(),
-      requestId: ctx.requestId,
-      method: ctx.method,
-      path: ctx.path,
-      model: body.model,
-      stream: body.stream ?? false,
-      toolCount,
-      account: "passthrough",
-      accountType: "passthrough",
-      responseStatus: 502,
-      responseTimeMs: Date.now() - requestStartTime,
-      errorType: "network_error",
-      errorMessage: errMsg,
-    });
+    logFinalRequest(502, "passthrough", "passthrough", "network_error", errMsg);
     const errorBody = buildClaudeError(
       502,
       `Passthrough fetch failed: ${errMsg}`,
@@ -1480,6 +1495,12 @@ async function handleClaudePassthroughRequest(args: {
 
   if (!response.ok) {
     const errorText = await response.text();
+    recordAttemptError(
+      "passthrough",
+      "passthrough",
+      response.status,
+      response.status === 429 ? "quota" : undefined,
+    );
     tracer?.logUpstreamResponseBody(errorText);
     logProxyBody({
       phase: "upstream_response",
@@ -1510,6 +1531,13 @@ async function handleClaudePassthroughRequest(args: {
     upstreamSpan?.end();
     tracer?.setError("api_error", errorText.slice(0, 500));
     tracer?.end(response.status, Date.now() - requestStartTime);
+    logFinalRequest(
+      response.status,
+      "passthrough",
+      "passthrough",
+      response.status === 429 ? "rate_limit_error" : "api_error",
+      errorText,
+    );
     try {
       return JSON.parse(errorText);
     } catch {
@@ -1529,6 +1557,7 @@ async function handleClaudePassthroughRequest(args: {
       upstreamSpan,
       upstreamResponseHeaders,
       logProxyBody,
+      logFinalRequest,
     });
   }
 
@@ -1543,6 +1572,7 @@ async function handleClaudePassthroughRequest(args: {
     upstreamSpan,
     upstreamResponseHeaders,
     logProxyBody,
+    logFinalRequest,
   });
 }
 
@@ -1597,28 +1627,57 @@ async function handleClaudePassthroughStreamResponse(args: {
   upstreamSpan?: ReturnType<ProxyTracer["startUpstreamAttempt"]>;
   upstreamResponseHeaders: Record<string, string>;
   logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
 }): Promise<Response> {
   const {
-    ctx,
-    body,
     bodyStr,
     response,
     tracer,
     requestStartTime,
-    toolCount,
     upstreamSpan,
     upstreamResponseHeaders,
     logProxyBody,
+    logFinalRequest,
   } = args;
   const responseHeaders = { ...upstreamResponseHeaders };
   const { stream: clientCaptureStream, capture: clientCapture } =
     createRawStreamCapture();
   const responseBody = response.body;
   if (!responseBody) {
+    recordAttemptError("passthrough", "passthrough", 502);
     throw new Error("Expected passthrough stream response body");
   }
   const trackedStream = trackUpstreamReadableStream(responseBody);
   let streamSource: ReadableStream<Uint8Array> = trackedStream.stream;
+  let streamFinalized = false;
+  const finalizeStream = (
+    status: number,
+    errorType?: string,
+    errorMessage?: string,
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+    },
+  ): boolean => {
+    if (streamFinalized) {
+      return false;
+    }
+    streamFinalized = true;
+    if (errorType === "stream_error") {
+      recordAttemptError("passthrough", "passthrough", status);
+    }
+    logFinalRequest(
+      status,
+      "passthrough",
+      "passthrough",
+      errorType,
+      errorMessage,
+      usage,
+    );
+    return true;
+  };
 
   if (tracer) {
     try {
@@ -1688,32 +1747,17 @@ async function handleClaudePassthroughStreamResponse(args: {
             Date.now() - requestStartTime,
           );
 
-          const traceCtx = capturedTracer.getTraceContext();
-          logRequest({
-            timestamp: new Date().toISOString(),
-            requestId: ctx.requestId,
-            method: ctx.method,
-            path: ctx.path,
-            model: body.model,
-            stream: true,
-            toolCount,
-            account: "passthrough",
-            accountType: "passthrough",
-            responseStatus: failure?.status ?? response.status,
-            responseTimeMs: Date.now() - requestStartTime,
-            inputTokens: data.usage.inputTokens,
-            outputTokens: data.usage.outputTokens,
-            cacheCreationTokens: data.usage.cacheCreationInputTokens,
-            cacheReadTokens: data.usage.cacheReadInputTokens,
-            traceId: traceCtx.traceId,
-            spanId: traceCtx.spanId,
-            ...(failure
-              ? {
-                  errorType: failure.errorType,
-                  errorMessage: failure.message,
-                }
-              : {}),
-          });
+          finalizeStream(
+            failure?.status ?? response.status,
+            failure?.errorType,
+            failure?.message,
+            {
+              inputTokens: data.usage.inputTokens,
+              outputTokens: data.usage.outputTokens,
+              cacheCreationTokens: data.usage.cacheCreationInputTokens,
+              cacheReadTokens: data.usage.cacheReadInputTokens,
+            },
+          );
           logProxyBody({
             phase: "upstream_response",
             headers: responseHeaders,
@@ -1740,32 +1784,15 @@ async function handleClaudePassthroughStreamResponse(args: {
           });
         })
         .catch((error) => {
-          capturedTracer.setError(
-            "stream_error",
-            error instanceof Error ? error.message : String(error),
-          );
+          if (streamFinalized) {
+            return;
+          }
+          const message =
+            error instanceof Error ? error.message : String(error);
+          capturedTracer.setError("stream_telemetry_error", message);
           capturedUpstreamSpan?.end();
           capturedTracer.end(500, Date.now() - requestStartTime);
-
-          const traceCtx = capturedTracer.getTraceContext();
-          logRequest({
-            timestamp: new Date().toISOString(),
-            requestId: ctx.requestId,
-            method: ctx.method,
-            path: ctx.path,
-            model: body.model,
-            stream: true,
-            toolCount,
-            account: "passthrough",
-            accountType: "passthrough",
-            responseStatus: 500,
-            responseTimeMs: Date.now() - requestStartTime,
-            errorType: "stream_error",
-            errorMessage:
-              error instanceof Error ? error.message : String(error),
-            traceId: traceCtx.traceId,
-            spanId: traceCtx.spanId,
-          });
+          finalizeStream(500, "stream_telemetry_error", message);
         });
     } catch {
       trackedStream.outcome.then((outcome) => {
@@ -1778,28 +1805,11 @@ async function handleClaudePassthroughStreamResponse(args: {
           failure?.status ?? response.status,
           Date.now() - requestStartTime,
         );
-        const traceCtx = tracer.getTraceContext();
-        logRequest({
-          timestamp: new Date().toISOString(),
-          requestId: ctx.requestId,
-          method: ctx.method,
-          path: ctx.path,
-          model: body.model,
-          stream: true,
-          toolCount,
-          account: "passthrough",
-          accountType: "passthrough",
-          responseStatus: failure?.status ?? response.status,
-          responseTimeMs: Date.now() - requestStartTime,
-          traceId: traceCtx.traceId,
-          spanId: traceCtx.spanId,
-          ...(failure
-            ? {
-                errorType: failure.errorType,
-                errorMessage: failure.message,
-              }
-            : {}),
-        });
+        finalizeStream(
+          failure?.status ?? response.status,
+          failure?.errorType,
+          failure?.message,
+        );
       });
     }
   } else {
@@ -1815,29 +1825,17 @@ async function handleClaudePassthroughStreamResponse(args: {
             data.streamErrorMessage,
           );
           const failure = getStreamFailureDetails(terminalOutcome);
-          logRequest({
-            timestamp: new Date().toISOString(),
-            requestId: ctx.requestId,
-            method: ctx.method,
-            path: ctx.path,
-            model: body.model,
-            stream: true,
-            toolCount,
-            account: "passthrough",
-            accountType: "passthrough",
-            responseStatus: failure?.status ?? response.status,
-            responseTimeMs: Date.now() - requestStartTime,
-            inputTokens: data.usage.inputTokens,
-            outputTokens: data.usage.outputTokens,
-            cacheCreationTokens: data.usage.cacheCreationInputTokens,
-            cacheReadTokens: data.usage.cacheReadInputTokens,
-            ...(failure
-              ? {
-                  errorType: failure.errorType,
-                  errorMessage: failure.message,
-                }
-              : {}),
-          });
+          finalizeStream(
+            failure?.status ?? response.status,
+            failure?.errorType,
+            failure?.message,
+            {
+              inputTokens: data.usage.inputTokens,
+              outputTokens: data.usage.outputTokens,
+              cacheCreationTokens: data.usage.cacheCreationInputTokens,
+              cacheReadTokens: data.usage.cacheReadInputTokens,
+            },
+          );
           logProxyBody({
             phase: "upstream_response",
             headers: responseHeaders,
@@ -1864,47 +1862,24 @@ async function handleClaudePassthroughStreamResponse(args: {
           });
         })
         .catch((error) => {
-          logRequest({
-            timestamp: new Date().toISOString(),
-            requestId: ctx.requestId,
-            method: ctx.method,
-            path: ctx.path,
-            model: body.model,
-            stream: true,
-            toolCount,
-            account: "passthrough",
-            accountType: "passthrough",
-            responseStatus: 500,
-            responseTimeMs: Date.now() - requestStartTime,
-            errorType: "stream_telemetry_error",
-            errorMessage:
+          if (!streamFinalized) {
+            finalizeStream(
+              500,
+              "stream_telemetry_error",
               error instanceof Error ? error.message : String(error),
-          });
+            );
+          }
         });
     } catch {
       // Streaming capture is best-effort; the tracked source still propagates
       // the transport failure to the client.
       trackedStream.outcome.then((outcome) => {
         const failure = getStreamFailureDetails(outcome);
-        logRequest({
-          timestamp: new Date().toISOString(),
-          requestId: ctx.requestId,
-          method: ctx.method,
-          path: ctx.path,
-          model: body.model,
-          stream: true,
-          toolCount,
-          account: "passthrough",
-          accountType: "passthrough",
-          responseStatus: failure?.status ?? response.status,
-          responseTimeMs: Date.now() - requestStartTime,
-          ...(failure
-            ? {
-                errorType: failure.errorType,
-                errorMessage: failure.message,
-              }
-            : {}),
-        });
+        finalizeStream(
+          failure?.status ?? response.status,
+          failure?.errorType,
+          failure?.message,
+        );
       });
     }
   }
@@ -1927,18 +1902,17 @@ async function handleClaudePassthroughJsonResponse(args: {
   upstreamSpan?: ReturnType<ProxyTracer["startUpstreamAttempt"]>;
   upstreamResponseHeaders: Record<string, string>;
   logProxyBody: ProxyBodyCaptureLogger;
+  logFinalRequest: ClaudeFinalRequestLogger;
 }): Promise<unknown> {
   const {
-    ctx,
-    body,
     bodyStr,
     response,
     tracer,
     requestStartTime,
-    toolCount,
     upstreamSpan,
     upstreamResponseHeaders,
     logProxyBody,
+    logFinalRequest,
   } = args;
   const responseText = await response.text();
   tracer?.logUpstreamResponseBody(responseText);
@@ -2011,42 +1985,23 @@ async function handleClaudePassthroughJsonResponse(args: {
     upstreamSpan?.end();
     tracer.end(response.status, Date.now() - requestStartTime);
 
-    const traceCtx = tracer.getTraceContext();
-    logRequest({
-      timestamp: new Date().toISOString(),
-      requestId: ctx.requestId,
-      method: ctx.method,
-      path: ctx.path,
-      model: body.model,
-      stream: false,
-      toolCount,
-      account: "passthrough",
-      accountType: "passthrough",
-      responseStatus: response.status,
-      responseTimeMs: Date.now() - requestStartTime,
-      inputTokens: usage?.input_tokens,
-      outputTokens: usage?.output_tokens,
-      cacheCreationTokens: usage?.cache_creation_input_tokens,
-      cacheReadTokens: usage?.cache_read_input_tokens,
-      traceId: traceCtx.traceId,
-      spanId: traceCtx.spanId,
-    });
+    logFinalRequest(
+      response.status,
+      "passthrough",
+      "passthrough",
+      undefined,
+      undefined,
+      {
+        inputTokens: usage?.input_tokens,
+        outputTokens: usage?.output_tokens,
+        cacheCreationTokens: usage?.cache_creation_input_tokens,
+        cacheReadTokens: usage?.cache_read_input_tokens,
+      },
+    );
   } else {
     upstreamSpan?.end();
     tracer?.end(response.status, Date.now() - requestStartTime);
-    logRequest({
-      timestamp: new Date().toISOString(),
-      requestId: ctx.requestId,
-      method: ctx.method,
-      path: ctx.path,
-      model: body.model,
-      stream: false,
-      toolCount,
-      account: "passthrough",
-      accountType: "passthrough",
-      responseStatus: response.status,
-      responseTimeMs: Date.now() - requestStartTime,
-    });
+    logFinalRequest(response.status, "passthrough", "passthrough");
   }
 
   return responseJson;
@@ -2188,7 +2143,9 @@ async function loadClaudeProxyAccounts(args: {
         expiresAt,
         label,
       };
-      const refreshed = await refreshToken(tempAccount);
+      const refreshed = await refreshTokenFromLatest(tempAccount, {
+        providerKey: key,
+      });
       if (!refreshed.success) {
         const account = {
           key,
@@ -2295,23 +2252,7 @@ async function loadClaudeProxyAccounts(args: {
   }
 
   for (const account of accounts) {
-    const state = getOrCreateRuntimeState(account.key);
-    const tokenChanged =
-      state.lastToken !== account.token ||
-      state.lastRefreshToken !== account.refreshToken;
-    if (tokenChanged) {
-      if (state.permanentlyDisabled) {
-        logger.always(
-          `[proxy] account=${account.label} eligible credentials reloaded; clearing stale runtime auth-disable state`,
-        );
-      }
-      // Eligibility was already resolved while loading accounts. This only
-      // clears stale in-process auth state after an explicit credential reload.
-      state.consecutiveRefreshFailures = 0;
-      state.permanentlyDisabled = false;
-    }
-    state.lastToken = account.token;
-    state.lastRefreshToken = account.refreshToken;
+    reconcileEligibleAccountRuntimeState(account);
   }
 
   await seedRuntimeQuotasFromDisk(accounts);
@@ -2529,7 +2470,6 @@ async function executeClaudeFallbackTranslation(args: {
 
     // Telemetry AFTER validation — not before like the old lazy path
     tracer?.end(200, Date.now() - requestStartTime);
-    recordFinalSuccess();
     logFinalRequest(200, "", providerLabel, undefined, undefined, {
       inputTokens: resolvedUsage.input,
       outputTokens: resolvedUsage.output,
@@ -2573,7 +2513,6 @@ async function executeClaudeFallbackTranslation(args: {
     toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
   };
   tracer?.end(200, Date.now() - requestStartTime);
-  recordFinalSuccess();
   const clientResponse = serializeClaudeResponse(internal, body.model);
   logFinalRequest(200, "", providerLabel, undefined, undefined, {
     inputTokens: internal.usage?.input,
@@ -2925,7 +2864,6 @@ function buildClaudeAnthropicFailureResponse(args: {
       summarizeErrorMessage(invalidRequestFailure.body),
     );
     tracer?.end(invalidRequestFailure.status, Date.now() - requestStartTime);
-    recordFinalError(invalidRequestFailure.status);
     try {
       const parsedError = JSON.parse(invalidRequestFailure.body);
       logFinalRequest(
@@ -3022,7 +2960,6 @@ function buildClaudeAnthropicFailureResponse(args: {
   const errorBody = buildClaudeError(429, errorMessage, "overloaded_error");
   tracer?.setError("rate_limit_error", errorMessage);
   tracer?.end(429, Date.now() - requestStartTime);
-  recordFinalError(429);
   logFinalRequest(429, "", "final", "rate_limit_error", errorMessage);
   const errorBodyText = JSON.stringify(errorBody);
   logProxyBody({
@@ -3206,7 +3143,6 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     upstreamSpan?.end();
     tracer?.setError("stream_error", "No response body from upstream");
     tracer?.end(502, Date.now() - requestStartTime);
-    recordFinalError(502, account.label, account.type);
     logFinalRequest(
       502,
       account.label,
@@ -3458,6 +3394,15 @@ function getStreamFailureDetails(
   return undefined;
 }
 
+function recordCommittedAnthropicStreamAttemptFailure(
+  outcome: StreamTerminalOutcome,
+  account: ProxyPassthroughAccount,
+): void {
+  if (outcome.kind === "upstream_error") {
+    recordAttemptError(account.label, account.type, 502);
+  }
+}
+
 function attachAnthropicSuccessStreamTelemetry(args: {
   account: ProxyPassthroughAccount;
   response: Response;
@@ -3520,6 +3465,10 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             rawOutcome,
             data.streamErrorMessage,
           );
+          recordCommittedAnthropicStreamAttemptFailure(
+            terminalOutcome,
+            account,
+          );
           capturedTracer.setUsage({
             inputTokens: data.usage.inputTokens,
             outputTokens: data.usage.outputTokens,
@@ -3571,11 +3520,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
           if (failure) {
             capturedTracer.setError(failure.errorType, failure.message);
             capturedTracer.end(failure.status, Date.now() - requestStartTime);
-            recordFinalError(
-              failure.status,
-              capturedAccountLabel,
-              account.type,
-            );
             logFinalRequest(
               failure.status,
               capturedAccountLabel,
@@ -3586,7 +3530,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             );
           } else {
             capturedTracer.end(200, Date.now() - requestStartTime);
-            recordFinalSuccess(capturedAccountLabel, account.type);
             logFinalRequest(
               200,
               capturedAccountLabel,
@@ -3623,17 +3566,16 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         })
         .catch((error) => {
           capturedTracer.setError(
-            "stream_error",
+            "stream_telemetry_error",
             error instanceof Error ? error.message : String(error),
           );
           capturedUpstreamSpan?.end();
           capturedTracer.end(500, Date.now() - requestStartTime);
-          recordFinalError(500, capturedAccountLabel, account.type);
           logFinalRequest(
             500,
             capturedAccountLabel,
             account.type,
-            "stream_error",
+            "stream_telemetry_error",
             error instanceof Error ? error.message : String(error),
           );
         });
@@ -3641,12 +3583,12 @@ function attachAnthropicSuccessStreamTelemetry(args: {
       // Interceptor attachment failed after stream setup. Preserve delivery but
       // still settle the request from the actual stream terminal outcome.
       streamOutcome.then((outcome) => {
+        recordCommittedAnthropicStreamAttemptFailure(outcome, account);
         const failure = getStreamFailureDetails(outcome);
         upstreamSpan?.end();
         if (failure) {
           tracer.setError(failure.errorType, failure.message);
           tracer.end(failure.status, Date.now() - requestStartTime);
-          recordFinalError(failure.status, account.label, account.type);
           logFinalRequest(
             failure.status,
             account.label,
@@ -3656,7 +3598,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
           );
         } else {
           tracer.end(response.status, Date.now() - requestStartTime);
-          recordFinalSuccess(account.label, account.type);
           logFinalRequest(response.status, account.label, account.type);
         }
       });
@@ -3676,6 +3617,10 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             rawOutcome,
             data.streamErrorMessage,
           );
+          recordCommittedAnthropicStreamAttemptFailure(
+            terminalOutcome,
+            account,
+          );
           const failure = getStreamFailureDetails(terminalOutcome);
           const usage = {
             inputTokens: data.usage.inputTokens,
@@ -3684,11 +3629,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             cacheReadTokens: data.usage.cacheReadInputTokens,
           };
           if (failure) {
-            recordFinalError(
-              failure.status,
-              capturedAccountLabel,
-              account.type,
-            );
             logFinalRequest(
               failure.status,
               capturedAccountLabel,
@@ -3698,7 +3638,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
               usage,
             );
           } else {
-            recordFinalSuccess(capturedAccountLabel, account.type);
             logFinalRequest(
               200,
               capturedAccountLabel,
@@ -3736,7 +3675,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         .catch((error) => {
           const message =
             error instanceof Error ? error.message : String(error);
-          recordFinalError(500, account.label, account.type);
           logFinalRequest(
             500,
             account.label,
@@ -3765,9 +3703,9 @@ function attachAnthropicSuccessStreamTelemetry(args: {
           // Non-fatal
         });
       streamOutcome.then((outcome) => {
+        recordCommittedAnthropicStreamAttemptFailure(outcome, account);
         const failure = getStreamFailureDetails(outcome);
         if (failure) {
-          recordFinalError(failure.status, account.label, account.type);
           logFinalRequest(
             failure.status,
             account.label,
@@ -3776,7 +3714,6 @@ function attachAnthropicSuccessStreamTelemetry(args: {
             failure.message,
           );
         } else {
-          recordFinalSuccess(account.label, account.type);
           logFinalRequest(response.status, account.label, account.type);
         }
       });
@@ -3921,7 +3858,6 @@ async function handleAnthropicJsonSuccessResponse(args: {
     tracer.recordBodySizes(finalBodyStr.length, responseJsonStr.length);
     upstreamSpan?.end();
     tracer.end(response.status, Date.now() - requestStartTime);
-    recordFinalSuccess(account.label, account.type);
     logFinalRequest(
       response.status,
       account.label,
@@ -3943,7 +3879,6 @@ async function handleAnthropicJsonSuccessResponse(args: {
             | Record<string, number>
             | undefined)
         : undefined;
-    recordFinalSuccess(account.label, account.type);
     logFinalRequest(
       response.status,
       account.label,
@@ -4077,7 +4012,6 @@ async function handleAnthropicSuccessfulNonStreamRetryResponse(args: {
     tracer.recordBodySizes(finalBodyStr.length, retryJsonStr.length);
     upstreamSpan?.end();
     tracer.end(retryResp.status, Date.now() - requestStartTime);
-    recordFinalSuccess(account.label, account.type);
     logFinalRequest(
       retryResp.status,
       account.label,
@@ -4093,7 +4027,6 @@ async function handleAnthropicSuccessfulNonStreamRetryResponse(args: {
     );
   } else {
     upstreamSpan?.end();
-    recordFinalSuccess(account.label, account.type);
     logFinalRequest(retryResp.status, account.label, account.type);
   }
 
@@ -4175,7 +4108,10 @@ async function handleAnthropicAuthRetry(args: {
     logger.always(
       `[proxy] ← 401 account=${account.label} refreshing (attempt ${authRetry + 1}/${MAX_AUTH_RETRIES})`,
     );
-    const refreshSucceeded = await refreshToken(account);
+    const refreshSucceeded = await refreshTokenFromLatest(
+      account,
+      account.persistTarget,
+    );
     if (!refreshSucceeded.success) {
       authRetryError = `refresh failed for account=${account.label} attempt ${authRetry + 1}/${MAX_AUTH_RETRIES}: ${refreshSucceeded.error?.slice(0, 200) ?? "unknown"}`;
       currentLastError = authRetryError;
@@ -4462,7 +4398,6 @@ async function handleAnthropicAuthRetry(args: {
         "api_error",
         summarizeErrorMessage(retryBody),
       );
-      recordFinalError(retryStatus, account.label, account.type);
       try {
         logFinalRequest(
           retryStatus,
@@ -4648,7 +4583,6 @@ function finalizeAnthropicTerminalFetchError(args: {
     logProxyBody,
     logFinalRequest,
   } = args;
-  recordFinalError(terminalError.status, account.label, account.type);
   tracer?.end(terminalError.status, Date.now() - requestStartTime);
   return buildAnthropicTerminalErrorResponse({
     responseStatus: terminalError.status,
@@ -4842,7 +4776,6 @@ async function handleAnthropicNonOkResponse(args: {
   }
 
   if (response.status === 404) {
-    recordFinalError(response.status, account.label, account.type);
     logger.always(`[proxy] ← 404 account=${account.label}`);
     logAttempt(404, "not_found_error", summarizeErrorMessage(errBody));
     tracer?.setError("not_found_error", summarizeErrorMessage(errBody));
@@ -4905,7 +4838,6 @@ async function handleAnthropicNonOkResponse(args: {
     };
   }
 
-  recordFinalError(response.status, account.label, account.type);
   logger.always(`[proxy] ← ${response.status} account=${account.label}`);
   logger.debug(`[claude-proxy] error body: ${errBody.substring(0, 200)}`);
   logAttempt(response.status, "api_error", summarizeErrorMessage(errBody));
@@ -4987,6 +4919,7 @@ function createClaudeRequestRuntimeContext(args: {
         : {}),
     });
   };
+  let finalRequestLogged = false;
   const logFinalRequest: ClaudeFinalRequestLogger = (
     status,
     accountLabel,
@@ -4995,6 +4928,36 @@ function createClaudeRequestRuntimeContext(args: {
     errorMessage,
     extra,
   ) => {
+    if (finalRequestLogged) {
+      logger.debug(
+        `[claude-proxy] ignored duplicate finalization for request ${ctx.requestId}`,
+      );
+      return;
+    }
+    finalRequestLogged = true;
+    const finalAccountLabel =
+      accountLabel ||
+      (status >= 400 ? PROXY_INTERNAL_ACCOUNT_LABEL : undefined);
+    const finalAccountType = accountLabel
+      ? accountType || undefined
+      : status >= 400
+        ? PROXY_INTERNAL_ACCOUNT_TYPE
+        : undefined;
+    if (status >= 400) {
+      recordFinalError(status, finalAccountLabel, finalAccountType, {
+        requestId: ctx.requestId,
+        errorType,
+        terminalOutcome:
+          errorType === "client_cancelled"
+            ? "client_cancelled"
+            : errorType?.includes("stream")
+              ? "stream_error"
+              : "handler_error",
+        message: errorMessage,
+      });
+    } else {
+      recordFinalSuccess(finalAccountLabel, finalAccountType);
+    }
     const traceCtx = tracer?.getTraceContext();
     logRequest({
       timestamp: new Date().toISOString(),
@@ -5004,8 +4967,8 @@ function createClaudeRequestRuntimeContext(args: {
       model: body.model,
       stream: !!body.stream,
       toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
-      account: accountLabel,
-      accountType,
+      account: finalAccountLabel ?? "",
+      accountType: finalAccountType ?? "",
       responseStatus: status,
       responseTimeMs: Date.now() - requestStartTime,
       ...(errorType ? { errorType } : {}),
@@ -5035,7 +4998,6 @@ function createClaudeRequestRuntimeContext(args: {
   ) => {
     const errorBody = buildClaudeError(status, message, errorType);
     const errorBodyText = JSON.stringify(errorBody);
-    recordFinalError(status, extra?.account, extra?.accountType);
     logFinalRequest(
       status,
       extra?.account ?? "",
@@ -5162,7 +5124,10 @@ async function prepareAnthropicAccountAttempt(args: {
   let authFailureMessage = currentAuthFailureMessage;
 
   if (needsRefresh(account)) {
-    const refreshed = await refreshToken(account);
+    const refreshed = await refreshTokenFromLatest(
+      account,
+      account.persistTarget,
+    );
     if (refreshed.success) {
       if (account.persistTarget) {
         await persistTokens(account.persistTarget, account);
@@ -6093,6 +6058,43 @@ function isClaudeProxyRouteRuntimeOptions(
   );
 }
 
+function buildEarlyClaudeRequestError(args: {
+  ctx: ServerContext;
+  body: ClaudeRequest | undefined;
+  status: number;
+  message: string;
+  errorType: string;
+}): unknown {
+  const { ctx, body, status, message, errorType } = args;
+  recordFinalError(
+    status,
+    PROXY_INTERNAL_ACCOUNT_LABEL,
+    PROXY_INTERNAL_ACCOUNT_TYPE,
+    {
+      requestId: ctx.requestId,
+      errorType,
+      terminalOutcome: "handler_error",
+      message,
+    },
+  );
+  void logRequest({
+    timestamp: new Date().toISOString(),
+    requestId: ctx.requestId,
+    method: ctx.method,
+    path: ctx.path,
+    model: typeof body?.model === "string" ? body.model : "",
+    stream: body?.stream ?? false,
+    toolCount: Array.isArray(body?.tools) ? body.tools.length : 0,
+    account: PROXY_INTERNAL_ACCOUNT_LABEL,
+    accountType: PROXY_INTERNAL_ACCOUNT_TYPE,
+    responseStatus: status,
+    responseTimeMs: 0,
+    errorType,
+    errorMessage: message,
+  });
+  return buildClaudeError(status, message);
+}
+
 /**
  * Create Claude-compatible proxy routes.
  *
@@ -6152,22 +6154,29 @@ export function createClaudeProxyRoutes(
             typeof body?.model !== "string" ||
             !Array.isArray(body?.messages)
           ) {
-            return buildClaudeError(
-              400,
-              "Missing required fields: model, messages",
-            );
+            return buildEarlyClaudeRequestError({
+              ctx,
+              body,
+              status: 400,
+              message: "Missing required fields: model, messages",
+              errorType: "invalid_request_error",
+            });
           }
 
           // 2. Resolve model via router (or pass through to anthropic)
           // Guard: without a model router, only Claude models are allowed.
           const modelLower = body.model.toLowerCase();
           if (!requestModelRouter && !modelLower.startsWith("claude-")) {
-            return buildClaudeError(
-              404,
-              `Model '${body.model}' is not an Anthropic model. ` +
+            return buildEarlyClaudeRequestError({
+              ctx,
+              body,
+              status: 404,
+              message:
+                `Model '${body.model}' is not an Anthropic model. ` +
                 `The proxy only supports Claude models. ` +
                 `Use a model router to route non-Claude models to other providers.`,
-            );
+              errorType: "not_found_error",
+            });
           }
 
           const route = requestModelRouter?.resolve(body.model) ?? {
@@ -6214,6 +6223,7 @@ export function createClaudeProxyRoutes(
                   tracer,
                   requestStartTime,
                   logProxyBody,
+                  logFinalRequest,
                 });
               }
 
@@ -6365,26 +6375,71 @@ function getOrCreateRuntimeState(accountKey: string): RuntimeAccountState {
   return initial;
 }
 
+function reconcileEligibleAccountRuntimeState(
+  account: ProxyPassthroughAccount,
+): void {
+  const state = getOrCreateRuntimeState(account.key);
+  const tokenChanged =
+    state.lastToken !== account.token ||
+    state.lastRefreshToken !== account.refreshToken;
+  const wasPermanentlyDisabled = state.permanentlyDisabled;
+  if (wasPermanentlyDisabled) {
+    logger.always(
+      `[proxy] account=${account.label} is enabled in the token store; clearing stale runtime auth-disable state`,
+    );
+  }
+  state.permanentlyDisabled = false;
+  if (tokenChanged || wasPermanentlyDisabled) {
+    state.consecutiveRefreshFailures = 0;
+  }
+  state.lastToken = account.token;
+  state.lastRefreshToken = account.refreshToken;
+}
+
 async function disableAccountUntilReauth(
   account: ProxyPassthroughAccount,
   state: RuntimeAccountState,
   reason: "missing_refresh_token" | "refresh_invalid",
-): Promise<void> {
-  state.permanentlyDisabled = true;
-
-  // Decision 7 (usage): Persist disabled state to disk so it survives restarts
+): Promise<boolean> {
   try {
     const { tokenStore } = await import("../../auth/tokenStore.js");
-    await tokenStore.markDisabled(account.key, reason);
+    const providerKey =
+      account.persistTarget &&
+      typeof account.persistTarget !== "string" &&
+      "providerKey" in account.persistTarget
+        ? account.persistTarget.providerKey
+        : undefined;
+    if (providerKey) {
+      const disabled = await tokenStore.markDisabledIfCurrent(
+        providerKey,
+        {
+          accessToken: account.token,
+          refreshToken: account.refreshToken,
+          expiresAt: account.expiresAt ?? 0,
+        },
+        reason,
+      );
+      if (!disabled) {
+        state.permanentlyDisabled = false;
+        logger.always(
+          `[proxy] account=${account.label} credentials changed while authentication was in flight; ignored stale disable`,
+        );
+        return false;
+      }
+    } else {
+      await tokenStore.markDisabled(account.key, reason);
+    }
   } catch (e) {
     logger.debug(
       `[proxy] failed to persist disabled state for ${account.label}: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
 
+  state.permanentlyDisabled = true;
   logger.always(
     `[proxy] account=${account.label} disabled until re-authentication. Run: neurolink auth login anthropic --method oauth`,
   );
+  return true;
 }
 
 async function coolAccountAfterTransientRefreshFailure(
@@ -6678,6 +6733,7 @@ export const __testHooks = {
   orderAccountsByQuota,
   resetEpochToMs,
   seedRuntimeQuotasFromDisk,
+  reconcileEligibleAccountRuntimeState,
   getAccountRuntimeState: (key: string): RuntimeAccountState | undefined => {
     const state = accountRuntimeState.get(key);
     return state ? { ...state } : undefined;

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -780,6 +780,42 @@ export type AnthropicUpstreamFetchResult = {
 // USAGE STATS TYPES (from usageStats.ts)
 // =============================================================================
 
+export type ProxyTerminalErrorCategory =
+  | "authentication"
+  | "client_cancelled"
+  | "fallback_exhausted"
+  | "invalid_request"
+  | "proxy_error"
+  | "rate_limit"
+  | "stream_error"
+  | "unclassified"
+  | "upstream_error"
+  | "other";
+
+/** Compact, redacted terminal failure retained independently of body logs. */
+export type ProxyTerminalErrorSummary = {
+  id: string;
+  at: number;
+  status: number;
+  category: ProxyTerminalErrorCategory;
+  requestId?: string;
+  account?: string;
+  accountType?: string;
+  errorType?: string;
+  errorCode?: string;
+  terminalOutcome?: string;
+  message?: string;
+};
+
+/** Optional terminal context supplied when a final request error is recorded. */
+export type ProxyTerminalErrorDetails = {
+  requestId?: string;
+  errorType?: string;
+  errorCode?: string;
+  terminalOutcome?: string;
+  message?: string;
+};
+
 export type AccountStats = {
   label: string;
   type: string;
@@ -811,6 +847,21 @@ export type ProxyStats = {
   accounts: Record<string, AccountStats>;
 };
 
+/** Bounded terminal-error state stored separately from counters and body logs. */
+export type ProxyTerminalErrorJournal = {
+  startedAt: number;
+  totalErrors: number;
+  counts: Record<ProxyTerminalErrorCategory, number>;
+  recent: ProxyTerminalErrorSummary[];
+};
+
+export type ProxyUsageStatsSnapshot = {
+  stats: ProxyStats;
+  statsVersion: number;
+  terminalErrors: ProxyTerminalErrorJournal;
+  terminalErrorsVersion: number;
+};
+
 /** Durability and reconciliation state for the proxy usage counters. */
 export type ProxyStatsPersistenceStatus = {
   enabled: boolean;
@@ -823,6 +874,14 @@ export type ProxyStatsPersistenceStatus = {
   lastReconciledAt: number | null;
   lastRecoveryAt: number | null;
   lastError: string | null;
+  terminalErrorsFilePath?: string | null;
+  terminalErrorsRevision?: number;
+  terminalErrorsPending?: number;
+  terminalErrorsInFlight?: number;
+  terminalErrorsUnpersisted?: number;
+  terminalErrorsLastFlushedAt?: number | null;
+  terminalErrorsLastRecoveryAt?: number | null;
+  terminalErrorsLastError?: string | null;
 };
 
 /** Versioned on-disk snapshot shared by overlapping proxy workers. */
@@ -831,6 +890,14 @@ export type PersistedProxyStatsSnapshot = {
   revision: number;
   updatedAt: number;
   stats: ProxyStats;
+};
+
+/** Versioned terminal-error snapshot isolated from rolling-worker counter writes. */
+export type PersistedProxyTerminalErrorSnapshot = {
+  schemaVersion: 1;
+  revision: number;
+  updatedAt: number;
+  journal: ProxyTerminalErrorJournal;
 };
 
 /** Ownership metadata for the proxy statistics cross-process lock. */
@@ -843,6 +910,7 @@ export type ProxyStatsLockOwner = {
 /** Construction options for an isolated proxy statistics store. */
 export type ProxyUsageStatsStoreOptions = {
   filePath?: string;
+  terminalErrorsFilePath?: string;
   flushIntervalMs?: number;
   lockTimeoutMs?: number;
   staleLockMs?: number;
@@ -2309,6 +2377,11 @@ export type StatusStats = {
   totalRateLimits: number;
   totalTransientRateLimits?: number;
   totalQuotaRateLimits?: number;
+  terminalErrors?: ProxyTerminalErrorJournal;
+  lastTerminalError?: ProxyTerminalErrorSummary | null;
+  terminalErrorDetailsComparable?: boolean;
+  terminalErrorDetailsMissing?: number;
+  terminalErrorDetailsExcess?: number;
   accounts?: {
     label: string;
     type: string;
@@ -2321,12 +2394,16 @@ export type StatusStats = {
     transientRateLimits?: number;
     quotaRateLimits?: number;
     cooling: boolean;
+    allowed?: boolean;
+    expired?: boolean;
     status?:
       | "active"
       | "cooling"
       | "disabled"
+      | "expired"
       | "excluded"
       | "removed"
+      | "internal"
       | "unattributed";
   }[];
   persistence?: ProxyStatsPersistenceStatus;

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -33,7 +33,9 @@ import { createSSEInterceptor } from "../src/lib/proxy/sseInterceptor.js";
 import {
   clearRefreshStateForTests,
   needsRefresh,
+  persistTokens,
   refreshToken,
+  refreshTokenFromLatest,
 } from "../src/lib/proxy/tokenRefresh.js";
 import {
   createStreamTerminalOutcomeTracker,
@@ -42,7 +44,9 @@ import {
 } from "../src/lib/proxy/streamOutcome.js";
 import {
   getStats,
+  getTerminalErrors,
   recordAttempt,
+  recordFinalError,
   resetUsageStatsForTests,
 } from "../src/lib/proxy/usageStats.js";
 import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
@@ -52,6 +56,29 @@ import {
 } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
 const tempDirs: string[] = [];
+
+function createRecordingErrorFinalRequestLogger() {
+  return vi.fn(
+    (
+      status: number,
+      accountLabel: string,
+      accountType: string,
+      errorType?: string,
+      errorMessage?: string,
+    ) => {
+      recordFinalError(status, accountLabel, accountType, {
+        errorType,
+        terminalOutcome:
+          errorType === "client_cancelled"
+            ? "client_cancelled"
+            : errorType?.includes("stream")
+              ? "stream_error"
+              : "handler_error",
+        message: errorMessage,
+      });
+    },
+  );
+}
 
 afterEach(async () => {
   vi.useRealTimers();
@@ -528,7 +555,7 @@ describe("upstream attempt classification and retry amplification", () => {
     );
     const logAttempt = vi.fn();
     const logProxyBody = vi.fn();
-    const logFinalRequest = vi.fn();
+    const logFinalRequest = createRecordingErrorFinalRequestLogger();
     const args = fetchArgs(logAttempt, logProxyBody);
 
     const result = await __testHooks.fetchAnthropicAccountResponse(args);
@@ -613,7 +640,7 @@ describe("upstream attempt classification and retry amplification", () => {
     };
     const logAttempt = vi.fn();
     const logProxyBody = vi.fn();
-    const logFinalRequest = vi.fn();
+    const logFinalRequest = createRecordingErrorFinalRequestLogger();
     const tracer = {
       logUpstreamResponseHeaders: vi.fn(),
       logUpstreamResponseBody: vi.fn(),
@@ -1117,6 +1144,53 @@ describe("upstream attempt classification and retry amplification", () => {
       }),
     ).toBe(false);
   });
+
+  it("counts a malformed terminal invalid-request body exactly once", () => {
+    const recordLoggedError = (
+      status: number,
+      _account: string,
+      _accountType: string,
+      errorType?: string,
+      message?: string,
+    ) => {
+      recordFinalError(status, undefined, undefined, {
+        requestId: "malformed-invalid-request",
+        errorType,
+        terminalOutcome: "handler_error",
+        message,
+      });
+    };
+
+    const result = __testHooks.buildClaudeAnthropicFailureResponse({
+      tracer: undefined,
+      requestStartTime: Date.now(),
+      authFailureMessage: null,
+      authCooldownMessage: null,
+      invalidRequestFailure: {
+        status: 400,
+        body: "upstream returned malformed invalid-request content",
+        contentType: "text/plain",
+      },
+      sawNetworkError: false,
+      sawTransientFailure: false,
+      sawRateLimit: false,
+      lastError: undefined,
+      fallbackFailureMessage: undefined,
+      orderedAccounts: [],
+      buildLoggedClaudeError: (status, message, errorType) => {
+        recordLoggedError(status, "", "final", errorType, message);
+        return { status, message, errorType };
+      },
+      logProxyBody: vi.fn(),
+      logFinalRequest: recordLoggedError,
+    });
+
+    expect(result).toMatchObject({
+      status: 400,
+      errorType: "invalid_request_error",
+    });
+    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+  });
 });
 
 describe("authoritative unified rate-limit handling", () => {
@@ -1336,6 +1410,126 @@ describe("refresh failure classification", () => {
     expect(__testHooks.isPermanentRefreshFailure(result)).toBe(false);
   });
 
+  it("uses the same form-encoded refresh contract as the interactive auth flow", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await refreshToken({
+      token: "old-access",
+      refreshToken: "old-refresh",
+      label: "account-form",
+    });
+
+    // OAuth 2.0 token endpoints require application/x-www-form-urlencoded
+    // (RFC 6749 §6) — matching anthropicOAuth.ts::_refreshAccessToken. A JSON
+    // body is nonstandard for this grant and can be rejected upstream.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/oauth/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        }),
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: "old-refresh",
+          client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+        }).toString(),
+      }),
+    );
+  });
+
+  it("keeps refreshing when persisted-state reconciliation (peekTokens) throws", async () => {
+    // A decryption/IO failure in the best-effort reconciliation read must not
+    // abort the refresh — otherwise a still-valid account is spuriously
+    // disabled instead of getting a fresh token.
+    vi.spyOn(tokenStore, "peekTokens").mockRejectedValue(
+      new Error("decrypt failed"),
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: "fresh-access", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    const account = {
+      token: "old-access",
+      refreshToken: "rt-value",
+      expiresAt: Date.now() - 1000,
+      label: "account-peek-throws",
+    };
+
+    const result = await refreshTokenFromLatest(account, {
+      providerKey: "anthropic:peek@example.com",
+    });
+
+    expect(result.success).toBe(true);
+    expect(account.token).toBe("fresh-access");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds TokenStore reads while persisting refreshed credentials", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(tokenStore, "peekTokens").mockReturnValue(
+      new Promise(() => undefined),
+    );
+    const saveTokens = vi
+      .spyOn(tokenStore, "saveTokens")
+      .mockResolvedValue(undefined);
+    const persistence = persistTokens(
+      { providerKey: "anthropic:peek-hangs@example.com" },
+      {
+        token: "fresh-access",
+        refreshToken: "fresh-refresh",
+        expiresAt: Date.now() + 60_000,
+        label: "peek-hangs@example.com",
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(persistence).resolves.toBeUndefined();
+    expect(saveTokens).not.toHaveBeenCalled();
+  });
+
+  it("bounds TokenStore writes while persisting refreshed credentials", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(tokenStore, "peekTokens").mockResolvedValue({
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() + 30_000,
+      tokenType: "Bearer",
+    });
+    vi.spyOn(tokenStore, "saveTokens").mockReturnValue(
+      new Promise(() => undefined),
+    );
+    const persistence = persistTokens(
+      { providerKey: "anthropic:save-hangs@example.com" },
+      {
+        token: "fresh-access",
+        refreshToken: "fresh-refresh",
+        expiresAt: Date.now() + 60_000,
+        label: "save-hangs@example.com",
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(persistence).resolves.toBeUndefined();
+  });
+
   it("serializes concurrent rotating-token refreshes", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
@@ -1382,6 +1576,74 @@ describe("refresh failure classification", () => {
     expect(await refreshToken(rotatedTokenCaller)).toEqual({ success: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(rotatedTokenCaller).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    });
+  });
+
+  it("adopts a newer persisted credential before refreshing a queued request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    vi.spyOn(tokenStore, "peekTokens").mockResolvedValue({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    });
+    const account = {
+      token: "stale-access",
+      refreshToken: "stale-refresh",
+      expiresAt: Date.now() - 1,
+      label: "account-a",
+    };
+
+    await expect(
+      refreshTokenFromLatest(account, {
+        providerKey: "anthropic:account-a",
+      }),
+    ).resolves.toEqual({ success: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(account).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    });
+  });
+
+  it("adopts credentials rotated while a stale refresh is in flight", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "not_found_error", message: "Not found" },
+        }),
+        { status: 404 },
+      ),
+    );
+    vi.spyOn(tokenStore, "peekTokens")
+      .mockResolvedValueOnce({
+        accessToken: "stale-access",
+        refreshToken: "stale-refresh",
+        expiresAt: 1,
+        tokenType: "Bearer",
+      })
+      .mockResolvedValueOnce({
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        tokenType: "Bearer",
+      });
+    const account = {
+      token: "stale-access",
+      refreshToken: "stale-refresh",
+      expiresAt: 1,
+      label: "account-a",
+    };
+
+    await expect(
+      refreshTokenFromLatest(account, {
+        providerKey: "anthropic:account-a",
+      }),
+    ).resolves.toEqual({ success: true });
+    expect(account).toMatchObject({
       token: "new-access",
       refreshToken: "new-refresh",
     });
@@ -1511,6 +1773,97 @@ describe("account restriction", () => {
     expect(await store.getDisabledReason(key)).toBe(
       "concurrent_operator_disable",
     );
+  });
+
+  it("does not let stale work disable a newer credential generation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-token-store-"));
+    tempDirs.push(dir);
+    const store = new TokenStore({
+      encryptionEnabled: false,
+      customStoragePath: join(dir, "tokens.json"),
+    });
+    const key = "anthropic:rotated@example.com";
+    const stale = {
+      accessToken: "stale-access",
+      refreshToken: "stale-refresh",
+      expiresAt: 100,
+    };
+    await store.saveTokens(key, { ...stale, tokenType: "Bearer" });
+    await store.saveTokens(key, {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: 200,
+      tokenType: "Bearer",
+    });
+
+    await expect(
+      store.markDisabledIfCurrent(key, stale, "refresh_invalid"),
+    ).resolves.toBe(false);
+    expect(await store.isDisabled(key)).toBe(false);
+    await expect(
+      store.markDisabledIfCurrent(
+        key,
+        {
+          accessToken: "new-access",
+          refreshToken: "new-refresh",
+          expiresAt: 200,
+        },
+        "refresh_invalid",
+      ),
+    ).resolves.toBe(true);
+    expect(await store.isDisabled(key)).toBe(true);
+  });
+
+  it("peeks credentials without rewriting token-store metadata", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-token-store-"));
+    tempDirs.push(dir);
+    const storagePath = join(dir, "tokens.json");
+    const store = new TokenStore({
+      encryptionEnabled: false,
+      customStoragePath: storagePath,
+    });
+    const key = "anthropic:peek@example.com";
+    await store.saveTokens(key, {
+      accessToken: "access",
+      refreshToken: "refresh",
+      expiresAt: 200,
+      tokenType: "Bearer",
+    });
+    const before = await readFile(storagePath, "utf8");
+
+    await expect(store.peekTokens(key)).resolves.toMatchObject({
+      accessToken: "access",
+      refreshToken: "refresh",
+      expiresAt: 200,
+    });
+
+    expect(await readFile(storagePath, "utf8")).toBe(before);
+  });
+
+  it("clears runtime disable state when auth enable keeps the same token", () => {
+    const account = {
+      key: "anthropic:enabled@example.com",
+      label: "enabled@example.com",
+      token: "same-access",
+      refreshToken: "same-refresh",
+      expiresAt: Date.now() + 60_000,
+      type: "oauth" as const,
+    };
+    __testHooks.setAccountRuntimeState(account.key, {
+      permanentlyDisabled: true,
+      consecutiveRefreshFailures: 3,
+      lastToken: account.token,
+      lastRefreshToken: account.refreshToken,
+    });
+
+    __testHooks.reconcileEligibleAccountRuntimeState(account);
+
+    expect(__testHooks.getAccountRuntimeState(account.key)).toMatchObject({
+      permanentlyDisabled: false,
+      consecutiveRefreshFailures: 0,
+      lastToken: account.token,
+      lastRefreshToken: account.refreshToken,
+    });
   });
 });
 
@@ -1804,7 +2157,7 @@ describe("stream terminal outcomes", () => {
       token: "test-token",
       type: "oauth" as const,
     };
-    const logFinalRequest = vi.fn();
+    const logFinalRequest = createRecordingErrorFinalRequestLogger();
     const logAttempt = vi.fn();
     const logProxyBody = vi.fn();
     const upstreamSpan = { end: vi.fn() };
@@ -1818,6 +2171,7 @@ describe("stream terminal outcomes", () => {
       setError: vi.fn(),
       end: vi.fn(),
     };
+    recordAttempt(account.label, account.type);
 
     const result = await __testHooks.handleAnthropicStreamingSuccessResponse({
       ctx: {} as never,
@@ -1862,7 +2216,247 @@ describe("stream terminal outcomes", () => {
     expect(tracer.setError).toHaveBeenCalledTimes(1);
     expect(tracer.end).toHaveBeenCalledTimes(1);
     expect(upstreamSpan.end).toHaveBeenCalledTimes(1);
-    expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 1,
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+  });
+
+  it("settles client-cancelled stream telemetry without failing the attempt", async () => {
+    const encoder = new TextEncoder();
+    let resolvePull: (() => void) | undefined;
+    const cancelUpstream = vi.fn(() => {
+      resolvePull?.();
+    });
+    const upstreamStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+          ),
+        );
+      },
+      pull() {
+        return new Promise<void>((resolve) => {
+          resolvePull = resolve;
+        });
+      },
+      cancel: cancelUpstream,
+    });
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    };
+    const logFinalRequest = createRecordingErrorFinalRequestLogger();
+    recordAttempt(account.label, account.type);
+
+    const result = await __testHooks.handleAnthropicStreamingSuccessResponse({
+      ctx: {} as never,
+      body: { model: "claude-opus-4-8", messages: [], stream: true },
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      response: new Response(upstreamStream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+      responseHeaders: { "content-type": "text/event-stream" },
+      requestStartTime: Date.now(),
+      fetchStartMs: Date.now(),
+      attemptNumber: 1,
+      finalBodyStr: "{}",
+      logAttempt: vi.fn(),
+      logProxyBody: vi.fn(),
+      logFinalRequest,
+    });
+
+    const reader = (result.response as Response).body!.getReader();
+    await reader.read();
+    await reader.cancel("client disconnected");
+    expect(cancelUpstream).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(logFinalRequest).toHaveBeenCalledTimes(1));
+
+    expect(logFinalRequest).toHaveBeenCalledWith(
+      499,
+      account.label,
+      account.type,
+      "client_cancelled",
+      "Client cancelled the streaming response",
+      expect.any(Object),
+    );
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 0,
+      totalRequests: 1,
+      totalSuccess: 0,
+      totalErrors: 1,
+    });
+  });
+});
+
+describe("terminal request coverage", () => {
+  const requestContext = (requestId: string, body: Record<string, unknown>) =>
+    ({
+      requestId,
+      method: "POST",
+      path: "/v1/messages",
+      headers: { "content-type": "application/json" },
+      query: {},
+      params: {},
+      body,
+      neurolink: {},
+      toolRegistry: {},
+      timestamp: Date.now(),
+      metadata: {},
+    }) as never;
+
+  const messagesHandler = (passthrough: boolean) => {
+    const route = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      passthrough,
+    ).routes.find(
+      (candidate) =>
+        candidate.method === "POST" && candidate.path === "/v1/messages",
+    );
+    if (!route) {
+      throw new Error("messages route not found");
+    }
+    return route.handler;
+  };
+
+  it("accounts for validation failures before routing starts", async () => {
+    const result = await messagesHandler(false)(
+      requestContext("invalid-request", { model: "claude-test" }),
+    );
+
+    expect(result).toMatchObject({
+      type: "error",
+      error: { type: "invalid_request_error" },
+    });
+    expect(getStats()).toMatchObject({
+      totalAttempts: 0,
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { invalid_request: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "invalid-request",
+          status: 400,
+          errorType: "invalid_request_error",
+        }),
+      ],
+    });
+  });
+
+  it("accounts for direct passthrough rate limits exactly once", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "quota exhausted" },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await messagesHandler(true)(
+      requestContext("passthrough-rate-limit", {
+        model: "claude-test",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    );
+
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 1,
+      totalRequests: 1,
+      totalErrors: 1,
+      totalRateLimits: 1,
+      totalQuotaRateLimits: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { rate_limit: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "passthrough-rate-limit",
+          status: 429,
+          account: "passthrough",
+          errorType: "rate_limit_error",
+        }),
+      ],
+    });
+  });
+
+  it("settles a cancelled direct passthrough stream", async () => {
+    let resolvePull: (() => void) | undefined;
+    const cancelUpstream = vi.fn(() => {
+      resolvePull?.();
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+              ),
+            );
+          },
+          pull() {
+            return new Promise<void>((resolve) => {
+              resolvePull = resolve;
+            });
+          },
+          cancel: cancelUpstream,
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+
+    const result = (await messagesHandler(true)(
+      requestContext("passthrough-cancelled", {
+        model: "claude-test",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    )) as Response;
+    const reader = result.body!.getReader();
+    await reader.read();
+    await reader.cancel("client disconnected");
+    await vi.waitFor(() => expect(getStats().totalRequests).toBe(1));
+
+    expect(cancelUpstream).toHaveBeenCalledOnce();
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 0,
+      totalRequests: 1,
+      totalSuccess: 0,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { client_cancelled: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "passthrough-cancelled",
+          status: 499,
+          account: "passthrough",
+          errorType: "client_cancelled",
+        }),
+      ],
+    });
   });
 });
 
@@ -2002,7 +2596,7 @@ describe("launchd lifecycle source invariants", () => {
       "utf8",
     );
     expect(source).toContain("let effectiveAccounts = nonCoolingAccounts;");
-    expect(source).toContain("eligible credentials reloaded");
+    expect(source).toContain("is enabled in the token store");
     expect(source).toContain("authCooldownMessage");
     expect(source).not.toContain("credentials changed, re-enabling");
     expect(source).not.toContain(

--- a/test/proxyTerminalErrorAccounting.test.ts
+++ b/test/proxyTerminalErrorAccounting.test.ts
@@ -1,0 +1,368 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleTranslatedJsonRequest,
+  handleTranslatedStreamRequest,
+} from "../src/lib/proxy/proxyTranslationEngine.js";
+import {
+  flushRequestLogs,
+  initRequestLogger,
+} from "../src/lib/proxy/requestLogger.js";
+import { createClaudeProxyRoutes } from "../src/lib/server/routes/claudeProxyRoutes.js";
+import {
+  getStats,
+  getTerminalErrors,
+  resetUsageStatsForTests,
+} from "../src/lib/proxy/usageStats.js";
+import type {
+  ParsedClaudeRequest,
+  ServerContext,
+} from "../src/lib/types/index.js";
+
+const tempDirs: string[] = [];
+
+const parsedRequest = {
+  prompt: "hello",
+  systemPrompt: "",
+  conversationMessages: [],
+  tools: {},
+  images: [],
+  stopSequences: [],
+} as unknown as ParsedClaudeRequest;
+
+function createContext(
+  requestId: string,
+  stream: () => Promise<unknown>,
+): ServerContext {
+  return {
+    requestId,
+    method: "POST",
+    path: "/v1/messages",
+    headers: {},
+    query: {},
+    params: {},
+    timestamp: Date.now(),
+    metadata: {},
+    neurolink: { stream: vi.fn(stream) },
+    toolRegistry: {},
+  } as unknown as ServerContext;
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for translated stream settlement");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function startRequestLogCapture(): Promise<string> {
+  const logDir = await mkdtemp(join(tmpdir(), "neurolink-terminal-logs-"));
+  tempDirs.push(logDir);
+  initRequestLogger(true, logDir);
+  return logDir;
+}
+
+async function readRequestRecords(
+  logDir: string,
+): Promise<Array<Record<string, unknown>>> {
+  await flushRequestLogs();
+  const requestLog = (await readdir(logDir)).find((file) =>
+    /^proxy-\d{4}-\d{2}-\d{2}\.jsonl$/.test(file),
+  );
+  if (!requestLog) {
+    return [];
+  }
+  return (await readFile(join(logDir, requestLog), "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await flushRequestLogs().catch(() => {
+    // The test assertion should remain the primary failure.
+  });
+  initRequestLogger(false);
+  await resetUsageStatsForTests();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("translated terminal accounting", () => {
+  it("attributes pre-routing validation failures to the proxy", async () => {
+    const logDir = await startRequestLogCapture();
+    const ctx = createContext(
+      "proxy-validation-error",
+      async () => undefined,
+    ) as ServerContext & { body: Record<string, unknown> };
+    ctx.body = { model: "claude-test" };
+    const messagesRoute = createClaudeProxyRoutes().routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+    if (!messagesRoute) {
+      throw new Error("messages route not found");
+    }
+
+    await expect(messagesRoute.handler(ctx)).resolves.toMatchObject({
+      type: "error",
+    });
+
+    expect(getStats().accounts["proxy/internal"]).toMatchObject({
+      label: "proxy/internal",
+      type: "internal",
+      errorCount: 1,
+    });
+    expect(getTerminalErrors().recent).toContainEqual(
+      expect.objectContaining({
+        requestId: "proxy-validation-error",
+        account: "proxy/internal",
+        accountType: "internal",
+        errorType: "invalid_request_error",
+      }),
+    );
+    expect(await readRequestRecords(logDir)).toContainEqual(
+      expect.objectContaining({
+        requestId: "proxy-validation-error",
+        account: "proxy/internal",
+        accountType: "internal",
+        responseStatus: 400,
+      }),
+    );
+  });
+
+  it("records an upstream interruption after output as one terminal error", async () => {
+    const logDir = await startRequestLogCapture();
+    const ctx = createContext("translated-stream-error", async () => ({
+      stream: (async function* () {
+        yield { text: "partial output" };
+        throw new Error("upstream socket reset");
+      })(),
+      toolCalls: [],
+      usage: { inputTokens: 4, outputTokens: 2 },
+      model: "translated-model",
+    }));
+
+    const response = await handleTranslatedStreamRequest({
+      ctx,
+      format: "claude",
+      requestModel: "claude-test",
+      parsed: parsedRequest,
+      attempts: [
+        { label: "translated-account", provider: "openai", model: "test" },
+      ],
+      requestStartTime: Date.now(),
+    });
+    const body = await response.text();
+
+    expect(body).toContain("partial output");
+    expect(body).toContain("Upstream stream interrupted");
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 1,
+      totalRequests: 1,
+      totalSuccess: 0,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { stream_error: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "translated-stream-error",
+          status: 502,
+          errorType: "stream_error",
+          terminalOutcome: "stream_error",
+        }),
+      ],
+    });
+    expect(await readRequestRecords(logDir)).toContainEqual(
+      expect.objectContaining({
+        requestId: "translated-stream-error",
+        responseStatus: 502,
+        errorType: "stream_error",
+      }),
+    );
+  });
+
+  it("records empty translated output as a failed attempt and request", async () => {
+    const logDir = await startRequestLogCapture();
+    const ctx = createContext("translated-empty-output", async () => ({
+      stream: (async function* () {
+        yield* [];
+      })(),
+      toolCalls: [],
+      usage: {},
+      model: "translated-model",
+    }));
+
+    await expect(
+      handleTranslatedJsonRequest({
+        ctx,
+        format: "claude",
+        requestModel: "claude-test",
+        parsed: parsedRequest,
+        attempts: [
+          {
+            label: "translated-account",
+            provider: "openai",
+            model: "test",
+          },
+        ],
+        requestStartTime: Date.now(),
+      }),
+    ).rejects.toThrow("returned no content or tool calls");
+
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 1,
+      totalRequests: 1,
+      totalSuccess: 0,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { upstream_error: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "translated-empty-output",
+          status: 500,
+          errorType: "generation_error",
+        }),
+      ],
+    });
+    expect(await readRequestRecords(logDir)).toContainEqual(
+      expect.objectContaining({
+        requestId: "translated-empty-output",
+        responseStatus: 500,
+        errorType: "generation_error",
+      }),
+    );
+  });
+
+  it("does not finalize translated exhaustion twice at the Claude route", async () => {
+    const logDir = await startRequestLogCapture();
+    const ctx = createContext("translated-route-exhaustion", async () => ({
+      stream: (async function* () {
+        yield* [];
+      })(),
+      toolCalls: [],
+      usage: {},
+      model: "translated-model",
+    })) as ServerContext & { body: Record<string, unknown> };
+    ctx.body = {
+      model: "claude-routed-model",
+      messages: [{ role: "user", content: "hello" }],
+    };
+    const modelRouter = {
+      resolve: () => ({ provider: "openai", model: "translated-model" }),
+      getFallbackChain: () => [],
+    };
+    const messagesRoute = createClaudeProxyRoutes(
+      modelRouter as never,
+    ).routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+    if (!messagesRoute) {
+      throw new Error("messages route not found");
+    }
+
+    await expect(messagesRoute.handler(ctx)).resolves.toMatchObject({
+      type: "error",
+    });
+
+    expect(getStats()).toMatchObject({
+      totalAttempts: 2,
+      totalAttemptErrors: 2,
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      recent: [expect.objectContaining({ status: 502 })],
+    });
+    const records = (await readRequestRecords(logDir)).filter(
+      (record) => record.requestId === "translated-route-exhaustion",
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      responseStatus: 502,
+      errorType: "generation_error",
+    });
+  });
+
+  it("records client cancellation once without marking the stream successful", async () => {
+    const logDir = await startRequestLogCapture();
+    let resolvePendingRead!: (value: IteratorResult<unknown>) => void;
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const iterator: AsyncIterator<unknown> = {
+      next: () => {
+        markReadStarted();
+        return new Promise((resolve) => {
+          resolvePendingRead = resolve;
+        });
+      },
+      return: async () => {
+        resolvePendingRead({ done: true, value: undefined });
+        return { done: true, value: undefined };
+      },
+    };
+    const ctx = createContext("translated-client-cancel", async () => ({
+      stream: { [Symbol.asyncIterator]: () => iterator },
+      toolCalls: [],
+      usage: {},
+      model: "translated-model",
+    }));
+
+    const response = await handleTranslatedStreamRequest({
+      ctx,
+      format: "claude",
+      requestModel: "claude-test",
+      parsed: parsedRequest,
+      attempts: [{ label: "translated-account" }],
+      requestStartTime: Date.now(),
+    });
+    const reader = response.body!.getReader();
+    await reader.read();
+    await readStarted;
+    await reader.cancel("client disconnected");
+    await waitUntil(() => getStats().totalRequests === 1);
+
+    expect(getStats()).toMatchObject({
+      totalAttempts: 1,
+      totalAttemptErrors: 0,
+      totalRequests: 1,
+      totalSuccess: 0,
+      totalErrors: 1,
+    });
+    expect(getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { client_cancelled: 1 },
+      recent: [
+        expect.objectContaining({
+          requestId: "translated-client-cancel",
+          status: 499,
+          errorType: "client_cancelled",
+          terminalOutcome: "client_cancelled",
+        }),
+      ],
+    });
+    expect(await readRequestRecords(logDir)).toContainEqual(
+      expect.objectContaining({
+        requestId: "translated-client-cancel",
+        responseStatus: 499,
+        errorType: "client_cancelled",
+      }),
+    );
+  });
+});

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdtemp, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   describeInstallFailure,
   getGlobalInstallArgs,
@@ -29,7 +29,10 @@ import {
 } from "../src/lib/proxy/updateState.js";
 import { markProxyReady } from "../src/lib/proxy/proxyHealth.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
-import { createProxyStartApp } from "../src/cli/commands/proxy.js";
+import {
+  createProxyStartApp,
+  sanitizeProxyStatusTerminalErrorMessage,
+} from "../src/cli/commands/proxy.js";
 import { StateFileManager } from "../src/cli/utils/serverUtils.js";
 import { tokenStore } from "../src/lib/auth/tokenStore.js";
 import { openProxyWorkerLog } from "../src/lib/proxy/workerLog.js";
@@ -168,6 +171,11 @@ describe("proxy runtime error finalization", () => {
       updateControlToken,
     });
 
+  beforeEach(() => {
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue([]);
+    vi.spyOn(tokenStore, "listDisabled").mockResolvedValue([]);
+  });
+
   it("records invalid JSON as one completed error", async () => {
     const { app } = await createApp(() => ({}));
     const response = await app.request("/v1/messages", {
@@ -182,14 +190,14 @@ describe("proxy runtime error finalization", () => {
     const status = await (await app.request("/status")).json();
     expect(status.stats.accounts).toEqual([
       expect.objectContaining({
-        label: "unattributed",
+        label: "proxy/internal",
         type: "internal",
         attempts: 0,
         requests: 1,
         success: 0,
         errors: 1,
         cooling: false,
-        status: "unattributed",
+        status: "internal",
       }),
     ]);
     expect(getProxyActivitySnapshot().activeRequests).toBe(0);
@@ -224,7 +232,13 @@ describe("proxy runtime error finalization", () => {
     recordAttempt("fallback@example.com", "oauth");
     recordFinalSuccess("fallback@example.com", "oauth");
     recordAttempt("primary@example.com", "oauth");
-    recordFinalError(502, "primary@example.com", "oauth");
+    recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "status-terminal-request",
+      errorType: "stream_error",
+      errorCode: "UND_ERR_SOCKET",
+      terminalOutcome: "stream_error",
+      message: "upstream stream interrupted",
+    });
 
     const response = await app.request("/status");
     expect(response.status).toBe(200);
@@ -240,6 +254,21 @@ describe("proxy runtime error finalization", () => {
       totalRateLimits: 1,
       totalTransientRateLimits: 1,
       totalQuotaRateLimits: 0,
+      terminalErrors: {
+        totalErrors: 1,
+        counts: { stream_error: 1 },
+      },
+      lastTerminalError: {
+        requestId: "status-terminal-request",
+        status: 502,
+        category: "stream_error",
+        errorType: "stream_error",
+        errorCode: "UND_ERR_SOCKET",
+        terminalOutcome: "stream_error",
+      },
+      terminalErrorDetailsComparable: true,
+      terminalErrorDetailsMissing: 0,
+      terminalErrorDetailsExcess: 0,
       persistence: {
         enabled: false,
         pendingMutations: 6,
@@ -271,6 +300,110 @@ describe("proxy runtime error finalization", () => {
         }),
       ]),
     );
+  });
+
+  it("shows stored accounts even before they have proxy traffic", async () => {
+    vi.mocked(tokenStore.listByPrefix).mockResolvedValue([
+      "anthropic:active@example.com",
+      "anthropic:expired@example.com",
+    ]);
+    vi.mocked(tokenStore.listDisabled).mockResolvedValue([
+      "anthropic:expired@example.com",
+    ]);
+    vi.spyOn(tokenStore, "peekTokens").mockImplementation(async (key) => ({
+      accessToken: "redacted-test-token",
+      expiresAt:
+        key === "anthropic:expired@example.com"
+          ? Date.now() - 1_000
+          : Date.now() + 60_000,
+      tokenType: "Bearer",
+    }));
+
+    const { app } = await createProxyStartApp({
+      neurolink: { getToolRegistry: () => ({}) } as never,
+      modelRouter: undefined,
+      strategy: "fill-first",
+      passthrough: false,
+      port: 55123,
+      host: "127.0.0.1",
+      proxyConfig: null,
+      primaryAccountKey: undefined,
+      accountAllowlist: new Set(["anthropic:active@example.com"]),
+    });
+    const body = await (await app.request("/status")).json();
+
+    expect(body.stats.accounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "active@example.com",
+          attempts: 0,
+          success: 0,
+          errors: 0,
+          status: "active",
+          allowed: true,
+          expired: false,
+        }),
+        expect.objectContaining({
+          label: "expired@example.com",
+          attempts: 0,
+          success: 0,
+          errors: 0,
+          status: "disabled",
+          allowed: false,
+          expired: true,
+        }),
+      ]),
+    );
+  });
+
+  it("bounds status token inspection when a token-store read hangs", async () => {
+    vi.useFakeTimers();
+    vi.mocked(tokenStore.listByPrefix).mockResolvedValue([
+      "anthropic:blocked@example.com",
+    ]);
+    vi.spyOn(tokenStore, "peekTokens").mockReturnValue(
+      new Promise(() => undefined),
+    );
+
+    const { app } = await createProxyStartApp({
+      neurolink: { getToolRegistry: () => ({}) } as never,
+      modelRouter: undefined,
+      strategy: "fill-first",
+      passthrough: false,
+      port: 55123,
+      host: "127.0.0.1",
+      proxyConfig: null,
+      primaryAccountKey: undefined,
+      accountAllowlist: undefined,
+    });
+    const responsePromise = app.request("/status");
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.stats.accounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "blocked@example.com",
+          attempts: 0,
+          status: "active",
+        }),
+      ]),
+    );
+  });
+
+  it("sanitizes terminal error messages before printing status", () => {
+    const message =
+      "\u001b[31mfailed\nrequest https://user:secret@api.example.com/path?access_token=hidden\u001b[0m Bearer abcdefghijklmnop";
+    const sanitized = sanitizeProxyStatusTerminalErrorMessage(message);
+
+    expect(sanitized).toBe("failed request https://api.example.com/path ***");
+    expect(sanitized).not.toContain("\u001b");
+    expect(sanitized).not.toContain("\n");
+    expect(sanitized).not.toContain("hidden");
+    expect(sanitized).not.toContain("abcdefghijklmnop");
   });
 
   it("keeps an active legacy OAuth account distinct from removed history", async () => {

--- a/test/proxyUsageStatsPersistence.test.ts
+++ b/test/proxyUsageStatsPersistence.test.ts
@@ -27,6 +27,10 @@ async function tempStatsPath(): Promise<string> {
   return join(dir, "proxy-usage-stats.json");
 }
 
+function terminalErrorsPath(filePath: string): string {
+  return join(dirname(filePath), "proxy-terminal-errors.json");
+}
+
 function createStore(
   filePath: string,
   options: Omit<ProxyUsageStatsStoreOptions, "filePath"> = {},
@@ -158,6 +162,148 @@ describe("persistent proxy usage statistics", () => {
       pendingMutations: 0,
       lastError: null,
     });
+    expect(observer.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { upstream_error: 1 },
+    });
+  });
+
+  it("persists a bounded redacted terminal-error journal separately", async () => {
+    const filePath = await tempStatsPath();
+    let now = 1_800_000_000_000;
+    const store = createStore(filePath, { now: () => now });
+    await store.initialize();
+
+    for (let index = 0; index < 25; index += 1) {
+      store.recordFinalError(502, "primary@example.com", "oauth", {
+        requestId: `request-${index}`,
+        errorType: "stream_error",
+        errorCode: "UND_ERR_SOCKET",
+        terminalOutcome: "stream_error",
+        message:
+          "x".repeat(490) +
+          ` Bearer secret-token-${index}-value ` +
+          "y".repeat(1_000),
+      });
+      now += 1;
+    }
+    await store.flush();
+
+    const replacement = createStore(filePath, { now: () => now });
+    await replacement.initialize();
+    const journal = replacement.getTerminalErrors();
+    expect(journal).toMatchObject({
+      startedAt: 1_800_000_000_000,
+      totalErrors: 25,
+      counts: { stream_error: 25 },
+    });
+    expect(journal.recent).toHaveLength(20);
+    expect(journal.recent[0].requestId).toBe("request-5");
+    expect(journal.recent.at(-1)).toMatchObject({
+      requestId: "request-24",
+      status: 502,
+      category: "stream_error",
+      account: "primary@example.com",
+      errorType: "stream_error",
+      errorCode: "UND_ERR_SOCKET",
+    });
+    expect(journal.recent.at(-1)?.message).toContain("***");
+    expect(journal.recent.at(-1)?.message).not.toContain("secret-token");
+    expect(journal.recent.at(-1)?.message).not.toContain("Bearer");
+    expect(journal.recent.at(-1)?.message?.length).toBeLessThanOrEqual(500);
+
+    const persistence = replacement.getPersistenceStatus();
+    expect(persistence).toMatchObject({
+      terminalErrorsFilePath: join(
+        dirname(filePath),
+        "proxy-terminal-errors.json",
+      ),
+      terminalErrorsRevision: 1,
+      terminalErrorsPending: 0,
+      terminalErrorsLastError: null,
+    });
+    expect(JSON.parse(await readFile(filePath, "utf8"))).not.toHaveProperty(
+      "journal",
+    );
+    expect(
+      JSON.parse(
+        await readFile(
+          join(dirname(filePath), "proxy-terminal-errors.json"),
+          "utf8",
+        ),
+      ),
+    ).toHaveProperty("journal.totalErrors", 25);
+  });
+
+  it("classifies not-found request failures as invalid requests", () => {
+    const store = new ProxyUsageStatsStore();
+    store.recordFinalError(404, undefined, "internal", {
+      errorType: "not_found_error",
+      message: "unsupported model",
+    });
+
+    expect(store.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { invalid_request: 1, other: 0 },
+      recent: [
+        expect.objectContaining({
+          status: 404,
+          category: "invalid_request",
+          errorType: "not_found_error",
+        }),
+      ],
+    });
+  });
+
+  it("classifies stream telemetry failures as proxy errors", () => {
+    const store = new ProxyUsageStatsStore();
+    store.recordFinalError(500, "primary@example.com", "oauth", {
+      errorType: "stream_telemetry_error",
+      message: "capture failed",
+    });
+
+    expect(store.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { proxy_error: 1, stream_error: 0 },
+      recent: [
+        expect.objectContaining({
+          category: "proxy_error",
+          errorType: "stream_telemetry_error",
+        }),
+      ],
+    });
+  });
+
+  it("sanitizes persisted terminal messages for status JSON", () => {
+    const store = new ProxyUsageStatsStore();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      errorType: "network_error",
+      message:
+        "\u001b[31mfailed\nrequest https://user:secret@api.example.com/path?access_token=hidden\u001b[0m Bearer abcdefghijklmnop",
+    });
+
+    const message = store.getTerminalErrors().recent[0].message;
+    expect(message).toBe("failed request https://api.example.com/path ***");
+    expect(message).not.toContain("\u001b");
+    expect(message).not.toContain("\n");
+    expect(message).not.toContain("hidden");
+    expect(message).not.toContain("abcdefghijklmnop");
+  });
+
+  it("returns counters and terminal details from one snapshot version", async () => {
+    const store = new ProxyUsageStatsStore();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "atomic-snapshot",
+      errorType: "stream_error",
+    });
+
+    const snapshot = await store.reconcileUsageSnapshot();
+    expect(snapshot.statsVersion).toBe(snapshot.terminalErrorsVersion);
+    expect(snapshot.stats.totalErrors).toBe(1);
+    expect(snapshot.terminalErrors).toMatchObject({
+      totalErrors: 1,
+      recent: [expect.objectContaining({ requestId: "atomic-snapshot" })],
+    });
   });
 
   it("serializes deltas from separate worker processes", async () => {
@@ -177,7 +323,16 @@ describe("persistent proxy usage statistics", () => {
           await store.initialize();
           for (let request = 0; request < ${requestsPerWorker}; request += 1) {
             store.recordAttempt(${JSON.stringify(`worker-${workerIndex}@example.com`)}, "oauth");
-            store.recordFinalSuccess(${JSON.stringify(`worker-${workerIndex}@example.com`)}, "oauth");
+            if (request === 0) {
+              store.recordFinalError(502, ${JSON.stringify(`worker-${workerIndex}@example.com`)}, "oauth", {
+                requestId: ${JSON.stringify(`worker-${workerIndex}-error`)},
+                errorType: "stream_error",
+                terminalOutcome: "stream_error",
+                message: "worker stream interrupted",
+              });
+            } else {
+              store.recordFinalSuccess(${JSON.stringify(`worker-${workerIndex}@example.com`)}, "oauth");
+            }
           }
           await store.flush();
         `;
@@ -194,14 +349,33 @@ describe("persistent proxy usage statistics", () => {
     expect(observer.getStats()).toMatchObject({
       totalAttempts: workerCount * requestsPerWorker,
       totalRequests: workerCount * requestsPerWorker,
-      totalSuccess: workerCount * requestsPerWorker,
+      totalSuccess: workerCount * (requestsPerWorker - 1),
+      totalErrors: workerCount,
     });
     expect(Object.keys(observer.getStats().accounts)).toHaveLength(workerCount);
     expect(observer.getPersistenceStatus()).toMatchObject({
       revision: workerCount,
       pendingMutations: 0,
       lastError: null,
+      terminalErrorsRevision: workerCount,
+      terminalErrorsPending: 0,
+      terminalErrorsLastError: null,
     });
+    expect(observer.getTerminalErrors()).toMatchObject({
+      totalErrors: workerCount,
+      counts: { stream_error: workerCount },
+    });
+    expect(
+      observer
+        .getTerminalErrors()
+        .recent.map((summary) => summary.requestId)
+        .sort(),
+    ).toEqual(
+      Array.from(
+        { length: workerCount },
+        (_, workerIndex) => `worker-${workerIndex}-error`,
+      ).sort(),
+    );
   }, 20_000);
 
   it("refreshes an active worker from deltas flushed by a draining worker", async () => {
@@ -332,6 +506,42 @@ describe("persistent proxy usage statistics", () => {
     );
   });
 
+  it("quarantines corrupt terminal-error state independently", async () => {
+    const filePath = await tempStatsPath();
+    const terminalFilePath = terminalErrorsPath(filePath);
+    await writeFile(terminalFilePath, "{not-json", { mode: 0o600 });
+    const store = createStore(filePath, { lockTimeoutMs: 100 });
+
+    await store.initialize();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "post-recovery-error",
+      errorType: "stream_error",
+    });
+    await store.flush();
+
+    expect(store.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { stream_error: 1 },
+    });
+    expect(store.getPersistenceStatus()).toMatchObject({
+      terminalErrorsRevision: 1,
+      terminalErrorsPending: 0,
+      terminalErrorsLastError: null,
+      terminalErrorsLastRecoveryAt: expect.any(Number),
+    });
+    expect(JSON.parse(await readFile(terminalFilePath, "utf8"))).toMatchObject({
+      journal: { totalErrors: 1 },
+    });
+    expect((await stat(terminalFilePath)).mode & 0o777).toBe(0o600);
+    const quarantined = (await readdir(dirname(filePath))).find((file) =>
+      file.startsWith("proxy-terminal-errors.json.corrupt."),
+    );
+    expect(quarantined).toBeDefined();
+    expect(await readFile(join(dirname(filePath), quarantined!), "utf8")).toBe(
+      "{not-json",
+    );
+  });
+
   it("retains only the newest corrupt snapshots", async () => {
     const filePath = await tempStatsPath();
     let now = 1_000;
@@ -431,6 +641,145 @@ describe("persistent proxy usage statistics", () => {
       revision: 1,
       pendingMutations: 0,
       lastError: null,
+    });
+  });
+
+  it("retries terminal metadata without duplicating persisted counters", async () => {
+    const filePath = await tempStatsPath();
+    const terminalFilePath = terminalErrorsPath(filePath);
+    await writeLockFile(`${terminalFilePath}.lock`);
+    const store = createStore(filePath, { lockTimeoutMs: 50 });
+    await store.initialize();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "terminal-lock-contention",
+      errorType: "stream_error",
+    });
+
+    await store.flush();
+
+    expect(store.getStats()).toMatchObject({
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(store.getPersistenceStatus()).toMatchObject({
+      revision: 1,
+      pendingMutations: 0,
+      terminalErrorsRevision: 0,
+      terminalErrorsPending: 1,
+    });
+    expect(store.getPersistenceStatus().terminalErrorsLastError).toContain(
+      "Timed out acquiring proxy stats lock",
+    );
+
+    await rm(`${terminalFilePath}.lock`, { force: true });
+    await store.flush();
+
+    const observer = createStore(filePath);
+    await observer.initialize();
+    expect(observer.getStats()).toMatchObject({
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(observer.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { stream_error: 1 },
+    });
+    expect(observer.getPersistenceStatus()).toMatchObject({
+      revision: 1,
+      terminalErrorsRevision: 1,
+      terminalErrorsPending: 0,
+      terminalErrorsLastError: null,
+    });
+  });
+
+  it("does not persist terminal metadata ahead of failed counters", async () => {
+    const filePath = await tempStatsPath();
+    const lockPath = `${filePath}.lock`;
+    const terminalFilePath = terminalErrorsPath(filePath);
+    await writeLockFile(lockPath);
+    const store = createStore(filePath, { lockTimeoutMs: 50 });
+    await store.initialize();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "counter-lock-contention",
+      errorType: "stream_error",
+    });
+
+    await store.flush();
+
+    expect(store.getPersistenceStatus()).toMatchObject({
+      revision: 0,
+      pendingMutations: 1,
+      terminalErrorsRevision: 0,
+      terminalErrorsPending: 1,
+    });
+    await expect(readFile(terminalFilePath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await rm(lockPath, { force: true });
+    await store.flush();
+
+    const observer = createStore(filePath);
+    await observer.initialize();
+    expect(observer.getStats()).toMatchObject({
+      totalRequests: 1,
+      totalErrors: 1,
+    });
+    expect(observer.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      counts: { stream_error: 1 },
+    });
+  });
+
+  it("flushes matched terminal batches while new traffic remains pending", async () => {
+    const filePath = await tempStatsPath();
+    const lockPath = `${filePath}.lock`;
+    await writeLockFile(lockPath);
+    const store = createStore(filePath, { lockTimeoutMs: 500 });
+    await store.initialize();
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "first-batch",
+      errorType: "stream_error",
+    });
+
+    const firstFlush = store.flush();
+    await waitUntil(() => {
+      const status = store.getPersistenceStatus();
+      return (
+        status.inFlightMutations === 1 && status.terminalErrorsInFlight === 1
+      );
+    });
+    store.recordFinalError(502, "primary@example.com", "oauth", {
+      requestId: "second-batch",
+      errorType: "stream_error",
+    });
+    await rm(lockPath, { force: true });
+    await firstFlush;
+
+    expect(store.getPersistenceStatus()).toMatchObject({
+      revision: 1,
+      pendingMutations: 1,
+      terminalErrorsRevision: 1,
+      terminalErrorsPending: 1,
+    });
+    const firstObserver = createStore(filePath);
+    await firstObserver.initialize();
+    expect(firstObserver.getStats().totalErrors).toBe(1);
+    expect(firstObserver.getTerminalErrors()).toMatchObject({
+      totalErrors: 1,
+      recent: [expect.objectContaining({ requestId: "first-batch" })],
+    });
+
+    await store.flush();
+    const finalObserver = createStore(filePath);
+    await finalObserver.initialize();
+    expect(finalObserver.getStats().totalErrors).toBe(2);
+    expect(finalObserver.getTerminalErrors()).toMatchObject({
+      totalErrors: 2,
+      recent: [
+        expect.objectContaining({ requestId: "first-batch" }),
+        expect.objectContaining({ requestId: "second-batch" }),
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary
- persist a bounded, redacted terminal-error journal separately from rolling usage counters
- expose error categories, latest terminal failure, and detail gaps through proxy status
- centralize exactly-once terminal accounting across routed, translated, passthrough, stream-error, and cancellation paths
- propagate downstream stream cancellation and persist matched counter/detail batches without blocking the request hot path

## Verification
- `pnpm vitest run` for all 9 proxy suites: 201 tests passed
- `pnpm run typecheck`: passed
- `pnpm run lint`: passed with existing warnings and no errors
- `pnpm run build`: passed, including CLI/browser builds and publint
- `pnpm run test:bugfixes`: 234 tests passed
- 50,000-request stats benchmark: p95 0.084 us, p99 0.167 us, exact persisted totals
- stream wrapper benchmark: about 0.391 ms p95 added for 64 chunks / 65 KB
- root integration suite requires live Vertex credentials unavailable in this isolated worktree; it was stopped after the credential precondition failures

## Safety
- no live proxy process, configuration, account, or persisted live state was touched
- branch is based on current `origin/release` and contains one commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable terminal-error tracking with per-category counts and a capped, sanitized “recent” journal.
  * Enhanced `proxy /status` output with “Since”, last terminal error, aggregated causes, and detail gap fields (comparable/missing/excess), plus improved internal/account attribution.

* **Bug Fixes**
  * Improved terminal outcome classification and ensured final request/usage accounting is recorded exactly once across translated, streaming, and SSE flows.
  * Hardened stream cancellation/error propagation and refined token refresh/disable behavior.

* **Tests**
  * Expanded end-to-end coverage for terminal-error accounting, persistence/recovery, cancellation, token hardening, and `/status` rendering safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->