### PR TITLE
docs(multimodal): document audio, video and Office file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,14 +596,16 @@ const batcher = new RequestBatcher({ maxBatchSize: 10, maxWaitMs: 50 });
 
 **17+ file categories supported** (50+ total file types including code languages) with intelligent content extraction and provider-agnostic processing:
 
-| Category      | Supported Types                                            | Processing                          |
-| ------------- | ---------------------------------------------------------- | ----------------------------------- |
-| **Documents** | Excel (`.xlsx`, `.xls`), Word (`.docx`), RTF, OpenDocument | Sheet extraction, text extraction   |
-| **Data**      | JSON, YAML, XML                                            | Validation, syntax highlighting     |
-| **Markup**    | HTML, SVG, Markdown, Text                                  | OWASP-compliant sanitization        |
-| **Code**      | 50+ languages (TypeScript, Python, Java, Go, etc.)         | Language detection, syntax metadata |
-| **Config**    | `.env`, `.ini`, `.toml`, `.cfg`                            | Secure parsing                      |
-| **Media**     | Images (PNG, JPEG, WebP, GIF), PDFs, CSV                   | Provider-specific formatting        |
+| Category      | Supported Types                                                                  | Processing                                                          |
+| ------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Documents** | Excel (`.xlsx`, `.xls`), Word (`.docx`), PowerPoint (`.pptx`), RTF, OpenDocument | Sheet extraction, text extraction, slide + speaker-notes extraction |
+| **Data**      | JSON, YAML, XML                                                                  | Validation, syntax highlighting                                     |
+| **Markup**    | HTML, SVG, Markdown, Text                                                        | OWASP-compliant sanitization                                        |
+| **Code**      | 50+ languages (TypeScript, Python, Java, Go, etc.)                               | Language detection, syntax metadata                                 |
+| **Config**    | `.env`, `.ini`, `.toml`, `.cfg`                                                  | Secure parsing                                                      |
+| **Media**     | Images (PNG, JPEG, WebP, GIF), PDFs, CSV                                         | Provider-specific formatting                                        |
+| **Audio**     | `.mp3`, `.wav`, `.m4a`, `.ogg`, `.flac`, `.webm`                                 | Automatic transcription + duration metadata                         |
+| **Video**     | `.mp4`, `.webm`, `.mov`, `.mkv`, `.avi`                                          | Keyframe extraction, metadata, embedded subtitles                   |
 
 ```typescript
 // Process any supported file type
@@ -622,6 +624,33 @@ const result = await neurolink.generate({
 // CLI: Use --file for any supported type
 // neurolink generate "Analyze this" --file ./report.xlsx --file ./config.json
 ```
+
+Audio and video attach the same way. Audio is transcribed automatically before
+the model sees it; video is reduced to keyframes plus metadata and any embedded
+subtitle track:
+
+```typescript
+const result = await neurolink.generate({
+  input: {
+    text: "What was decided in this meeting, and who owns each action item?",
+    files: [
+      "./standup.mp3", // transcribed, then folded into the prompt
+      "./demo.mp4", // keyframes + duration/codec metadata + subtitles
+      "./deck.pptx", // slides and speaker notes
+    ],
+  },
+});
+```
+
+```bash
+# Same thing from the CLI
+neurolink generate "Summarize this recording" --file ./standup.mp3
+neurolink generate "Describe what happens" --file ./demo.mp4
+```
+
+> Audio transcription needs a provider with a speech model configured (OpenAI
+> Whisper by default). Video keyframe extraction requires `ffmpeg` — install it
+> separately or rely on the bundled `ffmpeg-static`.
 
 **Key Features:**
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -61,7 +61,7 @@ Key flags:
 - `--image`, `-i` – attach one or more image files/URLs for multimodal prompts.
 - `--pdf` – attach one or more PDF files for document analysis.
 - `--csv`, `-c` – attach one or more CSV files for data analysis.
-- `--file` – attach any supported file type (auto-detected: Excel, Word, RTF, JSON, YAML, XML, HTML, SVG, Markdown, code files, and more).
+- `--file` – attach any supported file type, auto-detected. Covers Office documents (Word `.docx`, Excel `.xlsx`/`.xls`, PowerPoint `.pptx`, RTF, OpenDocument), **audio** (`.mp3`, `.wav`, `.m4a`, … — transcribed automatically), **video** (`.mp4`, `.webm`, `.mov`, `.mkv` — keyframes plus metadata and any embedded subtitles), archives, JSON, YAML, XML, HTML, SVG, Markdown, and 50+ code languages. Repeatable. Not available on `batch`, where it would collide with the prompts-file positional — use `generate` or `stream`.
 - `--temperature`, `-t` – creativity (default `0.7`).
 - `--maxTokens`, `--max` – response limit (default `1000`).
 - `--system`, `-s` – system prompt.

--- a/docs/features/office-documents.md
+++ b/docs/features/office-documents.md
@@ -118,27 +118,26 @@ for await (const chunk of stream) {
 
 ```bash
 # Attach Office files to your prompt
-neurolink generate "Summarize this document" --office report.docx --provider bedrock
+neurolink generate "Summarize this document" --file report.docx --provider bedrock
 
 # Multiple Office files
-neurolink generate "Compare these reports" --office q1.docx --office q2.docx --provider bedrock
+neurolink generate "Compare these reports" --file q1.docx --file q2.docx --provider bedrock
 
 # Excel spreadsheet analysis
-neurolink generate "Analyze sales trends" --office sales.xlsx --provider bedrock
+neurolink generate "Analyze sales trends" --file sales.xlsx --provider bedrock
 
 # PowerPoint presentation
-neurolink generate "Extract key points from slides" --office presentation.pptx --provider bedrock
+neurolink generate "Extract key points from slides" --file presentation.pptx --provider bedrock
 
 # Auto-detect file types
 neurolink generate "Analyze all documents" --file report.docx --file data.xlsx --provider bedrock
 
 # Stream mode with Office documents
-neurolink stream "Explain this document in detail" --office document.docx --provider bedrock
+neurolink stream "Explain this document in detail" --file document.docx --provider bedrock
 
-# Batch processing with Office documents
-echo "Summarize the key points" > prompts.txt
-echo "Extract action items" >> prompts.txt
-neurolink batch prompts.txt --office meeting-notes.docx --provider bedrock
+# Note: `batch` does NOT accept --file. The flag is deliberately unregistered
+# there because it would collide with the prompts-file positional, so Office
+# attachments are only available on `generate` and `stream`.
 ```
 
 ## API Reference
@@ -669,7 +668,7 @@ await neurolink.generate({
 
 ```bash
 # Change provider to supported one
-neurolink generate "Analyze document" --office doc.docx --provider bedrock
+neurolink generate "Analyze document" --file doc.docx --provider bedrock
 
 # Or use auto-detection with correct provider
 neurolink generate "Analyze document" --file doc.docx --provider vertex
@@ -935,11 +934,11 @@ const result = await neurolink.generate({
 
 ### Implementation Files
 
-- **`src/lib/utils/officeProcessor.ts`** - Office document validation and processing
+- **`src/lib/processors/document/`** - Office document validation and processing: `WordProcessor`, `ExcelProcessor`, `PptxProcessor`, `RtfProcessor`, `OpenDocumentProcessor`
 - **`src/lib/utils/fileDetector.ts`** - File type detection (includes Office formats)
 - **`src/lib/utils/messageBuilder.ts`** - Multimodal message construction
-- **`src/lib/types/fileTypes.ts`** - Office type definitions
-- **`src/cli/factories/commandFactory.ts`** - CLI `--office` flag handling
+- **`src/lib/types/file.ts`** - Office type definitions
+- **`src/cli/factories/commandFactory.ts`** - CLI `--file` flag handling
 
 ## Performance Considerations
 

--- a/docs/getting-started/providers/ollama.md
+++ b/docs/getting-started/providers/ollama.md
@@ -429,8 +429,22 @@ pnpm run cli -- generate "Describe this image" \
   --image ./photo.jpg
 ```
 
-:::warning[PDF Support]
-PDF inputs are not supported by the Ollama provider. Use a provider with native PDF support (OpenAI, Anthropic, Google Vertex AI, Google AI Studio) for PDF processing.
+:::note[PDF Support]
+Ollama has no native PDF input, so NeuroLink renders each page to an image and
+sends those instead. This means PDFs work, but only with a **vision model** such
+as `llava:7b` — a text-only model receives nothing usable.
+
+```bash
+pnpm run cli -- generate "Summarize this document" \
+  --provider ollama \
+  --model "llava:7b" \
+  --pdf ./report.pdf
+```
+
+The image fallback converts **at most the first 20 pages** (a token-overflow
+guard in the message builder) and costs one image per converted page. Anything
+past page 20 is not sent at all, so for longer documents use a provider with
+native PDF support — OpenAI, Anthropic, Google Vertex AI or Google AI Studio.
 :::
 
 ---


### PR DESCRIPTION
Closes #295, #506, #509, #511, #519

Four discoverability gaps — one of which was **actively wrong**, not merely missing.

### `docs/features/office-documents.md` — documented a flag that doesn't exist (#511)

Eight examples told users to run `--office report.docx`. There is no `--office` flag in `commandFactory` (grep: 0 hits); it errors out. The real entry point is `--file`.

Also corrected in that file:
- The `batch` example — `batch` **deliberately unregisters** `--file` (it would collide with the prompts-file positional), so Office attachments are `generate`/`stream` only. The blanket rename would have produced a second wrong example.
- Two stale source paths: `src/lib/types/fileTypes.ts` was renamed to `file.ts`.

### `docs/getting-started/providers/ollama.md` — contradicted shipped behaviour (#295)

A warning block stated *"PDF inputs are not supported by the Ollama provider"*. Ollama has no **native** PDF input, but NeuroLink renders pages to images for exactly this case, so PDFs do work — with a vision model. Replaced with what actually happens, including the `llava:7b` requirement and the per-page cost caveat.

### README (#506, #519) and `docs/cli/commands.md` (#509)

Neither mentioned PowerPoint, audio or video, despite `PptxProcessor`, `AudioProcessor` and `VideoProcessor` all shipping. `grep -i office README.md` returned zero matches. Added Audio and Video rows to the file-type table, PowerPoint to Documents, and a worked example.

## On accuracy

Format lists were read out of `WHISPER_SUPPORTED_FORMATS` and `SUPPORTED_VIDEO_MIME_TYPES` rather than assumed.

I deliberately left `--video-frames`/`--video-quality`/`--video-format` out of this PR. Those flags are currently inert and are fixed in #1295 — documenting them here as working would have been wrong until that lands.