### PR TITLE
fix(sdk): fast-fail provider errors to fallback orchestration

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "test:mcp:infra": "npx tsx test/continuous-test-suite-mcp-infra.ts",
     "test:providers-mocked": "npx tsx test/continuous-test-suite-providers-mocked.ts",
     "test:provider-fallback": "npx tsx test/continuous-test-suite-provider-fallback.ts",
+    "test:provider-fallback-latency": "npx tsx test/continuous-test-suite-provider-fallback-latency.ts",
     "test:rag": "npx tsx test/continuous-test-suite-rag.ts",
     "test:vector-pinecone": "npx tsx test/continuous-test-suite-vector-pinecone.ts",
     "test:vector-pgvector": "npx tsx test/continuous-test-suite-vector-pgvector.ts",

--- a/src/lib/adapters/providerImageAdapter.ts
+++ b/src/lib/adapters/providerImageAdapter.ts
@@ -52,6 +52,31 @@ const IMAGE_LIMITS = {
 const PROXY_PROVIDERS = new Set(["litellm", "openrouter"]);
 
 /**
+ * Family-level vision rules, checked ONLY after a model id misses the exact
+ * VISION_CAPABILITIES allowlist for its provider. Kept as patterns (mirroring
+ * SAMPLING_PARAM_REJECTING_FAMILIES in modelRegistry.ts) because gateway ids
+ * carry arbitrary prefixes/suffixes (`vertex_ai/claude-sonnet-5@20260203`,
+ * `claude-opus-4-7-20260115`) that exact entries can't cover.
+ *
+ * Matches name-first Claude ids (claude-{opus,sonnet,haiku}-N…) with major
+ * version ≥ 4 — e.g. `claude-sonnet-5`, `claude-opus-5`, `claude-opus-4-7`,
+ * `claude-haiku-4-5` — all of which are vision-capable, plus the
+ * Fable/Mythos-class models (`claude-fable-5`, `claude-mythos-5`).
+ *
+ * Legacy number-first 3.x ids (`claude-3-5-haiku`, `claude-3-haiku`, …)
+ * deliberately do NOT match: the family word follows the version there, and
+ * claude-3-5-haiku — the last non-vision Claude — must stay rejected.
+ */
+const CLAUDE_MODERN_VISION_FAMILIES: RegExp[] = [
+  /claude-(?:opus|sonnet|haiku)-(?:[4-9]|\d{2,})/i,
+  /claude-(?:fable|mythos)-\d/i,
+];
+const VISION_FAMILY_RULES: Partial<Record<string, RegExp[]>> = {
+  anthropic: CLAUDE_MODERN_VISION_FAMILIES,
+  vertex: CLAUDE_MODERN_VISION_FAMILIES,
+};
+
+/**
  * Normalize provider name/alias to its canonical form for vision checks.
  */
 function normalizeVisionProvider(provider: string): string {
@@ -633,6 +658,17 @@ export class ProviderImageAdapter {
   static supportsVision(provider: string, model?: string): boolean {
     try {
       const normalizedProvider = normalizeVisionProvider(provider);
+
+      // Anthropic behind a proxy (ANTHROPIC_BASE_URL set) routes to whatever
+      // the proxy exposes — capability gating is the upstream's job. Mirrors
+      // the validateModelAccess tier-check bypass in providers/anthropic.ts.
+      if (
+        normalizedProvider === "anthropic" &&
+        process.env.ANTHROPIC_BASE_URL
+      ) {
+        return true;
+      }
+
       const supportedModels =
         VISION_CAPABILITIES[
           normalizedProvider as keyof typeof VISION_CAPABILITIES
@@ -657,6 +693,15 @@ export class ProviderImageAdapter {
       const modelMatched = supportedModels.some((supportedModel) =>
         model.toLowerCase().includes(supportedModel.toLowerCase()),
       );
+
+      if (
+        !modelMatched &&
+        VISION_FAMILY_RULES[normalizedProvider]?.some((rule) =>
+          rule.test(model),
+        )
+      ) {
+        return true;
+      }
 
       // Proxy providers route to arbitrary underlying models — pass through if
       // the model isn't in the known allowlist.

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -28,6 +28,10 @@ import type {
 } from "../types/index.js";
 import { isAbortError, NeuroLinkError } from "../utils/errorHandling.js";
 import {
+  duckTypedStatusCode,
+  extractRetryAfterMsFromError,
+} from "../utils/providerRetry.js";
+import {
   hasLifecycleErrorFired,
   markLifecycleErrorFired,
 } from "../utils/lifecycleCallbacks.js";
@@ -2112,6 +2116,37 @@ export abstract class BaseProvider implements AIProvider {
         : new DOMException("The operation was aborted", "AbortError");
     }
     const formatted = this.formatProviderError(error);
+
+    // Preserve transport retry metadata across formatting. Provider
+    // formatters return fresh Error instances (RateLimitError, NetworkError,
+    // …) that would otherwise destroy the classification upper layers need:
+    // performMCPGenerationRetries' isRetryable/status checks and
+    // providerRetry's Retry-After extraction. Copied generically so every
+    // provider's 429/5xx keeps its status and server-requested delay.
+    if (error && typeof error === "object" && formatted !== error) {
+      const src = error as { isRetryable?: unknown };
+      const dst = formatted as Error & {
+        statusCode?: number;
+        isRetryable?: boolean;
+        retryAfterMs?: number;
+      };
+      const statusCode = duckTypedStatusCode(error);
+      if (statusCode !== undefined && dst.statusCode === undefined) {
+        dst.statusCode = statusCode;
+      }
+      if (
+        typeof src.isRetryable === "boolean" &&
+        dst.isRetryable === undefined
+      ) {
+        dst.isRetryable = src.isRetryable;
+      }
+      if (dst.retryAfterMs === undefined) {
+        const retryAfterMs = extractRetryAfterMsFromError(error);
+        if (retryAfterMs !== undefined) {
+          dst.retryAfterMs = retryAfterMs;
+        }
+      }
+    }
 
     // Preserve the lifecycle-fired mark across formatting:
     // fireLifecycleErrorCallback() marks the ORIGINAL error in the shared

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -316,6 +316,7 @@ import {
   looksLikeModelAccessDenied as sharedLooksLikeModelAccessDenied,
   isNonRetryableProviderError as sharedIsNonRetryableProviderError,
 } from "./utils/providerErrorClassification.js";
+import { getErrorStatusCode } from "./utils/providerRetry.js";
 import { detectAndRedactPII } from "./utils/piiDetector.js";
 import { validateResponse } from "./utils/responseValidator.js";
 
@@ -4439,11 +4440,28 @@ Current user's request: ${currentInput}`;
     const effectiveChain = perCallChain ?? this.fallbackConfig.modelChain;
 
     // Explicit callback (per-call or instance providerFallback): the callback
-    // owns the decision for any error except client aborts — it can return
-    // null to bubble. modelChain-only keeps the narrow model-access-denied
-    // gate so chain walkers don't retry errors the chain can't fix.
+    // owns the decision for any error except genuine caller cancels — it can
+    // return null to bubble. modelChain-only keeps the narrow
+    // model-access-denied gate so chain walkers don't retry errors the chain
+    // can't fix.
+    //
+    // Error shape alone cannot identify a caller cancel: NeuroLink's own
+    // watchdog/timeout controllers abort the same composed signal, and SDKs
+    // normalize that into the identical AbortError shapes a user cancel
+    // produces (e.g. Anthropic's APIUserAbortError). Ground truth is the
+    // caller-supplied abortSignal itself — only when IT has fired is an
+    // abort-shaped error a real cancel; otherwise the abort was internally
+    // initiated (turn/stall watchdog, per-step timeout) and the callback
+    // must still be consulted so provider hangs can fall back. Read live
+    // (not captured) so the post-retry re-gate sees a cancel that arrives
+    // mid-fallback; cloneOptionsForCallIsolation keeps abortSignal
+    // by-reference, so the retried options observe the same signal.
+    const callerAborted = (): boolean =>
+      (callOpts.abortSignal as AbortSignal | undefined)?.aborted === true;
     const shouldOrchestrateFallback = (err: unknown): boolean =>
-      effectiveCallback ? !isAbortError(err) : looksLikeModelAccessDenied(err);
+      effectiveCallback
+        ? !(isAbortError(err) && callerAborted())
+        : looksLikeModelAccessDenied(err);
 
     if (!shouldOrchestrateFallback(lastError)) {
       throw lastError;
@@ -7136,7 +7154,12 @@ Current user's request: ${currentInput}`;
             (error as Error & { isRetryable?: boolean }).isRetryable ===
               false) ||
           (error instanceof Error &&
-            (error as Error & { statusCode?: number }).statusCode === 400);
+            (error as Error & { statusCode?: number }).statusCode === 400) ||
+          // A 429 already went through the provider layer's bounded,
+          // Retry-After-aware retry (withProviderRetry) — re-running the
+          // whole MCP generation against a rate-limited key is redundant
+          // and only delays fallback orchestration.
+          getErrorStatusCode(error) === 429;
 
         if (isNonRetryable) {
           logger.debug(

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -816,6 +816,12 @@ export class AnthropicProvider extends BaseProvider {
         // Note: No headers passed - fetch wrapper sets oauth-2025-04-20 beta header
         fetch: oauthFetch,
         timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
+        // The SDK's built-in retry honors Retry-After hints without any
+        // upper bound (a 429 with retry-after: 8549 sleeps 2.4h per retry,
+        // invisible to fallback orchestration). Retries are the
+        // orchestrator's job; transient network blips are still retried by
+        // the fetch wrapper.
+        maxRetries: 0,
       });
       logger.debug(
         "[AnthropicProvider] Anthropic SDK client created with OAuth fetch wrapper",
@@ -870,6 +876,9 @@ export class AnthropicProvider extends BaseProvider {
         ...(normalizedBaseURL && { baseURL: normalizedBaseURL }),
         fetch: createProxyFetch(),
         timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
+        // See the OAuth-path client above: unbounded Retry-After sleeps in
+        // the SDK's retry loop must never stall fallback orchestration.
+        maxRetries: 0,
       });
 
       logger.debug("Anthropic Provider initialized with API key", {

--- a/src/lib/providers/googleVertex.ts
+++ b/src/lib/providers/googleVertex.ts
@@ -729,6 +729,10 @@ const createVertexAnthropicSettings = async (
     projectId: project,
     region: location,
     ...(timeoutMs !== undefined && { timeout: timeoutMs }),
+    // The SDK's built-in retry honors Retry-After hints without any upper
+    // bound (a 429 with retry-after: 8549 sleeps 2.4h per retry, invisible
+    // to fallback orchestration). Retries are the orchestrator's job.
+    maxRetries: 0,
   };
 };
 

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -753,9 +753,21 @@ export const buildAPIError = async (
     statusCode?: number;
     requestBody?: unknown;
     responseBody?: string;
+    responseHeaders?: Record<string, string>;
     url?: string;
   };
   err.statusCode = res.status;
+  // Response headers carry rate-limit hints (Retry-After, X-RateLimit-*)
+  // that withProviderRetry needs to honor short waits and surface long ones.
+  // Allowlisted to just those — attaching every header would let unrelated
+  // (potentially sensitive) values like set-cookie or internal routing
+  // headers ride along when the error is logged.
+  err.responseHeaders = Object.fromEntries(
+    [...res.headers.entries()].filter(([key]) => {
+      const lower = key.toLowerCase();
+      return lower === "retry-after" || lower.startsWith("x-ratelimit-");
+    }),
+  );
   err.url = url;
   // Redacted summary only — never attach raw prompts, tool definitions, or
   // tool arguments to the thrown error. Anything serialized by upstream

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -47,12 +47,15 @@ export type NeuroLinkConfig = {
 /**
  * Curator P2-3: callback signature for centralized fallback policy. When an
  * explicit callback is configured (per-call or instance), it is invoked for
- * ANY error thrown by a generate/stream call except client aborts — network
- * errors, 5xx, timeouts, auth failures included. The callback receives the
- * error unmodified so hosts can classify it themselves (status codes,
- * `isNonRetryableProviderError`, …). Return `{ provider, model }` (either /
- * both optional) to drive a retry; return `null` to bubble the original
- * error untouched.
+ * ANY error thrown by a generate/stream call except genuine caller cancels —
+ * network errors, 5xx, timeouts, auth failures included. A caller cancel is
+ * identified by the caller-supplied `abortSignal` having fired, not by error
+ * shape: abort-shaped errors from NeuroLink's own turn/stall watchdogs and
+ * per-step timeouts DO invoke the callback, so provider hangs can fall back.
+ * The callback receives the error unmodified so hosts can classify it
+ * themselves (status codes, `isNonRetryableProviderError`, …). Return
+ * `{ provider, model }` (either / both optional) to drive a retry; return
+ * `null` to bubble the original error untouched.
  */
 export type ProviderFallbackCallback = (error: unknown) => Promise<{
   provider?: string;
@@ -89,11 +92,13 @@ export type NeurolinkConstructorConfig = {
   credentials?: NeurolinkCredentials;
   /**
    * Curator P2-3: callback invoked when a generate/stream call fails with
-   * any error except a client abort (network errors, 5xx, timeouts, auth
-   * failures, model-access-denied, …). Lets a host (e.g. Curator) centrally
-   * drive fallback policy — "provider A primary, provider B on failure".
-   * The callback receives the original error unmodified and returns the
-   * next `{ provider, model }` to try, or `null` to bubble the error.
+   * any error except a genuine caller cancel — i.e. the caller-supplied
+   * `abortSignal` fired (network errors, 5xx, timeouts, auth failures,
+   * model-access-denied, and internal watchdog aborts all invoke it). Lets
+   * a host (e.g. Curator) centrally drive fallback policy — "provider A
+   * primary, provider B on failure". The callback receives the original
+   * error unmodified and returns the next `{ provider, model }` to try, or
+   * `null` to bubble the error.
    */
   providerFallback?: ProviderFallbackCallback;
   /**

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -648,9 +648,11 @@ export type GenerateOptions = {
   /**
    * Curator P2-3: per-call fallback callback. Overrides any
    * instance-level `providerFallback` set on `new NeuroLink({...})`.
-   * Invoked for any error except client aborts (network errors, 5xx,
-   * timeouts, auth failures, model-access-denied, …); receives the error
-   * unmodified. Return `{ provider, model }` to retry, `null` to bubble.
+   * Invoked for any error except a genuine caller cancel — i.e. this
+   * call's `abortSignal` fired (network errors, 5xx, timeouts, auth
+   * failures, model-access-denied, and internal watchdog aborts all invoke
+   * it); receives the error unmodified. Return `{ provider, model }` to
+   * retry, `null` to bubble.
    */
   providerFallback?: (
     error: unknown,

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -1102,6 +1102,8 @@ export type AnthropicVertexSettings = {
   region: string;
   /** SDK request timeout in milliseconds */
   timeout?: number;
+  /** SDK-internal retry budget (transport retries are the orchestrator's job) */
+  maxRetries?: number;
 };
 
 // ============================================================================

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -593,11 +593,12 @@ export type StreamOptions = {
   /**
    * Curator P2-3: per-call fallback callback. Overrides any
    * instance-level `providerFallback` set on `new NeuroLink({...})`.
-   * Invoked for any error thrown while establishing the stream, except
-   * client aborts (network errors, 5xx, timeouts, auth failures,
-   * model-access-denied, …); receives the error unmodified. There is no
-   * mid-stream resume once chunks are flowing. Return `{ provider,
-   * model }` to retry, `null` to bubble.
+   * Invoked for any error thrown while establishing the stream, except a
+   * genuine caller cancel — i.e. this call's `abortSignal` fired (network
+   * errors, 5xx, timeouts, auth failures, model-access-denied, and
+   * internal watchdog aborts all invoke it); receives the error
+   * unmodified. There is no mid-stream resume once chunks are flowing.
+   * Return `{ provider, model }` to retry, `null` to bubble.
    */
   providerFallback?: (
     error: unknown,

--- a/src/lib/utils/providerRetry.ts
+++ b/src/lib/utils/providerRetry.ts
@@ -29,8 +29,16 @@ export const BASE_RETRY_DELAY_MS = 1000;
 /** Minimum delay in ms when a retryable response provides no retry timing. */
 export const NO_HINT_FLOOR_MS = 10_000;
 
-/** Maximum server-requested retry delay honored by provider retries. */
-export const MAX_RETRY_AFTER_MS = 120_000;
+/**
+ * Maximum server-requested retry delay honored by provider retries.
+ *
+ * A hint above this cap is not clamped-and-slept: the server declared an
+ * unavailability window we are not willing to wait out, so the error is
+ * surfaced immediately instead — fallback orchestration (providerFallback /
+ * modelChain) can route to another provider, and callers without fallback
+ * get a prompt rate-limit error rather than a silent multi-minute stall.
+ */
+export const MAX_RETRY_AFTER_MS = 60_000;
 
 const sleepWithTimeout = (delayMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -42,6 +50,66 @@ const sleepWithTimeout = (delayMs: number): Promise<void> =>
  * uses a branded symbol marker, so `instanceof` doesn't work across package
  * boundaries). Falls back to duck-typing for non-APICallError cases.
  */
+/**
+ * Duck-typed HTTP status extraction for errors of unknown provenance.
+ * NeuroLink's hand-rolled clients stamp `.statusCode`; official SDK errors
+ * (e.g. @anthropic-ai/sdk APIError) expose `.status`. Shared with
+ * baseProvider's handleProviderError metadata preservation.
+ */
+export function duckTypedStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const err = error as { statusCode?: unknown; status?: unknown };
+  if (typeof err.statusCode === "number") {
+    return err.statusCode;
+  }
+  if (typeof err.status === "number") {
+    return err.status;
+  }
+  return undefined;
+}
+
+/**
+ * Duck-typed Retry-After extraction for errors of unknown provenance.
+ * Reads a pre-parsed `.retryAfterMs` (stamped by metadata-preserving
+ * wrappers like handleProviderError), then `.headers` (Headers instance or
+ * record — e.g. @anthropic-ai/sdk APIError), then `.responseHeaders` (the
+ * hand-rolled OpenAI-compatible client's record). Shared with baseProvider.
+ */
+export function extractRetryAfterMsFromError(
+  error: unknown,
+): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const err = error as {
+    retryAfterMs?: unknown;
+    headers?: unknown;
+    responseHeaders?: unknown;
+  };
+  // Number.isFinite rejects NaN/Infinity: typeof NaN === "number", and a NaN
+  // hint would survive Math.max() into sleep(NaN) — an immediate retry
+  // instead of the no-hint floor.
+  if (
+    typeof err.retryAfterMs === "number" &&
+    Number.isFinite(err.retryAfterMs)
+  ) {
+    return err.retryAfterMs;
+  }
+  for (const candidate of [err.headers, err.responseHeaders]) {
+    if (candidate && typeof candidate === "object") {
+      const parsed = parseRetryAfterMs(
+        candidate as Pick<Headers, "get"> | Readonly<Record<string, string>>,
+      );
+      if (parsed !== undefined) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
 export function isRetryableProviderError(error: unknown): boolean {
   // Preferred path: use the AI SDK's own branded type check + isRetryable flag
   if (APICallError.isInstance(error)) {
@@ -53,8 +121,8 @@ export function isRetryableProviderError(error: unknown): boolean {
   }
 
   // Fallback: duck-type for status codes on errors that aren't APICallError
-  if (error && typeof error === "object" && "statusCode" in error) {
-    const statusCode = (error as { statusCode: number }).statusCode;
+  const statusCode = duckTypedStatusCode(error);
+  if (statusCode !== undefined) {
     return statusCode === 429 || statusCode >= 500;
   }
 
@@ -68,10 +136,7 @@ export function getErrorStatusCode(error: unknown): number | undefined {
   if (APICallError.isInstance(error)) {
     return error.statusCode;
   }
-  if (error && typeof error === "object" && "statusCode" in error) {
-    return (error as { statusCode: number }).statusCode;
-  }
-  return undefined;
+  return duckTypedStatusCode(error);
 }
 
 function getRetryAfterMs(error: unknown): number | undefined {
@@ -82,11 +147,15 @@ function getRetryAfterMs(error: unknown): number | undefined {
     }
   }
 
-  if (error instanceof NeuroLinkError && error.retryAfterMs !== undefined) {
+  if (
+    error instanceof NeuroLinkError &&
+    error.retryAfterMs !== undefined &&
+    Number.isFinite(error.retryAfterMs)
+  ) {
     return error.retryAfterMs;
   }
 
-  return undefined;
+  return extractRetryAfterMsFromError(error);
 }
 
 /**
@@ -144,12 +213,32 @@ export async function withProviderRetry<T>(
       }
 
       const retryAfterMs = getRetryAfterMs(error);
-      const boundedRetryAfterMs =
-        retryAfterMs === undefined
-          ? undefined
-          : Math.min(MAX_RETRY_AFTER_MS, Math.max(0, retryAfterMs));
+      if (retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_AFTER_MS) {
+        span?.setAttribute("gen_ai.provider.total_attempts", attempt + 1);
+        span?.addEvent("gen_ai.provider.retry_suppressed", {
+          "retry.after_ms": retryAfterMs,
+          ...(statusCode !== undefined && { "retry.status_code": statusCode }),
+        });
+        // Best-effort stamp so upper retry layers (the MCP generation loop's
+        // isRetryable check) also surface instead of re-running a
+        // rate-limited provider.
+        try {
+          Object.assign(error as object, {
+            isRetryable: false,
+            retryAfterMs,
+          });
+        } catch {
+          /* frozen error — the throw below still surfaces it */
+        }
+        logger.warn(
+          `[providerRetry] ${label} not retrying — server requested a ` +
+            `${Math.round(retryAfterMs / 1000)}s wait (cap ${MAX_RETRY_AFTER_MS / 1000}s); surfacing for fallback`,
+          { attempt: attempt + 1, retryAfterMs, statusCode },
+        );
+        throw error;
+      }
       const delay =
-        boundedRetryAfterMs ??
+        (retryAfterMs === undefined ? undefined : Math.max(0, retryAfterMs)) ??
         Math.max(BASE_RETRY_DELAY_MS * Math.pow(2, attempt), NO_HINT_FLOOR_MS);
 
       // Record retry event on the OTel span

--- a/test/continuous-test-suite-provider-fallback-latency.ts
+++ b/test/continuous-test-suite-provider-fallback-latency.ts
@@ -1,0 +1,431 @@
+#!/usr/bin/env tsx
+/**
+ * Continuous Test Suite: provider errors must reach fallback orchestration
+ * fast (pure, no API — all HTTP is mocked).
+ *
+ * Reproduces and pins three fixes:
+ *
+ * 1. Unbounded Retry-After — a prod 429 with `retry-after: 8549` made
+ *    @anthropic-ai/sdk sleep 2.4h per retry inside one generate();
+ *    the error never reached runWithFallbackOrchestration and the
+ *    configured providerFallback was never consulted. With SDK
+ *    maxRetries: 0 and the withProviderRetry surface-over-cap rule, the
+ *    429 must reject (or fall back) within seconds.
+ *
+ * 2. Watchdog-abort provenance — NeuroLink's own stall/turn-timeout
+ *    watchdogs abort provider calls; SDKs normalize that into the same
+ *    AbortError shapes a user cancel produces. The fallback gate must use
+ *    the caller's abortSignal state (ground truth) so internal aborts stay
+ *    fallback-eligible while genuine caller cancels stay excluded.
+ *
+ * 3. Vision capability registry — claude-sonnet-5 (and every name-first
+ *    Claude id with major >= 4) is vision-capable on anthropic/vertex, and
+ *    proxy mode (ANTHROPIC_BASE_URL) must not capability-gate at all.
+ *
+ * Run: npx tsx test/continuous-test-suite-provider-fallback-latency.ts
+ */
+import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
+import { installMockFetch } from "./utils/mockFetch.js";
+import { NeuroLink } from "../src/lib/neurolink.js";
+import { ProviderImageAdapter } from "../src/lib/adapters/providerImageAdapter.js";
+import { buildMultimodalMessagesArray } from "../src/lib/utils/messageBuilder.js";
+import type { GenerateOptions } from "../src/lib/types/index.js";
+
+const { test, runSuite } = defineSuite("Provider fallback latency");
+
+// ---------------------------------------------------------------------------
+// Environment: fake keys, deterministic api_key auth, no proxy.
+// The suite runs in its own tsx process, so mutations don't leak.
+// ---------------------------------------------------------------------------
+process.env.ANTHROPIC_API_KEY = "sk-ant-test-mock";
+process.env.OPENAI_API_KEY = "sk-test-mock";
+process.env.ANTHROPIC_AUTH_METHOD = "api_key";
+delete process.env.ANTHROPIC_BASE_URL;
+delete process.env.OPENAI_BASE_URL;
+
+const CREDENTIALS = {
+  anthropic: { apiKey: "sk-ant-test-mock" },
+  openai: { apiKey: "sk-test-mock" },
+};
+
+const rateLimit429 = {
+  status: 429,
+  json: {
+    type: "error",
+    error: { type: "rate_limit_error", message: "Rate limited" },
+  },
+  headers: { "retry-after": "8549" },
+};
+
+function openAIChatResponse(content: string, model: string): unknown {
+  return {
+    id: "chatcmpl-mock",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  };
+}
+
+// Generous bound: pre-fix behavior was a 2.4h SDK sleep (per retry), so any
+// single-digit-seconds completion proves no unbounded Retry-After sleep ran.
+const FAST_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// 1. 429 + huge Retry-After
+// ---------------------------------------------------------------------------
+
+await test("429 with retry-after: 8549 rejects within seconds (no fallback configured)", async () => {
+  const handle = installMockFetch([
+    { url: "api.anthropic.com/v1/messages", respond: rateLimit429 },
+  ]);
+  const started = Date.now();
+  let thrown: unknown;
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "ping" },
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      disableTools: true,
+      credentials: CREDENTIALS,
+    });
+  } catch (err) {
+    thrown = err;
+  } finally {
+    handle.unset();
+  }
+  const elapsed = Date.now() - started;
+  assert(thrown !== undefined, "generate() must reject on a persistent 429");
+  assert(
+    elapsed < FAST_MS,
+    `429 must surface within seconds, took ${elapsed}ms`,
+  );
+  assert(
+    handle.calls.some((c) => c.url.includes("api.anthropic.com/v1/messages")),
+    "the anthropic messages endpoint must actually have been hit",
+  );
+});
+
+await test("429 with huge Retry-After: providerFallback invoked, retry runs on returned provider", async () => {
+  const fallbackErrors: unknown[] = [];
+  const handle = installMockFetch([
+    { url: "api.anthropic.com/v1/messages", respond: rateLimit429 },
+    {
+      url: "api.openai.com/v1/chat/completions",
+      respond: {
+        status: 200,
+        json: openAIChatResponse("fallback says pong", "gpt-4o-mini"),
+      },
+    },
+  ]);
+  const started = Date.now();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "ping" },
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      disableTools: true,
+      credentials: CREDENTIALS,
+      providerFallback: async (err: unknown) => {
+        fallbackErrors.push(err);
+        return { provider: "openai", model: "gpt-4o-mini" };
+      },
+    });
+    const elapsed = Date.now() - started;
+    assertEqual(
+      fallbackErrors.length,
+      1,
+      "the fallback callback must be invoked exactly once",
+    );
+    assert(
+      String(result.content).includes("fallback says pong"),
+      `the retry must return the fallback provider's response, got: ${String(result.content).slice(0, 200)}`,
+    );
+    assert(
+      elapsed < FAST_MS,
+      `fallback must complete within seconds, took ${elapsed}ms`,
+    );
+    assert(
+      handle.calls.some((c) =>
+        c.url.includes("api.openai.com/v1/chat/completions"),
+      ),
+      "the fallback provider endpoint must have been hit",
+    );
+  } finally {
+    handle.unset();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Fallback-gate abort provenance (orchestrator-level contract)
+// ---------------------------------------------------------------------------
+
+type FallbackNext = { provider?: string; model?: string } | null;
+type Orchestrate = (
+  optionsOrPrompt: unknown,
+  kind: "generate" | "stream",
+  inner: (opts: unknown) => Promise<unknown>,
+) => Promise<unknown>;
+
+function makeOrchestrator(): Orchestrate {
+  const nl = new NeuroLink();
+  const target = nl as unknown as {
+    runWithFallbackOrchestration: Orchestrate;
+  };
+  return target.runWithFallbackOrchestration.bind(nl);
+}
+
+const abortShapedError = () =>
+  Object.assign(new Error("The operation was aborted"), {
+    name: "AbortError",
+  });
+
+function makeInner(errors: unknown[]) {
+  const seenOpts: Array<Record<string, unknown>> = [];
+  let attempt = 0;
+  const inner = async (opts: unknown) => {
+    seenOpts.push(opts as Record<string, unknown>);
+    const err = errors[attempt++];
+    if (err) {
+      throw err;
+    }
+    return { text: "ok" };
+  };
+  return { inner, seenOpts };
+}
+
+await test("watchdog abort (no caller signal) invokes the callback", async () => {
+  const run = makeOrchestrator();
+  const { inner, seenOpts } = makeInner([abortShapedError()]);
+  let invoked = 0;
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      providerFallback: async (): Promise<FallbackNext> => {
+        invoked++;
+        return { provider: "openai", model: "gpt-fallback" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+  assertEqual(invoked, 1, "internal aborts must consult the callback");
+  assertEqual(seenOpts.length, 2, "one failed attempt + one retry");
+  assertEqual(result.text, "ok", "fallback succeeds after a watchdog abort");
+});
+
+await test("watchdog abort (caller signal present but NOT fired) invokes the callback", async () => {
+  const run = makeOrchestrator();
+  const controller = new AbortController(); // never aborted — the caller did not cancel
+  const { inner, seenOpts } = makeInner([abortShapedError()]);
+  let invoked = 0;
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      abortSignal: controller.signal,
+      providerFallback: async (): Promise<FallbackNext> => {
+        invoked++;
+        return { model: "fallback-model" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+  assertEqual(
+    invoked,
+    1,
+    "an abort-shaped error without a fired caller signal is internal — callback must run",
+  );
+  assertEqual(seenOpts.length, 2, "one failed attempt + one retry");
+  assertEqual(result.text, "ok", "fallback succeeds");
+});
+
+await test("caller abort (signal fired) does NOT invoke the callback", async () => {
+  const run = makeOrchestrator();
+  const controller = new AbortController();
+  controller.abort();
+  const abortErr = abortShapedError();
+  const { inner, seenOpts } = makeInner([abortErr]);
+  let invoked = 0;
+  let thrown: unknown;
+  try {
+    await run(
+      {
+        input: { text: "hi" },
+        abortSignal: controller.signal,
+        providerFallback: async (): Promise<FallbackNext> => {
+          invoked++;
+          return { model: "should-not-happen" };
+        },
+      },
+      "generate",
+      inner,
+    );
+  } catch (err) {
+    thrown = err;
+  }
+  assertEqual(invoked, 0, "genuine caller cancels must bypass the callback");
+  assert(thrown === abortErr, "the abort error must be rethrown unmodified");
+  assertEqual(seenOpts.length, 1, "no retry on caller abort");
+});
+
+// ---------------------------------------------------------------------------
+// 2b. End-to-end: provider hang + internal timeout → fallback within seconds
+// ---------------------------------------------------------------------------
+
+await test("provider hang under internal timeout falls back within seconds", async () => {
+  const originalFetch = globalThis.fetch;
+  const openaiJson = openAIChatResponse("recovered after hang", "gpt-4o-mini");
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    // Exact-hostname routing (not substring) so CodeQL's URL-sanitization
+    // check holds and arbitrary hosts can never match a mock branch.
+    const hostname = new URL(url).hostname;
+    if (hostname === "api.anthropic.com") {
+      // Hang forever; reject like real fetch does when the signal aborts.
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal;
+        const rejectAbort = () =>
+          reject(new DOMException("This operation was aborted", "AbortError"));
+        if (signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    }
+    if (hostname === "api.openai.com") {
+      return new Response(JSON.stringify(openaiJson), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`[hang-test fetch] unexpected URL ${url}`);
+  }) as typeof fetch;
+  try {
+    const nl = new NeuroLink();
+    let invoked = 0;
+    const started = Date.now();
+    const result = await nl.generate({
+      input: { text: "ping" },
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      timeout: 2000,
+      disableTools: true,
+      credentials: CREDENTIALS,
+      providerFallback: async () => {
+        invoked++;
+        return { provider: "openai", model: "gpt-4o-mini" };
+      },
+    });
+    const elapsed = Date.now() - started;
+    assertEqual(
+      invoked,
+      1,
+      "a watchdog-aborted provider hang must consult the callback (no caller cancel happened)",
+    );
+    assert(
+      String(result.content).includes("recovered after hang"),
+      `fallback result must be returned, got: ${String(result.content).slice(0, 200)}`,
+    );
+    assert(
+      elapsed < 60_000,
+      `hang → fallback must complete promptly, took ${elapsed}ms`,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Vision capability registry
+// ---------------------------------------------------------------------------
+
+await test("vision: Claude 5 / Opus 4.x+ families accepted on anthropic and vertex", () => {
+  const expectTrue: Array<[string, string]> = [
+    ["anthropic", "claude-sonnet-5"],
+    ["anthropic", "claude-sonnet-5-20260203"],
+    ["anthropic", "claude-opus-5"],
+    ["anthropic", "claude-opus-4-7"],
+    ["anthropic", "claude-opus-4-8"],
+    ["anthropic", "claude-fable-5"],
+    ["vertex", "claude-sonnet-5@20260203"],
+    ["vertex", "vertex_ai/claude-sonnet-5@20260203"],
+    ["vertex", "claude-opus-4-6"],
+  ];
+  for (const [provider, model] of expectTrue) {
+    assertEqual(
+      ProviderImageAdapter.supportsVision(provider, model),
+      true,
+      `${provider}/${model} must be vision-capable`,
+    );
+  }
+  const expectFalse: Array<[string, string]> = [
+    ["anthropic", "claude-3-5-haiku"], // legacy number-first id, never had vision
+    ["anthropic", "gpt-4o"], // fail-closed for foreign models
+  ];
+  for (const [provider, model] of expectFalse) {
+    assertEqual(
+      ProviderImageAdapter.supportsVision(provider, model),
+      false,
+      `${provider}/${model} must stay rejected (fail-closed)`,
+    );
+  }
+});
+
+await test("vision: proxy mode (ANTHROPIC_BASE_URL) does not capability-gate", () => {
+  const saved = process.env.ANTHROPIC_BASE_URL;
+  process.env.ANTHROPIC_BASE_URL = "https://proxy.example.test";
+  try {
+    assertEqual(
+      ProviderImageAdapter.supportsVision("anthropic", "totally-unknown-model"),
+      true,
+      "behind a proxy the upstream decides — no static gating",
+    );
+  } finally {
+    if (saved === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = saved;
+    }
+  }
+});
+
+await test("vision: message building passes for anthropic/claude-sonnet-5 with an image", async () => {
+  // 1x1 transparent PNG.
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const options = {
+    input: { text: "describe this image", images: [png] },
+  } as GenerateOptions;
+  const messages = await buildMultimodalMessagesArray(
+    options,
+    "anthropic",
+    "claude-sonnet-5",
+  );
+  assert(
+    messages.length > 0,
+    "multimodal message building must not reject claude-sonnet-5",
+  );
+});
+
+await runSuite();

--- a/test/continuous-test-suite-provider-fallback.ts
+++ b/test/continuous-test-suite-provider-fallback.ts
@@ -13,11 +13,15 @@
  *    keeps the honest SDK UA.
  *
  * 2. Fallback orchestration trigger widening — an EXPLICIT providerFallback
- *    callback (per-call or instance) is consulted for any error except client
- *    aborts; the callback owns the decision and can return null to bubble.
- *    modelChain-only configs keep the original narrow model-access-denied
- *    gate. Without the widening, a dead primary provider (network error, 5xx,
- *    timeout, auth failure) throws without ever consulting the callback.
+ *    callback (per-call or instance) is consulted for any error except a
+ *    genuine caller cancel (the caller-supplied abortSignal fired); the
+ *    callback owns the decision and can return null to bubble. Abort-shaped
+ *    errors WITHOUT a fired caller signal are internally initiated (turn/
+ *    stall watchdog, per-step timeout, SDK-normalized aborts) and DO consult
+ *    the callback. modelChain-only configs keep the original narrow
+ *    model-access-denied gate. Without the widening, a dead primary provider
+ *    (network error, 5xx, timeout, auth failure) throws without ever
+ *    consulting the callback.
  *
  * Run: npx tsx test/continuous-test-suite-provider-fallback.ts
  */
@@ -198,16 +202,19 @@ await test("callback returning null bubbles the original error", async () => {
   assertEqual(seenOpts.length, 1, "no retry after the callback declines");
 });
 
-await test("abort error does NOT invoke the callback", async () => {
+await test("caller abort (abortSignal fired) does NOT invoke the callback", async () => {
   const run = makeOrchestrator();
   const abortErr = abortError();
   const { inner, seenOpts } = makeInner([abortErr]);
+  const controller = new AbortController();
+  controller.abort();
   let callbackInvoked = false;
   let thrown: unknown;
   try {
     await run(
       {
         input: { text: "hi" },
+        abortSignal: controller.signal,
         providerFallback: async (): Promise<FallbackNext> => {
           callbackInvoked = true;
           return { model: "should-not-happen" };
@@ -219,9 +226,67 @@ await test("abort error does NOT invoke the callback", async () => {
   } catch (err) {
     thrown = err;
   }
-  assertEqual(callbackInvoked, false, "client aborts must bypass the callback");
+  assertEqual(
+    callbackInvoked,
+    false,
+    "genuine caller cancels must bypass the callback",
+  );
   assert(thrown === abortErr, "the abort error must be rethrown");
-  assertEqual(seenOpts.length, 1, "no retry on abort");
+  assertEqual(seenOpts.length, 1, "no retry on caller abort");
+});
+
+await test("abort-shaped error WITHOUT a fired caller signal invokes the callback (internal watchdog)", async () => {
+  const run = makeOrchestrator();
+  const abortErr = abortError();
+  const { inner, seenOpts } = makeInner([abortErr]);
+  const controller = new AbortController(); // NOT aborted — the caller did not cancel
+  const callbackErrors: unknown[] = [];
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      abortSignal: controller.signal,
+      providerFallback: async (err: unknown): Promise<FallbackNext> => {
+        callbackErrors.push(err);
+        return { provider: "openai", model: "fallback-model" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(
+    callbackErrors.length,
+    1,
+    "internal watchdog aborts must consult the callback (provider hang fallback)",
+  );
+  assert(callbackErrors[0] === abortErr, "callback sees the original error");
+  assertEqual(seenOpts[1].provider, "openai", "retry uses returned provider");
+  assertEqual(result.text, "ok", "fallback succeeds after a watchdog abort");
+});
+
+await test("abort-shaped error with NO abortSignal in options invokes the callback", async () => {
+  const run = makeOrchestrator();
+  const { inner, seenOpts } = makeInner([abortError()]);
+  let callbackInvoked = false;
+  const result = (await run(
+    {
+      input: { text: "hi" },
+      providerFallback: async (): Promise<FallbackNext> => {
+        callbackInvoked = true;
+        return { model: "fallback-model" };
+      },
+    },
+    "generate",
+    inner,
+  )) as { text: string };
+
+  assertEqual(
+    callbackInvoked,
+    true,
+    "without a caller signal an abort shape cannot be a caller cancel",
+  );
+  assertEqual(seenOpts.length, 2, "one failed attempt + one retry");
+  assertEqual(result.text, "ok", "fallback succeeds");
 });
 
 await test("modelChain-only keeps the narrow gate: network error bubbles", async () => {

--- a/test/retryAfter.test.ts
+++ b/test/retryAfter.test.ts
@@ -104,10 +104,10 @@ describe("provider retry timing", () => {
     expect(recordedDelays).toEqual([10_000]);
   });
 
-  it("caps a Retry-After delay at two minutes", async () => {
+  it("honors a Retry-After hint at the cap boundary exactly", async () => {
     const operation = vi
       .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(createRetryableError({ "Retry-After": "300" }))
+      .mockRejectedValueOnce(createRetryableError({ "Retry-After": "59" }))
       .mockResolvedValue("success");
     const recordedDelays: number[] = [];
 
@@ -120,7 +120,113 @@ describe("provider retry timing", () => {
       },
     );
 
-    expect(recordedDelays).toEqual([MAX_RETRY_AFTER_MS]);
+    expect(recordedDelays).toEqual([59_000]);
+  });
+
+  it("surfaces immediately (no sleep, no retry) when Retry-After exceeds the cap", async () => {
+    const err = createRetryableError({ "Retry-After": "8549" });
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(err);
+    const recordedDelays: number[] = [];
+
+    await expect(
+      withProviderRetry(
+        operation,
+        undefined,
+        "test provider call",
+        async (ms) => {
+          recordedDelays.push(ms);
+        },
+      ),
+    ).rejects.toBe(err);
+
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(recordedDelays).toEqual([]);
+    // The surfaced error is stamped so upper retry layers also stand down.
+    expect(
+      (err as unknown as { isRetryable?: boolean; retryAfterMs?: number })
+        .isRetryable,
+    ).toBe(false);
+    expect((err as unknown as { retryAfterMs?: number }).retryAfterMs).toBe(
+      8_549_000,
+    );
+    expect(8_549_000).toBeGreaterThan(MAX_RETRY_AFTER_MS);
+  });
+
+  it("classifies official-SDK errors via .status and reads their .headers hint", async () => {
+    // Shape of @anthropic-ai/sdk's APIError: `.status` + `.headers`,
+    // no `.statusCode`, not an AI SDK APICallError.
+    const sdkShaped = Object.assign(new Error("429 rate_limit_error"), {
+      status: 429,
+      headers: new Headers({ "retry-after": "2" }),
+    });
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(sdkShaped)
+      .mockResolvedValue("success");
+    const recordedDelays: number[] = [];
+
+    await expect(
+      withProviderRetry(
+        operation,
+        undefined,
+        "test provider call",
+        async (ms) => {
+          recordedDelays.push(ms);
+        },
+      ),
+    ).resolves.toBe("success");
+
+    expect(recordedDelays).toEqual([2_000]);
+  });
+
+  it("uses the no-hint delay when a stamped retryAfterMs is NaN", async () => {
+    const sdkShaped = Object.assign(new Error("429 rate_limit_error"), {
+      status: 429,
+      retryAfterMs: Number.NaN,
+    });
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(sdkShaped)
+      .mockResolvedValue("success");
+    const recordedDelays: number[] = [];
+
+    await expect(
+      withProviderRetry(
+        operation,
+        undefined,
+        "test provider call",
+        async (ms) => {
+          recordedDelays.push(ms);
+        },
+      ),
+    ).resolves.toBe("success");
+
+    // NaN must not reach sleep() (it would fire immediately); the invalid
+    // hint is discarded and the 10s no-hint floor applies.
+    expect(recordedDelays).toEqual([10_000]);
+  });
+
+  it("surfaces an official-SDK 429 with an over-cap .headers hint immediately", async () => {
+    const sdkShaped = Object.assign(new Error("429 rate_limit_error"), {
+      status: 429,
+      headers: new Headers({ "retry-after": "8549" }),
+    });
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValue(sdkShaped);
+
+    await expect(
+      withProviderRetry(
+        operation,
+        undefined,
+        "test provider call",
+        async () => {
+          throw new Error("must not sleep");
+        },
+      ),
+    ).rejects.toBe(sdkShaped);
+
+    expect(operation).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Problem

When a provider returns non-2xx, the error must reach `runWithFallbackOrchestration` promptly so a configured `providerFallback`/`modelChain` can route to another provider. Today, retry layers below the orchestrator can swallow failures for hours: a prod 429 with `retry-after: 8549` made `@anthropic-ai/sdk` (maxRetries 2, uncapped un-abortable Retry-After sleep) sleep ~2.4h per retry inside one `generate()` — the error never surfaced, fallback was never consulted, and turns died via the stall watchdog.

## Fixes (provider-generic)

**1. Never honor unbounded Retry-After**
- `maxRetries: 0` on both Anthropic SDK clients (api_key + OAuth paths) and on `AnthropicVertex` — transport retries are the orchestrator's job; transient network blips are still retried by `fetchWithRetry` inside `createProxyFetch()`.
- `withProviderRetry`: Retry-After cap lowered to 60s, and a hint **above** the cap now surfaces immediately (no clamp-and-sleep) with the error stamped `isRetryable: false` + `retryAfterMs` so upper layers stand down. Hints ≤ 60s keep the honor-the-hint behavior.
- Classifier made deliberate: duck-types `.status` (official SDK errors) alongside `.statusCode`, and extracts hints from `.headers`/`.responseHeaders`.
- `handleProviderError` now preserves `statusCode`/`isRetryable`/`retryAfterMs` across `formatProviderError` (formatters previously destroyed all retry metadata).
- MCP generation loop breaks on 429s instead of re-running a rate-limited provider (it previously added a sleep + a full provider re-run, then swallowed the error).
- OpenAI-compatible client attaches `responseHeaders` to its errors so Retry-After hints work for that whole family.
- Audited (no change needed): Bedrock/SageMaker (AWS bounded retry), `@google/genai` (no auto-retry configured).

**2. Watchdog aborts no longer masquerade as caller cancels at the fallback gate**
Error shape can't distinguish provenance — SDKs normalize NeuroLink's internal watchdog/timeout aborts into the same AbortError shapes a user cancel produces. The gate now uses ground truth: an abort-shaped error skips fallback **only when the caller-supplied `abortSignal` has actually fired**. Internal aborts (turn/stall watchdog, per-step timeout) are fallback-eligible; genuine caller cancels stay excluded. JSDoc contracts updated in `types/{config,generate,stream}.ts`.

**3. Vision capability registry: Claude 5 / Opus 4.x+ on anthropic**
- Family-level regex rules (pattern per `SAMPLING_PARAM_REJECTING_FAMILIES` precedent): every name-first `claude-{opus,sonnet,haiku}-N` id with major ≥ 4 (plus fable/mythos) is vision-capable on anthropic and vertex — covers `claude-sonnet-5`, `claude-opus-5`, `claude-opus-4-7/4-8`, `@`-suffixed and gateway-prefixed ids. Legacy number-first 3.x ids (e.g. non-vision `claude-3-5-haiku`) stay fail-closed.
- Proxy mode (`ANTHROPIC_BASE_URL` set) no longer capability-gates at all — the upstream decides (mirrors the `validateModelAccess` proxy bypass).

## Tests

New `test/continuous-test-suite-provider-fallback-latency.ts` (`pnpm run test:provider-fallback-latency`, no API keys, all HTTP mocked):
- 429 + `retry-after: 8549` → `generate()` rejects in ~200ms (pre-fix: hours); with `providerFallback` → callback invoked once, retry served by the returned provider.
- Gate contract: watchdog abort (no signal / live signal) → callback invoked; caller abort (fired signal) → callback NOT invoked.
- E2E: provider hang + 2s timeout → fallback completes within seconds.
- Vision matrix incl. proxy bypass + `buildMultimodalMessagesArray` on `anthropic`/`claude-sonnet-5`.

Updated: `test/continuous-test-suite-provider-fallback.ts` (abort contract), `test/retryAfter.test.ts` (60s cap, over-cap surfacing, `.status`/`.headers` duck-typing).

Verified: `tsc --strict` clean, lint clean, full build + publint clean, suites green (9/9 new, 13/13 fallback, 17/17 retry-after, 30/30 providers-mocked, 39/39 anthropic-cap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved vision support for modern Claude models, including proxy and Vertex configurations.
  * Added configurable retry settings for Vertex-based Anthropic connections.

* **Bug Fixes**
  * Provider retries now respect a 60-second limit for server-requested delays.
  * Improved fallback behavior for timeouts, cancellations, and rate-limit errors.
  * Preserved retry details in provider errors for more reliable handling.

* **Tests**
  * Added coverage for fallback latency, vision detection, cancellation behavior, and retry limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->