### PR TITLE
fix(providers): complete in-turn context guard coverage across native loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "test:anthropic-guard": "npx tsx test/continuous-test-suite-anthropic-guard.ts",
     "test:tool-storage-parity": "npx tsx test/continuous-test-suite-tool-storage-parity.ts",
     "test:redis-append-only": "npx tsx test/continuous-test-suite-redis-append-only.ts",
+    "test:gemini-guard": "npx tsx test/continuous-test-suite-gemini-guard.ts",
     "test:middleware": "npx tsx test/continuous-test-suite-middleware.ts",
     "test:observability": "npx tsx test/continuous-test-suite-observability.ts",
     "test:ppt": "npx tsx test/continuous-test-suite-ppt.ts",

--- a/src/lib/context/contextCompactor.ts
+++ b/src/lib/context/contextCompactor.ts
@@ -282,6 +282,26 @@ export class ContextCompactor {
             durationMs: Date.now() - spanStartTime,
           });
 
+          // A compaction that was ASKED to reclaim and reclaimed nothing is the
+          // signature of a mis-aimed target: the caller decided the request was
+          // over budget, but every stage gate compared against a number that
+          // said otherwise, so the pipeline no-opped and the request went out
+          // oversized anyway. That is exactly how the history-budget defect hid
+          // in production — silently, because "Complete" looked healthy. Warn
+          // loudly and stamp the span so it is greppable and alertable.
+          const reclaimedNothing = stagesUsed.length === 0;
+          if (reclaimedNothing) {
+            logger.warn("[Compaction] No-op — invoked but reclaimed nothing", {
+              requestId,
+              tokensBefore,
+              targetTokens,
+              messageCount: currentMessages.length,
+            });
+          }
+          span = SpanSerializer.updateAttributes(span, {
+            "context.noop": reclaimedNothing,
+          });
+
           const result: CompactionResult = {
             compacted: stagesUsed.length > 0,
             stagesUsed,

--- a/src/lib/context/geminiLoopGuard.ts
+++ b/src/lib/context/geminiLoopGuard.ts
@@ -1,0 +1,178 @@
+/**
+ * In-turn context guard for Gemini-shaped agent loops (native Vertex + AI
+ * Studio + Gemini 3).
+ *
+ * These loops already had `createContextGuard`, but it is **stop-only**: once
+ * the projected prompt crosses the threshold it breaks the loop and synthesizes
+ * an answer from whatever it has. That avoids a provider rejection, but it also
+ * ends the turn early — the model stops doing work it was mid-way through.
+ *
+ * This module brings them to parity with the other loops: reclaim budget and
+ * CONTINUE, falling back to the existing stop only when reclaiming cannot get
+ * back under the line. The reclaim policy is shared with every other provider
+ * via `loopGuardCore`; this module owns only the Gemini shape mapping.
+ *
+ * Gemini history is `{ role, parts[] }`, where a part is a `functionCall`
+ * (tool invocation) or `functionResponse` (its result). One model turn can
+ * carry several `functionCall` parts and the following user turn carries the
+ * matching `functionResponse` parts, so the CONTENT is the batch unit —
+ * dropping a call turn together with its response turn can never orphan a part,
+ * which Gemini rejects.
+ */
+
+import type {
+  GeminiGuardContent,
+  LoopGuardEntry,
+  LoopGuardPlan,
+} from "../types/index.js";
+import {
+  estimateTokens,
+  TOKENS_PER_MESSAGE,
+} from "../utils/tokenEstimation.js";
+import { generateToolOutputPreview } from "./toolOutputLimits.js";
+import { planLoopGuardReclaim } from "./loopGuardCore.js";
+import { logger } from "../utils/logger.js";
+
+/** Preview budget for an old tool output. Matches the other loop guards. */
+const OLD_TOOL_OUTPUT_PREVIEW_BYTES = 2_048;
+const OLD_TOOL_OUTPUT_PREVIEW_LINES = 60;
+
+/** Marker left where dropped history used to be. */
+export const GEMINI_ELISION_NOTE =
+  "[Earlier tool exchanges were removed to fit the context window.]";
+
+/** Serialize any value for estimation. Never throws. */
+function toText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    // Past V8's string cap: enormous by definition, so charge a large fixed
+    // size rather than aborting the estimate and with it the turn.
+    return "x".repeat(200_000);
+  }
+}
+
+function hasPart(content: GeminiGuardContent, key: string): boolean {
+  return (
+    Array.isArray(content.parts) &&
+    content.parts.some(
+      (part) => part && typeof part === "object" && key in part,
+    )
+  );
+}
+
+/** True when this content carries tool results worth previewing. */
+export function isGeminiToolResponseContent(
+  content: GeminiGuardContent,
+): boolean {
+  return hasPart(content, "functionResponse");
+}
+
+/** Head/tail preview for an oversized tool response payload. */
+export function previewGeminiToolResponseText(text: string): string {
+  const { preview } = generateToolOutputPreview(text, {
+    maxBytes: OLD_TOOL_OUTPUT_PREVIEW_BYTES,
+    maxLines: OLD_TOOL_OUTPUT_PREVIEW_LINES,
+  });
+  return preview;
+}
+
+function contentTokens(content: GeminiGuardContent, provider?: string): number {
+  return estimateTokens(toText(content.parts), provider) + TOKENS_PER_MESSAGE;
+}
+
+/** Map Gemini history onto the neutral view the shared policy operates on. */
+function toEntries(
+  contents: readonly GeminiGuardContent[],
+  provider?: string,
+): LoopGuardEntry[] {
+  return contents.map((content) => {
+    const tokens = contentTokens(content, provider);
+    if (isGeminiToolResponseContent(content)) {
+      // Only advertise a preview when it actually saves something: an
+      // already-small response must fall through to stage 2 rather than look
+      // shrinkable and stall the reclaim.
+      const previewed = toText(content.parts);
+      const previewTokens =
+        previewed.length > OLD_TOOL_OUTPUT_PREVIEW_BYTES
+          ? estimateTokens(previewGeminiToolResponseText(previewed), provider) +
+            TOKENS_PER_MESSAGE
+          : tokens;
+      return {
+        kind: "toolResult" as const,
+        tokens,
+        ...(previewTokens < tokens ? { previewTokens } : {}),
+      };
+    }
+    if (hasPart(content, "functionCall")) {
+      return { kind: "toolCall" as const, tokens };
+    }
+    return { kind: "other" as const, tokens };
+  });
+}
+
+/**
+ * Decide what to reclaim from a Gemini agent loop.
+ *
+ * Returns `undefined` when the history still fits, in which case the caller
+ * must leave it byte-identical — any rewrite invalidates the provider's cached
+ * prefix, so "no change" has to mean no change.
+ */
+export function planGeminiLoopReclaim(args: {
+  contents: readonly GeminiGuardContent[];
+  availableInputTokens: number;
+  fixedOverheadTokens?: number;
+  provider?: string;
+  observedPromptTokens?: number;
+}): LoopGuardPlan | undefined {
+  const {
+    contents,
+    availableInputTokens,
+    fixedOverheadTokens = 0,
+    provider,
+    observedPromptTokens,
+  } = args;
+
+  const entries = toEntries(contents, provider);
+
+  let calibration = 1;
+  if (observedPromptTokens && observedPromptTokens > 0) {
+    const rawEstimate =
+      fixedOverheadTokens + entries.reduce((sum, e) => sum + e.tokens, 0);
+    if (rawEstimate > 0) {
+      // Clamped: real tokenizers run up to ~1.3x the char estimate on dense
+      // code, and an unbounded ratio would compact the loop into uselessness.
+      calibration = Math.min(
+        3,
+        Math.max(1, observedPromptTokens / rawEstimate),
+      );
+    }
+  }
+
+  const plan = planLoopGuardReclaim(entries, {
+    availableInputTokens,
+    fixedOverheadTokens,
+    calibration,
+  });
+
+  if (!plan.fire) {
+    return undefined;
+  }
+
+  logger.info("[GeminiLoopGuard] Reclaiming agent-loop context", {
+    provider,
+    contents: contents.length,
+    toolResponsesTruncated: plan.truncate.length,
+    contentsDropped: plan.drop.length,
+    projectedTokens: plan.projectedTokens,
+    calibration,
+  });
+
+  return plan;
+}

--- a/src/lib/core/redisConversationMemoryManager.ts
+++ b/src/lib/core/redisConversationMemoryManager.ts
@@ -952,6 +952,23 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
   }
 
   /**
+   * True only for keys holding a conversation BLOB — the sole key type these
+   * scan-then-GET paths may read.
+   *
+   * `${keyPrefix}*` also matches the companion message LISTs and, when a
+   * custom key prefix does not end in `conversation:`, the user-index SETs
+   * (whose derived prefix then collapses onto `keyPrefix`). `GET` against
+   * either raises WRONGTYPE, and counting them would inflate session totals.
+   */
+  private isConversationBlobKey(key: string): boolean {
+    return (
+      !isSessionMessagesKey(key) &&
+      !key.endsWith(":sessions") &&
+      !key.startsWith(this.redisConfig.userSessionsKeyPrefix)
+    );
+  }
+
+  /**
    * Hydrate a deserialized blob's messages from the companion LIST when the
    * session uses split storage. Legacy blobs (messages inline) pass through
    * untouched — that is what makes the migration backward compatible.
@@ -1717,7 +1734,7 @@ User message: "${userMessage}"`;
     // returns them too. GET on a LIST raises WRONGTYPE, and counting them as
     // sessions would double `totalSessions` — filter them out exactly as the
     // session listing already skips `:sessions` index keys.
-    const sessionKeys = keys.filter((key) => !isSessionMessagesKey(key));
+    const sessionKeys = keys.filter((key) => this.isConversationBlobKey(key));
 
     // Count messages in each session
     let totalTurns = 0;
@@ -2005,7 +2022,7 @@ User message: "${userMessage}"`;
       for (const key of keys) {
         // Skip user session index keys (they end with :sessions) and the
         // companion message LISTs — GET on a LIST raises WRONGTYPE.
-        if (key.endsWith(":sessions") || isSessionMessagesKey(key)) {
+        if (!this.isConversationBlobKey(key)) {
           continue;
         }
         const raw = await this.redisClient.get(key);

--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -45,6 +45,12 @@ import {
 import { ERROR_CODES, NeuroLinkError } from "../../utils/errorHandling.js";
 import { logger } from "../../utils/logger.js";
 import {
+  GEMINI_ELISION_NOTE,
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+} from "../../context/geminiLoopGuard.js";
+import { getAvailableInputTokens } from "../../constants/contextWindows.js";
+import {
   composeAbortSignals,
   createTimeoutController,
   TimeoutError,
@@ -133,6 +139,86 @@ async function createGoogleGenAIClient(apiKey: string): Promise<GenAIClient> {
  * @note "Too many states for serving" errors can occur with complex schemas + tools.
  *       Solution: Simplify schema or use disableTools: true
  */
+
+/**
+ * Reclaim context from an AI Studio loop history IN PLACE.
+ *
+ * This loop had NO in-turn guard at all — it appended a model turn plus a tool
+ * turn every step with nothing bounding growth, so a long agentic run walked
+ * into a provider "context length exceeded" and lost every completed step.
+ * Shares its reclaim policy with the other provider loops via loopGuardCore.
+ *
+ * Returns true when something was reclaimed.
+ */
+function reclaimAiStudioContext(
+  contents: Array<{ role: string; parts: unknown[] }>,
+  modelName: string,
+): boolean {
+  const plan = planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: getAvailableInputTokens("googleAiStudio", modelName),
+    provider: "googleAiStudio",
+  });
+  if (!plan) {
+    return false;
+  }
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: Array<{ role: string; parts: unknown[] }> = [];
+  for (let i = 0; i < contents.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const content = contents[i];
+    if (truncateSet.has(i) && Array.isArray(content.parts)) {
+      rebuilt.push({
+        ...content,
+        parts: content.parts.map((part) => {
+          const record = part as {
+            functionResponse?: { name?: string; response?: unknown };
+          };
+          if (!record.functionResponse) {
+            return part;
+          }
+          const text = JSON.stringify(record.functionResponse.response) ?? "";
+          if (text.length <= 2048) {
+            return part;
+          }
+          return {
+            functionResponse: {
+              name: record.functionResponse.name,
+              response: { result: previewGeminiToolResponseText(text) },
+            },
+          };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(content);
+  }
+  if (dropSet.size > 0) {
+    let noteIndex = rebuilt.findIndex(
+      (c) =>
+        Array.isArray(c.parts) &&
+        c.parts.some(
+          (part) =>
+            !!(part as { functionCall?: unknown }).functionCall ||
+            !!(part as { functionResponse?: unknown }).functionResponse,
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      parts: [{ text: GEMINI_ELISION_NOTE }],
+    });
+  }
+  contents.length = 0;
+  contents.push(...rebuilt);
+  return true;
+}
+
 export class GoogleAIStudioProvider extends BaseProvider {
   private credentials?: { apiKey?: string };
 
@@ -846,6 +932,11 @@ export class GoogleAIStudioProvider extends BaseProvider {
             try {
               // Agentic loop for tool calling
               while (step < maxSteps) {
+                // In-turn context guard: this loop appends a model turn plus a
+                // tool turn every step with nothing bounding growth. No-op
+                // while the request still fits, so a loop that fits never pays
+                // a cache invalidation.
+                reclaimAiStudioContext(currentContents, modelName);
                 if (composedSignal?.aborted) {
                   throw composedSignal.reason instanceof Error
                     ? composedSignal.reason
@@ -1255,6 +1346,8 @@ export class GoogleAIStudioProvider extends BaseProvider {
 
           // Agentic loop for tool calling
           while (step < maxSteps) {
+            // In-turn context guard — see the stream twin.
+            reclaimAiStudioContext(currentContents, modelName);
             if (composedSignal?.aborted) {
               throw composedSignal.reason instanceof Error
                 ? composedSignal.reason

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -1632,6 +1632,18 @@ export function createContextGuard(
         projectedGrowthTokens += Math.ceil(chars / 4);
       }
     },
+    /**
+     * Clear the projection after the caller has reclaimed context.
+     *
+     * The observed prompt size reflects the pre-reclaim conversation, so
+     * leaving it in place would keep `shouldStop()` true forever and defeat
+     * the reclaim. Resetting to the fail-open state means the guard stays
+     * quiet until the next real usage report re-establishes the truth.
+     */
+    resetAfterReclaim(): void {
+      observedPromptTokens = 0;
+      projectedGrowthTokens = 0;
+    },
     /** True when issuing another model call risks crossing the threshold. */
     shouldStop(): boolean {
       return (

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -66,6 +66,16 @@ import {
 } from "../../utils/messageBuilder.js";
 import { logger } from "../../utils/logger.js";
 import {
+  GEMINI_ELISION_NOTE,
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+} from "../../context/geminiLoopGuard.js";
+import {
+  ANTHROPIC_ELISION_NOTE,
+  planAnthropicLoopReclaim,
+  previewAnthropicToolResultText,
+} from "../../context/anthropicLoopGuard.js";
+import {
   hasRestrictedOutputLimit,
   RESTRICTED_OUTPUT_TOKEN_LIMIT,
   toVertexAnthropicModelId,
@@ -789,6 +799,163 @@ const isAnthropicModel = (modelName: string): boolean => {
  *       Solution: Simplify schema or reduce number of tools if this occurs.
  * @see https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
  */
+
+/** Byte budget above which an old tool response is previewed, not kept whole. */
+const TOOL_RESPONSE_PREVIEW_BYTES = 2048;
+
+/**
+ * Reclaim context from a Gemini-shaped loop history IN PLACE.
+ *
+ * Returns true when something was actually reclaimed, which tells the caller
+ * it is safe to continue the loop instead of stopping. Mutates `contents` so
+ * the caller's array identity (captured by the request builder) stays valid.
+ */
+function reclaimVertexLoopContext(
+  contents: Array<{ role: string; parts: VertexNativeLoopPart[] }>,
+  modelName: string,
+  observedPromptTokens: number,
+): boolean {
+  const plan = planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: getContextWindowSize("vertex", modelName),
+    provider: "vertex",
+    observedPromptTokens,
+  });
+  if (!plan) {
+    return false;
+  }
+
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: Array<{ role: string; parts: VertexNativeLoopPart[] }> = [];
+  for (let i = 0; i < contents.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const content = contents[i];
+    if (truncateSet.has(i) && Array.isArray(content.parts)) {
+      rebuilt.push({
+        ...content,
+        parts: content.parts.map((part): VertexNativeLoopPart => {
+          if (!("functionResponse" in part)) {
+            return part;
+          }
+          const fn = part.functionResponse;
+          const text = JSON.stringify(fn.response) ?? "";
+          if (text.length <= TOOL_RESPONSE_PREVIEW_BYTES) {
+            return part;
+          }
+          // Rebuilt rather than cast: `functionResponse` requires `name`, and
+          // Critical Rule 14 forbids casting through `unknown` to paper over it.
+          return {
+            functionResponse: {
+              name: fn.name,
+              response: { result: previewGeminiToolResponseText(text) },
+            },
+          };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(content);
+  }
+
+  if (dropSet.size > 0) {
+    // Gemini requires the history to start with a user turn; the note is
+    // inserted before the first surviving tool turn, never at the end where a
+    // "history was removed" cue would follow the content it refers to.
+    let noteIndex = rebuilt.findIndex(
+      (c) =>
+        Array.isArray(c.parts) &&
+        c.parts.some(
+          (part) =>
+            !!(part as { functionCall?: unknown }).functionCall ||
+            !!(part as { functionResponse?: unknown }).functionResponse,
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      parts: [{ text: GEMINI_ELISION_NOTE } as VertexNativeLoopPart],
+    });
+  }
+
+  contents.length = 0;
+  contents.push(...rebuilt);
+  return true;
+}
+
+/**
+ * Reclaim context from a Vertex+Claude loop history IN PLACE.
+ *
+ * Same parity upgrade as the Gemini path, but this loop carries Anthropic
+ * content blocks, so it reuses the Anthropic adapter. Returns true when
+ * something was reclaimed and the loop may continue.
+ */
+function reclaimVertexAnthropicContext(
+  messages: VertexAnthropicMessage[],
+  modelName: string,
+  observedPromptTokens: number,
+): boolean {
+  const plan = planAnthropicLoopReclaim({
+    conversation: messages,
+    availableInputTokens: getContextWindowSize("vertex", modelName),
+    fixedOverheadTokens: 0,
+    provider: "vertex",
+    observedPromptTokens,
+  });
+  if (!plan) {
+    return false;
+  }
+  const dropSet = new Set(plan.drop);
+  const truncateSet = new Set(plan.truncate);
+  const rebuilt: VertexAnthropicMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (dropSet.has(i)) {
+      continue;
+    }
+    const message = messages[i];
+    if (truncateSet.has(i) && Array.isArray(message.content)) {
+      rebuilt.push({
+        ...message,
+        content: message.content.map((block) => {
+          if (block.type !== "tool_result") {
+            return block;
+          }
+          const text =
+            typeof block.content === "string"
+              ? block.content
+              : (JSON.stringify(block.content) ?? "");
+          return { ...block, content: previewAnthropicToolResultText(text) };
+        }),
+      });
+      continue;
+    }
+    rebuilt.push(message);
+  }
+  if (dropSet.size > 0) {
+    let noteIndex = rebuilt.findIndex(
+      (m) =>
+        Array.isArray(m.content) &&
+        m.content.some(
+          (b) => b.type === "tool_use" || b.type === "tool_result",
+        ),
+    );
+    if (noteIndex < 0) {
+      noteIndex = Math.min(1, rebuilt.length);
+    }
+    rebuilt.splice(noteIndex, 0, {
+      role: "user",
+      content: [{ type: "text", text: ANTHROPIC_ELISION_NOTE }],
+    });
+  }
+  messages.length = 0;
+  messages.push(...rebuilt);
+  return true;
+}
+
 export class GoogleVertexProvider extends BaseProvider {
   private projectId: string;
   private location: string;
@@ -2131,13 +2298,27 @@ export class GoogleVertexProvider extends BaseProvider {
         // conversation crosses the window threshold — synthesize from what
         // we have instead of stepping into a provider rejection.
         if (contextGuard.shouldStop()) {
-          hitContextLimit = true;
-          logger.warn(
-            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          // Parity upgrade: try to RECLAIM budget and keep going before
+          // falling back to the historic stop-only behaviour. Ending the turn
+          // early is safe but throws away work the model was mid-way through;
+          // dropping the oldest complete tool exchanges usually buys enough
+          // room to finish. Only when reclaiming changes nothing do we stop.
+          const reclaimed = reclaimVertexLoopContext(
+            currentContents,
+            modelName,
+            contextGuard.projectedNextPromptTokens,
           );
-          break;
+          if (reclaimed) {
+            contextGuard.resetAfterReclaim();
+          } else {
+            hitContextLimit = true;
+            logger.warn(
+              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            );
+            break;
+          }
         }
         step++;
         turnClock.noteProgress();
@@ -3381,13 +3562,27 @@ export class GoogleVertexProvider extends BaseProvider {
         // conversation crosses the window threshold — synthesize from what
         // we have instead of stepping into a provider rejection.
         if (contextGuard.shouldStop()) {
-          hitContextLimit = true;
-          logger.warn(
-            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          // Parity upgrade: try to RECLAIM budget and keep going before
+          // falling back to the historic stop-only behaviour. Ending the turn
+          // early is safe but throws away work the model was mid-way through;
+          // dropping the oldest complete tool exchanges usually buys enough
+          // room to finish. Only when reclaiming changes nothing do we stop.
+          const reclaimed = reclaimVertexLoopContext(
+            currentContents,
+            modelName,
+            contextGuard.projectedNextPromptTokens,
           );
-          break;
+          if (reclaimed) {
+            contextGuard.resetAfterReclaim();
+          } else {
+            hitContextLimit = true;
+            logger.warn(
+              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            );
+            break;
+          }
         }
         step++;
         turnClock.noteProgress();
@@ -4837,13 +5032,24 @@ export class GoogleVertexProvider extends BaseProvider {
           // Context guard: stop the tool loop before the accumulated
           // conversation crosses the window threshold (see generate twin).
           if (contextGuard.shouldStop()) {
-            hitContextLimit = true;
-            logger.warn(
-              `[GoogleVertex] Anthropic stream turn stopped by the context guard: ` +
-                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+            // Parity upgrade: reclaim and continue where possible; the
+            // historic stop-only behaviour remains the fallback.
+            const reclaimed = reclaimVertexAnthropicContext(
+              currentMessages,
+              modelName,
+              contextGuard.projectedNextPromptTokens,
             );
-            break;
+            if (reclaimed) {
+              contextGuard.resetAfterReclaim();
+            } else {
+              hitContextLimit = true;
+              logger.warn(
+                `[GoogleVertex] Anthropic stream turn stopped by the context guard: ` +
+                  `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+                  `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+              );
+              break;
+            }
           }
           step++;
           turnClock.noteProgress();
@@ -6417,13 +6623,22 @@ export class GoogleVertexProvider extends BaseProvider {
       // this step's appended tool results/output) would cross the window
       // threshold — stop the tool loop and synthesize from what we have.
       if (contextGuard.shouldStop()) {
-        hitContextLimit = true;
-        logger.warn(
-          `[GoogleVertex] Anthropic generate turn stopped by the context guard: ` +
-            `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-            `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+        const reclaimed = reclaimVertexAnthropicContext(
+          currentMessages,
+          modelName,
+          contextGuard.projectedNextPromptTokens,
         );
-        break;
+        if (reclaimed) {
+          contextGuard.resetAfterReclaim();
+        } else {
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Anthropic generate turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
+          );
+          break;
+        }
       }
       step++;
       turnClock.noteProgress();

--- a/src/lib/types/context.ts
+++ b/src/lib/types/context.ts
@@ -923,6 +923,16 @@ export type AnthropicGuardMessage = {
   content: string | AnthropicGuardBlock[];
 };
 
+/**
+ * Structural view of one Gemini history entry, loose enough to accept both the
+ * native Vertex loop's `{ role, parts }` array and `@google/genai` contents
+ * without a cast at either call site.
+ */
+export type GeminiGuardContent = {
+  role: string;
+  parts: unknown[];
+};
+
 /** Tuning for {@link planLoopGuardReclaim}. */
 export type LoopGuardPolicy = {
   availableInputTokens: number;

--- a/test/continuous-test-suite-gemini-guard.ts
+++ b/test/continuous-test-suite-gemini-guard.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Gemini loop guard adapter
+ *
+ * The native Vertex and AI Studio loops keep history as `{ role, parts[] }`,
+ * where a part is a `functionCall` (tool invocation) or `functionResponse`
+ * (its result). Vertex already had `createContextGuard`, but it is STOP-ONLY:
+ * it breaks the loop and synthesizes from whatever it has, ending the turn
+ * early. AI Studio had no guard at all.
+ *
+ * Both now reclaim and continue via the shared policy, falling back to the
+ * historic stop only when reclaiming changes nothing.
+ *
+ * The reclaim POLICY is tested in continuous-test-suite-loop-guard-core.ts.
+ * This suite covers the Gemini SHAPE MAPPING and the decision boundary.
+ *
+ * No API keys, no network, no LLM — pure function assertions.
+ *
+ * Run: npx tsx test/continuous-test-suite-gemini-guard.ts
+ *      pnpm run test:gemini-guard
+ */
+
+import {
+  planGeminiLoopReclaim,
+  previewGeminiToolResponseText,
+  isGeminiToolResponseContent,
+} from "../src/lib/context/geminiLoopGuard.js";
+import type { GeminiGuardContent } from "../src/lib/types/index.js";
+import { defineSuite } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Gemini loop guard");
+
+/**
+ * NOTE: assertion messages must NEVER interpolate payloads — the harness
+ * downgrades a throw to SKIP when the text matches `isExpectedProviderError()`,
+ * silently turning a failure into ⊘.
+ */
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+/** One agent step in Gemini shape: a model call turn, then a user result turn. */
+function step(i: number, outputChars: number): GeminiGuardContent[] {
+  return [
+    {
+      role: "model",
+      parts: [
+        { functionCall: { name: "read_file", args: { path: `/f${i}` } } },
+      ],
+    },
+    {
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            name: "read_file",
+            response: { result: "x".repeat(outputChars) },
+          },
+        },
+      ],
+    },
+  ];
+}
+
+const plan = (contents: GeminiGuardContent[], observedPromptTokens?: number) =>
+  planGeminiLoopReclaim({
+    contents,
+    availableInputTokens: 100_000,
+    provider: "vertex",
+    ...(observedPromptTokens !== undefined ? { observedPromptTokens } : {}),
+  });
+
+await runSuite(async () => {
+  section("A loop that fits must be left alone");
+
+  await test("short history returns undefined", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hello" }] },
+      ...step(1, 200),
+    ];
+    assert(plan(contents) === undefined, "guard acted on a history that fits");
+  });
+
+  await test("text-only history returns undefined", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hi" }] },
+      { role: "model", parts: [{ text: "hello" }] },
+    ];
+    assert(plan(contents) === undefined, "guard acted on a text-only history");
+  });
+
+  section("Part classification");
+
+  await test("functionResponse turns are recognised", async () => {
+    const [callTurn, resultTurn] = step(1, 100);
+    assert(
+      isGeminiToolResponseContent(resultTurn),
+      "a functionResponse turn was not recognised",
+    );
+    assert(
+      !isGeminiToolResponseContent(callTurn),
+      "a functionCall turn was misread as a response",
+    );
+  });
+
+  await test("a text-only turn is not a tool turn", async () => {
+    assert(
+      !isGeminiToolResponseContent({ role: "user", parts: [{ text: "hi" }] }),
+      "a plain text turn was misread as a tool response",
+    );
+  });
+
+  section("Reclaim decisions");
+
+  await test("fires and never proposes the first turn", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "THE ORIGINAL TASK" }] },
+    ];
+    for (let i = 0; i < 60; i++) {
+      contents.push(...step(i, 30_000));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire on an over-budget loop");
+    assert(!result!.drop.includes(0), "guard proposed dropping the task turn");
+    assert(
+      !result!.truncate.includes(0),
+      "guard proposed editing the task turn",
+    );
+  });
+
+  await test("dropped indices cover whole call/response pairs", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire");
+    const dropped = new Set(result!.drop);
+    const survivors = contents.filter((_, i) => !dropped.has(i));
+
+    // Gemini rejects a functionResponse with no preceding functionCall.
+    let openCalls = 0;
+    let orphans = 0;
+    for (const content of survivors) {
+      const hasCall = content.parts.some(
+        (p) => !!(p as { functionCall?: unknown }).functionCall,
+      );
+      const hasResp = content.parts.some(
+        (p) => !!(p as { functionResponse?: unknown }).functionResponse,
+      );
+      if (hasCall) {
+        openCalls++;
+      }
+      if (hasResp) {
+        if (openCalls === 0) {
+          orphans++;
+        } else {
+          openCalls--;
+        }
+      }
+    }
+    assert(orphans === 0, "a dropped batch left an orphaned functionResponse");
+    assert(openCalls === 0, "a dropped batch left a functionCall unanswered");
+  });
+
+  await test("small responses force drops rather than stalling", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents);
+    assert(result !== undefined, "guard did not fire");
+    assert(
+      result!.drop.length > 0,
+      "guard proposed no drops where truncation cannot help",
+    );
+  });
+
+  await test("reclaim converges below the low-water mark", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 300; i++) {
+      contents.push(...step(i, 1_200));
+    }
+    const result = plan(contents)!;
+    assert(
+      result.projectedTokens <= 100_000 * 0.6,
+      "reclaim did not reach the low-water mark",
+    );
+  });
+
+  section("Preview helper");
+
+  await test("oversized text shrinks, small text is untouched", async () => {
+    const small = "short";
+    assert(
+      previewGeminiToolResponseText(small) === small,
+      "small response was rewritten",
+    );
+    const large = "y".repeat(50_000);
+    const preview = previewGeminiToolResponseText(large);
+    assert(preview.length < large.length, "large response was not shrunk");
+    assert(preview.length > 0, "preview collapsed to nothing");
+  });
+
+  section("Usage calibration");
+
+  await test("a zero observed prompt count is ignored safely", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "hi" }] },
+      ...step(1, 100),
+    ];
+    assert(
+      plan(contents, 0) === undefined,
+      "zero observed tokens perturbed the decision",
+    );
+  });
+
+  await test("a higher observed count makes the guard no less eager", async () => {
+    const contents: GeminiGuardContent[] = [
+      { role: "user", parts: [{ text: "start" }] },
+    ];
+    for (let i = 0; i < 20; i++) {
+      contents.push(...step(i, 12_000));
+    }
+    const plain = plan(contents);
+    const calibrated = plan(contents, 300_000);
+    assert(
+      plain === undefined || calibrated !== undefined,
+      "calibration made the guard less eager than the raw estimate",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Closes the remaining in-turn context-guard gaps, so **all five** provider loops now reclaim and continue instead of overflowing or ending the turn early. Also fixes a pre-existing Redis key-collision bug and adds the compaction signal that would have caught the history-budget defect in production.

### Guard coverage, complete

| Loop | Before this stack | After |
|---|---|---|
| AI-SDK `generateText` | compact-and-continue | unchanged (+ low-water, #1282) |
| `openaiChatCompletionsBase` | **none** | compact-and-continue (#1283) |
| `anthropic` native stream | **none** | compact-and-continue (#1283) |
| `googleVertex` (Gemini ×2, Claude ×2) | **stop-only** | **reclaim-first, stop as fallback** |
| `googleAiStudio` (×2 loops) | **none** | **compact-and-continue** |

The Vertex upgrade is deliberately additive: `contextGuard.shouldStop()` now attempts a reclaim and only falls back to the historic stop when reclaiming changes nothing. Ending a turn early is safe but discards work the model was mid-way through.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Changes

- **`context/geminiLoopGuard.ts`** — Gemini shape adapter (`functionCall` / `functionResponse` parts) over the shared `loopGuardCore` policy
- **`googleVertex/client.ts`** — all four stop sites upgraded; Gemini loops use the Gemini adapter, Claude-on-Vertex loops reuse the Anthropic adapter
- **`googleNativeGemini3/utils.ts`** — `resetAfterReclaim()` on the context guard; without it the stale pre-reclaim projection would keep `shouldStop()` true forever and defeat the reclaim
- **`googleAiStudio/client.ts`** — both agentic loops guarded
- **`contextCompactor.ts`** — warns and stamps `context.noop` when compaction is invoked but reclaims nothing. That is the exact signature of a mis-aimed target: the caller says over-budget, every stage gate disagrees, the request goes out oversized, and `"[Compaction] Complete"` still looks healthy. It is how the history-budget defect (#1281) hid
- **`redisConversationMemoryManager.ts`** — scan-then-GET paths now use one `isConversationBlobKey()` predicate

## Pre-existing bug fixed

`defaultUserSessionsPrefix` derives via `keyPrefix.replace(/conversation:?$/, "user:sessions:")`. The replace only fires for a prefix **ending in `conversation:`** — the default. With any other custom prefix the derived value stayed identical to `keyPrefix`, so the user-index **SET** landed under the prefix that `getStats()` and session listing SCAN and then `GET` — raising `WRONGTYPE` against a SET.

Rather than change the derivation (a nested prefix is still matched by `${keyPrefix}*`), both scan paths now filter to conversation blobs only. This is on `release` today, independent of the append-only work.

## Testing

`pnpm run test:gemini-guard` — **11/11**, no API keys. Classification, reclaim decisions, whole-batch drops (an orphaned `functionResponse` is a hard Gemini rejection), low-water convergence, preview helper, calibration. Verified to fail **loudly** (`✗`, exit 1) on a deliberately broken assertion.

**Live against real Vertex** (`dev-ai-beta` service account):
- baseline: 6 tool calls, correct answer `43, 44, 45, 46, 47, 48`, guard silent — the loop fit, so history stayed byte-identical
- shrunken-window run: completed cleanly, 6 tool calls, no provider rejection

Honest limit: I did **not** observe a live Vertex firing. The model chose to batch all six tool calls into a single parallel step ("since they're all independent"), so history never grew across steps. Firing is covered deterministically by the unit suite; the live runs prove the wiring does not break the loop in either regime.

All nine suites green: `gemini-guard` 11/11, `redis-append-only` 10/10, `tool-storage-parity` 10/10, `tool-pairing` 15/15, `token-accounting` 10/10, `step-guard` 6/6, `loop-guard-core` 11/11, `openai-compat-guard` 9/9, `anthropic-guard` 10/10. `tsc --noEmit --strict` 0 errors, `eslint` 0 errors, prettier clean.

## Notes for reviewers

**Still not done, deliberately:** Phase 5.2 (dual tool-result representation) and 5.4 (activating `effectiveHistory` so compaction tags rather than rewrites). 5.4 in particular changes compaction semantics and would interact with #1281/#1282 — it belongs in its own PR with its own regression pass, not bolted onto this one.

**No AI Studio credentials** exist in this environment, so that adapter is unit-verified only. The Vertex path exercises the same `planGeminiLoopReclaim` code.

Top of the stack: #1280 → #1281 → #1282 → #1283 → #1285 → #1286 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
