### PR TITLE
ci(release): pin ffmpeg to 7.1 to fix publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
 
       - name: Install ffmpeg
         uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          # Pin to a known-good release, matching ci.yml. The unpinned default
+          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
+          # the download 404s and fails the job at extract ("xz: (stdin): File
+          # format not recognized"). Revert once upstream publishes it.
+          version: "7.1"
 
       - name: Verify ffmpeg installation
         run: |
@@ -82,6 +88,12 @@ jobs:
 
       - name: Install ffmpeg
         uses: AnimMouse/setup-ffmpeg@v1
+        with:
+          # Pin to a known-good release, matching ci.yml. The unpinned default
+          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
+          # the download 404s and fails the job at extract ("xz: (stdin): File
+          # format not recognized"). Revert once upstream publishes it.
+          version: "7.1"
 
       - name: Verify ffmpeg installation
         run: |


### PR DESCRIPTION
## Problem

The `Release and Publish` workflow fails at `Install ffmpeg` in **both** its `test` and `release` jobs, blocking npm publish:

```
Downloading FFmpeg 9.0 for Linux X64
xz: (stdin): File format not recognized
tar: Child returned status 1
##[error]Process completed with exit code 2
```

`AnimMouse/setup-ffmpeg@v1`'s Linux path builds its URL from the resolved version:

```sh
filename=ffmpeg-n$version-latest-linux$arch-gpl-$version.tar.xz
wget -qO- .../BtbN/FFmpeg-Builds/releases/download/latest/$filename | tar -xJ ...
```

Unpinned, it resolves `version=9.0`, but the `BtbN/FFmpeg-Builds` `latest` release only carries `n7.1` and `n8.1` linux64 GPL assets. The request 404s and the error body is piped straight into `tar -xJ`, which fails to extract.

`ci.yml` was already pinned to `7.1` for this exact failure in 47646411 — `release.yml` was missed, which is why CI is green while Release is red.

## Change

Pins both `setup-ffmpeg` steps in `release.yml` to `version: "7.1"`, matching `ci.yml`.

## Impact

npm is stuck at `10.10.6`. Two `fix(...)` commits on `release` are unpublished:

- `0b1abf1d` fix(core): append-only redis sessions and gemini loop guard coverage
- `ae2e1112` fix(context): harden redis writes and calibrate native loop reclaims

This commit is typed `ci`, which is `release: false` in `.releaserc.json`, so it cuts no version itself — the two pending `fix` commits drive the next patch release once the pipeline runs green.

## Note

An unrelated GitHub Actions **major outage** (incident opened 15:22 UTC, ongoing) is currently failing runs at `Set up job` with `Failed to resolve action download info / Service Unavailable`. Checks on this PR may fail for that reason until it clears; that is infrastructure, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated media-processing setup in automated test and release workflows to use a fixed, reliable version.
  * Added documentation explaining the version pinning and previous setup issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->