### PR TITLE
feat(proxy): persist exact account routing decisions

### DIFF
--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -68,6 +68,26 @@ function printAnalysis(
     logger.always(chalk.yellow("    Rate limits: unavailable"));
   }
   logger.always("");
+  logger.always(chalk.bold("  Account Routing"));
+  if (report.coverage.routingDecisions) {
+    logger.always(
+      `    Decisions: ${report.routing.records.length}, modes: ${JSON.stringify(report.routing.modes)}`,
+    );
+    logger.always(
+      `    Selection reasons: ${JSON.stringify(report.routing.selectionReasons)}`,
+    );
+    logger.always(
+      `    Initial accounts: ${JSON.stringify(report.routing.initialAccounts)}`,
+    );
+    logger.always(
+      `    Final account changed after retry: ${report.routing.finalAccountChanges}, outside candidate set: ${report.routing.finalOutsideCandidateSet}`,
+    );
+  } else {
+    logger.always(
+      chalk.yellow("    Routing decisions: unavailable (legacy or no logs)"),
+    );
+  }
+  logger.always("");
   logger.always(chalk.bold("  Latency (ms)"));
   const latencyHeader = `${"METRIC".padEnd(22)} ${"COUNT".padStart(7)} ${"P50".padStart(9)} ${"P95".padStart(9)} ${"P99".padStart(9)} ${"MAX".padStart(9)}`;
   logger.always(`    ${chalk.gray(latencyHeader)}`);
@@ -98,6 +118,9 @@ function printAnalysis(
   logger.always(chalk.bold("  Data Quality"));
   logger.always(
     `    ${report.dataQuality.linesRead} lines scanned, ${report.dataQuality.malformedLines} malformed, ${report.dataQuality.unsupportedLifecycleLines} unsupported lifecycle, ${report.dataQuality.lifecycleSequenceGaps} sequence gaps, ${report.dataQuality.lifecycleSequenceDuplicates} duplicates`,
+  );
+  logger.always(
+    `    Routing decisions: ${report.dataQuality.routingDecisions.valid} valid, ${report.dataQuality.routingDecisions.invalid} invalid, ${report.dataQuality.routingDecisions.absent} absent`,
   );
   for (const [stream, range] of Object.entries(report.dataQuality.streams)) {
     if (range.observedFrom) {

--- a/src/lib/proxy/accountCooldown.ts
+++ b/src/lib/proxy/accountCooldown.ts
@@ -6,16 +6,11 @@ import type {
   PersistedAccountCooldown,
 } from "../types/index.js";
 import { AsyncMutex } from "../utils/asyncMutex.js";
+import { ACCOUNT_COOLING_REASONS } from "./routingEvidence.js";
 import { writeJsonSnapshotAtomically } from "./snapshotPersistence.js";
 
 const COOLDOWN_FILE = "account-cooldowns.json";
-const VALID_REASONS = new Set<AccountCoolingReason>([
-  "weekly",
-  "session",
-  "unified",
-  "transient",
-  "auth",
-]);
+const VALID_REASONS = new Set<AccountCoolingReason>(ACCOUNT_COOLING_REASONS);
 
 let customCooldownFilePath: string | null = null;
 let cacheLoaded = false;

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -9,9 +9,19 @@ import type {
   ProxyAnalysisFinalRequestRecord,
   ProxyAnalysisOptions,
   ProxyAnalysisReport,
+  ProxyAnalysisRoutingRecord,
   ProxyAnalysisStreamName,
+  ProxyAccountRoutingCandidate,
+  ProxyAccountRoutingDecision,
   ProxyLatencySummary,
 } from "../types/index.js";
+import {
+  ACCOUNT_COOLING_REASONS,
+  PROXY_ACCOUNT_TYPES,
+  PROXY_ACCOUNT_ROUTING_MODES,
+  PROXY_ACCOUNT_ROUTING_REASONS,
+  PROXY_ACCOUNT_ROUTING_STRATEGIES,
+} from "./routingEvidence.js";
 
 const LIFECYCLE_FILE_PATTERN = /^proxy-lifecycle-\d{4}-\d{2}-\d{2}\.jsonl$/;
 const REQUEST_FILE_PATTERN = /^proxy-\d{4}-\d{2}-\d{2}\.jsonl$/;
@@ -24,6 +34,11 @@ const LIFECYCLE_EVENTS = new Set([
   "response_first_chunk",
   "request_terminal",
 ]);
+const ROUTING_STRATEGIES = new Set<string>(PROXY_ACCOUNT_ROUTING_STRATEGIES);
+const ROUTING_MODES = new Set<string>(PROXY_ACCOUNT_ROUTING_MODES);
+const ROUTING_REASONS = new Set<string>(PROXY_ACCOUNT_ROUTING_REASONS);
+const ROUTING_ACCOUNT_TYPES = new Set<string>(PROXY_ACCOUNT_TYPES);
+const COOLING_REASONS = new Set<string>(ACCOUNT_COOLING_REASONS);
 
 function isContainedPath(root: string, candidate: string): boolean {
   const candidateRelative = relative(root, candidate);
@@ -63,6 +78,155 @@ function finiteNumber(value: unknown): number | null {
 
 function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || (typeof value === "string" && value.length > 0);
+}
+
+function isNullableFiniteNumber(value: unknown): value is number | null {
+  return value === null || finiteNumber(value) !== null;
+}
+
+function routingCandidateValue(
+  value: unknown,
+): ProxyAccountRoutingCandidate | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const requiredBooleanFields = [
+    "configuredPrimary",
+    "usable",
+    "saturated",
+    "quotaObserved",
+    "coolingActive",
+  ];
+  const requiredNullableNumberFields = [
+    "quotaLastUpdated",
+    "quotaAgeMs",
+    "coolingUntil",
+    "sessionUsed",
+    "sessionResetAt",
+    "sessionResetBucket",
+    "weeklyUsed",
+    "weeklyResetAt",
+  ];
+  const requiredNullableStringFields = [
+    "unifiedStatus",
+    "overageStatus",
+    "sessionStatus",
+    "weeklyStatus",
+  ];
+  if (
+    !stringValue(candidate.account) ||
+    typeof candidate.accountType !== "string" ||
+    !ROUTING_ACCOUNT_TYPES.has(candidate.accountType) ||
+    !Number.isInteger(candidate.sourceIndex) ||
+    (candidate.sourceIndex as number) < 0 ||
+    !Number.isInteger(candidate.rank) ||
+    (candidate.rank as number) < 0 ||
+    requiredBooleanFields.some(
+      (field) => typeof candidate[field] !== "boolean",
+    ) ||
+    requiredNullableNumberFields.some(
+      (field) => !isNullableFiniteNumber(candidate[field]),
+    ) ||
+    requiredNullableStringFields.some(
+      (field) => !isNullableString(candidate[field]),
+    ) ||
+    !(
+      candidate.coolingReason === null ||
+      (typeof candidate.coolingReason === "string" &&
+        COOLING_REASONS.has(candidate.coolingReason))
+    )
+  ) {
+    return null;
+  }
+  return {
+    account: candidate.account as string,
+    accountType:
+      candidate.accountType as ProxyAccountRoutingCandidate["accountType"],
+    sourceIndex: candidate.sourceIndex as number,
+    rank: candidate.rank as number,
+    configuredPrimary: candidate.configuredPrimary as boolean,
+    usable: candidate.usable as boolean,
+    saturated: candidate.saturated as boolean,
+    quotaObserved: candidate.quotaObserved as boolean,
+    quotaLastUpdated: candidate.quotaLastUpdated as number | null,
+    quotaAgeMs: candidate.quotaAgeMs as number | null,
+    coolingActive: candidate.coolingActive as boolean,
+    coolingReason:
+      candidate.coolingReason as ProxyAccountRoutingCandidate["coolingReason"],
+    coolingUntil: candidate.coolingUntil as number | null,
+    unifiedStatus: candidate.unifiedStatus as string | null,
+    overageStatus: candidate.overageStatus as string | null,
+    sessionStatus: candidate.sessionStatus as string | null,
+    sessionUsed: candidate.sessionUsed as number | null,
+    sessionResetAt: candidate.sessionResetAt as number | null,
+    sessionResetBucket: candidate.sessionResetBucket as number | null,
+    weeklyStatus: candidate.weeklyStatus as string | null,
+    weeklyUsed: candidate.weeklyUsed as number | null,
+    weeklyResetAt: candidate.weeklyResetAt as number | null,
+  };
+}
+
+function routingDecisionValue(
+  value: unknown,
+): ProxyAccountRoutingDecision | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const decision = value as Record<string, unknown>;
+  const candidates = Array.isArray(decision.candidates)
+    ? decision.candidates.map(routingCandidateValue)
+    : [];
+  if (
+    decision.schemaVersion !== 1 ||
+    !stringValue(decision.evaluatedAt) ||
+    !Number.isFinite(Date.parse(String(decision.evaluatedAt))) ||
+    typeof decision.strategy !== "string" ||
+    !ROUTING_STRATEGIES.has(decision.strategy) ||
+    typeof decision.mode !== "string" ||
+    !ROUTING_MODES.has(decision.mode) ||
+    typeof decision.selectionReason !== "string" ||
+    !ROUTING_REASONS.has(decision.selectionReason) ||
+    typeof decision.quotaRoutingEnabled !== "boolean" ||
+    typeof decision.quotaInputsUsed !== "boolean" ||
+    finiteNumber(decision.sessionSoftLimit) === null ||
+    (decision.sessionSoftLimit as number) <= 0 ||
+    (decision.sessionSoftLimit as number) > 1 ||
+    !Number.isInteger(decision.sessionResetToleranceMs) ||
+    (decision.sessionResetToleranceMs as number) <= 0 ||
+    !isNullableString(decision.configuredPrimaryAccount) ||
+    typeof decision.configuredPrimaryMatched !== "boolean" ||
+    !Number.isInteger(decision.rotationOffset) ||
+    (decision.rotationOffset as number) < 0 ||
+    !stringValue(decision.initialAccount) ||
+    candidates.length === 0 ||
+    candidates.some((candidate) => candidate === null)
+  ) {
+    return null;
+  }
+  return {
+    schemaVersion: 1,
+    evaluatedAt: decision.evaluatedAt as string,
+    strategy: decision.strategy as ProxyAccountRoutingDecision["strategy"],
+    mode: decision.mode as ProxyAccountRoutingDecision["mode"],
+    selectionReason:
+      decision.selectionReason as ProxyAccountRoutingDecision["selectionReason"],
+    quotaRoutingEnabled: decision.quotaRoutingEnabled as boolean,
+    quotaInputsUsed: decision.quotaInputsUsed as boolean,
+    sessionSoftLimit: decision.sessionSoftLimit as number,
+    sessionResetToleranceMs: decision.sessionResetToleranceMs as number,
+    configuredPrimaryAccount: decision.configuredPrimaryAccount as
+      | string
+      | null,
+    configuredPrimaryMatched: decision.configuredPrimaryMatched as boolean,
+    rotationOffset: decision.rotationOffset as number,
+    initialAccount: decision.initialAccount as string,
+    candidates: candidates as ProxyAccountRoutingCandidate[],
+  };
 }
 
 function percentile(sorted: number[], fraction: number): number | null {
@@ -256,6 +420,54 @@ function summarizeFinalRequests(
     },
     finalRequestLatency,
     singleAttemptDelta,
+  };
+}
+
+function summarizeRouting(
+  finalRequests: Map<string, ProxyAnalysisFinalRequestRecord>,
+): ProxyAnalysisReport["routing"] {
+  const modes: Record<string, number> = {};
+  const selectionReasons: Record<string, number> = {};
+  const initialAccounts: Record<string, number> = {};
+  const records: ProxyAnalysisRoutingRecord[] = [];
+  let finalAccountChanges = 0;
+  let finalOutsideCandidateSet = 0;
+
+  for (const [requestId, request] of finalRequests) {
+    const decision = request.routingDecision;
+    if (!decision) {
+      continue;
+    }
+    increment(modes, decision.mode);
+    increment(selectionReasons, decision.selectionReason);
+    increment(initialAccounts, decision.initialAccount);
+    const finalCandidate = decision.candidates.some(
+      (candidate) =>
+        candidate.account === request.account &&
+        candidate.accountType === request.accountType,
+    );
+    if (!finalCandidate) {
+      finalOutsideCandidateSet += 1;
+    } else if (decision.initialAccount !== request.account) {
+      finalAccountChanges += 1;
+    }
+    records.push({
+      requestId,
+      timestamp: request.timestamp,
+      responseStatus: request.status,
+      finalAccount: request.account,
+      finalAccountType: request.accountType,
+      decision,
+    });
+  }
+
+  return {
+    modes,
+    selectionReasons,
+    initialAccounts,
+    finalAccountChanges,
+    finalOutsideCandidateSet,
+    records,
   };
 }
 
@@ -489,6 +701,9 @@ export async function analyzeProxyLogs(
 
   const finalRequests = new Map<string, ProxyAnalysisFinalRequestRecord>();
   const terminalStreamErrors = new Set<string>();
+  let validRoutingDecisions = 0;
+  let invalidRoutingDecisions = 0;
+  let absentRoutingDecisions = 0;
   for (const filePath of requestFiles) {
     linesRead += await readJsonLines(
       filePath,
@@ -509,7 +724,22 @@ export async function analyzeProxyLogs(
         if (status === null || !stringValue(record.method)) {
           return;
         }
+        const hasRoutingDecision = Object.prototype.hasOwnProperty.call(
+          record,
+          "routingDecision",
+        );
+        const routingDecision = hasRoutingDecision
+          ? routingDecisionValue(record.routingDecision)
+          : null;
+        if (routingDecision) {
+          validRoutingDecisions += 1;
+        } else if (hasRoutingDecision) {
+          invalidRoutingDecisions += 1;
+        } else {
+          absentRoutingDecisions += 1;
+        }
         finalRequests.set(requestId, {
+          timestamp: new Date(timestamp).toISOString(),
           status,
           durationMs: finiteNumber(record.responseTimeMs),
           account: stringValue(record.account) ?? "unknown",
@@ -519,6 +749,7 @@ export async function analyzeProxyLogs(
           cacheCreationTokens: finiteNumber(record.cacheCreationTokens),
           errorType: stringValue(record.errorType),
           errorCode: stringValue(record.errorCode),
+          routingDecision,
         });
       },
       () => {
@@ -608,6 +839,7 @@ export async function analyzeProxyLogs(
     attemptsByRequest,
     accounts,
   );
+  const routingSummary = summarizeRouting(finalRequests);
 
   return {
     generatedAt: new Date(nowMs).toISOString(),
@@ -626,6 +858,7 @@ export async function analyzeProxyLogs(
       attempts: totalAttempts > 0,
       attemptLatency: attemptLatency.length > 0,
       cacheUsage: finalSummary.cache.requestsWithUsage > 0,
+      routingDecisions: routingSummary.records.length > 0,
     },
     dataQuality: {
       linesRead,
@@ -654,6 +887,11 @@ export async function analyzeProxyLogs(
         invalidPaths,
         writeFailures,
         truncatedCaptures,
+      },
+      routingDecisions: {
+        valid: validRoutingDecisions,
+        invalid: invalidRoutingDecisions,
+        absent: absentRoutingDecisions,
       },
     },
     lifecycle: {
@@ -689,6 +927,7 @@ export async function analyzeProxyLogs(
       singleAttemptDelta: summarizeLatency(finalSummary.singleAttemptDelta),
     },
     cache: finalSummary.cache,
+    routing: routingSummary,
     accounts: [...accounts.values()].sort(
       (left, right) => right.attempts - left.attempts,
     ),

--- a/src/lib/proxy/requestLogger.ts
+++ b/src/lib/proxy/requestLogger.ts
@@ -307,6 +307,22 @@ function emitOtlpLogRecord(entry: RequestLogEntry): void {
           "account.name": entry.account,
           "account.type": entry.accountType,
 
+          // Compact routing summary. Full candidate evidence stays in JSONL.
+          ...(entry.routingDecision && {
+            "routing.mode": entry.routingDecision.mode,
+            "routing.strategy": entry.routingDecision.strategy,
+            "routing.selection_reason": entry.routingDecision.selectionReason,
+            "routing.initial_account": entry.routingDecision.initialAccount,
+            "routing.candidate_count": entry.routingDecision.candidates.length,
+            "routing.final_account_changed":
+              entry.routingDecision.initialAccount !== entry.account &&
+              entry.routingDecision.candidates.some(
+                (candidate) =>
+                  candidate.account === entry.account &&
+                  candidate.accountType === entry.accountType,
+              ),
+          }),
+
           // Token usage (when available)
           ...(entry.inputTokens !== undefined && {
             "ai.input_tokens": entry.inputTokens,

--- a/src/lib/proxy/routingEvidence.ts
+++ b/src/lib/proxy/routingEvidence.ts
@@ -1,0 +1,36 @@
+/** Schema-v1 routing evidence values shared by emitters and offline readers. */
+export const PROXY_ACCOUNT_ROUTING_STRATEGIES = [
+  "round-robin",
+  "fill-first",
+] as const;
+
+export const PROXY_ACCOUNT_ROUTING_MODES = [
+  "quota",
+  "primary",
+  "round_robin",
+  "single_account",
+] as const;
+
+export const PROXY_ACCOUNT_ROUTING_REASONS = [
+  "single_account",
+  "round_robin",
+  "configured_primary",
+  "insertion_order",
+  "availability",
+  "cooldown_recovery",
+  "quota_probe",
+  "session_headroom",
+  "session_reset",
+  "weekly_reset",
+  "weekly_utilization",
+] as const;
+
+export const PROXY_ACCOUNT_TYPES = ["oauth", "api_key"] as const;
+
+export const ACCOUNT_COOLING_REASONS = [
+  "weekly",
+  "session",
+  "unified",
+  "transient",
+  "auth",
+] as const;

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -104,7 +104,6 @@ import type {
   ClaudeFinalRequestLogger,
   ClaudeLoggedErrorBuilder,
   ClaudeRequest,
-  ClaudeRequestRuntimeContext,
   ClaudeProxyRouteRuntimeOptions,
   ClaudeSnapshot,
   ClaudeSnapshotBody,
@@ -114,10 +113,15 @@ import type {
   ParsedClaudeError,
   ParsedClaudeRequest,
   PreparedAnthropicAccountAttempt,
+  ProxyAccountRoutingCandidate,
+  ProxyAccountRoutingDecision,
+  ProxyAccountRoutingReason,
+  ProxyAccountSortMetrics,
   ProxyBodyCaptureLogger,
   ProxyPassthroughAccount,
   ResponseInfoContext,
   RouteGroup,
+  RoutedClaudeRequestRuntimeContext,
   RuntimeAccountState,
   ServerContext,
   StreamResult,
@@ -626,7 +630,7 @@ function accountSortMetrics(
   now: number,
   sessionSoftLimit: number,
   sessionResetToleranceMs: number,
-) {
+): ProxyAccountSortMetrics {
   const st = accountRuntimeState.get(accountKey);
   const q = st?.quota;
   const coolingActive = !!st?.coolingUntil && now < st.coolingUntil;
@@ -636,17 +640,23 @@ function accountSortMetrics(
   const sessionReset = resetEpochToMs(q?.sessionResetAt, now);
   const sessionTicking = sessionReset !== undefined;
   const weeklyTicking = weeklyReset !== undefined;
-  const sessionUsed = sessionTicking ? (q?.sessionUsed ?? 0) : 0;
-  const weeklyUsed = weeklyTicking ? (q?.weeklyUsed ?? -1) : q ? 0 : -1;
-  const sessionStatus = sessionTicking
-    ? (q?.sessionStatus ?? "unknown")
-    : "allowed";
-  const weeklyStatus = weeklyTicking
-    ? (q?.weeklyStatus ?? "unknown")
-    : "allowed";
+  const sessionUsed = q ? (sessionTicking ? (q.sessionUsed ?? 0) : 0) : null;
+  const weeklyUsed = q ? (weeklyTicking ? (q.weeklyUsed ?? null) : 0) : null;
+  const sessionStatus = q
+    ? sessionTicking
+      ? (q.sessionStatus ?? "unknown")
+      : "allowed"
+    : null;
+  const weeklyStatus = q
+    ? weeklyTicking
+      ? (q.weeklyStatus ?? "unknown")
+      : "allowed"
+    : null;
   const saturated =
     sessionStatus === "throttled" ||
-    (sessionTicking && sessionUsed >= sessionSoftLimit);
+    (sessionTicking && (sessionUsed ?? 0) >= sessionSoftLimit);
+  const quotaLastUpdated =
+    q && Number.isFinite(q.lastUpdated) ? q.lastUpdated : null;
   return {
     usable:
       !coolingActive &&
@@ -654,13 +664,105 @@ function accountSortMetrics(
       sessionStatus !== "rejected",
     saturated,
     hasQuota: !!q,
+    quotaLastUpdated,
+    quotaAgeMs:
+      quotaLastUpdated === null ? null : Math.max(0, now - quotaLastUpdated),
+    coolingActive,
+    coolingReason: st?.coolingReason ?? null,
     coolingUntil: st?.coolingUntil ?? 0,
+    unifiedStatus: q?.unifiedStatus ?? null,
+    overageStatus: q?.overageStatus ?? null,
+    sessionStatus,
+    sessionUsed,
     sessionResetBucket: sessionTicking
       ? Math.floor(sessionReset / sessionResetToleranceMs)
       : Number.POSITIVE_INFINITY,
     sessionReset: sessionReset ?? Number.POSITIVE_INFINITY,
+    weeklyStatus,
     weeklyReset: weeklyReset ?? Number.POSITIVE_INFINITY,
     weeklyUsed,
+    weeklyUsedForSort: weeklyUsed ?? -1,
+  };
+}
+
+function compareAccountRoutingFactors(
+  a: ProxyPassthroughAccount,
+  b: ProxyPassthroughAccount,
+  metricsByKey: ReadonlyMap<string, ProxyAccountSortMetrics>,
+  primaryKey: string | undefined,
+): [number, ProxyAccountRoutingReason] {
+  const ma = metricsByKey.get(a.key);
+  const mb = metricsByKey.get(b.key);
+  if (!ma || !mb) {
+    return [0, "insertion_order"];
+  }
+  if (ma.usable !== mb.usable) {
+    return [ma.usable ? -1 : 1, "availability"];
+  }
+  if (!ma.usable && !mb.usable) {
+    const au = ma.coolingUntil || Number.POSITIVE_INFINITY;
+    const bu = mb.coolingUntil || Number.POSITIVE_INFINITY;
+    return [
+      au === bu ? 0 : au - bu,
+      au === bu ? "insertion_order" : "cooldown_recovery",
+    ];
+  }
+  if (ma.hasQuota !== mb.hasQuota) {
+    return [ma.hasQuota ? 1 : -1, "quota_probe"];
+  }
+  if (ma.saturated !== mb.saturated) {
+    return [ma.saturated ? 1 : -1, "session_headroom"];
+  }
+  if (ma.saturated && mb.saturated) {
+    if (ma.sessionResetBucket !== mb.sessionResetBucket) {
+      return [ma.sessionResetBucket - mb.sessionResetBucket, "session_reset"];
+    }
+    if (ma.weeklyReset !== mb.weeklyReset) {
+      return [ma.weeklyReset - mb.weeklyReset, "weekly_reset"];
+    }
+  } else {
+    if (ma.weeklyReset !== mb.weeklyReset) {
+      return [ma.weeklyReset - mb.weeklyReset, "weekly_reset"];
+    }
+    if (ma.sessionResetBucket !== mb.sessionResetBucket) {
+      return [ma.sessionResetBucket - mb.sessionResetBucket, "session_reset"];
+    }
+  }
+  if (ma.weeklyUsedForSort !== mb.weeklyUsedForSort) {
+    return [mb.weeklyUsedForSort - ma.weeklyUsedForSort, "weekly_utilization"];
+  }
+  if (primaryKey && (a.key === primaryKey) !== (b.key === primaryKey)) {
+    return [a.key === primaryKey ? -1 : 1, "configured_primary"];
+  }
+  return [0, "insertion_order"];
+}
+
+function orderAccountsByQuotaWithMetrics(
+  accounts: ProxyPassthroughAccount[],
+  now: number,
+  primaryKey: string | undefined,
+  sessionSoftLimit: number,
+  sessionResetToleranceMs: number,
+): {
+  orderedAccounts: ProxyPassthroughAccount[];
+  metricsByKey: Map<string, ProxyAccountSortMetrics>;
+} {
+  const metricsByKey = new Map(
+    accounts.map((account) => [
+      account.key,
+      accountSortMetrics(
+        account.key,
+        now,
+        sessionSoftLimit,
+        sessionResetToleranceMs,
+      ),
+    ]),
+  );
+  return {
+    orderedAccounts: [...accounts].sort(
+      (a, b) => compareAccountRoutingFactors(a, b, metricsByKey, primaryKey)[0],
+    ),
+    metricsByKey,
   };
 }
 
@@ -696,48 +798,231 @@ function orderAccountsByQuota(
   sessionSoftLimit: number = getSessionSoftLimit(),
   sessionResetToleranceMs: number = getSessionResetToleranceMs(),
 ): ProxyPassthroughAccount[] {
-  const metrics = (key: string) =>
-    accountSortMetrics(key, now, sessionSoftLimit, sessionResetToleranceMs);
-  return [...accounts].sort((a, b) => {
-    const ma = metrics(a.key);
-    const mb = metrics(b.key);
-    if (ma.usable !== mb.usable) {
-      return ma.usable ? -1 : 1;
-    }
-    if (!ma.usable && !mb.usable) {
-      const au = ma.coolingUntil || Number.POSITIVE_INFINITY;
-      const bu = mb.coolingUntil || Number.POSITIVE_INFINITY;
-      return au - bu;
-    }
-    if (ma.hasQuota !== mb.hasQuota) {
-      return ma.hasQuota ? 1 : -1;
-    }
-    if (ma.saturated !== mb.saturated) {
-      return ma.saturated ? 1 : -1;
-    }
-    if (ma.saturated && mb.saturated) {
-      if (ma.sessionResetBucket !== mb.sessionResetBucket) {
-        return ma.sessionResetBucket - mb.sessionResetBucket;
+  return orderAccountsByQuotaWithMetrics(
+    accounts,
+    now,
+    primaryKey,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+  ).orderedAccounts;
+}
+
+function buildRoutingDecision(args: {
+  accounts: ProxyPassthroughAccount[];
+  orderedAccounts: ProxyPassthroughAccount[];
+  metricsByKey: ReadonlyMap<string, ProxyAccountSortMetrics>;
+  evaluatedAt: number;
+  strategy: "round-robin" | "fill-first";
+  primaryKey: string | undefined;
+  quotaRoutingEnabled: boolean;
+  quotaOrdered: boolean;
+  sessionSoftLimit: number;
+  sessionResetToleranceMs: number;
+  rotationOffset: number;
+}): ProxyAccountRoutingDecision {
+  const {
+    accounts,
+    orderedAccounts,
+    metricsByKey,
+    evaluatedAt,
+    strategy,
+    primaryKey,
+    quotaRoutingEnabled,
+    quotaOrdered,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+    rotationOffset,
+  } = args;
+  const sourceIndexes = new Map(
+    accounts.map((account, index) => [account.key, index]),
+  );
+  const configuredPrimaryMatched =
+    !!primaryKey && accounts.some((account) => account.key === primaryKey);
+  const candidates: ProxyAccountRoutingCandidate[] = orderedAccounts.map(
+    (account, rank) => {
+      const metrics = metricsByKey.get(account.key);
+      if (!metrics) {
+        throw new Error(
+          `Missing precomputed routing metrics for account ${account.label}`,
+        );
       }
-      if (ma.weeklyReset !== mb.weeklyReset) {
-        return ma.weeklyReset - mb.weeklyReset;
+      return {
+        account: account.label,
+        accountType: account.type,
+        sourceIndex: sourceIndexes.get(account.key) ?? rank,
+        rank,
+        configuredPrimary: !!primaryKey && account.key === primaryKey,
+        usable: metrics.usable,
+        saturated: metrics.saturated,
+        quotaObserved: metrics.hasQuota,
+        quotaLastUpdated: metrics.quotaLastUpdated,
+        quotaAgeMs: metrics.quotaAgeMs,
+        coolingActive: metrics.coolingActive,
+        coolingReason: metrics.coolingReason,
+        coolingUntil:
+          metrics.coolingUntil > 0 && Number.isFinite(metrics.coolingUntil)
+            ? metrics.coolingUntil
+            : null,
+        unifiedStatus: metrics.unifiedStatus,
+        overageStatus: metrics.overageStatus,
+        sessionStatus: metrics.sessionStatus,
+        sessionUsed: metrics.sessionUsed,
+        sessionResetAt: Number.isFinite(metrics.sessionReset)
+          ? metrics.sessionReset
+          : null,
+        sessionResetBucket: Number.isFinite(metrics.sessionResetBucket)
+          ? metrics.sessionResetBucket
+          : null,
+        weeklyStatus: metrics.weeklyStatus,
+        weeklyUsed: metrics.weeklyUsed,
+        weeklyResetAt: Number.isFinite(metrics.weeklyReset)
+          ? metrics.weeklyReset
+          : null,
+      };
+    },
+  );
+  const initialAccount = orderedAccounts[0];
+  let mode: ProxyAccountRoutingDecision["mode"];
+  let selectionReason: ProxyAccountRoutingReason;
+  if (orderedAccounts.length === 1) {
+    mode = "single_account";
+    selectionReason = "single_account";
+  } else if (quotaOrdered) {
+    mode = "quota";
+    selectionReason = compareAccountRoutingFactors(
+      orderedAccounts[0],
+      orderedAccounts[1],
+      metricsByKey,
+      primaryKey,
+    )[1];
+  } else if (strategy === "round-robin") {
+    mode = "round_robin";
+    selectionReason = "round_robin";
+  } else {
+    mode = "primary";
+    selectionReason =
+      configuredPrimaryMatched && initialAccount?.key === primaryKey
+        ? "configured_primary"
+        : "insertion_order";
+  }
+
+  return {
+    schemaVersion: 1,
+    evaluatedAt: new Date(evaluatedAt).toISOString(),
+    strategy,
+    mode,
+    selectionReason,
+    quotaRoutingEnabled,
+    quotaInputsUsed: quotaOrdered,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+    configuredPrimaryAccount: primaryKey ?? null,
+    configuredPrimaryMatched,
+    rotationOffset,
+    initialAccount: initialAccount?.label ?? "",
+    candidates,
+  };
+}
+
+function selectClaudeProxyAccountOrder(args: {
+  enabledAccounts: ProxyPassthroughAccount[];
+  accountStrategy: "round-robin" | "fill-first";
+  primaryAccountKey: string | undefined;
+  quotaRoutingEnabled: boolean;
+  sessionSoftLimit: number;
+  sessionResetToleranceMs: number;
+  setRoutingDecision: (decision: ProxyAccountRoutingDecision) => void;
+}): ProxyPassthroughAccount[] {
+  const {
+    enabledAccounts,
+    accountStrategy,
+    primaryAccountKey,
+    quotaRoutingEnabled,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+    setRoutingDecision,
+  } = args;
+  let orderedAccounts = [...enabledAccounts];
+  const evaluatedAt = Date.now();
+  let metricsByKey: Map<string, ProxyAccountSortMetrics>;
+  let rotationOffset = 0;
+  const quotaOrdered =
+    accountStrategy === "fill-first" &&
+    orderedAccounts.length > 1 &&
+    quotaRoutingEnabled;
+
+  if (!quotaOrdered && accountStrategy === "fill-first") {
+    // A hot-reloaded primary change must apply to this request.
+    maybeResetPrimaryToHome(enabledAccounts, primaryAccountKey);
+  }
+  if (quotaOrdered) {
+    const quotaOrder = orderAccountsByQuotaWithMetrics(
+      enabledAccounts,
+      evaluatedAt,
+      primaryAccountKey,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+    );
+    orderedAccounts = quotaOrder.orderedAccounts;
+    metricsByKey = quotaOrder.metricsByKey;
+    if (logger.shouldLog("debug")) {
+      logger.debug(
+        `[proxy] quota-ordered fill sequence: ${orderedAccounts
+          .map((account) => account.label)
+          .join(" → ")}`,
+      );
+    }
+  } else {
+    if (
+      accountStrategy === "round-robin" &&
+      orderedAccounts.length !== lastKnownAccountCount
+    ) {
+      primaryAccountIndex = resolveHomeIndex(
+        orderedAccounts,
+        primaryAccountKey,
+      );
+      lastKnownAccountCount = orderedAccounts.length;
+    }
+    if (orderedAccounts.length > 1) {
+      rotationOffset = primaryAccountIndex % orderedAccounts.length;
+      if (accountStrategy === "round-robin") {
+        primaryAccountIndex =
+          (primaryAccountIndex + 1) % orderedAccounts.length;
       }
-    } else {
-      if (ma.weeklyReset !== mb.weeklyReset) {
-        return ma.weeklyReset - mb.weeklyReset;
-      }
-      if (ma.sessionResetBucket !== mb.sessionResetBucket) {
-        return ma.sessionResetBucket - mb.sessionResetBucket;
+      if (rotationOffset > 0) {
+        const head = orderedAccounts.splice(0, rotationOffset);
+        orderedAccounts.push(...head);
       }
     }
-    if (ma.weeklyUsed !== mb.weeklyUsed) {
-      return mb.weeklyUsed - ma.weeklyUsed;
-    }
-    if (primaryKey && (a.key === primaryKey) !== (b.key === primaryKey)) {
-      return a.key === primaryKey ? -1 : 1;
-    }
-    return 0;
-  });
+    metricsByKey = new Map(
+      enabledAccounts.map((account) => [
+        account.key,
+        accountSortMetrics(
+          account.key,
+          evaluatedAt,
+          sessionSoftLimit,
+          sessionResetToleranceMs,
+        ),
+      ]),
+    );
+  }
+
+  setRoutingDecision(
+    buildRoutingDecision({
+      accounts: enabledAccounts,
+      orderedAccounts,
+      metricsByKey,
+      evaluatedAt,
+      strategy: accountStrategy,
+      primaryKey: primaryAccountKey,
+      quotaRoutingEnabled,
+      quotaOrdered,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+      rotationOffset,
+    }),
+  );
+  return orderedAccounts;
 }
 
 // ---------------------------------------------------------------------------
@@ -2019,6 +2304,7 @@ async function loadClaudeProxyAccounts(args: {
   sessionSoftLimit?: number;
   sessionResetToleranceMs?: number;
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+  setRoutingDecision: (decision: ProxyAccountRoutingDecision) => void;
 }): Promise<LoadedClaudeAccountContext | { response: unknown }> {
   const {
     ctx,
@@ -2032,6 +2318,7 @@ async function loadClaudeProxyAccounts(args: {
     sessionSoftLimit = getSessionSoftLimit(),
     sessionResetToleranceMs = getSessionResetToleranceMs(),
     buildLoggedClaudeError,
+    setRoutingDecision,
   } = args;
   const fs = await import("fs");
   const os = await import("os");
@@ -2269,58 +2556,15 @@ async function loadClaudeProxyAccounts(args: {
     return { response: buildLoggedClaudeError(401, reauthMsg) };
   }
 
-  let orderedAccounts = [...enabledAccounts];
-  const quotaOrdered =
-    accountStrategy === "fill-first" &&
-    orderedAccounts.length > 1 &&
-    quotaRoutingEnabled;
-  if (!quotaOrdered && accountStrategy === "fill-first") {
-    // Apply the request-scoped home before deriving this request's order. A
-    // hot-reloaded primary change must not lag by one request. Round-robin
-    // deliberately skips this reset so its rotating index remains strict.
-    maybeResetPrimaryToHome(enabledAccounts, primaryAccountKey);
-  }
-  if (quotaOrdered) {
-    // Fill-first with a smart fill order: spend the account whose weekly window
-    // expires soonest while temporarily demoting sessions without headroom.
-    // Supersedes the static home/primary index.
-    orderedAccounts = orderAccountsByQuota(
-      enabledAccounts,
-      Date.now(),
-      primaryAccountKey,
-      sessionSoftLimit,
-      sessionResetToleranceMs,
-    );
-    if (logger.shouldLog("debug")) {
-      logger.debug(
-        `[proxy] quota-ordered fill sequence: ${orderedAccounts
-          .map((a) => a.label)
-          .join(" → ")}`,
-      );
-    }
-  } else {
-    if (
-      accountStrategy === "round-robin" &&
-      orderedAccounts.length !== lastKnownAccountCount
-    ) {
-      primaryAccountIndex = resolveHomeIndex(
-        orderedAccounts,
-        primaryAccountKey,
-      );
-      lastKnownAccountCount = orderedAccounts.length;
-    }
-    if (orderedAccounts.length > 1) {
-      const idx = primaryAccountIndex % orderedAccounts.length;
-      if (accountStrategy === "round-robin") {
-        primaryAccountIndex =
-          (primaryAccountIndex + 1) % orderedAccounts.length;
-      }
-      if (idx > 0) {
-        const head = orderedAccounts.splice(0, idx);
-        orderedAccounts.push(...head);
-      }
-    }
-  }
+  const orderedAccounts = selectClaudeProxyAccountOrder({
+    enabledAccounts,
+    accountStrategy,
+    primaryAccountKey,
+    quotaRoutingEnabled,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+    setRoutingDecision,
+  });
 
   const normalizedAnthropicBody = normalizeClaudeRequestForAnthropic(body);
   const bodyStr = JSON.stringify(normalizedAnthropicBody);
@@ -4910,7 +5154,7 @@ function createClaudeRequestRuntimeContext(args: {
   ctx: ServerContext;
   body: ClaudeRequest;
   clientRequestBody: string;
-}): ClaudeRequestRuntimeContext {
+}): RoutedClaudeRequestRuntimeContext {
   const { ctx, body, clientRequestBody } = args;
   let tracer: ProxyTracer | undefined;
   try {
@@ -4960,6 +5204,16 @@ function createClaudeRequestRuntimeContext(args: {
         ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
         : {}),
     });
+  };
+  let routingDecision: ProxyAccountRoutingDecision | undefined;
+  const setRoutingDecision = (decision: ProxyAccountRoutingDecision): void => {
+    if (routingDecision) {
+      logger.debug(
+        `[claude-proxy] ignored duplicate routing decision for request ${ctx.requestId}`,
+      );
+      return;
+    }
+    routingDecision = decision;
   };
   let finalRequestLogged = false;
   const logFinalRequest: ClaudeFinalRequestLogger = (
@@ -5030,6 +5284,7 @@ function createClaudeRequestRuntimeContext(args: {
       ...(traceCtx
         ? { traceId: traceCtx.traceId, spanId: traceCtx.spanId }
         : {}),
+      ...(routingDecision ? { routingDecision } : {}),
     });
   };
   const buildLoggedClaudeError: ClaudeLoggedErrorBuilder = (
@@ -5074,6 +5329,7 @@ function createClaudeRequestRuntimeContext(args: {
     logProxyBody,
     logFinalRequest,
     buildLoggedClaudeError,
+    setRoutingDecision,
   };
 }
 
@@ -5602,6 +5858,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: ClaudeFinalRequestLogger;
+  setRoutingDecision: (decision: ProxyAccountRoutingDecision) => void;
 }): Promise<unknown> {
   const {
     ctx,
@@ -5618,6 +5875,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     buildLoggedClaudeError,
     logProxyBody,
     logFinalRequest,
+    setRoutingDecision,
   } = args;
   const parsedRequest = parseClaudeRequest(body);
   const loadedAccounts = await loadClaudeProxyAccounts({
@@ -5632,6 +5890,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     sessionSoftLimit,
     sessionResetToleranceMs,
     buildLoggedClaudeError,
+    setRoutingDecision,
   });
   if ("response" in loadedAccounts) {
     return loadedAccounts.response;
@@ -6234,6 +6493,7 @@ export function createClaudeProxyRoutes(
             logProxyBody,
             logFinalRequest,
             buildLoggedClaudeError,
+            setRoutingDecision,
           } = createClaudeRequestRuntimeContext({
             ctx,
             body,
@@ -6284,6 +6544,7 @@ export function createClaudeProxyRoutes(
                 buildLoggedClaudeError,
                 logProxyBody,
                 logFinalRequest,
+                setRoutingDecision,
               });
             } else {
               return handleTranslatedClaudeRequest({
@@ -6802,6 +7063,34 @@ export const __testHooks = {
   getStreamFailureDetails,
   trackUpstreamReadableStream,
   orderAccountsByQuota,
+  buildQuotaRoutingDecision: (
+    accounts: ProxyPassthroughAccount[],
+    now: number,
+    primaryKey: string | undefined,
+    sessionSoftLimit: number = getSessionSoftLimit(),
+    sessionResetToleranceMs: number = getSessionResetToleranceMs(),
+  ): ProxyAccountRoutingDecision => {
+    const order = orderAccountsByQuotaWithMetrics(
+      accounts,
+      now,
+      primaryKey,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+    );
+    return buildRoutingDecision({
+      accounts,
+      orderedAccounts: order.orderedAccounts,
+      metricsByKey: order.metricsByKey,
+      evaluatedAt: now,
+      strategy: "fill-first",
+      primaryKey,
+      quotaRoutingEnabled: true,
+      quotaOrdered: accounts.length > 1,
+      sessionSoftLimit,
+      sessionResetToleranceMs,
+      rotationOffset: 0,
+    });
+  },
   resetEpochToMs,
   seedRuntimeQuotasFromDisk,
   reconcileEligibleAccountRuntimeState,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -20,6 +20,13 @@ import type { Ora } from "ora";
 import type { MCPToolRegistry } from "../mcp/toolRegistry.js";
 import type { ProxyTracer } from "../proxy/proxyTracer.js";
 import type {
+  ACCOUNT_COOLING_REASONS,
+  PROXY_ACCOUNT_TYPES,
+  PROXY_ACCOUNT_ROUTING_MODES,
+  PROXY_ACCOUNT_ROUTING_REASONS,
+  PROXY_ACCOUNT_ROUTING_STRATEGIES,
+} from "../proxy/routingEvidence.js";
+import type {
   FallbackEntry,
   ModelMapping,
   ProxyRoutingConfig,
@@ -498,6 +505,80 @@ export type LoadProxyConfigOptions = {
 // REQUEST LOGGER TYPES (from requestLogger.ts)
 // =============================================================================
 
+export type ProxyAccountRoutingStrategy =
+  (typeof PROXY_ACCOUNT_ROUTING_STRATEGIES)[number];
+
+export type ProxyAccountRoutingMode =
+  (typeof PROXY_ACCOUNT_ROUTING_MODES)[number];
+
+export type ProxyAccountRoutingReason =
+  (typeof PROXY_ACCOUNT_ROUTING_REASONS)[number];
+
+export type ProxyAccountType = (typeof PROXY_ACCOUNT_TYPES)[number];
+
+export type ProxyAccountRoutingCandidate = {
+  account: string;
+  accountType: ProxyAccountType;
+  sourceIndex: number;
+  rank: number;
+  configuredPrimary: boolean;
+  usable: boolean;
+  saturated: boolean;
+  quotaObserved: boolean;
+  quotaLastUpdated: number | null;
+  quotaAgeMs: number | null;
+  coolingActive: boolean;
+  coolingReason: AccountCoolingReason | null;
+  coolingUntil: number | null;
+  unifiedStatus: string | null;
+  overageStatus: string | null;
+  sessionStatus: string | null;
+  sessionUsed: number | null;
+  sessionResetAt: number | null;
+  sessionResetBucket: number | null;
+  weeklyStatus: string | null;
+  weeklyUsed: number | null;
+  weeklyResetAt: number | null;
+};
+
+export type ProxyAccountRoutingDecision = {
+  schemaVersion: 1;
+  evaluatedAt: string;
+  strategy: ProxyAccountRoutingStrategy;
+  mode: ProxyAccountRoutingMode;
+  selectionReason: ProxyAccountRoutingReason;
+  quotaRoutingEnabled: boolean;
+  quotaInputsUsed: boolean;
+  sessionSoftLimit: number;
+  sessionResetToleranceMs: number;
+  configuredPrimaryAccount: string | null;
+  configuredPrimaryMatched: boolean;
+  rotationOffset: number;
+  initialAccount: string;
+  candidates: ProxyAccountRoutingCandidate[];
+};
+
+export type ProxyAccountSortMetrics = {
+  usable: boolean;
+  saturated: boolean;
+  hasQuota: boolean;
+  quotaLastUpdated: number | null;
+  quotaAgeMs: number | null;
+  coolingActive: boolean;
+  coolingReason: AccountCoolingReason | null;
+  coolingUntil: number;
+  unifiedStatus: string | null;
+  overageStatus: string | null;
+  sessionStatus: string | null;
+  sessionUsed: number | null;
+  sessionResetBucket: number;
+  sessionReset: number;
+  weeklyStatus: string | null;
+  weeklyReset: number;
+  weeklyUsed: number | null;
+  weeklyUsedForSort: number;
+};
+
 export type RequestLogEntry = {
   timestamp: string;
   requestId: string;
@@ -522,6 +603,8 @@ export type RequestLogEntry = {
   traceId?: string;
   /** OTel span ID for correlation with distributed traces */
   spanId?: string;
+  /** Exact secret-free inputs and result of initial account selection. */
+  routingDecision?: ProxyAccountRoutingDecision;
 };
 
 export type RequestAttemptLogEntry = {
@@ -607,6 +690,10 @@ export type ClaudeRequestRuntimeContext = {
   logProxyBody: ProxyBodyCaptureLogger;
   logFinalRequest: ClaudeFinalRequestLogger;
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
+};
+
+export type RoutedClaudeRequestRuntimeContext = ClaudeRequestRuntimeContext & {
+  setRoutingDecision: (decision: ProxyAccountRoutingDecision) => void;
 };
 
 export type AnthropicAttemptLogger = (
@@ -985,12 +1072,7 @@ export type AccountQuota = {
  *  - "unified"   : top-level unified limit rejected — cool for retry-after.
  *  - "transient" : short per-minute/burst 429 — cool for retry-after only.
  *  - "auth"      : transient refresh failure with bounded backoff. */
-export type AccountCoolingReason =
-  | "weekly"
-  | "session"
-  | "unified"
-  | "transient"
-  | "auth";
+export type AccountCoolingReason = (typeof ACCOUNT_COOLING_REASONS)[number];
 
 /** Restart-safe cooldown snapshot for one account. */
 export type PersistedAccountCooldown = {
@@ -1028,7 +1110,7 @@ export type ProxyPassthroughAccount = {
   token: string;
   refreshToken?: string;
   expiresAt?: number;
-  type: "oauth" | "api_key";
+  type: ProxyAccountType;
   persistTarget?: TokenPersistTarget;
 };
 
@@ -1432,6 +1514,7 @@ export type ProxyAnalysisReport = {
     attempts: boolean;
     attemptLatency: boolean;
     cacheUsage: boolean;
+    routingDecisions: boolean;
   };
   dataQuality: {
     linesRead: number;
@@ -1455,6 +1538,11 @@ export type ProxyAnalysisReport = {
       invalidPaths: number;
       writeFailures: number;
       truncatedCaptures: number;
+    };
+    routingDecisions: {
+      valid: number;
+      invalid: number;
+      absent: number;
     };
   };
   lifecycle: {
@@ -1504,6 +1592,14 @@ export type ProxyAnalysisReport = {
     inputTokens: number;
     requestHitRate: number | null;
   };
+  routing: {
+    modes: Record<string, number>;
+    selectionReasons: Record<string, number>;
+    initialAccounts: Record<string, number>;
+    finalAccountChanges: number;
+    finalOutsideCandidateSet: number;
+    records: ProxyAnalysisRoutingRecord[];
+  };
   accounts: ProxyAnalysisAccount[];
 };
 
@@ -1524,6 +1620,7 @@ export type ProxyAnalysisAttemptRecord = {
 
 /** Final request fields retained while joining offline proxy log records. */
 export type ProxyAnalysisFinalRequestRecord = {
+  timestamp: string;
   status: number;
   durationMs: number | null;
   account: string;
@@ -1533,6 +1630,17 @@ export type ProxyAnalysisFinalRequestRecord = {
   cacheCreationTokens: number | null;
   errorType: string | null;
   errorCode: string | null;
+  routingDecision: ProxyAccountRoutingDecision | null;
+};
+
+/** Validated account-routing evidence joined to a final request log. */
+export type ProxyAnalysisRoutingRecord = {
+  requestId: string;
+  timestamp: string;
+  responseStatus: number;
+  finalAccount: string;
+  finalAccountType: string;
+  decision: ProxyAccountRoutingDecision;
 };
 
 /** Request metadata retained by the HTTP adapter for terminal error logging. */

--- a/test/proxyAnalysis.test.ts
+++ b/test/proxyAnalysis.test.ts
@@ -33,6 +33,71 @@ describe("offline proxy log analysis", () => {
     const logDir = await mkdtemp(join(tmpdir(), "neurolink-analysis-"));
     tempDirs.push(logDir);
     const timestamp = "2026-07-18T11:00:00.000Z";
+    const routingDecision = {
+      schemaVersion: 1,
+      evaluatedAt: timestamp,
+      strategy: "fill-first",
+      mode: "quota",
+      selectionReason: "weekly_reset",
+      quotaRoutingEnabled: true,
+      quotaInputsUsed: true,
+      sessionSoftLimit: 0.97,
+      sessionResetToleranceMs: 900_000,
+      configuredPrimaryAccount: "anthropic:primary@example.com",
+      configuredPrimaryMatched: true,
+      rotationOffset: 0,
+      initialAccount: "primary@example.com",
+      candidates: [
+        {
+          account: "primary@example.com",
+          accountType: "oauth",
+          sourceIndex: 0,
+          rank: 0,
+          configuredPrimary: true,
+          usable: true,
+          saturated: false,
+          quotaObserved: true,
+          quotaLastUpdated: nowMs - 60_000,
+          quotaAgeMs: 60_000,
+          coolingActive: false,
+          coolingReason: null,
+          coolingUntil: null,
+          unifiedStatus: "allowed",
+          overageStatus: "allowed",
+          sessionStatus: "allowed",
+          sessionUsed: 0.2,
+          sessionResetAt: nowMs + 3_600_000,
+          sessionResetBucket: 1_970_700,
+          weeklyStatus: "allowed",
+          weeklyUsed: 0.7,
+          weeklyResetAt: nowMs + 86_400_000,
+        },
+        {
+          account: "fallback@example.com",
+          accountType: "oauth",
+          sourceIndex: 1,
+          rank: 1,
+          configuredPrimary: false,
+          usable: true,
+          saturated: false,
+          quotaObserved: true,
+          quotaLastUpdated: nowMs - 120_000,
+          quotaAgeMs: 120_000,
+          coolingActive: false,
+          coolingReason: null,
+          coolingUntil: null,
+          unifiedStatus: "allowed",
+          overageStatus: "allowed",
+          sessionStatus: "allowed",
+          sessionUsed: 0.1,
+          sessionResetAt: nowMs + 7_200_000,
+          sessionResetBucket: 1_970_704,
+          weeklyStatus: "allowed",
+          weeklyUsed: 0.1,
+          weeklyResetAt: nowMs + 172_800_000,
+        },
+      ],
+    };
 
     await writeJsonLines(logDir, "proxy-lifecycle-2026-07-18.jsonl", [
       {
@@ -129,6 +194,15 @@ describe("offline proxy log analysis", () => {
         inputTokens: 100,
         cacheReadTokens: 80,
         cacheCreationTokens: 5,
+        routingDecision: {
+          ...routingDecision,
+          unexpectedTopLevel: "discarded",
+          candidates: routingDecision.candidates.map((candidate, index) =>
+            index === 0
+              ? { ...candidate, unexpectedCandidateField: "discarded" }
+              : candidate,
+          ),
+        },
       },
       {
         timestamp,
@@ -138,6 +212,7 @@ describe("offline proxy log analysis", () => {
         accountType: "oauth",
         responseStatus: 429,
         responseTimeMs: 35,
+        routingDecision,
       },
       {
         timestamp,
@@ -149,6 +224,16 @@ describe("offline proxy log analysis", () => {
         responseTimeMs: 40,
         errorType: "transport_error",
         errorCode: "ETIMEDOUT",
+        routingDecision: { ...routingDecision, schemaVersion: 99 },
+      },
+      {
+        timestamp,
+        requestId: "request-4",
+        method: "POST",
+        account: "fallback@example.com",
+        accountType: "oauth",
+        responseStatus: 200,
+        responseTimeMs: 50,
       },
     ]);
 
@@ -162,6 +247,7 @@ describe("offline proxy log analysis", () => {
       malformedLines: 1,
       unsupportedLifecycleLines: 1,
       lifecycleSequenceGaps: 1,
+      routingDecisions: { valid: 2, invalid: 1, absent: 1 },
     });
     expect(report.coverage).toEqual({
       lifecycle: true,
@@ -169,6 +255,7 @@ describe("offline proxy log analysis", () => {
       attempts: true,
       attemptLatency: true,
       cacheUsage: true,
+      routingDecisions: true,
     });
     expect(report.lifecycle).toMatchObject({
       accepted: 2,
@@ -177,8 +264,8 @@ describe("offline proxy log analysis", () => {
       unsettled: 1,
     });
     expect(report.requests).toEqual({
-      completed: 3,
-      success: 1,
+      completed: 4,
+      success: 2,
       errors: 2,
       finalRateLimits: 1,
       recoveredAfterRetry: 1,
@@ -212,6 +299,28 @@ describe("offline proxy log analysis", () => {
       inputTokens: 100,
       requestHitRate: 1,
     });
+    expect(report.routing).toMatchObject({
+      modes: { quota: 2 },
+      selectionReasons: { weekly_reset: 2 },
+      initialAccounts: { "primary@example.com": 2 },
+      finalAccountChanges: 1,
+      finalOutsideCandidateSet: 0,
+    });
+    expect(report.routing.records).toHaveLength(2);
+    expect(report.routing.records[0]).toMatchObject({
+      requestId: "request-1",
+      timestamp,
+      responseStatus: 200,
+      finalAccount: "fallback@example.com",
+      finalAccountType: "oauth",
+      decision: routingDecision,
+    });
+    expect(report.routing.records[0]?.decision).not.toHaveProperty(
+      "unexpectedTopLevel",
+    );
+    expect(
+      report.routing.records[0]?.decision.candidates[0],
+    ).not.toHaveProperty("unexpectedCandidateField");
     expect(report.accounts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -354,6 +463,12 @@ describe("offline proxy log analysis", () => {
       attempts: false,
       attemptLatency: false,
       cacheUsage: false,
+      routingDecisions: false,
+    });
+    expect(report.dataQuality.routingDecisions).toEqual({
+      valid: 0,
+      invalid: 0,
+      absent: 0,
     });
     expect(report.requests.completed).toBe(0);
     expect(report.lifecycle.unsettled).toBe(0);

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -29,6 +29,10 @@ import {
   resolveProxyPaths,
   resolveProxyUsageStatsPath,
 } from "../src/lib/proxy/proxyPaths.js";
+import {
+  flushRequestLogs,
+  initRequestLogger,
+} from "../src/lib/proxy/requestLogger.js";
 import { createSSEInterceptor } from "../src/lib/proxy/sseInterceptor.js";
 import {
   clearRefreshStateForTests,
@@ -84,6 +88,8 @@ function createRecordingErrorFinalRequestLogger() {
 afterEach(async () => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  await flushRequestLogs().catch(() => undefined);
+  initRequestLogger(false);
   clearRefreshStateForTests();
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
@@ -141,6 +147,14 @@ describe("weekly-expiry quota routing", () => {
         15 * 60 * 1000,
       )
       .map((item) => item.label);
+  const decision = (labels: string[], now: number) =>
+    __testHooks.buildQuotaRoutingDecision(
+      labels.map(account),
+      now,
+      "anthropic:hello@neurolink.ink",
+      0.97,
+      15 * 60 * 1000,
+    );
 
   it("prioritizes the observed account whose weekly allowance expires first", () => {
     const now = Date.UTC(2026, 6, 17, 12, 52, 0);
@@ -178,6 +192,63 @@ describe("weekly-expiry quota routing", () => {
       "hello@neurolink.ink",
       "sachiny09@gmail.com",
     ]);
+
+    const routingDecision = decision(
+      ["hello@neurolink.ink", "sachiny09@gmail.com", "sachin.sharma@juspay.in"],
+      now,
+    );
+    expect(routingDecision).toMatchObject({
+      schemaVersion: 1,
+      evaluatedAt: "2026-07-17T12:52:00.000Z",
+      strategy: "fill-first",
+      mode: "quota",
+      selectionReason: "weekly_reset",
+      quotaRoutingEnabled: true,
+      quotaInputsUsed: true,
+      sessionSoftLimit: 0.97,
+      sessionResetToleranceMs: 900_000,
+      configuredPrimaryAccount: "anthropic:hello@neurolink.ink",
+      configuredPrimaryMatched: true,
+      rotationOffset: 0,
+      initialAccount: "sachin.sharma@juspay.in",
+      candidates: [
+        expect.objectContaining({
+          account: "sachin.sharma@juspay.in",
+          sourceIndex: 2,
+          rank: 0,
+          configuredPrimary: false,
+          usable: true,
+          saturated: false,
+          quotaObserved: true,
+          quotaLastUpdated: now,
+          quotaAgeMs: 0,
+          coolingActive: false,
+          coolingReason: null,
+          coolingUntil: null,
+          sessionStatus: "allowed",
+          sessionUsed: 0,
+          sessionResetAt: null,
+          sessionResetBucket: null,
+          weeklyStatus: "allowed",
+          weeklyUsed: 0.39,
+          weeklyResetAt: now + 12 * 60 * 60 * 1000,
+        }),
+        expect.objectContaining({
+          account: "hello@neurolink.ink",
+          sourceIndex: 0,
+          rank: 1,
+          configuredPrimary: true,
+        }),
+        expect.objectContaining({
+          account: "sachiny09@gmail.com",
+          sourceIndex: 1,
+          rank: 2,
+        }),
+      ],
+    });
+    expect(
+      Buffer.byteLength(JSON.stringify(routingDecision), "utf8"),
+    ).toBeLessThan(4096);
   });
 
   it("temporarily demotes an urgent weekly account at the session soft limit", () => {
@@ -201,8 +272,127 @@ describe("weekly-expiry quota routing", () => {
       "urgent@example.com",
     ]);
     expect(
+      decision(["urgent@example.com", "later@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "later@example.com",
+      selectionReason: "session_headroom",
+    });
+    expect(
       order(["urgent@example.com", "later@example.com"], now + 31 * 60 * 1000),
     ).toEqual(["urgent@example.com", "later@example.com"]);
+  });
+
+  it("probes an account with no quota snapshot before observed accounts", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    setQuota("observed@example.com", now, {
+      weeklyUsed: 0.1,
+      weeklyResetAt: Math.floor(now / 1000) + 60 * 60,
+    });
+
+    expect(
+      decision(["observed@example.com", "unknown@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "unknown@example.com",
+      selectionReason: "quota_probe",
+      candidates: [
+        expect.objectContaining({
+          account: "unknown@example.com",
+          quotaObserved: false,
+          quotaLastUpdated: null,
+          quotaAgeMs: null,
+        }),
+        expect.objectContaining({
+          account: "observed@example.com",
+          quotaObserved: true,
+        }),
+      ],
+    });
+  });
+
+  it("reports the exact comparator factor that selected the first account", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    const nowSec = Math.floor(now / 1000);
+    __testHooks.setAccountRuntimeState("anthropic:cooling@example.com", {
+      coolingUntil: now + 60_000,
+      coolingReason: "transient",
+    });
+    expect(
+      decision(["cooling@example.com", "available@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "available@example.com",
+      selectionReason: "availability",
+    });
+
+    __testHooks.setAccountRuntimeState("anthropic:early@example.com", {
+      coolingUntil: now + 30_000,
+      coolingReason: "transient",
+    });
+    __testHooks.setAccountRuntimeState("anthropic:late@example.com", {
+      coolingUntil: now + 90_000,
+      coolingReason: "transient",
+    });
+    expect(
+      decision(["late@example.com", "early@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "early@example.com",
+      selectionReason: "cooldown_recovery",
+    });
+
+    setQuota("high-usage@example.com", now, {
+      sessionUsed: 0.4,
+      sessionResetAt: nowSec + 60 * 60,
+      weeklyUsed: 0.8,
+      weeklyResetAt: nowSec + 24 * 60 * 60,
+    });
+    setQuota("low-usage@example.com", now, {
+      sessionUsed: 0.2,
+      sessionResetAt: nowSec + 60 * 60,
+      weeklyUsed: 0.2,
+      weeklyResetAt: nowSec + 24 * 60 * 60,
+    });
+    expect(
+      decision(["low-usage@example.com", "high-usage@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "high-usage@example.com",
+      selectionReason: "weekly_utilization",
+    });
+
+    expect(
+      decision(["other@example.com", "hello@neurolink.ink"], now),
+    ).toMatchObject({
+      initialAccount: "hello@neurolink.ink",
+      selectionReason: "configured_primary",
+    });
+  });
+
+  it("keeps unknown weekly usage out of evidence without changing its sort sentinel", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    const nowSec = Math.floor(now / 1000);
+    setQuota("unknown-usage@example.com", now, {
+      weeklyUsed: undefined,
+      weeklyResetAt: nowSec + 24 * 60 * 60,
+    });
+    setQuota("known-usage@example.com", now, {
+      weeklyUsed: 0.2,
+      weeklyResetAt: nowSec + 24 * 60 * 60,
+    });
+
+    expect(
+      decision(["unknown-usage@example.com", "known-usage@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "known-usage@example.com",
+      selectionReason: "weekly_utilization",
+      candidates: [
+        expect.objectContaining({
+          account: "known-usage@example.com",
+          weeklyUsed: 0.2,
+        }),
+        expect.objectContaining({
+          account: "unknown-usage@example.com",
+          weeklyUsed: null,
+        }),
+      ],
+    });
   });
 
   it("freshens an expired weekly window instead of routing on stale urgency", () => {
@@ -229,6 +419,7 @@ describe("weekly-expiry quota routing", () => {
     tempDirs.push(dir);
     initAccountCooldown(join(dir, "cooldowns.json"));
     initAccountQuota(join(dir, "quotas.json"));
+    initRequestLogger(true, dir);
 
     const accountKeys = [
       "anthropic:first@example.com",
@@ -325,6 +516,68 @@ describe("weekly-expiry quota routing", () => {
       "Bearer old-account-token",
       "Bearer first-account-token",
     ]);
+    await flushRequestLogs();
+    const requestLogName = (await readdir(dir)).find((name) =>
+      /^proxy-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name),
+    );
+    expect(requestLogName).toBeDefined();
+    const requestLogText = await readFile(join(dir, requestLogName!), "utf8");
+    const requestLogs = requestLogText
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(requestLogText).not.toContain("old-account-token");
+    expect(requestLogs).toHaveLength(2);
+    expect(requestLogs[0]).toMatchObject({
+      requestId: "configured-primary",
+      account: "old@example.com",
+      routingDecision: {
+        schemaVersion: 1,
+        strategy: "fill-first",
+        mode: "single_account",
+        selectionReason: "single_account",
+        quotaRoutingEnabled: false,
+        quotaInputsUsed: false,
+        configuredPrimaryAccount: "anthropic:old@example.com",
+        configuredPrimaryMatched: true,
+        rotationOffset: 0,
+        initialAccount: "old@example.com",
+        candidates: [
+          expect.objectContaining({
+            account: "old@example.com",
+            quotaObserved: false,
+            sessionStatus: null,
+            weeklyStatus: null,
+          }),
+        ],
+      },
+    });
+    expect(requestLogs[1]).toMatchObject({
+      requestId: "cleared-primary",
+      account: "first@example.com",
+      routingDecision: {
+        schemaVersion: 1,
+        strategy: "fill-first",
+        mode: "primary",
+        selectionReason: "insertion_order",
+        configuredPrimaryAccount: null,
+        configuredPrimaryMatched: false,
+        rotationOffset: 0,
+        initialAccount: "first@example.com",
+        candidates: [
+          expect.objectContaining({
+            account: "first@example.com",
+            sourceIndex: 0,
+            rank: 0,
+          }),
+          expect.objectContaining({
+            account: "old@example.com",
+            sourceIndex: 1,
+            rank: 1,
+          }),
+        ],
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Persist a versioned, secret-free account-routing decision on every routed Claude proxy final request so operators can explain the initial account order from exact request-time inputs instead of inferring it from aggregate usage.

## Changes Made

- Precompute quota/cooldown metrics once per eligible account and use the same immutable snapshot for sorting and evidence.
- Record strategy, mode, selection reason, configured-primary match, rotation offset, quota-routing controls, freshness, and ranked 5h/7d/cooldown inputs in compact request JSONL.
- Keep attempt logs authoritative for accounts actually tried; join the initial decision to the final serving account during offline analysis.
- Validate schema-v1 evidence in `proxy analyze`, count invalid/legacy records, and expose routing summaries plus exact records in JSON output.
- Emit only compact routing summary attributes to OTLP; full candidate evidence remains local.

## Compatibility and Safety

- No routing priority or fallback behavior is intentionally changed.
- Legacy request logs remain analyzable and are reported as routing evidence `absent`.
- No dependency, config, environment-variable, or deployment change.
- No request/response bodies, tokens, or credentials are added to routing evidence.

## Testing

- [x] 219 hermetic proxy tests pass across all nine `test/proxy*.test.ts` files.
- [x] Exact order/reason coverage for availability, cooldown recovery, quota probe, session headroom, weekly reset, weekly utilization, and configured primary.
- [x] Final request JSONL persistence, legacy/malformed analyzer compatibility, retry final-account change, and record-size coverage.
- [x] `pnpm typecheck`
- [x] `pnpm run check`
- [x] `pnpm run lint` (zero errors; baseline warnings only)
- [x] `pnpm run validate:all`
- [x] `pnpm run build` and `publint`
- [x] Full pre-commit and commit-message hooks

## Performance

Three-account decision plus JSON serialization: 3.937 microseconds/iteration over 50,000 iterations; serialized evidence is 1,922 bytes. Comparator-side quota recomputation is removed.

## Commit Policy

- [x] Rebases cleanly on current `origin/release` (v10.6.1 at creation)
- [x] Exactly one commit
- [x] No changeset or standalone analysis document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added routing-decision telemetry to proxy request logs (mode, strategy, reason, initial/final account change, candidates).
  * Enhanced offline proxy log analysis with a routing summary (mode/reason distributions, account-change metrics) and new coverage/data-quality counters for valid/invalid/absent decisions, including legacy/no-log messaging.
* **Bug Fixes**
  * Added stricter routing-decision validation/sanitization to ensure only well-formed routing evidence is reported.
  * Ensured routing decision logging is derived consistently, with legacy scenarios handled gracefully.
* **Tests**
  * Expanded offline analysis and quota-routing reliability tests to cover valid, invalid, and malformed routing decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->