### PR TITLE
test(proxy): cover the auto-fallback attempt regression in the continuous suite

### DIFF
--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -133,8 +133,16 @@ import {
   recordUpdateInstalled,
 } from "../src/lib/proxy/updateState.js";
 import { ModelRouter } from "../src/lib/proxy/modelRouter.js";
-import { __testHooks as claudeProxyTestHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
-import type { ProxySupervisorState } from "../src/lib/types/index.js";
+import {
+  __testHooks as claudeProxyTestHooks,
+  createClaudeProxyRoutes,
+} from "../src/lib/server/routes/claudeProxyRoutes.js";
+import {
+  getStats,
+  getTerminalErrors,
+  resetUsageStatsForTests,
+} from "../src/lib/proxy/usageStats.js";
+import type { ProxySupervisorState, ServerContext } from "../src/lib/types/index.js";
 
 import {
   GoogleVertexProvider,
@@ -9531,6 +9539,107 @@ exit 127
           e.message.includes("pnpm add fluent-ffmpeg") &&
           !e.message.includes("Cannot read properties")
         );
+      }
+    },
+  },
+
+  // ---------- auto-fallback became opt-in (regression from 33bdd141) ----------
+  {
+    // "fix(proxy): bound account admission and fallback routing" (33bdd141)
+    // made translation-layer auto-fallback opt-in, which silently changed how
+    // many upstream attempts an exhausted translated request makes. It went
+    // unnoticed because the only coverage lived in a test file no script runs.
+    //
+    // Both directions are asserted in one test so the global usage stats can be
+    // reset between them without depending on suite ordering.
+    name: "proxy routing: auto-fallback opt-in decides whether a second attempt happens",
+    category: "proxy",
+    fn: async () => {
+      const runExhaustedRequest = async (
+        requestId: string,
+        autoFallback: boolean,
+      ) => {
+        await resetUsageStatsForTests();
+        const ctx = {
+          requestId,
+          method: "POST",
+          path: "/v1/messages",
+          headers: {},
+          query: {},
+          params: {},
+          timestamp: Date.now(),
+          metadata: {},
+          // Yields nothing, so every attempt fails with "no content".
+          neurolink: {
+            stream: async () => ({
+              stream: (async function* () {
+                yield* [];
+              })(),
+              toolCalls: [],
+              usage: {},
+              model: "translated-model",
+            }),
+          },
+          toolRegistry: {},
+          body: {
+            model: "claude-routed-model",
+            messages: [{ role: "user", content: "hello" }],
+          },
+        } as unknown as ServerContext;
+
+        const modelRouter = {
+          resolve: () => ({ provider: "openai", model: "translated-model" }),
+          getFallbackChain: () => [],
+          isAutoFallbackEnabled: () => autoFallback,
+        };
+        const messagesRoute = createClaudeProxyRoutes(
+          modelRouter as never,
+        ).routes.find(
+          (route) => route.method === "POST" && route.path === "/v1/messages",
+        );
+        if (!messagesRoute) {
+          throw new Error("messages route not found");
+        }
+        const result = (await messagesRoute.handler(ctx)) as {
+          type?: string;
+        };
+        return {
+          result,
+          stats: getStats(),
+          terminal: getTerminalErrors(),
+        };
+      };
+
+      try {
+        // Opted in: a second attempt is made, and the terminal error is still
+        // finalized exactly once rather than twice.
+        const enabled = await runExhaustedRequest("autofallback-on", true);
+        const enabledOk =
+          enabled.result?.type === "error" &&
+          enabled.stats.totalAttempts === 2 &&
+          enabled.stats.totalAttemptErrors === 2 &&
+          enabled.stats.totalRequests === 1 &&
+          enabled.stats.totalErrors === 1 &&
+          // The journal, not just the counter: two attempts must still produce
+          // exactly ONE finalized terminal error, which is what "does not
+          // finalize twice" actually means.
+          enabled.terminal.totalErrors === 1 &&
+          enabled.terminal.recent.length === 1;
+
+        // Default: no second attempt, still one finalized terminal error.
+        const disabled = await runExhaustedRequest("autofallback-off", false);
+        const disabledOk =
+          disabled.result?.type === "error" &&
+          disabled.stats.totalAttempts === 1 &&
+          disabled.stats.totalAttemptErrors === 1 &&
+          disabled.stats.totalRequests === 1 &&
+          disabled.stats.totalErrors === 1 &&
+          disabled.terminal.totalErrors === 1 &&
+          disabled.terminal.recent.length === 1;
+
+        return enabledOk && disabledOk;
+      } finally {
+        await resetUsageStatsForTests();
       }
     },
   },

--- a/test/proxyTerminalErrorAccounting.test.ts
+++ b/test/proxyTerminalErrorAccounting.test.ts
@@ -264,6 +264,11 @@ describe("translated terminal accounting", () => {
     const modelRouter = {
       resolve: () => ({ provider: "openai", model: "translated-model" }),
       getFallbackChain: () => [],
+      // Auto-fallback became opt-in in 33bdd141, so a router without this makes
+      // one attempt and never reaches the double-finalization path under test.
+      // Behaviour is covered for real in continuous-test-suite-bugfixes.ts;
+      // this keeps the assertion here from stating something untrue.
+      isAutoFallbackEnabled: () => true,
     };
     const messagesRoute = createClaudeProxyRoutes(
       modelRouter as never,


### PR DESCRIPTION
Replaces #1267, which took the wrong approach (it wired Vitest files into `test:unit` and added a CI check enforcing that). The finding underneath is real and runner-independent, so it lands here in the form the repo actually uses.

## The regression

`33bdd141 fix(proxy): bound account admission and fallback routing` made translation-layer auto-fallback **opt-in**. That changed how many upstream attempts an exhausted translated request makes — two before, one now.

Nothing caught it. The only coverage was in `test/proxyTerminalErrorAccounting.test.ts`, which **no `package.json` script runs**, so its `totalAttempts: 2` assertion has been failing on `release` ever since and no one saw it. `33bdd141` updated the three orphaned proxy suites its author knew about and missed this one.

Bisected rather than assumed: passes at `65b27b75`, fails from `33bdd141` onward, still fails on today's `release`.

## The fix

Coverage goes into `test/continuous-test-suite-bugfixes.ts` — where `33bdd141` itself put its proxy tests, and which `test:unit` already runs. Per `CLAUDE.md:190` (*"all suites run via tsx; there is no vitest runner"*) and `:258`.

The test asserts **both** directions of the flag in one case, resetting the global usage stats between them so it doesn't depend on suite ordering:

- opted in → 2 attempts, 2 attempt errors, **1** finalized terminal error (not two — the thing the original test's name was about)
- default → 1 attempt, 1 attempt error, **1** finalized terminal error

It also opts the stale Vitest assertion into auto-fallback, so that file stops stating something untrue. It is **not** wired into any script — no `package.json` change in this PR.

## Verification

Two-sided negative control, since a one-sided one would pass on a test that only checks a single branch:

| Source patched to… | Result |
| --- | --- |
| always auto-fallback (pre-`33bdd141`) | **1 failed** |
| never auto-fallback | **1 failed** |
| unmodified | **241 passed** |

`pnpm run check`: 0 errors / 4,838 files. `pnpm run lint`: 0 errors.

## Still open, deliberately not bundled

Eleven other `test/*.test.ts` files remain unreferenced by any script, and `.github/workflows/ci.yml` runs no test step at all (`format:check`, `eslint`, `validate:all`, `build`, `build:cli`). Both need a direction from you on the intended end state for those 28 Vitest files — migrate to continuous suites, or delete — rather than a guess from me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy fallback behavior when requests are exhausted.
  * Ensured terminal errors are recorded only once, including after fallback attempts.
  * Improved accuracy of request, attempt, and usage statistics during proxy failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->