### PR TITLE
fix(proxy): close updater and worker review gaps

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -923,8 +923,9 @@ async function getRollingActivationFailure(
       failure.workerExitCode === null
         ? `exitCode=${failure.workerExitCode ?? "none"}`
         : null,
-      typeof failure.workerExitSignal === "string"
-        ? `exitSignal=${failure.workerExitSignal}`
+      typeof failure.workerExitSignal === "string" ||
+      failure.workerExitSignal === null
+        ? `exitSignal=${failure.workerExitSignal ?? "none"}`
         : null,
       typeof failure.supervisorAction === "string"
         ? `supervisorAction=${failure.supervisorAction}`

--- a/src/lib/proxy/globalInstaller.ts
+++ b/src/lib/proxy/globalInstaller.ts
@@ -195,18 +195,30 @@ const TRANSIENT_INSTALL_FAILURE_CODES = new Set([
   "EPIPE",
   "ETIMEDOUT",
 ]);
+const MAX_INSTALL_FAILURE_CAUSE_DEPTH = 10;
 
 /**
  * Return whether a global package-manager failure is likely environmental and
  * worth retrying. Configuration and permission failures deliberately return
  * false so the updater does not repeatedly mutate a broken installation.
+ *
+ * @param error - The package-manager error, including any nested `cause` chain.
  */
 export function isTransientInstallFailure(error: unknown): boolean {
   let current: unknown = error;
-  for (let depth = 0; depth < 5 && current; depth++) {
+  const seen = new Set<object>();
+  for (
+    let depth = 0;
+    depth < MAX_INSTALL_FAILURE_CAUSE_DEPTH && current;
+    depth++
+  ) {
     if (typeof current !== "object") {
       return false;
     }
+    if (seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
     const candidate = current as {
       code?: unknown;
       cause?: unknown;

--- a/src/lib/proxy/rollingWorkerSupervisor.ts
+++ b/src/lib/proxy/rollingWorkerSupervisor.ts
@@ -559,10 +559,12 @@ export class RollingWorkerSupervisor {
     if (this.active?.generation === worker.generation && !this.closed) {
       this.active = null;
       this.draining.set(worker.generation, worker);
-      // The child may own a duplicate of an incompletely transferred socket.
-      // SIGKILL closes its descriptor without worker-side shutdown(2), after
-      // which the parent rejects its copy rather than attempting unsafe replay.
-      worker.handle.terminate("SIGKILL");
+      if (!lifecycle.observedExit) {
+        // The child may own a duplicate of an incompletely transferred socket.
+        // SIGKILL closes its descriptor without worker-side shutdown(2), after
+        // which the parent rejects its copy rather than attempting unsafe replay.
+        worker.handle.terminate("SIGKILL");
+      }
       this.publishState();
     }
     this.rejectSocket(socket);

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -15,6 +15,7 @@ import {
   buildProxyTranslationPlan,
   parseRetryAfterMs,
 } from "../src/lib/proxy/routingPolicy.js";
+import { isTransientInstallFailure } from "../src/lib/proxy/globalInstaller.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 
 import {
@@ -3028,15 +3029,61 @@ const tests: TestFunction[] = [
         "utf-8",
       );
       const installFailureIndex = src.indexOf("global install failed");
-      const section = src.slice(
-        installFailureIndex,
-        src.indexOf("} else {", installFailureIndex),
-      );
+      const installFailureEnd = src.indexOf("} else {", installFailureIndex);
+      if (installFailureIndex < 0 || installFailureEnd < 0) {
+        return false;
+      }
+      const section = src.slice(installFailureIndex, installFailureEnd);
       return (
         section.includes("scheduleUpdateRetry(") &&
         section.includes('"transient install failure"') &&
         section.includes("return;") &&
         !section.includes("suppressVersion")
+      );
+    },
+  },
+  {
+    name: "updater: transient install classification retries network errors only",
+    category: "launchd-regression",
+    fn: () =>
+      isTransientInstallFailure(
+        Object.assign(new Error("npm timed out"), { code: "ETIMEDOUT" }),
+      ) &&
+      isTransientInstallFailure(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("DNS unavailable"), {
+            code: "EAI_AGAIN",
+          }),
+        }),
+      ) &&
+      !isTransientInstallFailure(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      ),
+  },
+  {
+    name: "updater: transient install retry budget remains bounded",
+    category: "launchd-regression",
+    fn: async () => {
+      const { readFileSync } = await import("fs");
+      const { join: pathJoin } = await import("path");
+      const src = readFileSync(
+        pathJoin(process.cwd(), "src/cli/commands/proxy.ts"),
+        "utf-8",
+      );
+      const retryStart = src.indexOf("const scheduleUpdateRetry");
+      const retryEnd = src.indexOf(
+        "// Run first check after a short delay",
+        retryStart,
+      );
+      if (retryStart < 0 || retryEnd < 0) {
+        return false;
+      }
+      const section = src.slice(retryStart, retryEnd);
+      return (
+        src.includes("UPDATE_RETRY_MAX_ATTEMPTS = 4") &&
+        section.includes("updateRetryAttempts >= UPDATE_RETRY_MAX_ATTEMPTS") &&
+        section.includes("retry budget exhausted") &&
+        section.includes("updateRetryAttempts += 1")
       );
     },
   },
@@ -9551,6 +9598,67 @@ exit 127
   },
 
   // ---------- auto-fallback became opt-in (regression from 33bdd141) ----------
+  {
+    name: "proxy fallback: an idle stream is aborted without ambiguous replay",
+    category: "proxy",
+    fn: async () => {
+      const originalSetTimeout = globalThis.setTimeout;
+      let cancelled = false;
+      const cancel = async (): Promise<void> => {
+        cancelled = true;
+      };
+      const abortSignals: AbortSignal[] = [];
+      let streamCalls = 0;
+      globalThis.setTimeout = ((callback, _delay, ...args) =>
+        originalSetTimeout(callback, 0, ...args)) as typeof setTimeout;
+      try {
+        await claudeProxyTestHooks.executeClaudeFallbackWithRetry({
+          ctx: {
+            neurolink: {
+              stream: async (options: { abortSignal?: AbortSignal }) => {
+                streamCalls += 1;
+                if (options.abortSignal) {
+                  abortSignals.push(options.abortSignal);
+                }
+                return {
+                  stream: {
+                    [Symbol.asyncIterator]: () => ({
+                      next: () => new Promise(() => undefined),
+                      return: cancel,
+                    }),
+                  },
+                  toolCalls: [],
+                  model: "fallback-model",
+                };
+              },
+            },
+          } as unknown as ServerContext,
+          body: {
+            model: "claude-sonnet-5",
+            messages: [],
+            stream: false,
+          },
+          requestStartTime: Date.now(),
+          logProxyBody: () => undefined,
+          logFinalRequest: () => undefined,
+          options: {} as never,
+          providerLabel: "auto-provider",
+        });
+        return false;
+      } catch (error) {
+        return (
+          error instanceof Error &&
+          error.message.includes("Fallback auto-provider stream timed out") &&
+          streamCalls === 1 &&
+          cancelled &&
+          abortSignals.length === 1 &&
+          abortSignals[0]?.aborted === true
+        );
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
+      }
+    },
+  },
   {
     // "fix(proxy): bound account admission and fallback routing" (33bdd141)
     // made translation-layer auto-fallback opt-in, which silently changed how

--- a/test/proxyRollingWorkerHandoff.test.ts
+++ b/test/proxyRollingWorkerHandoff.test.ts
@@ -626,6 +626,7 @@ describe("rolling proxy worker supervisor", () => {
       workerExitSignal: "SIGKILL",
       supervisorAction: "none",
     });
+    expect(worker.terminated).not.toContain("SIGKILL");
     void supervisor.close();
   });
 });

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -764,6 +764,14 @@ describe("global installer resolution", () => {
         Object.assign(new Error("permission denied"), { code: "EACCES" }),
       ),
     ).toBe(false);
+    const cyclic = Object.assign(
+      new Error("cyclic cause"),
+      {} as {
+        cause?: unknown;
+      },
+    );
+    cyclic.cause = cyclic;
+    expect(isTransientInstallFailure(cyclic)).toBe(false);
   });
 
   it("retries transient post-install trampoline failures", async () => {


### PR DESCRIPTION
Follow-up to merged #1275.

## Changes
- avoid a redundant SIGKILL after a confirmed worker exit
- render an explicit null worker exit signal as `none`
- harden transient installer cause traversal against cycles and deeper wrapping
- make the source-inspection regression fail deterministically when markers are absent
- add continuous-suite coverage for transient install classification and ambiguous idle-stream no-replay

## Verification
- `pnpm run test:bugfixes` (267/267)
- `pnpm exec vitest run test/proxyUpdaterFallback.test.ts test/proxyRollingWorkerHandoff.test.ts --reporter=dot` (71/71)
- full local pre-commit pipeline: check, format, lint, validation, security, package build, CLI build, browser build, publint

Repository-only follow-up. No live proxy was started, restarted, configured, or modified.