### PR TITLE
fix(context): reclaim to a low-water mark in the step budget guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:memory": "npx tsx test/continuous-test-suite-memory.ts",
     "test:tool-pairing": "npx tsx test/continuous-test-suite-tool-pairing.ts",
     "test:token-accounting": "npx tsx test/continuous-test-suite-token-accounting.ts",
+    "test:step-guard": "npx tsx test/continuous-test-suite-step-guard.ts",
     "test:middleware": "npx tsx test/continuous-test-suite-middleware.ts",
     "test:observability": "npx tsx test/continuous-test-suite-observability.ts",
     "test:ppt": "npx tsx test/continuous-test-suite-ppt.ts",

--- a/src/lib/context/stepBudgetGuard.ts
+++ b/src/lib/context/stepBudgetGuard.ts
@@ -55,6 +55,23 @@ const MAX_CALIBRATION_RATIO = 3;
 /** Messages at the end of the conversation the guard never modifies. */
 const PROTECTED_TAIL_MESSAGES = 4;
 
+/**
+ * Fraction of the context window the guard reclaims DOWN TO once it fires.
+ *
+ * The high-water mark (`thresholdRatio`) decides *when* to act; this low-water
+ * mark decides *how far*. Reclaiming only back to the threshold meant the very
+ * next step — which appends an assistant turn plus its tool results — crossed
+ * it again, so the guard mutated the message prefix on every single step of a
+ * long agentic run. Each of those mutations invalidates the Anthropic
+ * `cache_control` prefix from the edit point onward (see
+ * anthropicCacheBreakpoints), turning a ~0.1x cached read into full-price
+ * input every step.
+ *
+ * One deeper reclaim every N steps saves the same tokens and leaves the prefix
+ * stable in between, which is what makes the cache worth having.
+ */
+const CONTEXT_GUARD_LOW_WATER_RATIO = 0.6;
+
 /** Stage-1 preview budget for an old tool output (bytes). */
 const OLD_TOOL_OUTPUT_PREVIEW_BYTES = 2_048;
 
@@ -370,18 +387,29 @@ export function createStepBudgetGuard(config: StepBudgetGuardConfig) {
       return undefined;
     }
 
+    // Reclaim down to the LOW-WATER mark, not merely back under the threshold.
+    // See CONTEXT_GUARD_LOW_WATER_RATIO: stopping at the threshold guaranteed
+    // the next step crossed it again, mutating the cached prefix every step.
+    const lowWaterTokens = Math.floor(
+      (availableInput * CONTEXT_GUARD_LOW_WATER_RATIO) / calibration,
+    );
+
     // Stage 1: shrink old tool outputs to previews.
     const stage1 = truncateOldToolOutputs([...messages]);
     let compacted = stage1.messages;
     let newEstimate =
       overheadTokens + estimateStepMessagesTokens(compacted, provider);
 
-    // Stage 2: drop oldest complete tool exchanges if still over.
+    // Stage 2: drop oldest complete tool exchanges until under the low-water
+    // mark. Stage order is deliberately unchanged — truncating first preserves
+    // a preview of each output, and since BOTH stages edit the oldest messages
+    // the cache prefix is invalidated at roughly the same point either way.
+    // Frequency, not stage order, is what governs cache retention here.
     let droppedExchanges = 0;
-    if (newEstimate > effectiveThreshold) {
+    if (newEstimate > lowWaterTokens) {
       const stage2 = dropOldestToolExchanges(
         compacted,
-        effectiveThreshold,
+        lowWaterTokens,
         overheadTokens,
         provider,
       );
@@ -401,8 +429,13 @@ export function createStepBudgetGuard(config: StepBudgetGuardConfig) {
       model,
       estimatedTokens: rawEstimate,
       thresholdTokens: effectiveThreshold,
+      lowWaterTokens,
       calibration,
       afterTokens: newEstimate,
+      // Headroom reclaimed below the firing threshold. Roughly how many further
+      // steps can run before the guard mutates the prefix again — a value near
+      // zero means the cache is being invalidated every step.
+      headroomTokens: effectiveThreshold - newEstimate,
       toolOutputsTruncated: stage1.truncated,
       exchangesDropped: droppedExchanges,
     });

--- a/src/lib/utils/tokenEstimation.ts
+++ b/src/lib/utils/tokenEstimation.ts
@@ -130,7 +130,7 @@ function serializeForEstimate(value: unknown): string {
  * Includes message framing overhead.
  *
  * Counts `content` AND `args`. A `tool_call` is persisted with an EMPTY
- * `content` and its entire payload in `args` (see flushPendingToolExecutions),
+ * `content` and its entire payload in `args` (see flushPendingToolData),
  * so a content-only estimate scored a 39 KB Write call at ~28 tokens against a
  * real cost near 9,750 — the budget checker, the compaction trigger and the
  * summarization threshold were all blind to the single largest source of

--- a/test/continuous-test-suite-step-guard.ts
+++ b/test/continuous-test-suite-step-guard.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — agent-loop step budget guard hysteresis
+ *
+ * The regression: `dropOldestToolExchanges` reclaimed only back to the firing
+ * threshold. The very next step appends an assistant turn plus its tool
+ * results, immediately re-crosses, and the guard rewrites the OLDEST messages
+ * again — so a long agentic run mutated its own prompt prefix on every single
+ * step. Each mutation invalidates the Anthropic `cache_control` prefix from the
+ * edit point onward, converting a ~0.1x cached read into full-price input.
+ *
+ * The fix reclaims down to a LOW-WATER mark, so one deeper compaction buys many
+ * quiet steps. This suite asserts the guard fires rarely, not constantly.
+ *
+ * No API keys, no network, no LLM — pure function assertions.
+ *
+ * Run: npx tsx test/continuous-test-suite-step-guard.ts
+ *      pnpm run test:step-guard
+ */
+
+import { createStepBudgetGuard } from "../src/lib/context/stepBudgetGuard.js";
+import { getAvailableInputTokens } from "../src/lib/constants/contextWindows.js";
+import type { ModelMessage } from "../src/lib/types/index.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Step budget guard hysteresis");
+
+/**
+ * NOTE: assertion messages must NEVER interpolate message content or tool
+ * payloads — `defineSuite` downgrades a throw to SKIP when the text matches
+ * `isExpectedProviderError()`, silently turning a failure into ⊘.
+ */
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const PROVIDER = "openai";
+const MODEL = "gpt-4o";
+
+/** One tool exchange: an assistant tool-call message plus its tool result. */
+function toolExchange(index: number, outputChars: number): ModelMessage[] {
+  return [
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: `t${index}`,
+          toolName: "read_file",
+          input: { path: `/f${index}.ts` },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: `t${index}`,
+          toolName: "read_file",
+          output: { type: "text", value: "x".repeat(outputChars) },
+        },
+      ],
+    },
+  ] as unknown as ModelMessage[];
+}
+
+await runSuite(async () => {
+  section("Guard stays quiet below the threshold");
+
+  await test("small conversation is never modified", async () => {
+    const guard = createStepBudgetGuard({
+      provider: PROVIDER,
+      model: MODEL,
+    });
+    const messages = [
+      { role: "user", content: "hi" },
+      ...toolExchange(1, 100),
+    ] as ModelMessage[];
+    assert(
+      guard(messages) === undefined,
+      "guard modified a conversation that fits comfortably",
+    );
+  });
+
+  section("Guard reclaims real headroom when it fires");
+
+  await test("a firing reclaims well below the threshold", async () => {
+    const available = getAvailableInputTokens(PROVIDER, MODEL);
+    // Build a conversation comfortably over the ~85% firing threshold.
+    const messages: ModelMessage[] = [
+      { role: "user", content: "start" } as ModelMessage,
+    ];
+    for (let i = 0; i < 60; i++) {
+      messages.push(...toolExchange(i, 8000));
+    }
+    const guard = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    const out = guard(messages);
+    assert(out !== undefined, "guard did not fire on an over-budget step");
+
+    // Re-running the guard on its OWN output must be a no-op: if the reclaim
+    // only reached the threshold, the next step would immediately re-fire.
+    const guard2 = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    const second = guard2(out as ModelMessage[]);
+    assert(
+      second === undefined,
+      "guard output still sits above the firing threshold",
+    );
+
+    // And the reclaim must be substantial, not a token under the line.
+    const roughTokens = JSON.stringify(out).length / 4;
+    assert(
+      roughTokens < available * 0.8,
+      "reclaim left the conversation nearly at the threshold",
+    );
+  });
+
+  section("Hysteresis: firings must be rare across a long run");
+
+  await test("guard fires on a small minority of steps", async () => {
+    const guard = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    let messages: ModelMessage[] = [
+      { role: "user", content: "start" } as ModelMessage,
+    ];
+    for (let i = 0; i < 40; i++) {
+      messages.push(...toolExchange(i, 8000));
+    }
+
+    let firings = 0;
+    const STEPS = 40;
+    for (let step = 0; step < STEPS; step++) {
+      // Each step appends one more exchange, as a real agent loop would.
+      messages.push(...toolExchange(1000 + step, 8000));
+      const out = guard(messages);
+      if (out !== undefined) {
+        firings++;
+        messages = out as ModelMessage[];
+      }
+    }
+
+    // Pre-fix behaviour was a firing on essentially every step once over the
+    // line. With a low-water reclaim it must be a small fraction.
+    assert(
+      firings < STEPS / 2,
+      `guard mutated the prefix on ${firings} of ${STEPS} steps`,
+    );
+  });
+
+  await test("stage-2-dominant run does not fire every step", async () => {
+    // The regime the low-water mark actually exists for. Tool outputs BELOW
+    // the stage-1 preview budget cannot be shrunk by truncation, so dropping
+    // exchanges is the only lever. Reclaiming merely back to the threshold
+    // made this fire on 40 of 40 steps — a full prompt-cache invalidation per
+    // step. This is a long agentic run doing many small greps/reads.
+    const smallExchange = (i: number): ModelMessage[] =>
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: `s${i}`,
+              toolName: "grep",
+              input: { q: `q${i}` },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: `s${i}`,
+              toolName: "grep",
+              output: { type: "text", value: "y".repeat(1800) },
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[];
+
+    const guard = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    let messages: ModelMessage[] = [
+      { role: "user", content: "start" } as ModelMessage,
+    ];
+    for (let i = 0; i < 260; i++) {
+      messages.push(...smallExchange(i));
+    }
+
+    let firings = 0;
+    const STEPS = 40;
+    for (let step = 0; step < STEPS; step++) {
+      messages.push(...smallExchange(1000 + step));
+      const out = guard(messages);
+      if (out !== undefined) {
+        firings++;
+        messages = out as ModelMessage[];
+      }
+    }
+    assert(
+      firings <= STEPS / 4,
+      `guard mutated the prefix on ${firings} of ${STEPS} steps in the stage-2 regime`,
+    );
+  });
+
+  await test("protected tail is never modified", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "start" } as ModelMessage,
+    ];
+    for (let i = 0; i < 60; i++) {
+      messages.push(...toolExchange(i, 8000));
+    }
+    const tailBefore = JSON.stringify(messages.slice(-4));
+    const guard = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    const out = guard(messages);
+    assert(out !== undefined, "guard did not fire on an over-budget step");
+    assert(
+      JSON.stringify((out as ModelMessage[]).slice(-4)) === tailBefore,
+      "guard modified the protected tail messages",
+    );
+  });
+
+  await test("first user message survives compaction", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "THE ORIGINAL TASK" } as ModelMessage,
+    ];
+    for (let i = 0; i < 60; i++) {
+      messages.push(...toolExchange(i, 8000));
+    }
+    const guard = createStepBudgetGuard({ provider: PROVIDER, model: MODEL });
+    const out = guard(messages) as ModelMessage[];
+    assert(out !== undefined, "guard did not fire on an over-budget step");
+    assert(
+      JSON.stringify(out[0]) === JSON.stringify(messages[0]),
+      "guard modified the first user message",
+    );
+  });
+});


### PR DESCRIPTION
## Description

`dropOldestToolExchanges` reclaimed only back to the **firing threshold**. The next step appends an assistant turn plus its tool results, immediately re-crosses, and the guard rewrites the oldest messages again — so a long agentic run mutated its own prompt prefix on **every step**. Each mutation invalidates the Anthropic `cache_control` prefix from the edit point onward (see `anthropicCacheBreakpoints.ts`, which spends its budget caching exactly that history), converting a ~0.1x cached read into full-price input.

Measured over a 40-step simulated loop:

| Scenario | Reclaim-to-threshold | Low-water reclaim |
|---|---|---|
| Large tool outputs (stage 1 dominant) | 3/40 | 3/40 — no change |
| **Many small outputs (stage 2 dominant)** | **40/40** | **1/40** |

Each firing is a full prompt-cache invalidation, so that is a **40x reduction** in the regime where it bites.

The regime matters and is not the obvious one. With large outputs, stage 1 truncates to 2KB previews, overshoots well below the line and creates natural headroom — the bug is invisible. It only appears when outputs are **already below** the preview budget, so truncation cannot shrink them and dropping exchanges is the only lever. That is a long agentic run doing many small greps, reads and edits: the common case.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Changes

- `CONTEXT_GUARD_LOW_WATER_RATIO` (0.6): the threshold decides *when* the guard fires, the low-water mark decides *how far* it reclaims
- stage 2 targets the low-water mark instead of the threshold
- firing log now reports `lowWaterTokens` and `headroomTokens` — headroom near zero means the cache is being invalidated every step

## Testing

New no-API suite `pnpm run test:step-guard` — **6/6**. Includes an explicit stage-2-dominant regression that **fails without this change and passes with it** (verified both directions), plus protected-tail and first-user-message invariants.

- `tsc --noEmit --strict`: 0 errors
- `eslint`: 0 errors
- `test:tool-pairing` 15/15, `test:token-accounting` 10/10 still green
- `test:context`: byte-identical failure set to `release`

## Notes for reviewers

Stage order is deliberately **unchanged**. Truncating before dropping preserves a preview of each output, and since both stages edit the oldest messages the cache prefix breaks at roughly the same point either way — frequency, not stage order, governs cache retention here.

Two items from the original plan were dropped after reading `anthropicCacheBreakpoints.ts` rather than implemented: breakpoint re-anchoring (rolling markers already sit at the tail, so the new prefix re-caches on the next call automatically) and stage reordering (trades information loss for a benefit that does not materialize). Both would have been no-op diff padding once hysteresis landed.

Top of the 3-PR stack: #1280 -> #1281 -> this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation compaction to reclaim sufficient step-budget headroom when limits are reached.
  * Preserved key conversation context, including the initial user message and protected recent messages.
  * Reduced unnecessary repeated compaction during extended tool-driven conversations.
  * Improved diagnostics for compaction targets and reclaimed capacity.

* **Tests**
  * Added regression coverage for step-budget behavior across short and long conversations, including tool-heavy scenarios and protected conversation content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->