### PR TITLE
fix(ci): raise yama floor to v2.7.2 for the 5m litellm timeout

### DIFF
--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -99,11 +99,18 @@ jobs:
         # Don't auto-fail the job on the action's exit code — the next step maps
         # the verdict to the check result explicitly.
         continue-on-error: true
-        # External consumer → published action. Owned by juspay, so a tag pin is
-        # acceptable; for strict supply-chain immutability replace with the full
-        # commit SHA behind this tag, e.g.
-        #   uses: juspay/yama@fb05b9f62837ea0cba729c1c48dbe7f547f65d0c  # v2.6.0
-        uses: juspay/yama@v2.6.0
+        # External consumer → published action, pinned to an immutable commit
+        # SHA (a tag can be moved; the SHA cannot).
+        #
+        # v2.7.2 is a floor, not a cosmetic bump: it bundles
+        # @juspay/neurolink ^10.1.2, whose DEFAULT_TIMEOUTS carries
+        # litellm: "5m" (#1216). v2.6.0 bundled ^9.42.0, where the litellm
+        # default was 30s — reviews of large diffs die with "litellm generate
+        # operation timed out after 30000" and report an infrastructure failure
+        # with no verdict, which re-running the job does NOT fix.
+        #
+        # When bumping, keep the trailing tag comment in sync with the SHA.
+        uses: juspay/yama@b89b3aaaf5c9faa830d17d50611a7c2845de8159 # v2.7.2
         with:
           github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
           ai-provider: litellm


### PR DESCRIPTION
## Problem

This repo's Yama review pins `juspay/yama@v2.6.0`, which bundles `@juspay/neurolink ^9.42.0` — **predating our own #1216**, where `DEFAULT_TIMEOUTS` set `litellm: "5m"`. On `9.x` the litellm default is **30 s**, so a review of a large diff is killed mid-generation and reports an infrastructure failure with **no verdict**:

```
❌ Review failed: [litellm] Request timed out: litellm generate operation timed out after 30000
Yama decision: <none> (action outcome: failure)
```

Critically, **re-running the job does not fix this** — it is a configuration floor, not a transient blip.

## Evidence (from juspay/director, same action, same model)

director pins `v2.7.1` (`neurolink ^9.70.7`, also pre-#1216). Two of its PRs were re-run during this investigation and **both failed again on attempt 2** with the identical `timed out after 30000`; 8 of its last 30 Yama runs sit failed. Meanwhile **juspay/clairvoyance**, which already runs a ref carrying `neurolink ^10.1.2`, has **zero** timeout failures — its PR #930 was re-run at the same time and passed.

| yama ref | bundles `@juspay/neurolink` | litellm timeout |
| --- | --- | --- |
| `v2.6.0` ← this repo today | `^9.42.0` | **30 s** ❌ |
| `v2.7.1` | `^9.70.7` | **30 s** ❌ |
| `v2.7.2` ← this PR | `^10.1.2` | **5 m** ✅ |

We are currently on the oldest pin of the three repos, i.e. the most exposed.

## Fix

Bump `juspay/yama@v2.6.0` → `@v2.7.2` (latest release), and record *why* v2.7.2 is a **floor** rather than a cosmetic bump so it is not silently rolled back. The adjacent SHA-pin example comment is refreshed to v2.7.2's actual commit (`b89b3aa`) so it no longer points at the superseded v2.6.0.

No workflow logic, inputs, provider, model, or gating changed — only the action ref.

## Note on scope

This raises the floor so a **timeout** cannot silently kill a review. It is not a claim about every Yama failure mode — the failure seen on #1227 earlier was a *context-window overflow* (262 145 > 262 144 tokens), a different problem that this bump does not purport to fix.

## Verification

- `yama-review.yml` parses (`yaml.safe_load`) ✓
- `prettier --check` clean ✓
- Only `.github/workflows/yama-review.yml` modified ✓
- Full pre-commit gate (check + lint + validate:all + build) passed ✓
- Real confirmation is this PR's own Yama run — it exercises the new ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review workflow to use Yama version 2.7.2.
  * Refreshed the in-workflow notes to reflect the action’s default timeout behavior and align the referenced tag comment with the fixed version SHA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->