### PR TITLE
fix(core): append-only redis sessions and gemini loop guard coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "test:openai-compat-guard": "npx tsx test/continuous-test-suite-openai-compat-guard.ts",
     "test:anthropic-guard": "npx tsx test/continuous-test-suite-anthropic-guard.ts",
     "test:tool-storage-parity": "npx tsx test/continuous-test-suite-tool-storage-parity.ts",
+    "test:redis-append-only": "npx tsx test/continuous-test-suite-redis-append-only.ts",
+    "test:gemini-guard": "npx tsx test/continuous-test-suite-gemini-guard.ts",
     "test:middleware": "npx tsx test/continuous-test-suite-middleware.ts",
     "test:observability": "npx tsx test/continuous-test-suite-observability.ts",
     "test:ppt": "npx tsx test/continuous-test-suite-ppt.ts",

--- a/src/lib/context/contextCompactor.ts
+++ b/src/lib/context/contextCompactor.ts
@@ -282,6 +282,26 @@ export class ContextCompactor {
             durationMs: Date.now() - spanStartTime,
           });
 
+          // A compaction that was ASKED to reclaim and reclaimed nothing is the
+          // signature of a mis-aimed target: the caller decided the request was
+          // over budget, but every stage gate compared against a number that
+          // said otherwise, so the pipeline no-opped and the request went out
+          // oversized anyway. That is exactly how the history-budget defect hid
+          // in production — silently, because "Complete" looked healthy. Warn
+          // loudly and stamp the span so it is greppable and alertable.
+          const reclaimedNothing = stagesUsed.length === 0;
+          if (reclaimedNothing) {
+            logger.warn("[Compaction] No-op — invoked but reclaimed nothing", {
+              requestId,
+              tokensBefore,
+              targetTokens,
+              messageCount: currentMessages.length,
+            });
+          }
+          span = SpanSerializer.updateAttributes(span, {
+            "context.noop": reclaimedNothing,
+          });
+
           const result: CompactionResult = {
             compacted: stagesUsed.length > 0,
             stagesUsed,

--- a/src/lib/context/geminiLoopGuard.ts
+++ b/src/lib/context/geminiLoopGuard.ts
@@ -1,0 +1,178 @@
+/**
+ * In-turn context guard for Gemini-shaped agent loops (native Vertex + AI
+ * Studio + Gemini 3).
+ *
+ * These loops already had `createContextGuard`, but it is **stop-only**: once
+ * the projected prompt crosses the threshold it breaks the loop and synthesizes
+ * an answer from whatever it has. That avoids a provider rejection, but it also
+ * ends the turn early — the model stops doing work it was mid-way through.
+ *
+ * This module brings them to parity with the other loops: reclaim budget and
+ * CONTINUE, falling back to the existing stop only when reclaiming cannot get
+ * back under the line. The reclaim policy is shared with every other provider
+ * via `loopGuardCore`; this module owns only the Gemini shape mapping.
+ *
+ * Gemini history is `{ role, parts[] }`, where a part is a `functionCall`
+ * (tool invocation) or `functionResponse` (its result). One model turn can
+ * carry several `functionCall` parts and the following user turn carries the
+ * matching `functionResponse` parts, so the CONTENT is the batch unit —
+ * dropping a call turn together with its response turn can never orphan a part,
+ * which Gemini rejects.
+ */
+
+import type {
+  GeminiGuardContent,
+  LoopGuardEntry,
+  LoopGuardPlan,
+} from "../types/index.js";
+import {
+  estimateTokens,
+  TOKENS_PER_MESSAGE,
+} from "../utils/tokenEstimation.js";
+import { generateToolOutputPreview } from "./toolOutputLimits.js";
+import { planLoopGuardReclaim } from "./loopGuardCore.js";
+import { logger } from "../utils/logger.js";
+
+/** Preview budget for an old tool output. Matches the other loop guards. */
+const OLD_TOOL_OUTPUT_PREVIEW_BYTES = 2_048;
+const OLD_TOOL_OUTPUT_PREVIEW_LINES = 60;
+
+/** Marker left where dropped history used to be. */
+export const GEMINI_ELISION_NOTE =
+  "[Earlier tool exchanges were removed to fit the context window.]";
+
+/** Serialize any value for estimation. Never throws. */
+function toText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    // Past V8's string cap: enormous by definition, so charge a large fixed
+    // size rather than aborting the estimate and with it the turn.
+    return "x".repeat(200_000);
+  }
+}
+
+function hasPart(content: GeminiGuardContent, key: string): boolean {
+  return (
+    Array.isArray(content.parts) &&
+    content.parts.some(
+      (part) => part && typeof part === "object" && key in part,
+    )
+  );
+}
+
+/** True when this content carries tool results worth previewing. */
+export function isGeminiToolResponseContent(
+  content: GeminiGuardContent,
+): boolean {
+  return hasPart(content, "functionResponse");
+}
+
+/** Head/tail preview for an oversized tool response payload. */
+export function previewGeminiToolResponseText(text: string): string {
+  const { preview } = generateToolOutputPreview(text, {
+    maxBytes: OLD_TOOL_OUTPUT_PREVIEW_BYTES,
+    maxLines: OLD_TOOL_OUTPUT_PREVIEW_LINES,
+  });
+  return preview;
+}
+
+function contentTokens(content: GeminiGuardContent, provider?: string): number {
+  return estimateTokens(toText(content.parts), provider) + TOKENS_PER_MESSAGE;
+}
+
+/** Map Gemini history onto the neutral view the shared policy operates on. */
+function toEntries(
+  contents: readonly GeminiGuardContent[],
+  provider?: string,
+): LoopGuardEntry[] {
+  return contents.map((content) => {
+    const tokens = contentTokens(content, provider);
+    if (isGeminiToolResponseContent(content)) {
+      // Only advertise a preview when it actually saves something: an
+      // already-small response must fall through to stage 2 rather than look
+      // shrinkable and stall the reclaim.
+      const previewed = toText(content.parts);
+      const previewTokens =
+        previewed.length > OLD_TOOL_OUTPUT_PREVIEW_BYTES
+          ? estimateTokens(previewGeminiToolResponseText(previewed), provider) +
+            TOKENS_PER_MESSAGE
+          : tokens;
+      return {
+        kind: "toolResult" as const,
+        tokens,
+        ...(previewTokens < tokens ? { previewTokens } : {}),
+      };
+    }
+    if (hasPart(content, "functionCall")) {
+      return { kind: "toolCall" as const, tokens };
+    }
+    return { kind: "other" as const, tokens };
+  });
+}
+
+/**
+ * Decide what to reclaim from a Gemini agent loop.
+ *
+ * Returns `undefined` when the history still fits, in which case the caller
+ * must leave it byte-identical — any rewrite invalidates the provider's cached
+ * prefix, so "no change" has to mean no change.
+ */
+export function planGeminiLoopReclaim(args: {
+  contents: readonly GeminiGuardContent[];
+  availableInputTokens: number;
+  fixedOverheadTokens?: number;
+  provider?: string;
+  observedPromptTokens?: number;
+}): LoopGuardPlan | undefined {
+  const {
+    contents,
+    availableInputTokens,
+    fixedOverheadTokens = 0,
+    provider,
+    observedPromptTokens,
+  } = args;
+
+  const entries = toEntries(contents, provider);
+
+  let calibration = 1;
+  if (observedPromptTokens && observedPromptTokens > 0) {
+    const rawEstimate =
+      fixedOverheadTokens + entries.reduce((sum, e) => sum + e.tokens, 0);
+    if (rawEstimate > 0) {
+      // Clamped: real tokenizers run up to ~1.3x the char estimate on dense
+      // code, and an unbounded ratio would compact the loop into uselessness.
+      calibration = Math.min(
+        3,
+        Math.max(1, observedPromptTokens / rawEstimate),
+      );
+    }
+  }
+
+  const plan = planLoopGuardReclaim(entries, {
+    availableInputTokens,
+    fixedOverheadTokens,
+    calibration,
+  });
+
+  if (!plan.fire) {
+    return undefined;
+  }
+
+  logger.info("[GeminiLoopGuard] Reclaiming agent-loop context", {
+    provider,
+    contents: contents.length,
+    toolResponsesTruncated: plan.truncate.length,
+    contentsDropped: plan.drop.length,
+    projectedTokens: plan.projectedTokens,
+    calibration,
+  });
+
+  return plan;
+}

--- a/src/lib/core/redisConversationMemoryManager.ts
+++ b/src/lib/core/redisConversationMemoryManager.ts
@@ -39,6 +39,13 @@ import { logger } from "../utils/logger.js";
 import {
   createRedisClient,
   deserializeConversation,
+  encodeStoredMessages,
+  getSessionMessagesKey,
+  MESSAGES_KEY_SUFFIX,
+  isSessionMessagesKey,
+  parseStoredMessages,
+  serializeConversationMetadata,
+  usesSplitMessageStorage,
   getNormalizedConfig,
   getPooledRedisClient,
   getSessionKey,
@@ -229,8 +236,9 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
             redisClient.get(redisKey),
             REDIS_TIMEOUT_MS,
           );
-          const conversation = deserializeConversation(
-            conversationData || null,
+          const conversation = await this.hydrateMessages(
+            deserializeConversation(conversationData || null),
+            redisKey,
           );
           if (!conversation) {
             span.setAttribute("session.found", false);
@@ -329,7 +337,10 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
       }
       const redisKey = getSessionKey(this.redisConfig, sessionId, userId);
       const conversationData = await this.redisClient.get(redisKey);
-      return deserializeConversation(conversationData || null);
+      return this.hydrateMessages(
+        deserializeConversation(conversationData || null),
+        redisKey,
+      );
     } catch (error) {
       logger.error(
         "[RedisConversationMemoryManager] Failed to get raw session",
@@ -576,7 +587,16 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
             options.userId,
           );
           const conversationData = await this.redisClient.get(redisKey);
-          let conversation = deserializeConversation(conversationData);
+          let conversation = await this.hydrateMessages(
+            deserializeConversation(conversationData),
+            redisKey,
+          );
+          // Split-storage bookkeeping: whether this session already keeps its
+          // messages in the companion LIST, and how many it held before this
+          // turn — so only the new ones are appended rather than rewriting the
+          // whole conversation on every turn.
+          const wasSplitStorage = usesSplitMessageStorage(conversation);
+          const messageCountBeforeTurn = conversation?.messages.length ?? 0;
 
           const currentTime = new Date().toISOString();
           const normalizedUserId = options.userId || "randomUser";
@@ -759,11 +779,21 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
             }
           }
 
-          const serializedData = serializeConversation(conversation);
-          await this.redisClient.set(redisKey, serializedData);
+          // Append-only: push just this turn's messages and persist a SMALL
+          // metadata blob. A session not yet using split storage (new, or a
+          // legacy blob) is converted once here, then every later turn appends.
+          await this.persistConversation(
+            conversation,
+            options.sessionId,
+            options.userId,
+            wasSplitStorage ? messageCountBeforeTurn : undefined,
+          );
 
           // Log turn storage metadata for observability
-          const blobSizeBytes = Buffer.byteLength(serializedData, "utf8");
+          const blobSizeBytes = Buffer.byteLength(
+            serializeConversationMetadata(conversation),
+            "utf8",
+          );
           logger.info("[ConversationMemory] Turn stored", {
             requestId: options.requestId,
             sessionId: options.sessionId,
@@ -893,7 +923,16 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
                 conversation.summarizedMessage;
               latestConversation.lastTokenCount = conversation.lastTokenCount;
               latestConversation.lastCountedAt = conversation.lastCountedAt;
-              const freshSerialized = serializeConversation(latestConversation);
+              // Only summarization metadata changed, so the companion LIST is
+              // left alone. Critical: this re-read was NOT hydrated, so for a
+              // split session `messages` is empty — writing it with
+              // serializeConversation would drop the marker and make the record
+              // look like a legacy blob with zero messages (silent data loss).
+              const freshSerialized = usesSplitMessageStorage(
+                latestConversation,
+              )
+                ? serializeConversationMetadata(latestConversation)
+                : serializeConversation(latestConversation);
               await this.redisClient.set(redisKey, freshSerialized);
               if (this.redisConfig.ttl > 0) {
                 await this.redisClient.expire(redisKey, this.redisConfig.ttl);
@@ -909,6 +948,131 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
       });
     } finally {
       this.summarizationInProgress.delete(summarizationKey);
+    }
+  }
+
+  /**
+   * True only for keys holding a conversation BLOB — the sole key type these
+   * scan-then-GET paths may read.
+   *
+   * `${keyPrefix}*` also matches the companion message LISTs and, when a
+   * custom key prefix does not end in `conversation:`, the user-index SETs
+   * (whose derived prefix then collapses onto `keyPrefix`). `GET` against
+   * either raises WRONGTYPE, and counting them would inflate session totals.
+   */
+  private isConversationBlobKey(key: string): boolean {
+    return (
+      !isSessionMessagesKey(key) &&
+      !key.endsWith(":sessions") &&
+      !key.startsWith(this.redisConfig.userSessionsKeyPrefix)
+    );
+  }
+
+  /**
+   * Hydrate a deserialized blob's messages from the companion LIST when the
+   * session uses split storage. Legacy blobs (messages inline) pass through
+   * untouched — that is what makes the migration backward compatible.
+   */
+  private async hydrateMessages(
+    conversation: RedisConversationObject | null,
+    redisKey: string,
+  ): Promise<RedisConversationObject | null> {
+    if (!conversation || !usesSplitMessageStorage(conversation)) {
+      return conversation;
+    }
+    if (!this.redisClient) {
+      return conversation;
+    }
+    const entries = await this.redisClient.lRange(
+      `${redisKey}${MESSAGES_KEY_SUFFIX}`,
+      0,
+      -1,
+    );
+    // `lRange` is typed `(string | Buffer)[]` — the client returns Buffers when
+    // a connection is opened in binary mode. Normalize rather than assert, so
+    // a binary-mode client reads its history instead of throwing on parse.
+    conversation.messages = parseStoredMessages(
+      entries.map((entry) => entry.toString()),
+    );
+    return conversation;
+  }
+
+  /** Message count without materializing them — LLEN for split sessions. */
+  private async countMessages(
+    conversation: RedisConversationObject,
+    redisKey: string,
+  ): Promise<number> {
+    if (!usesSplitMessageStorage(conversation) || !this.redisClient) {
+      return conversation.messages.length;
+    }
+    // `lLen` is typed `number | \`${number}\`` (RESP3 can deliver it as a
+    // string), and callers add it to numbers — coerce so the count never
+    // concatenates instead of summing.
+    return Number(
+      await this.redisClient.lLen(`${redisKey}${MESSAGES_KEY_SUFFIX}`),
+    );
+  }
+
+  /** Load a session, messages included, regardless of storage format. */
+  private async loadConversation(
+    sessionId: string,
+    userId?: string,
+  ): Promise<RedisConversationObject | null> {
+    if (!this.redisClient) {
+      return null;
+    }
+    const redisKey = getSessionKey(this.redisConfig, sessionId, userId);
+    return this.hydrateMessages(
+      deserializeConversation(await this.redisClient.get(redisKey)),
+      redisKey,
+    );
+  }
+
+  /**
+   * Persist a conversation, splitting messages into the companion LIST.
+   * `appendFrom` appends only messages from that index onward (the per-turn
+   * fast path); omit it to rewrite the LIST wholesale, which is also how a
+   * legacy blob gets converted.
+   */
+  private async persistConversation(
+    conversation: RedisConversationObject,
+    sessionId: string,
+    userId: string | undefined,
+    appendFrom?: number,
+  ): Promise<void> {
+    if (!this.redisClient) {
+      return;
+    }
+    const redisKey = getSessionKey(this.redisConfig, sessionId, userId);
+    const messagesKey = getSessionMessagesKey(
+      this.redisConfig,
+      sessionId,
+      userId,
+    );
+    if (appendFrom === undefined) {
+      await this.redisClient.del(messagesKey);
+      if (conversation.messages.length > 0) {
+        await this.redisClient.rPush(
+          messagesKey,
+          encodeStoredMessages(conversation.messages),
+        );
+      }
+    } else {
+      const appended = conversation.messages.slice(appendFrom);
+      if (appended.length > 0) {
+        await this.redisClient.rPush(
+          messagesKey,
+          encodeStoredMessages(appended),
+        );
+      }
+    }
+    await this.redisClient.set(
+      redisKey,
+      serializeConversationMetadata(conversation),
+    );
+    if (this.redisConfig.ttl > 0) {
+      await this.redisClient.expire(redisKey, this.redisConfig.ttl);
+      await this.redisClient.expire(messagesKey, this.redisConfig.ttl);
     }
   }
 
@@ -963,8 +1127,9 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
             redisClient.get(redisKey),
             REDIS_TIMEOUT_MS,
           );
-          const conversation = deserializeConversation(
-            conversationData || null,
+          const conversation = await this.hydrateMessages(
+            deserializeConversation(conversationData || null),
+            redisKey,
           );
 
           logger.debug(
@@ -1284,7 +1449,10 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
       }
 
       // Deserialize the complete conversation object
-      const conversation = deserializeConversation(conversationData);
+      const conversation = await this.hydrateMessages(
+        deserializeConversation(conversationData),
+        sessionKey,
+      );
       if (!conversation) {
         logger.debug(
           "[RedisConversationMemoryManager] Failed to deserialize conversation data",
@@ -1444,7 +1612,10 @@ User message: "${userMessage}"`;
     try {
       const redisKey = getSessionKey(this.redisConfig, sessionId, userId);
       const conversationData = await this.redisClient.get(redisKey);
-      const conversation = deserializeConversation(conversationData || null);
+      const conversation = await this.hydrateMessages(
+        deserializeConversation(conversationData || null),
+        redisKey,
+      );
       return conversation?.messages ?? [];
     } catch (error) {
       logger.error(
@@ -1499,12 +1670,8 @@ User message: "${userMessage}"`;
       conversation.lastTokenCount = undefined;
       conversation.lastCountedAt = undefined;
 
-      const serializedData = serializeConversation(conversation);
-      await this.redisClient.set(redisKey, serializedData);
-
-      if (this.redisConfig.ttl > 0) {
-        await this.redisClient.expire(redisKey, this.redisConfig.ttl);
-      }
+      // Wholesale replacement: rewrite the LIST rather than appending.
+      await this.persistConversation(conversation, sessionId, userId);
 
       logger.debug(
         "[RedisConversationMemoryManager] Session messages replaced",
@@ -1563,12 +1730,21 @@ User message: "${userMessage}"`;
       },
     );
 
+    // Companion message LISTs share the session key prefix, so the SCAN above
+    // returns them too. GET on a LIST raises WRONGTYPE, and counting them as
+    // sessions would double `totalSessions` — filter them out exactly as the
+    // session listing already skips `:sessions` index keys.
+    const sessionKeys = keys.filter((key) => this.isConversationBlobKey(key));
+
     // Count messages in each session
     let totalTurns = 0;
 
-    for (const key of keys) {
+    for (const key of sessionKeys) {
       const conversationData = await this.redisClient.get(key);
-      const conversation = deserializeConversation(conversationData);
+      const conversation = await this.hydrateMessages(
+        deserializeConversation(conversationData),
+        key,
+      );
       if (conversation?.messages) {
         // Pinned skill messages are extra rows inside a turn — exclude them
         // so a skill-activating turn still counts as one turn.
@@ -1580,7 +1756,7 @@ User message: "${userMessage}"`;
     }
 
     return {
-      totalSessions: keys.length,
+      totalSessions: sessionKeys.length,
       totalTurns,
     };
   }
@@ -1612,8 +1788,10 @@ User message: "${userMessage}"`;
       async (span) => {
         try {
           const redisKey = getSessionKey(this.redisConfig, sessionId, userId);
+          // Delete the companion message LIST as well: leaving it behind would
+          // leak the messages and let a re-created session inherit them.
           const result = await withTimeout(
-            redisClient.del(redisKey),
+            redisClient.del([redisKey, `${redisKey}${MESSAGES_KEY_SUFFIX}`]),
             REDIS_TIMEOUT_MS,
           );
 
@@ -1842,8 +2020,9 @@ User message: "${userMessage}"`;
         `${this.redisConfig.keyPrefix}*`,
       );
       for (const key of keys) {
-        // Skip user session index keys (they end with :sessions)
-        if (key.endsWith(":sessions")) {
+        // Skip user session index keys (they end with :sessions) and the
+        // companion message LISTs — GET on a LIST raises WRONGTYPE.
+        if (!this.isConversationBlobKey(key)) {
           continue;
         }
         const raw = await this.redisClient.get(key);
@@ -1860,7 +2039,9 @@ User message: "${userMessage}"`;
           createdAt: session.createdAt,
           updatedAt: session.updatedAt,
           userId: session.userId,
-          messageCount: session.messages.length,
+          // LLEN for split sessions: the blob's inline array is empty here
+          // because this branch reads the raw key without hydrating.
+          messageCount: await this.countMessages(session, key),
           lastActive: this.formatTimeAgo(
             now - new Date(session.updatedAt).getTime(),
           ),
@@ -2200,8 +2381,12 @@ User message: "${userMessage}"`;
 
       conversation.updatedAt = new Date().toISOString();
 
-      // Write back to Redis
-      const serializedData = serializeConversation(conversation);
+      // Write back to Redis. Metadata-only change, so the companion LIST is
+      // untouched — but the split marker must survive (see the summarization
+      // writeback above for why dropping it loses messages).
+      const serializedData = usesSplitMessageStorage(conversation)
+        ? serializeConversationMetadata(conversation)
+        : serializeConversation(conversation);
       await withTimeout(this.redisClient.set(redisKey, serializedData), 5000);
 
       if (this.redisConfig.ttl > 0) {

--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -45,6 +45,12 @@ import {
 import { ERROR_CODES, NeuroLinkError } from "../../utils/errorHandling.js";
 import { logger } from "../../utils/logger.js";
 import {
+  GEMINI_ELISION_NOTE,
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+} from "../../context/geminiLoopGuard.js";
+import { getAvailableInputTokens } from "../../constants/contextWindows.js";
+import {
   composeAbortSignals,
   createTimeoutController,
   TimeoutError,
@@ -133,6 +139,86 @@ async function createGoogleGenAIClient(apiKey: string): Promise<GenAIClient> {
  * @note "Too many states for serving" errors can occur with complex schemas + tools.
  *       Solution: Simplify schema or use disableTools: true
  */
+
+/**
+ * Reclaim context from an AI Studio loop history IN PLACE.
+ *
+ * This loop had NO in-turn guard at all — it appended a model turn plus a tool
+ * turn every step with nothing bounding growth, so a long agentic run walked
+ * into a provider "context length exceeded" and lost every completed step.
+ * Shares its reclaim policy with the other provider loops via loopGuardCore.
+ *
+ * Returns true when something was reclaimed.
+ */
+function reclaimAiStudioContext(
+  contents: Array<{ role: string; parts: unknown[] }>,
+  modelName: string,
+): boolean {
+  const plan = planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: getAvailableInputTokens("googleAiStudio", modelName),
+    provider: "googleAiStudio",
+  });
+  if (!plan) {
+    return false;
+  }
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: Array<{ role: string; parts: unknown[] }> = [];
+  for (let i = 0; i < contents.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const content = contents[i];
+    if (truncateSet.has(i) && Array.isArray(content.parts)) {
+      rebuilt.push({
+        ...content,
+        parts: content.parts.map((part) => {
+          const record = part as {
+            functionResponse?: { name?: string; response?: unknown };
+          };
+          if (!record.functionResponse) {
+            return part;
+          }
+          const text = JSON.stringify(record.functionResponse.response) ?? "";
+          if (text.length <= 2048) {
+            return part;
+          }
+          return {
+            functionResponse: {
+              name: record.functionResponse.name,
+              response: { result: previewGeminiToolResponseText(text) },
+            },
+          };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(content);
+  }
+  if (dropSet.size > 0) {
+    let noteIndex = rebuilt.findIndex(
+      (c) =>
+        Array.isArray(c.parts) &&
+        c.parts.some(
+          (part) =>
+            !!(part as { functionCall?: unknown }).functionCall ||
+            !!(part as { functionResponse?: unknown }).functionResponse,
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      parts: [{ text: GEMINI_ELISION_NOTE }],
+    });
+  }
+  contents.length = 0;
+  contents.push(...rebuilt);
+  return true;
+}
+
 export class GoogleAIStudioProvider extends BaseProvider {
   private credentials?: { apiKey?: string };
 
@@ -846,6 +932,11 @@ export class GoogleAIStudioProvider extends BaseProvider {
             try {
               // Agentic loop for tool calling
               while (step < maxSteps) {
+                // In-turn context guard: this loop appends a model turn plus a
+                // tool turn every step with nothing bounding growth. No-op
+                // while the request still fits, so a loop that fits never pays
+                // a cache invalidation.
+                reclaimAiStudioContext(currentContents, modelName);
                 if (composedSignal?.aborted) {
                   throw composedSignal.reason instanceof Error
                     ? composedSignal.reason
@@ -1255,6 +1346,8 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Agentic loop for tool calling
           while (step < maxSteps) {
+            // In-turn context guard — see the stream twin.
+            reclaimAiStudioContext(currentContents, modelName);
             if (composedSignal?.aborted) {
               throw composedSignal.reason instanceof Error
                 ? composedSignal.reason

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -1632,6 +1632,18 @@ export function createContextGuard(
         projectedGrowthTokens += Math.ceil(chars / 4);
       }
     },
+    /**
+     * Clear the projection after the caller has reclaimed context.
+     *
+     * The observed prompt size reflects the pre-reclaim conversation, so
+     * leaving it in place would keep `shouldStop()` true forever and defeat
+     * the reclaim. Resetting to the fail-open state means the guard stays
+     * quiet until the next real usage report re-establishes the truth.
+     */
+    resetAfterReclaim(): void {
+      observedPromptTokens = 0;
+      projectedGrowthTokens = 0;
+    },
     /** True when issuing another model call risks crossing the threshold. */
     shouldStop(): boolean {
       return (

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -66,6 +66,16 @@ import {
 } from "../../utils/messageBuilder.js";
 import { logger } from "../../utils/logger.js";
 import {
+  GEMINI_ELISION_NOTE,
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+} from "../../context/geminiLoopGuard.js";
+import {
+  ANTHROPIC_ELISION_NOTE,
+  planAnthropicLoopReclaim,
+  previewAnthropicToolResultText,
+} from "../../context/anthropicLoopGuard.js";
+import {
   hasRestrictedOutputLimit,
   RESTRICTED_OUTPUT_TOKEN_LIMIT,
   toVertexAnthropicModelId,
@@ -789,6 +799,163 @@ const isAnthropicModel = (modelName: string): boolean => {
  *       Solution: Simplify schema or reduce number of tools if this occurs.
  * @see https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
  */
+
+/** Byte budget above which an old tool response is previewed, not kept whole. */
+const TOOL_RESPONSE_PREVIEW_BYTES = 2048;
+
+/**
+ * Reclaim context from a Gemini-shaped loop history IN PLACE.
+ *
+ * Returns true when something was actually reclaimed, which tells the caller
+ * it is safe to continue the loop instead of stopping. Mutates `contents` so
+ * the caller's array identity (captured by the request builder) stays valid.
+ */
+function reclaimVertexLoopContext(
+  contents: Array<{ role: string; parts: VertexNativeLoopPart[] }>,
+  modelName: string,
+  observedPromptTokens: number,
+): boolean {
+  const plan = planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: getContextWindowSize("vertex", modelName),
+    provider: "vertex",
+    observedPromptTokens,
+  });
+  if (!plan) {
+    return false;
+  }
+
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: Array<{ role: string; parts: VertexNativeLoopPart[] }> = [];
+  for (let i = 0; i < contents.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const content = contents[i];
+    if (truncateSet.has(i) && Array.isArray(content.parts)) {
+      rebuilt.push({
+        ...content,
+        parts: content.parts.map((part): VertexNativeLoopPart => {
+          if (!("functionResponse" in part)) {
+            return part;
+          }
+          const fn = part.functionResponse;
+          const text = JSON.stringify(fn.response) ?? "";
+          if (text.length <= TOOL_RESPONSE_PREVIEW_BYTES) {
+            return part;
+          }
+          // Rebuilt rather than cast: `functionResponse` requires `name`, and
+          // Critical Rule 14 forbids casting through `unknown` to paper over it.
+          return {
+            functionResponse: {
+              name: fn.name,
+              response: { result: previewGeminiToolResponseText(text) },
+            },
+          };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(content);
+  }
+
+  if (dropSet.size > 0) {
+    // Gemini requires the history to start with a user turn; the note is
+    // inserted before the first surviving tool turn, never at the end where a
+    // "history was removed" cue would follow the content it refers to.
+    let noteIndex = rebuilt.findIndex(
+      (c) =>
+        Array.isArray(c.parts) &&
+        c.parts.some(
+          (part) =>
+            !!(part as { functionCall?: unknown }).functionCall ||
+            !!(part as { functionResponse?: unknown }).functionResponse,
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      parts: [{ text: GEMINI_ELISION_NOTE } as VertexNativeLoopPart],
+    });
+  }
+
+  contents.length = 0;
+  contents.push(...rebuilt);
+  return true;
+}
+
+/**
+ * Reclaim context from a Vertex+Claude loop history IN PLACE.
+ *
+ * Same parity upgrade as the Gemini path, but this loop carries Anthropic
+ * content blocks, so it reuses the Anthropic adapter. Returns true when
+ * something was reclaimed and the loop may continue.
+ */
+function reclaimVertexAnthropicContext(
+  messages: VertexAnthropicMessage[],
+  modelName: string,
+  observedPromptTokens: number,
+): boolean {
+  const plan = planAnthropicLoopReclaim({
+    conversation: messages,
+    availableInputTokens: getContextWindowSize("vertex", modelName),
+    fixedOverheadTokens: 0,
+    provider: "vertex",
+    observedPromptTokens,
+  });
+  if (!plan) {
+    return false;
+  }
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: VertexAnthropicMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const message = messages[i];
+    if (truncateSet.has(i) && Array.isArray(message.content)) {
+      rebuilt.push({
+        ...message,
+        content: message.content.map((block) => {
+          if (block.type !== "tool_result") {
+            return block;
+          }
+          const text =
+            typeof block.content === "string"
+              ? block.content
+              : (JSON.stringify(block.content) ?? "");
+          return { ...block, content: previewAnthropicToolResultText(text) };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(message);
+  }
+  if (dropSet.size > 0) {
+    let noteIndex = rebuilt.findIndex(
+      (m) =>
+        Array.isArray(m.content) &&
+        m.content.some(
+          (b) => b.type === "tool_use" || b.type === "tool_result",
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      content: [{ type: "text", text: ANTHROPIC_ELISION_NOTE }],
+    });
+  }
+  messages.length = 0;
+  messages.push(...rebuilt);
+  return true;
+}
+
 export class GoogleVertexProvider extends BaseProvider {
   private projectId: string;
   private location: string;
@@ -2131,13 +2298,27 @@ export class GoogleVertexProvider extends BaseProvider {
         // conversation crosses the window threshold — synthesize from what
         // we have instead of stepping into a provider rejection.
         if (contextGuard.shouldStop()) {
-          hitContextLimit = true;
-          logger.warn(
-            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          // Parity upgrade: try to RECLAIM budget and keep going before
+          // falling back to the historic stop-only behaviour. Ending the turn
+          // early is safe but throws away work the model was mid-way through;
+          // dropping the oldest complete tool exchanges usually buys enough
+          // room to finish. Only when reclaiming changes nothing do we stop.
+          const reclaimed = reclaimVertexLoopContext(
+            currentContents,
+            modelName,
+            contextGuard.projectedNextPromptTokens,
           );
-          break;
+          if (reclaimed) {
+            contextGuard.resetAfterReclaim();
+          } else {
+            hitContextLimit = true;
+            logger.warn(
+              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            );
+            break;
+          }
         }
         step++;
         turnClock.noteProgress();
@@ -3381,13 +3562,27 @@ export class GoogleVertexProvider extends BaseProvider {
         // conversation crosses the window threshold — synthesize from what
         // we have instead of stepping into a provider rejection.
         if (contextGuard.shouldStop()) {
-          hitContextLimit = true;
-          logger.warn(
-            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          // Parity upgrade: try to RECLAIM budget and keep going before
+          // falling back to the historic stop-only behaviour. Ending the turn
+          // early is safe but throws away work the model was mid-way through;
+          // dropping the oldest complete tool exchanges usually buys enough
+          // room to finish. Only when reclaiming changes nothing do we stop.
+          const reclaimed = reclaimVertexLoopContext(
+            currentContents,
+            modelName,
+            contextGuard.projectedNextPromptTokens,
           );
-          break;
+          if (reclaimed) {
+            contextGuard.resetAfterReclaim();
+          } else {
+            hitContextLimit = true;
+            logger.warn(
+              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            );
+            break;
+          }
         }
         step++;
         turnClock.noteProgress();
@@ -4837,13 +5032,24 @@ export class GoogleVertexProvider extends BaseProvider {
           // Context guard: stop the tool loop before the accumulated
           // conversation crosses the window threshold (see generate twin).
           if (contextGuard.shouldStop()) {
-            hitContextLimit = true;
-            logger.warn(
-              `[GoogleVertex] Anthropic stream turn stopped by the context guard: ` +
-                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            // Parity upgrade: reclaim and continue where possible; the
+            // historic stop-only behaviour remains the fallback.
+            const reclaimed = reclaimVertexAnthropicContext(
+              currentMessages,
+              modelName,
+              contextGuard.projectedNextPromptTokens,
             );
-            break;
+            if (reclaimed) {
+              contextGuard.resetAfterReclaim();
+            } else {
+              hitContextLimit = true;
+              logger.warn(
+                `[GoogleVertex] Anthropic stream turn stopped by the context guard: ` +
+                  `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                  `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+              );
+              break;
+            }
           }
           step++;
           turnClock.noteProgress();
@@ -6417,13 +6623,22 @@ export class GoogleVertexProvider extends BaseProvider {
       // this step's appended tool results/output) would cross the window
       // threshold — stop the tool loop and synthesize from what we have.
       if (contextGuard.shouldStop()) {
-        hitContextLimit = true;
-        logger.warn(
-          `[GoogleVertex] Anthropic generate turn stopped by the context guard: ` +
-            `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-            `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+        const reclaimed = reclaimVertexAnthropicContext(
+          currentMessages,
+          modelName,
+          contextGuard.projectedNextPromptTokens,
         );
-        break;
+        if (reclaimed) {
+          contextGuard.resetAfterReclaim();
+        } else {
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Anthropic generate turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          );
+          break;
+        }
       }
       step++;
       turnClock.noteProgress();

--- a/src/lib/types/context.ts
+++ b/src/lib/types/context.ts
@@ -923,6 +923,16 @@ export type AnthropicGuardMessage = {
   content: string | AnthropicGuardBlock[];
 };
 
+/**
+ * Structural view of one Gemini history entry, loose enough to accept both the
+ * native Vertex loop's `{ role, parts }` array and `@google/genai` contents
+ * without a cast at either call site.
+ */
+export type GeminiGuardContent = {
+  role: string;
+  parts: unknown[];
+};
+
 /** Tuning for {@link planLoopGuardReclaim}. */
 export type LoopGuardPolicy = {
   availableInputTokens: number;

--- a/src/lib/utils/redis.ts
+++ b/src/lib/utils/redis.ts
@@ -499,3 +499,91 @@ export function getNormalizedConfig(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Split message storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Suffix of the companion LIST key holding a session's messages.
+ *
+ * Every `storeConversationTurn` used to re-serialize and SET the ENTIRE
+ * conversation, so per-turn write cost grew with history size. Measured
+ * against local Redis: 200 turns of 2KB messages stayed flat at 2ms, but 400
+ * turns of 20KB messages (~16MB blob) went 2ms -> 61ms, a 30x degradation on
+ * exactly the agentic tool-output profile. Splitting messages into an
+ * append-only LIST makes the per-turn write O(1) in conversation size.
+ */
+export const MESSAGES_KEY_SUFFIX = ":msgs";
+
+/**
+ * Marker on a stored blob meaning "messages live in the companion LIST".
+ * A blob WITHOUT it is a legacy record whose inline `messages` array is
+ * authoritative — it is read as-is and converted on its next write, which is
+ * what makes this migration backward compatible.
+ */
+export const MESSAGES_IN_LIST_MARKER = "__nlMessagesInList";
+
+/** Redis key holding a session's messages as an append-only LIST. */
+export function getSessionMessagesKey(
+  config: Required<RedisStorageConfig>,
+  sessionId: string,
+  userId?: string,
+): string {
+  return `${getSessionKey(config, sessionId, userId)}${MESSAGES_KEY_SUFFIX}`;
+}
+
+/**
+ * True for a companion messages LIST key.
+ *
+ * Scan-then-GET paths (`getStats`, session listing) match `${keyPrefix}*`, so
+ * they now also see these LIST keys — and `GET` on a LIST raises WRONGTYPE.
+ * They must filter with this, exactly as they already skip `:sessions` index
+ * keys.
+ */
+export function isSessionMessagesKey(key: string): boolean {
+  return key.endsWith(MESSAGES_KEY_SUFFIX);
+}
+
+/** Serialize the conversation WITHOUT its messages, flagged for split reads. */
+export function serializeConversationMetadata(
+  conversation: RedisConversationObject,
+): string {
+  return JSON.stringify({
+    ...conversation,
+    messages: [],
+    [MESSAGES_IN_LIST_MARKER]: true,
+  });
+}
+
+/** True when a deserialized blob's messages live in the companion LIST. */
+export function usesSplitMessageStorage(
+  conversation: RedisConversationObject | null | undefined,
+): boolean {
+  if (!conversation) {
+    return false;
+  }
+  const record: Record<string, unknown> = conversation;
+  return record[MESSAGES_IN_LIST_MARKER] === true;
+}
+
+/** Parse LRANGE entries, skipping any single entry that fails to parse. */
+export function parseStoredMessages(entries: string[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  for (const entry of entries) {
+    try {
+      messages.push(JSON.parse(entry) as ChatMessage);
+    } catch (error) {
+      // One corrupt entry must not destroy a whole session's history.
+      logger.warn("[redisUtils] Skipping unparseable stored message", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return messages;
+}
+
+/** Encode messages for RPUSH. */
+export function encodeStoredMessages(messages: ChatMessage[]): string[] {
+  return messages.map((message) => JSON.stringify(message));
+}

--- a/test/continuous-test-suite-gemini-guard.ts
+++ b/test/continuous-test-suite-gemini-guard.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Gemini loop guard adapter
+ *
+ * The native Vertex and AI Studio loops keep history as `{ role, parts[] }`,
+ * where a part is a `functionCall` (tool invocation) or `functionResponse`
+ * (its result). Vertex already had `createContextGuard`, but it is STOP-ONLY:
+ * it breaks the loop and synthesizes from whatever it has, ending the turn
+ * early. AI Studio had no guard at all.
+ *
+ * Both now reclaim and continue via the shared policy, falling back to the
+ * historic stop only when reclaiming changes nothing.
+ *
+ * The reclaim POLICY is tested in continuous-test-suite-loop-guard-core.ts.
+ * This suite covers the Gemini SHAPE MAPPING and the decision boundary.
+ *
+ * No API keys, no network, no LLM — pure function assertions.
+ *
+ * Run: npx tsx test/continuous-test-suite-gemini-guard.ts
+ *      pnpm run test:gemini-guard
+ */
+
+import {
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+  isGeminiToolResponseContent,
+} from "../src/lib/context/geminiLoopGuard.js";
+import type { GeminiGuardContent } from "../src/lib/types/index.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Gemini loop guard");
+
+/**
+ * NOTE: assertion messages must NEVER interpolate payloads — the harness
+ * downgrades a throw to SKIP when the text matches `isExpectedProviderError()`,
+ * silently turning a failure into ⊘.
+ */
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+/** One agent step in Gemini shape: a model call turn, then a user result turn. */
+function step(i: number, outputChars: number): GeminiGuardContent[] {
+  return [
+    {
+      role: "model",
+      parts: [
+        { functionCall: { name: "read_file", args: { path: `/f${i}` } } },
+      ],
+    },
+    {
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            name: "read_file",
+            response: { result: "x".repeat(outputChars) },
+          },
+        },
+      ],
+    },
+  ];
+}
+
+const plan = (contents: GeminiGuardContent[], observedPromptTokens?: number) =>
+  planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: 100_000,
+    provider: "vertex",
+    ...(observedPromptTokens !== undefined ? { observedPromptTokens } : {}),
+  });
+
+await runSuite(async () => {
+  section("A loop that fits must be left alone");
+
+  await test("short history returns undefined", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hello" }] },
+      ...step(1, 200),
+    ];
+    assert(plan(contents) === undefined, "guard acted on a history that fits");
+  });
+
+  await test("text-only history returns undefined", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hi" }] },
+      { role: "model", parts: [{ text: "hello" }] },
+    ];
+    assert(plan(contents) === undefined, "guard acted on a text-only history");
+  });
+
+  section("Part classification");
+
+  await test("functionResponse turns are recognised", async () => {
+    const [callTurn, resultTurn] = step(1, 100);
+    assert(
+      isGeminiToolResponseContent(resultTurn),
+      "a functionResponse turn was not recognised",
+    );
+    assert(
+      !isGeminiToolResponseContent(callTurn),
+      "a functionCall turn was misread as a response",
+    );
+  });
+
+  await test("a text-only turn is not a tool turn", async () => {
+    assert(
+      !isGeminiToolResponseContent({ role: "user", parts: [{ text: "hi" }] }),
+      "a plain text turn was misread as a tool response",
+    );
+  });
+
+  section("Reclaim decisions");
+
+  await test("fires and never proposes the first turn", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "THE ORIGINAL TASK" }] },
+    ];
+    for (let i = 0; i < 60; i++) {
+      contents.push(...step(i, 30_000));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire on an over-budget loop");
+    assert(!result!.drop.includes(0), "guard proposed dropping the task turn");
+    assert(
+      !result!.truncate.includes(0),
+      "guard proposed editing the task turn",
+    );
+  });
+
+  await test("dropped indices cover whole call/response pairs", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire");
+    const dropped = new Set(result!.drop);
+    const survivors = contents.filter((_, i) => !dropped.has(i));
+
+    // Gemini rejects a functionResponse with no preceding functionCall.
+    let openCalls = 0;
+    let orphans = 0;
+    for (const content of survivors) {
+      const hasCall = content.parts.some(
+        (p) => !!(p as { functionCall?: unknown }).functionCall,
+      );
+      const hasResp = content.parts.some(
+        (p) => !!(p as { functionResponse?: unknown }).functionResponse,
+      );
+      if (hasCall) {
+        openCalls++;
+      }
+      if (hasResp) {
+        if (openCalls === 0) {
+          orphans++;
+        } else {
+          openCalls--;
+        }
+      }
+    }
+    assert(orphans === 0, "a dropped batch left an orphaned functionResponse");
+    assert(openCalls === 0, "a dropped batch left a functionCall unanswered");
+  });
+
+  await test("small responses force drops rather than stalling", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire");
+    assert(
+      result!.drop.length > 0,
+      "guard proposed no drops where truncation cannot help",
+    );
+  });
+
+  await test("reclaim converges below the low-water mark", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents)!;
+    assert(
+      result.projectedTokens <= 100_000 * 0.6,
+      "reclaim did not reach the low-water mark",
+    );
+  });
+
+  section("Preview helper");
+
+  await test("oversized text shrinks, small text is untouched", async () => {
+    const small = "short";
+    assert(
+      previewGeminiToolResponseText(small) === small,
+      "small response was rewritten",
+    );
+    const large = "y".repeat(50_000);
+    const preview = previewGeminiToolResponseText(large);
+    assert(preview.length < large.length, "large response was not shrunk");
+    assert(preview.length > 0, "preview collapsed to nothing");
+  });
+
+  section("Usage calibration");
+
+  await test("a zero observed prompt count is ignored safely", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hi" }] },
+      ...step(1, 100),
+    ];
+    assert(
+      plan(contents, 0) === undefined,
+      "zero observed tokens perturbed the decision",
+    );
+  });
+
+  await test("a higher observed count makes the guard no less eager", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 20; i++) {
+      contents.push(...step(i, 12_000));
+    }
+    const plain = plan(contents);
+    const calibrated = plan(contents, 300_000);
+    assert(
+      plain === undefined || calibrated !== undefined,
+      "calibration made the guard less eager than the raw estimate",
+    );
+  });
+});

--- a/test/continuous-test-suite-redis-append-only.ts
+++ b/test/continuous-test-suite-redis-append-only.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Redis append-only message storage
+ *
+ * `storeConversationTurn` used to re-serialize and SET the ENTIRE conversation
+ * every turn, so per-turn write cost grew with history size. Measured against
+ * local Redis: 200 turns of 2KB messages stayed flat at 2ms, but 400 turns of
+ * 20KB messages (~16MB blob) went 2ms -> 61ms — a 30x degradation on exactly
+ * the agentic tool-output profile.
+ *
+ * Messages now live in an append-only companion LIST (`<key>:msgs`) while the
+ * blob keeps only metadata, flagged with a marker. A blob WITHOUT the marker is
+ * a legacy record whose inline messages are authoritative — read as-is and
+ * converted on its next write. That is the backward-compatibility contract this
+ * suite pins.
+ *
+ * Requires a local Redis on 127.0.0.1:6379; SKIPs cleanly when unavailable.
+ *
+ * Run: npx tsx test/continuous-test-suite-redis-append-only.ts
+ *      pnpm run test:redis-append-only
+ */
+
+import { createClient } from "redis";
+import { RedisConversationMemoryManager } from "../src/lib/core/redisConversationMemoryManager.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Redis append-only storage");
+
+/**
+ * NOTE: assertion messages must NEVER interpolate message content — the
+ * harness downgrades a throw to SKIP when the text matches
+ * `isExpectedProviderError()`, silently turning a failure into ⊘.
+ */
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const HOST = "127.0.0.1";
+const PORT = 6379;
+const PREFIX = `nltest:${Date.now()}:conversation:`;
+const USER = "u1";
+
+const raw = createClient({ socket: { host: HOST, port: PORT } });
+let redisUp = false;
+try {
+  await raw.connect();
+  await raw.ping();
+  redisUp = true;
+} catch {
+  redisUp = false;
+}
+
+function newManager(): RedisConversationMemoryManager {
+  return new RedisConversationMemoryManager(
+    {
+      enabled: true,
+      maxSessions: 50,
+      maxTurnsPerSession: 1000,
+      enableSummarization: false,
+    },
+    { host: HOST, port: PORT, keyPrefix: PREFIX, ttl: 300 },
+  );
+}
+
+async function storeTurns(
+  mgr: RedisConversationMemoryManager,
+  sessionId: string,
+  count: number,
+  body = "body",
+): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await mgr.storeConversationTurn({
+      sessionId,
+      userId: USER,
+      userMessage: `q${i} ${body}`,
+      aiResponse: `a${i} ${body}`,
+      enableSummarization: false,
+    });
+  }
+}
+
+const sessionKey = (sessionId: string): string =>
+  `${PREFIX}${USER}:${sessionId}`;
+
+await runSuite(async () => {
+  if (!redisUp) {
+    await test("redis reachable", async () => {
+      throw new Error("SKIP: no local Redis on 6379");
+    });
+    return;
+  }
+
+  section("Messages move to an append-only LIST");
+
+  await test("blob holds no messages, LIST holds them all", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-split";
+    await storeTurns(mgr, sid, 3);
+
+    const blob = JSON.parse((await raw.get(sessionKey(sid))) ?? "{}");
+    const listLen = await raw.lLen(`${sessionKey(sid)}:msgs`);
+    assert(blob.messages.length === 0, "metadata blob still carries messages");
+    assert(listLen === 6, "companion LIST does not hold every message");
+    await mgr.close();
+  });
+
+  await test("reads return the full history", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-read";
+    await storeTurns(mgr, sid, 4);
+    const messages = await mgr.getSessionMessages(sid, USER);
+    assert(messages.length === 8, "read path lost messages");
+    assert(
+      messages[0].role === "user" && messages[1].role === "assistant",
+      "message ordering was not preserved",
+    );
+    await mgr.close();
+  });
+
+  await test("buildContextMessages sees the split history", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-ctx";
+    await storeTurns(mgr, sid, 3);
+    const ctx = await mgr.buildContextMessages(sid, USER);
+    assert(ctx.length === 6, "context builder lost split messages");
+    await mgr.close();
+  });
+
+  section("Backward compatibility with legacy blobs");
+
+  await test("a legacy inline-messages blob is read correctly", async () => {
+    const sid = "s-legacy";
+    // Exactly the pre-migration on-disk shape: messages inline, no marker.
+    await raw.set(
+      sessionKey(sid),
+      JSON.stringify({
+        sessionId: sid,
+        userId: USER,
+        title: "legacy",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messages: [
+          { id: "m1", role: "user", content: "old q" },
+          { id: "m2", role: "assistant", content: "old a" },
+        ],
+      }),
+    );
+    const mgr = newManager();
+    await mgr.initialize();
+    const messages = await mgr.getSessionMessages(sid, USER);
+    assert(messages.length === 2, "legacy blob messages were not read");
+    assert(messages[0].content === "old q", "legacy message content was lost");
+    await mgr.close();
+  });
+
+  await test("a legacy blob converts on its next write, losing nothing", async () => {
+    const sid = "s-migrate";
+    await raw.set(
+      sessionKey(sid),
+      JSON.stringify({
+        sessionId: sid,
+        userId: USER,
+        title: "legacy",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messages: [
+          { id: "m1", role: "user", content: "old q" },
+          { id: "m2", role: "assistant", content: "old a" },
+        ],
+      }),
+    );
+    const mgr = newManager();
+    await mgr.initialize();
+    await storeTurns(mgr, sid, 1);
+
+    const listLen = await raw.lLen(`${sessionKey(sid)}:msgs`);
+    assert(listLen === 4, "conversion did not carry the legacy messages over");
+    const messages = await mgr.getSessionMessages(sid, USER);
+    assert(messages.length === 4, "history was lost during conversion");
+    assert(
+      messages[0].content === "old q",
+      "oldest legacy message was dropped",
+    );
+    await mgr.close();
+  });
+
+  section("Scan-based paths must not trip on the LIST keys");
+
+  await test("getStats does not double-count or hit WRONGTYPE", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    await storeTurns(mgr, "s-stats-1", 2);
+    await storeTurns(mgr, "s-stats-2", 2);
+    const stats = await mgr.getStats();
+    assert(stats.totalSessions >= 2, "session count collapsed after the split");
+    // The companion LIST keys must not be counted as sessions.
+    const allKeys = await raw.keys(`${PREFIX}*`);
+    const msgKeys = allKeys.filter((k) => k.endsWith(":msgs"));
+    assert(msgKeys.length > 0, "test did not actually create LIST keys");
+    assert(
+      stats.totalSessions === allKeys.length - msgKeys.length,
+      "message LIST keys were counted as sessions",
+    );
+    await mgr.close();
+  });
+
+  await test("listSessions reports a real message count", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-list";
+    await storeTurns(mgr, sid, 3);
+    const sessions = await mgr.listSessions();
+    const entry = sessions.find((s) => s.id === sid);
+    assert(entry !== undefined, "split session missing from the listing");
+    assert(entry!.messageCount === 6, "listing reported a stale message count");
+    await mgr.close();
+  });
+
+  section("Lifecycle");
+
+  await test("clearSession removes the companion LIST too", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-clear";
+    await storeTurns(mgr, sid, 2);
+    assert(
+      (await raw.exists(`${sessionKey(sid)}:msgs`)) === 1,
+      "test did not create a LIST to clear",
+    );
+    await mgr.clearSession(sid, USER);
+    assert(
+      (await raw.exists(`${sessionKey(sid)}:msgs`)) === 0,
+      "clearSession leaked the companion message LIST",
+    );
+    assert(
+      (await raw.exists(sessionKey(sid))) === 0,
+      "clearSession left the metadata blob behind",
+    );
+    await mgr.close();
+  });
+
+  await test("setSessionMessages replaces rather than appends", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-replace";
+    await storeTurns(mgr, sid, 3);
+    await mgr.setSessionMessages(
+      sid,
+      [{ id: "n1", role: "user", content: "only one" }],
+      USER,
+    );
+    const messages = await mgr.getSessionMessages(sid, USER);
+    assert(messages.length === 1, "replacement appended instead of replacing");
+    assert(
+      (await raw.lLen(`${sessionKey(sid)}:msgs`)) === 1,
+      "companion LIST was not rewritten on replacement",
+    );
+    await mgr.close();
+  });
+
+  await test("both keys carry a TTL", async () => {
+    const mgr = newManager();
+    await mgr.initialize();
+    const sid = "s-ttl";
+    await storeTurns(mgr, sid, 1);
+    assert((await raw.ttl(sessionKey(sid))) > 0, "metadata blob has no TTL");
+    assert(
+      (await raw.ttl(`${sessionKey(sid)}:msgs`)) > 0,
+      "companion LIST has no TTL and would outlive the session",
+    );
+    await mgr.close();
+  });
+
+  // Housekeeping: this suite writes under a unique prefix, so clean it up.
+  const leftovers = await raw.keys(`${PREFIX}*`);
+  if (leftovers.length > 0) {
+    await raw.del(leftovers);
+  }
+  await raw.quit();
+});


### PR DESCRIPTION
## Description

`storeConversationTurn` re-serialized and SET the **entire** conversation on every turn, so per-turn write cost grew with history size. Measured against local Redis before changing anything:

| Conversation profile | first turns | last turns | growth | total |
|---|---|---|---|---|
| 200 turns x 2KB messages | 2ms | 2ms | **1.0x — no problem** | 0.5s |
| 400 turns x 20KB messages (~16MB) | 2ms | 61ms | **30.5x** | 10.9s |

The problem only appears at multi-MB scale — which is exactly the agentic tool-output profile.

Messages now live in an append-only companion LIST (`<key>:msgs`); the blob keeps metadata only, flagged with a marker.

**After this change, same benchmark:**

| | first | last | growth | total |
|---|---|---|---|---|
| 400 turns x 20KB | 2ms | **18ms** | **9.0x** | **3.9s** |

**2.8x faster overall.** Honest caveat: it is *not* flat. The write is now O(1) in history size, but `storeConversationTurn` still hydrates the full history per turn to run its summarization checks, so the read remains O(n). Removing that is a separate change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Backward compatibility

A blob **without** the marker is a legacy record whose inline `messages` array is authoritative: it is read as-is, and converted to split storage on its next write. Both directions are covered by tests — reading a legacy blob, and converting one without losing its oldest message.

Rollback caveat worth knowing: a session written in split format and then read by *older* code would show an empty `messages` array, since older code does not know about the companion LIST. Forward-compat was not attempted.

## Changes

- `utils/redis.ts` — `MESSAGES_KEY_SUFFIX`, marker, key builder, `isSessionMessagesKey`, metadata serializer, `parseStoredMessages` (skips a single corrupt entry rather than losing the session), `encodeStoredMessages`
- `hydrateMessages` / `loadConversation` / `persistConversation` on the manager; every read site routed through hydration, keyed by raw Redis key so scan loops can reuse it
- `storeConversationTurn` appends only the current turn's messages
- `setSessionMessages` rewrites the LIST wholesale
- `clearSession` deletes both keys
- both keys carry the TTL

## Hazards found and fixed

These are why this landed as its own PR rather than riding along with #1285:

1. **`getStats()` and `listSessions()` scan `${keyPrefix}*` and `GET` each key.** The new LIST keys sit under that prefix, and `GET` on a LIST raises `WRONGTYPE`. Both are now filtered — the same way session listing already skips `:sessions` index keys.
2. **`getStats()` would have double-counted sessions**, since each session contributes two keys.
3. **`listSessions()` would have reported `messageCount: 0`** — the blob's inline array is empty under split storage. Now uses `LLEN`.
4. **Silent data loss in the summarization writeback.** It re-reads without hydrating and wrote with `serializeConversation`, which would have persisted `messages: []` *without* the marker — turning a split session into a legacy blob with zero messages. Both metadata-only writers now preserve the marker.
5. **`clearSession` would have leaked the companion LIST**, letting a re-created session inherit stale messages.

Items 1, 3 and 4 were caught by the test suite failing, not by review.

## Testing

`pnpm run test:redis-append-only` — **10/10** against live Redis, skipping cleanly when Redis is absent. Covers the split layout, read paths, `buildContextMessages`, both backward-compat cases, both scan paths, `clearSession`, `setSessionMessages` replacement semantics, and TTL on both keys. The suite writes under a unique prefix and cleans up after itself.

Verified to fail **loudly** (`✗`, exit 1) on a deliberately broken assertion, per the CLAUDE.md hazard where `isExpectedProviderError()` can downgrade a real failure to `⊘`.

Regressions, all green: `test:tool-storage-parity` 10/10, `test:tool-pairing` 15/15, `test:token-accounting` 10/10, `test:step-guard` 6/6, `test:loop-guard-core` 11/11, `test:openai-compat-guard` 9/9, `test:anthropic-guard` 10/10. `tsc --noEmit --strict` 0 errors, `eslint` 0 errors, prettier clean.

## Note on a pre-existing issue

While testing I hit `WRONGTYPE` from a *different* source: `defaultUserSessionsPrefix` derives from `keyPrefix.replace(/conversation:?$/, "user:sessions:")`. With the production default (`neurolink:conversation:`) the user-index SET lands on a separate prefix and there is no collision — but with any `keyPrefix` **not** ending in `conversation:`, the index SET falls under the scanned prefix and `getStats()` will `GET` it and throw. That is pre-existing on `release` and unrelated to this PR; my test prefix now mirrors production. Worth a separate look if custom key prefixes are used anywhere.

## Consolidated with #1287

#1287 (`fix(providers): complete in-turn context guard coverage across native loops`) was merged into this branch, so this PR now carries both changes. Per the repo's Single Commit Policy the branch has been squashed back to one commit — `fix(core): append-only redis sessions and gemini loop guard coverage` — and the title updated to match, so the squash-merge onto `release` names both halves rather than only the Redis one.

The second half adds the Gemini-shaped in-turn guard (`src/lib/context/geminiLoopGuard.ts`) and wires it into the Google AI Studio, Vertex and native-Gemini-3 loops, closing the last native loops that had no mid-turn context guard. Tree is byte-identical to the two-commit version.

Top of the stack: #1280 → #1281 → #1282 → #1283 → #1285 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Gemini and Anthropic conversations by automatically reclaiming older history or shortening oversized tool results when context limits are reached.
  * Added clear markers when conversation history is omitted during context recovery.
  * Added more efficient Redis conversation storage with separate message handling while preserving existing conversations and migration compatibility.

* **Bug Fixes**
  * Conversations now recover more reliably from context limits without unnecessarily stopping agent interactions.
  * Added warnings and monitoring details when compaction runs without reclaiming content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->