### PR TITLE
fix(proxy): make routing evidence non-fatal and bounded

### DIFF
--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -71,7 +71,7 @@ function printAnalysis(
   logger.always(chalk.bold("  Account Routing"));
   if (report.coverage.routingDecisions) {
     logger.always(
-      `    Decisions: ${report.routing.records.length}, modes: ${JSON.stringify(report.routing.modes)}`,
+      `    Decisions: ${report.routing.totalRecords} (${report.routing.records.length} retained), modes: ${JSON.stringify(report.routing.modes)}`,
     );
     logger.always(
       `    Selection reasons: ${JSON.stringify(report.routing.selectionReasons)}`,

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -39,6 +39,8 @@ const ROUTING_MODES = new Set<string>(PROXY_ACCOUNT_ROUTING_MODES);
 const ROUTING_REASONS = new Set<string>(PROXY_ACCOUNT_ROUTING_REASONS);
 const ROUTING_ACCOUNT_TYPES = new Set<string>(PROXY_ACCOUNT_TYPES);
 const COOLING_REASONS = new Set<string>(ACCOUNT_COOLING_REASONS);
+const MAX_RETAINED_ROUTING_RECORDS = 200;
+const MAX_ROUTING_RECORDS_BEFORE_COMPACTION = MAX_RETAINED_ROUTING_RECORDS * 2;
 
 function isContainedPath(root: string, candidate: string): boolean {
   const candidateRelative = relative(root, candidate);
@@ -429,7 +431,12 @@ function summarizeRouting(
   const modes: Record<string, number> = {};
   const selectionReasons: Record<string, number> = {};
   const initialAccounts: Record<string, number> = {};
-  const records: ProxyAnalysisRoutingRecord[] = [];
+  const retainedRecords: Array<{
+    record: ProxyAnalysisRoutingRecord;
+    timestampMs: number;
+    sequence: number;
+  }> = [];
+  let totalRecords = 0;
   let finalAccountChanges = 0;
   let finalOutsideCandidateSet = 0;
 
@@ -451,15 +458,39 @@ function summarizeRouting(
     } else if (decision.initialAccount !== request.account) {
       finalAccountChanges += 1;
     }
-    records.push({
-      requestId,
-      timestamp: request.timestamp,
-      responseStatus: request.status,
-      finalAccount: request.account,
-      finalAccountType: request.accountType,
-      decision,
+    totalRecords += 1;
+    retainedRecords.push({
+      record: {
+        requestId,
+        timestamp: request.timestamp,
+        responseStatus: request.status,
+        finalAccount: request.account,
+        finalAccountType: request.accountType,
+        decision,
+      },
+      timestampMs: Date.parse(request.timestamp),
+      sequence: totalRecords,
     });
+    if (retainedRecords.length > MAX_ROUTING_RECORDS_BEFORE_COMPACTION) {
+      retainedRecords.sort(
+        (left, right) =>
+          left.timestampMs - right.timestampMs ||
+          left.sequence - right.sequence,
+      );
+      retainedRecords.splice(
+        0,
+        retainedRecords.length - MAX_RETAINED_ROUTING_RECORDS,
+      );
+    }
   }
+
+  retainedRecords.sort(
+    (left, right) =>
+      left.timestampMs - right.timestampMs || left.sequence - right.sequence,
+  );
+  const records = retainedRecords
+    .slice(-MAX_RETAINED_ROUTING_RECORDS)
+    .map(({ record }) => record);
 
   return {
     modes,
@@ -467,6 +498,7 @@ function summarizeRouting(
     initialAccounts,
     finalAccountChanges,
     finalOutsideCandidateSet,
+    totalRecords,
     records,
   };
 }
@@ -858,7 +890,7 @@ export async function analyzeProxyLogs(
       attempts: totalAttempts > 0,
       attemptLatency: attemptLatency.length > 0,
       cacheUsage: finalSummary.cache.requestsWithUsage > 0,
-      routingDecisions: routingSummary.records.length > 0,
+      routingDecisions: routingSummary.totalRecords > 0,
     },
     dataQuality: {
       linesRead,

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -819,7 +819,7 @@ function buildRoutingDecision(args: {
   sessionSoftLimit: number;
   sessionResetToleranceMs: number;
   rotationOffset: number;
-}): ProxyAccountRoutingDecision {
+}): ProxyAccountRoutingDecision | undefined {
   const {
     accounts,
     orderedAccounts,
@@ -838,49 +838,49 @@ function buildRoutingDecision(args: {
   );
   const configuredPrimaryMatched =
     !!primaryKey && accounts.some((account) => account.key === primaryKey);
-  const candidates: ProxyAccountRoutingCandidate[] = orderedAccounts.map(
-    (account, rank) => {
-      const metrics = metricsByKey.get(account.key);
-      if (!metrics) {
-        throw new Error(
-          `Missing precomputed routing metrics for account ${account.label}`,
-        );
-      }
-      return {
-        account: account.label,
-        accountType: account.type,
-        sourceIndex: sourceIndexes.get(account.key) ?? rank,
-        rank,
-        configuredPrimary: !!primaryKey && account.key === primaryKey,
-        usable: metrics.usable,
-        saturated: metrics.saturated,
-        quotaObserved: metrics.hasQuota,
-        quotaLastUpdated: metrics.quotaLastUpdated,
-        quotaAgeMs: metrics.quotaAgeMs,
-        coolingActive: metrics.coolingActive,
-        coolingReason: metrics.coolingReason,
-        coolingUntil:
-          metrics.coolingUntil > 0 && Number.isFinite(metrics.coolingUntil)
-            ? metrics.coolingUntil
-            : null,
-        unifiedStatus: metrics.unifiedStatus,
-        overageStatus: metrics.overageStatus,
-        sessionStatus: metrics.sessionStatus,
-        sessionUsed: metrics.sessionUsed,
-        sessionResetAt: Number.isFinite(metrics.sessionReset)
-          ? metrics.sessionReset
+  const candidates: ProxyAccountRoutingCandidate[] = [];
+  for (const account of orderedAccounts) {
+    const metrics = metricsByKey.get(account.key);
+    if (!metrics) {
+      logger.warn(
+        `[proxy] routing evidence omitted because metrics are missing for account=${account.label}`,
+      );
+      return undefined;
+    }
+    candidates.push({
+      account: account.label,
+      accountType: account.type,
+      sourceIndex: sourceIndexes.get(account.key) ?? candidates.length,
+      rank: candidates.length,
+      configuredPrimary: !!primaryKey && account.key === primaryKey,
+      usable: metrics.usable,
+      saturated: metrics.saturated,
+      quotaObserved: metrics.hasQuota,
+      quotaLastUpdated: metrics.quotaLastUpdated,
+      quotaAgeMs: metrics.quotaAgeMs,
+      coolingActive: metrics.coolingActive,
+      coolingReason: metrics.coolingReason,
+      coolingUntil:
+        metrics.coolingUntil > 0 && Number.isFinite(metrics.coolingUntil)
+          ? metrics.coolingUntil
           : null,
-        sessionResetBucket: Number.isFinite(metrics.sessionResetBucket)
-          ? metrics.sessionResetBucket
-          : null,
-        weeklyStatus: metrics.weeklyStatus,
-        weeklyUsed: metrics.weeklyUsed,
-        weeklyResetAt: Number.isFinite(metrics.weeklyReset)
-          ? metrics.weeklyReset
-          : null,
-      };
-    },
-  );
+      unifiedStatus: metrics.unifiedStatus,
+      overageStatus: metrics.overageStatus,
+      sessionStatus: metrics.sessionStatus,
+      sessionUsed: metrics.sessionUsed,
+      sessionResetAt: Number.isFinite(metrics.sessionReset)
+        ? metrics.sessionReset
+        : null,
+      sessionResetBucket: Number.isFinite(metrics.sessionResetBucket)
+        ? metrics.sessionResetBucket
+        : null,
+      weeklyStatus: metrics.weeklyStatus,
+      weeklyUsed: metrics.weeklyUsed,
+      weeklyResetAt: Number.isFinite(metrics.weeklyReset)
+        ? metrics.weeklyReset
+        : null,
+    });
+  }
   const initialAccount = orderedAccounts[0];
   let mode: ProxyAccountRoutingDecision["mode"];
   let selectionReason: ProxyAccountRoutingReason;
@@ -1007,21 +1007,22 @@ function selectClaudeProxyAccountOrder(args: {
     );
   }
 
-  setRoutingDecision(
-    buildRoutingDecision({
-      accounts: enabledAccounts,
-      orderedAccounts,
-      metricsByKey,
-      evaluatedAt,
-      strategy: accountStrategy,
-      primaryKey: primaryAccountKey,
-      quotaRoutingEnabled,
-      quotaOrdered,
-      sessionSoftLimit,
-      sessionResetToleranceMs,
-      rotationOffset,
-    }),
-  );
+  const routingDecision = buildRoutingDecision({
+    accounts: enabledAccounts,
+    orderedAccounts,
+    metricsByKey,
+    evaluatedAt,
+    strategy: accountStrategy,
+    primaryKey: primaryAccountKey,
+    quotaRoutingEnabled,
+    quotaOrdered,
+    sessionSoftLimit,
+    sessionResetToleranceMs,
+    rotationOffset,
+  });
+  if (routingDecision) {
+    setRoutingDecision(routingDecision);
+  }
   return orderedAccounts;
 }
 
@@ -7069,7 +7070,7 @@ export const __testHooks = {
     primaryKey: string | undefined,
     sessionSoftLimit: number = getSessionSoftLimit(),
     sessionResetToleranceMs: number = getSessionResetToleranceMs(),
-  ): ProxyAccountRoutingDecision => {
+  ): ProxyAccountRoutingDecision | undefined => {
     const order = orderAccountsByQuotaWithMetrics(
       accounts,
       now,
@@ -7091,6 +7092,7 @@ export const __testHooks = {
       rotationOffset: 0,
     });
   },
+  buildRoutingDecision,
   resetEpochToMs,
   seedRuntimeQuotasFromDisk,
   reconcileEligibleAccountRuntimeState,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1598,6 +1598,9 @@ export type ProxyAnalysisReport = {
     initialAccounts: Record<string, number>;
     finalAccountChanges: number;
     finalOutsideCandidateSet: number;
+    /** Number of routing decisions aggregated before sampling records. */
+    totalRecords: number;
+    /** Most recent bounded sample retained for offline inspection. */
     records: ProxyAnalysisRoutingRecord[];
   };
   accounts: ProxyAnalysisAccount[];

--- a/test/proxyAnalysis.test.ts
+++ b/test/proxyAnalysis.test.ts
@@ -208,7 +208,7 @@ describe("offline proxy log analysis", () => {
         timestamp,
         requestId: "request-2",
         method: "POST",
-        account: "primary@example.com",
+        account: "outside@example.com",
         accountType: "oauth",
         responseStatus: 429,
         responseTimeMs: 35,
@@ -304,7 +304,8 @@ describe("offline proxy log analysis", () => {
       selectionReasons: { weekly_reset: 2 },
       initialAccounts: { "primary@example.com": 2 },
       finalAccountChanges: 1,
-      finalOutsideCandidateSet: 0,
+      finalOutsideCandidateSet: 1,
+      totalRecords: 2,
     });
     expect(report.routing.records).toHaveLength(2);
     expect(report.routing.records[0]).toMatchObject({
@@ -336,6 +337,98 @@ describe("offline proxy log analysis", () => {
         }),
       ]),
     );
+  });
+
+  it("bounds retained routing records while preserving aggregate counts", async () => {
+    const logDir = await mkdtemp(join(tmpdir(), "neurolink-routing-analysis-"));
+    tempDirs.push(logDir);
+    const timestamp = "2026-07-18T11:00:00.000Z";
+    const routingDecision = {
+      schemaVersion: 1,
+      evaluatedAt: timestamp,
+      strategy: "fill-first",
+      mode: "primary",
+      selectionReason: "configured_primary",
+      quotaRoutingEnabled: false,
+      quotaInputsUsed: false,
+      sessionSoftLimit: 0.97,
+      sessionResetToleranceMs: 900_000,
+      configuredPrimaryAccount: "anthropic:primary@example.com",
+      configuredPrimaryMatched: true,
+      rotationOffset: 0,
+      initialAccount: "primary@example.com",
+      candidates: [
+        {
+          account: "primary@example.com",
+          accountType: "oauth",
+          sourceIndex: 0,
+          rank: 0,
+          configuredPrimary: true,
+          usable: true,
+          saturated: false,
+          quotaObserved: false,
+          quotaLastUpdated: null,
+          quotaAgeMs: null,
+          coolingActive: false,
+          coolingReason: null,
+          coolingUntil: null,
+          unifiedStatus: null,
+          overageStatus: null,
+          sessionStatus: null,
+          sessionUsed: null,
+          sessionResetAt: null,
+          sessionResetBucket: null,
+          weeklyStatus: null,
+          weeklyUsed: null,
+          weeklyResetAt: null,
+        },
+      ],
+    };
+    await writeJsonLines(logDir, "proxy-2026-07-18.jsonl", [
+      ...Array.from({ length: 205 }, (_, index) => ({
+        timestamp: new Date(
+          Date.parse(timestamp) + index * 1_000,
+        ).toISOString(),
+        requestId: `request-${index + 1}`,
+        method: "POST",
+        account: "primary@example.com",
+        accountType: "oauth",
+        responseStatus: 200,
+        responseTimeMs: 1,
+        routingDecision,
+      })),
+      {
+        timestamp: "2026-07-18T11:10:00.000Z",
+        requestId: "request-1",
+        method: "POST",
+        account: "primary@example.com",
+        accountType: "oauth",
+        responseStatus: 200,
+        responseTimeMs: 1,
+        routingDecision,
+      },
+    ]);
+
+    const report = await analyzeProxyLogs({
+      logsDir: logDir,
+      since: "2h",
+      nowMs,
+    });
+
+    expect(report.dataQuality.routingDecisions).toEqual({
+      valid: 206,
+      invalid: 0,
+      absent: 0,
+    });
+    expect(report.routing).toMatchObject({
+      totalRecords: 205,
+      initialAccounts: { "primary@example.com": 205 },
+      finalAccountChanges: 0,
+      finalOutsideCandidateSet: 0,
+    });
+    expect(report.routing.records).toHaveLength(200);
+    expect(report.routing.records[0]?.requestId).toBe("request-7");
+    expect(report.routing.records.at(-1)?.requestId).toBe("request-1");
   });
 
   it("rejects ambiguous time windows instead of silently using all data", async () => {

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -251,6 +251,25 @@ describe("weekly-expiry quota routing", () => {
     ).toBeLessThan(4096);
   });
 
+  it("omits routing evidence instead of throwing when its metrics snapshot is incomplete", () => {
+    const primary = account("primary@example.com");
+    expect(
+      __testHooks.buildRoutingDecision({
+        accounts: [primary],
+        orderedAccounts: [primary],
+        metricsByKey: new Map(),
+        evaluatedAt: Date.UTC(2026, 6, 17, 12, 0, 0),
+        strategy: "fill-first",
+        primaryKey: primary.key,
+        quotaRoutingEnabled: true,
+        quotaOrdered: false,
+        sessionSoftLimit: 0.97,
+        sessionResetToleranceMs: 900_000,
+        rotationOffset: 0,
+      }),
+    ).toBeUndefined();
+  });
+
   it("temporarily demotes an urgent weekly account at the session soft limit", () => {
     const now = Date.UTC(2026, 6, 17, 12, 0, 0);
     const nowSec = Math.floor(now / 1000);


### PR DESCRIPTION
## Summary
- Never throw from routing-evidence generation when a future ordering path lacks a metrics snapshot; omit only the optional evidence.
- Bound offline routing-record retention to the most recent 200 records while retaining exact aggregate totals.
- Cover final-account-outside-candidate accounting and bounded analysis output.

## Validation
- `pnpm exec vitest run test/proxyAnalysis.test.ts test/proxyReliabilityHardening.test.ts test/proxyConfigHotReload.test.ts test/proxyRollingWorkerHandoff.test.ts test/proxyUpdaterFallback.test.ts` (155 passed)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- `pnpm run check`
- Repository pre-commit hook completed before commit.

## Scope
This is proxy-only and introduces no live-service action. It fixes the remaining review debt from #1237 without changing account-selection behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Routing analysis now retains the 200 most recent decision records while preserving accurate totals across all processed decisions.
  * Account routing reports clearly distinguish overall decision counts from the retained records available for inspection.
  * Routing coverage remains accurate even when the retained record sample is capped.
  * Account routing now handles incomplete metrics gracefully without interrupting proxy processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->