### PR TITLE
fix(proxy): prevent account bursts and implicit fallback escape

### DIFF
--- a/docs/features/claude-proxy-config-reference.md
+++ b/docs/features/claude-proxy-config-reference.md
@@ -339,7 +339,7 @@ The running proxy watches the resolved config path and proxy env path. Changes a
 The following values reload without restarting:
 
 - `routing.strategy`, unless `--strategy` supplied a fixed CLI override
-- model mappings, fallback chain, and passthrough models
+- model mappings, fallback chain, auto fallback, per-account admission, and passthrough models
 - primary account and account allowlist
 - quota routing, session soft limit, and reset tolerance
 - env interpolation used by those routing fields
@@ -426,6 +426,11 @@ routing:
   session-soft-limit: 0.97
   session-reset-tolerance-ms: 900000
 
+  # Bound concurrent upstream requests per OAuth account. A request first tries
+  # another eligible account at capacity, then queues only if all are full.
+  # The default is 2; valid range is 1 through 20.
+  max-inflight-per-account: 2
+
   # Primary (home) account: under fill-first without quota routing this account
   # is tried first. With quota routing enabled it is only the final tie-break;
   # session headroom and weekly expiry determine order first. Under round-robin
@@ -465,6 +470,12 @@ routing:
       model: "gemini-2.5-pro"
     - provider: "openai"
       model: "gpt-4o"
+
+  # Disabled by default. Set true only when it is acceptable for a request to
+  # use an unspecified provider selected by the translation layer after the
+  # configured fallback chain is exhausted. It is skipped when any account
+  # returned a rate limit; that case still returns 429.
+  auto-fallback: false
 
   # Passthrough models: model IDs that skip routing and go directly to Anthropic
   # Accepts: passthrough-models (kebab) or passthroughModels (camel)
@@ -546,6 +557,8 @@ cloaking:
 | `account-allowlist` / `accountAllowlist`                 | `string[]`                      | _(none)_ | No       | Allowed Anthropic account labels/keys. When present, unlisted TokenStore, legacy, and environment credentials are excluded before loading or refresh. Empty denies all; absent is unrestricted. Special fallback labels are `legacy-default` and `env`.                                                                                                                                  |
 | `model-mappings` / `modelMappings`                       | `ModelMapping[]`                | `[]`     | No       | Array of model-to-model remapping rules.                                                                                                                                                                                                                                                                                                                                                 |
 | `fallback-chain` / `fallbackChain`                       | `FallbackEntry[]`               | `[]`     | No       | Ordered list of alternative providers to try when primary accounts are exhausted.                                                                                                                                                                                                                                                                                                        |
+| `auto-fallback` / `autoFallback`                         | `boolean`                       | `false`  | No       | Allows a translation-layer-selected fallback provider after configured fallbacks fail. Keep disabled to restrict requests to explicit accounts and fallback entries.                                                                                                                                                                                                                     |
+| `max-inflight-per-account` / `maxInflightPerAccount`     | `integer`                       | `2`      | No       | Maximum concurrent upstream requests per OAuth account, from 1 through 20. Requests prefer an available ordered account before queueing.                                                                                                                                                                                                                                                 |
 | `passthrough-models` / `passthroughModels`               | `string[]`                      | `[]`     | No       | Model IDs that bypass routing and go directly to Anthropic.                                                                                                                                                                                                                                                                                                                              |
 | `quota-routing` / `quotaRouting`                         | `boolean`                       | `true`   | No       | Enables weekly-expiry-first quota ordering for fill-first with multiple accounts. Accounts at the session soft limit are temporarily demoted until their 5h window resets. The environment override takes precedence.                                                                                                                                                                    |
 | `session-soft-limit` / `sessionSoftLimit`                | `number`                        | `0.97`   | No       | Session utilization in `(0, 1]` at which quota routing proactively demotes an account.                                                                                                                                                                                                                                                                                                   |
@@ -588,6 +601,8 @@ The config loader validates the following:
 - If `version` is present, it must be a number.
 - `routing.account-allowlist` must be an array of non-empty strings when present.
 - `routing.quota-routing` must be a boolean when present.
+- `routing.auto-fallback` must be a boolean when present.
+- `routing.max-inflight-per-account` must be an integer from 1 through 20 when present.
 - `routing.session-soft-limit` must be a number in `(0, 1]` when present.
 - `routing.session-reset-tolerance-ms` must be a positive integer when present.
 - Plaintext API keys (not using `${ENV_VAR}` references) trigger a warning.

--- a/src/lib/proxy/modelRouter.ts
+++ b/src/lib/proxy/modelRouter.ts
@@ -5,15 +5,25 @@ import type {
   RouteResult,
 } from "../types/index.js";
 
+/** Default and accepted range for concurrent upstream requests per OAuth account. */
+export const MIN_MAX_INFLIGHT_PER_ACCOUNT = 1;
+export const MAX_MAX_INFLIGHT_PER_ACCOUNT = 20;
+export const DEFAULT_MAX_INFLIGHT_PER_ACCOUNT = 2;
+
 export class ModelRouter {
   private readonly mappings: Map<string, ModelMapping>;
   private readonly passthrough: Set<string>;
   private readonly fallback: FallbackEntry[];
+  private readonly autoFallback: boolean;
+  private readonly maxInflightPerAccount: number;
 
   constructor(config: ProxyRoutingConfig) {
     this.mappings = new Map(config.modelMappings.map((m) => [m.from, m]));
     this.passthrough = new Set(config.passthroughModels ?? []);
     this.fallback = config.fallbackChain;
+    this.autoFallback = config.autoFallback === true;
+    this.maxInflightPerAccount =
+      config.maxInflightPerAccount ?? DEFAULT_MAX_INFLIGHT_PER_ACCOUNT;
   }
 
   resolve(requestedModel: string): RouteResult {
@@ -39,6 +49,16 @@ export class ModelRouter {
 
   getFallbackChain(): FallbackEntry[] {
     return this.fallback;
+  }
+
+  /** Whether translation-layer auto-provider fallback is explicitly enabled. */
+  isAutoFallbackEnabled(): boolean {
+    return this.autoFallback;
+  }
+
+  /** Maximum concurrent upstream requests admitted for each OAuth account. */
+  getMaxInflightPerAccount(): number {
+    return this.maxInflightPerAccount;
   }
 
   /** Return the raw model mapping entries (used by /v1/models). */

--- a/src/lib/proxy/proxyConfig.ts
+++ b/src/lib/proxy/proxyConfig.ts
@@ -13,6 +13,10 @@
 
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
+import {
+  MAX_MAX_INFLIGHT_PER_ACCOUNT,
+  MIN_MAX_INFLIGHT_PER_ACCOUNT,
+} from "./modelRouter.js";
 import { logger } from "../utils/logger.js";
 import type {
   CloakingConfig,
@@ -304,6 +308,34 @@ export function validateProxyConfig(config: unknown): string[] {
       errors.push("routing.quota-routing must be a boolean");
     }
 
+    const rawAutoFallback = routing["auto-fallback"] ?? routing.autoFallback;
+    const normalizedAutoFallback =
+      typeof rawAutoFallback === "string"
+        ? rawAutoFallback.trim().toLowerCase()
+        : undefined;
+    if (
+      rawAutoFallback !== undefined &&
+      typeof rawAutoFallback !== "boolean" &&
+      normalizedAutoFallback !== "true" &&
+      normalizedAutoFallback !== "false"
+    ) {
+      errors.push("routing.auto-fallback must be a boolean");
+    }
+
+    const rawMaxInflight =
+      routing["max-inflight-per-account"] ?? routing.maxInflightPerAccount;
+    if (
+      rawMaxInflight !== undefined &&
+      (typeof rawMaxInflight !== "number" ||
+        !Number.isInteger(rawMaxInflight) ||
+        rawMaxInflight < MIN_MAX_INFLIGHT_PER_ACCOUNT ||
+        rawMaxInflight > MAX_MAX_INFLIGHT_PER_ACCOUNT)
+    ) {
+      errors.push(
+        "routing.max-inflight-per-account must be an integer between 1 and 20",
+      );
+    }
+
     const rawSessionSoftLimit =
       routing["session-soft-limit"] ?? routing.sessionSoftLimit;
     if (rawSessionSoftLimit !== undefined) {
@@ -419,6 +451,8 @@ function warnPlaintextApiKeys(
  * - `strategy` ("round-robin" | "fill-first")
  * - `model-mappings` / `modelMappings` — array of {from, to, provider}
  * - `fallback-chain` / `fallbackChain` — array of {provider, model}
+ * - `auto-fallback` / `autoFallback` — opt in to an unspecified provider
+ * - `max-inflight-per-account` / `maxInflightPerAccount` — concurrency cap
  * - `passthroughModels` / `passthrough-models` — array of model IDs
  * - `quota-routing` / `quotaRouting` — quota-aware fill-first ordering
  * - `session-soft-limit` / `sessionSoftLimit` — proactive handoff threshold
@@ -515,6 +549,39 @@ function parseRoutingConfig(
     } else {
       logger.warn(
         `[proxy-config] Ignoring routing.quotaRouting: expected boolean, got ${typeof rawQuotaRouting}`,
+      );
+    }
+  }
+
+  const rawAutoFallback = raw["auto-fallback"] ?? raw.autoFallback;
+  if (rawAutoFallback !== undefined) {
+    if (typeof rawAutoFallback === "boolean") {
+      result.autoFallback = rawAutoFallback;
+    } else if (
+      typeof rawAutoFallback === "string" &&
+      ["true", "false"].includes(rawAutoFallback.trim().toLowerCase())
+    ) {
+      result.autoFallback = rawAutoFallback.trim().toLowerCase() === "true";
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.autoFallback: expected boolean, got ${typeof rawAutoFallback}`,
+      );
+    }
+  }
+
+  const rawMaxInflight =
+    raw["max-inflight-per-account"] ?? raw.maxInflightPerAccount;
+  if (rawMaxInflight !== undefined) {
+    if (
+      typeof rawMaxInflight === "number" &&
+      Number.isInteger(rawMaxInflight) &&
+      rawMaxInflight >= MIN_MAX_INFLIGHT_PER_ACCOUNT &&
+      rawMaxInflight <= MAX_MAX_INFLIGHT_PER_ACCOUNT
+    ) {
+      result.maxInflightPerAccount = rawMaxInflight;
+    } else {
+      logger.warn(
+        `[proxy-config] Ignoring routing.maxInflightPerAccount: expected integer between 1 and 20, got ${String(rawMaxInflight)}`,
       );
     }
   }

--- a/src/lib/proxy/routingPolicy.ts
+++ b/src/lib/proxy/routingPolicy.ts
@@ -26,13 +26,16 @@ export function inferClaudeProxyModelTier(
  * Build a translation plan for a Claude-compatible proxy request.
  * The plan lists the primary provider followed by eligible fallback targets.
  * All configured fallback entries are always eligible — no contract-based gating.
- * When no fallback chain is configured, an "auto-provider" entry is appended.
+ * An "auto-provider" entry is appended only when explicitly enabled by the
+ * caller. This keeps an empty fallback chain from silently escaping to an
+ * unrelated provider.
  */
 export function buildProxyTranslationPlan(
   primary: { provider: string; model?: string },
   fallbackChain: FallbackEntry[],
   requestedModel: string,
   _parsed: ParsedClaudeRequest,
+  allowAutoFallback = false,
 ): ProxyTranslationPlan {
   const attempts: ProxyTranslationAttempt[] = [
     {
@@ -57,9 +60,12 @@ export function buildProxyTranslationPlan(
     });
   }
 
-  // Append auto-provider when no configured fallback chain exists,
-  // or when all configured entries were deduped (same as primary).
-  if (fallbackChain.length === 0 || attempts.length === 1) {
+  // A provider chosen by the translation layer is an explicit opt-in. It is
+  // intentionally not a default when configured entries are absent or deduped.
+  if (
+    allowAutoFallback &&
+    (fallbackChain.length === 0 || attempts.length === 1)
+  ) {
     attempts.push({ label: "auto-provider" });
   }
 

--- a/src/lib/proxy/runtimeConfig.ts
+++ b/src/lib/proxy/runtimeConfig.ts
@@ -327,6 +327,8 @@ async function buildCandidate(
         strategy,
         modelMappings: routing.modelMappings ?? [],
         fallbackChain: routing.fallbackChain ?? [],
+        autoFallback: routing.autoFallback,
+        maxInflightPerAccount: routing.maxInflightPerAccount,
         passthroughModels: routing.passthroughModels,
         quotaRouting: routing.quotaRouting,
         sessionSoftLimit: routing.sessionSoftLimit,

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -82,6 +82,11 @@ import {
   buildProxyTranslationPlan,
   parseRetryAfterMs,
 } from "../../proxy/routingPolicy.js";
+import {
+  DEFAULT_MAX_INFLIGHT_PER_ACCOUNT,
+  MAX_MAX_INFLIGHT_PER_ACCOUNT,
+  MIN_MAX_INFLIGHT_PER_ACCOUNT,
+} from "../../proxy/modelRouter.js";
 import type { ProxyTranslationPlan } from "../../types/index.js";
 import { writeJsonSnapshotAtomically } from "../../proxy/snapshotPersistence.js";
 import {
@@ -92,6 +97,8 @@ import {
 } from "../../proxy/usageStats.js";
 import type {
   AccountAllowlist,
+  AccountAdmissionLease,
+  AccountAdmissionState,
   AccountCooldownPlan,
   AccountQuota,
   AnthropicAttemptLogger,
@@ -119,6 +126,7 @@ import type {
   ProxyAccountSortMetrics,
   ProxyBodyCaptureLogger,
   ProxyPassthroughAccount,
+  QueuedAccountAdmission,
   ResponseInfoContext,
   RouteGroup,
   RoutedClaudeRequestRuntimeContext,
@@ -128,8 +136,9 @@ import type {
   StreamTerminalOutcome,
   TransientRateLimitRetryBudget,
 } from "../../types/index.js";
+import { sanitizeForLog } from "../../utils/logSanitize.js";
 import { logger } from "../../utils/logger.js";
-import { withTimeout } from "../../utils/async/withTimeout.js";
+import { raceWithAbort, withTimeout } from "../../utils/async/withTimeout.js";
 import { ProviderHealthChecker } from "../../utils/providerHealth.js";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -208,6 +217,209 @@ const transientCooldownAdmissionSchedules = new Map<
   string,
   { coolingUntil: number; nextAdmissionAt: number }
 >();
+
+/**
+ * Central per-account admission protects an OAuth account from a concurrent
+ * request herd. A lease stays held until a JSON response completes or an SSE
+ * response reaches a terminal state, so starting a stream cannot immediately
+ * make room for another stream on the same account.
+ */
+const accountAdmissionStates = new Map<string, AccountAdmissionState>();
+
+function getAccountAdmissionState(accountKey: string): AccountAdmissionState {
+  let state = accountAdmissionStates.get(accountKey);
+  if (!state) {
+    state = { active: 0, waiters: [] };
+    accountAdmissionStates.set(accountKey, state);
+  }
+  return state;
+}
+
+function normalizeAccountAdmissionCapacity(capacity: number): number {
+  return Number.isInteger(capacity) &&
+    capacity >= MIN_MAX_INFLIGHT_PER_ACCOUNT &&
+    capacity <= MAX_MAX_INFLIGHT_PER_ACCOUNT
+    ? capacity
+    : DEFAULT_MAX_INFLIGHT_PER_ACCOUNT;
+}
+
+function drainAccountAdmissionWaiters(
+  accountKey: string,
+  state: AccountAdmissionState,
+): void {
+  while (state.waiters.length > 0 && state.active < state.waiters[0].capacity) {
+    const waiter = state.waiters.shift();
+    if (!waiter) {
+      return;
+    }
+    state.active += 1;
+    waiter.resolve(createAccountAdmissionLease(accountKey, state));
+  }
+}
+
+function createAccountAdmissionLease(
+  accountKey: string,
+  state: AccountAdmissionState,
+): AccountAdmissionLease {
+  let released = false;
+  return {
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      state.active = Math.max(0, state.active - 1);
+      drainAccountAdmissionWaiters(accountKey, state);
+      discardAccountAdmissionState(accountKey, state);
+    },
+  };
+}
+
+function discardAccountAdmissionState(
+  accountKey: string,
+  state: AccountAdmissionState,
+): void {
+  if (state.active === 0 && state.waiters.length === 0) {
+    accountAdmissionStates.delete(accountKey);
+  }
+}
+
+function tryAcquireAccountAdmission(
+  accountKey: string,
+  capacity: number,
+): AccountAdmissionLease | undefined {
+  const state = getAccountAdmissionState(accountKey);
+  const normalizedCapacity = normalizeAccountAdmissionCapacity(capacity);
+  if (state.waiters.length > 0 || state.active >= normalizedCapacity) {
+    return undefined;
+  }
+  state.active += 1;
+  return createAccountAdmissionLease(accountKey, state);
+}
+
+function isAccountAdmissionAvailable(
+  accountKey: string,
+  capacity: number,
+): boolean {
+  const state = accountAdmissionStates.get(accountKey);
+  const normalizedCapacity = normalizeAccountAdmissionCapacity(capacity);
+  return (
+    !state || (state.waiters.length === 0 && state.active < normalizedCapacity)
+  );
+}
+
+function enqueueAccountAdmission(
+  accountKey: string,
+  capacity: number,
+): QueuedAccountAdmission {
+  const state = getAccountAdmissionState(accountKey);
+  const normalizedCapacity = normalizeAccountAdmissionCapacity(capacity);
+  let queued = true;
+  let grantedLease: AccountAdmissionLease | undefined;
+  let resolveAdmission: (lease: AccountAdmissionLease) => void;
+  const promise = new Promise<AccountAdmissionLease>((resolve) => {
+    resolveAdmission = resolve;
+  });
+  const waiter = {
+    capacity: normalizedCapacity,
+    resolve: (lease: AccountAdmissionLease) => {
+      queued = false;
+      grantedLease = lease;
+      resolveAdmission(lease);
+    },
+  };
+  state.waiters.push(waiter);
+  drainAccountAdmissionWaiters(accountKey, state);
+
+  return {
+    accountKey,
+    promise,
+    cancel: () => {
+      if (grantedLease) {
+        const lease = grantedLease;
+        grantedLease = undefined;
+        lease.release();
+        return;
+      }
+      if (!queued) {
+        return;
+      }
+      queued = false;
+      const index = state.waiters.indexOf(waiter);
+      if (index >= 0) {
+        state.waiters.splice(index, 1);
+        drainAccountAdmissionWaiters(accountKey, state);
+      }
+      discardAccountAdmissionState(accountKey, state);
+    },
+  };
+}
+
+async function acquireAccountAdmission(
+  accountKey: string,
+  capacity: number,
+  abortSignal?: AbortSignal,
+  timeoutMs: number = MAX_TRANSIENT_QUEUE_WAIT_MS,
+): Promise<AccountAdmissionLease | undefined> {
+  const queued = enqueueAccountAdmission(accountKey, capacity);
+  try {
+    return await withTimeout(
+      raceWithAbort(queued.promise, abortSignal),
+      timeoutMs,
+      `Account admission for ${accountKey} timed out after ${timeoutMs}ms`,
+    );
+  } catch (error) {
+    queued.cancel();
+    if (abortSignal?.aborted) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
+async function acquireFirstAvailableAccountAdmission(
+  accountKeys: string[],
+  capacity: number,
+  abortSignal?: AbortSignal,
+  timeoutMs: number = MAX_TRANSIENT_QUEUE_WAIT_MS,
+): Promise<{ accountKey: string; lease: AccountAdmissionLease } | undefined> {
+  const queuedAdmissions = [...new Set(accountKeys)].map((accountKey) =>
+    enqueueAccountAdmission(accountKey, capacity),
+  );
+  let winnerKey: string | undefined;
+  try {
+    return await withTimeout(
+      raceWithAbort(
+        Promise.race(
+          queuedAdmissions.map((queued) =>
+            queued.promise.then((lease) => {
+              if (winnerKey) {
+                lease.release();
+                return new Promise<never>(() => undefined);
+              }
+              winnerKey = queued.accountKey;
+              return { accountKey: queued.accountKey, lease };
+            }),
+          ),
+        ),
+        abortSignal,
+      ),
+      timeoutMs,
+      `Account admission timed out after ${timeoutMs}ms`,
+    );
+  } catch (error) {
+    if (abortSignal?.aborted) {
+      throw error;
+    }
+    return undefined;
+  } finally {
+    for (const queued of queuedAdmissions) {
+      if (queued.accountKey !== winnerKey) {
+        queued.cancel();
+      }
+    }
+  }
+}
 
 /** Track whether we've run the one-time startup prune. */
 let startupPruneDone = false;
@@ -1617,6 +1829,7 @@ async function handleTranslatedClaudeRequest(args: {
     modelRouter?.getFallbackChain() ?? [],
     body.model,
     parsed,
+    modelRouter?.isAutoFallbackEnabled?.() ?? false,
   );
   logProxyRoutingPlan(logProxyBody, "translated_request", plan);
   const attempts = plan.attempts;
@@ -2793,7 +3006,7 @@ async function executeClaudeFallbackWithRetry(
       }
       const delayMs = TRANSIENT_SAME_ACCOUNT_RETRY_DELAYS_MS[retry] ?? 250;
       logger.always(
-        `[proxy] retrying fallback=${args.providerLabel} after transient network error (${retry + 1}/${MAX_FALLBACK_NETWORK_RETRIES}) in ${delayMs}ms: ${describeTransportError(error)}`,
+        `[proxy] retrying fallback=${args.providerLabel} after transient network error (${retry + 1}/${MAX_FALLBACK_NETWORK_RETRIES}) in ${delayMs}ms: ${redactProviderErrorMessage(describeTransportError(error))}`,
       );
       await sleep(delayMs);
     }
@@ -2867,9 +3080,19 @@ async function tryConfiguredClaudeFallbackChain(args: {
         fallback.model,
       );
     if (!availability.available) {
+      const reason = availability.reason ?? "provider unavailable";
       logger.always(
-        `[proxy] fallback ${fallback.provider}/${fallback.model} health-check failed (${availability.reason ?? "provider unavailable"}), attempting anyway`,
+        `[proxy] fallback ${fallback.provider}/${fallback.model} health-check failed (${reason}), skipping`,
       );
+      recordFallbackAttempt({
+        provider: fallback.provider,
+        model: fallback.model,
+        status: "failure",
+        errorMessage: `[unavailable] ${reason}`,
+        durationMs: 0,
+      });
+      lastFallbackError = `[${fallback.provider}/${fallback.model}] unavailable: ${reason}`;
+      continue;
     }
 
     const fallbackStart = Date.now();
@@ -2906,10 +3129,11 @@ async function tryConfiguredClaudeFallbackChain(args: {
       });
       return { response };
     } catch (fallbackErr) {
-      const errMsg =
+      const errMsg = redactProviderErrorMessage(
         fallbackErr instanceof Error
           ? fallbackErr.message
-          : String(fallbackErr);
+          : String(fallbackErr),
+      );
 
       let errorClass = "unknown";
       if (
@@ -2938,7 +3162,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
       }
 
       logger.always(
-        `[proxy] fallback ${fallback.provider}/${fallback.model} failed [${errorClass}]: ${describeTransportError(fallbackErr)}`,
+        `[proxy] fallback ${fallback.provider}/${fallback.model} failed [${errorClass}]: ${redactProviderErrorMessage(describeTransportError(fallbackErr))}`,
       );
       recordFallbackAttempt({
         provider: fallback.provider,
@@ -2947,7 +3171,7 @@ async function tryConfiguredClaudeFallbackChain(args: {
         errorMessage: `[${errorClass}] ${errMsg}`,
         durationMs: Date.now() - fallbackStart,
       });
-      lastFallbackError = `[${fallback.provider}/${fallback.model}] ${describeTransportError(fallbackErr)}`;
+      lastFallbackError = `[${fallback.provider}/${fallback.model}] ${redactProviderErrorMessage(describeTransportError(fallbackErr))}`;
     }
   }
 
@@ -2984,6 +3208,7 @@ async function tryAutoClaudeFallback(args: {
       [],
       body.model,
       parsed,
+      true,
     );
     logProxyRoutingPlan(logProxyBody, "auto_fallback", plan);
     const autoAttempt = plan.attempts.find(
@@ -3019,7 +3244,9 @@ async function tryAutoClaudeFallback(args: {
     });
     return { response };
   } catch (fallbackErr) {
-    const errorMessage = describeTransportError(fallbackErr);
+    const errorMessage = redactProviderErrorMessage(
+      describeTransportError(fallbackErr),
+    );
     logger.always(`[proxy] fallback auto-provider failed: ${errorMessage}`);
     recordFallbackAttempt({
       provider: "auto-provider",
@@ -3242,6 +3469,7 @@ async function handleAnthropicSuccessfulResponse(args: {
   upstreamSpan?: import("@opentelemetry/api").Span;
   logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
+  onStreamTerminal?: () => void;
   logFinalRequest: (
     status: number,
     accountLabel: string,
@@ -3270,6 +3498,7 @@ async function handleAnthropicSuccessfulResponse(args: {
     upstreamSpan,
     logAttempt,
     logProxyBody,
+    onStreamTerminal,
     logFinalRequest,
   } = args;
   accountState.consecutiveRefreshFailures = 0;
@@ -3319,6 +3548,7 @@ async function handleAnthropicSuccessfulResponse(args: {
       logAttempt,
       logProxyBody,
       logFinalRequest,
+      onStreamTerminal,
     });
   }
 
@@ -3353,6 +3583,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
   upstreamSpan?: import("@opentelemetry/api").Span;
   logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
+  onStreamTerminal?: () => void;
   logFinalRequest: (
     status: number,
     accountLabel: string,
@@ -3380,6 +3611,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     upstreamSpan,
     logAttempt,
     logProxyBody,
+    onStreamTerminal,
     logFinalRequest,
   } = args;
   if (!response.body) {
@@ -3602,21 +3834,26 @@ async function handleAnthropicStreamingSuccessResponse(args: {
     },
   });
 
-  const result = attachAnthropicSuccessStreamTelemetry({
-    account,
-    response,
-    responseHeaders,
-    remainingStream,
-    streamOutcome: streamOutcomeTracker.outcome,
-    tracer,
-    requestStartTime,
-    attemptNumber,
-    finalBodyStr,
-    upstreamSpan,
-    logProxyBody,
-    logFinalRequest,
-  });
-  return { response: result };
+  const { response: result, telemetryDone } =
+    attachAnthropicSuccessStreamTelemetry({
+      account,
+      response,
+      responseHeaders,
+      remainingStream,
+      streamOutcome: streamOutcomeTracker.outcome,
+      tracer,
+      requestStartTime,
+      attemptNumber,
+      finalBodyStr,
+      upstreamSpan,
+      logProxyBody,
+      logFinalRequest,
+    });
+  void telemetryDone.then(
+    () => onStreamTerminal?.(),
+    () => onStreamTerminal?.(),
+  );
+  return { response: result, holdsAccountAdmission: true };
 }
 
 function getStreamFailureDetails(
@@ -3673,7 +3910,7 @@ function attachAnthropicSuccessStreamTelemetry(args: {
       cacheReadTokens?: number;
     },
   ) => void;
-}): Response {
+}): { response: Response; telemetryDone: Promise<void> } {
   const {
     account,
     response,
@@ -3691,6 +3928,7 @@ function attachAnthropicSuccessStreamTelemetry(args: {
   const { stream: clientCaptureStream, capture: clientCapture } =
     createRawStreamCapture();
   let streamSource: ReadableStream<Uint8Array> = remainingStream;
+  let telemetryDone: Promise<void>;
 
   if (tracer) {
     try {
@@ -3704,7 +3942,7 @@ function attachAnthropicSuccessStreamTelemetry(args: {
       const capturedRequestBytes = finalBodyStr.length;
       const capturedAccountLabel = account.label;
 
-      Promise.all([telemetry, clientCapture, streamOutcome])
+      telemetryDone = Promise.all([telemetry, clientCapture, streamOutcome])
         .then(([data, clientBody, rawOutcome]) => {
           const terminalOutcome = mergeStreamTerminalOutcome(
             rawOutcome,
@@ -3827,25 +4065,27 @@ function attachAnthropicSuccessStreamTelemetry(args: {
     } catch {
       // Interceptor attachment failed after stream setup. Preserve delivery but
       // still settle the request from the actual stream terminal outcome.
-      streamOutcome.then((outcome) => {
-        recordCommittedAnthropicStreamAttemptFailure(outcome, account);
-        const failure = getStreamFailureDetails(outcome);
-        upstreamSpan?.end();
-        if (failure) {
-          tracer.setError(failure.errorType, failure.message);
-          tracer.end(failure.status, Date.now() - requestStartTime);
-          logFinalRequest(
-            failure.status,
-            account.label,
-            account.type,
-            failure.errorType,
-            failure.message,
-          );
-        } else {
-          tracer.end(response.status, Date.now() - requestStartTime);
-          logFinalRequest(response.status, account.label, account.type);
-        }
-      });
+      telemetryDone = streamOutcome
+        .then((outcome) => {
+          recordCommittedAnthropicStreamAttemptFailure(outcome, account);
+          const failure = getStreamFailureDetails(outcome);
+          upstreamSpan?.end();
+          if (failure) {
+            tracer.setError(failure.errorType, failure.message);
+            tracer.end(failure.status, Date.now() - requestStartTime);
+            logFinalRequest(
+              failure.status,
+              account.label,
+              account.type,
+              failure.errorType,
+              failure.message,
+            );
+          } else {
+            tracer.end(response.status, Date.now() - requestStartTime);
+            logFinalRequest(response.status, account.label, account.type);
+          }
+        })
+        .catch(() => undefined);
     }
   } else {
     upstreamSpan?.end();
@@ -3856,7 +4096,11 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         });
       streamSource = streamSource.pipeThrough(noTracerInterceptor);
       const capturedAccountLabel = account.label;
-      Promise.all([noTracerTelemetry, clientCapture, streamOutcome])
+      telemetryDone = Promise.all([
+        noTracerTelemetry,
+        clientCapture,
+        streamOutcome,
+      ])
         .then(([data, clientBody, rawOutcome]) => {
           const terminalOutcome = mergeStreamTerminalOutcome(
             rawOutcome,
@@ -3947,21 +4191,23 @@ function attachAnthropicSuccessStreamTelemetry(args: {
         .catch(() => {
           // Non-fatal
         });
-      streamOutcome.then((outcome) => {
-        recordCommittedAnthropicStreamAttemptFailure(outcome, account);
-        const failure = getStreamFailureDetails(outcome);
-        if (failure) {
-          logFinalRequest(
-            failure.status,
-            account.label,
-            account.type,
-            failure.errorType,
-            failure.message,
-          );
-        } else {
-          logFinalRequest(response.status, account.label, account.type);
-        }
-      });
+      telemetryDone = streamOutcome
+        .then((outcome) => {
+          recordCommittedAnthropicStreamAttemptFailure(outcome, account);
+          const failure = getStreamFailureDetails(outcome);
+          if (failure) {
+            logFinalRequest(
+              failure.status,
+              account.label,
+              account.type,
+              failure.errorType,
+              failure.message,
+            );
+          } else {
+            logFinalRequest(response.status, account.label, account.type);
+          }
+        })
+        .catch(() => undefined);
     }
   }
 
@@ -3984,10 +4230,13 @@ function attachAnthropicSuccessStreamTelemetry(args: {
     }
   }
 
-  return new Response(clientStream, {
-    status: response.status,
-    headers: clientResponseHeaders,
-  });
+  return {
+    response: new Response(clientStream, {
+      status: response.status,
+      headers: clientResponseHeaders,
+    }),
+    telemetryDone,
+  };
 }
 
 async function handleAnthropicJsonSuccessResponse(args: {
@@ -4294,6 +4543,7 @@ async function handleAnthropicAuthRetry(args: {
   upstreamSpan?: import("@opentelemetry/api").Span;
   logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
+  onStreamTerminal?: () => void;
   logFinalRequest: (
     status: number,
     accountLabel: string,
@@ -4329,6 +4579,7 @@ async function handleAnthropicAuthRetry(args: {
     upstreamSpan,
     logAttempt,
     logProxyBody,
+    onStreamTerminal,
     logFinalRequest,
     lastError,
     authFailureMessage,
@@ -4446,6 +4697,7 @@ async function handleAnthropicAuthRetry(args: {
               logAttempt: retryLogAttempt,
               logProxyBody,
               logFinalRequest,
+              onStreamTerminal,
             })
           : {
               response: await handleAnthropicSuccessfulNonStreamRetryResponse({
@@ -4479,6 +4731,7 @@ async function handleAnthropicAuthRetry(args: {
         }
         return {
           response: successResult.response,
+          holdsAccountAdmission: successResult.holdsAccountAdmission,
           continueLoop: false,
           lastError: currentLastError,
           authFailureMessage: currentAuthFailureMessage,
@@ -5089,6 +5342,7 @@ async function handleAnthropicNonOkResponse(args: {
   }
 
   if (isTransientHttpFailure(response.status, errBody)) {
+    const upstreamOverload = isUpstreamOverload(response.status, errBody);
     recordAttemptError(
       account.label,
       account.type,
@@ -5097,7 +5351,7 @@ async function handleAnthropicNonOkResponse(args: {
     );
     currentSawTransientFailure = true;
     logger.always(
-      `[proxy] ← ${response.status} account=${account.label} (transient)`,
+      `[proxy] ← ${response.status} account=${account.label} (${upstreamOverload ? "overloaded" : "transient"})`,
     );
     currentLastError = errBody;
     logAttempt(
@@ -5112,11 +5366,17 @@ async function handleAnthropicNonOkResponse(args: {
           }
         : undefined,
     );
-    tracer?.setError("transient_error", summarizeErrorMessage(errBody));
-    tracer?.recordRetry(account.label, "transient");
+    tracer?.setError(
+      upstreamOverload ? "overloaded_error" : "transient_error",
+      summarizeErrorMessage(errBody),
+    );
+    tracer?.recordRetry(
+      account.label,
+      upstreamOverload ? "overloaded" : "transient",
+    );
     return {
       continueLoop: true,
-      retrySameAccount: true,
+      retrySameAccount: !upstreamOverload,
       lastError: currentLastError,
       authFailureMessage: currentAuthFailureMessage,
       sawTransientFailure: currentSawTransientFailure,
@@ -5959,6 +6219,28 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     }
   }
 
+  const accountAdmissionCapacity =
+    modelRouter?.getMaxInflightPerAccount?.() ??
+    DEFAULT_MAX_INFLIGHT_PER_ACCOUNT;
+  // When every eligible account is busy, reserve the first account that frees
+  // instead of arbitrarily waiting behind the last configured account.
+  let queuedAccountAdmission:
+    | { accountKey: string; lease: AccountAdmissionLease }
+    | undefined;
+  if (
+    effectiveAccounts.length > 0 &&
+    effectiveAccounts.every(
+      (account) =>
+        !isAccountAdmissionAvailable(account.key, accountAdmissionCapacity),
+    )
+  ) {
+    queuedAccountAdmission = await acquireFirstAvailableAccountAdmission(
+      effectiveAccounts.map((account) => account.key),
+      accountAdmissionCapacity,
+      ctx.abortSignal,
+    );
+  }
+
   accountLoop: for (const account of effectiveAccounts) {
     const accountState = getOrCreateRuntimeState(account.key);
     let transientSameAccountRetries = 0;
@@ -6012,210 +6294,138 @@ async function handleAnthropicRoutedClaudeRequest(args: {
         continue accountLoop;
       }
 
-      const fetchResult = await fetchAnthropicAccountResponse({
-        url,
-        headers: preparedAttempt.headers,
-        finalBodyStr: preparedAttempt.finalBodyStr,
-        account,
-        accountState,
-        enabledAccounts,
-        orderedAccounts,
-        tracer,
-        logAttempt,
-        logProxyBody,
-        fetchStartMs: preparedAttempt.fetchStartMs,
-        attemptNumber: loopState.attemptNumber,
-        currentLastError: loopState.lastError,
-        currentSawRateLimit: loopState.sawRateLimit,
-        currentSawNetworkError: loopState.sawNetworkError,
-        upstreamSpan: preparedAttempt.upstreamSpan,
-      });
-      loopState.lastError = fetchResult.lastError;
-      loopState.sawRateLimit = fetchResult.sawRateLimit;
-      loopState.sawNetworkError = fetchResult.sawNetworkError;
-      if (fetchResult.terminalError) {
-        return finalizeAnthropicTerminalFetchError({
-          terminalError: fetchResult.terminalError,
-          account,
-          tracer,
-          requestStartTime,
-          attemptNumber: loopState.attemptNumber,
-          logProxyBody,
-          logFinalRequest,
-        });
+      let admissionLease: AccountAdmissionLease | undefined;
+      if (queuedAccountAdmission?.accountKey === account.key) {
+        admissionLease = queuedAccountAdmission.lease;
+        queuedAccountAdmission = undefined;
+      } else {
+        admissionLease = tryAcquireAccountAdmission(
+          account.key,
+          accountAdmissionCapacity,
+        );
+        if (admissionLease && queuedAccountAdmission) {
+          // A preferred account became available while the race was being
+          // established; release the lower-priority reservation.
+          queuedAccountAdmission.lease.release();
+          queuedAccountAdmission = undefined;
+        }
       }
-      if (fetchResult.continueLoop || !fetchResult.response) {
-        // Genuine 429 (carries a cooldown plan derived from quota headers).
-        if (fetchResult.cooldownPlan) {
-          const plan = fetchResult.cooldownPlan;
-          // Refresh the account's quota snapshot for proactive selection.
-          if (fetchResult.quota) {
-            accountState.quota = fetchResult.quota;
-            saveAccountQuota(account.label, fetchResult.quota).catch(() => {
-              // Non-fatal: routing already has the in-memory snapshot.
-            });
-          }
-          // Publish the cooldown before retrying so requests arriving behind
-          // this one skip the throttled account instead of joining the burst.
-          let cooldownExtended = false;
-          if (
-            !accountState.coolingUntil ||
-            plan.coolingUntil > accountState.coolingUntil
-          ) {
-            accountState.coolingUntil = plan.coolingUntil;
-            accountState.coolingReason = plan.reason;
-            cooldownExtended = true;
-          }
-          if (cooldownExtended) {
-            await saveAccountCooldown(
-              account.key,
-              accountState.coolingUntil,
-              accountState.coolingReason ?? plan.reason,
-            ).catch(() => {
-              // Non-fatal: routing already has the in-memory cooldown.
-            });
-          }
-
-          // Transient retries are budgeted across all concurrent requests for
-          // this account/window. Exhaustion plans rotate immediately and never
-          // claim this budget.
-          const sharedRetrySlot = fetchResult.retrySameAccount
-            ? claimTransientRateLimitRetry(account.key, plan.coolingUntil)
-            : undefined;
-          if (
-            fetchResult.retrySameAccount &&
-            fetchResult.retryAfterMs !== undefined &&
-            rateLimitSameAccountRetries < MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES &&
-            sharedRetrySlot !== undefined
-          ) {
-            rateLimitSameAccountRetries += 1;
-            const base = Math.min(
-              fetchResult.retryAfterMs || 1_000,
-              MAX_RATE_LIMIT_RETRY_DELAY_MS,
-            );
-            // Stagger the two shared slots, then cap after jitter so the final
-            // sleep never exceeds the configured maximum.
-            const delayMs = Math.min(
-              MAX_RATE_LIMIT_RETRY_DELAY_MS,
-              jitteredDelay(base * sharedRetrySlot),
-            );
-            logger.always(
-              `[proxy] retrying same account=${account.label} after transient 429 (shared slot ${sharedRetrySlot}/${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
-            );
-            await sleep(delayMs);
-            continue;
-          }
-          // Exhaustion, or the shared transient retry budget being used up:
-          // rotate while the already-published cooldown remains active.
-          advancePrimaryIfCurrent(
-            account.key,
-            enabledAccounts.length,
-            orderedAccounts[0]?.key,
-          );
-          logger.always(
-            `[proxy] account=${account.label} rate-limited (${plan.reason}); cooling ~${minutesUntil(plan.coolingUntil, Date.now())}m until ${new Date(plan.coolingUntil).toISOString()}, rotating`,
-          );
-          continue accountLoop;
-        }
-        // Transient error retry (network errors, 529 overloaded)
-        if (
-          fetchResult.retrySameAccount &&
-          transientSameAccountRetries < MAX_TRANSIENT_SAME_ACCOUNT_RETRIES
-        ) {
-          transientSameAccountRetries += 1;
-          const delayMs = getTransientSameAccountRetryDelayMs(
-            transientSameAccountRetries,
-          );
-          logger.always(
-            `[proxy] retrying same account=${account.label} after transient network error (${transientSameAccountRetries}/${MAX_TRANSIENT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
-          );
-          await sleep(delayMs);
-          continue;
-        }
-        if (fetchResult.retrySameAccount) {
-          logger.always(
-            `[proxy] exhausted transient same-account retries for account=${account.label}; rotating`,
-          );
-        }
+      if (!admissionLease) {
+        // A later account may be immediately available. Preserve the routing
+        // order but do not leave a request queued behind a busy first choice.
         continue accountLoop;
       }
-
-      let upstreamSpan = fetchResult.upstreamSpan;
-      const response = fetchResult.response;
-      if (
-        response.status === 401 &&
-        account.type === "oauth" &&
-        account.refreshToken
-      ) {
-        const authRetryResult = await handleAnthropicAuthRetry({
-          ctx,
-          body,
+      let admissionTransferredToStream = false;
+      try {
+        const fetchResult = await fetchAnthropicAccountResponse({
+          url,
+          headers: preparedAttempt.headers,
+          finalBodyStr: preparedAttempt.finalBodyStr,
           account,
           accountState,
-          headers: preparedAttempt.headers,
-          buildUpstreamBody: preparedAttempt.buildUpstreamBody,
-          url,
           enabledAccounts,
           orderedAccounts,
           tracer,
-          requestStartTime,
-          allocateAttemptNumber: () => {
-            loopState.attemptNumber += 1;
-            return loopState.attemptNumber;
-          },
-          upstreamSpan,
           logAttempt,
           logProxyBody,
-          logFinalRequest,
-          lastError: loopState.lastError,
-          authFailureMessage: loopState.authFailureMessage,
-          sawRateLimit: loopState.sawRateLimit,
-          sawTransientFailure: loopState.sawTransientFailure,
-          sawNetworkError: loopState.sawNetworkError,
-        });
-        loopState.lastError = authRetryResult.lastError;
-        loopState.authFailureMessage = authRetryResult.authFailureMessage;
-        loopState.sawRateLimit = authRetryResult.sawRateLimit;
-        loopState.sawTransientFailure = authRetryResult.sawTransientFailure;
-        loopState.sawNetworkError = authRetryResult.sawNetworkError;
-        upstreamSpan = authRetryResult.upstreamSpan;
-        if (authRetryResult.response !== undefined) {
-          return authRetryResult.response;
-        }
-        if (authRetryResult.continueLoop) {
-          continue accountLoop;
-        }
-      }
-
-      if (!response.ok) {
-        const nonOkResult = await handleAnthropicNonOkResponse({
-          response,
-          account,
-          accountState,
-          enabledAccounts,
-          orderedAccounts,
-          tracer,
-          requestStartTime,
           fetchStartMs: preparedAttempt.fetchStartMs,
           attemptNumber: loopState.attemptNumber,
-          logAttempt,
-          logProxyBody,
-          logFinalRequest,
-          lastError: loopState.lastError,
-          authFailureMessage: loopState.authFailureMessage,
-          sawTransientFailure: loopState.sawTransientFailure,
-          invalidRequestFailure: loopState.invalidRequestFailure,
+          currentLastError: loopState.lastError,
+          currentSawRateLimit: loopState.sawRateLimit,
+          currentSawNetworkError: loopState.sawNetworkError,
+          upstreamSpan: preparedAttempt.upstreamSpan,
         });
-        loopState.lastError = nonOkResult.lastError;
-        loopState.authFailureMessage = nonOkResult.authFailureMessage;
-        loopState.sawTransientFailure = nonOkResult.sawTransientFailure;
-        loopState.invalidRequestFailure = nonOkResult.invalidRequestFailure;
-        if (nonOkResult.response !== undefined) {
-          return nonOkResult.response;
+        loopState.lastError = fetchResult.lastError;
+        loopState.sawRateLimit = fetchResult.sawRateLimit;
+        loopState.sawNetworkError = fetchResult.sawNetworkError;
+        if (fetchResult.terminalError) {
+          return finalizeAnthropicTerminalFetchError({
+            terminalError: fetchResult.terminalError,
+            account,
+            tracer,
+            requestStartTime,
+            attemptNumber: loopState.attemptNumber,
+            logProxyBody,
+            logFinalRequest,
+          });
         }
-        if (nonOkResult.continueLoop) {
+        if (fetchResult.continueLoop || !fetchResult.response) {
+          // Genuine 429 (carries a cooldown plan derived from quota headers).
+          if (fetchResult.cooldownPlan) {
+            const plan = fetchResult.cooldownPlan;
+            // Refresh the account's quota snapshot for proactive selection.
+            if (fetchResult.quota) {
+              accountState.quota = fetchResult.quota;
+              saveAccountQuota(account.label, fetchResult.quota).catch(() => {
+                // Non-fatal: routing already has the in-memory snapshot.
+              });
+            }
+            // Publish the cooldown before retrying so requests arriving behind
+            // this one skip the throttled account instead of joining the burst.
+            let cooldownExtended = false;
+            if (
+              !accountState.coolingUntil ||
+              plan.coolingUntil > accountState.coolingUntil
+            ) {
+              accountState.coolingUntil = plan.coolingUntil;
+              accountState.coolingReason = plan.reason;
+              cooldownExtended = true;
+            }
+            if (cooldownExtended) {
+              await saveAccountCooldown(
+                account.key,
+                accountState.coolingUntil,
+                accountState.coolingReason ?? plan.reason,
+              ).catch(() => {
+                // Non-fatal: routing already has the in-memory cooldown.
+              });
+            }
+
+            // Transient retries are budgeted across all concurrent requests for
+            // this account/window. Exhaustion plans rotate immediately and never
+            // claim this budget.
+            const sharedRetrySlot = fetchResult.retrySameAccount
+              ? claimTransientRateLimitRetry(account.key, plan.coolingUntil)
+              : undefined;
+            if (
+              fetchResult.retrySameAccount &&
+              fetchResult.retryAfterMs !== undefined &&
+              rateLimitSameAccountRetries <
+                MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES &&
+              sharedRetrySlot !== undefined
+            ) {
+              rateLimitSameAccountRetries += 1;
+              const base = Math.min(
+                fetchResult.retryAfterMs || 1_000,
+                MAX_RATE_LIMIT_RETRY_DELAY_MS,
+              );
+              // Stagger the two shared slots, then cap after jitter so the final
+              // sleep never exceeds the configured maximum.
+              const delayMs = Math.min(
+                MAX_RATE_LIMIT_RETRY_DELAY_MS,
+                jitteredDelay(base * sharedRetrySlot),
+              );
+              logger.always(
+                `[proxy] retrying same account=${account.label} after transient 429 (shared slot ${sharedRetrySlot}/${MAX_RATE_LIMIT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
+              );
+              await sleep(delayMs);
+              continue;
+            }
+            // Exhaustion, or the shared transient retry budget being used up:
+            // rotate while the already-published cooldown remains active.
+            advancePrimaryIfCurrent(
+              account.key,
+              enabledAccounts.length,
+              orderedAccounts[0]?.key,
+            );
+            logger.always(
+              `[proxy] account=${account.label} rate-limited (${plan.reason}); cooling ~${minutesUntil(plan.coolingUntil, Date.now())}m until ${new Date(plan.coolingUntil).toISOString()}, rotating`,
+            );
+            continue accountLoop;
+          }
+          // Transient error retry (network errors, 529 overloaded)
           if (
-            nonOkResult.retrySameAccount &&
+            fetchResult.retrySameAccount &&
             transientSameAccountRetries < MAX_TRANSIENT_SAME_ACCOUNT_RETRIES
           ) {
             transientSameAccountRetries += 1;
@@ -6223,65 +6433,174 @@ async function handleAnthropicRoutedClaudeRequest(args: {
               transientSameAccountRetries,
             );
             logger.always(
-              `[proxy] retrying same account=${account.label} after transient upstream ${response.status} (${transientSameAccountRetries}/${MAX_TRANSIENT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
+              `[proxy] retrying same account=${account.label} after transient network error (${transientSameAccountRetries}/${MAX_TRANSIENT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
             );
             await sleep(delayMs);
             continue;
           }
-          if (nonOkResult.retrySameAccount) {
+          if (fetchResult.retrySameAccount) {
             logger.always(
               `[proxy] exhausted transient same-account retries for account=${account.label}; rotating`,
             );
           }
           continue accountLoop;
         }
-        break accountLoop;
-      }
 
-      // Clear cooling on success — but only if the stored cooldown has already
-      // expired, so an older in-flight success can't wipe an active exhaustion
-      // cooldown just set by a concurrent 429. The success handler re-applies a
-      // cooldown via maybeCoolFromQuota if the fresh quota headers report the
-      // window flipped to "rejected" on this very request.
-      if (
-        accountState.coolingUntil &&
-        Date.now() >= accountState.coolingUntil
-      ) {
-        const expiredCooldown = accountState.coolingUntil;
-        accountState.coolingUntil = undefined;
-        accountState.coolingReason = undefined;
-        clearAccountCooldown(account.key, expiredCooldown).catch(() => {
-          // Best-effort cleanup; expired entries are ignored during seeding.
-        });
-      }
-
-      const successResult = await handleAnthropicSuccessfulResponse({
-        ctx,
-        body,
-        account,
-        accountState,
-        response,
-        tracer,
-        requestStartTime,
-        fetchStartMs: preparedAttempt.fetchStartMs,
-        attemptNumber: loopState.attemptNumber,
-        finalBodyStr: preparedAttempt.finalBodyStr,
-        upstreamSpan,
-        logAttempt,
-        logProxyBody,
-        logFinalRequest,
-      });
-      if ("retryNextAccount" in successResult) {
-        if (successResult.failure) {
-          loopState.lastError = successResult.failure.message;
-          loopState.sawRateLimit ||= successResult.failure.rateLimit;
-          loopState.sawTransientFailure ||= !successResult.failure.rateLimit;
+        let upstreamSpan = fetchResult.upstreamSpan;
+        const response = fetchResult.response;
+        if (
+          response.status === 401 &&
+          account.type === "oauth" &&
+          account.refreshToken
+        ) {
+          const authRetryResult = await handleAnthropicAuthRetry({
+            ctx,
+            body,
+            account,
+            accountState,
+            headers: preparedAttempt.headers,
+            buildUpstreamBody: preparedAttempt.buildUpstreamBody,
+            url,
+            enabledAccounts,
+            orderedAccounts,
+            tracer,
+            requestStartTime,
+            allocateAttemptNumber: () => {
+              loopState.attemptNumber += 1;
+              return loopState.attemptNumber;
+            },
+            upstreamSpan,
+            logAttempt,
+            logProxyBody,
+            logFinalRequest,
+            onStreamTerminal: admissionLease.release,
+            lastError: loopState.lastError,
+            authFailureMessage: loopState.authFailureMessage,
+            sawRateLimit: loopState.sawRateLimit,
+            sawTransientFailure: loopState.sawTransientFailure,
+            sawNetworkError: loopState.sawNetworkError,
+          });
+          loopState.lastError = authRetryResult.lastError;
+          loopState.authFailureMessage = authRetryResult.authFailureMessage;
+          loopState.sawRateLimit = authRetryResult.sawRateLimit;
+          loopState.sawTransientFailure = authRetryResult.sawTransientFailure;
+          loopState.sawNetworkError = authRetryResult.sawNetworkError;
+          upstreamSpan = authRetryResult.upstreamSpan;
+          if (authRetryResult.response !== undefined) {
+            admissionTransferredToStream =
+              authRetryResult.holdsAccountAdmission === true;
+            return authRetryResult.response;
+          }
+          if (authRetryResult.continueLoop) {
+            continue accountLoop;
+          }
         }
-        continue accountLoop;
+
+        if (!response.ok) {
+          const nonOkResult = await handleAnthropicNonOkResponse({
+            response,
+            account,
+            accountState,
+            enabledAccounts,
+            orderedAccounts,
+            tracer,
+            requestStartTime,
+            fetchStartMs: preparedAttempt.fetchStartMs,
+            attemptNumber: loopState.attemptNumber,
+            logAttempt,
+            logProxyBody,
+            logFinalRequest,
+            lastError: loopState.lastError,
+            authFailureMessage: loopState.authFailureMessage,
+            sawTransientFailure: loopState.sawTransientFailure,
+            invalidRequestFailure: loopState.invalidRequestFailure,
+          });
+          loopState.lastError = nonOkResult.lastError;
+          loopState.authFailureMessage = nonOkResult.authFailureMessage;
+          loopState.sawTransientFailure = nonOkResult.sawTransientFailure;
+          loopState.invalidRequestFailure = nonOkResult.invalidRequestFailure;
+          if (nonOkResult.response !== undefined) {
+            return nonOkResult.response;
+          }
+          if (nonOkResult.continueLoop) {
+            if (
+              nonOkResult.retrySameAccount &&
+              transientSameAccountRetries < MAX_TRANSIENT_SAME_ACCOUNT_RETRIES
+            ) {
+              transientSameAccountRetries += 1;
+              const delayMs = getTransientSameAccountRetryDelayMs(
+                transientSameAccountRetries,
+              );
+              logger.always(
+                `[proxy] retrying same account=${account.label} after transient upstream ${response.status} (${transientSameAccountRetries}/${MAX_TRANSIENT_SAME_ACCOUNT_RETRIES}) in ${delayMs}ms`,
+              );
+              await sleep(delayMs);
+              continue;
+            }
+            if (nonOkResult.retrySameAccount) {
+              logger.always(
+                `[proxy] exhausted transient same-account retries for account=${account.label}; rotating`,
+              );
+            }
+            continue accountLoop;
+          }
+          break accountLoop;
+        }
+
+        // Clear cooling on success — but only if the stored cooldown has already
+        // expired, so an older in-flight success can't wipe an active exhaustion
+        // cooldown just set by a concurrent 429. The success handler re-applies a
+        // cooldown via maybeCoolFromQuota if the fresh quota headers report the
+        // window flipped to "rejected" on this very request.
+        if (
+          accountState.coolingUntil &&
+          Date.now() >= accountState.coolingUntil
+        ) {
+          const expiredCooldown = accountState.coolingUntil;
+          accountState.coolingUntil = undefined;
+          accountState.coolingReason = undefined;
+          clearAccountCooldown(account.key, expiredCooldown).catch(() => {
+            // Best-effort cleanup; expired entries are ignored during seeding.
+          });
+        }
+
+        const successResult = await handleAnthropicSuccessfulResponse({
+          ctx,
+          body,
+          account,
+          accountState,
+          response,
+          tracer,
+          requestStartTime,
+          fetchStartMs: preparedAttempt.fetchStartMs,
+          attemptNumber: loopState.attemptNumber,
+          finalBodyStr: preparedAttempt.finalBodyStr,
+          upstreamSpan,
+          logAttempt,
+          logProxyBody,
+          logFinalRequest,
+          onStreamTerminal: admissionLease.release,
+        });
+        if ("retryNextAccount" in successResult) {
+          if (successResult.failure) {
+            loopState.lastError = successResult.failure.message;
+            loopState.sawRateLimit ||= successResult.failure.rateLimit;
+            loopState.sawTransientFailure ||= !successResult.failure.rateLimit;
+          }
+          continue accountLoop;
+        }
+        admissionTransferredToStream =
+          successResult.holdsAccountAdmission === true;
+        return successResult.response;
+      } finally {
+        if (!admissionTransferredToStream) {
+          admissionLease.release();
+        }
       }
-      return successResult.response;
     }
   }
+
+  queuedAccountAdmission?.lease.release();
 
   if (loopState.attemptNumber === 0) {
     acctSelectionSpan?.end();
@@ -6307,9 +6626,9 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     }
     fallbackFailureMessage = configuredFallbackResult.lastErrorMessage;
 
-    // Try auto-provider fallback when the configured chain didn't produce a
-    // response (either no chain configured, or all entries failed/deduped).
-    if (!loopState.sawRateLimit) {
+    // A translation-layer-selected provider is only permitted by an explicit
+    // routing setting. Empty fallback chains otherwise stay within OAuth.
+    if (!loopState.sawRateLimit && modelRouter?.isAutoFallbackEnabled?.()) {
       const autoFallbackResult = await tryAutoClaudeFallback({
         ctx,
         body,
@@ -7050,6 +7369,24 @@ export function isTransientHttpFailure(
   );
 }
 
+/**
+ * An upstream overload is already a capacity signal. Retrying it on the same
+ * OAuth account only consumes its remaining concurrency and delays rotation.
+ */
+export function isUpstreamOverload(status: number, errBody: string): boolean {
+  return (
+    status === 529 ||
+    parseClaudeErrorBody(errBody).errorType === "overloaded_error"
+  );
+}
+
+/** Remove provider credentials before they enter persistent proxy diagnostics. */
+const MAX_PROVIDER_ERROR_MESSAGE_LENGTH = 500;
+
+export function redactProviderErrorMessage(message: string): string {
+  return sanitizeForLog(message, MAX_PROVIDER_ERROR_MESSAGE_LENGTH);
+}
+
 // ---------------------------------------------------------------------------
 // Test hooks (not part of the public SDK API). Only consumed by the proxy
 // continuous-test-suite to drive the in-process resolver/reset logic without
@@ -7117,6 +7454,7 @@ export const __testHooks = {
     accountRuntimeState.clear();
     transientRateLimitRetryBudgets.clear();
     transientCooldownAdmissionSchedules.clear();
+    accountAdmissionStates.clear();
     primaryAccountIndex = 0;
     lastKnownAccountCount = 0;
   },
@@ -7133,12 +7471,24 @@ export const __testHooks = {
   isAntiAbuseConstruction429,
   fetchAnthropicAccountResponse,
   finalizeAnthropicTerminalFetchError,
+  handleAnthropicNonOkResponse,
   handleAnthropicAuthRetry,
   handleAnthropicStreamingSuccessResponse,
   claimTransientRateLimitRetry,
   claimTransientCooldownAdmission,
   waitForTransientAccountAvailability,
+  acquireAccountAdmission,
+  acquireFirstAvailableAccountAdmission,
+  tryAcquireAccountAdmission,
+  getAccountAdmissionSnapshot: (accountKey: string) => {
+    const state = accountAdmissionStates.get(accountKey);
+    return state
+      ? { active: state.active, waiting: state.waiters.length }
+      : { active: 0, waiting: 0 };
+  },
   describeTransportError,
+  redactProviderErrorMessage,
+  isUpstreamOverload,
   shouldAttemptClaudeFallback,
   executeClaudeFallbackWithRetry,
   buildClaudeAnthropicFailureResponse,

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -450,6 +450,7 @@ export function createOpenAIProxyRoutes(
             body.model,
             // The classifier only reads fields present on both types.
             adapted as Parameters<typeof buildProxyTranslationPlan>[3],
+            requestModelRouter?.isAutoFallbackEnabled?.() ?? false,
           );
           const attempts = plan.attempts;
 

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -42,6 +42,8 @@ export type ModelRouterInterface = {
   resolve(requestedModel: string): RouteResult;
   isClaudeTarget(requestedModel: string): boolean;
   getFallbackChain(): FallbackEntry[];
+  isAutoFallbackEnabled?(): boolean;
+  getMaxInflightPerAccount?(): number;
   getModelMappings?: () => ModelMapping[];
   getPassthroughModels?: () => string[];
 };
@@ -759,7 +761,29 @@ export type AnthropicSuccessResult =
       retryNextAccount: true;
       failure?: { message: string; rateLimit: boolean };
     }
-  | { response: Response | unknown };
+  | { response: Response | unknown; holdsAccountAdmission?: boolean };
+
+/** A release handle for one in-flight request admitted to an OAuth account. */
+export type AccountAdmissionLease = { release(): void };
+
+/** A cancellable queued request for per-account admission capacity. */
+export type QueuedAccountAdmission = {
+  accountKey: string;
+  promise: Promise<AccountAdmissionLease>;
+  cancel(): void;
+};
+
+/** One queued request waiting for per-account admission capacity. */
+export type AccountAdmissionWaiter = {
+  capacity: number;
+  resolve: (lease: AccountAdmissionLease) => void;
+};
+
+/** In-process request admission state for an OAuth account. */
+export type AccountAdmissionState = {
+  active: number;
+  waiters: AccountAdmissionWaiter[];
+};
 
 /** Result of buffering only enough upstream SSE to make a retry-safe decision. */
 export type AnthropicStreamPreflightResult =
@@ -784,6 +808,7 @@ export type ParsedSSEBuffer = {
 
 export type AnthropicAuthRetryResult = {
   response?: Response | unknown;
+  holdsAccountAdmission?: boolean;
   continueLoop: boolean;
   lastError: unknown;
   authFailureMessage: string | null;

--- a/src/lib/types/subscription.ts
+++ b/src/lib/types/subscription.ts
@@ -1116,6 +1116,10 @@ export type ProxyRoutingConfig = {
   strategy: "round-robin" | "fill-first";
   modelMappings: ModelMapping[];
   fallbackChain: FallbackEntry[];
+  /** Permit a last-resort provider chosen by the translation layer. Disabled by default. */
+  autoFallback?: boolean;
+  /** Maximum in-flight upstream requests per OAuth account. Defaults to two. */
+  maxInflightPerAccount?: number;
   passthroughModels?: string[];
   /** Enable quota-aware fill-first account ordering. Defaults to true. */
   quotaRouting?: boolean;

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -15,6 +15,7 @@ import {
   buildProxyTranslationPlan,
   parseRetryAfterMs,
 } from "../src/lib/proxy/routingPolicy.js";
+import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
 import {
   convertToModelMessages,
@@ -2249,19 +2250,28 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "buildProxyTranslationPlan: auto-provider added when no fallback chain",
+    name: "buildProxyTranslationPlan: auto-provider requires explicit opt-in",
     category: "routing-policy",
     fn: async () => {
       const parsed = makeParsedRequest();
-      const plan = buildProxyTranslationPlan(
+      const defaultPlan = buildProxyTranslationPlan(
         { provider: "anthropic", model: "claude-sonnet-4-20250514" },
         [],
         "claude-sonnet-4-20250514",
         parsed,
       );
+      const optInPlan = buildProxyTranslationPlan(
+        { provider: "anthropic", model: "claude-sonnet-4-20250514" },
+        [],
+        "claude-sonnet-4-20250514",
+        parsed,
+        true,
+      );
 
       return (
-        plan.attempts.length === 2 && plan.attempts[1].label === "auto-provider"
+        defaultPlan.attempts.length === 1 &&
+        optInPlan.attempts.length === 2 &&
+        optInPlan.attempts[1].label === "auto-provider"
       );
     },
   },
@@ -2332,6 +2342,143 @@ const tests: TestFunction[] = [
         !("modelTierCooldowns" in state) &&
         !("requestClassBackoffLevels" in state) &&
         !("modelTierBackoffLevels" in state)
+      );
+    },
+  },
+  {
+    name: "proxy routing: HTTP 529 overload rotates without same-account retry",
+    category: "routing-policy",
+    fn: async () => {
+      const account = {
+        key: "anthropic:primary@example.com",
+        label: "primary@example.com",
+        token: "test-token",
+        type: "oauth" as const,
+      };
+      const result = await __testHooks.handleAnthropicNonOkResponse({
+        response: new Response(
+          JSON.stringify({
+            type: "error",
+            error: { type: "overloaded_error", message: "Overloaded" },
+          }),
+          { status: 529, headers: { "content-type": "application/json" } },
+        ),
+        account,
+        accountState: {
+          consecutiveRefreshFailures: 0,
+          permanentlyDisabled: false,
+        },
+        enabledAccounts: [account],
+        orderedAccounts: [account],
+        requestStartTime: Date.now(),
+        fetchStartMs: Date.now(),
+        attemptNumber: 1,
+        logAttempt: () => undefined,
+        logProxyBody: () => undefined,
+        logFinalRequest: () => undefined,
+        lastError: undefined,
+        authFailureMessage: null,
+        sawTransientFailure: false,
+        invalidRequestFailure: null,
+      });
+      return (
+        result.continueLoop === true &&
+        result.retrySameAccount === false &&
+        result.sawTransientFailure === true
+      );
+    },
+  },
+  {
+    name: "proxy routing: account admission holds leases and releases waiters",
+    category: "routing-policy",
+    fn: async () => {
+      const accountKey = "anthropic:primary@example.com";
+      const first = await __testHooks.acquireAccountAdmission(accountKey, 1);
+      const second = __testHooks.acquireAccountAdmission(accountKey, 1);
+      const queued = __testHooks.getAccountAdmissionSnapshot(accountKey);
+      first?.release();
+      const secondLease = await second;
+      const admitted = __testHooks.getAccountAdmissionSnapshot(accountKey);
+      secondLease?.release();
+      const released = __testHooks.getAccountAdmissionSnapshot(accountKey);
+      return (
+        queued.active === 1 &&
+        queued.waiting === 1 &&
+        admitted.active === 1 &&
+        admitted.waiting === 0 &&
+        released.active === 0 &&
+        released.waiting === 0
+      );
+    },
+  },
+  {
+    name: "proxy routing: stream finalization logs before releasing admission",
+    category: "routing-policy",
+    fn: async () => {
+      let resolvePull: (() => void) | undefined;
+      let cancelled = false;
+      const encoder = new TextEncoder();
+      const upstreamStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+            ),
+          );
+        },
+        pull() {
+          return new Promise<void>((resolve) => {
+            resolvePull = resolve;
+          });
+        },
+        cancel() {
+          cancelled = true;
+          resolvePull?.();
+        },
+      });
+      const account = {
+        key: "anthropic:primary@example.com",
+        label: "primary@example.com",
+        token: "test-token",
+        type: "oauth" as const,
+      };
+      const sequence: string[] = [];
+      const result = await __testHooks.handleAnthropicStreamingSuccessResponse({
+        ctx: {} as never,
+        body: { model: "claude-opus-4-8", messages: [], stream: true },
+        account,
+        accountState: {
+          consecutiveRefreshFailures: 0,
+          permanentlyDisabled: false,
+        },
+        response: new Response(upstreamStream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+        responseHeaders: { "content-type": "text/event-stream" },
+        requestStartTime: Date.now(),
+        fetchStartMs: Date.now(),
+        attemptNumber: 1,
+        finalBodyStr: "{}",
+        logAttempt: () => undefined,
+        logProxyBody: () => undefined,
+        logFinalRequest: () => sequence.push("logFinalRequest"),
+        onStreamTerminal: () => sequence.push("onStreamTerminal"),
+      });
+      const reader = (result.response as Response).body?.getReader();
+      if (!reader) {
+        return false;
+      }
+      await reader.read();
+      await reader.cancel("client disconnected");
+      for (let attempt = 0; attempt < 10 && sequence.length < 2; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      return (
+        cancelled &&
+        sequence.length === 2 &&
+        sequence[0] === "logFinalRequest" &&
+        sequence[1] === "onStreamTerminal"
       );
     },
   },

--- a/test/proxyConfigHotReload.test.ts
+++ b/test/proxyConfigHotReload.test.ts
@@ -60,27 +60,48 @@ afterEach(async () => {
 });
 
 describe("proxy runtime configuration", () => {
-  it("parses kebab-case quota routing controls", async () => {
+  it("parses kebab-case routing controls", async () => {
     const parsed = await parseProxyConfigString(
       `
 routing:
   strategy: fill-first
   model-mappings: []
   fallback-chain: []
+  auto-fallback: \${AUTO_FALLBACK}
+  max-inflight-per-account: 3
   quota-routing: \${QUOTA_ROUTING}
   session-soft-limit: 0.91
   session-reset-tolerance-ms: 45000
 `,
       {
-        env: { QUOTA_ROUTING: "false" },
+        env: { QUOTA_ROUTING: "false", AUTO_FALLBACK: "true" },
       },
     );
 
     expect(parsed.routing).toMatchObject({
+      autoFallback: true,
+      maxInflightPerAccount: 3,
       quotaRouting: false,
       sessionSoftLimit: 0.91,
       sessionResetToleranceMs: 45_000,
     });
+  });
+
+  it("rejects non-numeric account admission limits", async () => {
+    await expect(
+      parseProxyConfigString(
+        JSON.stringify({
+          routing: {
+            strategy: "fill-first",
+            modelMappings: [],
+            fallbackChain: [],
+            maxInflightPerAccount: true,
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      "routing.max-inflight-per-account must be an integer between 1 and 20",
+    );
   });
 
   it("atomically publishes a new immutable routing generation", async () => {
@@ -94,6 +115,8 @@ routing:
           quotaRouting: false,
           sessionSoftLimit: 0.82,
           sessionResetToleranceMs: 1_500,
+          autoFallback: true,
+          maxInflightPerAccount: 3,
           primaryAccount: "Primary@Example.com",
           accountAllowlist: ["Primary@Example.com", "Secondary@Example.com"],
         },
@@ -126,6 +149,8 @@ routing:
       provider: "vertex",
       model: "old-primary",
     });
+    expect(first.modelRouter?.isAutoFallbackEnabled()).toBe(true);
+    expect(first.modelRouter?.getMaxInflightPerAccount()).toBe(3);
 
     await writeFile(
       configPath,
@@ -146,6 +171,8 @@ routing:
       provider: "vertex",
       model: "new-primary",
     });
+    expect(second.modelRouter?.isAutoFallbackEnabled()).toBe(false);
+    expect(second.modelRouter?.getMaxInflightPerAccount()).toBe(2);
     expect(second.accountAllowlist).toBeUndefined();
     expect(first.modelRouter?.resolve("hot-model")).toEqual({
       provider: "vertex",

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -62,7 +62,7 @@ import {
 
 const tempDirs: string[] = [];
 
-function createRecordingErrorFinalRequestLogger() {
+function createRecordingErrorFinalRequestLogger(onFinalized?: () => void) {
   return vi.fn(
     (
       status: number,
@@ -71,6 +71,7 @@ function createRecordingErrorFinalRequestLogger() {
       errorType?: string,
       errorMessage?: string,
     ) => {
+      onFinalized?.();
       recordFinalError(status, accountLabel, accountType, {
         errorType,
         terminalOutcome:
@@ -1281,6 +1282,47 @@ describe("upstream attempt classification and retry amplification", () => {
     );
   });
 
+  it("rotates immediately after an HTTP 529 overload", async () => {
+    const account = {
+      key: "anthropic:primary@example.com",
+      label: "primary@example.com",
+      token: "test-token",
+      type: "oauth" as const,
+    };
+    const result = await __testHooks.handleAnthropicNonOkResponse({
+      response: new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "overloaded_error", message: "Overloaded" },
+        }),
+        { status: 529, headers: { "content-type": "application/json" } },
+      ),
+      account,
+      accountState: {
+        consecutiveRefreshFailures: 0,
+        permanentlyDisabled: false,
+      },
+      enabledAccounts: [account],
+      orderedAccounts: [account],
+      requestStartTime: Date.now(),
+      fetchStartMs: Date.now(),
+      attemptNumber: 1,
+      logAttempt: vi.fn(),
+      logProxyBody: vi.fn(),
+      logFinalRequest: vi.fn(),
+      lastError: undefined,
+      authFailureMessage: null,
+      sawTransientFailure: false,
+      invalidRequestFailure: null,
+    });
+
+    expect(result).toMatchObject({
+      continueLoop: true,
+      retrySameAccount: false,
+      sawTransientFailure: true,
+    });
+  });
+
   it("shares two transient retries across an entire concurrent account window", () => {
     const now = 1_800_000_000_000;
     const coolingUntil = now + 60_000;
@@ -1367,6 +1409,109 @@ describe("upstream attempt classification and retry amplification", () => {
     await expect(firstAdmission).resolves.toEqual([account]);
     await vi.advanceTimersByTimeAsync(250);
     await expect(secondAdmission).resolves.toEqual([account]);
+  });
+
+  it("holds an account admission lease until the prior request releases it", async () => {
+    const accountKey = "anthropic:primary@example.com";
+    const first = await __testHooks.acquireAccountAdmission(accountKey, 1);
+    const second = __testHooks.acquireAccountAdmission(accountKey, 1);
+
+    expect(__testHooks.getAccountAdmissionSnapshot(accountKey)).toEqual({
+      active: 1,
+      waiting: 1,
+    });
+
+    first.release();
+    const secondLease = await second;
+    expect(__testHooks.getAccountAdmissionSnapshot(accountKey)).toEqual({
+      active: 1,
+      waiting: 0,
+    });
+
+    secondLease.release();
+    expect(__testHooks.getAccountAdmissionSnapshot(accountKey)).toEqual({
+      active: 0,
+      waiting: 0,
+    });
+  });
+
+  it("removes timed-out and aborted account admission waiters", async () => {
+    vi.useFakeTimers();
+    const accountKey = "anthropic:primary@example.com";
+    const first = await __testHooks.acquireAccountAdmission(accountKey, 1);
+    const timedOut = __testHooks.acquireAccountAdmission(
+      accountKey,
+      1,
+      undefined,
+      100,
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(timedOut).resolves.toBeUndefined();
+    expect(__testHooks.getAccountAdmissionSnapshot(accountKey)).toEqual({
+      active: 1,
+      waiting: 0,
+    });
+
+    const abortController = new AbortController();
+    const aborted = __testHooks.acquireAccountAdmission(
+      accountKey,
+      1,
+      abortController.signal,
+      1_000,
+    );
+    abortController.abort();
+    await expect(aborted).rejects.toMatchObject({ name: "AbortError" });
+    expect(__testHooks.getAccountAdmissionSnapshot(accountKey)).toEqual({
+      active: 1,
+      waiting: 0,
+    });
+
+    first.release();
+  });
+
+  it("uses whichever fully busy account frees first", async () => {
+    const primary = "anthropic:primary@example.com";
+    const secondary = "anthropic:secondary@example.com";
+    const primaryLease = await __testHooks.acquireAccountAdmission(primary, 1);
+    const secondaryLease = await __testHooks.acquireAccountAdmission(
+      secondary,
+      1,
+    );
+    const next = __testHooks.acquireFirstAvailableAccountAdmission(
+      [primary, secondary],
+      1,
+      undefined,
+      1_000,
+    );
+
+    secondaryLease.release();
+    await expect(next).resolves.toMatchObject({ accountKey: secondary });
+    const winner = await next;
+    winner?.lease.release();
+    primaryLease.release();
+
+    expect(__testHooks.getAccountAdmissionSnapshot(primary)).toEqual({
+      active: 0,
+      waiting: 0,
+    });
+    expect(__testHooks.getAccountAdmissionSnapshot(secondary)).toEqual({
+      active: 0,
+      waiting: 0,
+    });
+  });
+
+  it("allows a later account to serve while the first account is at capacity", async () => {
+    const primary = "anthropic:primary@example.com";
+    const secondary = "anthropic:secondary@example.com";
+    const primaryLease = await __testHooks.acquireAccountAdmission(primary, 1);
+
+    expect(__testHooks.tryAcquireAccountAdmission(primary, 1)).toBeUndefined();
+    const secondaryLease = __testHooks.tryAcquireAccountAdmission(secondary, 1);
+    expect(secondaryLease).toBeDefined();
+
+    primaryLease.release();
+    secondaryLease?.release();
   });
 
   it("never queues through a hard quota cooldown", async () => {
@@ -2524,7 +2669,13 @@ describe("stream terminal outcomes", () => {
       token: "test-token",
       type: "oauth" as const,
     };
-    const logFinalRequest = createRecordingErrorFinalRequestLogger();
+    const callbackSequence: string[] = [];
+    const logFinalRequest = createRecordingErrorFinalRequestLogger(() => {
+      callbackSequence.push("logFinalRequest");
+    });
+    const onStreamTerminal = vi.fn(() => {
+      callbackSequence.push("onStreamTerminal");
+    });
     recordAttempt(account.label, account.type);
 
     const result = await __testHooks.handleAnthropicStreamingSuccessResponse({
@@ -2547,6 +2698,7 @@ describe("stream terminal outcomes", () => {
       logAttempt: vi.fn(),
       logProxyBody: vi.fn(),
       logFinalRequest,
+      onStreamTerminal,
     });
 
     const reader = (result.response as Response).body!.getReader();
@@ -2554,6 +2706,8 @@ describe("stream terminal outcomes", () => {
     await reader.cancel("client disconnected");
     expect(cancelUpstream).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(logFinalRequest).toHaveBeenCalledTimes(1));
+    expect(onStreamTerminal).toHaveBeenCalledOnce();
+    expect(callbackSequence).toEqual(["logFinalRequest", "onStreamTerminal"]);
 
     expect(logFinalRequest).toHaveBeenCalledWith(
       499,

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -985,6 +985,33 @@ describe("request and attempt accounting", () => {
 });
 
 describe("fallback transport handling", () => {
+  it("redacts provider credentials before fallback errors are recorded", () => {
+    const message = __testHooks.redactProviderErrorMessage(
+      "upstream rejected api_key=sk-abcdefghijklmnop and authorization: Bearer token-value",
+    );
+
+    expect(message).toContain("***");
+    expect(message).not.toContain("sk-abcdefghijklmnop");
+    expect(message).not.toContain("token-value");
+  });
+
+  it("bounds redacted provider diagnostics", () => {
+    expect(
+      __testHooks.redactProviderErrorMessage("x".repeat(800)),
+    ).toHaveLength(500);
+  });
+
+  it("classifies HTTP 529 and SSE overloaded errors consistently", () => {
+    const overloadedBody = JSON.stringify({
+      type: "error",
+      error: { type: "overloaded_error", message: "Overloaded" },
+    });
+
+    expect(__testHooks.isUpstreamOverload(529, "gateway overload")).toBe(true);
+    expect(__testHooks.isUpstreamOverload(200, overloadedBody)).toBe(true);
+    expect(__testHooks.isUpstreamOverload(503, "temporary outage")).toBe(false);
+  });
+
   it("retries a fallback fetch failure before succeeding", async () => {
     vi.useFakeTimers();
     const stream = vi


### PR DESCRIPTION
## Summary
- add per-account upstream admission with a hot-reloadable `routing.max-inflight-per-account` cap (default 2), failover to a later available account, and stream-lifetime lease release
- make translation-layer auto fallback explicit (`routing.auto-fallback: true`); otherwise empty fallback chains stay inside the configured account/provider set
- rotate immediately on HTTP 529 overloads, skip unhealthy configured fallback providers, and sanitize fallback errors before durable diagnostics
- document both runtime-reloadable routing controls

## Verification
- `pnpm exec vitest run test/proxyConfigHotReload.test.ts test/proxyUpdaterFallback.test.ts test/proxyReliabilityHardening.test.ts` (127 passed)
- `pnpm exec tsc --noEmit --strict`
- `pnpm run build:cli`
- `pnpm run test:bugfixes` (234 passed)
- pre-commit hook: `check`, staged formatting, repository lint, and `prepack`

## Safety
- implemented and tested only in an isolated worktree; the live proxy was not restarted, reconfigured, or used as a test target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-account concurrency limits, defaulting to two simultaneous requests.
  * Added FIFO queuing and account rotation for busy or overloaded upstreams.
  * Added opt-in automatic provider fallback.
  * Routing settings can be updated at runtime without restarting the proxy.
* **Bug Fixes**
  * Streaming requests release account capacity when finished or cancelled.
  * Invalid configuration values are safely ignored with warnings.
  * Provider credentials and sensitive error details are redacted from diagnostics.
* **Documentation**
  * Updated the proxy configuration reference with new routing options and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->