### PR TITLE
test(harness): fail loudly when a suite runs against a stale dist

### DIFF
--- a/test/continuous-test-suite-auth.ts
+++ b/test/continuous-test-suite-auth.ts
@@ -86,6 +86,11 @@ import {
   createRoleAuthMiddleware,
 } from "../dist/lib/server/middleware/auth.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 // =============================================================================
 // HELPERS
 // =============================================================================

--- a/test/continuous-test-suite-avatar.ts
+++ b/test/continuous-test-suite-avatar.ts
@@ -30,6 +30,11 @@ import {
   ProviderRegistry,
 } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/test/continuous-test-suite-context.ts
+++ b/test/continuous-test-suite-context.ts
@@ -103,6 +103,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Context");
 
 /** Print-only logTest shim. Counters are driven by recordTest in the runner. */

--- a/test/continuous-test-suite-credentials.ts
+++ b/test/continuous-test-suite-credentials.ts
@@ -38,6 +38,11 @@ import type {
 import { ProviderFactory } from "../dist/lib/factories/providerFactory.js";
 import { ProviderRegistry } from "../dist/lib/factories/providerRegistry.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 // =============================================================================
 // CONFIG
 // =============================================================================

--- a/test/continuous-test-suite-dynamic.ts
+++ b/test/continuous-test-suite-dynamic.ts
@@ -38,6 +38,11 @@ import {
   isExpectedProviderError as harnessIsExpectedError,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const {
   recordTest,
   runSuite,

--- a/test/continuous-test-suite-evaluation.ts
+++ b/test/continuous-test-suite-evaluation.ts
@@ -96,6 +96,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Evaluation");
 
 /** Print-only logTest shim. Counters come from recordTest in the runner loop. */

--- a/test/continuous-test-suite-hitl.ts
+++ b/test/continuous-test-suite-hitl.ts
@@ -19,6 +19,11 @@ process.env.NEUROLINK_SKIP_MCP = "true";
 
 import { NeuroLink } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 // ============================================================
 // CONFIGURATION
 // ============================================================

--- a/test/continuous-test-suite-image-gen-extras.ts
+++ b/test/continuous-test-suite-image-gen-extras.ts
@@ -21,6 +21,11 @@ import * as path from "path";
 
 import { NeuroLink } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/test/continuous-test-suite-json-e2e.ts
+++ b/test/continuous-test-suite-json-e2e.ts
@@ -35,6 +35,11 @@ import { tool } from "ai";
 import { NeuroLink } from "../dist/index.js";
 import { defineSuite, assert, Skip } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite } = defineSuite("JSON Validity E2E (live)");
 const nl = new NeuroLink();
 

--- a/test/continuous-test-suite-mcp-bash.ts
+++ b/test/continuous-test-suite-mcp-bash.ts
@@ -24,6 +24,11 @@ import { bashTool } from "../dist/lib/agent/directTools.js";
 import type { BashToolResult } from "../dist/index.js";
 import { defineSuite, logSection, Skip } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("MCP bashTool");
 
 async function testExecuteBashCommand(): Promise<void> {

--- a/test/continuous-test-suite-mcp-cli.ts
+++ b/test/continuous-test-suite-mcp-cli.ts
@@ -40,6 +40,11 @@ import {
 } from "./helpers/harness.js";
 import { NeuroLink } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("MCP CLI Integration");
 
 /**

--- a/test/continuous-test-suite-mcp-http.ts
+++ b/test/continuous-test-suite-mcp-http.ts
@@ -96,6 +96,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Mcp Http");
 
 /** Print-only logTest shim. Counters come from recordTest in the runner loop. */

--- a/test/continuous-test-suite-mcp-infra.ts
+++ b/test/continuous-test-suite-mcp-infra.ts
@@ -66,6 +66,11 @@ import {
 } from "../dist/index.js";
 import { defineSuite, logSection } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("MCP Infrastructure");
 
 /**

--- a/test/continuous-test-suite-mcp-output-limits.ts
+++ b/test/continuous-test-suite-mcp-output-limits.ts
@@ -50,6 +50,11 @@ import {
   NEUROLINK_ARTIFACT_ID_KEY,
 } from "../dist/lib/mcp/mcpOutputNormalizer.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 function makeOutputLimitsPayload(sizeBytes: number): string {
   return "x".repeat(sizeBytes);
 }

--- a/test/continuous-test-suite-mcp-sdk.ts
+++ b/test/continuous-test-suite-mcp-sdk.ts
@@ -41,6 +41,11 @@ import {
 } from "./helpers/mcpHelpers.js";
 import { defineSuite, log, logSection } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("MCP Enhancements");
 
 // ============================================================

--- a/test/continuous-test-suite-mcp-spans.ts
+++ b/test/continuous-test-suite-mcp-spans.ts
@@ -31,6 +31,11 @@ const spans = installSpanCapture();
 import { NeuroLink } from "../dist/index.js";
 import { defineSuite, logSection } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite(
   "MCP Pipeline B span attributes (Issue #5)",
 );

--- a/test/continuous-test-suite-media-gen.ts
+++ b/test/continuous-test-suite-media-gen.ts
@@ -1509,6 +1509,11 @@ async function testVideoGenerationVertexAI(): Promise<boolean | null> {
 
 import { NeuroLink } from '${process.cwd()}/dist/index.js';
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 async function testVideoGenerationVertexAI() {
   console.log('Testing video generation via Vertex AI generate()...');
 

--- a/test/continuous-test-suite-memory.ts
+++ b/test/continuous-test-suite-memory.ts
@@ -28,6 +28,11 @@ import { fileURLToPath } from "url";
 import type { ProcessResult } from "../dist/index.js";
 import { NeuroLink } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/test/continuous-test-suite-music.ts
+++ b/test/continuous-test-suite-music.ts
@@ -28,6 +28,11 @@ import {
   ProviderRegistry,
 } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/test/continuous-test-suite-new-providers.ts
+++ b/test/continuous-test-suite-new-providers.ts
@@ -29,6 +29,11 @@ import "dotenv/config";
 import { NeuroLink } from "../dist/index.js";
 import { Skip } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 // ============================================================
 // LOGGING / RUNNER INFRASTRUCTURE
 // (Mirrors the convention used across continuous-test-suite-*.ts)

--- a/test/continuous-test-suite-observability.ts
+++ b/test/continuous-test-suite-observability.ts
@@ -114,6 +114,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Observability");
 
 // Legacy logTest shim — print-only, like the original. The counters are

--- a/test/continuous-test-suite-ppt.ts
+++ b/test/continuous-test-suite-ppt.ts
@@ -67,6 +67,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Ppt");
 
 /** Print-only logTest shim. Counters come from recordTest in the runner loop. */

--- a/test/continuous-test-suite-provider-matrix.ts
+++ b/test/continuous-test-suite-provider-matrix.ts
@@ -31,6 +31,11 @@ import {
 } from "./helpers/harness.js";
 import { PROVIDERS, hasProviderEnv } from "./helpers/providerMatrix.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite, opts } = defineSuite("Provider Capability Matrix");
 
 // ============================================================

--- a/test/continuous-test-suite-providers.ts
+++ b/test/continuous-test-suite-providers.ts
@@ -57,6 +57,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Providers");
 
 /** Print-only logTest shim. Counters are driven by recordTest in the runner. */

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -35,6 +35,11 @@ import { ConversationMemoryManager } from "../dist/lib/core/conversationMemoryMa
 import { buildContextFromPointer } from "../dist/lib/utils/conversationMemory.js";
 import { truncateWithSlidingWindow } from "../dist/lib/context/stages/slidingWindowTruncator.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",

--- a/test/continuous-test-suite-token-usage.ts
+++ b/test/continuous-test-suite-token-usage.ts
@@ -30,6 +30,11 @@ import { calculateCost } from "../dist/lib/utils/pricing.js";
 import { mergeUsage } from "../dist/lib/providers/openaiChatCompletionsClient.js";
 import { parseUsageFromResponseBody } from "../dist/lib/providers/sagemaker/streaming.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite } = defineSuite("Token Usage Accounting");
 
 // ============================================================

--- a/test/continuous-test-suite-tool-dedup.ts
+++ b/test/continuous-test-suite-tool-dedup.ts
@@ -58,6 +58,11 @@ import {
   skipUnlessTools,
 } from "./helpers/skipIf.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite } = defineSuite("Tool Signature Deduplication", {
   defaultProvider: "anthropic",
 });

--- a/test/continuous-test-suite-tool-routing-semantic.ts
+++ b/test/continuous-test-suite-tool-routing-semantic.ts
@@ -51,6 +51,11 @@ import { skipUnlessProviderAvailable } from "./helpers/skipIf.js";
 import { isExpectedProviderError } from "./helpers/envGuard.js";
 import { spy, stub, withStubs } from "./helpers/stubs.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite } = defineSuite(
   "L2 Embedding Fast-Path & Tool-Granularity",
 );

--- a/test/continuous-test-suite-tool-routing.ts
+++ b/test/continuous-test-suite-tool-routing.ts
@@ -38,6 +38,11 @@ import { stub, withStubs } from "./helpers/stubs.js";
 import { skipUnlessProviderAvailable } from "./helpers/skipIf.js";
 import { isExpectedProviderError } from "./helpers/envGuard.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { test, runSuite } = defineSuite("Pre-call Tool Routing");
 
 // ============================================================================

--- a/test/continuous-test-suite-tts.ts
+++ b/test/continuous-test-suite-tts.ts
@@ -91,6 +91,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Tts");
 
 /** Print-only logTest shim. Counters come from recordTest in the runner loop. */

--- a/test/continuous-test-suite-voice.ts
+++ b/test/continuous-test-suite-voice.ts
@@ -29,6 +29,11 @@ import { fileURLToPath } from "url";
 import type { ProcessResult } from "../dist/index.js";
 import { NeuroLink } from "../dist/index.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/test/continuous-test-suite-workflow.ts
+++ b/test/continuous-test-suite-workflow.ts
@@ -69,6 +69,11 @@ import {
   type ColorName,
 } from "./helpers/harness.js";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 const { recordTest, runSuite } = defineSuite("Workflow");
 
 /** Print-only logTest shim. Counters come from recordTest in the runner loop. */

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -3785,6 +3785,11 @@ async function testJsonFormatWithMultipleImagesSDK(): Promise<boolean | null> {
 import { NeuroLink } from '${process.cwd()}/dist/index.js';
 import { readFileSync } from 'fs';
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 async function run() {
   const sdk = new NeuroLink();
   const img = readFileSync('${process.cwd()}/${screenshotPath}');

--- a/test/helpers/distFreshness.ts
+++ b/test/helpers/distFreshness.ts
@@ -1,0 +1,112 @@
+/**
+ * Guard against running a suite against a stale `dist/`.
+ *
+ * 34 of the continuous suites import from `../dist/index.js` rather than from
+ * `src/`, and none of the `test:*` scripts build first. So a `dist/` left over
+ * from an earlier checkout silently exercises old code: the suite runs, reports
+ * failures with ordinary-looking assertion messages, and gives no hint that the
+ * artifact under test is not the source in the working tree.
+ *
+ * That is worse than a hard failure, because the output is indistinguishable
+ * from a genuine regression. It cost a real debugging detour: the skills suite
+ * reported 7 failures against a `dist/` three weeks older than HEAD, including
+ * failures for fixes that had just landed.
+ *
+ * This throws with an actionable message instead. It compares modification
+ * times only — it cannot prove the build matches the source, but "dist is older
+ * than a source file" is the case that actually bites, and it has no false
+ * positives after a real build.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Newest mtime under `dir`, or 0 when it does not exist. */
+function newestMtimeMs(dir: string, skip: ReadonlySet<string>): number {
+  if (!existsSync(dir)) {
+    return 0;
+  }
+  let newest = 0;
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (skip.has(entry.name)) {
+        continue;
+      }
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else {
+        const { mtimeMs } = statSync(full);
+        if (mtimeMs > newest) {
+          newest = mtimeMs;
+        }
+      }
+    }
+  };
+  walk(dir);
+  return newest;
+}
+
+/**
+ * Render an mtime as an age relative to now. Both sides of the comparison are
+ * shown in the error so a reader can see whether dist is minutes or weeks
+ * behind — "3 weeks" reads very differently from "20 seconds".
+ */
+function describeAge(mtimeMs: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - mtimeMs) / 1000));
+  if (seconds < 90) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 90) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.round(minutes / 60);
+  return hours < 48 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+}
+
+let checked = false;
+
+/**
+ * Throw when `dist/` is missing or older than the newest file in `src/`.
+ *
+ * Idempotent: only the first call does the walk, so suites that call it from
+ * several places pay for it once.
+ *
+ * Set `NEUROLINK_SKIP_DIST_FRESHNESS_CHECK=1` to bypass — intended for CI jobs
+ * that build in a separate step where mtimes may not survive artifact
+ * restoration, not for local use.
+ */
+export function assertDistFresh(): void {
+  if (checked || process.env.NEUROLINK_SKIP_DIST_FRESHNESS_CHECK === "1") {
+    return;
+  }
+  checked = true;
+
+  const distDir = join(REPO_ROOT, "dist");
+  if (!existsSync(join(distDir, "index.js"))) {
+    throw new Error(
+      "This suite imports from dist/, but dist/index.js does not exist.\n" +
+        "Run `pnpm run build` first.",
+    );
+  }
+
+  // node_modules is not under src/, but skip defensively in case of nesting.
+  const skip = new Set(["node_modules", ".DS_Store"]);
+  const newestSrc = newestMtimeMs(join(REPO_ROOT, "src"), skip);
+  const newestDist = newestMtimeMs(distDir, skip);
+
+  if (newestSrc > newestDist) {
+    throw new Error(
+      `dist/ is stale — src/ has changed since the last build ` +
+        `(newest src ${describeAge(newestSrc)}, newest dist ${describeAge(newestDist)}).\n` +
+        `This suite imports from dist/, so it would test the OLD code and report ` +
+        `failures that look exactly like real regressions.\n` +
+        `Run \`pnpm run build\` first.`,
+    );
+  }
+}

--- a/test/zod-schema-test-function.ts
+++ b/test/zod-schema-test-function.ts
@@ -25,6 +25,11 @@ import { NeuroLink } from "../dist/index.js";
 import * as path from "path";
 import { fileURLToPath } from "url";
 
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
+assertDistFresh();
+
 // Test data file paths - ES module compatible
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## The trap

**34** continuous suites import from `../dist/index.js` rather than `src/`, and **none** of the `test:*` scripts build first.

So a `dist/` left over from an earlier checkout gets exercised silently. The suite runs, reports ordinary-looking assertion failures, and gives no hint that the artifact under test isn't the source in your working tree.

That's worse than a hard failure, because the output is **indistinguishable from a real regression**.

## It bit me during this batch

Running the skills suite on `release` right after #1299 merged:

```
RESULTS: 44 passed, 7 failed, 0 skipped (of 51)

❌ 6b.  #1139: scoped skills fail closed when no scopeId is supplied
❌ 22c. reusing a soft-deleted skill's name is rejected (integrity)
❌ 22e. get() by name is case-insensitive, matching the uniqueness rule
   … 4 more
```

That reads unmistakably as "the merge broke seven things" — including tests for fixes that had *just landed*. The actual cause:

```
dist/index.js   19 Jul 01:03
HEAD            Aug 08 01:28
```

I'd run `build:cli`; the skills suite imports `dist/index.js`. After a full `pnpm run build`: **51/51, 0 failed.** Nothing was broken.

## The guard

`assertDistFresh()` compares the newest mtime under `src/` against the newest under `dist/`:

```
Error: dist/ is stale — src/ has changed since the last build
       (newest src 36s ago, newest dist 66s ago).
This suite imports from dist/, so it would test the OLD code and report
failures that look exactly like real regressions.
Run `pnpm run build` first.
```

It can't prove the build *matches* the source — but "dist is older than a source file" is the case that actually bites, and it has no false positives after a real build.

**Scoped deliberately:** wired into the 34 dist-importing suites only. Suites that read `src/` directly are untouched, so an unrelated stale build can't block them. `NEUROLINK_SKIP_DIST_FRESHNESS_CHECK=1` bypasses it for CI jobs that build in a separate step where mtimes may not survive artifact restoration.

I chose the guard over adding `pnpm run build &&` to 34 scripts: a full build per suite would make the split-suite layout far slower to iterate on, and the guard tells you *why* rather than just being slow.

## Verification

All three paths exercised:

| | Result |
| --- | --- |
| stale dist | throws with both ages + the fix command |
| fresh build | skills 51/51, mcp-infra 84 passed |
| `NEUROLINK_SKIP_DIST_FRESHNESS_CHECK=1` with stale dist | 51/51 — bypass restores old behaviour |

`pnpm run check` 0 errors · `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added build freshness validation across continuous and schema test suites.
  * Tests now fail early with actionable guidance when compiled artifacts are missing or outdated.
  * Added an optional bypass for scenarios requiring tests to run without the freshness check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->