### PR TITLE
fix(voice): bound MCP tool calls in the realtime agent

### DIFF
--- a/src/lib/types/livekit.ts
+++ b/src/lib/types/livekit.ts
@@ -553,4 +553,13 @@ export type BuildRealtimeMcpToolsParams = {
   publishEvent: RealtimeEventPublisher;
   /** Opens a HITL confirmation for destructive tools and awaits the decision. */
   requestConfirmation: RealtimeConfirmationRequester;
+  /**
+   * Hard cap per MCP tool call, in milliseconds (default 30000).
+   *
+   * Without one, a stalled MCP server holds the realtime turn open forever:
+   * Gemini waits on the function result, so the user gets silence rather than
+   * an error. Bounding the call turns that into a normal tool failure the
+   * model can talk about.
+   */
+  toolTimeoutMs?: number;
 };

--- a/src/lib/voice/livekit/realtimeMcpTools.ts
+++ b/src/lib/voice/livekit/realtimeMcpTools.ts
@@ -21,6 +21,15 @@ import { findSchemaIssue, sanitizeToolParameters } from "./schemaSanitizer.js";
 import type { BuildRealtimeMcpToolsParams } from "../../types/index.js";
 
 /**
+ * Default hard cap per MCP tool call.
+ *
+ * Chosen to sit well inside a conversational turn: a realtime voice user is
+ * waiting in silence while a tool runs, so a call that has not returned in
+ * 30s has already failed as far as the conversation is concerned.
+ */
+const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
+
+/**
  * The fields of an MCP tool result we render: text content parts and the error
  * flag. The result crosses a network boundary from an external MCP server, so it
  * is decoded with a schema (other content kinds — image, resource — are dropped).
@@ -109,8 +118,14 @@ export async function buildRealtimeMcpTools(
   tools: llmNs.ToolContext;
   client: { close: () => Promise<void> };
 }> {
-  const { mcpUrl, authToken, xContext, publishEvent, requestConfirmation } =
-    params;
+  const {
+    mcpUrl,
+    authToken,
+    xContext,
+    publishEvent,
+    requestConfirmation,
+    toolTimeoutMs = DEFAULT_TOOL_TIMEOUT_MS,
+  } = params;
 
   const { llm } = await import("@livekit/agents");
   const { Client: McpClient } =
@@ -180,10 +195,18 @@ export async function buildRealtimeMcpTools(
           publishEvent("tool-start", { name: mcpTool.name });
           const startedAt = Date.now();
           try {
-            const result = await client.callTool({
-              name: mcpTool.name,
-              arguments: args ?? {},
-            });
+            // Third argument is RequestOptions; the SDK aborts the in-flight
+            // request when `timeout` elapses. Without it a stalled server holds
+            // the turn open indefinitely — Gemini blocks on the function
+            // result, so the user hears nothing at all rather than an error.
+            const result = await client.callTool(
+              {
+                name: mcpTool.name,
+                arguments: args ?? {},
+              },
+              undefined,
+              { timeout: toolTimeoutMs },
+            );
             const text = mcpResultToText(result);
             logger.info("realtime.tool.result", {
               tool: mcpTool.name,


### PR DESCRIPTION
Closes #1102.

## The bug

`src/lib/voice/livekit/realtimeMcpTools.ts` called the MCP client with no request options:

```ts
const result = await client.callTool({
  name: mcpTool.name,
  arguments: args ?? {},
});
```

The `@modelcontextprotocol/sdk` signature is `callTool(params, resultSchema?, options?: RequestOptions)`, and without a `timeout` the request has no bound.

In speech-to-speech mode **Gemini owns the tool loop and blocks on the function result**, so a stalled MCP server doesn't produce an error — it produces *silence*. The turn stays open, `tool-result` never fires, and the browser keeps showing the in-progress indicator indefinitely.

## The fix

```ts
const result = await client.callTool(
  { name: mcpTool.name, arguments: args ?? {} },
  undefined,
  { timeout: toolTimeoutMs },
);
```

The SDK aborts the in-flight request when the timeout elapses. The existing `catch` already turns that into `Tool <name> failed: …` and publishes `tool-result` — so a hang becomes a normal tool failure the model can speak about.

Default **30s**, overridable per call site via a new optional `toolTimeoutMs` on `BuildRealtimeMcpToolsParams`.

## On the 30s default

Chosen against the *conversation*, not the server. A realtime voice user is sitting in silence while a tool runs; a call still outstanding at 30 seconds has already failed as far as the turn is concerned, whatever the server eventually does.

## On AbortSignal

The issue also floats threading an `AbortSignal` for user-interrupt cancellation. Left out deliberately — there's no interrupt signal plumbed into `buildRealtimeMcpTools` today, so it would mean widening the params and touching the agent's interrupt path. Worth doing, but as its own change; this one closes the unbounded-hang hole.

## Verification

| | |
|---|---|
| `pnpm run check` | 0 errors / 4,795 files |
| `pnpm run lint` | 0 errors |

No unit test: the module dynamically imports `@livekit/agents` and `@modelcontextprotocol/sdk` (both optional deps, absent in a default install), so exercising this path needs the realtime harness rather than a unit test. Saying so plainly rather than adding a test that mocks the thing under test.