### PR TITLE
fix(tts): stop downgrading OpenAI flac requests to mp3

### DIFF
--- a/src/lib/voice/providers/OpenAITTS.ts
+++ b/src/lib/voice/providers/OpenAITTS.ts
@@ -247,8 +247,14 @@ export class OpenAITTS implements TTSHandler {
 
   /**
    * Map TTSAudioFormat to OpenAI response_format.
-   * OpenAI TTS supports: mp3, wav, opus (ogg maps to opus).
-   * Unsupported formats are coerced to mp3 with a warning.
+   *
+   * OpenAI's /audio/speech accepts mp3, opus, aac, flac, wav and pcm. This map
+   * previously stopped at mp3/wav/ogg/opus/pcm16, so `flac` — a valid
+   * TTSAudioFormat *and* a real OpenAI response_format — was treated as
+   * unsupported and silently downgraded to mp3 (#479). A caller who asked for
+   * lossless got lossy, and the only signal was a warn-level log.
+   *
+   * Formats OpenAI genuinely cannot produce still coerce to mp3 with a warning.
    */
   private mapFormat(format: TTSAudioFormat): string {
     const formats: Partial<Record<TTSAudioFormat, string>> = {
@@ -256,6 +262,12 @@ export class OpenAITTS implements TTSHandler {
       wav: "wav",
       ogg: "opus", // OpenAI uses opus for ogg
       opus: "opus",
+      // #479: flac is the entry this fix added. It is a first-class OpenAI
+      // response_format and was the only TTSAudioFormat member missing from
+      // this map, so it fell through to the mp3 coercion below. The issue also
+      // mentions aac, but aac is not a member of TTSAudioFormat and therefore
+      // cannot be requested — no mapping is needed or possible for it.
+      flac: "flac",
       // OpenAI's "pcm" is raw 16-bit signed LE @ 24kHz (no header) — maps to
       // canonical pcm16 in TTSResult.format. See effectiveFormat() below.
       pcm16: "pcm",
@@ -263,7 +275,7 @@ export class OpenAITTS implements TTSHandler {
     const mapped = formats[format];
     if (mapped === undefined) {
       logger.warn(
-        `[OpenAITTSHandler] Unsupported format "${format}" — falling back to "mp3". Supported formats: mp3, wav, ogg, opus, pcm16.`,
+        `[OpenAITTSHandler] Unsupported format "${format}" — falling back to "mp3". Supported formats: mp3, wav, ogg, opus, flac, pcm16.`,
       );
       return "mp3";
     }
@@ -298,6 +310,8 @@ export class OpenAITTS implements TTSHandler {
         return "wav";
       case "opus":
         return "opus";
+      case "flac":
+        return "flac";
       // Raw PCM (16-bit signed LE @ 24kHz, no header) — keep semantics in
       // TTSResult.format so consumers don't write raw bytes to a .wav file.
       case "pcm":

--- a/test/continuous-test-suite-tts-unit.ts
+++ b/test/continuous-test-suite-tts-unit.ts
@@ -287,4 +287,49 @@ await test("getVoices reaches the handler", async () => {
   assert(Array.isArray(voices) && voices.length > 0, "voices are returned");
 });
 
+// --- TTS-008 (#479): OpenAI format mapping -----------------------------------
+
+await test("#479: flac is a real OpenAI response_format and must not downgrade to mp3", async () => {
+  const { OpenAITTS } = await import("../src/lib/voice/providers/OpenAITTS.js");
+  // Exercised off the prototype so no API key / constructor side effects are
+  // needed — mapFormat and effectiveFormat are pure.
+  const proto = OpenAITTS.prototype as unknown as {
+    mapFormat: (f: string) => string;
+    effectiveFormat: (f: string) => string;
+  };
+  const roundTrip = (f: string) => {
+    const wire = proto.mapFormat.call({}, f);
+    return { wire, back: proto.effectiveFormat.call({}, wire) };
+  };
+
+  // flac is BOTH a valid TTSAudioFormat and a documented OpenAI
+  // response_format, yet it used to fall through to the mp3 coercion branch —
+  // a caller asking for lossless silently received lossy.
+  assertEqual(roundTrip("flac").wire, "flac", "flac reaches the API as flac");
+  assertEqual(
+    roundTrip("flac").back,
+    "flac",
+    "TTSResult.format reports flac, not mp3",
+  );
+
+  // Unchanged mappings.
+  assertEqual(roundTrip("mp3").wire, "mp3", "mp3 unchanged");
+  assertEqual(roundTrip("wav").wire, "wav", "wav unchanged");
+  assertEqual(roundTrip("ogg").wire, "opus", "ogg still maps to opus");
+  assertEqual(roundTrip("pcm16").wire, "pcm", "pcm16 still maps to pcm");
+  assertEqual(
+    roundTrip("pcm16").back,
+    "pcm16",
+    "pcm round-trips back to pcm16 so callers do not mislabel raw bytes",
+  );
+
+  // m4a is in TTSAudioFormat (it is an STT input format) but OpenAI TTS cannot
+  // produce it — coercing to mp3 with a warning stays correct.
+  assertEqual(
+    roundTrip("m4a").wire,
+    "mp3",
+    "a format OpenAI genuinely cannot produce still coerces to mp3",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
Refs #479

## The bug

`flac` is **both** a valid `TTSAudioFormat` and a documented OpenAI `/audio/speech` `response_format`. But `mapFormat()` only listed mp3/wav/ogg/opus/pcm16, so a flac request fell into the unsupported-format branch and was coerced to mp3.

A caller who asked for lossless silently got lossy. The only signal was a warn-level log — and `TTSResult.format` then reported `"mp3"`, so nothing downstream could detect it either.

| requested | before | after |
| --- | --- | --- |
| `flac` | `mp3` → reported as `mp3` | **`flac` → reported as `flac`** |
| mp3 / wav / ogg / opus / pcm16 | unchanged | unchanged |
| m4a | `mp3` | `mp3` (correct — see below) |

## Scope, checked rather than assumed

The issue also names `aac`. **`aac` is absent from the `TTSAudioFormat` union**, so it cannot be requested at all and needs no mapping — adding it would mean widening the public type for a format nothing asks for.

`m4a`, `webm`, `mp4`, `mpeg` and `mpga` *are* in that union, but they're there as Whisper **input** formats sharing the type. OpenAI TTS cannot produce them, so coercing them to mp3 with a warning remains correct — the test asserts that explicitly so a later change doesn't "helpfully" map them to something OpenAI would reject.

## Verification

`mapFormat` and `effectiveFormat` are pure, so the test exercises them off the prototype — no API key, no network:

```
✓ #479: flac is a real OpenAI response_format and must not downgrade to mp3
Passed: 14   Failed: 0
```

Confirmed it catches the regression — removing the `flac` mapping makes it report `✗` and exit non-zero.

`pnpm run check` 0 errors.

## Not closing #479

The issue's other outstanding criterion — *"add duration estimation"* — is still unmet: `TTSResult.duration` is never populated by this handler. That's separate work, so this is `Refs`, not `Closes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for requesting and receiving OpenAI text-to-speech audio in FLAC format.
  - FLAC is now correctly reported as the selected audio format.

- **Bug Fixes**
  - Unsupported audio formats continue to fall back to MP3.
  - Format warnings now accurately include FLAC among supported options.

- **Tests**
  - Added coverage for FLAC mapping and existing audio-format behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->