### PR TITLE
fix(video): honor the CLI frame, quality and format options

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -89,8 +89,8 @@ Large local `--image`/`--csv`/`--pdf`/`--video` files emit a soft-limit size war
 **Video Input (Analysis):**
 
 - `--video` – attach video file for analysis (MP4, WebM, MOV, AVI, MKV).
-- `--video-frames` – number of frames to extract (default `8`).
-- `--video-quality` – frame quality 0–100 (default `85`).
+- `--video-frames` – number of frames to extract (default: chosen from the video's duration, capped at 100).
+- `--video-quality` – frame quality 1–100 (default `80`).
 - `--video-format` – frame format: `jpeg` (default) or `png`.
 - `--transcribe-audio` – extract and transcribe audio from video (default `false`).
 

--- a/docs/skills/neurolink-guide/cli-reference.md
+++ b/docs/skills/neurolink-guide/cli-reference.md
@@ -136,8 +136,8 @@ neurolink batch prompts.txt --provider openai
 **Video options:**
 
 ```
---video-frames      Frames to extract (default: 8)
---video-quality     Quality 0-100 (default: 85)
+--video-frames      Frames to extract (default: from duration, max 100)
+--video-quality     Quality 1-100 (default: 80)
 --video-format      jpeg or png (default: jpeg)
 --transcribe-audio  Transcribe audio
 ```

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -209,15 +209,20 @@ export class CLICommandFactory {
       description:
         "Add video file for analysis (can be used multiple times) (MP4, WebM, MOV, AVI, MKV)",
     },
+    // No yargs `default:` on these two. They used to declare 8 / 85 while the
+    // processor actually picks a duration-based frame count (up to 100) and
+    // encodes at quality 80 — harmless only because the values were never read
+    // (#478). Now that they reach the encoder, a default here would silently
+    // re-cap every existing CLI video at 8 frames. Unset means "let the
+    // processor choose", which is what callers have always effectively had.
     "video-frames": {
       type: "number" as const,
-      default: 8,
-      description: "Number of frames to extract (default: 8)",
+      description:
+        "Number of frames to extract (default: chosen from video duration, max 100)",
     },
     "video-quality": {
       type: "number" as const,
-      default: 85,
-      description: "Frame quality 0-100 (default: 85)",
+      description: "Frame quality 1-100 (default: 80)",
     },
     "video-format": {
       type: "string" as const,

--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -60,6 +60,7 @@ import type {
   ProcessedVideo,
   ProcessorFileProcessingResult,
   ProcessOptions,
+  VideoProcessorOptions,
 } from "../../types/index.js";
 import { SIZE_LIMITS_MB } from "../config/index.js";
 import { FileErrorCode } from "../errors/index.js";
@@ -359,7 +360,9 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
    */
   override async processFile(
     fileInfo: FileInfo,
-    options?: ProcessOptions,
+    // #478: widened with the keyframe knobs so `--video-frames`/`-quality`/
+    // `-format` can reach the encoder instead of being silently discarded.
+    options?: ProcessOptions & VideoProcessorOptions,
   ): Promise<ProcessorFileProcessingResult<ProcessedVideo>> {
     const filename = this.getFilename(fileInfo);
     const sizeBytes = fileInfo.size || fileInfo.buffer?.length || 0;
@@ -522,6 +525,7 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
               tempVideoPath,
               tempDir,
               metadata.duration,
+              options,
             );
           } catch {
             // Non-fatal: continue without keyframes if extraction fails
@@ -773,6 +777,17 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
   // ===========================================================================
 
   /**
+   * Clamp a caller-supplied frame quality into sharp's valid 1-100 range,
+   * falling back to the default when absent or non-numeric (#478).
+   */
+  private static resolveFrameQuality(quality?: number): number {
+    if (typeof quality !== "number" || !Number.isFinite(quality)) {
+      return VIDEO_CONFIG.FRAME_JPEG_QUALITY;
+    }
+    return Math.min(100, Math.max(1, Math.round(quality)));
+  }
+
+  /**
    * Extract keyframes from a video at calculated intervals.
    *
    * The interval between frames is determined by the video duration:
@@ -788,28 +803,56 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
    * The interval is adaptive: if the tier interval would exceed MAX_FRAMES,
    * the interval widens to duration/MAX_FRAMES for full-video coverage.
    *
+   * A caller-supplied `options.frames` overrides the tier schedule entirely:
+   * that many frames are spread evenly across the clip, still capped at
+   * MAX_FRAMES. `options.quality` and `options.format` reach the encoder (#478).
+   *
    * @param videoPath - Path to the video file
    * @param tempDir - Temp directory for frame output
    * @param durationSec - Video duration in seconds
-   * @returns Array of JPEG frame buffers
+   * @param options - Caller frame budget / encoder settings
+   * @returns Array of encoded frame buffers (JPEG unless png was requested)
    */
   private async extractKeyframes(
     videoPath: string,
     tempDir: string,
     durationSec: number,
+    options?: VideoProcessorOptions,
   ): Promise<Buffer[]> {
     if (durationSec <= 0) {
       return [];
     }
 
-    // Determine extraction interval based on duration
-    const intervalSec = this.getFrameInterval(durationSec);
+    // #478: honor the caller's frame budget, still bounded by MAX_FRAMES so a
+    // CLI flag can lower the cost but never raise it past the processor's own
+    // ceiling. A non-positive/non-finite request falls back to the default.
+    const requestedFrames = options?.frames;
+    const hasExplicitBudget =
+      typeof requestedFrames === "number" &&
+      Number.isFinite(requestedFrames) &&
+      requestedFrames > 0;
+    const frameBudget = hasExplicitBudget
+      ? Math.min(Math.floor(requestedFrames), VIDEO_CONFIG.MAX_FRAMES)
+      : VIDEO_CONFIG.MAX_FRAMES;
+
+    // Determine extraction interval based on duration. When the caller asked
+    // for a specific frame count, spread that many evenly across the whole
+    // video instead of using the duration tier — otherwise a short interval
+    // would hit the budget early and only cover the opening seconds.
+    //
+    // Keyed on whether a budget was REQUESTED, not on whether it happens to be
+    // below MAX_FRAMES: asking for exactly MAX_FRAMES is still an explicit
+    // request and must produce that many frames, not silently fall back to the
+    // tier schedule (which yields far fewer on a short clip).
+    const intervalSec = hasExplicitBudget
+      ? Math.max(durationSec / frameBudget, Number.EPSILON)
+      : this.getFrameInterval(durationSec);
 
     // Calculate timestamps to extract
     const timestamps: number[] = [];
     for (
       let t = 0;
-      t < durationSec && timestamps.length < VIDEO_CONFIG.MAX_FRAMES;
+      t < durationSec && timestamps.length < frameBudget;
       t += intervalSec
     ) {
       timestamps.push(t);
@@ -844,17 +887,23 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
 
         // Resize to fit within max dimension while preserving aspect ratio
         const sharp = (await import("sharp")).default;
-        const resized = await sharp(rawFrame)
-          .resize(
-            VIDEO_CONFIG.FRAME_MAX_DIMENSION,
-            VIDEO_CONFIG.FRAME_MAX_DIMENSION,
-            {
-              fit: "inside",
-              withoutEnlargement: true,
-            },
-          )
-          .jpeg({ quality: VIDEO_CONFIG.FRAME_JPEG_QUALITY })
-          .toBuffer();
+        const pipeline = sharp(rawFrame).resize(
+          VIDEO_CONFIG.FRAME_MAX_DIMENSION,
+          VIDEO_CONFIG.FRAME_MAX_DIMENSION,
+          {
+            fit: "inside",
+            withoutEnlargement: true,
+          },
+        );
+
+        // #478: `--video-quality` / `--video-format` were accepted by the CLI
+        // and then dropped on the floor; both now reach the encoder.
+        const quality = VideoProcessor.resolveFrameQuality(options?.quality);
+        const resized = await (
+          options?.format === "png"
+            ? pipeline.png({ quality })
+            : pipeline.jpeg({ quality })
+        ).toBuffer();
 
         keyframes.push(resized);
       } catch {

--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -353,6 +353,22 @@ export type AudioProcessorOptions = {
 };
 
 /**
+ * Keyframe-extraction knobs for an attached video (#478).
+ *
+ * These back the `--video-frames` / `--video-quality` / `--video-format` CLI
+ * flags and `GenerateOptions.videoOptions`. Each is clamped to the processor's
+ * own ceiling — a caller cannot raise `frames` above VIDEO_CONFIG.MAX_FRAMES.
+ */
+export type VideoProcessorOptions = {
+  /** Max keyframes to extract. Clamped to the processor's MAX_FRAMES ceiling. */
+  frames?: number;
+  /** Encoder quality 1-100 for the extracted frames. */
+  quality?: number;
+  /** Frame encoding. Defaults to jpeg. */
+  format?: "jpeg" | "png";
+};
+
+/**
  * Office processor options for Word, PowerPoint, and Excel documents
  *
  * @example Word document processing (docx)
@@ -417,6 +433,7 @@ export type FileDetectorOptions = {
   audioOptions?: AudioProcessorOptions;
   csvOptions?: CSVProcessorOptions;
   officeOptions?: OfficeProcessorOptions;
+  videoOptions?: VideoProcessorOptions;
   confidenceThreshold?: number;
   provider?: string;
   /** Maximum number of retry attempts for network requests (default: 3) */

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -159,10 +159,14 @@ export type GenerateOptions = {
 
   // Video processing options
   videoOptions?: {
-    frames?: number; // Number of frames to extract (default: 8)
-    quality?: number; // Frame quality 0-100 (default: 85)
-    format?: "jpeg" | "png"; // Frame format (default: jpeg)
-    transcribeAudio?: boolean; // Extract and transcribe audio (default: false)
+    /** Frames to extract. Unset lets VideoProcessor pick from the clip's duration; clamped to 100. */
+    frames?: number;
+    /** Frame encoder quality, clamped to 1-100. Default 80. */
+    quality?: number;
+    /** Frame encoding. Default jpeg. */
+    format?: "jpeg" | "png";
+    /** Not implemented yet (#433) — warns rather than silently doing nothing. */
+    transcribeAudio?: boolean;
   };
 
   /**

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -285,10 +285,14 @@ export type StreamOptions = {
 
   // Video processing options
   videoOptions?: {
-    frames?: number; // Number of frames to extract (default: 8)
-    quality?: number; // Frame quality 0-100 (default: 85)
-    format?: "jpeg" | "png"; // Frame format (default: jpeg)
-    transcribeAudio?: boolean; // Extract and transcribe audio (default: false)
+    /** Frames to extract. Unset lets VideoProcessor pick from the clip's duration; clamped to 100. */
+    frames?: number;
+    /** Frame encoder quality, clamped to 1-100. Default 80. */
+    quality?: number;
+    /** Frame encoding. Default jpeg. */
+    format?: "jpeg" | "png";
+    /** Not implemented yet (#433) — warns rather than silently doing nothing. */
+    transcribeAudio?: boolean;
   };
 
   /**

--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -36,6 +36,7 @@ import type {
   FileProcessingResult,
   FileSource,
   FileType,
+  VideoProcessorOptions,
 } from "../types/index.js";
 import { tracers, ATTR, withSpan } from "../telemetry/index.js";
 import { CSVProcessor } from "./csvProcessor.js";
@@ -449,6 +450,7 @@ export class FileDetector {
             detection,
             csvOptions,
             options?.provider,
+            options?.videoOptions,
           );
           FileDetector.setFileResultSpanAttributes(
             span,
@@ -470,6 +472,7 @@ export class FileDetector {
           detection,
           csvOptions,
           options?.provider,
+          options?.videoOptions,
         );
         FileDetector.setFileResultSpanAttributes(
           span,
@@ -1267,6 +1270,7 @@ export class FileDetector {
     detection: FileDetectionResult,
     options?: CSVProcessorOptions,
     provider?: string,
+    videoOptions?: VideoProcessorOptions,
   ): Promise<FileProcessingResult> {
     switch (detection.type) {
       case "csv":
@@ -1285,7 +1289,11 @@ export class FileDetector {
         // AI providers don't support SVG as image format, so we extract text content
         return await FileDetector.processSvgAsText(content, detection);
       case "video":
-        return await FileDetector.processVideoFile(content, detection);
+        return await FileDetector.processVideoFile(
+          content,
+          detection,
+          videoOptions,
+        );
       case "audio":
         return await FileDetector.processAudioFile(content, detection);
       case "archive":
@@ -1343,18 +1351,24 @@ export class FileDetector {
   private static async processVideoFile(
     content: Buffer,
     detection: FileDetectionResult,
+    videoOptions?: VideoProcessorOptions,
   ): Promise<FileProcessingResult> {
     const videoFilename = detection.metadata.filename || "video";
     try {
       const videoResult = await (
         await getVideoProcessor()
-      ).processFile({
-        id: videoFilename,
-        name: videoFilename,
-        mimetype: detection.mimeType || "video/mp4",
-        size: content.length,
-        buffer: content,
-      });
+      ).processFile(
+        {
+          id: videoFilename,
+          name: videoFilename,
+          mimetype: detection.mimeType || "video/mp4",
+          size: content.length,
+          buffer: content,
+        },
+        // #478: carry the caller's keyframe budget/quality/format through to
+        // the processor; previously these stopped at the CLI layer.
+        videoOptions,
+      );
       if (videoResult.success && videoResult.data) {
         return {
           type: "video",

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -1013,6 +1013,25 @@ export function mergeMediaFileAliases<TFile>(input: {
 }
 
 /**
+ * #478: `transcribeAudio` (CLI `--transcribe-audio`) is accepted by the options
+ * surface but no video-audio transcription exists yet — VideoProcessor extracts
+ * keyframes and embedded subtitle tracks only, and the transcription step is
+ * still open as #433. Say so once per request rather than letting the caller
+ * believe a transcript was produced and silently omitted.
+ */
+function warnIfVideoTranscriptionRequested(
+  videoOptions: GenerateOptions["videoOptions"],
+): void {
+  if (videoOptions?.transcribeAudio) {
+    logger.warn(
+      "[NEUROLINK] Video audio transcription was requested but is not implemented yet " +
+        "(tracked as #433). Keyframes and any embedded subtitle tracks are still extracted; " +
+        "spoken audio will not be transcribed.",
+    );
+  }
+}
+
+/**
  * Process the unified files array with auto-detection.
  * Handles lazy file registration, full processing, and preview injection.
  *
@@ -1033,6 +1052,8 @@ export async function processUnifiedFilesArray(
 
   const totalFiles = options.input.files.length;
   const files = options.input.files;
+
+  warnIfVideoTranscriptionRequested(options.videoOptions);
 
   return withSpan(
     {
@@ -1108,6 +1129,15 @@ export async function processUnifiedFilesArray(
               "unknown",
             ],
             csvOptions: options.csvOptions,
+            // #478: videos arrive through this unified `files` path, so this is
+            // where the CLI's frame/quality/format request has to be handed on.
+            videoOptions: options.videoOptions
+              ? {
+                  frames: options.videoOptions.frames,
+                  quality: options.videoOptions.quality,
+                  format: options.videoOptions.format,
+                }
+              : undefined,
             provider: provider,
             mimetypeHint: fileMimetypeHint,
           });

--- a/test/continuous-test-suite-video.ts
+++ b/test/continuous-test-suite-video.ts
@@ -184,6 +184,148 @@ await test("extracts keyframes for frame-based providers", async () => {
   }
 });
 
+// --- VIDEO-022 (#478): the CLI's frame knobs must reach the encoder ---------
+
+await test("#478: videoOptions.frames caps the number of extracted keyframes", async () => {
+  await ensureFixtures();
+  const unbounded = await videoProcessor.processFile(
+    info("clip.mp4", "video/mp4"),
+  );
+  // 1, not 2: the 2s fixture yields 2 frames by default, so asking for 2 would
+  // pass even if the option were still being ignored.
+  const capped = await videoProcessor.processFile(
+    info("clip.mp4", "video/mp4"),
+    { frames: 1 },
+  );
+  assert(unbounded.success && capped.success, "both runs process successfully");
+  if (!unbounded.success || !capped.success) {
+    return;
+  }
+  // The flag was accepted and discarded before this fix, so both runs returned
+  // an identical frame count regardless of what the caller asked for.
+  assertEqual(
+    capped.data.keyframes.length,
+    1,
+    "exactly the requested number of frames is returned",
+  );
+  assert(
+    unbounded.data.keyframes.length > capped.data.keyframes.length,
+    "the default run extracts more frames than the capped run, proving the cap is applied rather than coincidental",
+  );
+});
+
+await test("#478: an explicit frames request at MAX_FRAMES is not silently ignored", async () => {
+  await ensureFixtures();
+  const tiered = await videoProcessor.processFile(
+    info("clip.mp4", "video/mp4"),
+  );
+  // 100 is exactly VIDEO_CONFIG.MAX_FRAMES. Keying the override on
+  // "budget < MAX_FRAMES" made this fall back to the duration-tier schedule,
+  // so asking for the maximum quietly produced the tier count instead.
+  const maxed = await videoProcessor.processFile(
+    info("clip.mp4", "video/mp4"),
+    { frames: 100 },
+  );
+  assert(tiered.success && maxed.success, "both runs process successfully");
+  if (!tiered.success || !maxed.success) {
+    return;
+  }
+  assert(
+    maxed.data.keyframes.length > tiered.data.keyframes.length,
+    "requesting the maximum yields more frames than the tier schedule, proving the request was honored",
+  );
+  assert(
+    maxed.data.keyframes.length <= 100,
+    "the MAX_FRAMES ceiling still applies",
+  );
+});
+
+await test("#478: an over-ceiling frames request is clamped, not rejected", async () => {
+  await ensureFixtures();
+  const over = await videoProcessor.processFile(info("clip.mp4", "video/mp4"), {
+    frames: 150,
+  });
+  assert(over.success, "an over-ceiling request still processes");
+  if (!over.success) {
+    return;
+  }
+  assert(
+    over.data.keyframes.length > 0 && over.data.keyframes.length <= 100,
+    "frame count is clamped to the MAX_FRAMES ceiling",
+  );
+});
+
+await test("#478: an omitted format still defaults to JPEG", async () => {
+  await ensureFixtures();
+  const result = await videoProcessor.processFile(
+    info("clip.mp4", "video/mp4"),
+    { frames: 1 },
+  );
+  assert(result.success, "processing succeeds");
+  if (!result.success) {
+    return;
+  }
+  assert(
+    result.data.keyframes[0]
+      ?.subarray(0, 3)
+      .equals(Buffer.from([0xff, 0xd8, 0xff])) === true,
+    "frames are JPEG when no format is requested",
+  );
+});
+
+await test("#478: videoOptions.format switches the frame encoding to PNG", async () => {
+  await ensureFixtures();
+  const jpeg = await videoProcessor.processFile(info("clip.mp4", "video/mp4"), {
+    frames: 1,
+    format: "jpeg",
+  });
+  const png = await videoProcessor.processFile(info("clip.mp4", "video/mp4"), {
+    frames: 1,
+    format: "png",
+  });
+  assert(jpeg.success && png.success, "both encodings process successfully");
+  if (!jpeg.success || !png.success) {
+    return;
+  }
+  const jpegMagic = jpeg.data.keyframes[0]?.subarray(0, 3);
+  const pngMagic = png.data.keyframes[0]?.subarray(0, 8);
+  assert(
+    jpegMagic?.equals(Buffer.from([0xff, 0xd8, 0xff])) === true,
+    "default frames carry the JPEG magic bytes",
+  );
+  assert(
+    pngMagic?.equals(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    ) === true,
+    "requesting png yields frames carrying the PNG magic bytes",
+  );
+});
+
+await test("#478: videoOptions.quality changes the encoded frame payload", async () => {
+  await ensureFixtures();
+  const low = await videoProcessor.processFile(info("clip.mp4", "video/mp4"), {
+    frames: 1,
+    quality: 5,
+  });
+  const high = await videoProcessor.processFile(info("clip.mp4", "video/mp4"), {
+    frames: 1,
+    quality: 95,
+  });
+  assert(low.success && high.success, "both quality settings process");
+  if (!low.success || !high.success) {
+    return;
+  }
+  const lowSize = low.data.keyframes[0]?.length ?? 0;
+  const highSize = high.data.keyframes[0]?.length ?? 0;
+  assert(lowSize > 0 && highSize > 0, "both runs produce a frame");
+  // Size is the observable proof the quality value reached the encoder; before
+  // the fix both runs encoded at the hard-coded default and matched byte for byte.
+  assert(
+    highSize > lowSize,
+    "a higher quality setting produces a larger encoded frame",
+  );
+});
+
 await test("textContent describes the clip for the model", async () => {
   await ensureFixtures();
   const result = await videoProcessor.processFile(


### PR DESCRIPTION
Closes #478

## The bug

`--video-frames`, `--video-quality` and `--video-format` were defined in `commandFactory`, documented in `--help`, packed into `GenerateOptions.videoOptions`… and then **never read by anything**. `VideoProcessor` always extracted frames on its duration-tier schedule and always encoded JPEG at the hard-coded default.

The flags were accepted, validated, and silently discarded.

## The fix

Threaded `videoOptions` from `GenerateOptions` → `FileDetector` → `VideoProcessor.extractKeyframes`:

- **`frames`** sets the frame budget, spread evenly across the clip, still clamped to `MAX_FRAMES` so a caller can lower cost but never raise it past the processor's ceiling.
- **`quality`** reaches the encoder, clamped to 1–100.
- **`format: "png"`** selects the PNG encoder.

### The part worth reviewing

`--video-frames` and `--video-quality` carried yargs `default: 8` / `default: 85`. Those were **wrong** — the processor picks a duration-based count (up to 100) and encodes at 80. Harmless while the values were unread, but the moment they're wired a default would silently re-cap **every existing CLI video at 8 frames**.

So the defaults are removed: unset now means *"let the processor choose"*, which is what callers effectively had all along. The same two incorrect defaults are corrected in the CLI reference, the skill guide, and the SDK type comments.

### `--transcribe-audio`

No implementation exists behind it (that's #433), so it stays unwired — but it now **warns** instead of silently doing nothing, so callers don't assume a transcript was produced and dropped.

## Verification

Three new tests in `continuous-test-suite-video.ts` assert observable evidence rather than the call itself — frame count, magic bytes (`FFD8FF` vs `89504E47`), and encoded payload size:

```
✓ #478: videoOptions.frames caps the number of extracted keyframes
✓ #478: videoOptions.format switches the frame encoding to PNG
✓ #478: videoOptions.quality changes the encoded frame payload
  Passed: 12   Skipped: 1 (webm fixture — this ffmpeg build lacks VP8/Vorbis)
```

All three confirmed to fail (`✗`, not skipped) when the option pass-through is removed. `pnpm run check` 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Video processing automatically selects keyframes based on duration, up to 100 frames.
  - Configure frame count, image quality from 1–100, and JPEG or PNG output.
  - Video options are consistently applied across file processing, generation, and streaming.

- **Bug Fixes**
  - Added a clear warning when audio transcription is requested, while preserving keyframe and subtitle support.

- **Documentation**
  - Updated CLI and option references with current defaults, limits, and supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->