### PR TITLE
fix(memory): persist tool executions on every memory backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test:loop-guard-core": "npx tsx test/continuous-test-suite-loop-guard-core.ts",
     "test:openai-compat-guard": "npx tsx test/continuous-test-suite-openai-compat-guard.ts",
     "test:anthropic-guard": "npx tsx test/continuous-test-suite-anthropic-guard.ts",
+    "test:tool-storage-parity": "npx tsx test/continuous-test-suite-tool-storage-parity.ts",
     "test:middleware": "npx tsx test/continuous-test-suite-middleware.ts",
     "test:observability": "npx tsx test/continuous-test-suite-observability.ts",
     "test:ppt": "npx tsx test/continuous-test-suite-ppt.ts",

--- a/src/lib/core/conversationMemoryManager.ts
+++ b/src/lib/core/conversationMemoryManager.ts
@@ -545,6 +545,102 @@ export class ConversationMemoryManager implements IConversationMemoryManager {
     session.lastActivity = Date.now();
   }
 
+  /**
+   * Persist a step's tool calls and results as `tool_call` / `tool_result`
+   * messages, mirroring the Redis manager.
+   *
+   * Parity fix: this used to exist only on the Redis backend, so an in-memory
+   * session never turned tool activity into messages and every downstream path
+   * that reasons about tool batches (compaction, pruning, pair repair) saw a
+   * different history shape depending on `STORAGE_TYPE`.
+   *
+   * Calls are written before results — the same order the Redis flush uses —
+   * and `toolCallId` is carried on BOTH sides so `repairToolPairs` can match by
+   * id rather than adjacency (a parallel batch has no positional pairing).
+   */
+  async storeToolExecution(
+    sessionId: string,
+    userId: string | undefined,
+    toolCalls: Array<{
+      toolCallId?: string;
+      toolName?: string;
+      args?: Record<string, unknown>;
+      [key: string]: unknown;
+    }>,
+    toolResults: Array<{
+      toolCallId?: string;
+      output?: unknown;
+      result?: unknown;
+      error?: string;
+      [key: string]: unknown;
+    }>,
+    currentTime?: Date,
+  ): Promise<void> {
+    await this.ensureInitialized();
+
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = this.createNewSession(sessionId, userId);
+      this.sessions.set(sessionId, session);
+      this.enforceSessionLimit();
+    }
+
+    const timestamp = (currentTime ?? new Date()).toISOString();
+    const toolNameById = new Map<string, string>();
+
+    for (const toolCall of toolCalls ?? []) {
+      const toolCallId = toolCall.toolCallId ?? "";
+      const toolName = toolCall.toolName ?? "unknown";
+      if (toolCallId) {
+        toolNameById.set(toolCallId, toolName);
+      }
+      session.messages.push({
+        id: randomUUID(),
+        role: "tool_call",
+        content: "", // Tool calls carry their payload in `args`, not content.
+        tool: toolName,
+        ...(toolCallId ? { toolCallId } : {}),
+        args: (toolCall.args ?? {}) as Record<string, unknown>,
+        timestamp,
+      });
+    }
+
+    for (const toolResult of toolResults ?? []) {
+      const toolCallId = toolResult.toolCallId ?? "";
+      const toolName =
+        (toolCallId ? toolNameById.get(toolCallId) : undefined) ??
+        String(toolResult.toolName ?? "unknown");
+      const rawOutput =
+        "output" in toolResult ? toolResult.output : toolResult.result;
+      let content: string;
+      if (typeof rawOutput === "string") {
+        content = rawOutput;
+      } else {
+        try {
+          content = JSON.stringify(rawOutput ?? null) ?? "null";
+        } catch (error) {
+          content = `[Serialization failed: ${
+            error instanceof Error ? error.message : String(error)
+          }]`;
+        }
+      }
+      session.messages.push({
+        id: randomUUID(),
+        role: "tool_result",
+        content,
+        tool: toolName,
+        ...(toolCallId ? { toolCallId } : {}),
+        result: {
+          success: !toolResult.error,
+          ...(toolResult.error ? { error: String(toolResult.error) } : {}),
+        },
+        timestamp,
+      });
+    }
+
+    session.lastActivity = Date.now();
+  }
+
   /** Close/shutdown — no-op for in-memory manager (no external connections to release) */
   async close(): Promise<void> {
     // In-memory manager has nothing to close

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -15289,12 +15289,19 @@ Current user's request: ${currentInput}`;
       return;
     }
 
-    // Type guard to ensure it's Redis conversation memory manager
-    const redisMemory = this
-      .conversationMemory as RedisConversationMemoryManager;
+    // Any backend that implements storeToolExecution — no longer a Redis cast.
+    // The in-memory manager implements it too, so tool activity becomes
+    // tool_call/tool_result messages regardless of STORAGE_TYPE.
+    const memory = this.conversationMemory;
+    if (!memory?.storeToolExecution) {
+      logger.debug(
+        "Tool execution storage not supported by this memory backend",
+      );
+      return;
+    }
 
     try {
-      await redisMemory.storeToolExecution(
+      await memory.storeToolExecution(
         sessionId,
         userId,
         toolCalls,
@@ -15312,17 +15319,17 @@ Current user's request: ${currentInput}`;
   }
 
   /**
-   * Check if tool execution storage is available
-   * @returns boolean indicating if Redis storage is configured and available
+   * Check if tool execution storage is available.
+   *
+   * Now capability-based rather than Redis-specific: any configured memory
+   * backend implementing `storeToolExecution` qualifies. The old check
+   * required `STORAGE_TYPE === "redis"` AND a Redis manager by class name, so
+   * in-memory sessions reported false and silently skipped tool persistence.
+   *
+   * @returns whether the active memory backend can persist tool executions
    */
   isToolExecutionStorageAvailable(): boolean {
-    const isRedisStorage = process.env.STORAGE_TYPE === "redis";
-    const hasRedisConversationMemory =
-      this.conversationMemory &&
-      this.conversationMemory.constructor.name ===
-        "RedisConversationMemoryManager";
-
-    return !!(isRedisStorage && hasRedisConversationMemory);
+    return typeof this.conversationMemory?.storeToolExecution === "function";
   }
 
   /**

--- a/src/lib/types/conversationMemoryInterface.ts
+++ b/src/lib/types/conversationMemoryInterface.ts
@@ -67,6 +67,35 @@ export type IConversationMemoryManager = {
     userId?: string,
   ): Promise<void>;
 
+  /**
+   * Persist a step's tool calls and results as `tool_call` / `tool_result`
+   * messages on the session.
+   *
+   * Declared on the interface so every backend can implement it. Previously
+   * only the Redis manager had it, and the caller reached it by casting — so
+   * on in-memory storage tool activity never became messages at all, and the
+   * compaction, pruning and pair-repair paths saw a different history shape
+   * depending on `STORAGE_TYPE`.
+   */
+  storeToolExecution?(
+    sessionId: string,
+    userId: string | undefined,
+    toolCalls: Array<{
+      toolCallId?: string;
+      toolName?: string;
+      args?: Record<string, unknown>;
+      [key: string]: unknown;
+    }>,
+    toolResults: Array<{
+      toolCallId?: string;
+      output?: unknown;
+      result?: unknown;
+      error?: string;
+      [key: string]: unknown;
+    }>,
+    currentTime?: Date,
+  ): Promise<void>;
+
   /** Close/shutdown the memory manager and release resources (e.g., Redis connections) */
   close?(): Promise<void>;
 };

--- a/test/continuous-test-suite-tool-storage-parity.ts
+++ b/test/continuous-test-suite-tool-storage-parity.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — tool execution storage parity across backends
+ *
+ * `storeToolExecution` existed only on the Redis manager, and the caller
+ * reached it by casting. On in-memory storage tool activity therefore never
+ * became `tool_call` / `tool_result` messages at all, so every downstream path
+ * that reasons about tool batches — compaction, pruning, and the id-based pair
+ * repair — saw a different history shape depending on `STORAGE_TYPE`. Two code
+ * paths, one of them barely exercised.
+ *
+ * This suite pins the in-memory implementation to the same contract the Redis
+ * one follows: calls written before results, `toolCallId` carried on BOTH
+ * sides, and the resulting history surviving `repairToolPairs` untouched.
+ *
+ * No API keys, no network, no Redis, no LLM — pure in-memory assertions.
+ *
+ * Run: npx tsx test/continuous-test-suite-tool-storage-parity.ts
+ *      pnpm run test:tool-storage-parity
+ */
+
+import { ConversationMemoryManager } from "../src/lib/core/conversationMemoryManager.js";
+import { repairToolPairs } from "../src/lib/context/toolPairRepair.js";
+import type { ChatMessage } from "../src/lib/types/index.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Tool storage parity");
+
+/**
+ * NOTE: assertion messages must NEVER interpolate message content or tool
+ * payloads — `defineSuite` downgrades a throw to SKIP when the text matches
+ * `isExpectedProviderError()`, silently turning a failure into ⊘.
+ */
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function newManager(): ConversationMemoryManager {
+  return new ConversationMemoryManager({
+    enabled: true,
+    maxSessions: 10,
+    maxTurnsPerSession: 100,
+    enableSummarization: false,
+  });
+}
+
+async function storeBatch(
+  manager: ConversationMemoryManager,
+  sessionId: string,
+  pairs: Array<{ id: string; name: string; output: unknown; error?: string }>,
+): Promise<ChatMessage[]> {
+  await manager.storeToolExecution(
+    sessionId,
+    "user-1",
+    pairs.map((p) => ({
+      toolCallId: p.id,
+      toolName: p.name,
+      args: { q: p.name },
+    })),
+    pairs.map((p) => ({
+      toolCallId: p.id,
+      output: p.output,
+      ...(p.error ? { error: p.error } : {}),
+    })),
+  );
+  return manager.getSessionMessages(sessionId, "user-1");
+}
+
+await runSuite(async () => {
+  section("The in-memory backend must implement the contract");
+
+  await test("storeToolExecution exists on the in-memory manager", async () => {
+    const manager = newManager();
+    assert(
+      typeof manager.storeToolExecution === "function",
+      "in-memory manager does not implement storeToolExecution",
+    );
+  });
+
+  await test("a single call/result pair is persisted", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s1", [
+      { id: "t1", name: "read_file", output: "file body" },
+    ]);
+    assert(
+      messages.filter((m) => m.role === "tool_call").length === 1,
+      "tool_call message was not persisted",
+    );
+    assert(
+      messages.filter((m) => m.role === "tool_result").length === 1,
+      "tool_result message was not persisted",
+    );
+  });
+
+  section("Shape must match what downstream paths expect");
+
+  await test("toolCallId is carried on both sides", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s2", [
+      { id: "t1", name: "read_file", output: "body" },
+    ]);
+    const call = messages.find((m) => m.role === "tool_call");
+    const result = messages.find((m) => m.role === "tool_result");
+    assert(call?.toolCallId === "t1", "tool_call lost its toolCallId");
+    assert(result?.toolCallId === "t1", "tool_result lost its toolCallId");
+  });
+
+  await test("calls are written before results", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s3", [
+      { id: "t1", name: "a", output: "1" },
+      { id: "t2", name: "b", output: "2" },
+    ]);
+    const roles = messages.map((m) => m.role);
+    assert(
+      roles.join(",") === "tool_call,tool_call,tool_result,tool_result",
+      "batch ordering does not match the Redis backend contract",
+    );
+  });
+
+  await test("tool name is resolved onto the result via id", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s4", [
+      { id: "t1", name: "read_file", output: "body" },
+    ]);
+    const result = messages.find((m) => m.role === "tool_result");
+    assert(
+      result?.tool === "read_file",
+      "result did not inherit the tool name",
+    );
+  });
+
+  await test("non-string output is serialized, errors are recorded", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s5", [
+      { id: "t1", name: "a", output: { nested: { value: 7 } } },
+      { id: "t2", name: "b", output: null, error: "boom" },
+    ]);
+    const results = messages.filter((m) => m.role === "tool_result");
+    assert(
+      results[0].content.includes("nested"),
+      "object output was not serialized",
+    );
+    assert(
+      results[1].result?.success === false,
+      "error result was marked successful",
+    );
+    assert(results[1].result?.error === "boom", "error text was not recorded");
+  });
+
+  section("The persisted history must survive pair repair untouched");
+
+  await test("a parallel batch round-trips through repairToolPairs", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "s6", [
+      { id: "t1", name: "read_file", output: "body" },
+      { id: "t2", name: "grep", output: "matches" },
+      { id: "t3", name: "ls", output: "listing" },
+    ]);
+    const repaired = repairToolPairs(messages);
+    assert(
+      !repaired.repaired,
+      "pair repair modified a healthy in-memory tool batch",
+    );
+    assert(
+      repaired.messages.filter((m) => m.role === "tool_call").length ===
+        repaired.messages.filter((m) => m.role === "tool_result").length,
+      "pair repair left the batch unbalanced",
+    );
+
+    // Counts and roles alone would pass even if two parallel results traded
+    // toolCallIds — and a swapped id is exactly what the id-based repair is
+    // supposed to make impossible. Pin the id -> name mapping on both sides.
+    const expected = new Map([
+      ["t1", "read_file"],
+      ["t2", "grep"],
+      ["t3", "ls"],
+    ]);
+    for (const role of ["tool_call", "tool_result"] as const) {
+      const seen = repaired.messages
+        .filter((m) => m.role === role)
+        .map((m) => [m.toolCallId, m.tool] as const);
+      assert(
+        seen.length === expected.size,
+        `pair repair changed the ${role} count in a parallel batch`,
+      );
+      for (const [id, tool] of seen) {
+        assert(
+          id !== undefined && expected.has(id),
+          `a ${role} carries an id that was never issued`,
+        );
+        assert(
+          tool === expected.get(id!),
+          `a ${role} is bound to the wrong tool for its id`,
+        );
+      }
+    }
+  });
+
+  section("Session lifecycle");
+
+  await test("storing tools creates the session when absent", async () => {
+    const manager = newManager();
+    const messages = await storeBatch(manager, "brand-new", [
+      { id: "t1", name: "a", output: "1" },
+    ]);
+    assert(messages.length === 2, "session was not created on tool storage");
+  });
+
+  await test("empty batches are harmless", async () => {
+    const manager = newManager();
+    await manager.storeToolExecution("s7", "user-1", [], []);
+    const messages = await manager.getSessionMessages("s7", "user-1");
+    assert(messages.length === 0, "an empty batch wrote messages");
+  });
+
+  await test("tool messages append onto an existing session", async () => {
+    const manager = newManager();
+    await manager.storeConversationTurn({
+      sessionId: "s8",
+      userId: "user-1",
+      userMessage: "hello",
+      aiResponse: "hi",
+      enableSummarization: false,
+    });
+    const messages = await storeBatch(manager, "s8", [
+      { id: "t1", name: "a", output: "1" },
+    ]);
+    assert(
+      messages.length === 4,
+      "tool messages did not append onto the existing turn",
+    );
+    assert(
+      messages[0].role === "user" && messages[1].role === "assistant",
+      "existing turn ordering was disturbed",
+    );
+  });
+});


### PR DESCRIPTION
## Description

`storeToolExecution` existed only on `RedisConversationMemoryManager`, and `NeuroLink.storeToolExecutions` reached it with a cast:

```ts
const redisMemory = this.conversationMemory as RedisConversationMemoryManager;
await redisMemory.storeToolExecution(...);
```

`isToolExecutionStorageAvailable()` compounded it, requiring `STORAGE_TYPE === "redis"` **and** a class-name match. So on in-memory storage tool activity never became `tool_call` / `tool_result` messages at all.

That left two divergent history shapes. Everything downstream that reasons about tool batches — compaction, tool-output pruning, and the id-based pair repair from #1280 — behaved differently depending on `STORAGE_TYPE`, and the in-memory shape was the barely-exercised one.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `storeToolExecution` declared on `IConversationMemoryManager` (optional, so third-party backends stay valid)
- implemented on `ConversationMemoryManager`, mirroring the Redis contract exactly: calls written before results, `toolCallId` carried on **both** sides so `repairToolPairs` can match by id rather than adjacency, tool name resolved onto the result via that id, non-string output serialized with a guarded fallback, `result.success` / `result.error` recorded
- caller now dispatches through the interface instead of casting
- `isToolExecutionStorageAvailable()` is capability-based rather than Redis-specific

## Testing

`pnpm run test:tool-storage-parity` — **10/10**, no Redis required. Covers the contract, batch ordering, id propagation, serialization and error recording, session creation, empty batches, appending onto an existing turn, and a parallel batch round-tripping through `repairToolPairs` untouched.

Verified to fail **loudly** (`✗`, exit 1) on a deliberately broken assertion, per the CLAUDE.md hazard where `isExpectedProviderError()` can downgrade a real failure to `⊘`.

Regressions, all green: `test:tool-pairing` 15/15, `test:token-accounting` 10/10, `test:step-guard` 6/6, `test:loop-guard-core` 11/11, `test:openai-compat-guard` 9/9, `test:anthropic-guard` 10/10. `tsc --noEmit --strict` 0 errors, `eslint` 0 errors, prettier clean.

## Scope: append-only Redis storage is NOT in this PR

The planned O(n²) fix for `storeConversationTurn` is deliberately excluded. I measured it against local Redis first:

| Conversation profile | first turns | last turns | degradation |
|---|---|---|---|
| 200 turns x 2KB messages | 2ms | 2ms | **1.0x — no problem** |
| 400 turns x 20KB messages (~16MB) | 2ms | 61ms | **30.5x**, 10.9s total |

So the problem is real but only at multi-MB scale — which *is* the agentic tool-output profile, so it is worth fixing.

I built the split-storage design (`{key}:msgs` LIST + small metadata blob, with a marker so legacy blobs are read as-is and converted on next write) and then reverted it, because implementing it surfaced a hazard the plan had not accounted for: **`getStats()` and `listAllSessions()` scan keys by prefix and `GET` each one.** New `:msgs` LIST keys live under that same prefix, so those scans would hit `WRONGTYPE`. The code already special-cases `:sessions` keys, which shows this collision class is a known trap in this file.

Combined with 12 varied read sites, two-key TTL, and `clearSession` needing to delete both keys, it is a larger and more delicate change than one PR should absorb alongside this one. A half-migrated storage layer would make split-written sessions read as empty on unrouted paths — strictly worse than not starting. It deserves its own focused PR with a real-Redis test suite.

Top of the stack: #1280 → #1281 → #1282 → #1283 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool calls and results can now be persisted in supported conversation memory backends, including in-memory storage.
  - Stored tool activity preserves execution order, identifiers, names, outputs, and success or error details.
  - Sessions are created automatically when needed, and new tool activity can be appended to existing sessions.

- **Tests**
  - Added coverage validating tool-storage behavior, ordering, serialization, error handling, and session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->