### PR TITLE
feat(proxy): emit account limit headers and surface them on results

### DIFF
--- a/docs/features/claude-proxy.md
+++ b/docs/features/claude-proxy.md
@@ -573,7 +573,47 @@ When the target provider is `anthropic` (the default for any `claude-*` model), 
 6. Forward client headers as-is, preserving Claude Code's own request shape, then merge in required OAuth betas and trace headers when absent. The proxy extracts incoming `traceparent` and `x-neurolink-*` headers and injects outbound trace context plus `x-claude-code-session-id` when needed.
 7. For streaming: verify the first chunk (bootstrap retry), then forward the stream. For non-streaming: return JSON.
 
-This mode preserves the exact request format that Claude Code expects, including thinking blocks, cache control headers, and multi-turn tool use conversations. Rate-limit headers from Anthropic (`retry-after`, `anthropic-ratelimit-requests-remaining`, `anthropic-ratelimit-requests-limit`, `anthropic-ratelimit-tokens-remaining`, `anthropic-ratelimit-tokens-limit`) are passed through to the client.
+This mode preserves the exact request format that Claude Code expects, including thinking blocks, cache control headers, and multi-turn tool use conversations. Rate-limit headers from Anthropic are passed through to the client — see [Limit response headers](#limit-response-headers) below.
+
+### Limit response headers
+
+Every proxy response — streaming, non-streaming, and errors including 429 — carries the account's limit state. There are two layers.
+
+**Verbatim passthrough.** Anthropic's own `anthropic-ratelimit-*` headers and `retry-after` are forwarded unchanged. This is deliberate: a proxied response looks identical to a direct one, so a client needs only a single parser for both. Which family is present depends on the serving account:
+
+| Account type         | Headers                                                                                            | Semantics                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| OAuth / subscription | `anthropic-ratelimit-unified-5h-*`, `-7d-*`, `-status`, `-overage-status`                          | **Utilization** (0.0-1.0 of capacity _used_) plus a reset epoch. Anthropic publishes no absolute remaining count for subscription windows. |
+| API key              | `anthropic-ratelimit-requests-remaining`/`-limit`, `anthropic-ratelimit-tokens-remaining`/`-limit` | Absolute remaining counts.                                                                                                                 |
+
+**NeuroLink additions** (`x-neurolink-*`) carry what only the proxy knows:
+
+| Header                                                                     | Meaning                                                                                                                                          |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `x-neurolink-quota-source`                                                 | `live` (parsed from this response), `snapshot` (last known reading for the account), or `none` (no Anthropic account served it). Always present. |
+| `x-neurolink-account` / `-account-type`                                    | Which account served the request, and whether it is `oauth` or `api_key`.                                                                        |
+| `x-neurolink-served-by`                                                    | `anthropic`, or the fallback provider name when routing fell through.                                                                            |
+| `x-neurolink-quota-session-left-pct` / `-weekly-left-pct`                  | Derived headroom, `(1 - utilization) × 100`. Omitted when `quota-source` is `none`.                                                              |
+| `x-neurolink-quota-session-resets-in` / `-weekly-resets-in`                | Seconds until the window resets.                                                                                                                 |
+| `x-neurolink-quota-session-status` / `-weekly-status` / `-unified-status`  | `allowed`, `throttled`, or `rejected`.                                                                                                           |
+| `x-neurolink-account-cooling-until` / `-cooling-reason`                    | Set when the serving account is in a cooldown window.                                                                                            |
+| `x-neurolink-pool-available` / `-pool-cooling` / `-pool-best-session-left` | Account-pool headroom — how many accounts are usable and the best remaining capacity among them.                                                 |
+
+> **`quota-source` matters.** When a fallback provider serves the request, or Anthropic returns no quota headers, the proxy reports `none` and omits the headroom figures rather than echoing a stale snapshot. Treat `snapshot` as "last known", not "current".
+
+Account labels are frequently email addresses and are emitted as-is; the proxy binds to `127.0.0.1` by default. If you expose it beyond localhost, terminate and authenticate it in front — the proxy performs no inbound authentication of its own.
+
+**Consuming from the SDK.** The Anthropic provider parses these headers on every request in both auth modes and surfaces them on `result.limits` and `result.analytics.limits`, logs one line per request (escalating to WARN below 15% session headroom or on a `throttled`/`rejected` status), and sets `neurolink.claude.quota.*` span attributes alongside `gen_ai.usage.*`. This works without the proxy too — direct subscription traffic returns the same unified headers.
+
+```typescript
+const result = await neurolink.generate({
+  prompt: "...",
+  provider: "anthropic",
+});
+console.log(result.limits?.rateLimit.sessionLeftPct); // e.g. 58
+console.log(result.limits?.quotaSource); // "live"
+console.log(result.limits?.account); // set only when routed through the proxy
+```
 
 ### Translation mode (Claude to other provider)
 

--- a/package.json
+++ b/package.json
@@ -222,6 +222,8 @@
     "test:agent-plumbing": "npx tsx test/continuous-test-suite-agent-plumbing.ts",
     "test:tool-execution-recorder": "npx tsx test/continuous-test-suite-tool-execution-recorder.ts",
     "test:proxy-terminal-errors": "npx tsx test/continuous-test-suite-proxy-terminal-errors.ts",
+    "test:proxy-limit-headers": "npx tsx test/continuous-test-suite-proxy-limit-headers.ts",
+    "test:anthropic-limit-capture": "npx tsx test/continuous-test-suite-anthropic-limit-capture.ts",
     "test:audio": "npx tsx test/continuous-test-suite-audio.ts",
     "test:office": "npx tsx test/continuous-test-suite-office.ts",
     "test:tts:unit": "npx tsx test/continuous-test-suite-tts-unit.ts",

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1931,10 +1931,35 @@ export async function createProxyStartApp(params: {
         toolRegistry: params.neurolink.getToolRegistry(),
         timestamp: Date.now(),
         metadata: {},
+        // Route handlers publish limit/quota headers here. Only the streaming
+        // paths build their own Response (and set headers directly); every
+        // JSON and error path returns a plain object, so without this the
+        // headers had nowhere to go. Applied to each c.json() return below.
+        responseHeaders: {} as Record<string, string>,
+      };
+
+      /** Copy handler-published headers onto the outgoing response. */
+      const applyResponseHeaders = (): void => {
+        for (const [key, value] of Object.entries(ctx.responseHeaders)) {
+          c.header(key, value);
+        }
       };
 
       const result = await route.handler(ctx);
       if (result instanceof Response) {
+        // Streaming responses own their headers; merge in anything the
+        // handler published on the context that the Response lacks. A Response
+        // obtained from fetch() carries immutable headers, so this is
+        // best-effort — the body must still reach the client either way.
+        try {
+          for (const [key, value] of Object.entries(ctx.responseHeaders)) {
+            if (!result.headers.has(key)) {
+              result.headers.set(key, value);
+            }
+          }
+        } catch {
+          // Immutable header guard — skip enrichment, keep the response.
+        }
         return result;
       }
 
@@ -1983,6 +2008,7 @@ export async function createProxyStartApp(params: {
         });
         return new Response(responseStream, {
           headers: {
+            ...ctx.responseHeaders,
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
             Connection: "keep-alive",
@@ -1998,6 +2024,7 @@ export async function createProxyStartApp(params: {
         const httpResult = result as Record<string, unknown>;
         const status = (httpResult.httpStatus as number) ?? 200;
         delete httpResult.httpStatus;
+        applyResponseHeaders();
         return c.json(result, status as 400);
       }
 
@@ -2012,9 +2039,11 @@ export async function createProxyStartApp(params: {
           error?: { type?: string };
         };
         const status = mapClaudeErrorTypeToStatus(errorResult.error?.type);
+        applyResponseHeaders();
         return c.json(result, status as 400);
       }
 
+      applyResponseHeaders();
       return c.json(result ?? {});
     });
   }

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -31,6 +31,15 @@ import {
 import type { NeuroLink } from "../../neurolink.js";
 import { createOAuthFetch } from "../../proxy/oauthFetch.js";
 import { createProxyFetch } from "../../proxy/proxyFetch.js";
+import {
+  getCapturedLimitSnapshot,
+  getCapturedResponseHeaders,
+  logClaudeLimitSnapshot,
+  runInLimitCaptureScope,
+  setLimitSpanAttributes,
+  withLimitCapture,
+  wrapFetchWithLimitCapture,
+} from "./rateLimitCapture.js";
 import type {
   UnknownRecord,
   AnthropicProviderConfig,
@@ -42,6 +51,7 @@ import type {
   AnthropicAuthMethod,
   AnthropicRateLimitInfo,
   AnthropicResponseMetadata,
+  ClaudeLimitSnapshot,
   ClaudeSubscriptionTier,
   ClaudeUsageInfo,
   OAuthToken,
@@ -271,43 +281,10 @@ const detectAuthMethod = (
   return method;
 };
 
-/**
- * Parse rate limit information from Anthropic API response headers.
- * @param headers - Response headers from Anthropic API
- * @returns Parsed rate limit information
- */
-const parseRateLimitHeaders = (
-  headers: Headers | Record<string, string>,
-): AnthropicRateLimitInfo => {
-  const getHeader = (name: string): string | null => {
-    if (headers instanceof Headers) {
-      return headers.get(name);
-    }
-    return headers[name] || headers[name.toLowerCase()] || null;
-  };
-
-  const parseNumber = (value: string | null): number | undefined => {
-    if (!value) {
-      return undefined;
-    }
-    const num = parseInt(value, 10);
-    return isNaN(num) ? undefined : num;
-  };
-
-  return {
-    requestsLimit: parseNumber(getHeader("anthropic-ratelimit-requests-limit")),
-    requestsRemaining: parseNumber(
-      getHeader("anthropic-ratelimit-requests-remaining"),
-    ),
-    requestsReset: getHeader("anthropic-ratelimit-requests-reset") || undefined,
-    tokensLimit: parseNumber(getHeader("anthropic-ratelimit-tokens-limit")),
-    tokensRemaining: parseNumber(
-      getHeader("anthropic-ratelimit-tokens-remaining"),
-    ),
-    tokensReset: getHeader("anthropic-ratelimit-tokens-reset") || undefined,
-    retryAfter: parseNumber(getHeader("retry-after")),
-  };
-};
+// Rate-limit header parsing lives in `rateLimitCapture.ts`, which sees the raw
+// fetch Response and understands both header families (unified subscription
+// windows and the legacy per-tier counters). The module-private copy that used
+// to sit here parsed only the legacy family and had no callers.
 
 // ───────────────────────────────────────────────────────────────────────────
 // Native Messages-API conversion helpers (NeuroLink/V3 shapes → Anthropic)
@@ -798,7 +775,10 @@ export class AnthropicProvider extends BaseProvider {
       client = new Anthropic({
         apiKey: "oauth-authenticated", // Placeholder, actual auth is in fetch wrapper
         // Note: No headers passed - fetch wrapper sets oauth-2025-04-20 beta header
-        fetch: oauthFetch,
+        // Limit capture wraps the OAuth fetch so subscription quota headers
+        // (anthropic-ratelimit-unified-*) are recorded on every request —
+        // streaming and non-streaming alike.
+        fetch: wrapFetchWithLimitCapture(oauthFetch),
         timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
         // The SDK's built-in retry honors Retry-After hints without any
         // upper bound (a 429 with retry-after: 8549 sleeps 2.4h per retry,
@@ -858,7 +838,10 @@ export class AnthropicProvider extends BaseProvider {
         apiKey: apiKeyToUse,
         defaultHeaders: headers,
         ...(normalizedBaseURL && { baseURL: normalizedBaseURL }),
-        fetch: createProxyFetch(),
+        // Same capture as the OAuth branch: works for direct API-key traffic
+        // (legacy requests/tokens counters) and for the NeuroLink Claude proxy
+        // (verbatim unified quota plus x-neurolink-* account/pool state).
+        fetch: wrapFetchWithLimitCapture(createProxyFetch()),
         timeout: ANTHROPIC_CLIENT_TIMEOUT_MS,
         // See the OAuth-path client above: unbounded Retry-After sleeps in
         // the SDK's retry loop must never stall fallback orchestration.
@@ -1246,31 +1229,26 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   /**
-   * Update response metadata from API response headers.
-   * This should be called after each API request to track rate limits.
-   * @param headers - Response headers from the API
-   * @param requestId - Optional request ID
+   * Update response metadata from a captured limit snapshot.
+   *
+   * Takes already-parsed rate-limit info rather than raw headers: parsing now
+   * lives in `rateLimitCapture`, which is the only layer that sees the raw
+   * response and understands both header families (unified subscription
+   * windows and legacy per-tier counters).
+   *
+   * @param rateLimit - Parsed rate-limit figures
+   * @param requestId - Optional Anthropic request ID
+   * @param usageUpdate - Optional token counts to fold into usage tracking
    */
   protected updateResponseMetadata(
-    headers: Headers | Record<string, string>,
+    rateLimit: AnthropicRateLimitInfo,
     requestId?: string,
     usageUpdate?: { inputTokens?: number; outputTokens?: number },
   ): void {
     this.lastResponseMetadata = {
-      rateLimit: parseRateLimitHeaders(headers),
-      requestId:
-        requestId ||
-        (headers instanceof Headers
-          ? headers.get("x-request-id") || undefined
-          : headers["x-request-id"]),
-      serverTiming:
-        headers instanceof Headers
-          ? headers.get("server-timing") || undefined
-          : headers["server-timing"],
+      rateLimit,
+      ...(requestId ? { requestId } : {}),
     };
-
-    // Update usage tracking
-    const rateLimit = this.lastResponseMetadata.rateLimit;
     if (this.usageInfo) {
       this.usageInfo.requestCount++;
       this.usageInfo.messagesUsed++;
@@ -1603,7 +1581,10 @@ export class AnthropicProvider extends BaseProvider {
           response: {
             id: response.id,
             modelId: response.model,
-            headers: {},
+            // Real response headers, captured by the fetch wrapper. This used
+            // to be a hardcoded `{}`, which silently discarded every
+            // rate-limit and quota header Anthropic returns.
+            headers: getCapturedResponseHeaders() ?? {},
             body: response,
           },
         };
@@ -1689,10 +1670,51 @@ export class AnthropicProvider extends BaseProvider {
     analysisSchema?: ValidationSchema,
   ): Promise<EnhancedGenerateResult | null> {
     await this.refreshAuthIfNeeded();
-    return super.generate(optionsOrPrompt, analysisSchema);
+    // Open a per-request capture scope around the whole turn. Scoping here
+    // rather than on the instance is what makes it concurrency-safe: several
+    // generate() calls can be in flight on one provider instance, and an
+    // instance field would attribute one call's limits to another.
+    const { result, snapshot } = await withLimitCapture(() =>
+      super.generate(optionsOrPrompt, analysisSchema),
+    );
+    if (result && snapshot) {
+      this.recordLimitSnapshot(snapshot);
+      result.limits = snapshot;
+      if (result.analytics) {
+        result.analytics.limits = snapshot;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Fold a captured snapshot into the provider's usage bookkeeping and log it.
+   *
+   * `updateResponseMetadata` had no callers before this — the metadata it
+   * maintains, and the public `getLastResponseMetadata()` / `getUsageInfo()`
+   * that read it, were never populated by anything.
+   */
+  private recordLimitSnapshot(snapshot: ClaudeLimitSnapshot): void {
+    this.updateResponseMetadata(snapshot.rateLimit, snapshot.requestId);
+    setLimitSpanAttributes(snapshot);
+    logClaudeLimitSnapshot(snapshot, this.modelName);
   }
 
   protected async executeStream(
+    options: StreamOptions,
+    analysisSchema?: ValidationSchema,
+  ): Promise<StreamResult> {
+    // The capture scope must outlive this call: the SSE loop keeps running in
+    // the background after executeStream returns, and its per-step HTTP
+    // requests are what carry the limit headers. AsyncLocalStorage.run
+    // propagates into every continuation started inside, so the whole stream
+    // lifetime shares one slot.
+    return runInLimitCaptureScope(() =>
+      this.executeStreamInCaptureScope(options, analysisSchema),
+    );
+  }
+
+  private async executeStreamInCaptureScope(
     options: StreamOptions,
     _analysisSchema?: ValidationSchema,
   ): Promise<StreamResult> {
@@ -2244,8 +2266,8 @@ export class AnthropicProvider extends BaseProvider {
       // stream consumers and session cost tracking saw no usage at all.
       // Chained off finishPromise so requestDuration reflects the DRAINED
       // stream, not the milliseconds it took to construct this result object.
-      analytics: finishPromise.then(() =>
-        streamAnalyticsCollector.createAnalytics(
+      analytics: finishPromise.then(async () => {
+        const analytics = await streamAnalyticsCollector.createAnalytics(
           this.providerName,
           modelId,
           {
@@ -2260,8 +2282,16 @@ export class AnthropicProvider extends BaseProvider {
               `${this.providerName}-stream-${Date.now()}`,
             streamingMode: true,
           },
-        ),
-      ),
+        );
+        // Still inside the capture scope opened by executeStream, so this sees
+        // the limits reported by the last upstream step of the stream.
+        const snapshot = getCapturedLimitSnapshot();
+        if (snapshot && analytics) {
+          this.recordLimitSnapshot(snapshot);
+          analytics.limits = snapshot;
+        }
+        return analytics;
+      }),
     };
   }
 

--- a/src/lib/providers/anthropic/rateLimitCapture.ts
+++ b/src/lib/providers/anthropic/rateLimitCapture.ts
@@ -1,0 +1,460 @@
+/**
+ * Anthropic rate-limit / quota header capture.
+ *
+ * Anthropic returns limit state on the response headers of every request:
+ * `anthropic-ratelimit-unified-*` for subscription (OAuth) accounts,
+ * `anthropic-ratelimit-{requests,tokens}-*` for API-key accounts. The NeuroLink
+ * Claude proxy forwards those verbatim and adds `x-neurolink-*` for what only
+ * it knows (which account served the request, pool headroom, whether the
+ * numbers are live or a carried-over snapshot).
+ *
+ * None of it used to reach the SDK: `doGenerate` returned a hardcoded empty
+ * header bag and the streaming loop never looked. The capture point here is the
+ * `fetch` the Anthropic SDK is constructed with — it is invoked exactly once
+ * per HTTP request on BOTH the streaming and non-streaming paths, so a single
+ * wrapper covers everything without touching the SSE loop or switching the
+ * non-streaming call to `.withResponse()`.
+ *
+ * Scoping is per-request via AsyncLocalStorage rather than a field on the
+ * provider: a provider instance is shared across concurrent calls, so an
+ * instance field would race and attribute one request's limits to another.
+ *
+ * @module providers/anthropic/rateLimitCapture
+ */
+
+import { AsyncLocalStorage } from "async_hooks";
+import { trace } from "@opentelemetry/api";
+import type {
+  AnthropicRateLimitInfo,
+  ClaudeLimitCaptureSlot,
+  ClaudeLimitSnapshot,
+} from "../../types/index.js";
+import { logger } from "../../utils/logger.js";
+
+/** Below this much session headroom (percent), log at WARN instead of INFO. */
+const LOW_HEADROOM_WARN_PCT = 15;
+
+const limitCaptureStorage = new AsyncLocalStorage<ClaudeLimitCaptureSlot>();
+
+function headerOf(headers: Headers, name: string): string | undefined {
+  const value = headers.get(name);
+  return value === null || value === "" ? undefined : value;
+}
+
+function numberOf(headers: Headers, name: string): number | undefined {
+  const raw = headerOf(headers, name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function intOf(headers: Headers, name: string): number | undefined {
+  const raw = headerOf(headers, name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** 0.0-1.0 utilization → whole-percent remaining, clamped to [0, 100]. */
+function leftPctFrom(utilization: number | undefined): number | undefined {
+  if (utilization === undefined) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(100, Math.round((1 - utilization) * 100)));
+}
+
+/**
+ * Parse both Anthropic rate-limit header families into a single shape.
+ *
+ * Which family is present depends on the account type, so every field is
+ * optional and absence is normal rather than an error.
+ */
+export function parseAnthropicLimitHeaders(
+  headers: Headers,
+): AnthropicRateLimitInfo {
+  const sessionUtilization = numberOf(
+    headers,
+    "anthropic-ratelimit-unified-5h-utilization",
+  );
+  const weeklyUtilization = numberOf(
+    headers,
+    "anthropic-ratelimit-unified-7d-utilization",
+  );
+
+  const info: AnthropicRateLimitInfo = {};
+
+  // Legacy per-tier counters — these ARE absolute remaining counts.
+  const requestsLimit = intOf(headers, "anthropic-ratelimit-requests-limit");
+  const requestsRemaining = intOf(
+    headers,
+    "anthropic-ratelimit-requests-remaining",
+  );
+  const requestsReset = headerOf(headers, "anthropic-ratelimit-requests-reset");
+  const tokensLimit = intOf(headers, "anthropic-ratelimit-tokens-limit");
+  const tokensRemaining = intOf(
+    headers,
+    "anthropic-ratelimit-tokens-remaining",
+  );
+  const tokensReset = headerOf(headers, "anthropic-ratelimit-tokens-reset");
+  const retryAfter = intOf(headers, "retry-after");
+
+  if (requestsLimit !== undefined) {
+    info.requestsLimit = requestsLimit;
+  }
+  if (requestsRemaining !== undefined) {
+    info.requestsRemaining = requestsRemaining;
+  }
+  if (requestsReset !== undefined) {
+    info.requestsReset = requestsReset;
+  }
+  if (tokensLimit !== undefined) {
+    info.tokensLimit = tokensLimit;
+  }
+  if (tokensRemaining !== undefined) {
+    info.tokensRemaining = tokensRemaining;
+  }
+  if (tokensReset !== undefined) {
+    info.tokensReset = tokensReset;
+  }
+  if (retryAfter !== undefined) {
+    info.retryAfter = retryAfter;
+  }
+
+  // Unified subscription windows — utilization only, no absolute remaining.
+  if (sessionUtilization !== undefined) {
+    info.sessionUtilization = sessionUtilization;
+    const left = leftPctFrom(sessionUtilization);
+    if (left !== undefined) {
+      info.sessionLeftPct = left;
+    }
+  }
+  const sessionStatus = headerOf(
+    headers,
+    "anthropic-ratelimit-unified-5h-status",
+  );
+  if (sessionStatus !== undefined) {
+    info.sessionStatus = sessionStatus;
+  }
+  const sessionResetAt = intOf(headers, "anthropic-ratelimit-unified-5h-reset");
+  if (sessionResetAt !== undefined) {
+    info.sessionResetAt = sessionResetAt;
+  }
+
+  if (weeklyUtilization !== undefined) {
+    info.weeklyUtilization = weeklyUtilization;
+    const left = leftPctFrom(weeklyUtilization);
+    if (left !== undefined) {
+      info.weeklyLeftPct = left;
+    }
+  }
+  const weeklyStatus = headerOf(
+    headers,
+    "anthropic-ratelimit-unified-7d-status",
+  );
+  if (weeklyStatus !== undefined) {
+    info.weeklyStatus = weeklyStatus;
+  }
+  const weeklyResetAt = intOf(headers, "anthropic-ratelimit-unified-7d-reset");
+  if (weeklyResetAt !== undefined) {
+    info.weeklyResetAt = weeklyResetAt;
+  }
+
+  const unifiedStatus = headerOf(headers, "anthropic-ratelimit-unified-status");
+  if (unifiedStatus !== undefined) {
+    info.unifiedStatus = unifiedStatus;
+  }
+  const overageStatus = headerOf(
+    headers,
+    "anthropic-ratelimit-unified-overage-status",
+  );
+  if (overageStatus !== undefined) {
+    info.overageStatus = overageStatus;
+  }
+
+  return info;
+}
+
+/** True when a parsed info object carries no usable signal at all. */
+function isEmptyRateLimitInfo(info: AnthropicRateLimitInfo): boolean {
+  return Object.keys(info).length === 0;
+}
+
+/**
+ * Build a snapshot from a response, or undefined when the response carries
+ * neither Anthropic rate-limit headers nor NeuroLink proxy metadata.
+ */
+export function buildLimitSnapshot(
+  headers: Headers,
+  status: number,
+  now: number = Date.now(),
+): ClaudeLimitSnapshot | undefined {
+  const rateLimit = parseAnthropicLimitHeaders(headers);
+  const quotaSource = headerOf(headers, "x-neurolink-quota-source");
+  const account = headerOf(headers, "x-neurolink-account");
+  const accountType = headerOf(headers, "x-neurolink-account-type");
+  const servedBy = headerOf(headers, "x-neurolink-served-by");
+  const poolAvailable = intOf(headers, "x-neurolink-pool-available");
+  const poolCooling = intOf(headers, "x-neurolink-pool-cooling");
+  const poolBest = intOf(headers, "x-neurolink-pool-best-session-left");
+  const coolingUntil = intOf(headers, "x-neurolink-account-cooling-until");
+  const coolingReason = headerOf(headers, "x-neurolink-account-cooling-reason");
+  const requestId = headerOf(headers, "x-request-id");
+
+  const hasProxyMetadata =
+    quotaSource !== undefined ||
+    account !== undefined ||
+    servedBy !== undefined;
+  if (isEmptyRateLimitInfo(rateLimit) && !hasProxyMetadata) {
+    return undefined;
+  }
+
+  const pool =
+    poolAvailable !== undefined ||
+    poolCooling !== undefined ||
+    poolBest !== undefined
+      ? {
+          ...(poolAvailable !== undefined ? { available: poolAvailable } : {}),
+          ...(poolCooling !== undefined ? { cooling: poolCooling } : {}),
+          ...(poolBest !== undefined ? { bestSessionLeftPct: poolBest } : {}),
+        }
+      : undefined;
+
+  return {
+    rateLimit,
+    ...(quotaSource === "live" ||
+    quotaSource === "snapshot" ||
+    quotaSource === "none"
+      ? { quotaSource }
+      : {}),
+    ...(account !== undefined ? { account } : {}),
+    ...(accountType !== undefined ? { accountType } : {}),
+    ...(servedBy !== undefined ? { servedBy } : {}),
+    ...(coolingUntil !== undefined
+      ? { accountCoolingUntil: coolingUntil }
+      : {}),
+    ...(coolingReason !== undefined
+      ? { accountCoolingReason: coolingReason }
+      : {}),
+    ...(pool ? { pool } : {}),
+    ...(requestId !== undefined ? { requestId } : {}),
+    status,
+    capturedAt: now,
+  };
+}
+
+/**
+ * Wrap a fetch so every response's limit headers are captured into the
+ * enclosing `withLimitCapture` scope. A no-op outside such a scope.
+ *
+ * Capture never alters the response and never throws — a parsing failure must
+ * not be able to break a request that the provider would otherwise complete.
+ */
+export function wrapFetchWithLimitCapture(inner: typeof fetch): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await inner(input, init);
+    const slot = limitCaptureStorage.getStore();
+    if (!slot) {
+      return response;
+    }
+    try {
+      const raw: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        raw[key] = value;
+      });
+      slot.headers = raw;
+      const snapshot = buildLimitSnapshot(response.headers, response.status);
+      if (snapshot) {
+        // Last write wins: a retried or multi-step call reports the most
+        // recent upstream state, which is the one a caller acts on.
+        slot.snapshot = snapshot;
+      }
+    } catch {
+      // Diagnostics only — never disturb the response.
+    }
+    return response;
+  };
+}
+
+/**
+ * Run `body` in a capture scope and return its result alongside whatever limit
+ * snapshot the underlying HTTP request(s) produced.
+ */
+export async function withLimitCapture<T>(
+  body: () => Promise<T>,
+): Promise<{ result: T; snapshot?: ClaudeLimitSnapshot }> {
+  const slot: ClaudeLimitCaptureSlot = {};
+  const result = await limitCaptureStorage.run(slot, body);
+  return {
+    result,
+    ...(slot.snapshot ? { snapshot: slot.snapshot } : {}),
+  };
+}
+
+/**
+ * Current scope's snapshot, if any. Lets a long-running loop (the streaming
+ * path) read limits mid-flight without unwinding the scope.
+ */
+export function getCapturedLimitSnapshot(): ClaudeLimitSnapshot | undefined {
+  return limitCaptureStorage.getStore()?.snapshot;
+}
+
+/** Raw headers of the most recent captured response in this scope. */
+export function getCapturedResponseHeaders():
+  | Record<string, string>
+  | undefined {
+  return limitCaptureStorage.getStore()?.headers;
+}
+
+/** Enter a capture scope without wrapping a single call — for streaming, where
+ *  the scope must outlive the function that opened it. */
+export function runInLimitCaptureScope<T>(body: () => T): T {
+  return limitCaptureStorage.run({}, body);
+}
+
+/**
+ * Attach limit state to the currently active OTel span.
+ *
+ * Uses the active span rather than threading one down from the generation
+ * layer: that layer is provider-agnostic and should not learn about Anthropic
+ * quota headers just to record them. The active span during a turn is the one
+ * already carrying `gen_ai.usage.*` and `neurolink.cost`, so "what did this
+ * cost" and "how much is left" answer from the same trace.
+ */
+export function setLimitSpanAttributes(snapshot: ClaudeLimitSnapshot): void {
+  const span = trace.getActiveSpan();
+  if (!span) {
+    return;
+  }
+  const { rateLimit } = snapshot;
+  const attrs: Array<[string, string | number | undefined]> = [
+    ["neurolink.claude.quota.session_left_pct", rateLimit.sessionLeftPct],
+    ["neurolink.claude.quota.weekly_left_pct", rateLimit.weeklyLeftPct],
+    ["neurolink.claude.quota.requests_remaining", rateLimit.requestsRemaining],
+    ["neurolink.claude.quota.tokens_remaining", rateLimit.tokensRemaining],
+    ["neurolink.claude.quota.source", snapshot.quotaSource],
+    ["neurolink.claude.account", snapshot.account],
+    ["neurolink.claude.served_by", snapshot.servedBy],
+    ["neurolink.claude.pool.available", snapshot.pool?.available],
+    [
+      "neurolink.claude.pool.best_session_left_pct",
+      snapshot.pool?.bestSessionLeftPct,
+    ],
+  ];
+  for (const [key, value] of attrs) {
+    if (value !== undefined) {
+      span.setAttribute(key, value);
+    }
+  }
+}
+
+/** Seconds-from-now for an epoch-seconds reset, or undefined if absent/past. */
+function resetsInSeconds(
+  resetAt: number | undefined,
+  now: number,
+): number | undefined {
+  if (!resetAt || resetAt <= 0) {
+    return undefined;
+  }
+  // Tolerate a value already expressed in ms (year 2100 in seconds).
+  const ms = resetAt > 4_102_444_800 ? resetAt : resetAt * 1000;
+  return ms > now ? Math.round((ms - now) / 1000) : undefined;
+}
+
+/**
+ * Emit one structured line per request describing remaining capacity.
+ *
+ * Leads with headroom ("how much is left") because that is the figure an
+ * operator acts on; the raw utilization stays available on the snapshot for
+ * anything computing against it. Escalates to WARN when the session window is
+ * nearly spent or the provider has already flagged the account as
+ * throttled/rejected.
+ */
+export function logClaudeLimitSnapshot(
+  snapshot: ClaudeLimitSnapshot,
+  model?: string,
+  now: number = Date.now(),
+): void {
+  const { rateLimit } = snapshot;
+
+  // A fallback provider served this — there is no Anthropic capacity to report.
+  if (snapshot.quotaSource === "none" && snapshot.servedBy) {
+    logger.debug("[Anthropic] request served without account quota", {
+      servedBy: snapshot.servedBy,
+      ...(model ? { model } : {}),
+    });
+    return;
+  }
+
+  const details: Record<string, unknown> = {
+    ...(model ? { model } : {}),
+    ...(snapshot.account ? { account: snapshot.account } : {}),
+    ...(snapshot.accountType ? { accountType: snapshot.accountType } : {}),
+    ...(snapshot.servedBy ? { servedBy: snapshot.servedBy } : {}),
+    ...(snapshot.quotaSource ? { quotaSource: snapshot.quotaSource } : {}),
+  };
+
+  if (rateLimit.sessionLeftPct !== undefined) {
+    details.sessionLeftPct = rateLimit.sessionLeftPct;
+    const resets = resetsInSeconds(rateLimit.sessionResetAt, now);
+    if (resets !== undefined) {
+      details.sessionResetsInSec = resets;
+    }
+  }
+  if (rateLimit.weeklyLeftPct !== undefined) {
+    details.weeklyLeftPct = rateLimit.weeklyLeftPct;
+    const resets = resetsInSeconds(rateLimit.weeklyResetAt, now);
+    if (resets !== undefined) {
+      details.weeklyResetsInSec = resets;
+    }
+  }
+  // API-key accounts report absolute remaining rather than a percentage.
+  if (rateLimit.requestsRemaining !== undefined) {
+    details.requestsRemaining = rateLimit.requestsRemaining;
+  }
+  if (rateLimit.tokensRemaining !== undefined) {
+    details.tokensRemaining = rateLimit.tokensRemaining;
+  }
+  if (rateLimit.retryAfter !== undefined) {
+    details.retryAfterSec = rateLimit.retryAfter;
+  }
+  if (snapshot.pool) {
+    details.pool = snapshot.pool;
+  }
+
+  if (Object.keys(details).length === 0) {
+    return;
+  }
+
+  const status = (
+    rateLimit.unifiedStatus ??
+    rateLimit.sessionStatus ??
+    ""
+  ).toLowerCase();
+  const lowHeadroom =
+    rateLimit.sessionLeftPct !== undefined &&
+    rateLimit.sessionLeftPct <= LOW_HEADROOM_WARN_PCT;
+  const flagged = status === "throttled" || status === "rejected";
+
+  if (lowHeadroom || flagged) {
+    // `always`, not `warn`: this logger suppresses everything below `error`
+    // unless debug mode is on, and "you are about to run out of capacity" is
+    // precisely the thing an operator must see during a normal run. The
+    // routine per-request line below stays debug-gated so this stays rare
+    // enough to mean something.
+    logger.always(
+      `[Anthropic] account limits running low — ${JSON.stringify({
+        ...details,
+        ...(status ? { status } : {}),
+      })}`,
+    );
+    return;
+  }
+  logger.info("[Anthropic] account limits", details);
+}

--- a/src/lib/proxy/quotaHeaders.ts
+++ b/src/lib/proxy/quotaHeaders.ts
@@ -1,0 +1,245 @@
+/**
+ * Proxy response quota headers.
+ *
+ * The proxy already knows, per request, exactly how much subscription capacity
+ * the serving account has left — it parses Anthropic's `anthropic-ratelimit-*`
+ * headers to route on them (see `accountQuota.ts`). Historically none of that
+ * reached the client: only the SSE path forwarded a small legacy allowlist, and
+ * every JSON/error path dropped headers entirely.
+ *
+ * This module turns that state into response headers in two layers:
+ *
+ * 1. **Verbatim passthrough** of Anthropic's own `anthropic-ratelimit-*` and
+ *    `retry-after` headers. This is the load-bearing part: a proxied response
+ *    then looks byte-identical to a direct one, so a consumer needs exactly one
+ *    parser for both.
+ * 2. **`x-neurolink-*`** for what only the proxy can know — which account
+ *    served the request, pool headroom, whether the numbers are live or stale,
+ *    and the derived "how much is left" percentages.
+ *
+ * Pure CPU, no I/O — safe on the hot path and directly unit-testable.
+ *
+ * @module proxy/quotaHeaders
+ */
+
+import type { AccountQuota, ProxyQuotaHeaderContext } from "../types/index.js";
+
+/** Upstream headers forwarded to the client untouched. */
+const UPSTREAM_PREFIX = "anthropic-ratelimit-";
+const UPSTREAM_EXTRA_HEADERS = ["retry-after"];
+
+/**
+ * A value beyond ~year 2100 expressed in seconds is already milliseconds —
+ * same heuristic the cooldown planner uses, kept in sync deliberately so
+ * "resets in" and the actual cooldown never disagree.
+ */
+const EPOCH_SECONDS_CEILING = 4_102_444_800;
+
+/**
+ * Strip anything that cannot legally appear in a header value.
+ *
+ * Account labels originate from user email addresses, so this is not
+ * theoretical: a CR/LF in a label would let a crafted account name inject
+ * additional response headers. Non-ASCII is dropped rather than encoded —
+ * these are diagnostic values, not content.
+ */
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+/** Epoch seconds (or ms) → seconds from now, floored at 0. Undefined when the
+ *  timestamp is absent, zero, or already in the past. */
+function secondsUntil(
+  resetEpoch: number | undefined,
+  now: number,
+): number | undefined {
+  if (!resetEpoch || resetEpoch <= 0) {
+    return undefined;
+  }
+  const ms =
+    resetEpoch > EPOCH_SECONDS_CEILING ? resetEpoch : resetEpoch * 1000;
+  if (ms <= now) {
+    return undefined;
+  }
+  return Math.round((ms - now) / 1000);
+}
+
+/**
+ * Convert a 0.0-1.0 utilization fraction into a whole-percent "left" figure.
+ *
+ * Anthropic publishes utilization (used), never remaining, for subscription
+ * windows — there is no absolute message or token count to report, so the
+ * honest derived form is a percentage. Clamped because a utilization above 1.0
+ * (overage) would otherwise produce a negative "left".
+ */
+export function utilizationToLeftPct(used: number): number {
+  if (!Number.isFinite(used)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, Math.round((1 - used) * 100)));
+}
+
+/**
+ * Copy Anthropic's rate-limit headers verbatim from an upstream response.
+ *
+ * Covers both header families: the unified subscription windows
+ * (`unified-5h-*`, `unified-7d-*`) and the legacy per-tier counters
+ * (`requests-remaining`, `tokens-remaining`, ...) that API-key accounts get.
+ * Which family is present depends on the serving account type, which is why
+ * `x-neurolink-account-type` accompanies them.
+ */
+export function pickUpstreamRateLimitHeaders(
+  headers: Headers | Record<string, string>,
+): Record<string, string> {
+  const picked: Record<string, string> = {};
+  const consider = (key: string, value: string): void => {
+    const lower = key.toLowerCase();
+    if (
+      lower.startsWith(UPSTREAM_PREFIX) ||
+      UPSTREAM_EXTRA_HEADERS.includes(lower)
+    ) {
+      const clean = sanitizeHeaderValue(value);
+      if (clean) {
+        picked[lower] = clean;
+      }
+    }
+  };
+
+  if (typeof (headers as Headers).forEach === "function") {
+    (headers as Headers).forEach((value, key) => consider(key, value));
+    return picked;
+  }
+  for (const [key, value] of Object.entries(
+    headers as Record<string, string>,
+  )) {
+    if (typeof value === "string") {
+      consider(key, value);
+    }
+  }
+  return picked;
+}
+
+/**
+ * Build the `x-neurolink-*` half of the contract from proxy-side state.
+ *
+ * Always emits `x-neurolink-quota-source` — even when it is "none". A consumer
+ * that sees quota numbers with no provenance cannot tell a fresh reading from a
+ * snapshot carried over from a previous request, and would happily log stale
+ * capacity as current.
+ */
+export function buildQuotaResponseHeaders(
+  context: ProxyQuotaHeaderContext,
+  now: number = Date.now(),
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "x-neurolink-quota-source": context.source,
+  };
+
+  const set = (name: string, value: string | number | undefined): void => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    const clean = sanitizeHeaderValue(String(value));
+    if (clean) {
+      headers[name] = clean;
+    }
+  };
+
+  set("x-neurolink-account", context.accountLabel);
+  set("x-neurolink-account-type", context.accountType);
+  set("x-neurolink-served-by", context.servedBy);
+  set("x-neurolink-attempt", context.attempt);
+  set("x-neurolink-account-cooling-until", context.coolingUntil);
+  set("x-neurolink-account-cooling-reason", context.coolingReason);
+
+  if (context.pool) {
+    set("x-neurolink-pool-available", context.pool.available);
+    set("x-neurolink-pool-cooling", context.pool.cooling);
+    set("x-neurolink-pool-best-session-left", context.pool.bestSessionLeftPct);
+  }
+
+  const quota = context.quota;
+  if (quota && context.source !== "none") {
+    set(
+      "x-neurolink-quota-session-left-pct",
+      utilizationToLeftPct(quota.sessionUsed),
+    );
+    set("x-neurolink-quota-session-status", quota.sessionStatus);
+    set(
+      "x-neurolink-quota-session-resets-in",
+      secondsUntil(quota.sessionResetAt, now),
+    );
+    set(
+      "x-neurolink-quota-weekly-left-pct",
+      utilizationToLeftPct(quota.weeklyUsed),
+    );
+    set("x-neurolink-quota-weekly-status", quota.weeklyStatus);
+    set(
+      "x-neurolink-quota-weekly-resets-in",
+      secondsUntil(quota.weeklyResetAt, now),
+    );
+    set("x-neurolink-quota-unified-status", quota.unifiedStatus);
+    set("x-neurolink-quota-overage-status", quota.overageStatus);
+    set(
+      "x-neurolink-quota-fallback-pct",
+      Math.round((quota.fallbackPercentage ?? 0) * 100),
+    );
+    set("x-neurolink-quota-updated-at", quota.lastUpdated);
+  }
+
+  return headers;
+}
+
+/**
+ * Full response header set: upstream verbatim + proxy-derived.
+ *
+ * Upstream headers are applied first so a `x-neurolink-*` key can never be
+ * shadowed by an upstream one (they share no names today, but the ordering
+ * makes the precedence explicit rather than incidental).
+ */
+export function buildProxyLimitHeaders(args: {
+  upstreamHeaders?: Headers | Record<string, string>;
+  context: ProxyQuotaHeaderContext;
+  now?: number;
+}): Record<string, string> {
+  return {
+    ...(args.upstreamHeaders
+      ? pickUpstreamRateLimitHeaders(args.upstreamHeaders)
+      : {}),
+    ...buildQuotaResponseHeaders(args.context, args.now),
+  };
+}
+
+/** Compute pool headroom from the runtime account states backing a request. */
+export function summarizePoolHeadroom(
+  entries: ReadonlyArray<{
+    coolingUntil?: number;
+    quota?: AccountQuota;
+  }>,
+  now: number = Date.now(),
+): { available: number; cooling: number; bestSessionLeftPct?: number } {
+  let available = 0;
+  let cooling = 0;
+  let bestSessionLeftPct: number | undefined;
+
+  for (const entry of entries) {
+    const isCooling = !!entry.coolingUntil && entry.coolingUntil > now;
+    if (isCooling) {
+      cooling += 1;
+      continue;
+    }
+    available += 1;
+    if (entry.quota) {
+      const left = utilizationToLeftPct(entry.quota.sessionUsed);
+      if (bestSessionLeftPct === undefined || left > bestSessionLeftPct) {
+        bestSessionLeftPct = left;
+      }
+    }
+  }
+
+  return {
+    available,
+    cooling,
+    ...(bestSessionLeftPct !== undefined ? { bestSessionLeftPct } : {}),
+  };
+}

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -41,6 +41,10 @@ import {
   saveAccountQuota,
 } from "../../proxy/accountQuota.js";
 import {
+  buildProxyLimitHeaders,
+  summarizePoolHeadroom,
+} from "../../proxy/quotaHeaders.js";
+import {
   buildClaudeError,
   ClaudeStreamSerializer,
   generateToolUseId,
@@ -125,6 +129,7 @@ import type {
   ProxyBodyCaptureLogger,
   ProxyQuotaCooldownUpdate,
   ProxyPassthroughAccount,
+  ProxyQuotaSource,
   QueuedAccountAdmission,
   ResponseInfoContext,
   RouteGroup,
@@ -662,6 +667,79 @@ function resetEpochToMs(
   // Heuristic: a value beyond ~year 2100 in seconds (4102444800) is already ms.
   const ms = resetEpoch > 4_102_444_800 ? resetEpoch : resetEpoch * 1000;
   return ms > now ? ms : undefined;
+}
+
+/**
+ * Publish limit/quota headers for this response onto the request context.
+ *
+ * Every response path funnels through here so the header contract is defined
+ * once. The proxy runtime copies `ctx.responseHeaders` onto JSON and error
+ * responses, and merges them into streaming Responses for keys those don't
+ * already set — so a single call covers both shapes.
+ */
+function publishLimitHeaders(
+  ctx: ServerContext,
+  args: {
+    upstreamHeaders?: Headers | Record<string, string>;
+    quota?: AccountQuota | null;
+    source: ProxyQuotaSource;
+    account?: ProxyPassthroughAccount;
+    accountState?: RuntimeAccountState;
+    /** Overrides the account's own type — used by passthrough, which has no
+     *  pooled account but is still a distinct serving mode. */
+    accountType?: string;
+    servedBy?: string;
+    attempt?: number;
+    poolAccounts?: ReadonlyArray<ProxyPassthroughAccount>;
+  },
+): void {
+  try {
+    const pool = args.poolAccounts
+      ? summarizePoolHeadroom(
+          args.poolAccounts.map((account) => {
+            const state = accountRuntimeState.get(account.key);
+            return {
+              ...(state?.coolingUntil !== undefined
+                ? { coolingUntil: state.coolingUntil }
+                : {}),
+              ...(state?.quota ? { quota: state.quota } : {}),
+            };
+          }),
+        )
+      : undefined;
+
+    const headers = buildProxyLimitHeaders({
+      ...(args.upstreamHeaders
+        ? { upstreamHeaders: args.upstreamHeaders }
+        : {}),
+      context: {
+        quota: args.quota ?? null,
+        source: args.source,
+        ...(args.account ? { accountLabel: args.account.label } : {}),
+        ...((args.accountType ?? args.account?.type)
+          ? { accountType: args.accountType ?? args.account?.type }
+          : {}),
+        ...(args.servedBy ? { servedBy: args.servedBy } : {}),
+        ...(args.attempt !== undefined ? { attempt: args.attempt } : {}),
+        ...(args.accountState?.coolingUntil !== undefined
+          ? { coolingUntil: args.accountState.coolingUntil }
+          : {}),
+        ...(args.accountState?.coolingReason
+          ? { coolingReason: args.accountState.coolingReason }
+          : {}),
+        ...(pool ? { pool } : {}),
+      },
+    });
+
+    ctx.responseHeaders = { ...(ctx.responseHeaders ?? {}), ...headers };
+  } catch (error) {
+    // Diagnostics must never break a response that is otherwise fine.
+    logger.debug(
+      `[proxy] failed to publish limit headers: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 /** Clamp a cooldown target epoch-ms into [now+MIN, now+MAX]. */
@@ -2076,6 +2154,21 @@ async function handleClaudePassthroughRequest(args: {
   });
   tracer?.logUpstreamResponseHeaders(upstreamResponseHeaders);
 
+  // Passthrough uses the caller's own credentials, so there is no account pool
+  // to report — but the upstream quota headers are still the caller's real
+  // limits. Published before the ok/non-ok split so a 429 carries them too.
+  {
+    const passthroughQuota = parseQuotaHeaders(response.headers);
+    publishLimitHeaders(ctx, {
+      upstreamHeaders: response.headers,
+      quota: passthroughQuota,
+      source: passthroughQuota ? "live" : "none",
+      accountType: "passthrough",
+      servedBy: "anthropic",
+      attempt: 1,
+    });
+  }
+
   if (!response.ok) {
     const errorText = await response.text();
     recordAttemptError(
@@ -2213,6 +2306,7 @@ async function handleClaudePassthroughStreamResponse(args: {
   logFinalRequest: ClaudeFinalRequestLogger;
 }): Promise<Response> {
   const {
+    ctx,
     bodyStr,
     response,
     tracer,
@@ -2470,7 +2564,13 @@ async function handleClaudePassthroughStreamResponse(args: {
   const clientStream = streamSource.pipeThrough(clientCaptureStream);
   return new Response(clientStream, {
     status: response.status,
-    headers: responseHeaders,
+    // Upstream headers first, then the proxy's own — passthrough already
+    // forwarded everything Anthropic sent, so this only adds the x-neurolink-*
+    // fields the client cannot derive on its own.
+    headers: {
+      ...responseHeaders,
+      ...((ctx.responseHeaders ?? {}) as Record<string, string>),
+    },
   });
 }
 
@@ -3211,6 +3311,14 @@ async function tryConfiguredClaudeFallbackChain(args: {
         attemptCount: fallbackPlan.attempts.slice(1).length,
         reason: "fallback_success",
       });
+      // A different provider produced this response — say so, and report no
+      // quota. Emitting the last Anthropic snapshot here would attribute one
+      // provider's capacity to another's output.
+      publishLimitHeaders(ctx, {
+        quota: null,
+        source: "none",
+        servedBy: fallback.provider,
+      });
       return { response };
     } catch (fallbackErr) {
       const errMsg = redactProviderErrorMessage(
@@ -3325,6 +3433,13 @@ async function tryAutoClaudeFallback(args: {
       model: body.model,
       attemptCount: 1,
       reason: "fallback_success",
+    });
+    // See the configured-chain path: never attribute Anthropic quota to a
+    // response another provider produced.
+    publishLimitHeaders(ctx, {
+      quota: null,
+      source: "none",
+      servedBy: "auto-provider",
     });
     return { response };
   } catch (fallbackErr) {
@@ -3554,6 +3669,8 @@ async function handleAnthropicSuccessfulResponse(args: {
   logAttempt: AnthropicAttemptLogger;
   logProxyBody: ProxyBodyCaptureLogger;
   onStreamTerminal?: () => void;
+  /** Accounts eligible for this request, used to report pool headroom. */
+  poolAccounts?: ReadonlyArray<ProxyPassthroughAccount>;
   logFinalRequest: (
     status: number,
     accountLabel: string,
@@ -3583,6 +3700,7 @@ async function handleAnthropicSuccessfulResponse(args: {
     logAttempt,
     logProxyBody,
     onStreamTerminal,
+    poolAccounts,
     logFinalRequest,
   } = args;
   accountState.consecutiveRefreshFailures = 0;
@@ -3624,6 +3742,21 @@ async function handleAnthropicSuccessfulResponse(args: {
     responseHeaders[key] = value;
   });
   tracer?.logUpstreamResponseHeaders(responseHeaders);
+
+  // Surface limits to the client. `quota` is non-null only when this upstream
+  // response actually carried the unified headers; otherwise fall back to the
+  // account's last snapshot and label it as such, so a consumer never mistakes
+  // a carried-over reading for a fresh one.
+  publishLimitHeaders(ctx, {
+    upstreamHeaders: response.headers,
+    quota: quota ?? accountState.quota ?? null,
+    source: quota ? "live" : accountState.quota ? "snapshot" : "none",
+    account,
+    accountState,
+    servedBy: "anthropic",
+    attempt: attemptNumber,
+    ...(poolAccounts ? { poolAccounts } : {}),
+  });
 
   if (body.stream) {
     return handleAnthropicStreamingSuccessResponse({
@@ -3693,6 +3826,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
   ) => void;
 }): Promise<AnthropicSuccessResult> {
   const {
+    ctx,
     account,
     accountState,
     response,
@@ -3939,6 +4073,7 @@ async function handleAnthropicStreamingSuccessResponse(args: {
 
   const { response: result, telemetryDone } =
     attachAnthropicSuccessStreamTelemetry({
+      ctx,
       account,
       response,
       responseHeaders,
@@ -3989,6 +4124,7 @@ function recordCommittedAnthropicStreamAttemptFailure(
 }
 
 function attachAnthropicSuccessStreamTelemetry(args: {
+  ctx: ServerContext;
   account: ProxyPassthroughAccount;
   response: Response;
   responseHeaders: Record<string, string>;
@@ -4015,6 +4151,7 @@ function attachAnthropicSuccessStreamTelemetry(args: {
   ) => void;
 }): { response: Response; telemetryDone: Promise<void> } {
   const {
+    ctx,
     account,
     response,
     responseHeaders,
@@ -4315,23 +4452,18 @@ function attachAnthropicSuccessStreamTelemetry(args: {
   }
 
   const clientStream = streamSource.pipeThrough(clientCaptureStream);
+  // Limit headers published on the context are applied here rather than left
+  // to the runtime wrapper: this Response goes straight to the client on every
+  // mount (proxy runtime and the generic server adapters alike), so the
+  // streaming path has to carry them itself. The previous five-name allowlist
+  // forwarded only the legacy counters and dropped the unified subscription
+  // windows entirely.
   const clientResponseHeaders: Record<string, string> = {
+    ...((ctx.responseHeaders ?? {}) as Record<string, string>),
     "content-type": "text/event-stream",
     "cache-control": "no-cache",
     connection: "keep-alive",
   };
-  for (const headerName of [
-    "retry-after",
-    "anthropic-ratelimit-requests-remaining",
-    "anthropic-ratelimit-requests-limit",
-    "anthropic-ratelimit-tokens-remaining",
-    "anthropic-ratelimit-tokens-limit",
-  ]) {
-    const value = response.headers.get(headerName);
-    if (value) {
-      clientResponseHeaders[headerName] = value;
-    }
-  }
 
   return {
     response: new Response(clientStream, {
@@ -6757,6 +6889,7 @@ async function handleAnthropicRoutedClaudeRequest(args: {
           logProxyBody,
           logFinalRequest,
           onStreamTerminal: admissionLease.release,
+          poolAccounts: enabledAccounts,
         });
         if ("retryNextAccount" in successResult) {
           if (successResult.failure) {
@@ -6822,6 +6955,25 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     }
 
     loopState.fallbackFailureMessage = fallbackFailureMessage;
+  }
+
+  // Terminal failure — usually "every account is rate-limited". This is the
+  // response a caller most needs limit data on, and historically the one that
+  // carried none. No single account served it, so report the account we would
+  // have tried first plus pool headroom, explicitly marked as a snapshot.
+  {
+    const primary = orderedAccounts[0];
+    const primaryState = primary
+      ? accountRuntimeState.get(primary.key)
+      : undefined;
+    publishLimitHeaders(ctx, {
+      quota: primaryState?.quota ?? null,
+      source: primaryState?.quota ? "snapshot" : "none",
+      ...(primary ? { account: primary } : {}),
+      ...(primaryState ? { accountState: primaryState } : {}),
+      attempt: loopState.attemptNumber,
+      poolAccounts: enabledAccounts,
+    });
   }
 
   return buildClaudeAnthropicFailureResponse({

--- a/src/lib/types/analytics.ts
+++ b/src/lib/types/analytics.ts
@@ -4,6 +4,7 @@
  */
 
 import type { JsonValue, UnknownRecord } from "./common.js";
+import type { ClaudeLimitSnapshot } from "./subscription.js";
 
 /**
  * Token usage information (consolidated from multiple sources)
@@ -51,6 +52,13 @@ export type AnalyticsData = {
   elapsedMs?: number;
   /** Verbatim provider finish/stop reason for the terminal model call. */
   rawFinishReason?: string;
+  /**
+   * Account limit state observed on this request — subscription window
+   * headroom, reset times, and (via the NeuroLink Claude proxy) which account
+   * served it and how much the pool has left. Present for Anthropic traffic
+   * whose response carried rate-limit headers.
+   */
+  limits?: ClaudeLimitSnapshot;
 };
 
 /**

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -6,6 +6,7 @@ import type {
 } from "./knowledge.js";
 import type { SkillsCallOptions } from "./skills.js";
 import type { AnalyticsData, TokenUsage } from "./analytics.js";
+import type { ClaudeLimitSnapshot } from "./subscription.js";
 import type { JsonValue } from "./common.js";
 import type { Content, ImageWithAltText } from "./content.js";
 import type { ChatMessage, ConversationMemoryConfig } from "./conversation.js";
@@ -1080,6 +1081,18 @@ export type GenerateResult = {
     count: number;
     errors: Array<{ code: string; message: string }>;
   };
+
+  /**
+   * Account limit state for this request, parsed from Anthropic's
+   * `anthropic-ratelimit-*` response headers (plus the NeuroLink Claude
+   * proxy's `x-neurolink-*` additions when routed through it).
+   *
+   * Subscription windows report utilization, so headroom is a percentage
+   * (`sessionLeftPct`) rather than an absolute count — Anthropic publishes no
+   * remaining message or token figure for them. API-key accounts do carry
+   * absolute `requestsRemaining` / `tokensRemaining`.
+   */
+  limits?: ClaudeLimitSnapshot;
 };
 
 /**

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1106,6 +1106,52 @@ export type AccountQuota = {
   lastUpdated: number;
 };
 
+/**
+ * Provenance of the quota numbers attached to a single proxy response.
+ *  - "live"     : parsed from THIS upstream response's headers.
+ *  - "snapshot" : the last known snapshot for the serving account; the upstream
+ *                 response carried no quota headers.
+ *  - "none"     : no Anthropic account served this request (fallback provider,
+ *                 or a failure before any account was reached).
+ *
+ * Consumers must not treat "snapshot" as current. Without this distinction a
+ * stale reading is indistinguishable from a fresh one.
+ */
+export type ProxyQuotaSource = "live" | "snapshot" | "none";
+
+/** Aggregate account-pool headroom at the moment a response was produced. */
+export type ProxyPoolHeadroom = {
+  /** Accounts eligible to serve a request right now (not cooling/disabled). */
+  available: number;
+  /** Accounts currently in a cooldown window. */
+  cooling: number;
+  /** Best session headroom across available accounts, as a percentage 0-100.
+   *  Undefined when no available account has a quota snapshot. */
+  bestSessionLeftPct?: number;
+};
+
+/**
+ * Everything the proxy knows about limits and routing for one response.
+ * Consumed by `buildQuotaResponseHeaders` — kept as data (not headers) so the
+ * assembly stays pure and testable.
+ */
+export type ProxyQuotaHeaderContext = {
+  quota: AccountQuota | null;
+  source: ProxyQuotaSource;
+  /** Account label that served the request; omitted for fallback/no-account. */
+  accountLabel?: string;
+  accountType?: string;
+  /** Which upstream actually produced the response ("anthropic" or a fallback
+   *  provider name). Lets a consumer avoid attributing quota to the wrong one. */
+  servedBy?: string;
+  /** 1-based attempt index within the routing loop. */
+  attempt?: number;
+  /** Epoch ms until which the serving account is cooling, when applicable. */
+  coolingUntil?: number;
+  coolingReason?: AccountCoolingReason;
+  pool?: ProxyPoolHeadroom;
+};
+
 // =============================================================================
 // CLAUDE PROXY ROUTE TYPES (from claudeProxyRoutes.ts)
 // =============================================================================

--- a/src/lib/types/subscription.ts
+++ b/src/lib/types/subscription.ts
@@ -127,6 +127,88 @@ export type AnthropicRateLimitInfo = {
    * Retry-After header value in seconds (present on 429 responses)
    */
   retryAfter?: number;
+
+  /**
+   * Subscription (OAuth) window utilization, 0.0-1.0 of capacity USED, from
+   * `anthropic-ratelimit-unified-5h-utilization`.
+   *
+   * Anthropic publishes utilization for subscription windows, never an
+   * absolute remaining count — there is no message or token figure to report.
+   * `sessionLeftPct` below is the derived "how much is left".
+   */
+  sessionUtilization?: number;
+  /** "allowed" | "throttled" | "rejected" for the 5h window. */
+  sessionStatus?: string;
+  /** Unix epoch seconds at which the 5h window resets. */
+  sessionResetAt?: number;
+  /** Whole-percent capacity remaining in the 5h window (100 - utilization). */
+  sessionLeftPct?: number;
+
+  /** 7d window utilization, 0.0-1.0 of capacity USED. */
+  weeklyUtilization?: number;
+  weeklyStatus?: string;
+  weeklyResetAt?: number;
+  weeklyLeftPct?: number;
+
+  /** Authoritative top-level unified status; can be "rejected" even while both
+   *  sub-windows still report "allowed". */
+  unifiedStatus?: string;
+  /** Whether overage is permitted once a window is exhausted. */
+  overageStatus?: string;
+};
+
+/**
+ * Per-request limit snapshot as observed by the Anthropic provider.
+ *
+ * Assembled from response headers on every request — whether the provider is
+ * talking directly to Anthropic (both auth methods) or through the NeuroLink
+ * Claude proxy. The `account`/`pool`/`servedBy` fields are populated only by
+ * the proxy, which is the only party that knows them.
+ */
+export type ClaudeLimitSnapshot = {
+  /** Rate-limit figures parsed from `anthropic-ratelimit-*` headers. */
+  rateLimit: AnthropicRateLimitInfo;
+  /**
+   * Provenance of the quota numbers. "snapshot" means the proxy reported a
+   * previously captured reading rather than one from this response; "none"
+   * means no Anthropic account served the request (e.g. a fallback provider).
+   * Absent when talking directly to Anthropic, where any figures are live.
+   */
+  quotaSource?: "live" | "snapshot" | "none";
+  /** Proxy account label that served the request. */
+  account?: string;
+  /** "oauth" | "api_key" | "passthrough". */
+  accountType?: string;
+  /** Upstream that produced the response — "anthropic" or a fallback provider. */
+  servedBy?: string;
+  /** Epoch ms until which the serving account is cooling. */
+  accountCoolingUntil?: number;
+  accountCoolingReason?: string;
+  /** Proxy account-pool headroom at response time. */
+  pool?: {
+    available?: number;
+    cooling?: number;
+    bestSessionLeftPct?: number;
+  };
+  /** Anthropic request id, for correlating with provider-side logs. */
+  requestId?: string;
+  /** HTTP status of the response the snapshot came from. */
+  status?: number;
+  /** Epoch ms when this snapshot was captured. */
+  capturedAt: number;
+};
+
+/**
+ * Per-request capture slot the Anthropic fetch wrapper writes into.
+ *
+ * Held in AsyncLocalStorage for the duration of a generate/stream call, so
+ * concurrent calls on one provider instance cannot see each other's limits.
+ * `headers` keeps the raw response header bag so the AI-SDK model adapter can
+ * report real response headers.
+ */
+export type ClaudeLimitCaptureSlot = {
+  snapshot?: ClaudeLimitSnapshot;
+  headers?: Record<string, string>;
 };
 
 /**

--- a/test/continuous-test-suite-anthropic-limit-capture.ts
+++ b/test/continuous-test-suite-anthropic-limit-capture.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env tsx
+
+/**
+ * Continuous Test Suite — Anthropic Provider Limit Capture (HTTP round trip)
+ *
+ * Exercises the seam the in-process suite cannot: a real HTTP request from the
+ * Anthropic provider, through a real socket, to a server that answers with the
+ * headers the NeuroLink Claude proxy emits. This is the exact shape of the
+ * "point the SDK at the proxy as a direct provider" setup — `ANTHROPIC_BASE_URL`
+ * plus an API key — and proves that limits survive the wire and land on
+ * `result.limits`.
+ *
+ * HERMETIC. A local stub upstream stands in for the proxy, so the suite needs
+ * no credentials, contacts no real account, and consumes no subscription quota.
+ * `ANTHROPIC_API_KEY` is a placeholder the stub ignores.
+ *
+ * NOTE on assertion messages: the harness downgrades a failure to SKIP when the
+ * text matches `isExpectedProviderError()`. Report field names, never payloads.
+ *
+ * Run with: npx tsx test/continuous-test-suite-anthropic-limit-capture.ts
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { assert, assertEqual, defineSuite } from "./helpers/harness.js";
+
+const { test, section, runSuite } = defineSuite("Anthropic Limit Capture");
+
+// ---------------------------------------------------------------------------
+// Stub upstream — answers like the NeuroLink Claude proxy
+// ---------------------------------------------------------------------------
+
+type StubOptions = {
+  /** Extra response headers, typically the quota set. */
+  headers?: Record<string, string>;
+  status?: number;
+  body?: string;
+};
+
+function messageBody(): string {
+  return JSON.stringify({
+    id: "msg_stub",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    content: [{ type: "text", text: "pong" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 8, output_tokens: 2 },
+  });
+}
+
+/** Headers a proxy-served response carries: Anthropic verbatim + x-neurolink-*. */
+function proxyStyleHeaders(): Record<string, string> {
+  const fiveHoursOut = Math.floor(Date.now() / 1000) + 5 * 3600;
+  const weekOut = Math.floor(Date.now() / 1000) + 7 * 86400;
+  return {
+    "anthropic-ratelimit-unified-status": "allowed",
+    "anthropic-ratelimit-unified-5h-utilization": "0.42",
+    "anthropic-ratelimit-unified-5h-status": "allowed",
+    "anthropic-ratelimit-unified-5h-reset": String(fiveHoursOut),
+    "anthropic-ratelimit-unified-7d-utilization": "0.19",
+    "anthropic-ratelimit-unified-7d-status": "allowed",
+    "anthropic-ratelimit-unified-7d-reset": String(weekOut),
+    "x-request-id": "req_stub_1",
+    "x-neurolink-quota-source": "live",
+    "x-neurolink-account": "stub@example.com",
+    "x-neurolink-account-type": "oauth",
+    "x-neurolink-served-by": "anthropic",
+    "x-neurolink-quota-session-left-pct": "58",
+    "x-neurolink-quota-weekly-left-pct": "81",
+    "x-neurolink-pool-available": "3",
+    "x-neurolink-pool-cooling": "1",
+    "x-neurolink-pool-best-session-left": "88",
+  };
+}
+
+async function withStubUpstream(
+  options: StubOptions,
+  body: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const received: Array<Record<string, string | string[] | undefined>> = [];
+  const server: Server = createServer((req, res) => {
+    received.push(req.headers);
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      res.writeHead(options.status ?? 200, {
+        "content-type": "application/json",
+        ...(options.headers ?? {}),
+      });
+      res.end(options.body ?? messageBody());
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  const priorBaseUrl = process.env.ANTHROPIC_BASE_URL;
+  const priorApiKey = process.env.ANTHROPIC_API_KEY;
+  const priorAuthMethod = process.env.ANTHROPIC_AUTH_METHOD;
+  process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${port}`;
+  process.env.ANTHROPIC_API_KEY = "sk-ant-stub-not-a-real-key";
+  // Force api_key mode so a developer's real OAuth credentials on this machine
+  // are never picked up by the provider under test.
+  process.env.ANTHROPIC_AUTH_METHOD = "api_key";
+
+  try {
+    await body(`http://127.0.0.1:${port}`);
+  } finally {
+    const restore = (key: string, value: string | undefined): void => {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    };
+    restore("ANTHROPIC_BASE_URL", priorBaseUrl);
+    restore("ANTHROPIC_API_KEY", priorApiKey);
+    restore("ANTHROPIC_AUTH_METHOD", priorAuthMethod);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+/** Fresh provider per test — the constructor reads env at construction time. */
+async function createProvider(): Promise<{
+  generate: (prompt: string, withAnalytics?: boolean) => Promise<unknown>;
+}> {
+  const { AnthropicProvider } =
+    await import("../src/lib/providers/anthropic/client.js");
+  const provider = new AnthropicProvider("claude-sonnet-4-6");
+  return {
+    generate: (prompt: string, withAnalytics = false) =>
+      provider.generate({
+        input: { text: prompt },
+        disableTools: true,
+        maxTokens: 16,
+        ...(withAnalytics ? { enableAnalytics: true } : {}),
+      } as never),
+  };
+}
+
+// ===========================================================================
+
+section("HTTP round trip");
+
+await test("surfaces proxy limit headers on the generate result", async () => {
+  await withStubUpstream({ headers: proxyStyleHeaders() }, async () => {
+    const provider = await createProvider();
+    const result = (await provider.generate("ping", true)) as {
+      limits?: {
+        rateLimit: Record<string, unknown>;
+        quotaSource?: string;
+        account?: string;
+        servedBy?: string;
+        pool?: Record<string, unknown>;
+      };
+      analytics?: { limits?: unknown };
+    } | null;
+
+    assert(result !== null, "the stub upstream should produce a result");
+    assert(
+      result?.limits !== undefined,
+      "result.limits must be populated from response headers",
+    );
+    assertEqual(
+      result?.limits?.rateLimit.sessionLeftPct,
+      58,
+      "session headroom must survive the HTTP round trip",
+    );
+    assertEqual(
+      result?.limits?.rateLimit.weeklyLeftPct,
+      81,
+      "weekly headroom must survive the HTTP round trip",
+    );
+    assertEqual(
+      result?.limits?.quotaSource,
+      "live",
+      "quota provenance must survive the HTTP round trip",
+    );
+    assertEqual(
+      result?.limits?.account,
+      "stub@example.com",
+      "serving account must survive the HTTP round trip",
+    );
+    assertEqual(
+      result?.limits?.pool?.available,
+      3,
+      "pool headroom must survive the HTTP round trip",
+    );
+    assert(
+      result?.analytics?.limits !== undefined,
+      "analytics.limits must mirror result.limits",
+    );
+  });
+});
+
+await test("reports absolute remaining counts for an api-key style response", async () => {
+  await withStubUpstream(
+    {
+      headers: {
+        "anthropic-ratelimit-requests-limit": "1000",
+        "anthropic-ratelimit-requests-remaining": "937",
+        "anthropic-ratelimit-tokens-limit": "80000",
+        "anthropic-ratelimit-tokens-remaining": "79250",
+      },
+    },
+    async () => {
+      const provider = await createProvider();
+      const result = (await provider.generate("ping")) as {
+        limits?: { rateLimit: Record<string, unknown> };
+      } | null;
+
+      assertEqual(
+        result?.limits?.rateLimit.requestsRemaining,
+        937,
+        "absolute remaining requests must survive the round trip",
+      );
+      assertEqual(
+        result?.limits?.rateLimit.tokensRemaining,
+        79250,
+        "absolute remaining tokens must survive the round trip",
+      );
+      assert(
+        result?.limits?.rateLimit.sessionLeftPct === undefined,
+        "an api-key response has no subscription window headroom to report",
+      );
+    },
+  );
+});
+
+await test("leaves limits unset when the upstream reports nothing", async () => {
+  await withStubUpstream({ headers: {} }, async () => {
+    const provider = await createProvider();
+    const result = (await provider.generate("ping")) as {
+      limits?: unknown;
+    } | null;
+
+    assert(result !== null, "the stub upstream should produce a result");
+    assertEqual(
+      result?.limits,
+      undefined,
+      "no limit headers must mean no fabricated limits field",
+    );
+  });
+});
+
+await runSuite();

--- a/test/continuous-test-suite-proxy-limit-headers.ts
+++ b/test/continuous-test-suite-proxy-limit-headers.ts
@@ -1,0 +1,719 @@
+#!/usr/bin/env tsx
+
+/**
+ * Continuous Test Suite — Proxy Limit / Quota Response Headers
+ *
+ * Covers the full path that makes account limits visible to a normal NeuroLink
+ * run:
+ *   1. the pure header builder (`proxy/quotaHeaders.ts`),
+ *   2. the proxy route emitting headers on every response shape — routed JSON,
+ *      routed streaming, terminal 429, and fallback,
+ *   3. the Anthropic provider capturing them back off the wire.
+ *
+ * HERMETIC BY CONSTRUCTION. This suite must never touch the developer's real
+ * proxy state or make a network call:
+ *   - `initAccountQuota` / `initAccountCooldown` redirect all persistence into
+ *     a temp dir, so `~/.neurolink/` is never read or written.
+ *   - `globalThis.fetch` is stubbed, so nothing leaves the process.
+ *   - request headers deliberately omit `user-agent: claude-cli/` and
+ *     `x-claude-code-session-id`. `isLikelyClaudeClient` keys off those, and
+ *     header snapshots are NOT redirected in dev mode — tripping that
+ *     heuristic would write into the real `~/.neurolink/header-snapshots/`.
+ *
+ * NOTE on assertion messages: the harness classifies a thrown error as SKIP
+ * when the text matches `isExpectedProviderError()`. Quoting a response
+ * payload here (which contains "rate_limit_error", "429", ...) would turn a
+ * real failure into a silent skip. Report header names and key paths only,
+ * never values. See CLAUDE.md.
+ *
+ * Run with: npx tsx test/continuous-test-suite-proxy-limit-headers.ts
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  initAccountQuota,
+  flushAccountQuotaStateForTests,
+} from "../src/lib/proxy/accountQuota.js";
+import { initAccountCooldown } from "../src/lib/proxy/accountCooldown.js";
+import {
+  buildProxyLimitHeaders,
+  buildQuotaResponseHeaders,
+  pickUpstreamRateLimitHeaders,
+  summarizePoolHeadroom,
+  utilizationToLeftPct,
+} from "../src/lib/proxy/quotaHeaders.js";
+import {
+  buildLimitSnapshot,
+  parseAnthropicLimitHeaders,
+  withLimitCapture,
+  wrapFetchWithLimitCapture,
+} from "../src/lib/providers/anthropic/rateLimitCapture.js";
+import { createClaudeProxyRoutes } from "../src/lib/server/routes/claudeProxyRoutes.js";
+import { tokenStore } from "../src/lib/auth/tokenStore.js";
+import { resetUsageStatsForTests } from "../src/lib/proxy/usageStats.js";
+import type { AccountQuota, ServerContext } from "../src/lib/types/index.js";
+import { assert, assertEqual, defineSuite } from "./helpers/harness.js";
+
+const { test, section, runSuite } = defineSuite("Proxy Limit Headers");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A representative subscription-account response header set. */
+function upstreamQuotaHeaders(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  const fiveHoursOut = Math.floor(Date.now() / 1000) + 5 * 3600;
+  const weekOut = Math.floor(Date.now() / 1000) + 7 * 86400;
+  return {
+    "content-type": "application/json",
+    "anthropic-ratelimit-unified-status": "allowed",
+    "anthropic-ratelimit-unified-5h-utilization": "0.42",
+    "anthropic-ratelimit-unified-5h-status": "allowed",
+    "anthropic-ratelimit-unified-5h-reset": String(fiveHoursOut),
+    "anthropic-ratelimit-unified-7d-utilization": "0.19",
+    "anthropic-ratelimit-unified-7d-status": "allowed",
+    "anthropic-ratelimit-unified-7d-reset": String(weekOut),
+    "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+    "anthropic-ratelimit-unified-fallback": "available",
+    "anthropic-ratelimit-unified-overage-status": "allowed",
+    "x-request-id": "req_test_123",
+    ...overrides,
+  };
+}
+
+const MESSAGE_BODY = JSON.stringify({
+  id: "msg_test",
+  type: "message",
+  role: "assistant",
+  model: "claude-sonnet-4-6",
+  content: [{ type: "text", text: "ok" }],
+  stop_reason: "end_turn",
+  usage: { input_tokens: 10, output_tokens: 5 },
+});
+
+function sampleQuota(overrides: Partial<AccountQuota> = {}): AccountQuota {
+  return {
+    unifiedStatus: "allowed",
+    sessionUsed: 0.42,
+    sessionStatus: "allowed",
+    sessionResetAt: Math.floor(Date.now() / 1000) + 3600,
+    weeklyUsed: 0.19,
+    weeklyStatus: "allowed",
+    weeklyResetAt: Math.floor(Date.now() / 1000) + 7 * 86400,
+    fallbackPercentage: 0.5,
+    fallbackStatus: "available",
+    overageStatus: "allowed",
+    lastUpdated: Date.now(),
+    ...overrides,
+  };
+}
+
+/**
+ * Build a request context. Client headers stay minimal on purpose — see the
+ * header-snapshot warning in the file docblock.
+ */
+function createContext(requestId: string, stream = false): ServerContext {
+  return {
+    requestId,
+    method: "POST",
+    path: "/v1/messages",
+    headers: { "content-type": "application/json" },
+    query: {},
+    params: {},
+    timestamp: Date.now(),
+    metadata: {},
+    responseHeaders: {},
+    body: {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 16,
+      ...(stream ? { stream: true } : {}),
+    },
+    neurolink: { stream: async () => undefined },
+    toolRegistry: {},
+  } as unknown as ServerContext;
+}
+
+const findMessagesRoute = () => {
+  const route = createClaudeProxyRoutes(
+    undefined,
+    "",
+    "fill-first",
+    false,
+  ).routes.find((r) => r.method === "POST" && r.path === "/v1/messages");
+  if (!route) {
+    throw new Error("messages route not found");
+  }
+  return route;
+};
+
+// ---------------------------------------------------------------------------
+// Hermetic environment
+// ---------------------------------------------------------------------------
+
+type Restore = () => void;
+
+/**
+ * Per-test account identity counter.
+ *
+ * The route module keeps account runtime state (cooldowns especially) in a
+ * module-level map with no reset hook, so an account cooled by the 429 test
+ * would still be cooling for every test after it. Distinct labels keep tests
+ * order-independent instead of quietly coupling them.
+ */
+let accountSeq = 0;
+
+/**
+ * Redirect every piece of proxy persistence into a temp dir, install a stub
+ * fetch and a stub token store, run `body`, then restore everything.
+ */
+async function withIsolatedProxy(
+  args: {
+    accounts?: string[];
+    fetchImpl: (
+      url: string,
+      init?: RequestInit,
+    ) => Promise<Response> | Response;
+  },
+  body: () => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "neurolink-limit-headers-"));
+  accountSeq += 1;
+  const accounts = args.accounts ?? [
+    `anthropic:tester${accountSeq}@example.com`,
+  ];
+
+  // Persistence → temp dir. Without this the suite would read and rewrite the
+  // developer's real ~/.neurolink/account-quotas.json.
+  initAccountQuota(join(dir, "quotas.json"));
+  initAccountCooldown(join(dir, "cooldowns.json"));
+  await resetUsageStatsForTests();
+
+  const restores: Restore[] = [];
+  const patch = <T extends object, K extends keyof T>(
+    target: T,
+    key: K,
+    value: T[K],
+  ): void => {
+    const original = target[key];
+    target[key] = value;
+    restores.push(() => {
+      target[key] = original;
+    });
+  };
+
+  patch(globalThis, "fetch", (async (
+    url: RequestInfo | URL,
+    init?: RequestInit,
+  ) => args.fetchImpl(String(url), init)) as typeof fetch);
+
+  patch(tokenStore, "pruneExpired", async () => undefined);
+  patch(tokenStore, "listByPrefix", async () => accounts);
+  patch(tokenStore, "isDisabled", async () => false);
+  patch(tokenStore, "listDisabled", async () => []);
+  patch(tokenStore, "loadTokens", async (key: string) => ({
+    accessToken: `token-for-${key}`,
+    refreshToken: "refresh-token",
+    expiresAt: Date.now() + 3600_000,
+    tokenType: "Bearer",
+  }));
+
+  try {
+    await body();
+  } finally {
+    for (const restore of restores.reverse()) {
+      restore();
+    }
+    await flushAccountQuotaStateForTests().catch(() => undefined);
+    await resetUsageStatsForTests().catch(() => undefined);
+    // Point persistence back at a throwaway path so a later flush from this
+    // process can never land in the real state dir.
+    initAccountQuota(join(dir, "quotas.json"));
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function headersOf(ctx: ServerContext): Record<string, string> {
+  return (ctx.responseHeaders ?? {}) as Record<string, string>;
+}
+
+// ===========================================================================
+// 1. Pure builder
+// ===========================================================================
+
+section("Header builder (pure)");
+
+await test("derives whole-percent headroom from utilization", () => {
+  assertEqual(utilizationToLeftPct(0.42), 58, "58% should remain at 0.42 used");
+  assertEqual(utilizationToLeftPct(0), 100, "an unused window is 100% left");
+  assertEqual(utilizationToLeftPct(1), 0, "a full window is 0% left");
+});
+
+await test("clamps overage utilization instead of reporting negative headroom", () => {
+  assertEqual(
+    utilizationToLeftPct(1.35),
+    0,
+    "utilization above 1.0 must clamp to 0, not go negative",
+  );
+});
+
+await test("forwards both Anthropic rate-limit header families verbatim", () => {
+  const picked = pickUpstreamRateLimitHeaders({
+    ...upstreamQuotaHeaders(),
+    "anthropic-ratelimit-requests-remaining": "42",
+    "anthropic-ratelimit-tokens-remaining": "1000",
+    "retry-after": "30",
+    "set-cookie": "should-not-be-forwarded",
+  });
+
+  assert(
+    picked["anthropic-ratelimit-unified-5h-utilization"] === "0.42",
+    "unified 5h utilization must pass through verbatim",
+  );
+  assert(
+    picked["anthropic-ratelimit-requests-remaining"] === "42",
+    "legacy absolute remaining count must pass through verbatim",
+  );
+  assert(picked["retry-after"] === "30", "retry-after must pass through");
+  assert(
+    picked["set-cookie"] === undefined,
+    "unrelated headers must not be forwarded",
+  );
+});
+
+await test("always reports quota provenance", () => {
+  const live = buildQuotaResponseHeaders({
+    quota: sampleQuota(),
+    source: "live",
+  });
+  assertEqual(
+    live["x-neurolink-quota-source"],
+    "live",
+    "a fresh reading must be labelled live",
+  );
+
+  const none = buildQuotaResponseHeaders({ quota: null, source: "none" });
+  assertEqual(
+    none["x-neurolink-quota-source"],
+    "none",
+    "provenance must be present even when there is no quota",
+  );
+});
+
+await test("omits quota figures entirely when no account served the request", () => {
+  const headers = buildQuotaResponseHeaders({
+    quota: sampleQuota(),
+    source: "none",
+    servedBy: "vertex",
+  });
+  assert(
+    headers["x-neurolink-quota-session-left-pct"] === undefined,
+    "a fallback-served response must not carry session headroom",
+  );
+  assertEqual(
+    headers["x-neurolink-served-by"],
+    "vertex",
+    "the serving provider must be named",
+  );
+});
+
+await test("sanitizes header values so an account label cannot inject headers", () => {
+  const headers = buildQuotaResponseHeaders({
+    quota: null,
+    source: "none",
+    accountLabel: "evil\r\nx-injected: yes",
+  });
+  const label = headers["x-neurolink-account"] ?? "";
+  assert(
+    !label.includes("\r") && !label.includes("\n"),
+    "CR/LF must be stripped from the account label",
+  );
+  assert(
+    headers["x-injected"] === undefined,
+    "a crafted label must not produce an extra header",
+  );
+});
+
+await test("summarizes pool headroom across accounts", () => {
+  const now = Date.now();
+  const summary = summarizePoolHeadroom(
+    [
+      { quota: sampleQuota({ sessionUsed: 0.9 }) },
+      { quota: sampleQuota({ sessionUsed: 0.1 }) },
+      { coolingUntil: now + 60_000, quota: sampleQuota({ sessionUsed: 1 }) },
+    ],
+    now,
+  );
+  assertEqual(summary.available, 2, "two accounts are usable");
+  assertEqual(summary.cooling, 1, "one account is cooling");
+  assertEqual(
+    summary.bestSessionLeftPct,
+    90,
+    "best headroom comes from the least-used available account",
+  );
+});
+
+await test("merges upstream and proxy headers into one set", () => {
+  const headers = buildProxyLimitHeaders({
+    upstreamHeaders: upstreamQuotaHeaders(),
+    context: {
+      quota: sampleQuota(),
+      source: "live",
+      accountLabel: "tester@example.com",
+      accountType: "oauth",
+      servedBy: "anthropic",
+    },
+  });
+  assert(
+    headers["anthropic-ratelimit-unified-5h-utilization"] !== undefined,
+    "verbatim upstream header missing from merged set",
+  );
+  assert(
+    headers["x-neurolink-quota-session-left-pct"] !== undefined,
+    "derived headroom header missing from merged set",
+  );
+});
+
+// ===========================================================================
+// 2. Proxy routes — every response shape
+// ===========================================================================
+
+section("Proxy route emission");
+
+await test("routed JSON success publishes verbatim and derived headers", async () => {
+  await withIsolatedProxy(
+    {
+      fetchImpl: () =>
+        new Response(MESSAGE_BODY, {
+          status: 200,
+          headers: upstreamQuotaHeaders(),
+        }),
+    },
+    async () => {
+      const ctx = createContext("limit-json");
+      await findMessagesRoute().handler(ctx);
+      const headers = headersOf(ctx);
+
+      assertEqual(
+        headers["anthropic-ratelimit-unified-5h-utilization"],
+        "0.42",
+        "upstream utilization must reach the client verbatim",
+      );
+      assertEqual(
+        headers["x-neurolink-quota-session-left-pct"],
+        "58",
+        "derived session headroom must be published",
+      );
+      assertEqual(
+        headers["x-neurolink-quota-source"],
+        "live",
+        "a response carrying quota headers is a live reading",
+      );
+      assertEqual(
+        headers["x-neurolink-served-by"],
+        "anthropic",
+        "an account-served response must name anthropic",
+      );
+      assert(
+        headers["x-neurolink-account"] !== undefined,
+        "the serving account must be identified",
+      );
+      assert(
+        headers["x-neurolink-pool-available"] !== undefined,
+        "pool headroom must be reported",
+      );
+    },
+  );
+});
+
+await test("routed streaming success carries headers on the Response", async () => {
+  await withIsolatedProxy(
+    {
+      fetchImpl: () => {
+        const sse =
+          `event: message_start\ndata: ${JSON.stringify({
+            type: "message_start",
+            message: {
+              id: "msg_1",
+              model: "claude-sonnet-4-6",
+              usage: { input_tokens: 5, output_tokens: 0 },
+            },
+          })}\n\n` +
+          `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`;
+        return new Response(sse, {
+          status: 200,
+          headers: upstreamQuotaHeaders({
+            "content-type": "text/event-stream",
+          }),
+        });
+      },
+    },
+    async () => {
+      const ctx = createContext("limit-stream", true);
+      const result = await findMessagesRoute().handler(ctx);
+
+      assert(
+        result instanceof Response,
+        "the streaming path must return a Response",
+      );
+      const response = result as Response;
+      assertEqual(
+        response.headers.get("anthropic-ratelimit-unified-5h-utilization"),
+        "0.42",
+        "streaming responses must forward unified quota, not only the legacy allowlist",
+      );
+      assertEqual(
+        response.headers.get("x-neurolink-quota-session-left-pct"),
+        "58",
+        "streaming responses must carry derived headroom",
+      );
+      // Drain so the capture pipeline settles before the stub is restored.
+      await response.text().catch(() => undefined);
+    },
+  );
+});
+
+await test("terminal rate-limit failure still reports limits", async () => {
+  const exhausted = upstreamQuotaHeaders({
+    "anthropic-ratelimit-unified-status": "rejected",
+    "anthropic-ratelimit-unified-5h-utilization": "1.0",
+    "anthropic-ratelimit-unified-5h-status": "rejected",
+    "retry-after": "120",
+  });
+  await withIsolatedProxy(
+    {
+      fetchImpl: () =>
+        new Response(
+          JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "limit reached" },
+          }),
+          { status: 429, headers: exhausted },
+        ),
+    },
+    async () => {
+      const ctx = createContext("limit-429");
+      await findMessagesRoute().handler(ctx);
+      const headers = headersOf(ctx);
+
+      assert(
+        headers["x-neurolink-quota-source"] !== undefined,
+        "a terminal failure must still state quota provenance",
+      );
+      assert(
+        headers["x-neurolink-pool-available"] !== undefined,
+        "a terminal failure must report pool headroom",
+      );
+      assertEqual(
+        headers["x-neurolink-quota-session-left-pct"],
+        "0",
+        "an exhausted session window must report zero headroom",
+      );
+    },
+  );
+});
+
+await test("never fabricates headroom when upstream sends no quota headers", async () => {
+  // Deliberately NOT tested by emptying the account list: with no accounts the
+  // route falls through to a stored/legacy credential, which would pull a real
+  // developer account into the run. A stub account with a quota-less upstream
+  // response exercises the same branch hermetically.
+  await withIsolatedProxy(
+    {
+      fetchImpl: () =>
+        new Response(MESSAGE_BODY, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    },
+    async () => {
+      const ctx = createContext("limit-no-quota-headers");
+      await findMessagesRoute().handler(ctx);
+      const headers = headersOf(ctx);
+
+      assertEqual(
+        headers["x-neurolink-quota-source"],
+        "none",
+        "a response with no quota headers and no snapshot must report source none",
+      );
+      assert(
+        headers["x-neurolink-quota-session-left-pct"] === undefined,
+        "source=none must never be accompanied by headroom figures",
+      );
+      assert(
+        headers["x-neurolink-served-by"] === "anthropic",
+        "the serving upstream must still be identified",
+      );
+    },
+  );
+});
+
+// ===========================================================================
+// 3. Provider-side capture
+// ===========================================================================
+
+section("Provider capture");
+
+await test("parses both header families off a response", () => {
+  const headers = new Headers({
+    ...upstreamQuotaHeaders(),
+    "anthropic-ratelimit-requests-remaining": "17",
+    "anthropic-ratelimit-tokens-remaining": "900",
+  });
+  const info = parseAnthropicLimitHeaders(headers);
+
+  assertEqual(info.sessionUtilization, 0.42, "session utilization must parse");
+  assertEqual(info.sessionLeftPct, 58, "session headroom must be derived");
+  assertEqual(info.weeklyLeftPct, 81, "weekly headroom must be derived");
+  assertEqual(
+    info.requestsRemaining,
+    17,
+    "absolute remaining requests must parse",
+  );
+  assertEqual(
+    info.tokensRemaining,
+    900,
+    "absolute remaining tokens must parse",
+  );
+});
+
+await test("reads proxy account and pool metadata into the snapshot", () => {
+  const headers = new Headers({
+    ...upstreamQuotaHeaders(),
+    "x-neurolink-quota-source": "live",
+    "x-neurolink-account": "tester@example.com",
+    "x-neurolink-account-type": "oauth",
+    "x-neurolink-served-by": "anthropic",
+    "x-neurolink-pool-available": "3",
+    "x-neurolink-pool-cooling": "1",
+    "x-neurolink-pool-best-session-left": "88",
+  });
+  const snapshot = buildLimitSnapshot(headers, 200);
+
+  assert(
+    snapshot !== undefined,
+    "a quota-bearing response must yield a snapshot",
+  );
+  assertEqual(snapshot?.quotaSource, "live", "provenance must be carried over");
+  assertEqual(
+    snapshot?.account,
+    "tester@example.com",
+    "serving account must be carried over",
+  );
+  assertEqual(
+    snapshot?.pool?.available,
+    3,
+    "pool availability must be carried",
+  );
+  assertEqual(
+    snapshot?.pool?.bestSessionLeftPct,
+    88,
+    "best pool headroom must be carried",
+  );
+  assertEqual(
+    snapshot?.requestId,
+    "req_test_123",
+    "request id must be carried",
+  );
+});
+
+await test("yields no snapshot for a response with nothing to report", () => {
+  const snapshot = buildLimitSnapshot(
+    new Headers({ "content-type": "application/json" }),
+    200,
+  );
+  assertEqual(
+    snapshot,
+    undefined,
+    "a response with no limit or proxy headers must not fabricate a snapshot",
+  );
+});
+
+await test("captures limits through the wrapped fetch", async () => {
+  const stub = (async () =>
+    new Response(MESSAGE_BODY, {
+      status: 200,
+      headers: upstreamQuotaHeaders(),
+    })) as unknown as typeof fetch;
+  const wrapped = wrapFetchWithLimitCapture(stub);
+
+  const { snapshot } = await withLimitCapture(async () => {
+    await wrapped("https://api.anthropic.com/v1/messages");
+  });
+
+  assert(snapshot !== undefined, "the wrapper must capture a snapshot");
+  assertEqual(
+    snapshot?.rateLimit.sessionLeftPct,
+    58,
+    "captured headroom must match the response",
+  );
+});
+
+await test("keeps concurrent requests' limits separate", async () => {
+  // The whole reason capture is scoped via AsyncLocalStorage rather than an
+  // instance field: one provider instance serves many concurrent calls.
+  const makeStub = (utilization: string) =>
+    (async () =>
+      new Response(MESSAGE_BODY, {
+        status: 200,
+        headers: upstreamQuotaHeaders({
+          "anthropic-ratelimit-unified-5h-utilization": utilization,
+        }),
+      })) as unknown as typeof fetch;
+
+  const callA = withLimitCapture(async () => {
+    const wrapped = wrapFetchWithLimitCapture(makeStub("0.10"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await wrapped("https://api.anthropic.com/v1/messages");
+  });
+  const callB = withLimitCapture(async () => {
+    const wrapped = wrapFetchWithLimitCapture(makeStub("0.80"));
+    await wrapped("https://api.anthropic.com/v1/messages");
+  });
+
+  const [a, b] = await Promise.all([callA, callB]);
+  assertEqual(
+    a.snapshot?.rateLimit.sessionLeftPct,
+    90,
+    "the slower call must report its own headroom",
+  );
+  assertEqual(
+    b.snapshot?.rateLimit.sessionLeftPct,
+    20,
+    "the faster call must report its own headroom",
+  );
+});
+
+await test("capture never breaks a request when parsing fails", async () => {
+  const hostile = {
+    get: () => {
+      throw new Error("header access exploded");
+    },
+    forEach: () => {
+      throw new Error("header iteration exploded");
+    },
+  };
+  const stub = (async () => ({
+    status: 200,
+    headers: hostile,
+  })) as unknown as typeof fetch;
+  const wrapped = wrapFetchWithLimitCapture(stub);
+
+  const { result } = await withLimitCapture(async () => {
+    const response = await wrapped("https://api.anthropic.com/v1/messages");
+    return (response as unknown as { status: number }).status;
+  });
+
+  assertEqual(
+    result,
+    200,
+    "a capture failure must not prevent the response from being returned",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
# Pull Request

## Description

The Claude proxy now reports account limit state on **every** response, and the Anthropic provider consumes it — so a normal NeuroLink run can log how much subscription capacity is left, per request, whether it is talking to the proxy or straight to Anthropic.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

The proxy already parsed Anthropic's `anthropic-ratelimit-*` headers on every upstream response — it routes accounts on them. None of that reached the client: only the SSE path forwarded a five-name legacy allowlist (which does not include the unified subscription headers at all), and every JSON and error path dropped headers entirely. So the one component that knows exactly how much quota is left was the only component that could see it.

On the consuming side, the Anthropic provider parsed rate-limit headers into a private field that nothing read, and the AI-SDK model adapter reported `headers: {}` unconditionally.

Result: pointing the SDK at the proxy as a direct provider (`ANTHROPIC_BASE_URL` + dummy key, the setup we actually use) gave zero visibility into account headroom. You found out an account was exhausted when a request 429'd.

### Key domain constraint

Anthropic publishes **utilization** (0.0-1.0 of capacity *used*) for subscription/OAuth windows — there is no absolute remaining message or token count for them. "How much is left" is only derivable as `(1 - utilization) × 100`, and that is what is reported. Absolute `requests-remaining` / `tokens-remaining` exist only for API-key accounts and are passed through unchanged when present. No absolute remaining is ever synthesized for a subscription account.

## Changes Made

**Proxy — emits limit headers on every response path**

- New `src/lib/proxy/quotaHeaders.ts` — pure header assembly, no I/O. Two layers: Anthropic's `anthropic-ratelimit-*` and `retry-after` forwarded **verbatim** (so a proxied response is byte-identical to a direct one and a client needs exactly one parser), plus `x-neurolink-*` for what only the proxy knows — serving account, pool headroom, quota provenance, derived left-percentages. Header values are sanitized, since account labels are user email addresses and a CR/LF would otherwise permit response-header injection.
- `claudeProxyRoutes.ts` — headers published at every terminus: routed success (JSON and streaming), passthrough (before the ok/non-ok split, so a **429 carries them too**), terminal failure, and both fallback-provider success paths. All wrapped in try/catch — diagnostics must never break a response.
- `cli/commands/proxy.ts` — `ctx.responseHeaders` (existing NeuroLink convention, already honoured by the server adapters) is now populated on the proxy app, applied to every `c.json()` return and merged best-effort into `Response` objects.
- `x-neurolink-quota-source` is **always** emitted, including `none`. Without provenance a consumer cannot distinguish a fresh reading from a snapshot carried over from a previous request, and would log stale capacity as current. When a fallback provider serves the request, headroom figures are omitted rather than echoed stale.

**Anthropic provider — consumes them in both auth modes**

- New `src/lib/providers/anthropic/rateLimitCapture.ts`. Capture happens in a **fetch wrapper**, which covers streaming and non-streaming uniformly without `.withResponse()` plumbing, and is installed on both the OAuth and API-key branches — so this works for direct subscription traffic, not only through the proxy.
- Per-request state lives in `AsyncLocalStorage`, so concurrent calls on one provider instance cannot see each other's limits (there is a test for exactly this).
- Surfaces on `result.limits` and `result.analytics.limits`; sets `neurolink.claude.quota.*` span attributes on the active span; logs one line per request.
- `doGenerate` now reports the real response headers instead of a hardcoded `{}`.

**Logging note:** the low-headroom warning (< 15% session, or a `throttled`/`rejected` status) uses `logger.always`, not `logger.warn`. `logger.shouldLog()` suppresses everything below `error` unless debug mode is on, so a `warn` here would be invisible in a normal run — which defeats the point. The routine per-request line stays debug-gated.

**Types** — `ProxyQuotaSource`, `ProxyPoolHeadroom`, `ProxyQuotaHeaderContext` in `types/proxy.ts`; `ClaudeLimitSnapshot`, `ClaudeLimitCaptureSlot` and the unified-window fields on `AnthropicRateLimitInfo` in `types/subscription.ts`; `limits?` on `GenerateResult` and `AnalyticsData`. All in the canonical `src/lib/types/` location.

## Breaking Changes

- [x] No breaking changes

Every new field is optional and additive. `limits` is left `undefined` when a response carries nothing to report — no fabricated values.

## Explicitly out of scope

Decided deliberately, not overlooked:

- **Proxy inbound API-key auth** — the proxy binds to `127.0.0.1`; authenticating it is an infrastructure concern handled in front of it, not inside NeuroLink.
- **Honouring `baseURL` in OAuth mode** — OAuth is fixed-local for NeuroLink's purposes.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Existing tests pass
- [x] Manual testing completed

Two new suites, both **hermetic** — no credentials, no network egress, no `~/.neurolink` writes, no subscription quota consumed:

| Suite | Coverage | Result |
| --- | --- | --- |
| `pnpm run test:proxy-limit-headers` | 18 tests — header assembly, every proxy emission path (routed, streaming, passthrough, 429, terminal failure, fallback), provider-side capture, concurrency isolation | 18/18 |
| `pnpm run test:anthropic-limit-capture` | 3 tests — real HTTP round trip over a socket: provider → stub upstream answering with proxy-shaped headers → `result.limits` | 3/3 |

Isolation is achieved by redirecting quota/cooldown persistence to a temp dir and stubbing `globalThis.fetch` and the token store. Two traps worth knowing for anyone extending these: stubbing `tokenStore.listByPrefix` to `[]` does **not** give a no-account proxy — it falls through to the legacy credential and can pull a real developer account into the test; and account cooldown state lives in a module-level map with no reset hook, so each test uses a distinct account label.

Regression: `test:proxy-terminal-errors` 5/5, `test:proxy-openai-format` 10/10.

**Harness sabotage check** (per CLAUDE.md): an assertion was deliberately broken to confirm it reports `✗` / `RESULT: FAIL` / exit 1 rather than being downgraded to `⊘ skipped` by `isExpectedProviderError`. Confirmed, then restored. Assertion messages report field names, never payloads, for this reason.

### Manual verification

A real proxy route mounted on a real HTTP socket, driven by a real `AnthropicProvider` pointed at it via `ANTHROPIC_BASE_URL` + a dummy key — i.e. the exact production setup:

```json
{
  "rateLimit": { "sessionUtilization": 0.73, "sessionLeftPct": 27,
                 "weeklyUtilization": 0.41, "weeklyLeftPct": 59 },
  "quotaSource": "live",
  "account": "demo-account@example.com",
  "accountType": "oauth",
  "servedBy": "anthropic",
  "pool": { "available": 1, "cooling": 0, "bestSessionLeftPct": 27 },
  "status": 200
}
```

### One real bug this testing caught

Streaming responses initially carried no quota headers at all — they relied on the outer runtime wrapper, which does not apply on the generic-adapter mount. Fixed by threading `ctx` into `attachAnthropicSuccessStreamTelemetry` and `handleClaudePassthroughStreamResponse` and building the client response headers from `ctx.responseHeaders`. This also retired the old five-name allowlist that silently dropped every unified subscription header.

## Code Quality

- [x] ESLint passes — 0 errors, 46 warnings, **identical to the pre-change baseline** (verified by stashing and re-running)
- [x] Prettier applied
- [x] TypeScript strict — `tsc --noEmit` clean
- [x] `pnpm run build` succeeds, publint clean
- [x] No `console.log`, no hardcoded keys or secrets
- [x] Self-review completed

Complies with CLAUDE.md Rules 2 (types canonical), 7 (`type` not `interface`), 9 (unique type names), 13 (barrel-only type imports) and 14 (no double assertions).

## Documentation

- [x] JSDoc on all new public functions and types
- [x] `docs/features/claude-proxy.md` — new "Limit response headers" section with both header tables and an SDK consumption example

## Security Considerations

- [x] Security review needed

Two points a reviewer should look at directly:

1. **Header injection** — account labels are user-controlled email addresses. `sanitizeHeaderValue()` strips everything outside `\x20-\x7E`, so a CR/LF in a label cannot inject additional response headers.
2. **Account label disclosure** — `x-neurolink-account` emits the label as-is, usually an email address. This is fine on a localhost-bound proxy and is documented as such. Happy to hash it if reviewers prefer; it is a one-line change.

## Dependencies

- [x] No dependency changes

## Performance Impact

- [x] No performance impact

Header assembly is pure CPU on data the proxy has already parsed for routing.

## Deployment Notes

- [x] No special deployment steps

Purely additive. Existing clients ignore the new headers; the SDK populates `limits` only when a response carries them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy responses now include quota, rate-limit, account, retry, and pool availability information.
  * Claude generation results and analytics now expose captured limit and quota details.
  * Streaming, fallback, success, and error responses consistently publish relevant quota metadata.
  * Added support for subscription-window and API-key rate-limit reporting.

* **Documentation**
  * Expanded passthrough-mode documentation with header details, quota semantics, security guidance, and usage examples.

* **Tests**
  * Added comprehensive coverage for quota headers, streaming responses, provider parsing, and end-to-end limit capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->