### PR TITLE
fix(types): make duplicate type names unique

### DIFF
--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -744,17 +744,17 @@ export type CLIMCPServerConfig = {
  * OpenAI setup configuration types
  */
 export namespace OpenAISetup {
-  export type SetupOptions = {
+  export type OpenAISetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type OpenAISetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
 
-  export type Config = {
+  export type OpenAISetupConfig = {
     apiKey?: string;
     organization?: string;
     model?: string;
@@ -766,17 +766,17 @@ export namespace OpenAISetup {
  * Anthropic setup configuration types
  */
 export namespace AnthropicSetup {
-  export type SetupOptions = {
+  export type AnthropicSetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type AnthropicSetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
 
-  export type Config = {
+  export type AnthropicSetupConfig = {
     apiKey?: string;
     model?: string;
     isReconfiguring?: boolean;
@@ -787,17 +787,17 @@ export namespace AnthropicSetup {
  * Google AI setup configuration types
  */
 export namespace GoogleAISetup {
-  export type SetupOptions = {
+  export type GoogleAISetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type GoogleAISetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
 
-  export type Config = {
+  export type GoogleAISetupConfig = {
     apiKey?: string;
     model?: string;
     isReconfiguring?: boolean;
@@ -808,17 +808,17 @@ export namespace GoogleAISetup {
  * Azure setup configuration types
  */
 export namespace AzureSetup {
-  export type SetupOptions = {
+  export type AzureSetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type AzureSetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
 
-  export type Config = {
+  export type AzureSetupConfig = {
     apiKey?: string;
     endpoint?: string;
     deploymentName?: string;
@@ -832,12 +832,12 @@ export namespace AzureSetup {
  * AWS Bedrock setup configuration types
  */
 export namespace BedrockSetup {
-  export type SetupOptions = {
+  export type BedrockSetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type BedrockSetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
@@ -861,12 +861,12 @@ export namespace BedrockSetup {
  * GCP/Vertex AI setup configuration types
  */
 export namespace GCPSetup {
-  export type SetupOptions = {
+  export type GCPSetupOptions = {
     checkOnly?: boolean;
     interactive?: boolean;
   };
 
-  export type SetupArgv = {
+  export type GCPSetupArgv = {
     check?: boolean;
     nonInteractive?: boolean;
   };
@@ -883,7 +883,7 @@ export namespace GCPSetup {
  * Hugging Face setup configuration types
  */
 export namespace HuggingFaceSetup {
-  export type SetupArgs = {
+  export type HuggingFaceSetupArgs = {
     check?: boolean;
     nonInteractive?: boolean;
     help?: boolean;
@@ -894,7 +894,7 @@ export namespace HuggingFaceSetup {
  * Mistral setup configuration types
  */
 export namespace MistralSetup {
-  export type SetupArgs = {
+  export type MistralSetupArgs = {
     check?: boolean;
     nonInteractive?: boolean;
     help?: boolean;

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -1721,7 +1721,7 @@ export type ProviderHealthCheckOptions = {
  */
 export namespace BedrockTypes {
   // Based on AWS SDK Bedrock types
-  export type Client = {
+  export type BedrockClient = {
     send(command: unknown): Promise<unknown>;
     config: {
       region?: string;
@@ -1744,7 +1744,7 @@ export namespace BedrockTypes {
  */
 export namespace MistralTypes {
   // Based on Mistral SDK types
-  export type Client = {
+  export type MistralClient = {
     chat?: {
       complete?: (options: unknown) => Promise<unknown>;
       stream?: (options: unknown) => AsyncIterable<unknown>;


### PR DESCRIPTION
## Summary

This PR resolves **#1171** by fixing the `unique-type-names` Pattern Analysis violations caused by duplicate exported type names in the type definitions.

#1171 

The reported issue stemmed from generic type names such as `SetupOptions`, `SetupArgv`, `Config`, `SetupArgs`, and `Client` being declared across multiple provider-specific namespaces. Since these types are re-exported through the shared barrel exports, the duplicate names resulted in global naming collisions and triggered the repository's `unique-type-names` safeguard.

## Changes Made

* Renamed duplicate provider-specific type aliases to globally unique, descriptive names.
* Replaced generic type names with provider-scoped alternatives (e.g., `OpenAISetupOptions`, `AnthropicSetupOptions`, `GoogleAISetupArgv`, `BedrockClient`, and `MistralClient`).
* Preserved the existing functionality and type behavior while improving naming consistency and readability.
* Limited the changes to the affected type definition files to keep the diff focused and minimize the impact on the codebase.

## Expected Outcome

* Eliminates all duplicate exported type names reported in Issue **#1171**.
* Resolves the `unique-type-names` Pattern Analysis findings.
* Prevents naming collisions introduced by barrel exports.
* Improves the clarity and maintainability of provider-specific type definitions.
* Introduces no runtime behavior changes, as the modifications are limited to type declarations.

## Validation

* Verified that the duplicate type declarations reported by the issue have been removed.
* Confirmed that no stale references remain within the repository after the renaming.
* Ensured the branch is rebased on the latest `release` branch and contains a single commit in accordance with the repository's contribution guidelines.

### Expected Output

Before:

```text
unique-type-names: Duplicate type name 'SetupArgs'
unique-type-names: Duplicate type name 'SetupOptions'
unique-type-names: Duplicate type name 'SetupArgv'
unique-type-names: Duplicate type name 'Config'
unique-type-names: Duplicate type name 'Client'
```

After:

```text
✔ No duplicate exported type names detected.
✔ unique-type-names Pattern Analysis passes.
```

Closes #1171.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved provider-specific type naming across supported CLI setup and client integrations.
  * Replaced ambiguous generic type names with clearer, provider-qualified names for better consistency and discoverability.
  * Underlying type structures and configuration fields remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->