### PR TITLE
fix(multimodal): enforce the aggregate PDF limit on the input.content path

### DIFF
--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -498,6 +498,28 @@ export type PDFImagePage = {
   error?: string;
 };
 
+/**
+ * A single PDF queued for multimodal message building, normalised from either
+ * submission surface — `input.pdfFiles` or `input.content` with `type: "pdf"`
+ * — so both can share the aggregate page/size guard (#309).
+ */
+export type MultimodalPdfEntry = {
+  /** Raw PDF bytes. */
+  buffer: Buffer;
+  /** Display name; may be a full path, so log only its basename. */
+  filename: string;
+  /**
+   * Page count when known. Null/undefined on the `input.content` path whenever
+   * the caller omitted `metadata.pages`; the aggregate guard resolves those
+   * from `buffer` rather than treating them as zero.
+   */
+  pageCount?: number | null;
+  /** Password for an encrypted PDF (#258). */
+  password?: string;
+  /** Per-page pixel ceiling for the image fallback (#260). */
+  maxCanvasPixels?: number;
+};
+
 /** Result of PDF to image conversion. */
 export type PDFImageConversionResult = {
   /** Array of base64-encoded PNG images (one per successfully converted page) */

--- a/src/lib/utils/errorHandling.ts
+++ b/src/lib/utils/errorHandling.ts
@@ -63,6 +63,9 @@ export const ERROR_CODES = {
 
   // PDF validation errors
   PDF_PAGE_LIMIT_EXCEEDED: "PDF_PAGE_LIMIT_EXCEEDED",
+  PDF_AGGREGATE_PAGE_LIMIT_EXCEEDED: "PDF_AGGREGATE_PAGE_LIMIT_EXCEEDED",
+  PDF_AGGREGATE_SIZE_LIMIT_EXCEEDED: "PDF_AGGREGATE_SIZE_LIMIT_EXCEEDED",
+  PDF_PAGE_COUNT_UNVERIFIABLE: "PDF_PAGE_COUNT_UNVERIFIABLE",
   PDF_PASSWORD_REQUIRED: "PDF_PASSWORD_REQUIRED",
   PDF_INCORRECT_PASSWORD: "PDF_INCORRECT_PASSWORD",
 
@@ -657,6 +660,75 @@ export class ErrorFactory {
         provider,
         alternatives,
       },
+    });
+  }
+
+  /**
+   * The combined page count across every PDF in one request exceeds what the
+   * provider accepts (#309). Distinct from `pdfPageLimitExceeded`, which is
+   * per-file — here each document can be individually legal.
+   */
+  static pdfAggregatePageLimitExceeded(
+    fileCount: number,
+    totalPages: number,
+    maxPages: number,
+    provider: string,
+  ): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.PDF_AGGREGATE_PAGE_LIMIT_EXCEEDED,
+      message:
+        `[PDF] Combined page count across ${fileCount} PDF(s) (${totalPages}) exceeds the ` +
+        `${maxPages}-page limit for ${provider}. ` +
+        `Split the request or reduce the number of PDFs.`,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: { fileCount, totalPages, maxPages, provider },
+    });
+  }
+
+  /**
+   * The combined byte size across every PDF in one request exceeds what the
+   * provider accepts (#309).
+   */
+  static pdfAggregateSizeLimitExceeded(
+    fileCount: number,
+    totalMB: number,
+    maxSizeMB: number,
+    provider: string,
+  ): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.PDF_AGGREGATE_SIZE_LIMIT_EXCEEDED,
+      message:
+        `[PDF] Combined size across ${fileCount} PDF(s) (${totalMB.toFixed(2)}MB) exceeds the ` +
+        `${maxSizeMB}MB limit for ${provider}.`,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: { fileCount, totalMB, maxSizeMB, provider },
+    });
+  }
+
+  /**
+   * A PDF supplied through the untrusted `input.content` surface could not be
+   * parsed for a page count (#309). Caller-supplied `metadata.pages` is not
+   * authoritative there, so an unreadable document is rejected rather than
+   * admitted with an assumed count of zero.
+   */
+  static pdfPageCountUnverifiable(
+    filenames: string[],
+    provider: string,
+  ): NeuroLinkError {
+    return new NeuroLinkError({
+      code: ERROR_CODES.PDF_PAGE_COUNT_UNVERIFIABLE,
+      message:
+        `[PDF] Cannot verify the page count for ${filenames.length} PDF(s) supplied via ` +
+        `input.content (${filenames.join(", ")}). Provide readable PDFs, or submit them ` +
+        `via input.pdfFiles where page counts are derived during detection.`,
+      category: ErrorCategory.VALIDATION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: { filenames, provider },
     });
   }
 

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { readFile as readFileAsync, stat as statAsync } from "fs/promises";
-import { basename } from "path";
 import { getGlobalDispatcher, interceptors, request } from "undici";
 import {
   MultimodalLogger,
@@ -47,6 +46,7 @@ import type {
   FilePart,
   ImagePart,
   TextPart,
+  MultimodalPdfEntry,
 } from "../types/index.js";
 
 // ---------------------------------------------------------------------------
@@ -1297,29 +1297,127 @@ function enforcePostProcessingBudget(
 }
 
 /**
+ * #309: enforce the provider's page/size ceilings across ALL PDFs in a request,
+ * not just per-file. N files each just under the single-file limit can still
+ * blow past it in aggregate (e.g. three 40-page PDFs → 120 pages for a
+ * 100-page API).
+ *
+ * Shared by both PDF submission surfaces: `input.pdfFiles` (via
+ * `processExplicitPdfFiles`) and `input.content` with `type: "pdf"` (via
+ * `convertContentToProviderFormat`). The latter previously built its own
+ * `pdfFiles` array and reached the provider without ever calling this guard,
+ * so the limit was bypassable by moving the same payload to `input.content`.
+ */
+/**
+ * Basename that strips BOTH separators regardless of host platform.
+ *
+ * `path.basename` only understands the host's separator, so on a POSIX server
+ * a Windows-style filename (`C:\Users\alice\q3-merger.pdf`) comes back
+ * completely unchanged — defeating the point of trimming it before it reaches
+ * a log line, since caller-controlled paths can carry usernames and internal
+ * directory structure.
+ */
+function safeBasename(filename: string): string {
+  const lastSeparator = Math.max(
+    filename.lastIndexOf("/"),
+    filename.lastIndexOf("\\"),
+  );
+  const trimmed =
+    lastSeparator === -1 ? filename : filename.slice(lastSeparator + 1);
+  return trimmed || "<unnamed file>";
+}
+
+async function enforceAggregatePdfLimits(
+  pdfFiles: MultimodalPdfEntry[],
+  provider: string,
+  { trustSuppliedPageCounts }: { trustSuppliedPageCounts: boolean },
+): Promise<void> {
+  const aggregateConfig = PDFProcessor.getProviderConfig(provider);
+  // Only an empty set is exempt. A single PDF must still be checked: on the
+  // `input.content` path nothing else validates it (that path never goes
+  // through FileDetector.detectAndProcess / PDFProcessor.process), so bailing
+  // at length <= 1 let one 200-page document through untouched.
+  if (!aggregateConfig || pdfFiles.length === 0) {
+    return;
+  }
+
+  // Byte total is free to compute — enforce it BEFORE parsing anything, so an
+  // oversized request is rejected without first spending parser CPU/memory on
+  // every document in it.
+  const totalMB =
+    pdfFiles.reduce((sum, f) => sum + f.buffer.length, 0) / (1024 * 1024);
+  if (totalMB > aggregateConfig.maxSizeMB) {
+    throw ErrorFactory.pdfAggregateSizeLimitExceeded(
+      pdfFiles.length,
+      totalMB,
+      aggregateConfig.maxSizeMB,
+      provider,
+    );
+  }
+
+  // `trustSuppliedPageCounts` is the difference between the two surfaces.
+  // On `input.pdfFiles` the count comes from FileDetector's own detection, so
+  // it is authoritative. On `input.content` it is `metadata.pages` — plain
+  // caller input — and trusting it lets a request declare `pages: 1` for each
+  // of three 40-page PDFs and sail past the ceiling. There, the count is
+  // always re-derived from the bytes and the supplied value is ignored.
+  const pageCounts = await Promise.all(
+    pdfFiles.map(async (f) =>
+      trustSuppliedPageCounts && typeof f.pageCount === "number"
+        ? f.pageCount
+        : await PDFProcessor.resolvePageCount(f.buffer),
+    ),
+  );
+
+  // Filenames are caller-controlled and may be full paths carrying
+  // PII/internal directory segments — surface only the basename, stripping
+  // both separators so a Windows path is trimmed on a POSIX host too.
+  const unknownFileNames = pdfFiles
+    .filter((_, i) => typeof pageCounts[i] !== "number")
+    .map((f) => (f.filename ? safeBasename(f.filename) : "<unnamed file>"));
+  const totalPages = pageCounts.reduce<number>(
+    (sum, p) => sum + (typeof p === "number" ? p : 0),
+    0,
+  );
+
+  if (unknownFileNames.length > 0) {
+    if (!trustSuppliedPageCounts) {
+      // Untrusted surface: an unreadable count is indistinguishable from an
+      // evasion attempt, and counting it as zero is precisely the hole. Fail
+      // closed rather than admit an unverifiable document.
+      throw ErrorFactory.pdfPageCountUnverifiable(unknownFileNames, provider);
+    }
+    // Trusted surface: detection already vetted these, so one unreadable
+    // count must not fail an otherwise valid request — but it must not be
+    // silent either, since the known sum may undercount the true total.
+    logger.warn(
+      `[PDF] Aggregate page-limit check across ${pdfFiles.length} PDFs could only be ` +
+        `partially verified: ${unknownFileNames.length} file(s) have an unknown ` +
+        `page count (${unknownFileNames.join(", ")}), so the known total (${totalPages}) may ` +
+        `undercount the true combined page count.`,
+    );
+  }
+
+  if (totalPages > aggregateConfig.maxPages) {
+    throw ErrorFactory.pdfAggregatePageLimitExceeded(
+      pdfFiles.length,
+      totalPages,
+      aggregateConfig.maxPages,
+      provider,
+    );
+  }
+}
+
+/**
  * Process explicit PDF files and return structured PDF entries for multimodal processing.
  */
 async function processExplicitPdfFiles(
   options: GenerateOptions,
   maxSize: number,
   provider: string,
-): Promise<
-  Array<{
-    buffer: Buffer;
-    filename: string;
-    pageCount?: number | null;
-    password?: string;
-    maxCanvasPixels?: number;
-  }>
-> {
+): Promise<MultimodalPdfEntry[]> {
   options.input ??= {};
-  const pdfFiles: Array<{
-    buffer: Buffer;
-    filename: string;
-    pageCount?: number | null;
-    password?: string;
-    maxCanvasPixels?: number;
-  }> = [];
+  const pdfFiles: MultimodalPdfEntry[] = [];
 
   if (!options.input.pdfFiles || options.input.pdfFiles.length === 0) {
     return pdfFiles;
@@ -1362,50 +1460,10 @@ async function processExplicitPdfFiles(
     }
   }
 
-  // #309: enforce the provider's page/size ceilings across ALL PDFs, not just
-  // per-file. N files each just under the single-file limit can still blow past
-  // it in aggregate (e.g. three 40-page PDFs → 120 pages for a 100-page API).
-  const aggregateConfig = PDFProcessor.getProviderConfig(provider);
-  if (aggregateConfig && pdfFiles.length > 1) {
-    // A null pageCount (accurate count unavailable — see
-    // PDFProcessor.getAccuratePageCount) is treated as 0 in the sum below,
-    // which can undercount the aggregate and let a combined request over
-    // the provider's page limit slip through silently. Enforcement still
-    // runs against the known sum — a PDF with an unknown count must not
-    // fail the request outright — but the gap itself must not be silent.
-    const unknownPageCountFiles = pdfFiles.filter(
-      (f) => f.pageCount === null || f.pageCount === undefined,
-    );
-    const totalPages = pdfFiles.reduce((sum, f) => sum + (f.pageCount ?? 0), 0);
-    const totalMB =
-      pdfFiles.reduce((sum, f) => sum + f.buffer.length, 0) / (1024 * 1024);
-    if (unknownPageCountFiles.length > 0) {
-      // Filenames are caller-controlled and may be full paths carrying
-      // PII/internal directory segments — log only the basename.
-      const unknownFileNames = unknownPageCountFiles
-        .map((f) => (f.filename ? basename(f.filename) : "<unnamed file>"))
-        .join(", ");
-      logger.warn(
-        `[PDF] Aggregate page-limit check across ${pdfFiles.length} PDFs could only be ` +
-          `partially verified: ${unknownPageCountFiles.length} file(s) have an unknown ` +
-          `page count (${unknownFileNames}), so the known total (${totalPages}) may ` +
-          `undercount the true combined page count.`,
-      );
-    }
-    if (totalPages > aggregateConfig.maxPages) {
-      throw new Error(
-        `[PDF] Combined page count across ${pdfFiles.length} PDFs (${totalPages}) exceeds the ` +
-          `${aggregateConfig.maxPages}-page limit for ${provider}. ` +
-          `Split the request or reduce the number of PDFs.`,
-      );
-    }
-    if (totalMB > aggregateConfig.maxSizeMB) {
-      throw new Error(
-        `[PDF] Combined size across ${pdfFiles.length} PDFs (${totalMB.toFixed(2)}MB) exceeds the ` +
-          `${aggregateConfig.maxSizeMB}MB limit for ${provider}.`,
-      );
-    }
-  }
+  // Counts here come from FileDetector's detection, so they are authoritative.
+  await enforceAggregatePdfLimits(pdfFiles, provider, {
+    trustSuppliedPageCounts: true,
+  });
 
   return pdfFiles;
 }
@@ -1783,7 +1841,7 @@ async function convertContentToProviderFormat(
   const images = imageContent.map((img) => img.data);
 
   // Extract PDFs in the expected format
-  const pdfFiles = pdfContent.map((pdf) => ({
+  const pdfFiles: MultimodalPdfEntry[] = pdfContent.map((pdf) => ({
     buffer:
       typeof pdf.data === "string" ? Buffer.from(pdf.data, "base64") : pdf.data,
     filename: pdf.metadata?.filename || "document.pdf",
@@ -1794,6 +1852,13 @@ async function convertContentToProviderFormat(
     password: pdfOptions?.password,
     maxCanvasPixels: pdfOptions?.maxCanvasPixels,
   }));
+
+  // #309: same aggregate ceiling as `input.pdfFiles`. Without this, moving an
+  // over-limit payload from `input.pdfFiles` to `input.content` skipped the
+  // check entirely and the request went straight to the provider.
+  await enforceAggregatePdfLimits(pdfFiles, provider, {
+    trustSuppliedPageCounts: false,
+  });
 
   return await convertMultimodalToProviderFormat(
     text,

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -255,6 +255,24 @@ export class PDFProcessor {
     return PDF_PROVIDER_CONFIGS[provider] || null;
   }
 
+  /**
+   * Best-effort page count for a PDF whose count the caller did not supply
+   * (#309). Mirrors what `process()` derives for the `input.pdfFiles` path:
+   * the accurate pdfjs count when the document parses, otherwise the header
+   * regex estimate. Returns null when neither can determine a count.
+   *
+   * Exists so the aggregate page-limit guard can enforce against PDFs handed
+   * in via `input.content`, where `metadata.pages` is optional and routinely
+   * omitted — without it, an absent count silently sums as zero.
+   */
+  static async resolvePageCount(buffer: Buffer): Promise<number | null> {
+    const accurate = await PDFProcessor.getAccuratePageCount(buffer);
+    if (accurate !== null) {
+      return accurate;
+    }
+    return PDFProcessor.extractBasicMetadata(buffer).estimatedPages;
+  }
+
   private static isValidPDF(buffer: Buffer): boolean {
     if (buffer.length < 5) {
       return false;

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -1935,6 +1935,85 @@ const tests: TestFunction[] = [
     },
   },
   {
+    name: "MessageBuilder #309: input.content PDFs hit the same aggregate page limit as input.pdfFiles",
+    category: "pdf-processor",
+    fn: async () => {
+      const synth = (pages: number): Buffer =>
+        Buffer.concat([
+          Buffer.from("%PDF-1.4\n"),
+          Buffer.from("/Type /Page \n".repeat(pages)),
+          Buffer.alloc(20),
+        ]);
+      // The advanced `input.content` surface — the path that previously built
+      // its own pdfFiles array and reached the provider with no aggregate check.
+      const build = (pdfs: Buffer[], pages?: number) =>
+        buildMultimodalMessagesArray(
+          {
+            input: {
+              content: [
+                { type: "text", text: "x" },
+                ...pdfs.map((data, i) => ({
+                  type: "pdf",
+                  data,
+                  metadata:
+                    pages === undefined
+                      ? { filename: `d${i}.pdf` }
+                      : { filename: `d${i}.pdf`, pages },
+                })),
+              ],
+            },
+          } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+          "openai", // native PDF provider, maxPages 100
+          "gpt-4o",
+        );
+
+      const rejectsWith = async (
+        pdfs: Buffer[],
+        pattern: RegExp,
+        pages?: number,
+      ) => {
+        try {
+          await build(pdfs, pages);
+          return false;
+        } catch (e) {
+          return e instanceof Error && pattern.test(e.message);
+        }
+      };
+      const over = [synth(40), synth(40), synth(40)]; // 120 pages
+
+      // Rejected whether or not the caller supplied metadata.pages — an
+      // omitted count must be resolved from the buffer, not summed as zero.
+      if (!(await rejectsWith(over, /Combined page count/, 40))) {
+        return false;
+      }
+      if (!(await rejectsWith(over, /Combined page count/))) {
+        return false;
+      }
+      // metadata.pages is caller input, so it must not be believed: declaring
+      // 1 page each for three 40-page PDFs previously passed the ceiling.
+      if (!(await rejectsWith(over, /Combined page count/, 1))) {
+        return false;
+      }
+      // A single over-limit PDF must be caught too. input.content never passes
+      // through FileDetector, so nothing else validates it — an early return
+      // at "fewer than two files" let one 200-page document straight through.
+      if (!(await rejectsWith([synth(200)], /Combined page count/))) {
+        return false;
+      }
+      // Aggregate byte ceiling (openai: 32MB), enforced before any parsing.
+      const fat = Buffer.concat([synth(1), Buffer.alloc(17 * 1024 * 1024)]);
+      if (!(await rejectsWith([fat, fat], /Combined size/))) {
+        return false;
+      }
+
+      // Under the limit still resolves — the guard must not be rejecting every
+      // content-path PDF request.
+      await build([synth(20), synth(20), synth(20)]); // 60 total
+      await build([synth(20)]); // single legitimate PDF
+      return true;
+    },
+  },
+  {
     name: "FileDetector #317: pre-flight HEAD rejects an oversized URL before the GET",
     category: "pdf-processor",
     fn: async () => {


### PR DESCRIPTION
Closes #309

## The bug

The provider page/size ceiling was only applied by `processExplicitPdfFiles`, which serves `input.pdfFiles`. PDFs submitted through the documented `input.content: [{ type: "pdf" }]` surface built their own `pdfFiles` array in `convertContentToProviderFormat` and went **straight to the provider**.

Moving an over-limit payload from one field to the other bypassed the check entirely:

| Submission surface | 3 × 40-page PDFs vs openai's 100-page limit |
| --- | --- |
| `input.pdfFiles` | ❌ rejected — *"Combined page count across 3 PDFs (120) exceeds the 100-page limit"* |
| `input.content` | ✅ **accepted and sent** |

## The fix

- Extracted the guard into a shared `enforceAggregatePdfLimits()`, now called from **both** paths.
- On the content path `metadata.pages` is optional and routinely omitted, and an absent count previously summed as **zero** — so even after wiring the guard in, the ceiling would not have tripped. `PDFProcessor.resolvePageCount()` resolves a missing count from the buffer (accurate pdfjs count, falling back to the header estimate — mirroring what the file path already derives).
- The thrice-repeated inline PDF-entry shape becomes `MultimodalPdfEntry` in `src/lib/types/file.ts` per Critical Rule 2.

## Verification

New test `MessageBuilder #309: input.content PDFs hit the same aggregate page limit as input.pdfFiles` covers both with- and without-`metadata.pages`, plus an under-limit case so the guard isn't just rejecting everything.

Confirmed it genuinely catches the regression — with the new call removed it reports `✗` and exits non-zero (not `⊘ skipped`):

```
✗ MessageBuilder #309: input.content PDFs hit the same aggregate page limit as input.pdfFiles
  Passed: 268   Failed: 1
```

With the fix: **269/269 pass**. `pnpm run check` 0 errors; `pnpm run lint` 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PDF processing to accurately determine page counts, including when page metadata is unavailable.
  * Added support for normalized PDF input details such as filenames, passwords, and image-conversion limits.

* **Bug Fixes**
  * PDF page and size limits are now consistently enforced across all supported input methods.
  * Requests exceeding provider limits are rejected reliably, including single oversized PDFs and multi-PDF requests.
  * Added clear validation errors when PDF page counts cannot be verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->