### PR TITLE
fix(proxy): honor Anthropic overage availability

### DIFF
--- a/src/lib/proxy/accountQuota.ts
+++ b/src/lib/proxy/accountQuota.ts
@@ -51,6 +51,39 @@ export function getUnifiedRateLimitStatus(
 }
 
 /**
+ * Whether Anthropic explicitly permits a request to use overage after a
+ * subscription window is exhausted. Fresh responses require all three
+ * provider signals. Older persisted snapshots predate the raw fallback and
+ * upgrade-path fields, but retain a positive fallback percentage together with
+ * an allowed overage status, which is the equivalent provider state.
+ */
+export function isQuotaOverageAvailable(
+  quota:
+    | Pick<
+        AccountQuota,
+        | "fallbackPercentage"
+        | "fallbackStatus"
+        | "overageStatus"
+        | "upgradePaths"
+      >
+    | null
+    | undefined,
+): boolean {
+  if (quota?.overageStatus?.trim().toLowerCase() !== "allowed") {
+    return false;
+  }
+  const explicitFallback = quota.fallbackStatus?.trim().toLowerCase();
+  const hasExplicitOveragePath = (quota.upgradePaths ?? "")
+    .split(",")
+    .map((path) => path.trim().toLowerCase())
+    .includes("overage");
+  if (explicitFallback === "available" && hasExplicitOveragePath) {
+    return true;
+  }
+  return explicitFallback === undefined && (quota.fallbackPercentage ?? 0) > 0;
+}
+
+/**
  * Parse Anthropic rate-limit / quota headers into an `AccountQuota`.
  * Returns `null` when key headers are absent.
  * Pure computation — no I/O, no blocking.
@@ -87,6 +120,8 @@ export function parseQuotaHeaders(
     weeklyStatus: getHeader(headers, `${P}unified-7d-status`) ?? "unknown",
     weeklyResetAt: weeklyResetRaw ? parseInt(weeklyResetRaw, 10) || 0 : 0,
     fallbackPercentage: fallbackRaw ? parseFloat(fallbackRaw) || 0 : 0,
+    fallbackStatus: getHeader(headers, `${P}unified-fallback`) ?? "unknown",
+    upgradePaths: getHeader(headers, `${P}unified-upgrade-paths`),
     overageStatus:
       getHeader(headers, `${P}unified-overage-status`) ?? "unknown",
     lastUpdated: Date.now(),

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -120,6 +120,7 @@ function routingCandidateValue(
     "sessionStatus",
     "weeklyStatus",
   ];
+  const optionalNullableStringFields = ["fallbackStatus", "upgradePaths"];
   if (
     !stringValue(candidate.account) ||
     typeof candidate.accountType !== "string" ||
@@ -137,6 +138,15 @@ function routingCandidateValue(
     requiredNullableStringFields.some(
       (field) => !isNullableString(candidate[field]),
     ) ||
+    optionalNullableStringFields.some(
+      (field) =>
+        field in candidate &&
+        candidate[field] !== undefined &&
+        !isNullableString(candidate[field]),
+    ) ||
+    ("overageEligible" in candidate &&
+      candidate.overageEligible !== undefined &&
+      typeof candidate.overageEligible !== "boolean") ||
     !(
       candidate.coolingReason === null ||
       (typeof candidate.coolingReason === "string" &&
@@ -162,6 +172,9 @@ function routingCandidateValue(
       candidate.coolingReason as ProxyAccountRoutingCandidate["coolingReason"],
     coolingUntil: candidate.coolingUntil as number | null,
     unifiedStatus: candidate.unifiedStatus as string | null,
+    fallbackStatus: candidate.fallbackStatus as string | null | undefined,
+    upgradePaths: candidate.upgradePaths as string | null | undefined,
+    overageEligible: candidate.overageEligible as boolean | undefined,
     overageStatus: candidate.overageStatus as string | null,
     sessionStatus: candidate.sessionStatus as string | null,
     sessionUsed: candidate.sessionUsed as number | null,

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -34,6 +34,7 @@ import {
 } from "../../proxy/accountSelection.js";
 import {
   getUnifiedRateLimitStatus,
+  isQuotaOverageAvailable,
   loadAccountQuotas,
   parseQuotaHeaders,
   saveAccountQuota,
@@ -125,6 +126,7 @@ import type {
   ProxyAccountRoutingReason,
   ProxyAccountSortMetrics,
   ProxyBodyCaptureLogger,
+  ProxyQuotaCooldownUpdate,
   ProxyPassthroughAccount,
   QueuedAccountAdmission,
   ResponseInfoContext,
@@ -651,9 +653,9 @@ function clampCooldownUntil(untilMs: number, now: number): number {
  * The unified subscription limits expose per-window status + reset:
  *   - weekly (7d) "rejected"  → hard cap for the week; cool until the 7d reset.
  *   - session (5h) "rejected" → paced out for this session; cool until the 5h reset.
- * Both mean "retrying this account is futile until its window resets" → rotate
- * immediately (no same-account retries) and park the account until the ACTUAL
- * reset — never the legacy 60s hardcap that let us re-hammer a spent account.
+ * Both mean "retrying this account is futile until its window resets" unless
+ * the provider explicitly enables overage. In that case, the subscription
+ * window is exhausted but the account remains usable for paid fallback.
  *
  * Anything else (window still "allowed" but momentarily 429'd — a per-minute
  * burst / acceleration limit) is transient: honor retry-after as a floor,
@@ -676,7 +678,8 @@ function planCooldownFor429(
       rotateImmediately: true,
     };
   }
-  if (quota && quota.sessionStatus === "rejected") {
+  const overageAvailable = isQuotaOverageAvailable(quota);
+  if (quota && quota.sessionStatus === "rejected" && !overageAvailable) {
     const reset =
       resetEpochToMs(quota.sessionResetAt, now) ??
       (retryAfterMs > 0 ? now + retryAfterMs : now + DEFAULT_COOLING_PERIOD_MS);
@@ -689,7 +692,7 @@ function planCooldownFor429(
   // Anthropic may reject the authoritative top-level unified limit while both
   // 5h and 7d sub-window statuses still say "allowed". Treating this as a
   // transient burst retries a known-exhausted account and delays failover.
-  if (unifiedStatus?.trim().toLowerCase() === "rejected") {
+  if (unifiedStatus?.trim().toLowerCase() === "rejected" && !overageAvailable) {
     const reset =
       retryAfterMs > 0 ? now + retryAfterMs : now + DEFAULT_HARD_COOLDOWN_MS;
     return {
@@ -721,27 +724,51 @@ function minutesUntil(untilMs: number, now: number): number {
  * flipped to "rejected" (the boundary request that spends the last of the quota
  * still returns 200 but reports rejected/next-reset). Parks the account until
  * its reset so the next request skips it instead of discovering the limit via a
- * 429. Never shortens an existing, longer cooldown.
+ * 429, except when the provider explicitly enables paid overage.
  */
-function maybeCoolFromQuota(
+function reconcileCooldownFromQuota(
   state: RuntimeAccountState,
   quota: AccountQuota,
   now: number,
-): boolean {
+): ProxyQuotaCooldownUpdate {
+  const overageAvailable = isQuotaOverageAvailable(quota);
   let until: number | undefined;
   let reason: RuntimeAccountState["coolingReason"];
   if (quota.weeklyStatus === "rejected") {
     until = resetEpochToMs(quota.weeklyResetAt, now);
     reason = "weekly";
-  } else if (quota.sessionStatus === "rejected") {
+  }
+  if (
+    until === undefined &&
+    overageAvailable &&
+    state.coolingUntil &&
+    (state.coolingReason === "session" || state.coolingReason === "unified")
+  ) {
+    const previousCoolingUntil = state.coolingUntil;
+    state.coolingUntil = undefined;
+    state.coolingReason = undefined;
+    logger.always(
+      "[proxy] clearing subscription cooldown because Anthropic explicitly permits overage",
+    );
+    return { kind: "cleared", coolingUntil: previousCoolingUntil };
+  }
+  if (
+    until === undefined &&
+    quota.sessionStatus === "rejected" &&
+    !overageAvailable
+  ) {
     until = resetEpochToMs(quota.sessionResetAt, now);
     reason = "session";
-  } else if (quota.unifiedStatus === "rejected") {
+  } else if (
+    until === undefined &&
+    quota.unifiedStatus === "rejected" &&
+    !overageAvailable
+  ) {
     until = now + DEFAULT_HARD_COOLDOWN_MS;
     reason = "unified";
   }
   if (until === undefined) {
-    return false;
+    return null;
   }
   const clamped = clampCooldownUntil(until, now);
   if (!state.coolingUntil || clamped > state.coolingUntil) {
@@ -750,9 +777,13 @@ function maybeCoolFromQuota(
     logger.always(
       `[proxy] proactively cooling account (${reason}) ~${minutesUntil(clamped, now)}m from success-response quota (status rejected)`,
     );
-    return true;
+    return {
+      kind: "cooled",
+      coolingUntil: clamped,
+      coolingReason: reason ?? "unified",
+    };
   }
-  return false;
+  return null;
 }
 
 /**
@@ -787,6 +818,22 @@ async function seedRuntimeQuotasFromDisk(
       ) {
         state.coolingUntil = persistedCooldown.coolingUntil;
         state.coolingReason = persistedCooldown.reason;
+      }
+      if (state.quota) {
+        const cooldownUpdate = reconcileCooldownFromQuota(
+          state,
+          state.quota,
+          now,
+        );
+        if (cooldownUpdate?.kind === "cooled") {
+          await saveAccountCooldown(
+            account.key,
+            cooldownUpdate.coolingUntil,
+            cooldownUpdate.coolingReason,
+          );
+        } else if (cooldownUpdate?.kind === "cleared") {
+          await clearAccountCooldown(account.key, cooldownUpdate.coolingUntil);
+        }
       }
     }
   } catch {
@@ -864,6 +911,7 @@ function accountSortMetrics(
       ? (q.weeklyStatus ?? "unknown")
       : "allowed"
     : null;
+  const overageEligible = isQuotaOverageAvailable(q);
   const saturated =
     sessionStatus === "throttled" ||
     (sessionTicking && (sessionUsed ?? 0) >= sessionSoftLimit);
@@ -873,7 +921,9 @@ function accountSortMetrics(
     usable:
       !coolingActive &&
       weeklyStatus !== "rejected" &&
-      sessionStatus !== "rejected",
+      (sessionStatus !== "rejected" || overageEligible) &&
+      (q?.unifiedStatus?.trim().toLowerCase() !== "rejected" ||
+        overageEligible),
     saturated,
     hasQuota: !!q,
     quotaLastUpdated,
@@ -883,6 +933,9 @@ function accountSortMetrics(
     coolingReason: st?.coolingReason ?? null,
     coolingUntil: st?.coolingUntil ?? 0,
     unifiedStatus: q?.unifiedStatus ?? null,
+    fallbackStatus: q?.fallbackStatus ?? null,
+    upgradePaths: q?.upgradePaths ?? null,
+    overageEligible,
     overageStatus: q?.overageStatus ?? null,
     sessionStatus,
     sessionUsed,
@@ -1077,6 +1130,9 @@ function buildRoutingDecision(args: {
           ? metrics.coolingUntil
           : null,
       unifiedStatus: metrics.unifiedStatus,
+      fallbackStatus: metrics.fallbackStatus,
+      upgradePaths: metrics.upgradePaths,
+      overageEligible: metrics.overageEligible,
       overageStatus: metrics.overageStatus,
       sessionStatus: metrics.sessionStatus,
       sessionUsed: metrics.sessionUsed,
@@ -3508,17 +3564,27 @@ async function handleAnthropicSuccessfulResponse(args: {
   if (quota) {
     // Stash the latest quota on runtime state so the next request can pick the
     // account whose window resets soonest (max-utilization) and proactively
-    // skip any whose window is already rejected — without eating a 429 first.
+    // skip rejected windows unless Anthropic explicitly permits overage.
     accountState.quota = quota;
-    if (maybeCoolFromQuota(accountState, quota, Date.now())) {
-      const { coolingUntil, coolingReason } = accountState;
-      if (coolingUntil !== undefined && coolingReason !== undefined) {
-        saveAccountCooldown(account.key, coolingUntil, coolingReason).catch(
-          () => {
-            // Non-fatal: cooldown is already active in memory.
-          },
-        );
-      }
+    const cooldownUpdate = reconcileCooldownFromQuota(
+      accountState,
+      quota,
+      Date.now(),
+    );
+    if (cooldownUpdate?.kind === "cooled") {
+      saveAccountCooldown(
+        account.key,
+        cooldownUpdate.coolingUntil,
+        cooldownUpdate.coolingReason,
+      ).catch(() => {
+        // Non-fatal: cooldown is already active in memory.
+      });
+    } else if (cooldownUpdate?.kind === "cleared") {
+      clearAccountCooldown(account.key, cooldownUpdate.coolingUntil).catch(
+        () => {
+          // Non-fatal: the next successful response will reconcile again.
+        },
+      );
     }
     saveAccountQuota(account.label, quota).catch(() => {
       // Non-fatal: quota persistence is best-effort
@@ -4434,18 +4500,27 @@ async function handleAnthropicSuccessfulNonStreamRetryResponse(args: {
   const retryQuota = parseQuotaHeaders(retryResp.headers);
   if (retryQuota) {
     // Keep the auth-retry success path in parity with the main success path:
-    // stash quota for proactive selection and proactively cool if this
-    // response reveals the window flipped to "rejected".
+    // stash quota for proactive selection and reconcile a rejected window.
     accountState.quota = retryQuota;
-    if (maybeCoolFromQuota(accountState, retryQuota, Date.now())) {
-      const { coolingUntil, coolingReason } = accountState;
-      if (coolingUntil !== undefined && coolingReason !== undefined) {
-        saveAccountCooldown(account.key, coolingUntil, coolingReason).catch(
-          () => {
-            // Non-fatal: cooldown is already active in memory.
-          },
-        );
-      }
+    const cooldownUpdate = reconcileCooldownFromQuota(
+      accountState,
+      retryQuota,
+      Date.now(),
+    );
+    if (cooldownUpdate?.kind === "cooled") {
+      saveAccountCooldown(
+        account.key,
+        cooldownUpdate.coolingUntil,
+        cooldownUpdate.coolingReason,
+      ).catch(() => {
+        // Non-fatal: cooldown is already active in memory.
+      });
+    } else if (cooldownUpdate?.kind === "cleared") {
+      clearAccountCooldown(account.key, cooldownUpdate.coolingUntil).catch(
+        () => {
+          // Non-fatal: the next successful response will reconcile again.
+        },
+      );
     }
     saveAccountQuota(account.label, retryQuota).catch((error) => {
       logger.debug("[proxy] Failed to persist account quota after auth retry", {
@@ -6550,8 +6625,8 @@ async function handleAnthropicRoutedClaudeRequest(args: {
         // Clear cooling on success — but only if the stored cooldown has already
         // expired, so an older in-flight success can't wipe an active exhaustion
         // cooldown just set by a concurrent 429. The success handler re-applies a
-        // cooldown via maybeCoolFromQuota if the fresh quota headers report the
-        // window flipped to "rejected" on this very request.
+        // cooldown via reconcileCooldownFromQuota when fresh quota headers
+        // report a rejected window without explicit overage availability.
         if (
           accountState.coolingUntil &&
           Date.now() >= accountState.coolingUntil
@@ -7397,6 +7472,7 @@ export const __testHooks = {
   resolveHomeIndex,
   maybeResetPrimaryToHome,
   planCooldownFor429,
+  reconcileCooldownFromQuota,
   isPermanentRefreshFailure,
   getStreamFailureDetails,
   trackUpstreamReadableStream,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -533,6 +533,9 @@ export type ProxyAccountRoutingCandidate = {
   coolingReason: AccountCoolingReason | null;
   coolingUntil: number | null;
   unifiedStatus: string | null;
+  fallbackStatus?: string | null;
+  upgradePaths?: string | null;
+  overageEligible?: boolean;
   overageStatus: string | null;
   sessionStatus: string | null;
   sessionUsed: number | null;
@@ -570,6 +573,9 @@ export type ProxyAccountSortMetrics = {
   coolingReason: AccountCoolingReason | null;
   coolingUntil: number;
   unifiedStatus: string | null;
+  fallbackStatus?: string | null;
+  upgradePaths?: string | null;
+  overageEligible?: boolean;
   overageStatus: string | null;
   sessionStatus: string | null;
   sessionUsed: number | null;
@@ -858,6 +864,15 @@ export type AccountCooldownPlan = {
   rotateImmediately: boolean;
 };
 
+export type ProxyQuotaCooldownUpdate =
+  | {
+      kind: "cooled";
+      coolingUntil: number;
+      coolingReason: AccountCoolingReason;
+    }
+  | { kind: "cleared"; coolingUntil: number }
+  | null;
+
 export type TransientRateLimitRetryBudget = {
   coolingUntil: number;
   retriesClaimed: number;
@@ -1081,6 +1096,10 @@ export type AccountQuota = {
   weeklyResetAt: number;
   /** 0.0-1.0  (from fallback-percentage) */
   fallbackPercentage: number;
+  /** Provider fallback availability, for example "available". */
+  fallbackStatus?: string;
+  /** Comma-separated provider upgrade paths, for example "overage". */
+  upgradePaths?: string;
   /** "allowed" | "rejected" */
   overageStatus: string;
   /** Epoch ms when we last captured this data */

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -21,6 +21,7 @@ import {
   flushAccountQuotaStateForTests,
   getUnifiedRateLimitStatus,
   initAccountQuota,
+  isQuotaOverageAvailable,
   loadAccountQuotas,
   parseQuotaHeaders,
   saveAccountQuota,
@@ -1612,6 +1613,158 @@ describe("upstream attempt classification and retry amplification", () => {
 });
 
 describe("authoritative unified rate-limit handling", () => {
+  it("keeps an exhausted subscription window eligible when explicit overage is available", () => {
+    const now = 1_800_000_000_000;
+    const headers = new Headers({
+      "anthropic-ratelimit-unified-status": "rejected",
+      "anthropic-ratelimit-unified-5h-status": "rejected",
+      "anthropic-ratelimit-unified-5h-utilization": "1.0",
+      "anthropic-ratelimit-unified-5h-reset": String(now / 1000 + 3600),
+      "anthropic-ratelimit-unified-7d-status": "allowed",
+      "anthropic-ratelimit-unified-7d-utilization": "0.4",
+      "anthropic-ratelimit-unified-7d-reset": String(now / 1000 + 86400),
+      "anthropic-ratelimit-unified-fallback": "available",
+      "anthropic-ratelimit-unified-overage-status": "allowed",
+      "anthropic-ratelimit-unified-upgrade-paths": "overage",
+    });
+
+    const quota = parseQuotaHeaders(headers);
+    expect(quota).toMatchObject({
+      fallbackStatus: "available",
+      overageStatus: "allowed",
+      upgradePaths: "overage",
+    });
+    expect(isQuotaOverageAvailable(quota)).toBe(true);
+    expect(
+      __testHooks.planCooldownFor429(quota, 5_000, now, "rejected"),
+    ).toEqual({
+      reason: "transient",
+      coolingUntil: now + 5_000,
+      rotateImmediately: false,
+    });
+
+    const runtimeState = {
+      consecutiveRefreshFailures: 0,
+      permanentlyDisabled: false,
+      coolingUntil: now + 3600_000,
+      coolingReason: "session" as const,
+    };
+    expect(
+      __testHooks.reconcileCooldownFromQuota(
+        runtimeState as never,
+        quota!,
+        now,
+      ),
+    ).toEqual({ kind: "cleared", coolingUntil: now + 3600_000 });
+    expect(runtimeState.coolingUntil).toBeUndefined();
+    expect(runtimeState.coolingReason).toBeUndefined();
+  });
+
+  it("does not infer overage availability from a partial header set", () => {
+    expect(
+      isQuotaOverageAvailable({
+        fallbackPercentage: 0,
+        fallbackStatus: "available",
+        overageStatus: "allowed",
+      }),
+    ).toBe(false);
+    expect(
+      isQuotaOverageAvailable({
+        fallbackPercentage: 0.5,
+        fallbackStatus: "unknown",
+        overageStatus: "allowed",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps absent upgrade paths nullable for routing diagnostics", () => {
+    const quota = parseQuotaHeaders(
+      new Headers({
+        "anthropic-ratelimit-unified-5h-utilization": "0.2",
+        "anthropic-ratelimit-unified-7d-utilization": "0.3",
+      }),
+    );
+    expect(quota?.upgradePaths).toBeUndefined();
+  });
+
+  it("honors the equivalent overage state in older persisted quota snapshots", () => {
+    expect(
+      isQuotaOverageAvailable({
+        fallbackPercentage: 0.5,
+        overageStatus: "allowed",
+      }),
+    ).toBe(true);
+  });
+
+  it("reports an overage-eligible rejected account as usable for routing", () => {
+    const now = 1_800_000_000_000;
+    __testHooks.resetAllRuntimeState();
+    __testHooks.setAccountRuntimeState("anthropic:overage", {
+      quota: {
+        unifiedStatus: "rejected",
+        sessionUsed: 1,
+        sessionStatus: "rejected",
+        sessionResetAt: now / 1000 + 3600,
+        weeklyUsed: 0.4,
+        weeklyStatus: "allowed",
+        weeklyResetAt: now / 1000 + 86400,
+        fallbackPercentage: 0.5,
+        fallbackStatus: "available",
+        overageStatus: "allowed",
+        upgradePaths: "overage",
+        lastUpdated: now,
+      },
+    });
+    const decision = __testHooks.buildQuotaRoutingDecision(
+      [
+        {
+          key: "anthropic:overage",
+          label: "overage",
+          token: "t",
+          type: "oauth",
+        },
+        { key: "anthropic:other", label: "other", token: "t", type: "oauth" },
+      ] as never,
+      now,
+      undefined,
+    );
+    expect(
+      decision?.candidates.find((candidate) => candidate.account === "overage"),
+    ).toMatchObject({ usable: true, overageEligible: true });
+    __testHooks.resetAllRuntimeState();
+  });
+
+  it("preserves weekly exhaustion even when overage is otherwise available", () => {
+    const now = 1_800_000_000_000;
+    const runtimeState = {
+      consecutiveRefreshFailures: 0,
+      permanentlyDisabled: false,
+      coolingUntil: now + 3600_000,
+      coolingReason: "session" as const,
+    };
+    expect(
+      __testHooks.reconcileCooldownFromQuota(
+        runtimeState as never,
+        {
+          unifiedStatus: "rejected",
+          sessionUsed: 1,
+          sessionStatus: "rejected",
+          sessionResetAt: now / 1000 + 3600,
+          weeklyUsed: 1,
+          weeklyStatus: "rejected",
+          weeklyResetAt: now / 1000 + 86_400,
+          fallbackPercentage: 0.5,
+          fallbackStatus: "available",
+          overageStatus: "allowed",
+          upgradePaths: "overage",
+          lastUpdated: now,
+        },
+        now,
+      ),
+    ).toMatchObject({ kind: "cooled", coolingReason: "weekly" });
+    expect(runtimeState.coolingReason).toBe("weekly");
+  });
+
   it("rotates immediately when unified is rejected but 5h and 7d are allowed", () => {
     const now = 1_800_000_000_000;
     const retryAfterMs = 12 * 60 * 60 * 1000;
@@ -1681,6 +1834,50 @@ describe("cooldown persistence", () => {
     await clearAccountCooldown("anthropic:a", coolingUntil + 1);
     expect(await loadAccountCooldowns()).toHaveProperty("anthropic:a");
     await clearAccountCooldown("anthropic:a", coolingUntil);
+    expect(await loadAccountCooldowns()).not.toHaveProperty("anthropic:a");
+  });
+
+  it("clears a legacy session cooldown when persisted quota permits overage", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-overage-seed-"));
+    tempDirs.push(dir);
+    const cooldownPath = join(dir, "account-cooldowns.json");
+    const quotaPath = join(dir, "account-quotas.json");
+    const now = Date.now();
+    const coolingUntil = now + 60 * 60_000;
+
+    initAccountCooldown(cooldownPath);
+    initAccountQuota(quotaPath);
+    await saveAccountQuota("a", {
+      unifiedStatus: "rejected",
+      sessionUsed: 1,
+      sessionStatus: "rejected",
+      sessionResetAt: Math.floor(coolingUntil / 1000),
+      weeklyUsed: 0.4,
+      weeklyStatus: "allowed",
+      weeklyResetAt: Math.floor((now + 24 * 60 * 60_000) / 1000),
+      fallbackPercentage: 0.5,
+      overageStatus: "allowed",
+      lastUpdated: now,
+    });
+    await flushAccountQuotaStateForTests();
+    await saveAccountCooldown("anthropic:a", coolingUntil, "session");
+
+    __testHooks.resetAllRuntimeState();
+    initAccountCooldown(cooldownPath);
+    initAccountQuota(quotaPath);
+    await __testHooks.seedRuntimeQuotasFromDisk([
+      {
+        key: "anthropic:a",
+        label: "a",
+        token: "test-token",
+        type: "oauth",
+      },
+    ]);
+
+    expect(__testHooks.getAccountRuntimeState("anthropic:a")).toMatchObject({
+      coolingUntil: undefined,
+      coolingReason: undefined,
+    });
     expect(await loadAccountCooldowns()).not.toHaveProperty("anthropic:a");
   });
 


### PR DESCRIPTION
## Summary
- retain Anthropic fallback and upgrade-path quota headers
- keep accounts eligible when the provider explicitly permits overage, including legacy persisted quota snapshots
- clear false session/unified cooldowns while preserving weekly exhaustion and real-429 transient backoff
- expose overage eligibility in routing diagnostics

## Verification
- `pnpm exec vitest run test/proxyReliabilityHardening.test.ts test/proxyAnalysis.test.ts` (90 passed)
- `pnpm run build:cli`
- scoped Prettier and ESLint (no errors; pre-existing max-lines warnings only)

## Scope
Repository-only change. The live proxy was not restarted or configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for provider-enabled quota overage.
  * Accounts eligible for overage can remain available after reaching standard limits.
  * Added visibility into fallback status, upgrade options, and overage eligibility.

* **Bug Fixes**
  * Prevented eligible accounts from being incorrectly marked unavailable during quota enforcement.
  * Improved quota recovery by clearing outdated cooldowns when capacity is restored.
  * Added support for restoring quota state from legacy records and preserving weekly limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->