### PR TITLE
fix(ci): skip duplicate GitHub Package publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: neurolink-release-publish
+      cancel-in-progress: false
     permissions:
       contents: write
       packages: write
@@ -120,9 +123,20 @@ jobs:
       - name: Publish to GitHub Packages
         run: |
           if [ -f "package.json" ]; then
-            echo "📦 Publishing to GitHub Packages..."
-            pnpm publish --access public --no-git-checks --registry https://npm.pkg.github.com
-            echo "✅ Published to GitHub Packages successfully!"
+            package_name="$(node -p "require('./package.json').name")"
+            package_version="$(node -p "require('./package.json').version")"
+
+            if lookup_output="$(npm view "${package_name}@${package_version}" version --registry https://npm.pkg.github.com 2>&1)"; then
+              echo "GitHub Packages already contains ${package_name}@${package_version}; skipping publish."
+            elif printf '%s\n' "$lookup_output" | grep -qxE 'npm (ERR!|error) code E404'; then
+              echo "Publishing ${package_name}@${package_version} to GitHub Packages..."
+              pnpm publish --access public --no-git-checks --registry https://npm.pkg.github.com
+              echo "Published ${package_name}@${package_version} to GitHub Packages."
+            else
+              printf '%s\n' "$lookup_output" >&2
+              echo "Unable to determine whether ${package_name}@${package_version} exists in GitHub Packages; refusing to publish." >&2
+              exit 1
+            fi
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The release workflow runs for every push to `release`, but semantic-release correctly makes no version for `test`, `docs`, `ci`, and `chore` commits. The unconditional GitHub Packages step then attempts to republish the package version already in `package.json`, failing with `You cannot publish over the previously published versions`.

## Fix
Before publishing to GitHub Packages, query the authenticated registry for the exact package name and version.

- Existing version: skip successfully.
- Missing version (404): publish.
- Authentication or other registry error: fail without attempting a publish.

This is idempotent and also retries a GitHub Packages version that was missed after a successful npm release.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`\n- `git diff --check`\n- Mocked shell paths: existing package skips; 404 publishes; 401 fails without publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package release handling to avoid publishing versions that already exist.
  * Releases now stop safely when the package registry returns an unexpected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->