### PR TITLE
fix(multimodal): deliver attached files on the Vertex stream path and via audioFiles/videoFiles

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -318,8 +318,12 @@ export abstract class BaseProvider implements AIProvider {
     });
 
     // ===== EARLY MULTIMODAL DETECTION =====
+    // #1259: audioFiles was missing here while videoFiles was present, so an
+    // audio-only stream skipped this branch entirely.
     const hasFileInput =
-      !!options.input?.files?.length || !!options.input?.videoFiles?.length;
+      !!options.input?.files?.length ||
+      !!options.input?.videoFiles?.length ||
+      !!options.input?.audioFiles?.length;
     if (hasFileInput) {
       // ===== VIDEO ANALYSIS DETECTION =====
       // Check if video frames are present and handle with fake streaming

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -60,7 +60,10 @@ import {
 import { ERROR_CODES, NeuroLinkError } from "../../utils/errorHandling.js";
 import { applyVertexAnthropicCacheBreakpoints } from "../../utils/anthropicCacheBreakpoints.js";
 import { FileDetector } from "../../utils/fileDetector.js";
-import { processUnifiedFilesArray } from "../../utils/messageBuilder.js";
+import {
+  mergeMediaFileAliases,
+  processUnifiedFilesArray,
+} from "../../utils/messageBuilder.js";
 import { logger } from "../../utils/logger.js";
 import {
   hasRestrictedOutputLimit,
@@ -1205,6 +1208,48 @@ export class GoogleVertexProvider extends BaseProvider {
     this.validateStreamOptions(options);
   }
 
+  /**
+   * Preprocess file input before routing to the native SDKs.
+   *
+   * BaseProvider runs this via `buildMultimodalMessagesArray`, but Vertex
+   * overrides both `generate()` and `executeStream()` to reach the native
+   * @google/genai / @anthropic-ai/vertex-sdk clients directly, so neither
+   * inherits it. Without this the file content never reaches the model and
+   * the reply is an entirely plausible "no document is attached" — a silent
+   * wrong answer rather than an error.
+   *
+   * #1258: only `generate()` used to call this, so the same document that
+   * `generate()` read back correctly came back as "no documents attached"
+   * through `stream()`. Sharing one method is what keeps the two paths from
+   * drifting apart again.
+   *
+   * #1259: the alias fold has to happen *before* the `files` check, or
+   * requests carrying only `audioFiles`/`videoFiles` look empty here and skip
+   * preprocessing entirely.
+   */
+  private async preprocessNativeFileInput(
+    options: TextGenerationOptions | StreamOptions,
+  ): Promise<void> {
+    if (options.input) {
+      mergeMediaFileAliases(options.input);
+    }
+    if (!options.input?.files?.length) {
+      return;
+    }
+    try {
+      // Mutates options.input.text / .images / .pdfFiles in place.
+      await processUnifiedFilesArray(
+        options as Parameters<typeof processUnifiedFilesArray>[0],
+        100 * 1024 * 1024,
+        this.providerName,
+      );
+    } catch (fileError) {
+      logger.warn(
+        `[GoogleVertex] processUnifiedFilesArray threw, continuing without file content: ${fileError instanceof Error ? fileError.message : String(fileError)}`,
+      );
+    }
+  }
+
   protected async executeStream(
     options: StreamOptions,
     _analysisSchema?: ZodType<unknown> | Schema<unknown>,
@@ -1234,6 +1279,10 @@ export class GoogleVertexProvider extends BaseProvider {
         // Tool filter (a0269210): trust options.tools — caller (BaseProvider.stream)
         // already merged MCP/built-in tools and applied any enabledToolNames filter.
         const optionTools = options.tools || {};
+
+        // #1258: stream() must run the same file preprocessing generate()
+        // does, or attached files are dropped on this path alone.
+        await this.preprocessNativeFileInput(options);
 
         // Emit a `neurolink.message.build` span for the native stream path
         // so observability tooling sees the same hierarchy it sees on
@@ -7491,25 +7540,7 @@ export class GoogleVertexProvider extends BaseProvider {
           ? await this.getToolsForStream(options)
           : {};
 
-        // Process the unified `input.files` array before routing to the
-        // native SDK. BaseProvider.generate() runs this preprocessing via
-        // buildMultimodalMessagesArray, but Vertex's override skips it,
-        // which would otherwise drop text-file content (and the
-        // mimetype-hint contract) on the floor. Mutates options.input.text /
-        // options.input.images / options.input.pdfFiles in place.
-        if (options.input?.files && options.input.files.length > 0) {
-          try {
-            await processUnifiedFilesArray(
-              options as Parameters<typeof processUnifiedFilesArray>[0],
-              100 * 1024 * 1024,
-              this.providerName,
-            );
-          } catch (fileError) {
-            logger.warn(
-              `[GoogleVertex] processUnifiedFilesArray threw, continuing without file content: ${fileError instanceof Error ? fileError.message : String(fileError)}`,
-            );
-          }
-        }
+        await this.preprocessNativeFileInput(options);
 
         // Emit a `neurolink.message.build` span so observability tooling
         // sees the message-construction phase even on the native (Pipeline B)

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -973,6 +973,46 @@ function appendDetectedFileResult(
 }
 
 /**
+ * Fold the `audioFiles` / `videoFiles` aliases into the unified `files` array.
+ *
+ * #284 gave audio and video their own input fields, but neither has a
+ * dedicated processor — both are meant to travel through the same
+ * auto-detecting `files` pipeline that already understands "audio"/"video"
+ * FileDetector results (see `appendDetectedFileResult`). The fold used to live
+ * inline in `buildMultimodalMessagesArray`, which meant any path that bypassed
+ * that builder never performed it and dropped the files silently: the model
+ * received the prompt alone and answered as though nothing were attached
+ * (#1259). GoogleVertex's native SDK path and `buildMultimodalOptions`
+ * (Bedrock) are both such paths, so the fold has to be callable from them.
+ *
+ * The aliases are cleared once merged, which makes the call idempotent: a
+ * provider override and the shared builder can both call this on the same
+ * options object without attaching every file twice.
+ *
+ * Mutates in place, matching `processUnifiedFilesArray` below — downstream
+ * stages all read `options.input.files`.
+ */
+export function mergeMediaFileAliases<TFile>(input: {
+  // Generic in the `files` element type: callers' arrays also admit
+  // FileWithMetadata, and narrowing to Buffer | string here would force an
+  // assertion at every call site rather than fixing the type.
+  files?: Array<TFile | Buffer | string>;
+  audioFiles?: Array<Buffer | string>;
+  videoFiles?: Array<Buffer | string>;
+}): void {
+  if (!input.audioFiles?.length && !input.videoFiles?.length) {
+    return;
+  }
+  input.files = [
+    ...(input.files ?? []),
+    ...(input.audioFiles ?? []),
+    ...(input.videoFiles ?? []),
+  ];
+  input.audioFiles = undefined;
+  input.videoFiles = undefined;
+}
+
+/**
  * Process the unified files array with auto-detection.
  * Handles lazy file registration, full processing, and preview injection.
  *
@@ -1440,18 +1480,7 @@ export async function buildMultimodalMessagesArray(
   // rest of this function, avoiding 60+ "possibly undefined" errors.
   const inp = options.input;
 
-  // #284: audioFiles/videoFiles have no dedicated processor — route them
-  // through the same auto-detecting `files` pipeline that already
-  // understands "audio"/"video" FileDetector results (see
-  // appendDetectedFileResult), instead of silently dropping them once
-  // detectMultimodal() routes an audio/video-only request here.
-  if (inp.audioFiles?.length || inp.videoFiles?.length) {
-    inp.files = [
-      ...(inp.files || []),
-      ...(inp.audioFiles || []),
-      ...(inp.videoFiles || []),
-    ];
-  }
+  mergeMediaFileAliases(inp);
 
   // Compute provider-specific max PDF size once for consistent validation
   const pdfConfig = PDFProcessor.getProviderConfig(provider);

--- a/src/lib/utils/multimodalOptionsBuilder.ts
+++ b/src/lib/utils/multimodalOptionsBuilder.ts
@@ -13,6 +13,8 @@ import type { StreamOptions } from "../types/index.js";
  *   - input.files: Auto-detected file types
  *   - input.csvFiles: CSV files for tabular data
  *   - input.pdfFiles: PDF documents (Buffer | string paths)
+ *   - input.audioFiles: Audio files (Buffer | string paths)
+ *   - input.videoFiles: Video files (Buffer | string paths)
  *   - csvOptions: CSV parsing options
  *   - systemPrompt: System-level instructions
  *   - conversationMessages: Chat history
@@ -24,7 +26,7 @@ import type { StreamOptions } from "../types/index.js";
  * @param {string} providerName - Provider identifier (e.g., "vertex", "openai", "anthropic")
  * @param {string} modelName - Model identifier (e.g., "gemini-2.5-flash", "gpt-4o")
  * @returns {object} Normalized options object with:
- *   - input: { text, images, content, files, csvFiles, pdfFiles }
+ *   - input: { text, images, content, files, csvFiles, pdfFiles, audioFiles, videoFiles }
  *   - csvOptions: CSV processing options
  *   - systemPrompt: System prompt string
  *   - conversationHistory: Message history array
@@ -55,6 +57,11 @@ export function buildMultimodalOptions(
       files: options.input?.files,
       csvFiles: options.input?.csvFiles,
       pdfFiles: options.input?.pdfFiles,
+      // #1259: this is a whitelist — a field omitted here is dropped
+      // silently, and the model answers as though nothing were attached.
+      // audioFiles/videoFiles were missing, so Bedrock received neither.
+      audioFiles: options.input?.audioFiles,
+      videoFiles: options.input?.videoFiles,
     },
     csvOptions: options.csvOptions,
     pdfOptions: options.pdfOptions,

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -19,7 +19,9 @@ import {
 import {
   convertToModelMessages,
   buildMultimodalMessagesArray,
+  mergeMediaFileAliases,
 } from "../src/lib/utils/messageBuilder.js";
+import { buildMultimodalOptions } from "../src/lib/utils/multimodalOptionsBuilder.js";
 import {
   CSVProcessor,
   isValidCsvRow,
@@ -7246,6 +7248,64 @@ exit 127
       const audioHasMarker =
         JSON.stringify(audioMessages).includes("## Audio File:");
       return videoHasMarker && audioHasMarker;
+    },
+  },
+  {
+    name: "mergeMediaFileAliases #1259: folds audio/video aliases into files, idempotently",
+    category: "message-builder",
+    fn: async () => {
+      const a = Buffer.from("audio");
+      const v = Buffer.from("video");
+      const f = Buffer.from("file");
+      const input: {
+        files?: Array<Buffer | string>;
+        audioFiles?: Array<Buffer | string>;
+        videoFiles?: Array<Buffer | string>;
+      } = { files: [f], audioFiles: [a], videoFiles: [v] };
+
+      mergeMediaFileAliases(input);
+      const foldedAll = input.files?.length === 3;
+      const aliasesCleared = !input.audioFiles && !input.videoFiles;
+
+      // Idempotence is the point: a provider override and the shared builder
+      // can both call this on one options object, and a non-idempotent fold
+      // would attach every file twice.
+      mergeMediaFileAliases(input);
+      const stillThree = input.files?.length === 3;
+
+      // A no-alias input must not be touched at all (not even to [] ).
+      const untouched: { files?: Array<Buffer | string> } = {};
+      mergeMediaFileAliases(untouched);
+
+      return (
+        foldedAll &&
+        aliasesCleared &&
+        stillThree &&
+        untouched.files === undefined
+      );
+    },
+  },
+  {
+    name: "buildMultimodalOptions #1259: forwards audioFiles/videoFiles",
+    category: "message-builder",
+    fn: async () => {
+      // This builder is a field whitelist, so an omitted field is dropped
+      // silently and the model answers as though nothing were attached.
+      // audioFiles/videoFiles were missing, which is what made Bedrock ignore
+      // both. Assert every media field survives the round trip.
+      const audio = Buffer.from("audio-bytes");
+      const video = Buffer.from("video-bytes");
+      const built = buildMultimodalOptions(
+        {
+          input: { text: "describe", audioFiles: [audio], videoFiles: [video] },
+        } as Parameters<typeof buildMultimodalOptions>[0],
+        "bedrock",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      );
+      return (
+        built.input.audioFiles?.[0] === audio &&
+        built.input.videoFiles?.[0] === video
+      );
     },
   },
   {


### PR DESCRIPTION
Two silent data-loss bugs where an attached file never reached the model. Neither raised an error — the model answered from the prompt alone, so the caller got a fluent, confident, wrong answer. Both were found while building the multimodal test suites in #1257 and are reproduced there as skipped regression markers.

## #1258 — `stream()` dropped files on Vertex

`GoogleVertex` overrides **both** `generate()` and `executeStream()` to reach the native SDKs directly, so neither inherits `BaseProvider`'s preprocessing. Only `generate()` called `processUnifiedFilesArray`. The same `.docx` that `generate()` read back as `"ORCHID"` came back from `stream()` as *"no documents attached"*.

Both paths now share one `preprocessNativeFileInput()` method — that is what stops them drifting apart again, rather than a second copy of the same block.

## #1259 — `input.audioFiles` / `input.videoFiles` were never delivered

The fold of those aliases into the unified `files` array lived **inline inside `buildMultimodalMessagesArray`**, so every path that bypasses that builder skipped it:

| Site | Failure |
|---|---|
| `googleVertex/client.ts` | checks `input.files` before preprocessing; with only `audioFiles` set it saw an empty array and skipped |
| `multimodalOptionsBuilder.ts` | a field **whitelist** that simply omitted both fields — silently costing Bedrock the same |
| `baseProvider.ts` | stream file-input check tested `videoFiles` but not `audioFiles` |

The fold is now an exported, **idempotent** helper (`mergeMediaFileAliases`) called from all three. Idempotence matters: a provider override and the shared builder can both run on one options object, and a non-idempotent fold would attach every file twice.

## Verified live against Vertex

Same repro inputs that produced the bug reports:

```
audioFiles (7s tone)   NOTHING_RECEIVED         ->  "7"
videoFiles             NOTHING_RECEIVED         ->  "320x240"
stream() + .docx       "no documents attached"  ->  "ORCHID"
```

The `7` is deliberate — a duration with no prior. An earlier attempt asserted the sample rate and had to be thrown out: the model returns `44100` with **no file attached at all**, so it proved nothing.

## Tests

Regression tests in `continuous-test-suite-bugfixes.ts` cover the idempotent fold and the whitelist forwarding, both network-free.

- `pnpm run check` — 0 errors, 4,837 files
- bugfixes suite — **236 passed, 0 failed**
- lint / prettier — clean

Once this lands, the three skipped markers in #1257 become live assertions.

Closes #1258
Closes #1259