### PR TITLE
fix(proxy): harden status and lifecycle telemetry

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -134,6 +134,8 @@ const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
 const PROXY_LIFECYCLE_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LEGACY_STATUS_ACCOUNT_CACHE_TTL_MS = 5_000;
 const PROXY_STATUS_TOKEN_READ_TIMEOUT_MS = 2_000;
+const PROXY_STATUS_RECONCILE_TIMEOUT_MS = 750;
+const PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS = 750;
 let legacyStatusAccountCache:
   | { credentialsPath: string; expiresAt: number; label: string | null }
   | undefined;
@@ -2045,11 +2047,32 @@ export async function createProxyStartApp(params: {
     const activeAccountAllowlist = runtimeConfig
       ? runtimeConfig.accountAllowlist
       : params.accountAllowlist;
-    const { getReconciledUsageSnapshot, getUsageStatsPersistenceStatus } =
-      await import("../../lib/proxy/usageStats.js");
+    const {
+      getReconciledUsageSnapshot,
+      getUsageSnapshot,
+      getUsageStatsPersistenceStatus,
+    } = await import("../../lib/proxy/usageStats.js");
     const { loadAccountCooldowns } =
       await import("../../lib/proxy/accountCooldown.js");
-    const usageSnapshot = await getReconciledUsageSnapshot();
+    let usageSnapshot = getUsageSnapshot();
+    let snapshotSource: "reconciled" | "memory" = "memory";
+    try {
+      usageSnapshot = await withTimeout(
+        getReconciledUsageSnapshot(),
+        PROXY_STATUS_RECONCILE_TIMEOUT_MS,
+        "[proxy] /status usage reconciliation timed out",
+      );
+      snapshotSource = "reconciled";
+    } catch (error) {
+      // Status must not become an outage amplifier when a cross-process lock or
+      // a slow filesystem stalls reconciliation. The process-local snapshot is
+      // coherent and its source is explicit to callers.
+      logger.debug(
+        `[proxy] /status using memory stats snapshot: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
     const { stats, terminalErrors } = usageSnapshot;
     const terminalErrorDetailsComparable =
       usageSnapshot.statsVersion === usageSnapshot.terminalErrorsVersion;
@@ -2064,43 +2087,74 @@ export async function createProxyStartApp(params: {
     const supervisorState = loadProxySupervisorState();
     const rollingSupervisorRunning = isRollingHandoffCapable(supervisorState);
     const updateState = loadUpdateState();
-    const cooldowns = await loadAccountCooldowns();
+    const cooldowns = await withTimeout(
+      loadAccountCooldowns(),
+      PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS,
+      "[proxy] /status cooldown inspection timed out",
+    ).catch((error) => {
+      logger.debug(
+        `[proxy] /status using empty cooldown snapshot: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return {};
+    });
     const storedAccountKeys = new Set<string>();
     const storedAccountExpirations = new Map<string, number>();
     const disabledAccountKeys = new Set<string>();
     let accountInventoryLoaded = false;
     try {
       const { tokenStore } = await import("../../lib/auth/tokenStore.js");
-      const storedKeys = await tokenStore.listByPrefix("anthropic:");
-      for (const key of storedKeys) {
-        const normalizedKey = normalizeAnthropicAccountKey(key);
-        storedAccountKeys.add(normalizedKey);
-      }
-      await Promise.all(
-        storedKeys.map(async (key) => {
-          const normalizedKey = normalizeAnthropicAccountKey(key);
-          try {
-            const tokens = await withTimeout(
-              tokenStore.peekTokens(key),
-              PROXY_STATUS_TOKEN_READ_TIMEOUT_MS,
-              "[proxy] /status token inspection timed out",
-            );
-            if (tokens) {
-              storedAccountExpirations.set(normalizedKey, tokens.expiresAt);
-            }
-          } catch (err) {
-            logger.debug(
-              `[proxy] /status: failed to inspect token metadata for ${normalizedKey}: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-            );
-          }
-        }),
+      const storedKeys = await withTimeout(
+        tokenStore.listByPrefix("anthropic:"),
+        PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS,
+        "[proxy] /status account enumeration timed out",
       );
-      for (const key of await tokenStore.listDisabled()) {
+      for (const key of storedKeys) {
+        storedAccountKeys.add(normalizeAnthropicAccountKey(key));
+      }
+      // Once account names are known, preserve them even when optional token
+      // metadata is slow. That keeps the status table useful and avoids
+      // incorrectly presenting known accounts as removed.
+      accountInventoryLoaded = true;
+      const inventory = await withTimeout(
+        (async () => {
+          const tokenExpirations = await Promise.all(
+            storedKeys.map(async (key) => {
+              try {
+                const tokens = await withTimeout(
+                  tokenStore.peekTokens(key),
+                  PROXY_STATUS_TOKEN_READ_TIMEOUT_MS,
+                  "[proxy] /status token inspection timed out",
+                );
+                return tokens ? ([key, tokens.expiresAt] as const) : undefined;
+              } catch (error) {
+                logger.debug(
+                  `[proxy] /status: failed to inspect token metadata for ${normalizeAnthropicAccountKey(key)}: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`,
+                );
+                return undefined;
+              }
+            }),
+          );
+          const disabledKeys = await tokenStore.listDisabled();
+          return { tokenExpirations, disabledKeys };
+        })(),
+        PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS,
+        "[proxy] /status account metadata timed out",
+      );
+      for (const expiration of inventory.tokenExpirations) {
+        if (expiration) {
+          storedAccountExpirations.set(
+            normalizeAnthropicAccountKey(expiration[0]),
+            expiration[1],
+          );
+        }
+      }
+      for (const key of inventory.disabledKeys) {
         disabledAccountKeys.add(normalizeAnthropicAccountKey(key));
       }
-      accountInventoryLoaded = true;
     } catch (err) {
       logger.debug(
         `[proxy] /status: failed to resolve account cooldown labels: ${
@@ -2109,7 +2163,11 @@ export async function createProxyStartApp(params: {
       );
     }
     const legacyAccountLabel = accountInventoryLoaded
-      ? await resolveLegacyStatusAccountLabel(storedAccountKeys.size)
+      ? await withTimeout(
+          resolveLegacyStatusAccountLabel(storedAccountKeys.size),
+          PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS,
+          "[proxy] /status legacy account inspection timed out",
+        ).catch(() => null)
       : null;
     const now = Date.now();
     const health = buildProxyHealthResponse(readiness, {
@@ -2117,7 +2175,16 @@ export async function createProxyStartApp(params: {
       passthrough: activePassthrough,
       version: PROXY_VERSION,
     });
-    const primaryAccount = await resolveStatusPrimaryAccount(activeProxyConfig);
+    const primaryAccount = await withTimeout(
+      resolveStatusPrimaryAccount(activeProxyConfig),
+      PROXY_STATUS_ACCOUNT_INVENTORY_TIMEOUT_MS,
+      "[proxy] /status primary account inspection timed out",
+    ).catch(() => ({
+      configured: activeProxyConfig?.routing?.primaryAccount?.trim() || null,
+      key: null,
+      label: null,
+      source: "fallback" as const,
+    }));
     const activeUpdaterPid =
       supervisorState?.updaterPid ?? runtimeState?.updaterPid;
     const accountRows: NonNullable<StatusStats["accounts"]> = Object.values(
@@ -2314,6 +2381,7 @@ export async function createProxyStartApp(params: {
         terminalErrorDetailsComparable,
         terminalErrorDetailsMissing,
         terminalErrorDetailsExcess,
+        snapshotSource,
         accounts: accountRows,
         primaryAccount,
         persistence: getUsageStatsPersistenceStatus(),

--- a/src/lib/proxy/proxyLifecycle.ts
+++ b/src/lib/proxy/proxyLifecycle.ts
@@ -16,6 +16,8 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_QUEUE_CAPACITY = 10_000;
 const DEFAULT_BATCH_SIZE = 256;
 const DEFAULT_FLUSH_INTERVAL_MS = 25;
+const DEFAULT_MAX_WRITE_RETRIES = 3;
+const MAX_WRITE_RETRY_DELAY_MS = 1_000;
 const LIFECYCLE_APPEND_TIMEOUT_MS = 2_000;
 const MAX_SHORT_FIELD_LENGTH = 256;
 const SESSION_KEY_FILE = ".proxy-lifecycle-session-key";
@@ -25,6 +27,7 @@ let lifecycleLogDir: string | undefined;
 let queueCapacity = DEFAULT_QUEUE_CAPACITY;
 let batchSize = DEFAULT_BATCH_SIZE;
 let flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS;
+let maxWriteRetries = DEFAULT_MAX_WRITE_RETRIES;
 let processInstanceId = randomUUID();
 let sessionHashKey: Buffer = randomBytes(32);
 let nextSequence = 1;
@@ -36,10 +39,13 @@ let queueDrops = 0;
 let invalidDrops = 0;
 let writeDrops = 0;
 let writeFailures = 0;
+let writeRetries = 0;
 let inFlight = 0;
 let queue: QueuedProxyLifecycleEvent[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | undefined;
 let flushInFlight: Promise<void> | undefined;
+let nextFlushDelayMs: number | undefined;
+let appendLifecycleFile: typeof appendFile = appendFile;
 
 function positiveInteger(value: number | undefined, fallback: number): number {
   return Number.isInteger(value) && (value ?? 0) > 0
@@ -144,7 +150,7 @@ function clearScheduledFlush(): void {
   }
 }
 
-function scheduleFlush(): void {
+function scheduleFlush(delayMs: number = flushIntervalMs): void {
   if (flushTimer || flushInFlight || queue.length === 0) {
     return;
   }
@@ -152,7 +158,7 @@ function scheduleFlush(): void {
   flushTimer = setTimeout(() => {
     flushTimer = undefined;
     void startFlush();
-  }, flushIntervalMs);
+  }, delayMs);
   flushTimer.unref?.();
 }
 
@@ -164,33 +170,70 @@ async function flushBatch(): Promise<void> {
   const batch = queue.splice(0, batchSize);
   inFlight += batch.length;
   try {
-    const byPath = new Map<string, string[]>();
+    const byPath = new Map<string, QueuedProxyLifecycleEvent[]>();
     for (const item of batch) {
       const path = join(item.logDir, `proxy-lifecycle-${item.date}.jsonl`);
-      const lines = byPath.get(path) ?? [];
-      lines.push(`${JSON.stringify(item.record)}\n`);
-      byPath.set(path, lines);
+      const items = byPath.get(path) ?? [];
+      items.push(item);
+      byPath.set(path, items);
     }
 
-    for (const [path, lines] of byPath) {
+    const retries: QueuedProxyLifecycleEvent[] = [];
+    let retryDelayMs = 0;
+    for (const [path, items] of byPath) {
+      const lines = items.map((item) => `${JSON.stringify(item.record)}\n`);
       try {
         // This best-effort telemetry sink intentionally avoids fsync so request
         // throughput is not coupled to storage latency. Loss is surfaced by
         // writeDrops/writeFailures rather than delaying proxy responses.
         await withTimeout(
-          appendFile(path, lines.join(""), { mode: 0o600 }),
+          appendLifecycleFile(path, lines.join(""), { mode: 0o600 }),
           LIFECYCLE_APPEND_TIMEOUT_MS,
           "Timed out writing proxy lifecycle metadata",
         );
         written += lines.length;
       } catch (error) {
-        dropped += lines.length;
-        writeDrops += lines.length;
         writeFailures += 1;
+        const retryable = items.filter(
+          (item) => item.writeRetries < maxWriteRetries,
+        );
+        const exhausted = items.length - retryable.length;
+        if (retryable.length > 0) {
+          const nextRetries = retryable.map((item) => ({
+            ...item,
+            writeRetries: item.writeRetries + 1,
+          }));
+          retries.push(...nextRetries);
+          writeRetries += nextRetries.length;
+          retryDelayMs = Math.max(
+            retryDelayMs,
+            Math.min(
+              MAX_WRITE_RETRY_DELAY_MS,
+              flushIntervalMs *
+                2 ** Math.max(...nextRetries.map((item) => item.writeRetries)),
+            ),
+          );
+        }
+        if (exhausted > 0) {
+          dropped += exhausted;
+          writeDrops += exhausted;
+        }
         logger.warn("[proxy] lifecycle metadata write failed", {
+          path,
+          retrying: retryable.length,
+          dropped: exhausted,
           error: error instanceof Error ? error.message : String(error),
         });
       }
+    }
+    if (retries.length > 0) {
+      // Keep retried records ahead of newly admitted records. This preserves
+      // per-file sequence order while continuing to keep request paths async.
+      queue.unshift(...retries);
+      nextFlushDelayMs = Math.max(
+        nextFlushDelayMs ?? 0,
+        retryDelayMs || flushIntervalMs,
+      );
     }
   } finally {
     inFlight = Math.max(0, inFlight - batch.length);
@@ -209,13 +252,17 @@ function startFlush(): Promise<void> {
       if (flushInFlight === currentFlush) {
         flushInFlight = undefined;
       }
-      scheduleFlush();
+      const delayMs = nextFlushDelayMs;
+      nextFlushDelayMs = undefined;
+      scheduleFlush(delayMs);
     },
     () => {
       if (flushInFlight === currentFlush) {
         flushInFlight = undefined;
       }
-      scheduleFlush();
+      const delayMs = nextFlushDelayMs;
+      nextFlushDelayMs = undefined;
+      scheduleFlush(delayMs);
     },
   );
   return currentFlush;
@@ -225,6 +272,7 @@ export function configureProxyLifecycleLogger(
   options: ProxyLifecycleLoggerOptions,
 ): void {
   clearScheduledFlush();
+  nextFlushDelayMs = undefined;
   loggerEnabled = false;
   lifecycleLogDir = undefined;
   queueCapacity = positiveInteger(
@@ -232,6 +280,10 @@ export function configureProxyLifecycleLogger(
     DEFAULT_QUEUE_CAPACITY,
   );
   batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
+  maxWriteRetries = positiveInteger(
+    options.maxWriteRetries,
+    DEFAULT_MAX_WRITE_RETRIES,
+  );
   flushIntervalMs = positiveInteger(
     options.flushIntervalMs,
     DEFAULT_FLUSH_INTERVAL_MS,
@@ -315,6 +367,7 @@ export function logProxyLifecycleEvent(input: ProxyLifecycleEventInput): void {
       logDir: lifecycleLogDir,
       date: String(record.timestamp).slice(0, 10),
       record,
+      writeRetries: 0,
     });
     enqueued += 1;
     scheduleFlush();
@@ -350,6 +403,7 @@ export function getProxyLifecycleLoggerSnapshot(): ProxyLifecycleLoggerSnapshot 
     invalidDrops,
     writeDrops,
     writeFailures,
+    writeRetries,
     pending: queue.length,
     inFlight,
     flushing: flushInFlight !== undefined,
@@ -363,6 +417,7 @@ export function resetProxyLifecycleLoggerForTests(): void {
   queueCapacity = DEFAULT_QUEUE_CAPACITY;
   batchSize = DEFAULT_BATCH_SIZE;
   flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS;
+  maxWriteRetries = DEFAULT_MAX_WRITE_RETRIES;
   processInstanceId = randomUUID();
   sessionHashKey = randomBytes(32);
   nextSequence = 1;
@@ -374,7 +429,17 @@ export function resetProxyLifecycleLoggerForTests(): void {
   invalidDrops = 0;
   writeDrops = 0;
   writeFailures = 0;
+  writeRetries = 0;
   inFlight = 0;
   queue = [];
   flushInFlight = undefined;
+  nextFlushDelayMs = undefined;
+  appendLifecycleFile = appendFile;
 }
+
+/** Isolated failure injection for lifecycle durability tests. */
+export const __proxyLifecycleTestHooks = {
+  setAppendFileForTests(append: typeof appendFile): void {
+    appendLifecycleFile = append;
+  },
+};

--- a/src/lib/proxy/usageStats.ts
+++ b/src/lib/proxy/usageStats.ts
@@ -1438,6 +1438,11 @@ export function getStats(): ProxyStats {
   return defaultStore.getStats();
 }
 
+/** Return the process-local coherent snapshot without filesystem reconciliation. */
+export function getUsageSnapshot(): ProxyUsageStatsSnapshot {
+  return defaultStore.getUsageSnapshot();
+}
+
 export async function getReconciledStats(): Promise<ProxyStats> {
   return defaultStore.reconcile();
 }

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -1492,6 +1492,8 @@ export type ProxyLifecycleLoggerSnapshot = {
   invalidDrops: number;
   writeDrops: number;
   writeFailures: number;
+  /** Events requeued after a transient lifecycle metadata write failure. */
+  writeRetries: number;
   pending: number;
   inFlight: number;
   flushing: boolean;
@@ -1504,6 +1506,8 @@ export type ProxyLifecycleLoggerOptions = {
   queueCapacity?: number;
   batchSize?: number;
   flushIntervalMs?: number;
+  /** Bounded retries for a metadata batch that cannot be appended immediately. */
+  maxWriteRetries?: number;
 };
 
 /** Serialized lifecycle line awaiting a bounded batch write. */
@@ -1511,6 +1515,7 @@ export type QueuedProxyLifecycleEvent = {
   logDir: string;
   date: string;
   record: Record<string, unknown>;
+  writeRetries: number;
 };
 
 /** Percentile summary used by offline proxy log analysis. */
@@ -2559,6 +2564,8 @@ export type StatusStats = {
   terminalErrorDetailsComparable?: boolean;
   terminalErrorDetailsMissing?: number;
   terminalErrorDetailsExcess?: number;
+  /** Whether this status response reconciled shared state or used local memory. */
+  snapshotSource?: "reconciled" | "memory";
   accounts?: {
     label: string;
     type: string;

--- a/test/proxyObservabilityFoundation.test.ts
+++ b/test/proxyObservabilityFoundation.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -21,6 +22,7 @@ import {
 } from "../src/lib/proxy/proxyActivity.js";
 import {
   configureProxyLifecycleLogger,
+  __proxyLifecycleTestHooks,
   flushProxyLifecycleEvents,
   getProxyLifecycleLoggerSnapshot,
   hashProxyLifecycleSessionId,
@@ -537,6 +539,7 @@ describe("bounded proxy lifecycle metadata", () => {
       enabled: true,
       logDir,
       flushIntervalMs: 60_000,
+      maxWriteRetries: 1,
     });
     await rm(logDir, { recursive: true, force: true });
     logProxyLifecycleEvent({
@@ -558,7 +561,8 @@ describe("bounded proxy lifecycle metadata", () => {
       queueDrops: 0,
       invalidDrops: 0,
       writeDrops: 1,
-      writeFailures: 1,
+      writeFailures: 2,
+      writeRetries: 1,
       pending: 0,
       inFlight: 0,
     });
@@ -568,6 +572,55 @@ describe("bounded proxy lifecycle metadata", () => {
         snapshot.pending +
         snapshot.inFlight,
     );
+  });
+
+  it("recovers lifecycle metadata after one transient append failure", async () => {
+    const logDir = await makeTempDir();
+    let appendCalls = 0;
+    __proxyLifecycleTestHooks.setAppendFileForTests(
+      async (path, data, options) => {
+        appendCalls += 1;
+        if (appendCalls === 1) {
+          throw new Error("transient lifecycle storage failure");
+        }
+        await appendFile(path, data, options);
+      },
+    );
+    configureProxyLifecycleLogger({
+      enabled: true,
+      logDir,
+      flushIntervalMs: 60_000,
+      maxWriteRetries: 2,
+    });
+    logProxyLifecycleEvent({
+      event: "request_terminal",
+      requestId: "retry-after-transient-failure",
+      method: "POST",
+      path: "/v1/messages",
+      responseStatus: 200,
+      terminalOutcome: "completed",
+      timestampMs: Date.parse("2026-07-17T03:30:00.000Z"),
+    });
+
+    await flushProxyLifecycleEvents();
+
+    expect(appendCalls).toBe(2);
+    await expect(
+      readJsonLines(join(logDir, "proxy-lifecycle-2026-07-17.jsonl")),
+    ).resolves.toMatchObject([
+      { requestId: "retry-after-transient-failure", sequence: 1 },
+    ]);
+    expect(getProxyLifecycleLoggerSnapshot()).toMatchObject({
+      attempted: 1,
+      enqueued: 1,
+      written: 1,
+      dropped: 0,
+      writeDrops: 0,
+      writeFailures: 1,
+      writeRetries: 1,
+      pending: 0,
+      inFlight: 0,
+    });
   });
 
   it("disables lifecycle logging when its directory cannot be created", async () => {

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -46,6 +46,7 @@ import {
   recordFinalSuccess,
   resetUsageStatsForTests,
 } from "../src/lib/proxy/usageStats.js";
+import * as usageStats from "../src/lib/proxy/usageStats.js";
 
 const tempDirs: string[] = [];
 
@@ -393,6 +394,35 @@ describe("proxy runtime error finalization", () => {
         }),
       ]),
     );
+  });
+
+  it("returns a marked memory snapshot when shared stats reconciliation hangs", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(usageStats, "getReconciledUsageSnapshot").mockReturnValue(
+      new Promise(() => undefined),
+    );
+    vi.mocked(tokenStore.listByPrefix).mockResolvedValue([]);
+    vi.mocked(tokenStore.listDisabled).mockResolvedValue([]);
+
+    const { app } = await createProxyStartApp({
+      neurolink: { getToolRegistry: () => ({}) } as never,
+      modelRouter: undefined,
+      strategy: "fill-first",
+      passthrough: false,
+      port: 55123,
+      host: "127.0.0.1",
+      proxyConfig: null,
+      primaryAccountKey: undefined,
+      accountAllowlist: undefined,
+    });
+    const responsePromise = app.request("/status");
+
+    await vi.advanceTimersByTimeAsync(750);
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.stats.snapshotSource).toBe("memory");
   });
 
   it("sanitizes terminal error messages before printing status", () => {

--- a/tools/testing/proxyLifecycleBenchmark.ts
+++ b/tools/testing/proxyLifecycleBenchmark.ts
@@ -213,6 +213,7 @@ try {
           invalidDrops: afterFlush.invalidDrops,
           writeDrops: afterFlush.writeDrops,
           writeFailures: afterFlush.writeFailures,
+          writeRetries: afterFlush.writeRetries,
           pending: afterFlush.pending,
           inFlight: afterFlush.inFlight,
         },


### PR DESCRIPTION
## Summary
- retry bounded lifecycle metadata append failures before declaring a durable drop, while exposing retry counters
- keep `/status` available when shared stats, token metadata, cooldowns, or primary-account lookups stall; responses identify a memory snapshot explicitly
- add deterministic fault-injection coverage and include lifecycle retries in the performance report

## Verification
- `pnpm exec vitest run test/proxyAnalysis.test.ts test/proxyConfigHotReload.test.ts test/proxyObservabilityFoundation.test.ts test/proxyReliabilityHardening.test.ts test/proxyReplay.test.ts test/proxyRollingWorkerHandoff.test.ts test/proxyUpdaterFallback.test.ts test/proxyUsageStatsPersistence.test.ts test/retryAfter.test.ts --reporter=dot` (259 passed)
- `pnpm run proxy:performance` (all lifecycle, stats, transport, and rolling gates passed; rolling handoff preserved the active stream and 100 concurrent requests with zero failures)
- `pnpm exec tsc --noEmit --strict`, `pnpm run lint`, `pnpm run validate:all`, and `pnpm run build`

## Scope
No live proxy configuration, process, port, account, or state was touched. All tests use temporary directories and loopback fixture processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy status requests now remain responsive when account, token, or usage data is slow to load.
  * Status results fall back to the latest in-memory usage snapshot and identify the data source.
  * Account names remain available even when detailed account information times out.

* **Reliability**
  * Failed proxy lifecycle writes are retried automatically with controlled backoff.
  * Repeatedly failed records are safely discarded after the configured retry limit.

* **Observability**
  * Logging metrics now report write retries alongside existing failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->