### PR TITLE
refactor(utils): consolidate optional-dependency imports behind tryImport

### DIFF
--- a/src/cli/factories/sagemakerCommandFactory.ts
+++ b/src/cli/factories/sagemakerCommandFactory.ts
@@ -5,21 +5,10 @@ import inquirer from "inquirer";
 import type { EndpointSummary } from "@aws-sdk/client-sagemaker";
 
 async function loadSageMakerControl() {
-  try {
-    return await import(/* @vite-ignore */ "@aws-sdk/client-sagemaker");
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("client-sagemaker")
-    ) {
-      throw new Error(
-        'SageMaker setup requires "@aws-sdk/client-sagemaker". Install it with:\n  pnpm add @aws-sdk/client-sagemaker',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  return tryImport<typeof import("@aws-sdk/client-sagemaker")>(
+    "@aws-sdk/client-sagemaker",
+    "SageMaker setup",
+  );
 }
 import type {
   UnknownRecord,
@@ -27,6 +16,7 @@ import type {
   SecureConfiguration,
 } from "../../lib/types/index.js";
 import { logger } from "../../lib/utils/logger.js";
+import { tryImport } from "../../lib/utils/tryImport.js";
 import {
   checkSageMakerConfiguration,
   getSageMakerConfig,

--- a/src/lib/features/ppt/slideGenerator.ts
+++ b/src/lib/features/ppt/slideGenerator.ts
@@ -40,29 +40,22 @@ export async function loadPptxGenJS(): Promise<new () => PptxPresentation> {
   if (_pptxGenJS) {
     return _pptxGenJS;
   }
-  try {
-    const mod = await import(/* @vite-ignore */ "pptxgenjs");
-    // ESM/CJS interop: pptxgenjs v4 may double-wrap the default export.
-    // The runtime shape is genuinely dynamic, so probe it as `unknown`.
-    const rawDefault: unknown = mod.default;
-    const Ctor =
-      typeof rawDefault === "function"
-        ? rawDefault
-        : (rawDefault as { default: new () => PptxPresentation }).default;
-    _pptxGenJS = Ctor as new () => PptxPresentation;
-    return _pptxGenJS;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("pptxgenjs")) {
-      throw new Error(
-        'PPT generation requires the "pptxgenjs" package. Install it with:\n  pnpm add pptxgenjs',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  const mod = await tryImport<typeof import("pptxgenjs")>(
+    "pptxgenjs",
+    "PPT generation",
+  );
+  // ESM/CJS interop: pptxgenjs v4 may double-wrap the default export.
+  // The runtime shape is genuinely dynamic, so probe it as `unknown`.
+  const rawDefault: unknown = mod.default;
+  const Ctor =
+    typeof rawDefault === "function"
+      ? rawDefault
+      : (rawDefault as { default: new () => PptxPresentation }).default;
+  _pptxGenJS = Ctor as new () => PptxPresentation;
+  return _pptxGenJS;
 }
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
 import {
   withTimeout,
   ErrorFactory,

--- a/src/lib/processors/document/ExcelProcessor.ts
+++ b/src/lib/processors/document/ExcelProcessor.ts
@@ -51,35 +51,25 @@ import type {
 } from "../../types/index.js";
 import { SIZE_LIMITS } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
+import { tryImport } from "../../utils/tryImport.js";
 
 let _exceljs: typeof import("exceljs") | null = null;
 async function loadExcelJS() {
   if (_exceljs) {
     return _exceljs;
   }
-  try {
-    const mod: unknown = await import(/* @vite-ignore */ "exceljs");
-    // exceljs is a CommonJS module. Under Node ESM (and some bundlers) the
-    // `Workbook` constructor is exposed at runtime on the namespace's `default`
-    // export rather than on the namespace itself — so a bare
-    // `new ExcelJS.Workbook()` throws "ExcelJS.Workbook is not a constructor"
-    // (TS still types it as present via esModuleInterop, masking the bug).
-    // Normalise here so the constructor is reachable regardless of interop style.
-    const ns = mod as { Workbook?: unknown; default?: unknown };
-    _exceljs = (
-      ns.Workbook ? ns : (ns.default ?? ns)
-    ) as typeof import("exceljs");
-    return _exceljs;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("exceljs")) {
-      throw new Error(
-        'Excel file processing requires the "exceljs" package. Install it with:\n  pnpm add exceljs',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  const mod = await tryImport("exceljs", "Excel file processing");
+  // exceljs is a CommonJS module. Under Node ESM (and some bundlers) the
+  // `Workbook` constructor is exposed at runtime on the namespace's `default`
+  // export rather than on the namespace itself — so a bare
+  // `new ExcelJS.Workbook()` throws "ExcelJS.Workbook is not a constructor"
+  // (TS still types it as present via esModuleInterop, masking the bug).
+  // Normalise here so the constructor is reachable regardless of interop style.
+  const ns = mod as { Workbook?: unknown; default?: unknown };
+  _exceljs = (
+    ns.Workbook ? ns : (ns.default ?? ns)
+  ) as typeof import("exceljs");
+  return _exceljs;
 }
 
 // Re-export for consumers who import from this module

--- a/src/lib/processors/document/WordProcessor.ts
+++ b/src/lib/processors/document/WordProcessor.ts
@@ -41,25 +41,18 @@ import type {
 } from "../../types/index.js";
 import { SIZE_LIMITS } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
+import { tryImport } from "../../utils/tryImport.js";
 
 let _mammoth: typeof import("mammoth") | null = null;
 async function loadMammoth() {
   if (_mammoth) {
     return _mammoth;
   }
-  try {
-    _mammoth = await import(/* @vite-ignore */ "mammoth");
-    return _mammoth;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("mammoth")) {
-      throw new Error(
-        'Word document processing requires the "mammoth" package. Install it with:\n  pnpm add mammoth',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  _mammoth = await tryImport<typeof import("mammoth")>(
+    "mammoth",
+    "Word document processing",
+  );
+  return _mammoth;
 }
 
 // Re-export for consumers who import from this module

--- a/src/lib/processors/media/AudioProcessor.ts
+++ b/src/lib/processors/media/AudioProcessor.ts
@@ -48,28 +48,18 @@ import { SIZE_LIMITS_MB } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
 import { withTimeout } from "../../utils/timeout.js";
 import { formatMediaDuration } from "../../utils/mediaDuration.js";
+import { tryImport } from "../../utils/tryImport.js";
 
 let _musicMetadata: typeof import("music-metadata") | null = null;
 async function loadMusicMetadata() {
   if (_musicMetadata) {
     return _musicMetadata;
   }
-  try {
-    _musicMetadata = await import(/* @vite-ignore */ "music-metadata");
-    return _musicMetadata;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("music-metadata")
-    ) {
-      throw new Error(
-        'Audio processing requires the "music-metadata" package. Install it with:\n  pnpm add music-metadata',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  _musicMetadata = await tryImport<typeof import("music-metadata")>(
+    "music-metadata",
+    "Audio processing",
+  );
+  return _musicMetadata;
 }
 
 // =============================================================================

--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -65,26 +65,51 @@ import { SIZE_LIMITS_MB } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
 import { tracers, ATTR, withSpan } from "../../telemetry/index.js";
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
+
+/**
+ * Narrow a loaded `fluent-ffmpeg` export to the shape this file actually uses:
+ * a callable carrying the `ffprobe` and `setFfmpegPath` statics.
+ *
+ * `tryImport` proves only that the package RESOLVES. Callers invoke the export
+ * and reach straight for its statics, so a package whose shape changed (ESM
+ * rewrite, major bump, a shim in node_modules) would otherwise surface as
+ * "Cannot read properties of undefined (reading 'ffprobe')" from inside
+ * probeVideo — blaming the call site instead of the package that is wrong.
+ */
+export function assertFluentFfmpegShape(
+  mod: unknown,
+): asserts mod is typeof import("fluent-ffmpeg") {
+  // Not `Partial<typeof import("fluent-ffmpeg")>`: Partial maps over properties
+  // and drops the call signature, so `typeof x === "function"` would narrow the
+  // result to `never`. Probe the statics structurally instead.
+  const statics = mod as { ffprobe?: unknown; setFfmpegPath?: unknown };
+  if (
+    typeof mod !== "function" ||
+    typeof statics.ffprobe !== "function" ||
+    typeof statics.setFfmpegPath !== "function"
+  ) {
+    throw new Error(
+      `The installed "fluent-ffmpeg" package does not export a callable with ` +
+        `ffprobe and setFfmpegPath statics (got ${typeof mod}). ` +
+        `Reinstall a compatible version:\n  pnpm add fluent-ffmpeg`,
+    );
+  }
+}
 
 // fluent-ffmpeg's default export is callable + has static methods — avoid caching
 // the module type (it confuses TS); Node's module cache handles dedup.
 async function loadFluentFfmpeg() {
-  try {
-    const mod = await import(/* @vite-ignore */ "fluent-ffmpeg");
-    return mod.default;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("fluent-ffmpeg")
-    ) {
-      throw new Error(
-        'Video processing requires the "fluent-ffmpeg" package. Install it with:\n  pnpm add fluent-ffmpeg',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  // fluent-ffmpeg is CJS (`export =`), so `typeof import(...)` describes the
+  // callable itself and carries no `default`. Under Node ESM the namespace
+  // still wraps it, so ask for that shape explicitly.
+  const mod = await tryImport<{ default: typeof import("fluent-ffmpeg") }>(
+    "fluent-ffmpeg",
+    "Video processing",
+  );
+  const ffmpeg = mod.default;
+  assertFluentFfmpegShape(ffmpeg);
+  return ffmpeg;
 }
 
 let _mediabunny: typeof import("mediabunny") | null = null;
@@ -92,22 +117,11 @@ async function loadMediaBunny() {
   if (_mediabunny) {
     return _mediabunny;
   }
-  try {
-    _mediabunny = await import(/* @vite-ignore */ "mediabunny");
-    return _mediabunny;
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("mediabunny")
-    ) {
-      throw new Error(
-        'Video processing requires the "mediabunny" package. Install it with:\n  pnpm add mediabunny',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  _mediabunny = await tryImport<typeof import("mediabunny")>(
+    "mediabunny",
+    "Video processing",
+  );
+  return _mediabunny;
 }
 
 // =============================================================================

--- a/src/lib/providers/sagemaker/client.ts
+++ b/src/lib/providers/sagemaker/client.ts
@@ -26,6 +26,7 @@ import {
   getRetryDelay,
 } from "./errors.js";
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
 
 /**
  * Lazily load `@aws-sdk/client-sagemaker-runtime`.
@@ -39,21 +40,10 @@ import { logger } from "../../utils/logger.js";
 async function loadSageMakerRuntime(): Promise<
   typeof import("@aws-sdk/client-sagemaker-runtime")
 > {
-  try {
-    return await import(/* @vite-ignore */ "@aws-sdk/client-sagemaker-runtime");
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("client-sagemaker-runtime")
-    ) {
-      throw new Error(
-        'SageMaker inference requires "@aws-sdk/client-sagemaker-runtime". Install it with:\n  pnpm add @aws-sdk/client-sagemaker-runtime',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  return tryImport<typeof import("@aws-sdk/client-sagemaker-runtime")>(
+    "@aws-sdk/client-sagemaker-runtime",
+    "SageMaker inference",
+  );
 }
 
 /**

--- a/src/lib/server/voice/voiceWebSocketHandler.ts
+++ b/src/lib/server/voice/voiceWebSocketHandler.ts
@@ -6,6 +6,7 @@ import { timingSafeEqualString } from "./tokenCompare.js";
 import { CartesiaStream } from "../../adapters/tts/cartesiaHandler.js";
 import { NeuroLink } from "../../neurolink.js";
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
 import { withTimeout } from "../../utils/async/withTimeout.js";
 import type {
   ClientControlMessage,
@@ -17,24 +18,11 @@ import type {
 } from "../../types/index.js";
 
 async function loadCobra(accessKey: string): Promise<CobraInstance> {
-  try {
-    const mod = (await import(/* @vite-ignore */ "@picovoice/cobra-node")) as {
-      Cobra: new (key: string) => CobraInstance;
-    };
-    return new mod.Cobra(accessKey);
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (
-      e?.code === "ERR_MODULE_NOT_FOUND" &&
-      e.message.includes("cobra-node")
-    ) {
-      throw new Error(
-        'Voice activity detection requires "@picovoice/cobra-node". Install it with:\n  pnpm add @picovoice/cobra-node',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  const mod = await tryImport<{ Cobra: new (key: string) => CobraInstance }>(
+    "@picovoice/cobra-node",
+    "Voice activity detection",
+  );
+  return new mod.Cobra(accessKey);
 }
 
 const SONIOX_URL =

--- a/src/lib/services/server/ai/observability/instrumentation.ts
+++ b/src/lib/services/server/ai/observability/instrumentation.ts
@@ -45,6 +45,7 @@ import type {
 } from "../../../../types/index.js";
 import { extractMcpErrorText } from "../../../../utils/mcpErrorText.js";
 import { logger } from "../../../../utils/logger.js";
+import { tryImport } from "../../../../utils/tryImport.js";
 import { LANGFUSE_ATTR } from "../../../../telemetry/attributes.js";
 
 const LOG_PREFIX = "[OpenTelemetry]";
@@ -728,19 +729,10 @@ class ContextEnricher implements SpanProcessor {
 async function createLangfuseProcessor(
   config: LangfuseConfig,
 ): Promise<LangfuseSpanProcessorType> {
-  let mod: typeof import("@langfuse/otel");
-  try {
-    mod = await import(/* @vite-ignore */ "@langfuse/otel");
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("langfuse")) {
-      throw new Error(
-        'Langfuse observability requires "@langfuse/otel". Install it with:\n  pnpm add @langfuse/otel',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  const mod = await tryImport<typeof import("@langfuse/otel")>(
+    "@langfuse/otel",
+    "Langfuse observability",
+  );
   return new mod.LangfuseSpanProcessor({
     publicKey: config.publicKey,
     secretKey: config.secretKey,

--- a/src/lib/tasks/backends/bullmqBackend.ts
+++ b/src/lib/tasks/backends/bullmqBackend.ts
@@ -9,6 +9,7 @@
 
 import type { Queue, Worker, Job } from "bullmq";
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
 import { TaskError } from "../errors.js";
 import {
   type Task,
@@ -19,18 +20,7 @@ import {
 } from "../../types/index.js";
 
 async function loadBullMQ() {
-  try {
-    return await import(/* @vite-ignore */ "bullmq");
-  } catch (err) {
-    const e = err instanceof Error ? (err as NodeJS.ErrnoException) : null;
-    if (e?.code === "ERR_MODULE_NOT_FOUND" && e.message.includes("bullmq")) {
-      throw new Error(
-        'BullMQ task backend requires the "bullmq" package. Install it with:\n  pnpm add bullmq',
-        { cause: err },
-      );
-    }
-    throw err;
-  }
+  return tryImport<typeof import("bullmq")>("bullmq", "BullMQ task backend");
 }
 
 const QUEUE_NAME = "neurolink-tasks";

--- a/src/lib/utils/tryImport.ts
+++ b/src/lib/utils/tryImport.ts
@@ -1,0 +1,103 @@
+/**
+ * Dynamically import an optional dependency, converting a missing package into
+ * an actionable error.
+ *
+ * NeuroLink declares 42 `optionalDependencies`, and each loader had grown its
+ * own copy of the same try/catch: check `err.code`, substring-match the package
+ * name, rethrow a friendlier Error. The copies had drifted — some said
+ * `pnpm add`, one said `npm install`, and the phrasing varied per call site.
+ *
+ * Only missing-module failures are intercepted. A package that is installed but
+ * throws while evaluating (syntax error, ESM/CJS interop, a broken transitive
+ * dep) rethrows unchanged — turning those into "please install X" would send
+ * the caller after a package they already have. The same applies to specifiers
+ * that are not installable packages at all (relative paths, file/data URLs):
+ * they rethrow untouched rather than producing an unrunnable install command.
+ *
+ * @param pkg - Module specifier. The install hint is only produced for bare
+ *   package names; anything else rethrows the loader's own error.
+ * @param feature - Human-readable capability name, used to open the message.
+ * @returns The imported module namespace, typed as `T` (`unknown` if the
+ *   caller does not supply a type argument, since the shape cannot be known
+ *   for a dynamic specifier).
+ * @throws The loader's original error, or an `Error` naming the package and
+ *   the `pnpm add` command when a bare package is genuinely absent. The
+ *   original failure is always preserved on `cause`.
+ *
+ * @example
+ * ```ts
+ * const ExcelJS = await tryImport<typeof import("exceljs")>(
+ *   "exceljs",
+ *   "Excel file processing",
+ * );
+ * ```
+ */
+export async function tryImport<T = unknown>(
+  pkg: string,
+  feature: string,
+): Promise<T> {
+  try {
+    return (await import(/* @vite-ignore */ pkg)) as T;
+  } catch (err) {
+    if (isMissingModule(err, pkg)) {
+      throw new Error(
+        `${feature} requires the "${pkg}" package. Install it with:\n  pnpm add ${pkg}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * True only when `err` is the module loader failing to resolve `pkg` itself.
+ *
+ * The package name is matched inside quotes because that is how both loaders
+ * format it — ESM `Cannot find package 'x' imported from …`, CJS
+ * `Cannot find module 'x'`. Matching the bare substring instead (as the
+ * hand-rolled copies did) also matches a *transitive* dependency whose path
+ * happens to contain the name, which would blame the wrong package.
+ *
+ * The specifier must also be a bare package name. Without that check a missing
+ * relative path or file URL is rewritten into `pnpm add ./fixtures/thing.mjs`,
+ * which is not a command anyone can run — and this helper is already called
+ * with `file:` and `data:` URLs, so that path is reachable rather than
+ * theoretical.
+ */
+function isMissingModule(err: unknown, pkg: string): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  if (!isBarePackageSpecifier(pkg)) {
+    return false;
+  }
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+  return err.message.includes(`'${pkg}'`) || err.message.includes(`"${pkg}"`);
+}
+
+/**
+ * True for specifiers that name an installable package — `exceljs`,
+ * `@scope/pkg`, `pkg/sub/path`.
+ *
+ * False for the two things an install hint cannot help with: filesystem paths
+ * (`./x`, `../x`, `/x`, and Windows `C:\x`, which the scheme test below also
+ * rejects) and any URL (`file:`, `data:`, `http:`), including the `node:`
+ * builtins, which are never installed.
+ */
+function isBarePackageSpecifier(specifier: string): boolean {
+  if (specifier.length === 0) {
+    return false;
+  }
+  if (
+    specifier.startsWith("/") ||
+    specifier.startsWith("./") ||
+    specifier.startsWith("../")
+  ) {
+    return false;
+  }
+  // RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"
+  return !/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(specifier);
+}

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -57,8 +57,13 @@ import fs, {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join as pathJoin, resolve as resolvePath } from "node:path";
-import { pathToFileURL } from "node:url";
+import {
+  basename,
+  dirname,
+  join as pathJoin,
+  resolve as resolvePath,
+} from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn as spawnProcess } from "node:child_process";
 import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
 import http from "node:http";
@@ -185,9 +190,14 @@ type TestFunction = {
 // Helpers (delegated to shared harness where possible)
 // ============================================================================
 
+import { tryImport } from "../src/lib/utils/tryImport.js";
+import { assertFluentFfmpegShape } from "../src/lib/processors/media/VideoProcessor.js";
 import { defineSuite, log, logSection } from "./helpers/harness.js";
 
 const { recordTest, runSuite } = defineSuite("Production Bugfix Verification");
+
+/** A package name that will never resolve, for the missing-dependency cases. */
+const ABSENT_PKG = "neurolink-definitely-not-installed-abc123";
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -9286,6 +9296,242 @@ exit 127
         }
       }
       return !claudeProxyTestHooks.hasAccountAdmissionState(accountKey);
+    },
+  },
+
+  // ---------- tryImport: optional-dependency loading ----------
+  {
+    name: "tryImport returns the module namespace when the package resolves",
+    category: "optional-deps",
+    fn: async () => {
+      const mod = await tryImport<typeof import("node:path")>(
+        "node:path",
+        "Path handling",
+      );
+      return typeof mod.join === "function";
+    },
+  },
+  {
+    name: "tryImport converts a missing package into an actionable install hint",
+    category: "optional-deps",
+    fn: async () => {
+      const err = await tryImport(ABSENT_PKG, "Widget rendering").catch(
+        (e: unknown) => e,
+      );
+      return (
+        err instanceof Error &&
+        err.message.includes(
+          `Widget rendering requires the "${ABSENT_PKG}" package.`,
+        ) &&
+        err.message.includes(`pnpm add ${ABSENT_PKG}`)
+      );
+    },
+  },
+  {
+    name: "tryImport preserves the original resolution error as `cause`",
+    category: "optional-deps",
+    fn: async () => {
+      const err = await tryImport(ABSENT_PKG, "Widget rendering").catch(
+        (e: unknown) => e,
+      );
+      const cause = (err as Error)?.cause as NodeJS.ErrnoException | undefined;
+      return err instanceof Error && cause?.code === "ERR_MODULE_NOT_FOUND";
+    },
+  },
+  {
+    // The fixture module itself exists — only something it imports is absent.
+    // Rewriting this into "install the fixture" would send the caller after a
+    // package they already have, which is why the match is quoted-name-exact
+    // rather than a bare substring.
+    name: "tryImport rethrows unchanged when a TRANSITIVE dependency is missing",
+    category: "optional-deps",
+    fn: async () => {
+      const fixture = pathToFileURL(
+        pathJoin(
+          dirname(fileURLToPath(import.meta.url)),
+          "fixtures",
+          "tryImport",
+          "importsMissingDep.mjs",
+        ),
+      ).href;
+      const err = await tryImport(fixture, "Fixture feature").catch(
+        (e: unknown) => e,
+      );
+      return (
+        err instanceof Error &&
+        !err.message.includes("Install it with") &&
+        err.message.includes("neurolink-fixture-absent-transitive-dep")
+      );
+    },
+  },
+  {
+    // `pnpm add /tmp/….mjs` is not a command anyone can run. A path that fails
+    // to resolve is a broken path, not an absent dependency.
+    //
+    // Absolute rather than relative deliberately: Node reports the *resolved*
+    // path in its message, so a relative specifier never matches the quoted
+    // name and was already rejected by accident. An absolute path matches
+    // itself exactly, which is what made this reachable.
+    name: "tryImport offers no install hint for a missing ABSOLUTE path",
+    category: "optional-deps",
+    fn: async () => {
+      const err = await tryImport(
+        "/tmp/neurolink-definitely-missing-abc123.mjs",
+        "Fixture feature",
+      ).catch((e: unknown) => e);
+      return (
+        err instanceof Error &&
+        !err.message.includes("Install it with") &&
+        !err.message.includes("pnpm add")
+      );
+    },
+  },
+  {
+    // The reachable case: this suite already calls tryImport() with a file URL,
+    // so a typoed fixture path would otherwise be reported as a missing package.
+    name: "tryImport offers no install hint for a missing file: URL",
+    category: "optional-deps",
+    fn: async () => {
+      const missing = pathToFileURL(
+        pathJoin(
+          dirname(fileURLToPath(import.meta.url)),
+          "fixtures",
+          "tryImport",
+          "no-such-fixture.mjs",
+        ),
+      ).href;
+      const err = await tryImport(missing, "Fixture feature").catch(
+        (e: unknown) => e,
+      );
+      return (
+        err instanceof Error &&
+        !err.message.includes("Install it with") &&
+        !err.message.includes("pnpm add")
+      );
+    },
+  },
+  {
+    // The bare-specifier gate must not exclude legitimate package shapes —
+    // scoped names contain a "/" and must still be treated as installable.
+    name: "tryImport still offers an install hint for a scoped package name",
+    category: "optional-deps",
+    fn: async () => {
+      const scoped = "@neurolink/definitely-not-installed-abc123";
+      const err = await tryImport(scoped, "Widget rendering").catch(
+        (e: unknown) => e,
+      );
+      return err instanceof Error && err.message.includes(`pnpm add ${scoped}`);
+    },
+  },
+  {
+    // A URL that resolves but throws while evaluating is a real failure, not a
+    // missing dependency — the caller needs the original error.
+    name: "tryImport rethrows non-module errors unchanged",
+    category: "optional-deps",
+    fn: async () => {
+      const err = await tryImport(
+        "data:text/javascript,throw new Error('boom')",
+        "Evaluation feature",
+      ).catch((e: unknown) => e);
+      return err instanceof Error && err.message === "boom";
+    },
+  },
+
+  // ---------- fluent-ffmpeg export-shape guard ----------
+  {
+    // Positive control against the real package, not a stand-in: if a future
+    // bump changes the export shape, this fails here rather than as a TypeError
+    // deep inside probeVideo. fluent-ffmpeg is an optionalDependency, so an
+    // install that skipped it skips this case rather than failing it.
+    name: "assertFluentFfmpegShape accepts the installed fluent-ffmpeg export",
+    category: "optional-deps",
+    fn: async () => {
+      // Loaded through tryImport, the helper this PR adds, precisely because it
+      // separates "the package is absent" from "the package is present but
+      // broken". A bare `.catch(() => null)` would swallow the second case and
+      // silently skip — turning the positive control into a no-op exactly when
+      // a broken install is what it should be catching.
+      let mod: { default: unknown };
+      try {
+        mod = await tryImport<{ default: unknown }>(
+          "fluent-ffmpeg",
+          "Video processing",
+        );
+      } catch (error) {
+        // tryImport only rewrites a genuinely-absent bare package into an
+        // install hint; anything else is rethrown untouched and must fail here.
+        if (
+          error instanceof Error &&
+          error.message.includes("pnpm add fluent-ffmpeg")
+        ) {
+          return null as unknown as boolean; // optional dep not installed — skip
+        }
+        throw error;
+      }
+      assertFluentFfmpegShape(mod.default);
+      return true;
+    },
+  },
+  {
+    // The shape an ESM-rewritten fluent-ffmpeg would produce: named exports
+    // only, so `mod.default` is undefined and every call site breaks.
+    name: "assertFluentFfmpegShape rejects a namespace with no callable default",
+    category: "optional-deps",
+    fn: async () => {
+      const rejects = (value: unknown) => {
+        try {
+          assertFluentFfmpegShape(value);
+          return false;
+        } catch (e) {
+          return (
+            e instanceof Error &&
+            e.message.includes(
+              '"fluent-ffmpeg" package does not export a callable',
+            )
+          );
+        }
+      };
+      return rejects(undefined) && rejects({ ffprobe: () => {} });
+    },
+  },
+  {
+    // Callable but stripped — a shim or a partial mock in node_modules.
+    name: "assertFluentFfmpegShape rejects a callable missing the statics",
+    category: "optional-deps",
+    fn: async () => {
+      const rejects = (value: unknown) => {
+        try {
+          assertFluentFfmpegShape(value);
+          return false;
+        } catch (e) {
+          return (
+            e instanceof Error &&
+            e.message.includes("ffprobe and setFfmpegPath statics")
+          );
+        }
+      };
+      return (
+        rejects(() => {}) &&
+        rejects(Object.assign(() => {}, { ffprobe: () => {} }))
+      );
+    },
+  },
+  {
+    // The whole point of the guard: the message has to point at the dependency,
+    // not at whatever line happened to dereference it.
+    name: "assertFluentFfmpegShape names the package and the install command",
+    category: "optional-deps",
+    fn: async () => {
+      try {
+        assertFluentFfmpegShape({});
+        return false;
+      } catch (e) {
+        return (
+          e instanceof Error &&
+          e.message.includes("pnpm add fluent-ffmpeg") &&
+          !e.message.includes("Cannot read properties")
+        );
+      }
     },
   },
 ];

--- a/test/fixtures/tryImport/importsMissingDep.mjs
+++ b/test/fixtures/tryImport/importsMissingDep.mjs
@@ -1,0 +1,8 @@
+// Fixture: this module exists, but the package it imports does not.
+//
+// Importing it produces ERR_MODULE_NOT_FOUND naming the *transitive* package,
+// not this file — which is exactly the case tryImport must NOT rewrite into
+// "install this module", because the module itself is present.
+import "neurolink-fixture-absent-transitive-dep";
+
+export const unreachable = true;


### PR DESCRIPTION
## What

NeuroLink declares **42 `optionalDependencies`**, and ten loaders had each grown their own copy of the same try/catch around a dynamic import: inspect `err.code`, substring-match the package name, rethrow a friendlier `Error`.

The copies had drifted. `proxyFetch.ts` said `npm install proxy-agent` while every other site said `pnpm add`; the phrasing alternated between `requires the "x" package` and `requires "x"`; some checked only `ERR_MODULE_NOT_FOUND`, missing the CJS `MODULE_NOT_FOUND`.

This adds `tryImport(pkg, feature)` and routes all **11 call sites** through it. No hand-rolled `MODULE_NOT_FOUND` check remains in `src/`.

```ts
const ExcelJS = await tryImport<typeof import("exceljs")>(
  "exceljs",
  "Excel file processing",
);
```

## Migrated call sites

`bullmqBackend` · `ExcelProcessor` · `WordProcessor` · `AudioProcessor` · `VideoProcessor` (×2) · `slideGenerator` · `instrumentation` (Langfuse) · `sagemakerCommandFactory` · `sagemaker/client` · `voiceWebSocketHandler`

## One deliberate behaviour change

The package name is now matched **inside quotes** — `'x'` / `"x"` — which is how both loaders format it (`Cannot find package 'x' imported from …`, `Cannot find module 'x'`).

The previous bare-substring match also matched a **transitive** dependency whose path happened to contain the name. That turns "your installed package has a broken dependency" into "please install a package you already have", sending the reader in the wrong direction. A fixture module whose own import is missing covers this case explicitly.

Everything else is preserved: only missing-module failures are intercepted, `cause` is retained, and a package that resolves but throws while evaluating rethrows untouched.

## Notes

- `fluent-ffmpeg` is typed as `{ default: … }` rather than `typeof import(...)` because it is CJS (`export =`), so the module type describes the callable itself and carries no `default`.
- Interop and memoisation logic stays at each call site — `tryImport` only owns resolution and the error message.

## Verification

| | |
|---|---|
| `pnpm run check` | 0 errors / 4,790 files |
| `pnpm run lint` | 0 errors |
| `pnpm run test:try-import:vitest` | 5/5 pass |

New script `test:try-import:vitest`, chained into `test:unit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional integrations, including document, media, voice, analytics, task-processing, and cloud-service features.
  * Added clearer installation guidance when optional components are unavailable.
  * Added compatibility validation for media-processing support.
* **Tests**
  * Expanded coverage for missing dependencies, transitive loading failures, invalid module paths, and media integration compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->