### PR TITLE
fix(ci): restore prettier formatting on the bugfixes suite

### DIFF
--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -142,7 +142,10 @@ import {
   getTerminalErrors,
   resetUsageStatsForTests,
 } from "../src/lib/proxy/usageStats.js";
-import type { ProxySupervisorState, ServerContext } from "../src/lib/types/index.js";
+import type {
+  ProxySupervisorState,
+  ServerContext,
+} from "../src/lib/types/index.js";
 
 import {
   GoogleVertexProvider,


### PR DESCRIPTION
**CI has been red on `release` since `51c530f6`.** The "Check code formatting" step fails:

```
> prettier --check .
[warn] test/continuous-test-suite-bugfixes.ts
[warn] Code style issues found in the above file.
```

## Cause

A type import sits on one line that exceeds prettier's print width:

```ts
import type { ProxySupervisorState, ServerContext } from "../src/lib/types/index.js";
```

That file was last touched by a conflict resolution I completed with `git rebase --continue`, **which does not run the pre-commit hook** — so `format:staged` never reformatted the result. The PR's own CI ran against the same content, so the miss rode through to release, where `prettier --check .` finally surfaced it.

## The fix

One import statement, split across lines. Nothing else.

- `prettier --check .` — clean
- `pnpm run test:bugfixes` — **265/265**

## Note for anyone reproducing

A fresh worktree has no `dist/`, and 7 of the bugfixes tests shell out to the built CLI. They fail with a missing-binary error until `pnpm run build:cli` runs. That is a local-environment artifact, not a regression — after building, the suite is 265/265.