### PR TITLE
fix(test): stop the root suite exiting before it runs

### DIFF
--- a/test/continuous-test-suite-providers.ts
+++ b/test/continuous-test-suite-providers.ts
@@ -24,7 +24,7 @@ import "dotenv/config";
 
 import * as fs from "fs";
 import * as path from "path";
-import { ESLint } from "eslint";
+import { checkProviderBaseClasses } from "./helpers/providerBaseClass.js";
 import { NeuroLink } from "../dist/index.js";
 import { ProviderImageAdapter } from "../dist/adapters/providerImageAdapter.js";
 import { resolveModel } from "../dist/utils/modelAliasResolver.js";
@@ -2361,36 +2361,28 @@ async function testProviderRegistrationCompleteness(): Promise<boolean | null> {
 }
 
 // --- Test #20c: Provider Base Class Inheritance (Issue #1177 / Pattern Analysis provider-base-class) ---
-export async function testProviderBaseClassInheritance(): Promise<
-  boolean | null
-> {
+async function testProviderBaseClassInheritance(): Promise<boolean | null> {
   logTest("Provider Base Class Inheritance", "TESTING");
   try {
-    const eslint = new ESLint();
-    const results = await eslint.lintFiles(["src/lib/providers/**/*.ts"]);
-
-    const failures: string[] = [];
-    let checkedFilesCount = 0;
-
-    for (const result of results) {
-      checkedFilesCount++;
-      for (const msg of result.messages) {
-        if (msg.ruleId === "neurolink/provider-base-class") {
-          const relPath = path.relative(process.cwd(), result.filePath);
-          failures.push(`${relPath}:${msg.line}: ${msg.message}`);
-        }
-      }
-    }
+    const { ok, checkedFiles, failures } = await checkProviderBaseClasses();
 
     if (failures.length > 0) {
       logTest("Provider Base Class Inheritance", "FAIL", failures.join("; "));
+      return false;
+    }
+    if (!ok) {
+      logTest(
+        "Provider Base Class Inheritance",
+        "FAIL",
+        "provider glob matched no files — the check verified nothing",
+      );
       return false;
     }
 
     logTest(
       "Provider Base Class Inheritance",
       "PASS",
-      `Verified provider classes across ${checkedFilesCount} provider files extend BaseProvider or a recognized provider base class (ESLint rule neurolink/provider-base-class)`,
+      `Verified provider classes across ${checkedFiles} provider files extend BaseProvider or a recognized provider base class (ESLint rule neurolink/provider-base-class)`,
     );
     return true;
   } catch (error) {

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -60,7 +60,7 @@ import type {
   TerminateEmployeesParams,
 } from "./types/mcp.js";
 import { testComplexZodSchemaMultiProvider } from "./zod-schema-test-function.js";
-import { testProviderBaseClassInheritance } from "./continuous-test-suite-providers.js";
+import { checkProviderBaseClasses } from "./helpers/providerBaseClass.js";
 
 // Provider-specific token limits
 const PROVIDER_MAX_TOKENS: Record<string, number> = {
@@ -4522,6 +4522,45 @@ async function testCloakingRuntime(): Promise<boolean | null> {
     return true;
   } catch (error: unknown) {
     logTest("Cloaking Runtime", "FAIL", getErrorMessage(error));
+    return false;
+  }
+}
+
+/**
+ * Provider base-class conformance (Issue #1177).
+ *
+ * The check itself lives in `./helpers/providerBaseClass.js`. It must not be
+ * imported from `continuous-test-suite-providers.ts`: that module ends in a
+ * top-level `await runSuite(...)`, which calls `process.exit()` — importing it
+ * would run the providers suite and terminate this one before it starts.
+ */
+async function testProviderBaseClassInheritance(): Promise<boolean | null> {
+  logTest("Provider Base Class Inheritance", "TESTING");
+  try {
+    const { ok, checkedFiles, failures } = await checkProviderBaseClasses();
+
+    if (failures.length > 0) {
+      logTest("Provider Base Class Inheritance", "FAIL", failures.join("; "));
+      return false;
+    }
+    if (!ok) {
+      logTest(
+        "Provider Base Class Inheritance",
+        "FAIL",
+        "provider glob matched no files — the check verified nothing",
+      );
+      return false;
+    }
+
+    logTest(
+      "Provider Base Class Inheritance",
+      "PASS",
+      `Verified provider classes across ${checkedFiles} provider files (ESLint rule neurolink/provider-base-class)`,
+    );
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logTest("Provider Base Class Inheritance", "FAIL", msg);
     return false;
   }
 }

--- a/test/helpers/providerBaseClass.ts
+++ b/test/helpers/providerBaseClass.ts
@@ -1,0 +1,59 @@
+/**
+ * Provider base-class conformance check (Issue #1177).
+ *
+ * Lives here, apart from any suite, because every `continuous-test-suite-*.ts`
+ * is a self-executing script: each ends in a top-level `await runSuite(...)`,
+ * and `runSuite` finishes with `process.exit()`. Importing one from another
+ * therefore runs that whole suite and exits the process before the importer's
+ * own tests get to run — so shared test logic has to live in a module with no
+ * top-level side effects.
+ *
+ * Deliberately logging-free: each suite has its own local `logTest`, so this
+ * returns a result and lets the caller report it.
+ */
+
+import * as path from "node:path";
+import { ESLint } from "eslint";
+
+const RULE_ID = "neurolink/provider-base-class";
+const PROVIDER_GLOB = "src/lib/providers/**/*.ts";
+
+export type ProviderBaseClassCheck = {
+  ok: boolean;
+  /** Files the glob actually matched. Zero means the check proved nothing. */
+  checkedFiles: number;
+  /** `path:line: message` for each violation. */
+  failures: string[];
+};
+
+/**
+ * Run the `provider-base-class` ESLint rule over the provider tree.
+ *
+ * Runs the real rule rather than re-implementing it, so there is a single
+ * source of truth and no exclusion list to drift out of sync. The glob is
+ * recursive, so providers nested in per-provider directories are covered.
+ */
+export async function checkProviderBaseClasses(): Promise<ProviderBaseClassCheck> {
+  const eslint = new ESLint();
+  const results = await eslint.lintFiles([PROVIDER_GLOB]);
+
+  const failures: string[] = [];
+  for (const result of results) {
+    for (const msg of result.messages) {
+      if (msg.ruleId === RULE_ID) {
+        const relPath = path.relative(process.cwd(), result.filePath);
+        failures.push(`${relPath}:${msg.line}: ${msg.message}`);
+      }
+    }
+  }
+
+  // A glob that matches nothing would otherwise report a cheerful pass while
+  // verifying nothing at all — the failure mode a conformance check can least
+  // afford.
+  const checkedFiles = results.length;
+  return {
+    ok: checkedFiles > 0 && failures.length === 0,
+    checkedFiles,
+    failures,
+  };
+}


### PR DESCRIPTION
## The bug

`pnpm test` currently runs none of its own tests, and reports success.

#1245 wired the provider base-class check into the root suite with a cross-suite import:

```ts
// test/continuous-test-suite.ts
import { testProviderBaseClassInheritance } from "./continuous-test-suite-providers.js";
```

But every `continuous-test-suite-*.ts` is a **self-executing script**, not a library. Each ends with:

```ts
// test/continuous-test-suite-providers.ts (last line)
await runSuite(runAllTests);
```

and `runSuite` ends with:

```ts
// test/helpers/harness.ts:482
process.exit(failed > 0 ? 1 : 0);
```

A static ESM import evaluates the imported module's body before the importer runs. So the **providers** suite executes, then `process.exit()` fires, and the root suite never starts.

## Reproduction

On `release` (`4c3f3a21`):

```
$ npx tsx test/continuous-test-suite.ts
======================================================================
  Providers                       <-- the wrong suite
======================================================================
  Structured Output - Vertex ...
```

With this change:

```
$ npx tsx test/continuous-test-suite.ts
======================================================================
  Continuous Test Suite (root)    <-- correct
======================================================================
  NeuroLink Continuous Test Suite
```

CI did not catch it because no workflow runs the continuous suites — `test (20)` in `ci.yml` runs formatting, linting and the build.

## The fix

Move the check into `test/helpers/providerBaseClass.ts`, a module with **no top-level side effects**, and have both suites call it. It stays logging-free and returns a result, because each suite has its own local `logTest`.

This keeps the property #1245 was after — one source of truth, the real ESLint rule rather than a regex, and a recursive `src/lib/providers/**/*.ts` glob that follows providers into subdirectories.

## Also

The previous version reported PASS when the glob matched nothing, so a broken glob would have looked like success. It now fails explicitly.

## Verification

| | |
|---|---|
| `pnpm run check` | 0 errors / 4,795 files |
| `pnpm run lint` | 0 errors |
| helper standalone | `ok=true checkedFiles=48 failures=0` |
| root suite | starts and proceeds correctly |

## Note on the wider pattern

Every `continuous-test-suite-*.ts` carries this hazard — any future cross-suite import hits it. A guard would prevent a recurrence:

```ts
import { pathToFileURL } from "node:url";
if (import.meta.url === pathToFileURL(process.argv[1]).href) {
  await runSuite(runAllTests);
}
```

Left out here deliberately: it touches ~40 files and is a separate concern from restoring `pnpm test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved provider conformance checks through shared validation across test suites.
  * Tests now report detailed violations, fail when no provider files are found, and handle unexpected validation errors.
  * Added confirmation that provider coverage was successfully checked.
  * Standardized validation results to improve consistency and reliability across automated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->