### PR TITLE
fix(processors): render audio and video durations in one shared format

### DIFF
--- a/src/lib/processors/media/AudioProcessor.ts
+++ b/src/lib/processors/media/AudioProcessor.ts
@@ -47,6 +47,7 @@ import type {
 import { SIZE_LIMITS_MB } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
 import { withTimeout } from "../../utils/timeout.js";
+import { formatMediaDuration } from "../../utils/mediaDuration.js";
 
 let _musicMetadata: typeof import("music-metadata") | null = null;
 async function loadMusicMetadata() {
@@ -479,7 +480,7 @@ export class AudioProcessor extends BaseFileProcessor<ProcessedAudio> {
       textContent: "",
       metadata: {
         duration: 0,
-        durationFormatted: "0:00",
+        durationFormatted: formatMediaDuration(0),
         codec: "unknown",
         lossless: false,
         fileSize: buffer.length,
@@ -737,28 +738,15 @@ export class AudioProcessor extends BaseFileProcessor<ProcessedAudio> {
   /**
    * Format a duration in seconds to a human-readable string.
    *
-   * @param seconds - Duration in seconds
-   * @returns Formatted string: "M:SS" for < 1 hour, "H:MM:SS" for >= 1 hour
+   * Delegates to the shared formatter so audio and video describe the same
+   * file the same way — this used to render "0:02" where VideoProcessor
+   * rendered "2s".
    *
-   * @example
-   * formatDuration(225)   // "3:45"
-   * formatDuration(3750)  // "1:02:30"
-   * formatDuration(0)     // "0:00"
+   * @param seconds - Duration in seconds
+   * @returns Formatted string: "45s", "3m 45s", "1h 2m 30s"
    */
   private formatDuration(seconds: number): string {
-    if (!seconds || seconds <= 0) {
-      return "0:00";
-    }
-
-    const totalSeconds = Math.round(seconds);
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const secs = totalSeconds % 60;
-
-    if (hours > 0) {
-      return `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
-    }
-    return `${minutes}:${String(secs).padStart(2, "0")}`;
+    return formatMediaDuration(seconds);
   }
 
   /**

--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -52,6 +52,7 @@ import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 
 import { BaseFileProcessor } from "../base/BaseFileProcessor.js";
+import { formatMediaDuration } from "../../utils/mediaDuration.js";
 import type {
   FfprobeData,
   FfprobeStream,
@@ -307,7 +308,7 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
       keyframes: [],
       metadata: {
         duration: 0,
-        durationFormatted: "0s",
+        durationFormatted: formatMediaDuration(0),
         width: 0,
         height: 0,
         codec: "unknown",
@@ -1112,30 +1113,16 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
   /**
    * Format a duration in seconds to a human-readable string.
    *
+   * Delegates to the shared formatter so audio and video agree — see
+   * `formatMediaDuration`. Rounding replaces the previous truncation, so a
+   * 2.6s clip now reads "3s" rather than "2s" and matches what the audio
+   * side reports for the same stream.
+   *
    * @param seconds - Duration in seconds
    * @returns Formatted string (e.g., "1h 23m 45s")
    */
   private formatDuration(seconds: number): string {
-    if (seconds <= 0) {
-      return "0s";
-    }
-
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    const parts: string[] = [];
-    if (hours > 0) {
-      parts.push(`${hours}h`);
-    }
-    if (minutes > 0) {
-      parts.push(`${minutes}m`);
-    }
-    if (secs > 0 || parts.length === 0) {
-      parts.push(`${secs}s`);
-    }
-
-    return parts.join(" ");
+    return formatMediaDuration(seconds);
   }
 
   /**

--- a/src/lib/utils/mediaDuration.ts
+++ b/src/lib/utils/mediaDuration.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared duration formatting for the media processors.
+ *
+ * AudioProcessor and VideoProcessor each carried their own private
+ * `formatDuration`, and they disagreed: the same two-second file rendered as
+ * "0:02" from audio and "2s" from video, and a zero duration as "0:00" versus
+ * "0s". Both strings land in the `textContent` handed to the model, often in
+ * the same request when a video's muxed audio is described alongside it, so
+ * the mismatch reads as two different facts about one file.
+ *
+ * The explicit-unit form wins over the "m:ss" clock form because these strings
+ * are consumed by a language model, not rendered in a player scrubber: "1m 30s"
+ * has exactly one reading, while "1:30" is ambiguous between 1m30s and 1h30m
+ * and has to be disambiguated from context that may not be present.
+ */
+
+/**
+ * Format a duration in seconds as explicit units — "45s", "1m 30s", "1h 2m 3s".
+ *
+ * Non-finite, negative and zero durations all render as "0s": callers reach
+ * this with a probe failure or a stream that reports no duration, and a
+ * fabricated number would be worse than an obvious zero.
+ */
+export function formatMediaDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "0s";
+  }
+
+  const total = Math.round(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  // Keep the seconds term when it is the only one, so sub-minute durations
+  // never render as an empty string.
+  if (secs > 0 || parts.length === 0) {
+    parts.push(`${secs}s`);
+  }
+
+  return parts.join(" ");
+}

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -31,6 +31,7 @@ import {
   dedupeColumnNames,
 } from "../src/lib/utils/csvProcessor.js";
 import { NeuroLinkError } from "../src/lib/utils/errorHandling.js";
+import { formatMediaDuration } from "../src/lib/utils/mediaDuration.js";
 import { ErrorCategory } from "../src/lib/constants/enums.js";
 import { decodeBuffer } from "../src/lib/utils/textEncoding.js";
 import { CSVLoader } from "../src/lib/rag/document/loaders.js";
@@ -7453,6 +7454,44 @@ exit 127
         built.input.audioFiles?.[0] === audio &&
         built.input.videoFiles?.[0] === video
       );
+    },
+  },
+  {
+    name: "formatMediaDuration: audio and video render the same duration identically",
+    category: "message-builder",
+    fn: async () => {
+      // The two media processors used to disagree — a 2s file read "0:02"
+      // from audio and "2s" from video, and both strings reach the model,
+      // sometimes in one request. Pin the shared format and the edge cases.
+      const cases: Array<[number, string]> = [
+        [0, "0s"],
+        [-5, "0s"],
+        [Number.NaN, "0s"],
+        [Number.POSITIVE_INFINITY, "0s"],
+        [2, "2s"],
+        [45, "45s"],
+        [60, "1m"],
+        [90, "1m 30s"],
+        [3600, "1h"],
+        [3750, "1h 2m 30s"],
+        // Rounds rather than truncates, so audio and video agree on the same
+        // fractional stream duration.
+        [2.6, "3s"],
+      ];
+      const wrong = cases.filter(
+        ([input, expected]) => formatMediaDuration(input) !== expected,
+      );
+      if (wrong.length > 0) {
+        throw new Error(
+          `unexpected duration formatting: ${wrong
+            .map(
+              ([input, expected]) =>
+                `${input} → "${formatMediaDuration(input)}" (expected "${expected}")`,
+            )
+            .join(", ")}`,
+        );
+      }
+      return true;
     },
   },
   {


### PR DESCRIPTION
Raised in review on #1257 by @Tara-ag:

> VideoProcessor renders duration as "2s" while AudioProcessor uses "0:00" (m:ss) format. Both feed the same model so the inconsistency may confuse LLM prompts.

## The problem

`AudioProcessor` and `VideoProcessor` each carried their own private `formatDuration`, and they disagreed:

| Input | AudioProcessor | VideoProcessor |
|---|---|---|
| 2s | `0:02` | `2s` |
| 0 | `0:00` | `0s` |
| 2.6s | `3s` (rounds) | `2s` (truncates) |

Both strings land in the `textContent` handed to the model — frequently **in the same request**, since a video's muxed audio track is described alongside the video. The mismatch reads as two different facts about one file.

## The fix

Both delegate to a shared `formatMediaDuration()`.

**Explicit units win over the clock form** because these strings are read by a language model, not rendered in a player scrubber: `1m 30s` has exactly one reading, while `1:30` is ambiguous between 1m30s and 1h30m and needs context that may not be present.

Video previously truncated where audio rounded, so the two also disagreed on fractional durations; the shared helper rounds, and a 2.6s clip now reads `3s` on both sides. Non-finite and negative inputs render `0s` rather than a fabricated number — callers reach this on a failed probe, and an obvious zero beats an invented figure.

## Scope

This changes a user-visible metadata string (`metadata.durationFormatted`) on the audio side. No test or caller in the repo pins the old format — checked before changing it.

## Verification

- `pnpm run check` — 0 errors, 4,838 files
- bugfixes suite — **235 passed, 0 failed**
- new regression test pins the format across both processors, including the zero / negative / non-finite / rounding edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized audio and video duration displays across the app.
  * Durations now use clear units, such as `45s`, `3m 45s`, and `1h 2m 30s`.
  * Improved handling of invalid, zero, negative, and fractional duration values.

* **Tests**
  * Added coverage to verify consistent duration formatting in common and edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->