### PR TITLE
fix(context): harden redis writes and calibrate native loop reclaims

### DIFF
--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -382,7 +382,16 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
  * `lm-studio` -> `lmstudio`, `nvidia-nim` -> `nvidianim`, `llama.cpp` -> `llamacpp`.
  */
 const PROVIDER_ALIAS_MAP: Record<string, string> = {
-  googleaistudio: "google-ai-studio",
+  // Both spellings resolve to `google-ai`, the ONLY key this table holds for
+  // AI Studio. `google-ai-studio` was never a key, so every realistic spelling
+  // ("googleAiStudio" from the native client, "google-ai-studio", "googleai")
+  // missed the table and fell back to DEFAULT_CONTEXT_WINDOW — reporting
+  // 128K for a 1,048,576-token Gemini. That understated the loop-guard budget
+  // by ~8x, so AI Studio agent loops reclaimed tool history that still fitted
+  // comfortably. `google-ai` itself only resolved via the raw-provider
+  // fallback below, which the normalized lookup now covers directly.
+  googleaistudio: "google-ai",
+  googleai: "google-ai",
   lmstudio: "lm-studio",
   llamacpp: "llamacpp",
   nvidianim: "nvidia-nim",

--- a/src/lib/context/anthropicLoopGuard.ts
+++ b/src/lib/context/anthropicLoopGuard.ts
@@ -166,6 +166,7 @@ export function planAnthropicLoopReclaim(args: {
   observedPromptTokens?: number;
   previousSentEstimate?: number;
   onSentEstimate?: (tokens: number) => void;
+  observedDescribesCurrentPayload?: boolean;
 }): LoopGuardPlan | undefined {
   const {
     conversation,
@@ -175,33 +176,49 @@ export function planAnthropicLoopReclaim(args: {
     observedPromptTokens,
     previousSentEstimate,
     onSentEstimate,
+    observedDescribesCurrentPayload = false,
   } = args;
 
   const entries = toEntries(conversation, provider);
   const rawEstimate =
     fixedOverheadTokens + entries.reduce((sum, e) => sum + e.tokens, 0);
 
-  // Calibration compares a real prompt-token count against THIS guard's
-  // estimate for the very request that produced it. Dividing by the estimate
-  // for the CURRENT conversation would be a category error: the loop has since
-  // appended an assistant tool_use message plus its tool_result, so the
-  // denominator is always larger than the numerator's request. The ratio then
-  // reads below 1 and the `Math.max(1, …)` floor pins calibration at 1 — the
-  // correction silently never applies, which is exactly when a dense-code run
-  // overflows the window.
+  // Calibration divides a real prompt-token count by THIS guard's estimate for
+  // the payload that count describes. Both halves must describe the SAME
+  // payload, and there are two legitimate pairings:
+  //
+  //  - A caller that plans on EVERY step passes the provider's count for the
+  //    previous request together with `previousSentEstimate`, the estimate
+  //    recorded for that same request. Dividing that count by the estimate for
+  //    the CURRENT conversation would be a category error — the loop has since
+  //    appended an assistant tool_use message plus its tool_result, so the
+  //    denominator is always the larger of the two, the ratio reads below 1 and
+  //    the `Math.max(1, …)` floor pins calibration at 1. The correction then
+  //    silently never applies, which is exactly when a dense-code run overflows.
+  //
+  //  - A caller that plans only when a real-token guard trips has no estimate
+  //    for an earlier request, but its trigger (`projectedNextPromptTokens`) is
+  //    already a projection of the payload ABOUT TO BE SENT. It sets
+  //    `observedDescribesCurrentPayload`, and the denominator is this module's
+  //    estimate of the current history — the same payload again.
+  //
+  // Without the flag such a caller gets calibration 1, which makes its reclaim
+  // inert: the guard trips on real tokens at the same ratio this planner tests
+  // its (smaller) char estimate against, so the plan never fires and the loop
+  // falls back to stopping the turn.
+  const sentEstimate = observedDescribesCurrentPayload
+    ? rawEstimate
+    : previousSentEstimate;
   let calibration = 1;
   if (
     observedPromptTokens &&
     observedPromptTokens > 0 &&
-    previousSentEstimate &&
-    previousSentEstimate > 0
+    sentEstimate &&
+    sentEstimate > 0
   ) {
     // Clamped: real tokenizers run up to ~1.3x the char estimate on dense
     // code, and an unbounded ratio would compact the loop into uselessness.
-    calibration = Math.min(
-      3,
-      Math.max(1, observedPromptTokens / previousSentEstimate),
-    );
+    calibration = Math.min(3, Math.max(1, observedPromptTokens / sentEstimate));
   }
 
   const plan = planLoopGuardReclaim(entries, {

--- a/src/lib/context/geminiLoopGuard.ts
+++ b/src/lib/context/geminiLoopGuard.ts
@@ -123,6 +123,18 @@ function toEntries(
  * Returns `undefined` when the history still fits, in which case the caller
  * must leave it byte-identical — any rewrite invalidates the provider's cached
  * prefix, so "no change" has to mean no change.
+ *
+ * `observedPromptTokens` must be a count for the payload ABOUT TO BE SENT —
+ * every Gemini-shaped loop plans only when its `createContextGuard` trips, and
+ * that guard's `projectedNextPromptTokens` is exactly that: the provider's real
+ * count for the last request plus the growth measured since. Dividing it by
+ * this module's estimate of the current history therefore compares two views of
+ * one payload, which is what makes the correction meaningful. A count for an
+ * EARLIER request must not be passed here: the loop has appended a model turn
+ * and its tool turn since, so the denominator would always be the larger of the
+ * two, the ratio would read below 1 and the `Math.max(1, …)` floor would pin
+ * calibration at 1 — silently disabling the correction. `planAnthropicLoopReclaim`
+ * carries `previousSentEstimate` for callers in that other position.
  */
 export function planGeminiLoopReclaim(args: {
   contents: readonly GeminiGuardContent[];

--- a/src/lib/core/redisConversationMemoryManager.ts
+++ b/src/lib/core/redisConversationMemoryManager.ts
@@ -739,6 +739,22 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
               ? options.enableSummarization
               : this.config.enableSummarization;
 
+          // Append-only: push just this turn's messages and persist a SMALL
+          // metadata blob. A session not yet using split storage (new, or a
+          // legacy blob) is converted once here, then every later turn appends.
+          await this.persistConversation(
+            conversation,
+            options.sessionId,
+            options.userId,
+            wasSplitStorage ? messageCountBeforeTurn : undefined,
+          );
+
+          // Scheduled AFTER the write, never before it. On the single turn that
+          // converts a legacy session, `checkAndSummarize` re-reads the blob and
+          // writes it back; observing the pre-conversion blob would make it
+          // re-serialize the record WITHOUT the split marker, so a later SET
+          // would strip the marker while the companion LIST already held the
+          // messages — the next read would then serve the stale inline copy.
           if (shouldSummarize) {
             const normalizedUserId = options.userId || "randomUser";
             const summarizationKey = `${options.sessionId}:${normalizedUserId}`;
@@ -778,16 +794,6 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
               );
             }
           }
-
-          // Append-only: push just this turn's messages and persist a SMALL
-          // metadata blob. A session not yet using split storage (new, or a
-          // legacy blob) is converted once here, then every later turn appends.
-          await this.persistConversation(
-            conversation,
-            options.sessionId,
-            options.userId,
-            wasSplitStorage ? messageCountBeforeTurn : undefined,
-          );
 
           // Log turn storage metadata for observability
           const blobSizeBytes = Buffer.byteLength(
@@ -983,10 +989,12 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
     if (!this.redisClient) {
       return conversation;
     }
-    const entries = await this.redisClient.lRange(
-      `${redisKey}${MESSAGES_KEY_SUFFIX}`,
-      0,
-      -1,
+    // `getSession` and `buildContextMessages` guard their own GET with
+    // `withTimeout`; both now also depend on this read, so leaving it unguarded
+    // would let a hung LIST read block the request thread anyway.
+    const entries = await withTimeout(
+      this.redisClient.lRange(`${redisKey}${MESSAGES_KEY_SUFFIX}`, 0, -1),
+      REDIS_TIMEOUT_MS,
     );
     // `lRange` is typed `(string | Buffer)[]` — the client returns Buffers when
     // a connection is opened in binary mode. Normalize rather than assert, so
@@ -1009,7 +1017,10 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
     // string), and callers add it to numbers — coerce so the count never
     // concatenates instead of summing.
     return Number(
-      await this.redisClient.lLen(`${redisKey}${MESSAGES_KEY_SUFFIX}`),
+      await withTimeout(
+        this.redisClient.lLen(`${redisKey}${MESSAGES_KEY_SUFFIX}`),
+        REDIS_TIMEOUT_MS,
+      ),
     );
   }
 
@@ -1049,31 +1060,29 @@ export class RedisConversationMemoryManager implements IConversationMemoryManage
       sessionId,
       userId,
     );
+    // One MULTI, not four to six independent commands. The replace path is a
+    // DEL followed by an RPUSH, and on the legacy-conversion path the inline
+    // blob is the only copy of the history until the SET lands — so a failure
+    // between any two of them leaves the session either empty or unrecoverable.
+    // Grouping them also collapses the round trips, which is the point of the
+    // append-only layout.
+    const tx = this.redisClient.multi();
     if (appendFrom === undefined) {
-      await this.redisClient.del(messagesKey);
-      if (conversation.messages.length > 0) {
-        await this.redisClient.rPush(
-          messagesKey,
-          encodeStoredMessages(conversation.messages),
-        );
-      }
-    } else {
-      const appended = conversation.messages.slice(appendFrom);
-      if (appended.length > 0) {
-        await this.redisClient.rPush(
-          messagesKey,
-          encodeStoredMessages(appended),
-        );
-      }
+      tx.del(messagesKey);
     }
-    await this.redisClient.set(
-      redisKey,
-      serializeConversationMetadata(conversation),
-    );
+    const toPush =
+      appendFrom === undefined
+        ? conversation.messages
+        : conversation.messages.slice(appendFrom);
+    if (toPush.length > 0) {
+      tx.rPush(messagesKey, encodeStoredMessages(toPush));
+    }
+    tx.set(redisKey, serializeConversationMetadata(conversation));
     if (this.redisConfig.ttl > 0) {
-      await this.redisClient.expire(redisKey, this.redisConfig.ttl);
-      await this.redisClient.expire(messagesKey, this.redisConfig.ttl);
+      tx.expire(redisKey, this.redisConfig.ttl);
+      tx.expire(messagesKey, this.redisConfig.ttl);
     }
+    await withTimeout(tx.exec(), REDIS_TIMEOUT_MS);
   }
 
   /**

--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -49,7 +49,10 @@ import {
   planGeminiLoopReclaim,
   previewGeminiToolResponseText,
 } from "../../context/geminiLoopGuard.js";
-import { getAvailableInputTokens } from "../../constants/contextWindows.js";
+import {
+  getAvailableInputTokens,
+  getContextWindowSize,
+} from "../../constants/contextWindows.js";
 import {
   composeAbortSignals,
   createTimeoutController,
@@ -66,6 +69,7 @@ import {
   collectStreamChunks,
   collectStreamChunksIncremental,
   computeMaxSteps,
+  createContextGuard,
   createTextChannel,
   buildUserPartsWithMultimodal,
   executeNativeToolCalls,
@@ -153,11 +157,13 @@ async function createGoogleGenAIClient(apiKey: string): Promise<GenAIClient> {
 function reclaimAiStudioContext(
   contents: Array<{ role: string; parts: unknown[] }>,
   modelName: string,
+  observedPromptTokens?: number,
 ): boolean {
   const plan = planGeminiLoopReclaim({
     contents,
     availableInputTokens: getAvailableInputTokens("googleAiStudio", modelName),
     provider: "googleAiStudio",
+    ...(observedPromptTokens ? { observedPromptTokens } : {}),
   });
   if (!plan) {
     return false;
@@ -928,6 +934,15 @@ export class GoogleAIStudioProvider extends BaseProvider {
               string,
               { count: number; lastError: string }
             >();
+            // Cheap trigger for the in-turn reclaim, mirroring the Vertex twin.
+            // Planning serializes the WHOLE accumulated history to estimate it,
+            // so running it unconditionally charges that once per step for the
+            // life of the turn; the guard tracks real prompt counts plus
+            // measured growth instead, and it supplies the observed count that
+            // calibrates the planner's char estimate.
+            const contextGuard = createContextGuard(
+              getContextWindowSize("googleAiStudio", modelName),
+            );
 
             try {
               // Agentic loop for tool calling
@@ -935,8 +950,20 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 // In-turn context guard: this loop appends a model turn plus a
                 // tool turn every step with nothing bounding growth. No-op
                 // while the request still fits, so a loop that fits never pays
-                // a cache invalidation.
-                reclaimAiStudioContext(currentContents, modelName);
+                // a cache invalidation. Step 0 still plans unconditionally —
+                // the guard has no usage to go on yet, and the incoming history
+                // can already be oversized before the first call.
+                if (step === 0 || contextGuard.shouldStop()) {
+                  if (
+                    reclaimAiStudioContext(
+                      currentContents,
+                      modelName,
+                      contextGuard.projectedNextPromptTokens,
+                    )
+                  ) {
+                    contextGuard.resetAfterReclaim();
+                  }
+                }
                 if (composedSignal?.aborted) {
                   throw composedSignal.reason instanceof Error
                     ? composedSignal.reason
@@ -978,6 +1005,13 @@ export class GoogleAIStudioProvider extends BaseProvider {
                   totalOutputTokens += chunkResult.outputTokens;
                   totalCacheReadTokens += chunkResult.cacheReadTokens ?? 0;
                   totalReasoningTokens += chunkResult.reasoningTokens ?? 0;
+                  // `inputTokens` is this step's promptTokenCount — the FULL
+                  // prompt size for the request just made, which is what the
+                  // guard projects the next request from.
+                  contextGuard.noteUsage(
+                    chunkResult.inputTokens,
+                    chunkResult.outputTokens,
+                  );
 
                   const stepText = extractTextFromParts(
                     chunkResult.rawResponseParts,
@@ -1079,6 +1113,15 @@ export class GoogleAIStudioProvider extends BaseProvider {
                     role: "user",
                     parts: functionResponses as unknown[],
                   });
+                  // Project this step's growth: the appended tool results ride
+                  // the next prompt, which the provider has not reported on yet.
+                  try {
+                    contextGuard.noteAppendedChars(
+                      JSON.stringify(functionResponses).length,
+                    );
+                  } catch {
+                    /* estimation is best-effort — never break the loop */
+                  }
                 } catch (error) {
                   logger.error("[GoogleAIStudio] Native SDK error", error);
                   throw this.handleProviderError(error);
@@ -1343,11 +1386,25 @@ export class GoogleAIStudioProvider extends BaseProvider {
             string,
             { count: number; lastError: string }
           >();
+          // Cheap reclaim trigger — see the stream twin.
+          const contextGuard = createContextGuard(
+            getContextWindowSize("googleAiStudio", modelName),
+          );
 
           // Agentic loop for tool calling
           while (step < maxSteps) {
             // In-turn context guard — see the stream twin.
-            reclaimAiStudioContext(currentContents, modelName);
+            if (step === 0 || contextGuard.shouldStop()) {
+              if (
+                reclaimAiStudioContext(
+                  currentContents,
+                  modelName,
+                  contextGuard.projectedNextPromptTokens,
+                )
+              ) {
+                contextGuard.resetAfterReclaim();
+              }
+            }
             if (composedSignal?.aborted) {
               throw composedSignal.reason instanceof Error
                 ? composedSignal.reason
@@ -1377,6 +1434,10 @@ export class GoogleAIStudioProvider extends BaseProvider {
               totalOutputTokens += chunkResult.outputTokens;
               totalCacheReadTokens += chunkResult.cacheReadTokens ?? 0;
               totalReasoningTokens += chunkResult.reasoningTokens ?? 0;
+              contextGuard.noteUsage(
+                chunkResult.inputTokens,
+                chunkResult.outputTokens,
+              );
 
               const stepText = extractTextFromParts(
                 chunkResult.rawResponseParts,
@@ -1473,6 +1534,15 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 role: "user",
                 parts: functionResponses,
               });
+              // Project this step's growth: the appended tool results ride
+              // the next prompt, which the provider has not reported on yet.
+              try {
+                contextGuard.noteAppendedChars(
+                  JSON.stringify(functionResponses).length,
+                );
+              } catch {
+                /* estimation is best-effort — never break the loop */
+              }
             } catch (error) {
               logger.error("[GoogleAIStudio] Native SDK generate error", error);
               throw this.handleProviderError(error);

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -117,7 +117,10 @@ import {
   resolveTurnStopReason,
   DedupExecuteMap,
 } from "../googleNativeGemini3/index.js";
-import { getContextWindowSize } from "../../constants/contextWindows.js";
+import {
+  getAvailableInputTokens,
+  getContextWindowSize,
+} from "../../constants/contextWindows.js";
 import { resolveLiveTool } from "../../tools/toolDiscovery.js";
 import {
   ATTR,
@@ -817,7 +820,10 @@ function reclaimVertexLoopContext(
 ): boolean {
   const plan = planGeminiLoopReclaim({
     contents,
-    availableInputTokens: getContextWindowSize("vertex", modelName),
+    // The usable INPUT budget, not the whole window: the window has to hold the
+    // model's output too, and the AI Studio twin already reclaims against this
+    // same definition.
+    availableInputTokens: getAvailableInputTokens("vertex", modelName),
     provider: "vertex",
     observedPromptTokens,
   });
@@ -901,10 +907,19 @@ function reclaimVertexAnthropicContext(
 ): boolean {
   const plan = planAnthropicLoopReclaim({
     conversation: messages,
-    availableInputTokens: getContextWindowSize("vertex", modelName),
+    // Usable input budget, matching the Gemini twin above.
+    availableInputTokens: getAvailableInputTokens("vertex", modelName),
     fixedOverheadTokens: 0,
     provider: "vertex",
     observedPromptTokens,
+    // This loop plans only when its context guard trips, so the count it hands
+    // over is the guard's projection for the request about to be sent, not a
+    // previous request's total. Without saying so the planner has no
+    // denominator, calibration stays pinned at 1, and the reclaim is inert:
+    // the guard fires on real tokens at the same ratio the planner tests its
+    // smaller char estimate against, so the plan never fires and the turn stops
+    // instead of continuing.
+    observedDescribesCurrentPayload: true,
   });
   if (!plan) {
     return false;

--- a/src/lib/utils/redis.ts
+++ b/src/lib/utils/redis.ts
@@ -3,6 +3,7 @@
  * Helper functions for Redis storage operations
  */
 
+import { randomUUID } from "crypto";
 import { createClient, type RedisClientOptions } from "redis";
 import type {
   ChatMessage,
@@ -258,6 +259,75 @@ export function serializeConversation(
   }
 }
 
+/** The exact role set `ChatMessage` allows. */
+const STORED_MESSAGE_ROLES: ReadonlySet<string> = new Set([
+  "user",
+  "assistant",
+  "system",
+  "tool_call",
+  "tool_result",
+]);
+
+function isStoredMessageRole(role: unknown): role is ChatMessage["role"] {
+  return typeof role === "string" && STORED_MESSAGE_ROLES.has(role);
+}
+
+/**
+ * True for a complete `ChatMessage` — `id` included, because callers keying
+ * summary pointers and condensation groups off it are entitled to find one.
+ */
+export function isStoredChatMessage(value: unknown): value is ChatMessage {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate: Partial<ChatMessage> = value;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.content === "string" &&
+    isStoredMessageRole(candidate.role)
+  );
+}
+
+/**
+ * Coerce a stored entry into a complete `ChatMessage`, or `undefined` when its
+ * shape is unusable.
+ *
+ * Shared by BOTH read paths on purpose. Inline blobs have always been
+ * validated; once messages moved into the companion LIST the split read
+ * bypassed that check, so `null`, a number or a bare string survived
+ * `JSON.parse` and reached callers that dereference `.role`, `.content` and
+ * `.metadata`. The two storage formats must offer the same read guarantee.
+ *
+ * `id` is a separate matter: it is required on `ChatMessage`, but no read path
+ * has ever enforced it, so history written before it existed carries none.
+ * Rejecting those records would empty otherwise-healthy sessions, so a missing
+ * id is backfilled rather than fatal — prefixed, so a synthesized id is never
+ * mistaken for one an existing pointer could reference.
+ */
+export function normalizeStoredMessage(
+  value: unknown,
+): ChatMessage | undefined {
+  if (isStoredChatMessage(value)) {
+    return value;
+  }
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const candidate: Partial<ChatMessage> = value;
+  if (
+    typeof candidate.content !== "string" ||
+    !isStoredMessageRole(candidate.role)
+  ) {
+    return undefined;
+  }
+  return {
+    ...candidate,
+    id: `legacy-${randomUUID()}`,
+    role: candidate.role,
+    content: candidate.content,
+  };
+}
+
 /**
  * Deserializes conversation object from Redis storage
  */
@@ -308,22 +378,11 @@ export function deserializeConversation(
     }
 
     // Validate each message in the messages array
-    const isValidHistory = conversation.messages.every(
-      (m): m is ChatMessage =>
-        typeof m === "object" &&
-        m !== null &&
-        "role" in m &&
-        "content" in m &&
-        typeof m.role === "string" &&
-        typeof m.content === "string" &&
-        (m.role === "user" ||
-          m.role === "assistant" ||
-          m.role === "system" ||
-          m.role === "tool_call" ||
-          m.role === "tool_result"),
+    const normalizedMessages = conversation.messages.map(
+      normalizeStoredMessage,
     );
 
-    if (!isValidHistory) {
+    if (normalizedMessages.some((message) => message === undefined)) {
       logger.warn("[redisUtils] Invalid messages structure", {
         messageCount: conversation.messages.length,
         firstMessage:
@@ -333,6 +392,10 @@ export function deserializeConversation(
       });
       return null;
     }
+
+    conversation.messages = normalizedMessages.filter(
+      (message): message is ChatMessage => message !== undefined,
+    );
 
     logger.debug("[redisUtils] Conversation deserialized successfully", {
       sessionId: conversation.sessionId,
@@ -567,12 +630,20 @@ export function usesSplitMessageStorage(
   return record[MESSAGES_IN_LIST_MARKER] === true;
 }
 
-/** Parse LRANGE entries, skipping any single entry that fails to parse. */
+/** Parse LRANGE entries, skipping any single entry that is not usable. */
 export function parseStoredMessages(entries: string[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
   for (const entry of entries) {
     try {
-      messages.push(JSON.parse(entry) as ChatMessage);
+      // `JSON.parse` succeeds for `null`, numbers and bare strings, so the
+      // catch below cannot filter them — the shape has to be checked.
+      const parsed: unknown = JSON.parse(entry);
+      const message = normalizeStoredMessage(parsed);
+      if (!message) {
+        logger.warn("[redisUtils] Skipping stored message with invalid shape");
+        continue;
+      }
+      messages.push(message);
     } catch (error) {
       // One corrupt entry must not destroy a whole session's history.
       logger.warn("[redisUtils] Skipping unparseable stored message", {

--- a/test/continuous-test-suite-anthropic-guard.ts
+++ b/test/continuous-test-suite-anthropic-guard.ts
@@ -220,18 +220,62 @@ await runSuite(async () => {
     );
   });
 
-  await test("a higher observed count makes the guard no less eager", async () => {
+  await test("a count for the current payload fires a guard the estimate alone would not", async () => {
+    // The other legitimate pairing: a caller that plans only when a real-token
+    // guard trips has no estimate for an earlier request, but its trigger is
+    // already a projection of the payload about to be sent. It says so with
+    // `observedDescribesCurrentPayload`, and the denominator becomes this
+    // module's estimate of the current history — the same payload twice.
     const conversation: AnthropicGuardMessage[] = [
       { role: "user", content: "start" },
     ];
     for (let i = 0; i < 20; i++) {
       conversation.push(...step(i, 12_000));
     }
-    const plain = plan(conversation);
-    const calibrated = plan(conversation, 300_000);
+
+    // Premise: uncalibrated this history is under the line, so anything that
+    // fires below can only be the correction.
     assert(
-      plain === undefined || calibrated !== undefined,
-      "calibration made the guard less eager than the raw estimate",
+      plan(conversation) === undefined,
+      "fixture fires uncalibrated, so it cannot demonstrate the correction",
+    );
+
+    // A count with NEITHER pairing must change nothing — there is no estimate
+    // to divide it by, and guessing one is what pins calibration at 1.
+    assert(
+      plan(conversation, 300_000) === undefined,
+      "an unpaired observed count perturbed the decision",
+    );
+
+    const calibrated = planAnthropicLoopReclaim({
+      conversation,
+      availableInputTokens: 100_000,
+      fixedOverheadTokens: 0,
+      provider: "anthropic",
+      observedPromptTokens: 90_000,
+      observedDescribesCurrentPayload: true,
+    });
+    assert(
+      calibrated !== undefined,
+      "a real count for the current payload did not tighten the threshold",
+    );
+    assert(
+      calibrated!.truncate.length > 0 || calibrated!.drop.length > 0,
+      "the calibrated plan reclaims nothing",
+    );
+
+    // Monotone in the ratio: a bigger under-count must reclaim more.
+    const stronger = planAnthropicLoopReclaim({
+      conversation,
+      availableInputTokens: 100_000,
+      fixedOverheadTokens: 0,
+      provider: "anthropic",
+      observedPromptTokens: 300_000,
+      observedDescribesCurrentPayload: true,
+    })!;
+    assert(
+      stronger.projectedTokens < calibrated!.projectedTokens,
+      "a larger under-count did not reclaim more",
     );
   });
 

--- a/test/continuous-test-suite-gemini-guard.ts
+++ b/test/continuous-test-suite-gemini-guard.ts
@@ -225,18 +225,39 @@ await runSuite(async () => {
     );
   });
 
-  await test("a higher observed count makes the guard no less eager", async () => {
+  await test("a real count above the estimate fires a guard the estimate alone would not", async () => {
     const contents: GeminiGuardContent[] = [
       { role: "user", parts: [{ text: "start" }] },
     ];
     for (let i = 0; i < 20; i++) {
       contents.push(...step(i, 12_000));
     }
-    const plain = plan(contents);
-    const calibrated = plan(contents, 300_000);
+
+    // Premise of the whole test: uncalibrated this history is under the line.
+    // Asserting it keeps the case honest — a fixture that already fires would
+    // let the rest pass while calibration did nothing at all.
     assert(
-      plain === undefined || calibrated !== undefined,
-      "calibration made the guard less eager than the raw estimate",
+      plan(contents) === undefined,
+      "fixture fires uncalibrated, so it cannot demonstrate the correction",
+    );
+
+    // The provider counts ~1.2x this module's char estimate, which is enough
+    // to pull the threshold below the very same history.
+    const calibrated = plan(contents, 90_000);
+    assert(
+      calibrated !== undefined,
+      "a real count above the estimate did not tighten the threshold",
+    );
+    assert(
+      calibrated!.truncate.length > 0 || calibrated!.drop.length > 0,
+      "the calibrated plan reclaims nothing",
+    );
+
+    // Monotone in the ratio: a bigger under-count must reclaim more.
+    const stronger = plan(contents, 300_000)!;
+    assert(
+      stronger.projectedTokens < calibrated!.projectedTokens,
+      "a larger under-count did not reclaim more",
     );
   });
 });

--- a/test/continuous-test-suite-litellm-context-windows.ts
+++ b/test/continuous-test-suite-litellm-context-windows.ts
@@ -110,6 +110,39 @@ await test("falls back to the static litellm _default when nothing is registered
   );
 });
 
+// The alias map pointed at `google-ai-studio`, which this table has never held,
+// so all of these fell through to DEFAULT_CONTEXT_WINDOW — an ~8x understatement
+// that made the AI Studio loop guard reclaim tool history that still fitted.
+// `google-ai` resolved only by raw-provider fallback.
+//
+// One test per spelling: the failing alias belongs in the test NAME, not in an
+// assertion message, where `isExpectedProviderError()` could downgrade it to ⊘.
+for (const spelling of [
+  "googleAiStudio",
+  "google-ai-studio",
+  "google-ai",
+  "googleai",
+]) {
+  await test(`AI Studio spelling "${spelling}" resolves to the real Gemini window`, () => {
+    clearRuntimeContextWindows();
+    assertEqual(
+      getContextWindowSize(spelling, "gemini-2.5-pro"),
+      1_048_576,
+      "the provider alias did not reach the google-ai table",
+    );
+  });
+}
+
+await test("a per-model AI Studio window survives alias normalization", () => {
+  clearRuntimeContextWindows();
+  // Not merely "bigger than the default": a real per-model entry must win.
+  assertEqual(
+    getContextWindowSize("googleAiStudio", "gemini-2.5-flash-image"),
+    32_768,
+    "a small per-model window must survive alias normalization",
+  );
+});
+
 await test("prefers a runtime-registered window over the static default", () => {
   clearRuntimeContextWindows();
   registerRuntimeContextWindow("litellm", "glm-private", 262_144);

--- a/test/continuous-test-suite-redis-append-only.ts
+++ b/test/continuous-test-suite-redis-append-only.ts
@@ -24,6 +24,10 @@ import "dotenv/config";
 
 import { createClient } from "redis";
 import { RedisConversationMemoryManager } from "../src/lib/core/redisConversationMemoryManager.js";
+import {
+  deserializeConversation,
+  parseStoredMessages,
+} from "../src/lib/utils/redis.js";
 import { defineSuite } from "./helpers/harness.js";
 
 const { test, runSuite, section } = defineSuite("Redis append-only storage");
@@ -45,6 +49,11 @@ const PREFIX = `nltest:${Date.now()}:conversation:`;
 const USER = "u1";
 
 const raw = createClient({ socket: { host: HOST, port: PORT } });
+// node-redis emits `error` on an unreachable server, and an EventEmitter with
+// no `error` listener throws globally — which would crash the process on the
+// no-Redis machines this suite is written to skip on, before the catch below
+// ever runs.
+raw.on("error", () => {});
 let redisUp = false;
 try {
   await raw.connect();
@@ -87,6 +96,68 @@ const sessionKey = (sessionId: string): string =>
   `${PREFIX}${USER}:${sessionId}`;
 
 await runSuite(async () => {
+  // These need no server: they pin the read-path contract both storage formats
+  // must honour, so they run even on a machine without Redis.
+  section("Both read paths validate what they return");
+
+  await test("a stored message with no id is repaired, not discarded", async () => {
+    // `id` is required on ChatMessage but no read path ever enforced it, so
+    // history written before it existed carries none. Dropping those records
+    // would empty healthy sessions.
+    const [message] = parseStoredMessages([
+      JSON.stringify({ role: "user", content: "hello" }),
+    ]);
+    assert(message !== undefined, "an id-less message was discarded");
+    assert(
+      typeof message.id === "string" && message.id.length > 0,
+      "the repaired message carries no id",
+    );
+    assert(
+      message.role === "user" && message.content === "hello",
+      "repair altered the message body",
+    );
+  });
+
+  await test("values JSON.parse accepts but callers cannot use are skipped", async () => {
+    // `null`, numbers and bare strings all survive JSON.parse, so the catch
+    // around it cannot filter them — the shape has to be checked.
+    const messages = parseStoredMessages([
+      "null",
+      "42",
+      '"bare string"',
+      "{not json",
+      JSON.stringify({ role: "assistant", content: "kept", id: "m1" }),
+    ]);
+    assert(messages.length === 1, "an unusable entry reached the caller");
+    assert(messages[0].id === "m1", "the valid entry was not the survivor");
+  });
+
+  await test("the inline blob path repairs and rejects identically", async () => {
+    const blob = (messages: unknown[]): string =>
+      JSON.stringify({
+        title: "t",
+        sessionId: "s",
+        userId: "u",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        messages,
+      });
+
+    const repaired = deserializeConversation(
+      blob([{ role: "user", content: "hello" }]),
+    );
+    assert(repaired !== null, "an id-less inline blob was thrown away");
+    assert(
+      typeof repaired.messages[0]?.id === "string",
+      "the inline path returned a message with no id",
+    );
+
+    assert(
+      deserializeConversation(blob([{ role: "user" }])) === null,
+      "the inline path accepted a message with no content",
+    );
+  });
+
   if (!redisUp) {
     await test("redis reachable", async () => {
       throw new Error("SKIP: no local Redis on 6379");


### PR DESCRIPTION
## Description

#1286 merged three minutes before its automated review landed, so its findings were never addressed on the PR. This resolves all of them against `release`, plus one bug the review did not find that is larger than anything in it.

CodeRabbit does not auto-review PRs whose base is not the default branch, so nothing in the #1280→#1287 stack was reviewed until #1286 was retargeted onto `release`. Absence of comments on the rest of the stack was absence of review, not approval.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## The bug the review missed: AI Studio budgets against a 128K window

`PROVIDER_ALIAS_MAP` mapped `googleaistudio` → `"google-ai-studio"`. That key has never existed in `MODEL_CONTEXT_WINDOWS` — the key is `"google-ai"` — so the lookup missed and fell through to `DEFAULT_CONTEXT_WINDOW`:

```
before                          after
googleAiStudio    -> 128000     -> 1048576
google-ai-studio  -> 128000     -> 1048576
googleai          -> 128000     -> 1048576
google-ai         -> 1048576    -> 1048576   (only ever worked via raw-provider fallback)
```

The native AI Studio client passes the literal `"googleAiStudio"`, so its loop-guard budget was understated ~8x: the reclaim fired at ~70,720 estimated tokens on a model holding 1,048,576. #1287 gave that loop a reclaim for the first time, so this shipped as premature truncation of tool history that still fitted comfortably — paying to re-run tools whose results had just been discarded.

| | before | after |
|---|---|---|
| reclaim budget | 83,200 | 984,576 |
| guard trip point | 108,800 | 891,289 |

Fixed at the root (the alias map) rather than at the three call sites, so any caller reaching the table by a non-canonical spelling is covered.

## Review findings

**Redis session storage**

- `persistConversation` issued up to six independent commands. The replace path is `DEL` then `RPUSH`, and on the legacy-conversion turn the inline blob is the only copy of the history until the `SET` lands — a failure between any two left the session empty or unrecoverable. Now one `MULTI`, which also collapses the round trips the append-only layout exists to save.
- `hydrateMessages`' `lRange` and `countMessages`' `lLen` were unguarded while the sibling `GET` on the same paths already used `withTimeout`. Both wrapped.
- The split read path skipped the shape validation the inline path always had. `JSON.parse` succeeds for `null`, numbers and bare strings, so the surrounding `catch` could not filter them and they reached callers dereferencing `.role` / `.content` / `.metadata`. Extracted `isStoredChatMessage`, now used by **both** read paths — same guarantee whichever storage format a session is in.
- `id` is required on `ChatMessage` but no read path ever enforced it, so a guard that returns `value is ChatMessage` without checking it is lying to every caller keying summary pointers off it. It now checks `id` — and because history written before `id` existed carries none, and one such message makes `deserializeConversation` return `null` for the entire session, `normalizeStoredMessage` backfills the missing id as `legacy-<uuid>` instead of rejecting. Prefixed so a synthesized id is never mistaken for one an existing pointer references.
- Background summarization was scheduled with `setImmediate` **before** the awaited write. On the one turn that converts a legacy session, `checkAndSummarize` re-reads the blob and branches on `usesSplitMessageStorage`; observing the pre-conversion blob makes it re-serialize the record **without** the split marker while the companion LIST already holds the messages, so the next read serves the stale inline copy. Scheduling moved after the write. The block only schedules — nothing else changes.

**Loop-guard calibration**

The review's diagnosis was correct in kind and wrong in location. Calibration divides a real prompt-token count by this module's estimate **of the same payload**, and there are two legitimate pairings:

- a planner that runs every step pairs the previous request's real count with `previousSentEstimate`
- a planner that runs only when a real-token guard trips pairs that guard's `projectedNextPromptTokens` — already a projection of the payload about to be sent — with its own current estimate

Vertex-Gemini is the second kind and was correct as written; switching it to `previousSentEstimate` as suggested would have pinned its calibration at 1 and made the reclaim inert. The genuinely broken paths were **Vertex-Claude** and **AI Studio**, which the review did not name. `planAnthropicLoopReclaim` now takes `observedDescribesCurrentPayload` to state which pairing the caller is in, and `planGeminiLoopReclaim` documents the constraint it already relied on.

This matters because the two thresholds are the same ratio: the guard trips on real tokens at 0.85 of the window, the planner tests its smaller char estimate against 0.85 of the budget. Uncalibrated, the plan never fires when the guard trips — so the turn stops instead of continuing, which is the exact failure the guard was added to remove.

**Budget definition** — both Vertex reclaims budgeted against `getContextWindowSize`, the whole window, which has to hold the model's output too. Now `getAvailableInputTokens`, matching the AI Studio twin. Concretely, the low-water target on Vertex Gemini moves from 629K to 590K with genuine output headroom.

**AI Studio reclaim cost** — the reclaim ran unconditionally on every step, and planning serializes the entire accumulated history to estimate it, so a 30-step turn paid that 30 times. Now gated behind the same cheap `createContextGuard` the Vertex twin uses, in both the stream and generate loops, with `noteUsage` / `noteAppendedChars` feeding it. Step 0 still plans unconditionally — the guard is fail-open until the first usage report, and an incoming history can already be oversized.

**Tests**

- the gemini calibration assertion was `plain === undefined || calibrated !== undefined`, which is true whenever the fixture does not fire — and it did not. The anthropic twin was worse: after #1283 introduced `previousSentEstimate`, passing `observedPromptTokens` alone cannot calibrate at all, so it compared a value against itself. Both replaced with differential assertions that pin the premise (the fixture does **not** fire uncalibrated), the effect, and monotonicity in the ratio.
- the append-only suite's raw `createClient` had no `error` listener. An EventEmitter with no `error` handler throws globally, so on a machine without Redis the process died before the `catch` that exists to skip the suite.

## Testing

All no-API, all verified green:

| suite | |
|---|---|
| `test:gemini-guard` | 11/11 |
| `test:anthropic-guard` | 13/13 |
| `test:loop-guard-core` | 12/12 |
| `test:step-guard` | 6/6 |
| `test:tool-pairing` | 18/18 |
| `test:openai-compat-guard` | 12/12 |
| `test:tool-storage-parity` | 10/10 |
| `test:redis-append-only` | 13/13 (10 against a real local Redis, 3 server-free) |
| `test:token-accounting` | 10/10 |
| `test:litellm-context-windows` | 22/22 |

The new alias test was verified to fail **loudly** (`✗`, `RESULT: FAIL`) when the fix is reverted, per the CLAUDE.md hazard where `isExpectedProviderError()` can downgrade a real failure to `⊘`.

`tsc --noEmit --strict` 0 errors · `eslint` 0 errors (49 pre-existing `max-lines-per-function` warnings) · `prettier --check` clean · `pnpm run build` exit 0, `publint` clean.

## Deliberately out of scope

- `fixedOverheadTokens` is still 0 on the Vertex and AI Studio reclaim paths, so calibration's numerator (real prompt tokens, which include the system instruction and tool declarations) is measured against a denominator that excludes them. This biases calibration upward — more eager reclaim, the fail-safe direction. Plumbing declarations to all six call sites is a separate change.
- AI Studio still has no stop-and-synthesize fallback when a reclaim cannot help, unlike Vertex. Pre-existing.
- The Redis read path remains O(n) per turn, as noted in #1286.
- Concurrent turns on one session can still lose a write. The stale value is the `GET` at the top of `storeConversationTurn`, not the transaction — `WATCH` around the `MULTI` would abort a payload already built from a stale read, trading a lost earlier turn for a lost current one. Closing it means watching the whole read-modify-write with a retry that re-runs the turn assembly, on an isolated connection. This PR did not introduce it: the same `DEL` → `RPUSH` → `SET` ran as independent commands before, with a strictly wider window.

## Verification not performed

No live provider run against AI Studio or Vertex. Coverage here is unit-level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Google AI Studio context limits, including model-specific limits.
  - Improved context management during Gemini, Anthropic, and Vertex conversations to reduce truncation and improve tool-loop reliability.
  - Prevented malformed persisted messages from disrupting conversation loading.
  - Improved Redis conversation saves with timeouts and atomic updates, reducing data-loss and availability issues.

- **Tests**
  - Added regression coverage for provider aliases, context reclamation, persisted message validation, and Redis failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->