### PR TITLE
fix(proxy): retry transient updater installs and expose worker exits

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -87,6 +87,7 @@ import {
 import {
   describeInstallFailure,
   getGlobalInstallArgs,
+  isTransientInstallFailure,
   resolveGlobalInstaller,
   validateInstalledVersion,
 } from "../../lib/proxy/globalInstaller.js";
@@ -900,6 +901,10 @@ async function getRollingActivationFailure(
             version?: string;
             phase?: string;
             message?: string;
+            workerPid?: number;
+            workerExitCode?: number | null;
+            workerExitSignal?: string | null;
+            supervisorAction?: string;
           } | null;
         } | null;
       };
@@ -912,7 +917,22 @@ async function getRollingActivationFailure(
     ) {
       return null;
     }
-    return `${failure.phase}: ${failure.message}`;
+    const workerDetail = [
+      typeof failure.workerPid === "number" ? `pid=${failure.workerPid}` : null,
+      typeof failure.workerExitCode === "number" ||
+      failure.workerExitCode === null
+        ? `exitCode=${failure.workerExitCode ?? "none"}`
+        : null,
+      typeof failure.workerExitSignal === "string"
+        ? `exitSignal=${failure.workerExitSignal}`
+        : null,
+      typeof failure.supervisorAction === "string"
+        ? `supervisorAction=${failure.supervisorAction}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return `${failure.phase}: ${failure.message}${workerDetail ? ` (${workerDetail})` : ""}`;
   } catch {
     return null;
   }
@@ -4153,6 +4173,8 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     const NATURAL_WINDOW_WAIT_MS = 10 * 60 * 1000; // prefer no admission pause
     const UPDATE_DRAIN_TIMEOUT_MS = 30 * 60 * 1000; // preserve long streams
     const UPDATE_RETRY_DELAY_MS = 5 * 60 * 1000;
+    const UPDATE_RETRY_MAX_DELAY_MS = 30 * 60 * 1000;
+    const UPDATE_RETRY_MAX_ATTEMPTS = 4;
     const UPDATE_ACTIVITY_POLL_MS = 10 * 1000;
     const UPDATE_TIMEOUT_MS = 30 * 1000; // 30 seconds to come healthy
 
@@ -4180,6 +4202,8 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     let updateCheckTimeout: NodeJS.Timeout | undefined;
     let updateCheckInterval: NodeJS.Timeout | undefined;
     let updateRetryTimeout: NodeJS.Timeout | undefined;
+    let updateRetryAttempts = 0;
+    let updateRetryVersion: string | null = null;
     const stopUpdateChecks = (): void => {
       guardStopping = true;
       if (updateCheckTimeout) {
@@ -4230,6 +4254,8 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
         );
 
         if (!result.updateAvailable) {
+          updateRetryAttempts = 0;
+          updateRetryVersion = null;
           persistUpdaterState("clear update deferral", () =>
             clearUpdateDeferral(),
           );
@@ -4311,7 +4337,10 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
                 ),
               );
             }
-            scheduleUpdateRetry();
+            scheduleUpdateRetry(
+              "update window unavailable",
+              result.latestVersion,
+            );
             return;
           }
 
@@ -4320,7 +4349,10 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           if (!drainActive) {
             updateWindow = await waitForWindow(0);
             if (!updateWindow.ready) {
-              scheduleUpdateRetry();
+              scheduleUpdateRetry(
+                "update drain unavailable",
+                result.latestVersion,
+              );
               return;
             }
           }
@@ -4420,6 +4452,12 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
             persistUpdaterState("record update failure", () =>
               recordUpdateFailure(result.latestVersion, "install", detail),
             );
+            if (isTransientInstallFailure(installErr)) {
+              scheduleUpdateRetry(
+                "transient install failure",
+                result.latestVersion,
+              );
+            }
             return;
           }
         } else {
@@ -4452,6 +4490,8 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
           persistUpdaterState("record installed update", () =>
             recordUpdateInstalled(result.latestVersion),
           );
+          updateRetryAttempts = 0;
+          updateRetryVersion = null;
           logger.always(
             `[updater] trampoline validated at v${validation.version} after ${validation.attempts} attempt(s)`,
           );
@@ -4668,14 +4708,32 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
       }
     };
 
-    const scheduleUpdateRetry = (): void => {
+    const scheduleUpdateRetry = (reason: string, version: string): void => {
       if (guardStopping || updateRetryTimeout) {
         return;
       }
+      if (updateRetryVersion !== version) {
+        updateRetryVersion = version;
+        updateRetryAttempts = 0;
+      }
+      if (updateRetryAttempts >= UPDATE_RETRY_MAX_ATTEMPTS) {
+        logger.always(
+          `[updater] retry budget exhausted after ${updateRetryAttempts} attempt(s); waiting for the periodic check`,
+        );
+        return;
+      }
+      updateRetryAttempts += 1;
+      const delay = Math.min(
+        UPDATE_RETRY_MAX_DELAY_MS,
+        UPDATE_RETRY_DELAY_MS * 2 ** (updateRetryAttempts - 1),
+      );
+      logger.always(
+        `[updater] retry scheduled reason=${reason} attempt=${updateRetryAttempts}/${UPDATE_RETRY_MAX_ATTEMPTS} delayMs=${delay}`,
+      );
       updateRetryTimeout = setTimeout(() => {
         updateRetryTimeout = undefined;
         void runUpdateCheck();
-      }, UPDATE_RETRY_DELAY_MS);
+      }, delay);
       updateRetryTimeout.unref?.();
     };
 

--- a/src/lib/proxy/globalInstaller.ts
+++ b/src/lib/proxy/globalInstaller.ts
@@ -185,6 +185,43 @@ export function getGlobalInstallArgs(
     : ["install", "--global", "--no-audit", "--no-fund", packageSpec];
 }
 
+const TRANSIENT_INSTALL_FAILURE_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+
+/**
+ * Return whether a global package-manager failure is likely environmental and
+ * worth retrying. Configuration and permission failures deliberately return
+ * false so the updater does not repeatedly mutate a broken installation.
+ */
+export function isTransientInstallFailure(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (typeof current !== "object") {
+      return false;
+    }
+    const candidate = current as {
+      code?: unknown;
+      cause?: unknown;
+    };
+    if (
+      typeof candidate.code === "string" &&
+      TRANSIENT_INSTALL_FAILURE_CODES.has(candidate.code)
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
 /**
  * Validate a freshly installed CLI with retries. Global package replacement
  * can leave executable shims briefly unavailable while filesystem metadata and

--- a/src/lib/proxy/rollingWorkerSupervisor.ts
+++ b/src/lib/proxy/rollingWorkerSupervisor.ts
@@ -2,6 +2,7 @@ import type {
   RollingCandidateWorker,
   RollingManagedWorker,
   RollingQueuedSocket,
+  RollingWorkerFailureDetails,
   RollingWorkerHandle,
   RollingWorkerSupervisorOptions,
   RollingWorkerSupervisorSnapshot,
@@ -264,6 +265,7 @@ export class RollingWorkerSupervisor {
       const finish = (
         error?: Error,
         phase: "startup" | "activation" = "startup",
+        details?: RollingWorkerFailureDetails,
       ): void => {
         if (settled) {
           return;
@@ -277,6 +279,7 @@ export class RollingWorkerSupervisor {
               expectedVersion,
               phase,
               error.message,
+              details,
             );
           }
           if (this.candidate?.generation === generation) {
@@ -402,6 +405,12 @@ export class RollingWorkerSupervisor {
             new Error(
               `worker ${handle.pid} exited before readiness (code=${code ?? "none"}, signal=${signal ?? "none"})`,
             ),
+            "startup",
+            {
+              workerPid: handle.pid,
+              workerExitCode: code,
+              workerExitSignal: signal,
+            },
           );
           return;
         }
@@ -414,6 +423,11 @@ export class RollingWorkerSupervisor {
               expectedVersion,
               "runtime",
               `worker exited (code=${code ?? "none"}, signal=${signal ?? "none"})`,
+              {
+                workerPid: handle.pid,
+                workerExitCode: code,
+                workerExitSignal: signal,
+              },
             );
           }
           this.options.log?.(
@@ -520,11 +534,24 @@ export class RollingWorkerSupervisor {
   ): void {
     this.failedTransfers += 1;
     const detail = this.describeTransferError(error);
+    const lifecycle = this.extractLifecycleFailureDetails(
+      error,
+      worker.handle.pid,
+    );
     this.recordFailure(
       worker.generation,
       worker.version,
       "transfer",
       `worker ${worker.handle.pid} failed to accept a transferred socket: ${detail}`,
+      {
+        ...lifecycle.details,
+        // If the error already records an exit, the supervisor did not cause
+        // that exit. Otherwise this captures the deliberate cleanup following
+        // the failed transfer, not a claimed root cause for the failure.
+        supervisorAction: lifecycle.observedExit
+          ? "none"
+          : "sigkill_after_transfer_failure",
+      },
     );
     this.options.log?.(
       `[proxy-supervisor] socket transfer failed generation=${worker.generation} pid=${worker.handle.pid}: ${detail}`,
@@ -555,11 +582,44 @@ export class RollingWorkerSupervisor {
     return code ? `${code}: ${error.message}` : error.message;
   }
 
+  private extractLifecycleFailureDetails(
+    error: unknown,
+    fallbackPid: number,
+  ): { details: RollingWorkerFailureDetails; observedExit: boolean } {
+    const context =
+      error &&
+      typeof error === "object" &&
+      "context" in error &&
+      (error as { context?: unknown }).context &&
+      typeof (error as { context?: unknown }).context === "object"
+        ? ((error as { context: Record<string, unknown> }).context ?? {})
+        : {};
+    const workerPid =
+      typeof context.workerPid === "number" ? context.workerPid : fallbackPid;
+    const hasExitCode =
+      typeof context.exitCode === "number" || context.exitCode === null;
+    const hasExitSignal =
+      typeof context.signal === "string" || context.signal === null;
+    return {
+      details: {
+        workerPid,
+        ...(hasExitCode
+          ? { workerExitCode: context.exitCode as number | null }
+          : {}),
+        ...(hasExitSignal
+          ? { workerExitSignal: context.signal as string | null }
+          : {}),
+      },
+      observedExit: hasExitCode || hasExitSignal,
+    };
+  }
+
   private recordFailure(
     generation: number,
     version: string,
     phase: NonNullable<RollingWorkerSupervisorSnapshot["lastFailure"]>["phase"],
     message: string,
+    details: RollingWorkerFailureDetails = {},
   ): void {
     this.lastFailure = {
       at: new Date().toISOString(),
@@ -567,6 +627,7 @@ export class RollingWorkerSupervisor {
       version,
       phase,
       message: message.slice(0, 1_000),
+      ...details,
     };
   }
 

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -991,6 +991,10 @@ export type ProxyRollingState = {
     version: string;
     phase: "startup" | "activation" | "runtime" | "transfer";
     message: string;
+    workerPid?: number;
+    workerExitCode?: number | null;
+    workerExitSignal?: string | null;
+    supervisorAction?: "none" | "sigkill_after_transfer_failure";
   } | null;
 };
 

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -2246,6 +2246,13 @@ export type SpawnProxySocketWorkerOptions = {
   socketAckTimeoutMs?: number;
 };
 
+export type RollingWorkerFailureDetails = {
+  workerPid?: number;
+  workerExitCode?: number | null;
+  workerExitSignal?: string | null;
+  supervisorAction?: "none" | "sigkill_after_transfer_failure";
+};
+
 export type RollingWorkerSupervisorSnapshot = {
   generation: number;
   active: { pid: number; version: string; generation: number } | null;
@@ -2258,13 +2265,15 @@ export type RollingWorkerSupervisorSnapshot = {
   queuedSockets: number;
   rejectedSockets: number;
   failedTransfers: number;
-  lastFailure: {
-    at: string;
-    generation: number;
-    version: string;
-    phase: "startup" | "activation" | "runtime" | "transfer";
-    message: string;
-  } | null;
+  lastFailure:
+    | ({
+        at: string;
+        generation: number;
+        version: string;
+        phase: "startup" | "activation" | "runtime" | "transfer";
+        message: string;
+      } & RollingWorkerFailureDetails)
+    | null;
 };
 
 export type RollingWorkerSupervisorOptions = {

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -3027,12 +3027,16 @@ const tests: TestFunction[] = [
         pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
         "utf-8",
       );
+      const installFailureIndex = src.indexOf("global install failed");
       const section = src.slice(
-        src.indexOf("global install failed"),
-        src.indexOf("global install failed") + 400,
+        installFailureIndex,
+        src.indexOf("} else {", installFailureIndex),
       );
       return (
-        section.includes("return;") && !section.includes("suppressVersion")
+        section.includes("scheduleUpdateRetry(") &&
+        section.includes('"transient install failure"') &&
+        section.includes("return;") &&
+        !section.includes("suppressVersion")
       );
     },
   },

--- a/test/proxyRollingWorkerHandoff.test.ts
+++ b/test/proxyRollingWorkerHandoff.test.ts
@@ -146,9 +146,9 @@ class FakeWorker implements RollingWorkerHandle {
     }
   }
 
-  failPendingSockets(message: string): void {
+  failPendingSockets(error: string | Error): void {
     for (const callback of this.pendingSocketCallbacks.splice(0)) {
-      callback(new Error(message));
+      callback(typeof error === "string" ? new Error(error) : error);
     }
   }
 
@@ -574,6 +574,8 @@ describe("rolling proxy worker supervisor", () => {
       lastFailure: {
         phase: "transfer",
         message: expect.stringContaining("worker IPC failed"),
+        workerPid: 475,
+        supervisorAction: "sigkill_after_transfer_failure",
       },
     });
     expect(workers[0].terminated).toContain("SIGKILL");
@@ -592,6 +594,37 @@ describe("rolling proxy worker supervisor", () => {
         phase: "transfer",
         message: expect.stringContaining("worker IPC failed"),
       },
+    });
+    void supervisor.close();
+  });
+
+  it("records an already-observed worker exit separately from cleanup", async () => {
+    const worker = new FakeWorker(480);
+    const supervisor = new RollingWorkerSupervisor({
+      spawnWorker: () => worker,
+    });
+    const initial = supervisor.start("9.93.1");
+    worker.ready(1, "9.93.1");
+    await initial;
+    worker.deferSocketCallbacks = true;
+    supervisor.acceptSocket(new FakeSocket());
+
+    worker.failPendingSockets(
+      Object.assign(new Error("worker exited before transfer commit"), {
+        context: {
+          workerPid: 480,
+          exitCode: null,
+          signal: "SIGKILL",
+        },
+      }),
+    );
+
+    expect(supervisor.snapshot().lastFailure).toMatchObject({
+      phase: "transfer",
+      workerPid: 480,
+      workerExitCode: null,
+      workerExitSignal: "SIGKILL",
+      supervisorAction: "none",
     });
     void supervisor.close();
   });

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   describeInstallFailure,
   getGlobalInstallArgs,
+  isTransientInstallFailure,
   resolveGlobalInstaller,
   validateInstalledVersion,
 } from "../src/lib/proxy/globalInstaller.js";
@@ -743,6 +744,28 @@ describe("global installer resolution", () => {
     expect(describeInstallFailure(error)).toContain("stderr: secondary detail");
   });
 
+  it("retries transient installer failures but not permission failures", () => {
+    expect(
+      isTransientInstallFailure(
+        Object.assign(new Error("npm timed out"), { code: "ETIMEDOUT" }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientInstallFailure(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("DNS unavailable"), {
+            code: "EAI_AGAIN",
+          }),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientInstallFailure(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      ),
+    ).toBe(false);
+  });
+
   it("retries transient post-install trampoline failures", async () => {
     const execFileSync = vi
       .fn()
@@ -1085,7 +1108,7 @@ describe("fallback transport handling", () => {
     );
   });
 
-  it("times out and retries a fallback stream that never yields", async () => {
+  it("does not replay an ambiguous fallback stream that never yields", async () => {
     vi.useFakeTimers();
     const cancel = vi.fn().mockResolvedValue(undefined);
     const abortSignals: AbortSignal[] = [];
@@ -1121,9 +1144,9 @@ describe("fallback transport handling", () => {
 
     await vi.runAllTimersAsync();
     await rejection;
-    expect(stream).toHaveBeenCalledTimes(2);
-    expect(cancel).toHaveBeenCalledTimes(2);
-    expect(abortSignals).toHaveLength(2);
+    expect(stream).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(abortSignals).toHaveLength(1);
     expect(abortSignals.every((signal) => signal.aborted)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- retry only transient global-install failures with a bounded per-version exponential backoff
- preserve no-replay handling for ambiguous fallback-stream failures
- persist rolling-worker exit metadata and distinguish observed exits from supervisor cleanup

## Verification
- `pnpm run test:bugfixes` (265/265)
- `pnpm exec vitest run test/proxyUpdaterFallback.test.ts test/proxyRollingWorkerHandoff.test.ts --reporter=dot` (71/71)
- full local pre-commit pipeline: check, formatting, lint, validation, security, package build, CLI build, browser build, publint

## Scope
Repository-only changes. The installed/live proxy was not started, restarted, configured, or otherwise modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy update reliability with automatic retries for temporary installation failures and unavailable maintenance windows.
  * Added version-specific exponential backoff, capped at four attempts and 30 minutes.
  * Enhanced rolling update errors with worker process and supervisor details.
  * Prevented ambiguous fallback streams from being replayed.
  * Retry state now resets after successful installation or when updates are unavailable.

* **Tests**
  * Expanded coverage for retry classification, worker handoff failures, exit metadata, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->