### PR TITLE
fix(pdf): make the render scale and page ceiling reachable from generate()

### DIFF
--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -535,6 +535,10 @@ export type MultimodalPdfEntry = {
   password?: string;
   /** Per-page pixel ceiling for the image fallback (#260). */
   maxCanvasPixels?: number;
+  /** Render scale for the image fallback (#297). */
+  scale?: number;
+  /** Max pages converted by the image fallback (#297). */
+  maxPages?: number;
 };
 
 /** Result of PDF to image conversion. */

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -155,6 +155,17 @@ export type GenerateOptions = {
     password?: string;
     /** Max rendered-canvas pixels per page (#260 memory guard); oversized pages auto-downscale. */
     maxCanvasPixels?: number;
+    /**
+     * Render scale for the image fallback used by providers without native PDF
+     * support (#297). Higher is sharper but costs roughly the square in memory
+     * and tokens. Range 0.1-10; defaults to PDF_LIMITS.DEFAULT_SCALE (1.5).
+     */
+    scale?: number;
+    /**
+     * Max pages converted by the image fallback (#297). Pages beyond this are
+     * not sent to the model at all. Defaults to PDF_LIMITS.DEFAULT_MAX_PAGES (20).
+     */
+    maxPages?: number;
   };
 
   // Video processing options
@@ -1423,6 +1434,10 @@ export type TextGenerationOptions = {
     password?: string;
     /** Max rendered-canvas pixels per page (#260 memory guard); oversized pages auto-downscale. */
     maxCanvasPixels?: number;
+    /** Render scale for the image fallback (#297); defaults to PDF_LIMITS.DEFAULT_SCALE. */
+    scale?: number;
+    /** Max pages converted by the image fallback (#297); defaults to PDF_LIMITS.DEFAULT_MAX_PAGES. */
+    maxPages?: number;
   };
 
   enableSummarization?: boolean; // Enable/disable summarization for this specific request

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -281,6 +281,17 @@ export type StreamOptions = {
     password?: string;
     /** Max rendered-canvas pixels per page (#260 memory guard); oversized pages auto-downscale. */
     maxCanvasPixels?: number;
+    /**
+     * Render scale for the image fallback used by providers without native PDF
+     * support (#297). Higher is sharper but costs roughly the square in memory
+     * and tokens. Range 0.1-10; defaults to PDF_LIMITS.DEFAULT_SCALE (1.5).
+     */
+    scale?: number;
+    /**
+     * Max pages converted by the image fallback (#297). Pages beyond this are
+     * not sent to the model at all. Defaults to PDF_LIMITS.DEFAULT_MAX_PAGES (20).
+     */
+    maxPages?: number;
   };
 
   // Video processing options

--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -10,6 +10,7 @@ import {
   STRUCTURED_OUTPUT_INSTRUCTIONS,
 } from "../config/conversationMemory.js";
 import { getAvailableInputTokens } from "../constants/contextWindows.js";
+import { PDF_LIMITS } from "../core/constants.js";
 import {
   enforceAggregateFileBudget,
   FILE_READ_BUDGET_PERCENT,
@@ -1479,6 +1480,10 @@ async function processExplicitPdfFiles(
           // #260: carry the per-page canvas-pixel ceiling so the caller can
           // raise (or lower) the memory guard for the image-fallback render.
           maxCanvasPixels: options.pdfOptions?.maxCanvasPixels,
+          // #297: render scale / page ceiling, so the lowered default is
+          // actually reachable and callers can trade sharpness for memory.
+          scale: options.pdfOptions?.scale,
+          maxPages: options.pdfOptions?.maxPages,
         });
         logger.info(
           `[PDF] ✅ Queued for multimodal: ${filename} (${result.metadata?.estimatedPages ?? "unknown"} pages)`,
@@ -1881,6 +1886,8 @@ async function convertContentToProviderFormat(
     // guard as the `input.pdfFiles` path (see `processExplicitPdfFiles`).
     password: pdfOptions?.password,
     maxCanvasPixels: pdfOptions?.maxCanvasPixels,
+    scale: pdfOptions?.scale,
+    maxPages: pdfOptions?.maxPages,
   }));
 
   // #309: same aggregate ceiling as `input.pdfFiles`. Without this, moving an
@@ -2318,13 +2325,9 @@ async function convertSimpleImagesToProviderFormat(
 async function convertMultimodalToProviderFormat(
   text: string,
   images: Array<Buffer | string | ImageWithAltText>,
-  pdfFiles: Array<{
-    buffer: Buffer;
-    filename: string;
-    pageCount?: number | null;
-    password?: string;
-    maxCanvasPixels?: number;
-  }>,
+  // The canonical entry shape (#309) rather than a fourth copy of it inline —
+  // which is what let the render knobs stop short of this function.
+  pdfFiles: MultimodalPdfEntry[],
   provider: string,
   model: string,
 ): Promise<Array<TextPart | ImagePart | FilePart>> {
@@ -2375,17 +2378,49 @@ async function convertMultimodalToProviderFormat(
 
     for (const pdf of pdfFiles) {
       try {
+        const effectiveMaxPages = pdf.maxPages ?? PDF_LIMITS.DEFAULT_MAX_PAGES;
         const conversionResult = await PDFImageConverter.convertToImages(
           pdf.buffer,
           {
-            scale: 2.0, // High quality for OCR/analysis
-            maxPages: 20, // Limit pages to prevent token overflow
+            // #297: this is the only PDF→image call the product actually makes,
+            // and it used to hardcode scale 2.0 — silently overriding the
+            // lowered PDF_LIMITS.DEFAULT_SCALE and keeping the memory cost the
+            // issue reports (a 100-page render at 2.0 is ~776MB; 1.5 is ~44%
+            // fewer pixels per page). Callers can raise it back per request.
+            scale: pdf.scale ?? PDF_LIMITS.DEFAULT_SCALE,
+            // Page ceiling guards token overflow; also now caller-adjustable
+            // rather than a constant nothing could reach.
+            maxPages: effectiveMaxPages,
             ...(pdf.password ? { password: pdf.password } : {}), // #258
             ...(pdf.maxCanvasPixels
               ? { maxCanvasPixels: pdf.maxCanvasPixels }
               : {}), // #260
           },
         );
+
+        // The renderer stops at maxPages, so a longer document is silently
+        // truncated — say so rather than letting the model answer from a
+        // partial document as though it had the whole thing.
+        //
+        // Keyed on the cap being reached, not on pdf.pageCount: that field is
+        // null whenever `input.content` omits `metadata.pages`, which is the
+        // common case, so a page-count comparison would simply never fire
+        // there. Reaching the cap is also unambiguous — a short count caused by
+        // per-page render failures (#294 isolates those into `errors`) would
+        // otherwise be misreported as a maxPages truncation.
+        if (conversionResult.pageCount >= effectiveMaxPages) {
+          logger.warn(
+            `[PDF→Image] ${safeBasename(pdf.filename)} hit the ${effectiveMaxPages}-page ` +
+              `conversion limit. Any pages beyond that were not sent — the model may be ` +
+              `answering from a partial document. Raise pdfOptions.maxPages or split the file.`,
+          );
+        }
+        if (conversionResult.errors && conversionResult.errors.length > 0) {
+          logger.warn(
+            `[PDF→Image] ${safeBasename(pdf.filename)}: ${conversionResult.errors.length} page(s) ` +
+              `failed to render and were omitted (page ${conversionResult.errors.map((e) => e.page).join(", ")}).`,
+          );
+        }
 
         logger.info(
           `[PDF→Image] ✅ Converted ${pdf.filename}: ${conversionResult.pageCount} page(s) → images`,

--- a/src/lib/utils/pdfProcessor.ts
+++ b/src/lib/utils/pdfProcessor.ts
@@ -454,6 +454,7 @@ export class PDFProcessor {
       format,
       scale,
       maxCanvasPixels,
+      maxPages,
     });
 
     logger.debug("[PDF→Image] ✅ PDF validation passed", {
@@ -639,7 +640,12 @@ export class PDFProcessor {
    */
   private static validateImageConversionInput(
     pdfBuffer: Buffer,
-    opts: { format: string; scale: number; maxCanvasPixels: number },
+    opts: {
+      format: string;
+      scale: number;
+      maxCanvasPixels: number;
+      maxPages?: number;
+    },
   ): number {
     if (opts.format !== "png") {
       throw new Error(
@@ -658,6 +664,18 @@ export class PDFProcessor {
     if (!Number.isFinite(opts.maxCanvasPixels) || opts.maxCanvasPixels <= 0) {
       throw new Error(
         `Invalid maxCanvasPixels: ${opts.maxCanvasPixels}. Must be a finite number greater than 0.`,
+      );
+    }
+    // #297: maxPages became caller-controlled, and an unvalidated 0/-1/NaN
+    // silently converts nothing, surfacing later as a misleading
+    // "PDF has 0 pages" from deep inside the renderer. Reject it here where
+    // the message can still name the offending option.
+    if (
+      opts.maxPages !== undefined &&
+      (!Number.isInteger(opts.maxPages) || opts.maxPages < 1)
+    ) {
+      throw new Error(
+        `Invalid maxPages: ${opts.maxPages}. Must be a whole number of at least 1.`,
       );
     }
     if (!pdfBuffer || pdfBuffer.length < 5) {
@@ -713,6 +731,7 @@ export class PDFProcessor {
       format,
       scale,
       maxCanvasPixels,
+      maxPages,
     });
 
     const pdfToImgModule = await import("pdf-to-img");

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -1828,6 +1828,77 @@ const tests: TestFunction[] = [
     },
   },
   {
+    name: "MessageBuilder #297: the real conversion path honors the default scale and caller overrides",
+    category: "pdf-processor",
+    fn: async () => {
+      // The lowered PDF_LIMITS.DEFAULT_SCALE was unreachable in production:
+      // buildMultimodalMessagesArray hardcoded `scale: 2.0`, and pdfOptions
+      // exposed neither scale nor maxPages, so no caller could reach it.
+      const { PDFImageConverter } =
+        await import("../src/lib/utils/pdfProcessor.js");
+      const pdf = readFileSync("test/fixtures/multi-page.pdf");
+      const seen: Array<{ scale?: number; maxPages?: number }> = [];
+      // Keep the ORIGINAL unbound function for restoration: putting a bound
+      // copy back would leave the class carrying a different function identity
+      // for every later test in the suite.
+      const original = PDFImageConverter.convertToImages;
+      const callOriginal = original.bind(PDFImageConverter);
+      (
+        PDFImageConverter as unknown as Record<string, unknown>
+      ).convertToImages = async (
+        buffer: Buffer,
+        opts: { scale?: number; maxPages?: number },
+      ) => {
+        seen.push({ scale: opts?.scale, maxPages: opts?.maxPages });
+        return callOriginal(buffer, opts);
+      };
+      try {
+        const build = async (pdfOptions?: Record<string, number>) => {
+          seen.length = 0;
+          await buildMultimodalMessagesArray(
+            {
+              input: { text: "x", pdfFiles: [pdf] },
+              ...(pdfOptions ? { pdfOptions } : {}),
+            } as unknown as Parameters<typeof buildMultimodalMessagesArray>[0],
+            "azure", // no native PDF support -> takes the image-conversion path
+            "gpt-4o",
+          );
+          return seen[0];
+        };
+        const byDefault = await build();
+        if (byDefault?.scale !== 1.5 || byDefault?.maxPages !== 20) {
+          return false;
+        }
+        const scaled = await build({ scale: 0.8 });
+        if (scaled?.scale !== 0.8) {
+          return false;
+        }
+        const capped = await build({ maxPages: 3 });
+        if (capped?.maxPages !== 3 || capped?.scale !== 1.5) {
+          return false;
+        }
+        // A caller-supplied maxPages of 0/-1/2.5 used to reach the renderer and
+        // surface later as a misleading "PDF has 0 pages".
+        for (const bad of [0, -1, 2.5]) {
+          let rejected = false;
+          try {
+            await build({ maxPages: bad });
+          } catch (e) {
+            rejected = e instanceof Error && /Invalid maxPages/.test(e.message);
+          }
+          if (!rejected) {
+            return false;
+          }
+        }
+        return true;
+      } finally {
+        (
+          PDFImageConverter as unknown as Record<string, unknown>
+        ).convertToImages = original;
+      }
+    },
+  },
+  {
     name: "PDFProcessor #297: defaults to scale 1.5 and logs a memory estimate before conversion",
     category: "pdf-processor",
     fn: async () => {


### PR DESCRIPTION
Closes #297 · leaves #302 open with a reason

## The gap

`PDF_LIMITS.DEFAULT_SCALE` was lowered to **1.5** to cut the image-fallback memory cost. It never took effect.

The only PDF→image call the product actually makes hardcoded `scale: 2.0` and `maxPages: 20`, and `GenerateOptions.pdfOptions` exposed **neither** knob — so no caller could reach the new default either. The 776MB-for-100-pages figure in the issue was unchanged in practice for every provider without native PDF support (Azure, Mistral, Ollama, …).

The constant was lowered; the product kept rendering at 2.0.

## The fix

Verified against the real path by intercepting the converter:

| request | reaches converter |
| --- | --- |
| default | `{scale: 1.5, maxPages: 20}` |
| `pdfOptions: { scale: 0.8 }` | `{scale: 0.8, maxPages: 20}` |
| `pdfOptions: { maxPages: 3 }` | `{scale: 1.5, maxPages: 3}` |

Both knobs are now settable per request and carried through the `input.pdfFiles` and `input.content` paths alike.

**Silent truncation also fixed.** Pages past `maxPages` were dropped without a word — the model answered from a partial document as though it had the whole thing. That now warns with the page counts and how to raise the ceiling.

The root cause of the knobs stopping one frame short: `convertMultimodalToProviderFormat` held a *fourth* inline copy of the PDF entry shape. It now uses `MultimodalPdfEntry` (#309).

## What I did not do — #302

`PDFProcessor.convertToImagesStream` is still reachable from nowhere (grep: zero references outside its own file and the docs). I left it that way deliberately.

Wiring it into this call site would **not** lower peak memory: `buildMultimodalMessagesArray` collects every page into one `images` array before building the message, so the pages end up resident regardless of how they arrive. Making streaming pay off needs a streaming-aware message pipeline, which is a redesign rather than a call-site swap. Claiming #302 here would have been closing it on paper.

## Verification

```
Passed: 270   Failed: 0
✓ MessageBuilder #297: the real conversion path honors the default scale and caller overrides
```

Confirmed the new test catches a regression — restoring the hardcoded `scale: 2.0` makes it report `✗` and exit non-zero. `tsc --noEmit --strict` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PDF fallback settings to control image-rendering scale and the maximum number of converted pages.
  * These options are available for standard generation, text generation, and streaming workflows.
  * Custom settings can be provided per request, with sensible defaults applied automatically.

* **Bug Fixes**
  * PDF conversions now consistently honor configured rendering settings.
  * Invalid page-limit values are rejected with a clear error.
  * Warnings are shown when page limits truncate documents or individual pages cannot be rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->