### PR TITLE
fix(proxy): retry subscription beta-rejection 400s on the next account

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -4675,6 +4675,48 @@ async function handleAnthropicNonOkResponse(args: {
   });
 
   if (isInvalidRequestError(response.status, errBody)) {
+    if (isSubscriptionBetaRejection(response.status, errBody)) {
+      // Subscription-specific beta rejection (an account whose plan tier lacks
+      // an optional beta the proxy injected). The SAME request can succeed on
+      // another account whose tier grants the beta — or on a fallback provider —
+      // so advance to the next account instead of failing the client here.
+      //
+      // Deliberately do NOT store this in `currentInvalidRequestFailure`: that
+      // field is a deterministic "malformed request" signal that both
+      // suppresses provider fallback (shouldAttemptClaudeFallback) and outranks
+      // transient/rate-limit failures in the final response. A beta rejection is
+      // neither terminal nor higher-priority — a later account's real 429/5xx
+      // must still take precedence, and fallback must stay eligible. The reason
+      // is carried in `lastError`, so if every account rejects the beta the
+      // exhaustion response still explains why.
+      logger.always(
+        `[proxy] ← ${response.status} account=${account.label} beta unavailable for subscription; advancing to next account`,
+      );
+      logAttempt(
+        response.status,
+        "invalid_request_error",
+        summarizeErrorMessage(errBody),
+      );
+      tracer?.setError("invalid_request_error", summarizeErrorMessage(errBody));
+      tracer?.recordRetry(account.label, "beta_unavailable");
+      // A tier's lack of a beta is stable, not transient — advance the
+      // fill-first primary pointer (like the auth/rate-limit rotation paths) so
+      // this account stops being retried first on every future request.
+      advancePrimaryIfCurrent(
+        account.key,
+        enabledAccounts.length,
+        orderedAccounts[0]?.key,
+      );
+      currentLastError = summarizeErrorMessage(errBody);
+      return {
+        continueLoop: true,
+        lastError: currentLastError,
+        authFailureMessage: currentAuthFailureMessage,
+        sawTransientFailure: currentSawTransientFailure,
+        invalidRequestFailure: currentInvalidRequestFailure,
+        upstreamSpan: undefined,
+      };
+    }
     logger.always(
       `[proxy] ← ${response.status} upstream invalid_request_error`,
     );
@@ -6654,6 +6696,35 @@ export function isInvalidRequestError(
   return (
     parsed.errorType === "invalid_request_error" ||
     errBody.includes("invalid_request_error")
+  );
+}
+
+/**
+ * A subscription-specific beta rejection. Anthropic returns
+ * `400 invalid_request_error` with a message like
+ * "The long context beta is not yet available for this subscription." when an
+ * account's plan tier does not grant an optional beta the proxy injected (see
+ * CLAUDE_CODE_OAUTH_BETAS in anthropicOAuth.ts). Unlike a genuinely malformed
+ * request, the SAME request can succeed on a different account whose tier
+ * grants the beta — so this must be treated as retryable on the next account
+ * rather than a terminal client-facing 400.
+ */
+export function isSubscriptionBetaRejection(
+  status: number,
+  errBody: string,
+): boolean {
+  if (status !== 400) {
+    return false;
+  }
+  const parsed = parseClaudeErrorBody(errBody);
+  if (parsed.errorType !== "invalid_request_error") {
+    return false;
+  }
+  const message = (parsed.message ?? "").toLowerCase();
+  return (
+    message.includes("beta") &&
+    message.includes("subscription") &&
+    message.includes("available")
   );
 }
 

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -53,6 +53,7 @@ import { parseProxyConfigString } from "../src/lib/proxy/proxyConfig.js";
 import {
   __testHooks,
   createClaudeProxyRoutes,
+  isSubscriptionBetaRejection,
 } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
 const tempDirs: string[] = [];
@@ -2603,4 +2604,309 @@ describe("launchd lifecycle source invariants", () => {
       "nonCoolingAccounts.length > 0 ? nonCoolingAccounts : orderedAccounts",
     );
   });
+});
+
+describe("OAuth subscription beta-rejection handling", () => {
+  const BETA_REJECTION_BODY = JSON.stringify({
+    type: "error",
+    error: {
+      type: "invalid_request_error",
+      message:
+        "The long context beta is not yet available for this subscription.",
+    },
+  });
+
+  const messagesRequestContext = (requestId: string) =>
+    ({
+      requestId,
+      method: "POST",
+      path: "/v1/messages",
+      headers: {},
+      query: {},
+      params: {},
+      body: {
+        model: "claude-test",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      },
+      neurolink: {},
+      toolRegistry: {},
+      timestamp: Date.now(),
+      metadata: {},
+    }) as never;
+
+  const successResponse = () =>
+    new Response(
+      JSON.stringify({
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  it("classifies a subscription beta rejection, not a generic invalid_request", () => {
+    // Real Anthropic subscription-beta rejection → retryable on next account.
+    expect(isSubscriptionBetaRejection(400, BETA_REJECTION_BODY)).toBe(true);
+    // Generic malformed request → NOT a beta rejection (must fast-fail).
+    expect(
+      isSubscriptionBetaRejection(
+        400,
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: "model: field required",
+          },
+        }),
+      ),
+    ).toBe(false);
+    // Same message shape but a non-400 status → not classified.
+    expect(isSubscriptionBetaRejection(429, BETA_REJECTION_BODY)).toBe(false);
+    // A different error type at 400, even with matching words → not classified.
+    expect(
+      isSubscriptionBetaRejection(
+        400,
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "rate_limit_error",
+            message: "beta available subscription",
+          },
+        }),
+      ),
+    ).toBe(false);
+    // Unparseable body → not classified.
+    expect(isSubscriptionBetaRejection(400, "not json")).toBe(false);
+  });
+
+  it("advances to the next account when one account's subscription lacks the beta", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-beta-advance-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+
+    const accountKeys = [
+      "anthropic:betaless@example.com",
+      "anthropic:betaok@example.com",
+    ];
+    vi.spyOn(tokenStore, "pruneExpired").mockResolvedValue(undefined);
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue(accountKeys);
+    vi.spyOn(tokenStore, "isDisabled").mockResolvedValue(false);
+    vi.spyOn(tokenStore, "loadTokens").mockImplementation(async (key) => ({
+      accessToken: key.includes("betaless@example.com")
+        ? "betaless-token"
+        : "betaok-token",
+      refreshToken: "test-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    }));
+
+    const attemptedTokens: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      attemptedTokens.push(headers.authorization);
+      if (headers.authorization === "Bearer betaless-token") {
+        return new Response(BETA_REJECTION_BODY, {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return successResponse();
+    });
+
+    const primaryAccountKey = "anthropic:betaless@example.com";
+    const routeGroup = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      false,
+      primaryAccountKey,
+      {
+        runtimeConfigProvider: () => ({
+          generation: 1,
+          strategy: "fill-first",
+          modelRouter: undefined,
+          passthrough: false,
+          primaryAccountKey,
+          accountAllowlist: undefined,
+          quotaRoutingEnabled: false,
+          sessionSoftLimit: 0.97,
+          sessionResetToleranceMs: 15 * 60 * 1000,
+        }),
+      },
+    );
+    const messagesRoute = routeGroup.routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+    expect(messagesRoute).toBeDefined();
+
+    // betaless rejects the beta → proxy advances → betaok returns 200.
+    await expect(
+      messagesRoute!.handler(messagesRequestContext("beta-advance")),
+    ).resolves.toMatchObject({ type: "message" });
+    expect(attemptedTokens).toEqual([
+      "Bearer betaless-token",
+      "Bearer betaok-token",
+    ]);
+  });
+
+  it("returns an explanatory exhaustion error when every account's subscription lacks the beta", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-beta-allfail-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+
+    const accountKeys = [
+      "anthropic:betaless-a@example.com",
+      "anthropic:betaless-b@example.com",
+    ];
+    vi.spyOn(tokenStore, "pruneExpired").mockResolvedValue(undefined);
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue(accountKeys);
+    vi.spyOn(tokenStore, "isDisabled").mockResolvedValue(false);
+    vi.spyOn(tokenStore, "loadTokens").mockImplementation(async (key) => ({
+      accessToken: key.includes("betaless-a@example.com")
+        ? "token-a"
+        : "token-b",
+      refreshToken: "test-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    }));
+
+    const attemptedTokens: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      attemptedTokens.push(headers.authorization);
+      return new Response(BETA_REJECTION_BODY, {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const primaryAccountKey = "anthropic:betaless-a@example.com";
+    const routeGroup = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      false,
+      primaryAccountKey,
+      {
+        runtimeConfigProvider: () => ({
+          generation: 1,
+          strategy: "fill-first",
+          modelRouter: undefined,
+          passthrough: false,
+          primaryAccountKey,
+          accountAllowlist: undefined,
+          quotaRoutingEnabled: false,
+          sessionSoftLimit: 0.97,
+          sessionResetToleranceMs: 15 * 60 * 1000,
+        }),
+      },
+    );
+    const messagesRoute = routeGroup.routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+
+    // Both accounts reject the beta → after exhausting the rotation the client
+    // gets an error that still explains the beta reason (carried via lastError),
+    // but the beta rejection is NOT recorded as a deterministic invalid_request
+    // 400 (which would suppress fallback and outrank later failures).
+    const result = await messagesRoute!.handler(
+      messagesRequestContext("beta-allfail"),
+    );
+    expect(result).toMatchObject({ type: "error" });
+    expect(JSON.stringify(result)).toContain(
+      "beta is not yet available for this subscription",
+    );
+    expect(attemptedTokens).toEqual(["Bearer token-a", "Bearer token-b"]);
+  });
+
+  it("lets a later account's real failure take precedence over an earlier beta rejection", async () => {
+    // Mixed failure: account A lacks the beta, account B is rate-limited, none
+    // succeed. The client must see the rate-limit (429/retry) reality — the
+    // earlier beta rejection must NOT be stored as invalidRequestFailure and
+    // mask it.
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-beta-mixed-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+
+    const accountKeys = [
+      "anthropic:betaless@example.com",
+      "anthropic:limited@example.com",
+    ];
+    vi.spyOn(tokenStore, "pruneExpired").mockResolvedValue(undefined);
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue(accountKeys);
+    vi.spyOn(tokenStore, "isDisabled").mockResolvedValue(false);
+    vi.spyOn(tokenStore, "loadTokens").mockImplementation(async (key) => ({
+      accessToken: key.includes("betaless@example.com")
+        ? "betaless-token"
+        : "limited-token",
+      refreshToken: "test-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    }));
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      if (headers.authorization === "Bearer betaless-token") {
+        return new Response(BETA_REJECTION_BODY, {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "slow down" },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const primaryAccountKey = "anthropic:betaless@example.com";
+    const routeGroup = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      false,
+      primaryAccountKey,
+      {
+        runtimeConfigProvider: () => ({
+          generation: 1,
+          strategy: "fill-first",
+          modelRouter: undefined,
+          passthrough: false,
+          primaryAccountKey,
+          accountAllowlist: undefined,
+          quotaRoutingEnabled: false,
+          sessionSoftLimit: 0.97,
+          sessionResetToleranceMs: 15 * 60 * 1000,
+        }),
+      },
+    );
+    const messagesRoute = routeGroup.routes.find(
+      (route) => route.method === "POST" && route.path === "/v1/messages",
+    );
+
+    const result = await messagesRoute!.handler(
+      messagesRequestContext("beta-mixed"),
+    );
+    // The client sees the rate-limit reality: a 429 Response with retry-after,
+    // NOT the earlier beta rejection masking it as a deterministic 400.
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(429);
+    const body = await (result as Response).text();
+    expect(body).toContain("overloaded_error");
+    expect(body).not.toContain(
+      "beta is not yet available for this subscription",
+    );
+    // Real 429 same-account retry backoff runs here — allow headroom over the
+    // default 5s per-test timeout so slower CI can't flake this.
+  }, 15000);
 });


### PR DESCRIPTION
## Problem

The proxy injects all Claude Code optional betas — including `context-management-2025-06-27` (the "long context" beta) — into **every** OAuth request via `applyOAuthHeaders` (`oauthFetch.ts`), unconditionally (`includeOptionalBetas` defaults `true` and is never set `false`).

When a request is routed to an account whose subscription tier does **not** grant one of those betas, Anthropic returns:

```
400 invalid_request_error: "The long context beta is not yet available for this subscription."
```

`isInvalidRequestError` classified this as a **generic** malformed-request 400 → the retry loop returned `continueLoop: false` and passed the 400 straight back to the client. This conflates a *subscription-specific* rejection (which succeeds on a higher-tier account) with a *malformed-request* 400 (genuinely non-retryable), so requests that overflow onto a lower-tier account fail client-side even though another account would have served them.

Discovered during live proxy-telemetry validation: `sachiny09@gmail.com` (lower tier) 400s on the context-management beta while `hello@neurolink.ink` / `sachin.sharma@juspay.in` (higher tier) return 200.

## Fix

Add `isSubscriptionBetaRejection(status, errBody)` — a narrow classifier that only matches a `400 invalid_request_error` whose message mentions `beta` + `subscription` + `available`. In `handleAnthropicNonOkResponse`, when a beta rejection is detected the proxy now **advances to the next account** (`continueLoop: true`) instead of failing.

The 400 is still recorded as the **fallback terminal error**, so if *every* account rejects the beta the client receives the real, explanatory `invalid_request_error` 400 rather than a generic exhaustion error. Behavior is strictly ≥ the previous code: a beta rejection now tries the remaining accounts first, and only falls back to the same 400 if none succeed.

- No account is disabled (this is a request error, not a credential rejection) — unchanged.
- Genuinely malformed requests still fast-fail (the classifier is narrow: it requires the beta/subscription/availability wording under `invalid_request_error`).

## Tests

`test/proxyReliabilityHardening.test.ts` (+3):
- **classifier** — real beta rejection → `true`; generic invalid_request, non-400 status, other error types, and unparseable bodies → `false`.
- **advancement** — account A beta-rejects, account B succeeds → client gets `200`; both accounts attempted in order.
- **exhaustion fallback** — every account beta-rejects → client gets the explanatory `invalid_request_error` 400.

Validated: `tsc --strict` clean, `svelte-check` 0 errors, `lint` 0 errors, vitest **67/67**, pre-commit `check + lint + validate:all + build` gate passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Anthropic subscription beta access rejections.
  * Automatically retries with another upstream account when the requested beta is unavailable.
  * Returns a clearer explanatory error when no eligible account is available.
  * Preserves existing behavior for unrelated invalid-request errors, avoiding masking later failures.

* **Tests**
  * Added coverage for beta-unavailability classification and account-rotation retry behavior, including precedence cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->