### PR TITLE
fix(skills): reserve a deprecated skill's name and match names case-insensitively

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -142,6 +142,7 @@ const sidebars: SidebarsConfig = {
             "features/credential-validation",
             "features/regional-streaming",
             "features/mcp-tools-showcase",
+            "features/skills",
             "features/embeddings",
             "features/rag",
             "features/observability",

--- a/src/lib/skills/skillsManager.ts
+++ b/src/lib/skills/skillsManager.ts
@@ -114,11 +114,18 @@ export class SkillsManager {
     // name-find would resolve non-deterministically to the stale deprecated one
     // across store backends. Fall back to any match only when no active skill
     // carries the name.
+    //
+    // Matched case-insensitively to agree with assertNameAvailable, which
+    // enforces uniqueness that way: names differing only in case cannot
+    // coexist, so a case-sensitive lookup could only fail to find a skill that
+    // is definitively there (`get("DEPLOY")` returned null for "deploy").
+    const wanted = idOrName.toLowerCase();
     const entry =
       index.find(
         (item) =>
-          item.name === idOrName && (item.status ?? "active") === "active",
-      ) ?? index.find((item) => item.name === idOrName);
+          item.name.toLowerCase() === wanted &&
+          (item.status ?? "active") === "active",
+      ) ?? index.find((item) => item.name.toLowerCase() === wanted);
     return entry ? this.store.get(entry.id) : null;
   }
 
@@ -310,14 +317,27 @@ export class SkillsManager {
     excludeId?: string,
   ): Promise<void> {
     const index = await this.getIndex(true);
+    // Deliberately NOT filtered to active (#1139). Soft-delete only flips
+    // status to "deprecated" — the entry stays in the index, so allowing a new
+    // skill to take the name left two entries sharing it. Every name-based
+    // lookup (CLI `skills show/delete <name>`, the skill_update/skill_delete
+    // tools, the `:id`-or-name REST routes) then had to guess which one the
+    // caller meant, and iteration order differs across store backends.
+    //
+    // A deprecated skill's name therefore stays reserved. Reusing it requires
+    // hard-deleting the old skill first, which is the explicit choice the
+    // ambiguity demands.
     const clash = index.find(
       (item) =>
-        item.id !== excludeId &&
-        item.name.toLowerCase() === name.toLowerCase() &&
-        (item.status ?? "active") === "active",
+        item.id !== excludeId && item.name.toLowerCase() === name.toLowerCase(),
     );
     if (clash) {
-      throw new Error(`A skill named "${name}" already exists`);
+      const suffix =
+        (clash.status ?? "active") === "active"
+          ? ""
+          : ` (that name belongs to a deprecated skill, id ${clash.id}; ` +
+            `remove it before reusing the name)`;
+      throw new Error(`A skill named "${name}" already exists${suffix}`);
     }
   }
 }

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -1260,30 +1260,81 @@ async function testMutations(): Promise<void> {
   );
 
   await runTest(
-    "22c. get() by name resolves the active skill after soft-delete + same-name recreate (integrity)",
+    "22c. reusing a soft-deleted skill's name is rejected (integrity)",
     async () => {
       const nl = makeSkillsInstance({ allowMutations: true });
       const del = getToolExecute(nl, "skill_delete");
       const create = getToolExecute(nl, "skill_create");
-      // Soft-delete skill-refund (name "REFUND_dispute_escalation"), then create
-      // a new active skill reusing that exact name — allowed, since the clash
-      // check only guards active skills. Both entries now share the name.
+      // Soft-delete skill-refund, then try to reuse its name. #1139 closed this
+      // off: a deprecated skill keeps its name reserved, because allowing the
+      // reuse left two index entries sharing one name and every name-based
+      // lookup then had to guess which was meant.
       await del({ skillId: "skill-refund" });
       const created = (await create({
         name: "REFUND_dispute_escalation",
         description: "Fresh active version of the refund SOP.",
         instructions: "NEW refund handling instructions.",
-      })) as { success: boolean };
-      assert(created.success, "recreate with the reused name should succeed");
-      // Name resolution must be deterministic: the ACTIVE skill, never the stale
-      // deprecated one (which a bare index.find would non-deterministically hit).
-      const resolved = await nl
-        .getSkillsManager()
-        ?.get("REFUND_dispute_escalation");
+      })) as { success: boolean; error?: string };
       assert(
-        resolved?.status === "active" &&
-          resolved?.instructions === "NEW refund handling instructions.",
-        `get(name) must resolve the active skill, got status=${resolved?.status}`,
+        !created.success,
+        "reusing a soft-deleted skill's name must be rejected",
+      );
+      assert(
+        (created.error ?? "").includes("deprecated"),
+        "the error should explain that the name belongs to a deprecated skill",
+      );
+    },
+  );
+
+  await runTest(
+    "22d. get() prefers the active entry when a legacy duplicate-name pair exists",
+    async () => {
+      // The collision can no longer be created through the API, but stores
+      // written before #1139 can still hold the pair, so get()'s active-first
+      // resolution remains load-bearing. Seeded directly to represent that
+      // legacy data rather than through the (now-blocking) mutation path.
+      const nl = makeSkillsInstance({
+        storage: {
+          type: "memory",
+          skills: [
+            {
+              id: "legacy-stale",
+              name: "duplicated_name",
+              description: "Stale deprecated entry.",
+              instructions: "OLD instructions.",
+              status: "deprecated",
+            },
+            {
+              id: "legacy-active",
+              name: "duplicated_name",
+              description: "Active entry sharing the name.",
+              instructions: "NEW instructions.",
+              status: "active",
+            },
+          ],
+        },
+      });
+      const resolved = await nl.getSkillsManager()?.get("duplicated_name");
+      assert(
+        resolved?.id === "legacy-active" &&
+          resolved?.instructions === "NEW instructions.",
+        `get(name) must resolve the active entry, got id=${resolved?.id}`,
+      );
+    },
+  );
+
+  await runTest(
+    "22e. get() by name is case-insensitive, matching the uniqueness rule",
+    async () => {
+      // assertNameAvailable compares lowercased, so "REFUND_dispute_escalation"
+      // and "refund_dispute_escalation" cannot coexist. A case-sensitive
+      // lookup could therefore only ever fail to find a skill that is present.
+      const manager = makeSkillsInstance().getSkillsManager();
+      assert(manager, "manager missing");
+      const upper = await manager.get("REFUND_DISPUTE_ESCALATION");
+      assert(
+        upper?.id === "skill-refund",
+        `differently-cased name must resolve, got id=${upper?.id}`,
       );
     },
   );


### PR DESCRIPTION
Refs #1139 (finding 1 + the open nit)

## The half-closed fix

`get()` was taught to prefer an active entry when resolving by name, but `assertNameAvailable()` still filtered to `status === "active"`. So the collision itself was never prevented — only papered over on one read path.

Reproduced against an in-memory store:

```
R1 created: 5c9a7945 active
R2 after soft-delete, get('deploy').status = deprecated
R3 second create SUCCEEDED: 3307db4e     <-- COLLISION
R4 index entries named 'deploy': 5c9a7945=deprecated | 3307db4e=active
```

Two entries, one name — exactly what the issue is titled after, and what every name-based lookup (CLI `skills show/delete <name>`, the `skill_update`/`skill_delete` tools, the id-or-name REST routes) then had to guess between, with iteration order differing across store backends.

After the fix:

```
R3 second create REJECTED — A skill named "deploy" already exists (that name belongs
   to a deprecated skill, id 5c9a7945-…; remove it before reusing the name)
R4 index entries named 'deploy': 5c9a7945=deprecated
```

This is the issue's own suggested fix: *"have `assertNameAvailable()` also reject reuse of a deprecated skill's name."* `get()`'s active-first resolution is **kept** — stores written before this change can still hold the pair, so that defence remains load-bearing.

## A second bug found while verifying

`assertNameAvailable` compares **lowercased**; `get()`'s name fallback compared **exactly**. Since names differing only in case cannot coexist, a case-sensitive lookup could only ever fail to find a skill that is definitively present:

```
get("REFUND_DISPUTE_ESCALATION")  ->  null      (for skill "refund_dispute_escalation")
```

Both now compare case-insensitively.

## Tests

Test **22c** encoded the old behaviour — its comment literally read *"allowed, since the clash check only guards active skills"* — so it is rewritten to assert the rejection. Two tests added:

- **22d** — `get()` still prefers the active entry when a legacy duplicate-name pair exists, seeded directly at the store to represent pre-fix data (the pair can no longer be created through the API).
- **22e** — case-insensitive lookup.

```
RESULTS: 51 passed, 0 failed, 0 skipped (of 51)
```

`pnpm run check` 0 errors · `prettier --check` clean.

## Nits from the issue

- `docs/features/skills.md` was missing from `docs-site/sidebars.ts` (reachable only by direct URL) — **added**.
- `formatSkillsPromptIndex` returning a non-null block at `promptIndexMaxItems === 0` — **already fixed** on `release`, no change needed.

Findings 2 (scope leak) and 3 (`allowMutations` REST gating) were already fixed; test `32b. Server: mutation routes rejected when allowMutations is false` passes. Once this merges, #1139 can close.