### PR TITLE
fix(proxy): snapshot live log analysis

### DIFF
--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -20,6 +20,7 @@ function printAnalysis(
   logger.always(chalk.bold.cyan("NeuroLink Proxy Analysis"));
   logger.always(chalk.gray("=".repeat(50)));
   logger.always(`  Since:       ${chalk.cyan(report.since)}`);
+  logger.always(`  Until:       ${chalk.cyan(report.until)}`);
   logger.always(`  Logs:        ${chalk.cyan(report.logsDir)}`);
   logger.always(
     `  Files:       ${report.files.requests} request, ${report.files.attempts} attempt, ${report.files.lifecycle} lifecycle, ${report.files.debug} debug`,
@@ -184,6 +185,11 @@ export const proxyAnalyzeCommand: CommandModule<object, ProxyAnalyzeArgs> = {
         default: "24h",
         description: "ISO timestamp or lookback such as 6h, 1d, or 1w",
       })
+      .option("until", {
+        type: "string",
+        description:
+          "ISO timestamp or lookback such as 6h, 1d, or 1w; defaults to analysis start time",
+      })
       .option("format", {
         type: "string",
         choices: ["text", "json"] as const,
@@ -205,6 +211,7 @@ export const proxyAnalyzeCommand: CommandModule<object, ProxyAnalyzeArgs> = {
       const report = await analyzeProxyLogs({
         logsDir: argv.logsDir,
         since: argv.since,
+        until: argv.until,
       });
       if (argv.format === "json") {
         logger.always(JSON.stringify(report, null, 2));

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -271,6 +271,23 @@ function parseSince(value: string, nowMs: number): number {
   return parsed;
 }
 
+function parseUntil(value: string, nowMs: number): number {
+  let parsed: number;
+  try {
+    parsed = parseSince(value, nowMs);
+  } catch {
+    throw new Error(
+      `Invalid --until value "${value}". Use an ISO timestamp or a duration such as 6h, 1d, or 1w.`,
+    );
+  }
+  if (parsed > nowMs) {
+    throw new Error(
+      `Invalid --until value "${value}". It must not be later than the analysis start time.`,
+    );
+  }
+  return parsed;
+}
+
 async function readJsonLines(
   filePath: string,
   onRecord: (record: Record<string, unknown>) => void,
@@ -530,6 +547,12 @@ export async function analyzeProxyLogs(
 ): Promise<ProxyAnalysisReport> {
   const nowMs = options?.nowMs ?? Date.now();
   const sinceMs = parseSince(options?.since ?? "24h", nowMs);
+  const untilMs = options?.until ? parseUntil(options.until, nowMs) : nowMs;
+  if (untilMs < sinceMs) {
+    throw new Error(
+      `Invalid analysis window: --until must not be earlier than --since.`,
+    );
+  }
   const logsDir = resolve(
     options?.logsDir ?? join(homedir(), ".neurolink", "logs"),
   );
@@ -580,7 +603,7 @@ export async function analyzeProxyLogs(
       filePath,
       (record) => {
         const timestamp = observeTimestamp("lifecycle", record);
-        if (timestamp === null || timestamp < sinceMs) {
+        if (timestamp === null || timestamp < sinceMs || timestamp > untilMs) {
           return;
         }
         const event = stringValue(record.event);
@@ -670,7 +693,7 @@ export async function analyzeProxyLogs(
       filePath,
       (record) => {
         const timestamp = observeTimestamp("attempts", record);
-        if (timestamp === null || timestamp < sinceMs) {
+        if (timestamp === null || timestamp < sinceMs || timestamp > untilMs) {
           return;
         }
         const requestId = stringValue(record.requestId);
@@ -741,7 +764,7 @@ export async function analyzeProxyLogs(
       filePath,
       (record) => {
         const timestamp = observeTimestamp("requests", record);
-        if (timestamp === null || timestamp < sinceMs) {
+        if (timestamp === null || timestamp < sinceMs || timestamp > untilMs) {
           return;
         }
         const requestId = stringValue(record.requestId);
@@ -801,7 +824,7 @@ export async function analyzeProxyLogs(
       filePath,
       (record) => {
         const timestamp = observeTimestamp("debug", record);
-        if (timestamp === null || timestamp < sinceMs) {
+        if (timestamp === null || timestamp < sinceMs || timestamp > untilMs) {
           return;
         }
         if (record.type !== "body_capture") {
@@ -876,6 +899,7 @@ export async function analyzeProxyLogs(
   return {
     generatedAt: new Date(nowMs).toISOString(),
     since: new Date(sinceMs).toISOString(),
+    until: new Date(untilMs).toISOString(),
     logsDir,
     files: {
       lifecycle: lifecycleFiles.length,

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -929,6 +929,7 @@ export type ProxyStatusArgs = {
 export type ProxyAnalyzeArgs = {
   logsDir?: string;
   since?: string;
+  until?: string;
   format?: "text" | "json";
   quiet?: boolean;
 };

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1501,6 +1501,7 @@ export type ProxyAnalysisStreamName =
 export type ProxyAnalysisReport = {
   generatedAt: string;
   since: string;
+  until: string;
   logsDir: string;
   files: {
     lifecycle: number;
@@ -1610,6 +1611,7 @@ export type ProxyAnalysisReport = {
 export type ProxyAnalysisOptions = {
   logsDir?: string;
   since?: string;
+  until?: string;
   nowMs?: number;
 };
 

--- a/test/proxyAnalysis.test.ts
+++ b/test/proxyAnalysis.test.ts
@@ -438,6 +438,59 @@ describe("offline proxy log analysis", () => {
     await expect(
       analyzeProxyLogs({ logsDir: logDir, since: "recently", nowMs }),
     ).rejects.toThrow("Invalid --since value");
+    await expect(
+      analyzeProxyLogs({
+        logsDir: logDir,
+        since: "1h",
+        until: "later",
+        nowMs,
+      }),
+    ).rejects.toThrow("Invalid --until value");
+    await expect(
+      analyzeProxyLogs({
+        logsDir: logDir,
+        since: "1h",
+        until: "2h",
+        nowMs,
+      }),
+    ).rejects.toThrow("--until must not be earlier than --since");
+  });
+
+  it("uses a fixed end-of-snapshot cutoff while logs continue to append", async () => {
+    const logDir = await mkdtemp(join(tmpdir(), "neurolink-analysis-"));
+    tempDirs.push(logDir);
+    await writeJsonLines(logDir, "proxy-2026-07-18.jsonl", [
+      {
+        timestamp: "2026-07-18T11:00:00.000Z",
+        requestId: "included",
+        method: "POST",
+        account: "primary@example.com",
+        accountType: "oauth",
+        responseStatus: 200,
+      },
+      {
+        timestamp: "2026-07-18T11:31:00.000Z",
+        requestId: "appended-after-cutoff",
+        method: "POST",
+        account: "primary@example.com",
+        accountType: "oauth",
+        responseStatus: 502,
+      },
+    ]);
+
+    const report = await analyzeProxyLogs({
+      logsDir: logDir,
+      since: "2h",
+      until: "2026-07-18T11:30:00.000Z",
+      nowMs,
+    });
+
+    expect(report.until).toBe("2026-07-18T11:30:00.000Z");
+    expect(report.requests).toMatchObject({
+      completed: 1,
+      success: 1,
+      errors: 0,
+    });
   });
 
   it("does not mislabel legacy end-to-end timing as account-attempt latency", async () => {


### PR DESCRIPTION
## Summary
- Add a fixed `--until` cutoff to `neurolink proxy analyze`; default to the analysis start time.
- Exclude records after the cutoff from every reliability aggregate.
- Emit the exact report window and reject inverted windows.

## Validation
- `pnpm exec vitest run test/proxyAnalysis.test.ts` (7 passed)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- Full repository pre-commit validation, lint, security validation, and production build passed.

## Scope
Read-only proxy analysis only. It does not touch or restart the live service.