### PR TITLE
Fix/litellm pdf config

### DIFF
--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -101,14 +101,14 @@ const PDF_PROVIDER_CONFIGS: Record<string, PDFProviderConfig> = {
   litellm: {
     maxSizeMB: 10,
     maxPages: 100,
-    supportsNative: true,
+    supportsNative: false, // LiteLLM is a proxy — underlying model may not support native PDF; default to safe text extraction
     requiresCitations: false,
     apiType: "files-api",
   },
   "openai-compatible": {
     maxSizeMB: 10,
     maxPages: 100,
-    supportsNative: false, // LiteLLM is a proxy — underlying model may not support native PDF; default to safe text extraction
+    supportsNative: false,
     requiresCitations: false,
     apiType: "files-api",
   },


### PR DESCRIPTION
**Pull Request**
## Description

Fix swapped `supportsNative` config for LiteLLM in PDF processor. LiteLLM is a proxy — it should default to safe text extraction (`false`), not native PDF support (`true`). The comment explaining this was also on the wrong provider.

## Related Issues

Fixes #1009

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `litellm.supportsNative` from `true` to `false`
- Moved the proxy explanation comment from `openai-compatible` to `litellm`

## Testing

- [x] Build passes (`npm run build`)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing compatibility for the LiteLLM provider by routing PDFs through image conversion when native PDF support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->