### PR TITLE
fix: send claude-cli User-Agent on Anthropic api_key proxy path + widen explicit providerFallback to non-abort errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:mcp:limits": "npx tsx test/continuous-test-suite-mcp-output-limits.ts",
     "test:mcp:infra": "npx tsx test/continuous-test-suite-mcp-infra.ts",
     "test:providers-mocked": "npx tsx test/continuous-test-suite-providers-mocked.ts",
+    "test:provider-fallback": "npx tsx test/continuous-test-suite-provider-fallback.ts",
     "test:rag": "npx tsx test/continuous-test-suite-rag.ts",
     "test:vector-pinecone": "npx tsx test/continuous-test-suite-vector-pinecone.ts",
     "test:vector-pgvector": "npx tsx test/continuous-test-suite-vector-pgvector.ts",

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -4383,7 +4383,7 @@ Current user's request: ${currentInput}`;
    * Curator P2-3: wraps a generate/stream call with the fallback
    * orchestration (`providerFallback` callback + `modelChain` walker).
    *
-   * On a model-access-denied error from the inner call:
+   * On a qualifying error from the inner call:
    *  1. Resolve the effective callback (per-call > instance > synthesised
    *     from modelChain) and the effective chain (per-call > instance).
    *  2. Walk attempts: invoke callback (or pop next chain entry) → emit
@@ -4391,6 +4391,12 @@ Current user's request: ${currentInput}`;
    *     model}.
    *  3. Stop on first success, on a callback returning null, or after
    *     exhausting the chain (throw the most recent error).
+   *
+   * What qualifies depends on how fallback was configured: an EXPLICIT
+   * `providerFallback` callback is consulted for any error except client
+   * aborts (the callback owns the decision — it receives the error
+   * unmodified and can return null to bubble), while modelChain-only
+   * configs keep the narrow model-access-denied gate.
    */
   private async runWithFallbackOrchestration<T>(
     optionsOrPrompt: GenerateOptions | DynamicOptions | string,
@@ -4402,11 +4408,9 @@ Current user's request: ${currentInput}`;
       return initialAttempt.ok;
     }
     let lastError = initialAttempt.error;
-    if (!looksLikeModelAccessDenied(lastError)) {
-      throw lastError;
-    }
 
-    // Build the chain orchestration.
+    // Resolve the fallback configuration BEFORE gating so the gate can
+    // distinguish an explicit callback from a modelChain-only setup.
     const requestedProvider = (
       typeof optionsOrPrompt === "object"
         ? (optionsOrPrompt as { provider?: string }).provider
@@ -4433,6 +4437,17 @@ Current user's request: ${currentInput}`;
     const effectiveCallback =
       perCallCallback ?? this.fallbackConfig.providerFallback;
     const effectiveChain = perCallChain ?? this.fallbackConfig.modelChain;
+
+    // Explicit callback (per-call or instance providerFallback): the callback
+    // owns the decision for any error except client aborts — it can return
+    // null to bubble. modelChain-only keeps the narrow model-access-denied
+    // gate so chain walkers don't retry errors the chain can't fix.
+    const shouldOrchestrateFallback = (err: unknown): boolean =>
+      effectiveCallback ? !isAbortError(err) : looksLikeModelAccessDenied(err);
+
+    if (!shouldOrchestrateFallback(lastError)) {
+      throw lastError;
+    }
 
     if (!effectiveCallback && !effectiveChain) {
       throw lastError;
@@ -4515,7 +4530,7 @@ Current user's request: ${currentInput}`;
       }
       lastError = retryAttempt.error;
       attemptedRequestedModel = next.model ?? attemptedRequestedModel;
-      if (!looksLikeModelAccessDenied(lastError)) {
+      if (!shouldOrchestrateFallback(lastError)) {
         throw lastError;
       }
     }

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -948,6 +948,13 @@ export class AnthropicProvider extends BaseProvider {
       }
     }
 
+    if (usingProxy) {
+      // WAFs in front of ANTHROPIC_BASE_URL proxies commonly block the bare
+      // SDK UA ("Anthropic/JS x.y.z"); send the claude-cli UA the OAuth path
+      // already uses. Direct-to-Anthropic traffic keeps the honest SDK UA.
+      headers["User-Agent"] = CLAUDE_CLI_USER_AGENT;
+    }
+
     // Add subscription-specific headers if applicable
     if (this.subscriptionTier !== "api") {
       headers["x-subscription-tier"] = this.subscriptionTier;

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -45,10 +45,14 @@ export type NeuroLinkConfig = {
 };
 
 /**
- * Curator P2-3: callback signature for centralized fallback policy. Invoked
- * when a generate/stream call fails with what looks like a model-access-denied
- * error. Return `{ provider, model }` (either / both optional) to drive a
- * retry; return `null` to bubble the original error untouched.
+ * Curator P2-3: callback signature for centralized fallback policy. When an
+ * explicit callback is configured (per-call or instance), it is invoked for
+ * ANY error thrown by a generate/stream call except client aborts — network
+ * errors, 5xx, timeouts, auth failures included. The callback receives the
+ * error unmodified so hosts can classify it themselves (status codes,
+ * `isNonRetryableProviderError`, …). Return `{ provider, model }` (either /
+ * both optional) to drive a retry; return `null` to bubble the original
+ * error untouched.
  */
 export type ProviderFallbackCallback = (error: unknown) => Promise<{
   provider?: string;
@@ -84,16 +88,21 @@ export type NeurolinkConstructorConfig = {
    */
   credentials?: NeurolinkCredentials;
   /**
-   * Curator P2-3: callback invoked on model-access-denied. Lets a host (e.g.
-   * Curator) centrally drive fallback policy. The callback receives the
-   * original error and returns the next `{ provider, model }` to try, or
-   * `null` to bubble the error.
+   * Curator P2-3: callback invoked when a generate/stream call fails with
+   * any error except a client abort (network errors, 5xx, timeouts, auth
+   * failures, model-access-denied, …). Lets a host (e.g. Curator) centrally
+   * drive fallback policy — "provider A primary, provider B on failure".
+   * The callback receives the original error unmodified and returns the
+   * next `{ provider, model }` to try, or `null` to bubble the error.
    */
   providerFallback?: ProviderFallbackCallback;
   /**
-   * Curator P2-3: ordered list of model names to try in sequence on
-   * model-access-denied. Sugar over `providerFallback`. The current
-   * provider is preserved across the chain; only the model name changes.
+   * Curator P2-3: ordered list of model names to try in sequence. Sugar
+   * over `providerFallback`, but with a narrower trigger: without an
+   * explicit callback the chain only advances on model-access-denied
+   * errors — other failures (network, 5xx, timeouts) bubble immediately.
+   * The current provider is preserved across the chain; only the model
+   * name changes.
    */
   modelChain?: string[];
   /**

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -648,6 +648,9 @@ export type GenerateOptions = {
   /**
    * Curator P2-3: per-call fallback callback. Overrides any
    * instance-level `providerFallback` set on `new NeuroLink({...})`.
+   * Invoked for any error except client aborts (network errors, 5xx,
+   * timeouts, auth failures, model-access-denied, …); receives the error
+   * unmodified. Return `{ provider, model }` to retry, `null` to bubble.
    */
   providerFallback?: (
     error: unknown,
@@ -655,7 +658,9 @@ export type GenerateOptions = {
 
   /**
    * Curator P2-3: per-call ordered model chain. Overrides any
-   * instance-level `modelChain`. Tried in order on model-access-denied.
+   * instance-level `modelChain`. Without an explicit `providerFallback`
+   * callback the chain only advances on model-access-denied errors —
+   * other failures (network, 5xx, timeouts) bubble immediately.
    */
   modelChain?: string[];
 

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -593,6 +593,11 @@ export type StreamOptions = {
   /**
    * Curator P2-3: per-call fallback callback. Overrides any
    * instance-level `providerFallback` set on `new NeuroLink({...})`.
+   * Invoked for any error thrown while establishing the stream, except
+   * client aborts (network errors, 5xx, timeouts, auth failures,
+   * model-access-denied, …); receives the error unmodified. There is no
+   * mid-stream resume once chunks are flowing. Return `{ provider,
+   * model }` to retry, `null` to bubble.
    */
   providerFallback?: (
     error: unknown,
@@ -600,7 +605,9 @@ export type StreamOptions = {
 
   /**
    * Curator P2-3: per-call ordered model chain. Overrides any
-   * instance-level `modelChain`. Tried in order on model-access-denied.
+   * instance-level `modelChain`. Without an explicit `providerFallback`
+   * callback the chain only advances on model-access-denied errors —
+   * other failures (network, 5xx, timeouts) bubble immediately.
    */
   modelChain?: string[];
 

--- a/test/continuous-test-suite-provider-fallback.ts
+++ b/test/continuous-test-suite-provider-fallback.ts
@@ -1,0 +1,402 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: provider fallback orchestration + Anthropic proxy
+ * User-Agent (pure, no API).
+ *
+ * Covers two related resilience fixes:
+ *
+ * 1. Anthropic api_key+proxy User-Agent — when ANTHROPIC_BASE_URL routes
+ *    traffic through a proxy, the api_key client must send the claude-cli
+ *    User-Agent instead of the bare "@anthropic-ai/sdk" default. WAFs in
+ *    front of proxy deployments (e.g. Cloudflare) block "Anthropic/JS x.y.z"
+ *    outright, returning 403 for every request. Direct-to-Anthropic traffic
+ *    keeps the honest SDK UA.
+ *
+ * 2. Fallback orchestration trigger widening — an EXPLICIT providerFallback
+ *    callback (per-call or instance) is consulted for any error except client
+ *    aborts; the callback owns the decision and can return null to bubble.
+ *    modelChain-only configs keep the original narrow model-access-denied
+ *    gate. Without the widening, a dead primary provider (network error, 5xx,
+ *    timeout, auth failure) throws without ever consulting the callback.
+ *
+ * Run: npx tsx test/continuous-test-suite-provider-fallback.ts
+ */
+import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
+import { NeuroLink } from "../src/lib/neurolink.js";
+import { AnthropicProvider } from "../src/lib/providers/anthropic.js";
+import { CLAUDE_CLI_USER_AGENT } from "../src/lib/auth/anthropicOAuth.js";
+
+const { test, runSuite } = defineSuite(
+  "Provider fallback + Anthropic proxy UA",
+);
+
+// ---------------------------------------------------------------------------
+// Fallback orchestration (runWithFallbackOrchestration)
+// ---------------------------------------------------------------------------
+
+type FallbackNext = { provider?: string; model?: string } | null;
+type Orchestrate = (
+  optionsOrPrompt: unknown,
+  kind: "generate" | "stream",
+  inner: (opts: unknown) => Promise<unknown>,
+) => Promise<unknown>;
+
+// The orchestration is a private method; invoke it directly with a stub
+// inner so the tests are deterministic and free of provider/network
+// machinery (which has its own retry layers that would mask the gate).
+function makeOrchestrator(
+  config?: ConstructorParameters<typeof NeuroLink>[0],
+): Orchestrate {
+  const nl = new NeuroLink(config);
+  const target = nl as unknown as {
+    runWithFallbackOrchestration: Orchestrate;
+  };
+  return target.runWithFallbackOrchestration.bind(nl);
+}
+
+const networkError = () =>
+  new Error("connect ECONNREFUSED 10.0.0.1:443 — fetch failed");
+const serverError = () =>
+  Object.assign(new Error("Internal Server Error"), { status: 500 });
+const abortError = () =>
+  Object.assign(new Error("The operation was aborted"), {
+    name: "AbortError",
+  });
+const accessDeniedError = () =>
+  Object.assign(new Error("model access denied"), {
+    name: "ModelAccessDeniedError",
+  });
+
+// A stub inner that throws the queued errors in order, then succeeds.
+function makeInner(errors: unknown[]) {
+  const seenOpts: Array<Record<string, unknown>> = [];
+  let attempt = 0;
+  const inner = async (opts: unknown) => {
+    seenOpts.push(opts as Record<string, unknown>);
+    const err = errors[attempt++];
+    if (err) {
+      throw err;
+    }
+    return { text: "ok", attempt };
+  };
+  return { inner, seenOpts };
+}
+
+await test("explicit callback consulted on a synthetic network error", async () => {
+  const run = makeOrchestrator();
+  const netErr = networkError();
+  const { inner, seenOpts } = makeInner([netErr]);
+  const callbackErrors: unknown[] = [];
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      provider: "anthropic",
+      model: "claude-primary",
+      providerFallback: async (err: unknown): Promise<FallbackNext> => {
+        callbackErrors.push(err);
+        return { provider: "openai", model: "gpt-fallback" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(callbackErrors.length, 1, "callback must be invoked once");
+  assert(
+    callbackErrors[0] === netErr,
+    "callback must receive the original error object unmodified",
+  );
+  assertEqual(seenOpts.length, 2, "one failed attempt + one retry");
+  assertEqual(
+    seenOpts[1].provider,
+    "openai",
+    "retry must use the provider returned by the callback",
+  );
+  assertEqual(
+    seenOpts[1].model,
+    "gpt-fallback",
+    "retry must use the model returned by the callback",
+  );
+  assertEqual(
+    seenOpts[1].providerFallback,
+    undefined,
+    "providerFallback must be stripped from the retried options",
+  );
+  assertEqual(
+    seenOpts[1].modelChain,
+    undefined,
+    "modelChain must be stripped from the retried options",
+  );
+  assertEqual(result.text, "ok", "the successful retry result is returned");
+});
+
+await test("explicit callback consulted on a synthetic 5xx provider error", async () => {
+  const run = makeOrchestrator();
+  const err500 = serverError();
+  const { inner, seenOpts } = makeInner([err500]);
+  const callbackErrors: unknown[] = [];
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      provider: "anthropic",
+      providerFallback: async (err: unknown): Promise<FallbackNext> => {
+        callbackErrors.push(err);
+        return { provider: "vertex" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assert(callbackErrors[0] === err500, "callback must see the 5xx error");
+  assertEqual(seenOpts[1].provider, "vertex", "retry uses returned provider");
+  assertEqual(result.text, "ok", "success returned after 5xx fallback");
+});
+
+await test("instance-level explicit callback is widened too", async () => {
+  const callbackErrors: unknown[] = [];
+  const run = makeOrchestrator({
+    providerFallback: async (err: unknown): Promise<FallbackNext> => {
+      callbackErrors.push(err);
+      return { model: "instance-fallback" };
+    },
+  });
+  const { inner, seenOpts } = makeInner([networkError()]);
+  const result = (await run(
+    { input: { text: "hi" }, provider: "anthropic", model: "primary" },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(callbackErrors.length, 1, "instance callback must be invoked");
+  assertEqual(
+    seenOpts[1].model,
+    "instance-fallback",
+    "retry uses the instance callback's model",
+  );
+  assertEqual(result.text, "ok", "success returned");
+});
+
+await test("callback returning null bubbles the original error", async () => {
+  const run = makeOrchestrator();
+  const netErr = networkError();
+  const { inner, seenOpts } = makeInner([netErr, netErr]);
+  let thrown: unknown;
+  try {
+    await run(
+      {
+        input: { text: "hi" },
+        providerFallback: async (): Promise<FallbackNext> => null,
+      },
+      "generate",
+      inner,
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  assert(thrown === netErr, "the original error object must bubble");
+  assertEqual(seenOpts.length, 1, "no retry after the callback declines");
+});
+
+await test("abort error does NOT invoke the callback", async () => {
+  const run = makeOrchestrator();
+  const abortErr = abortError();
+  const { inner, seenOpts } = makeInner([abortErr]);
+  let callbackInvoked = false;
+  let thrown: unknown;
+  try {
+    await run(
+      {
+        input: { text: "hi" },
+        providerFallback: async (): Promise<FallbackNext> => {
+          callbackInvoked = true;
+          return { model: "should-not-happen" };
+        },
+      },
+      "generate",
+      inner,
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  assertEqual(callbackInvoked, false, "client aborts must bypass the callback");
+  assert(thrown === abortErr, "the abort error must be rethrown");
+  assertEqual(seenOpts.length, 1, "no retry on abort");
+});
+
+await test("modelChain-only keeps the narrow gate: network error bubbles", async () => {
+  const run = makeOrchestrator();
+  const netErr = networkError();
+  const { inner, seenOpts } = makeInner([netErr]);
+  let thrown: unknown;
+  try {
+    await run(
+      {
+        input: { text: "hi" },
+        model: "claude-primary",
+        modelChain: ["claude-primary", "claude-fallback"],
+      },
+      "generate",
+      inner,
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  assert(
+    thrown === netErr,
+    "without an explicit callback, non-access-denied errors must bubble",
+  );
+  assertEqual(seenOpts.length, 1, "the chain must not advance");
+});
+
+await test("modelChain-only still walks the chain on model-access-denied", async () => {
+  const run = makeOrchestrator();
+  const { inner, seenOpts } = makeInner([accessDeniedError()]);
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      model: "claude-primary",
+      modelChain: ["claude-primary", "claude-fallback"],
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(
+    seenOpts[1].model,
+    "claude-fallback",
+    "the chain must advance past the requested model",
+  );
+  assertEqual(result.text, "ok", "chain fallback succeeds");
+});
+
+await test("post-retry gate widened: callback consulted again when the retry fails differently", async () => {
+  const run = makeOrchestrator();
+  const netErr = networkError();
+  const err502 = Object.assign(new Error("502 Bad Gateway"), { status: 502 });
+  const { inner, seenOpts } = makeInner([netErr, err502]);
+  const callbackErrors: unknown[] = [];
+  const models = ["second", "third"];
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      model: "first",
+      providerFallback: async (err: unknown): Promise<FallbackNext> => {
+        callbackErrors.push(err);
+        return { model: models[callbackErrors.length - 1] };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(callbackErrors.length, 2, "callback invoked for both failures");
+  assert(callbackErrors[0] === netErr, "first invocation sees the first error");
+  assert(
+    callbackErrors[1] === err502,
+    "second invocation sees the retry's non-access-denied error (previously bypassed the callback)",
+  );
+  assertEqual(seenOpts[2].model, "third", "third attempt uses the new model");
+  assertEqual(result.text, "ok", "success returned on the third attempt");
+});
+
+// ---------------------------------------------------------------------------
+// Anthropic proxy User-Agent
+// ---------------------------------------------------------------------------
+
+type ClientInternals = {
+  client: { _options?: { defaultHeaders?: Record<string, string> } };
+};
+
+function withAnthropicEnv(
+  baseUrl: string | undefined,
+  fn: () => void | Promise<void>,
+): void | Promise<void> {
+  const saved = process.env.ANTHROPIC_BASE_URL;
+  if (baseUrl === undefined) {
+    delete process.env.ANTHROPIC_BASE_URL;
+  } else {
+    process.env.ANTHROPIC_BASE_URL = baseUrl;
+  }
+  const restore = () => {
+    if (saved === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = saved;
+    }
+  };
+  try {
+    const out = fn();
+    if (out instanceof Promise) {
+      return out.finally(restore);
+    }
+    restore();
+    return out;
+  } catch (err) {
+    restore();
+    throw err;
+  }
+}
+
+await test("proxy mode: api_key path spoofs the claude-cli User-Agent", () =>
+  withAnthropicEnv("https://proxy.example.test", () => {
+    // credentials.apiKey (without oauthToken) forces the api_key branch.
+    const provider = new AnthropicProvider(undefined, undefined, undefined, {
+      apiKey: "sk-ant-test-dummy",
+    });
+    const headers = provider.getAuthHeaders();
+    assertEqual(
+      headers["User-Agent"],
+      CLAUDE_CLI_USER_AGENT,
+      "proxy mode must override the SDK User-Agent with the claude-cli UA",
+    );
+    assert(
+      CLAUDE_CLI_USER_AGENT.startsWith("claude-cli/"),
+      "spoofed UA must be the claude-cli one the OAuth path already uses",
+    );
+    // The constructed SDK client must actually carry it as a default header
+    // (defaultHeaders merge AFTER the SDK's built-in UA, so this wins).
+    const client = (provider as unknown as ClientInternals).client;
+    assertEqual(
+      client._options?.defaultHeaders?.["User-Agent"],
+      CLAUDE_CLI_USER_AGENT,
+      "client defaultHeaders must carry the User-Agent override",
+    );
+  }));
+
+await test("direct mode (no ANTHROPIC_BASE_URL): honest SDK User-Agent kept", () =>
+  withAnthropicEnv(undefined, () => {
+    const provider = new AnthropicProvider(undefined, undefined, undefined, {
+      apiKey: "sk-ant-test-dummy",
+    });
+    const headers = provider.getAuthHeaders();
+    assertEqual(
+      "User-Agent" in headers,
+      false,
+      "direct-to-Anthropic traffic must not override the SDK User-Agent",
+    );
+    const client = (provider as unknown as ClientInternals).client;
+    assertEqual(
+      client._options?.defaultHeaders?.["User-Agent"],
+      undefined,
+      "client defaultHeaders must not contain a User-Agent override",
+    );
+  }));
+
+await test("proxy mode UA override applies with beta features disabled", () =>
+  withAnthropicEnv("https://proxy.example.test", () => {
+    const provider = new AnthropicProvider(
+      undefined,
+      undefined,
+      { enableBetaFeatures: false },
+      { apiKey: "sk-ant-test-dummy" },
+    );
+    const headers = provider.getAuthHeaders();
+    assertEqual(
+      headers["User-Agent"],
+      CLAUDE_CLI_USER_AGENT,
+      "UA override must not be gated behind enableBetaFeatures",
+    );
+  }));
+
+await runSuite();


### PR DESCRIPTION
## Summary

Two independent upstream fixes surfaced by Curator's end-to-end test against a keyless Anthropic-format proxy (`ANTHROPIC_BASE_URL` + dummy key + `ANTHROPIC_AUTH_METHOD=api_key`). Both were proven by hand-patching dist in the Curator worktree; the patched setup passes REST/MCP/memory/file-generation e2e.

### 1. `fix(anthropic)`: api_key+proxy path leaked the raw SDK User-Agent

Every request through the proxy got `403 "Your request was blocked."` from the Cloudflare WAF in front of it. Bisection proved the trigger is exactly `User-Agent: Anthropic/JS 0.102.0` (the official `@anthropic-ai/sdk` default) — same body + all other headers pass. WAFs blocking the bare SDK UA is a generic hazard for any `ANTHROPIC_BASE_URL` proxy deployment. The OAuth path already spoofs the UA (`claude-cli/…`); only the api_key path leaked.

**Fix:** in `AnthropicProvider.getAuthHeaders()`, when `ANTHROPIC_BASE_URL` is set, set `User-Agent` to the existing `CLAUDE_CLI_USER_AGENT` — outside the `enableBetaFeatures` gate so it applies regardless of beta configuration. These headers flow into `new Anthropic({ defaultHeaders })`, and `defaultHeaders` merges after the SDK's built-in UA, so the override wins. Direct-to-Anthropic api_key traffic keeps the honest SDK UA.

### 2. `feat(sdk)`: fallback orchestration never fired on provider outages

`runWithFallbackOrchestration` (wrapping both `generate()` and `stream()`) gated ALL fallback on `looksLikeModelAccessDenied` **before** consulting the configured `providerFallback` callback — so the callback was never invoked for network errors, 5xx, timeouts, or auth failures; a dead primary provider just threw. This defeated the "provider A primary, provider B on failure" use case the mechanism was built for (Curator P2-3).

**Fix (opt-in widening, no behavior change for existing users):**

- When an **explicit** `providerFallback` callback is configured (per-call or instance), it is consulted for any error except client aborts (`isAbortError`). The callback receives the error unmodified (hosts can classify status codes / `isNonRetryableProviderError` themselves) and can return `null` to bubble.
- The same predicate now guards the post-retry check at the bottom of the attempt loop, so a retry's differently-shaped failure no longer bypasses the callback.
- **modelChain-only** configs keep the original narrow model-access-denied gate exactly as before.
- Unchanged: `model.fallback` event emission, `cloneOptionsForCallIsolation` on retries, `maxAttempts` guard, stripping `providerFallback`/`modelChain` from retried options, stream scope (only errors thrown from the wrapped inner call are caught; no mid-stream resume).
- `providerFallback` / `modelChain` JSDoc updated in `types/config`, `types/generate`, `types/stream` to document both the widened trigger and the modelChain-only narrow behavior.

## Tests

New `test/continuous-test-suite-provider-fallback.ts` (pure, no API; `pnpm run test:provider-fallback`) — 11/11 passing:

- explicit callback invoked on synthetic network error / 5xx; retry uses the returned `{provider, model}`; hooks stripped from retried options; success returned
- instance-level explicit callback widened too
- callback returning `null` bubbles the original error (object identity)
- abort error does NOT invoke the callback
- modelChain-only still requires model-access-denied (negative network-error test + positive chain-walk test)
- post-retry gate: callback consulted again when the retry fails with a different non-access-denied error
- UA: proxy mode → `getAuthHeaders()` and the constructed client's `defaultHeaders` carry `User-Agent: claude-cli/…`; unset → no override; override applies with `enableBetaFeatures: false`

## Verification

- `npx tsx test/continuous-test-suite-provider-fallback.ts` — 11/11 PASS
- `tsc --noEmit --strict` — clean
- `prettier` + `eslint` on touched files — 0 errors (pre-existing max-lines warnings only)
- `pnpm run build` — passes
