### PR TITLE
fix(multimodal): stop dropping images above the lazy-reference threshold

### DIFF
--- a/src/lib/utils/messageBuilder.ts
+++ b/src/lib/utils/messageBuilder.ts
@@ -80,13 +80,32 @@ const EXTENSION_TYPE_MAP: Record<string, string> = {
   // Image
   jpg: "image",
   jpeg: "image",
+  jpe: "image",
+  jfif: "image",
   png: "image",
+  apng: "image",
   gif: "image",
   webp: "image",
   bmp: "image",
   tiff: "image",
   tif: "image",
   avif: "image",
+  // Below this line the entries exist because this map now decides whether an
+  // image is processed eagerly (see isEagerMultimodalFile), not merely how its
+  // tokens are estimated. An extension missing here classifies as `undefined`
+  // and takes the lazy path, which drops the pixels — so a gap is a dropped
+  // photo, not a slightly-off estimate. HEIC is the one that matters most:
+  // it is what an iPhone writes by default.
+  heic: "image",
+  heif: "image",
+  ico: "image",
+  jp2: "image",
+  jpx: "image",
+  // NB: `svg` is deliberately absent here — it is mapped to its own "svg"
+  // routing type further down, and listing it twice is a duplicate key whose
+  // second entry silently wins. `isEagerMultimodalFile` accepts both types
+  // instead, so SVG takes the eager path without this map having to lie about
+  // which processor handles it.
   // Archive
   zip: "archive",
   tar: "archive",
@@ -137,6 +156,20 @@ function inferFileTypeFromExtension(filePath: string): string | undefined {
 function inferFileTypeFromBuffer(buf: Buffer): string | undefined {
   if (buf.length < 4) {
     return undefined;
+  }
+
+  // SVG is markup and has no magic number, so every signature check below
+  // misses it and a raw SVG Buffer classified as `undefined` — which meant the
+  // lazy path, which previews markup away. Checked first because the sniff is
+  // a cheap look at the head and cannot collide with a binary signature.
+  //
+  // Deliberately a substring scan over the head rather than a prolog-stripping
+  // regex: the obvious pattern for skipping comments and a DOCTYPE is two
+  // nested quantifiers, which is a ReDoS waiting to happen inside what is
+  // supposed to be a cheap type check. Over-matching is harmless here — the
+  // only consequence of a false positive is that a file is processed eagerly.
+  if (buf.subarray(0, 1024).toString("latin1").includes("<svg")) {
+    return "svg";
   }
 
   // PNG
@@ -1088,7 +1121,11 @@ export async function processUnifiedFilesArray(
         try {
           // ─── Lazy file registration path ──────────────────────────────
           const fileSize = fileRegistry ? getFileSize(file) : 0;
-          if (fileRegistry && fileSize > SIZE_TIER_THRESHOLDS.TINY_MAX) {
+          if (
+            fileRegistry &&
+            fileSize > SIZE_TIER_THRESHOLDS.TINY_MAX &&
+            !isEagerMultimodalFile(file)
+          ) {
             const registered = await tryRegisterFileReference(
               file,
               fileSize,
@@ -2583,6 +2620,110 @@ function getFileSource(file: FileInput): "buffer" | "path" | "url" | "datauri" {
     }
   }
   return "buffer";
+}
+
+/**
+ * Whether a file must be processed eagerly rather than lazily referenced.
+ *
+ * The lazy path registers a file and injects a short textual *preview* in place
+ * of the file itself. Whether that is an acceptable trade depends entirely on
+ * whether a description of the file can answer questions about it:
+ *
+ *   pdf    lazy -> preview carries the extracted text   ✔ content survives
+ *   image  lazy -> preview carries ~98 chars of prose   ✘ the pixels are gone
+ *
+ * An image is the case where the bytes ARE the content: no prose summary
+ * substitutes for them, so the model receives a description of a file instead
+ * of the file. Measured end-to-end on `release`, asking "what number is
+ * written in this image?":
+ *
+ *   tiny.png  1.6 KB -> "7391"              (under TINY_MAX, eager, correct)
+ *   big.png    11 KB -> NOTHING_RECEIVED    (lazy, image never arrived)
+ *   big.jpg    19 KB -> NOTHING_RECEIVED
+ *
+ * 10 KB is far below any real photo, so this affected essentially every image
+ * attached by path — an ordinary JPEG, not just unusual formats.
+ *
+ * Scoped to images deliberately, and audio deserves spelling out because the
+ * reason is not the one it appears to be. An audio file's message contains only
+ * a metadata block — duration, codec, sample rate — on BOTH paths; no audio
+ * bytes are handed to the provider either way. Moving audio to the eager path
+ * would therefore change nothing about what the model receives. That audio
+ * content never reaches the model at all is a separate and pre-existing gap,
+ * not something this threshold decision can repair, and it is easy to mistake
+ * for working code because the metadata block answers exactly the questions
+ * ("how long is it?", "what sample rate?") a test is most tempted to ask.
+ * Video is left alone for the opposite reason: its frames are measurably
+ * present in the message and a model reads them correctly.
+ *
+ * Note this costs no extra memory: `tryRegisterFileReference` already calls
+ * `getFileBuffer()` and reads the whole file to register it. The lazy path was
+ * never lazy about reading — only about processing — so the difference here is
+ * simply whether the bytes survive.
+ */
+function isEagerMultimodalFile(file: FileInput): boolean {
+  if (typeof file === "string") {
+    return isImageLikeType(inferFileTypeFromExtension(file));
+  }
+  if (Buffer.isBuffer(file)) {
+    return isImageLikeType(inferFileTypeFromBuffer(file));
+  }
+
+  // A `FileWithMetadata` carries two independent declarations, and either one
+  // alone is enough: the shape exists for Slack/Curator-style uploads that
+  // arrive as bytes plus a mimetype, so its `filename` may be extensionless or
+  // simply wrong. Reading them as a `??` chain meant the first *recognised*
+  // name won outright — `upload.pdf` with `mimetype: "image/png"` classified as
+  // a PDF and lost its pixels down the lazy path. Any declaration of an image
+  // is therefore decisive.
+  const declared = [
+    inferFileTypeFromExtension(file.filename),
+    inferFileTypeFromMimetype(file.mimetype),
+  ];
+  if (declared.some(isImageLikeType)) {
+    return true;
+  }
+
+  // The buffer sniff is the last resort rather than a third vote, because it is
+  // a substring scan: an HTML page with an inline `<svg>` icon in its head
+  // would otherwise be pulled onto the eager path and sent in full, which is
+  // the opposite of what the size tiers are for. It only speaks when nothing
+  // else did.
+  return declared.every((type) => type === undefined)
+    ? isImageLikeType(inferFileTypeFromBuffer(file.buffer))
+    : false;
+}
+
+/**
+ * Whether a routing type should have its bytes preserved rather than previewed.
+ *
+ * "svg" is a separate routing type rather than a sub-case of "image" (it goes
+ * to the sanitizer, not to a vision encoder), but it is still an image as far
+ * as this decision is concerned: its markup IS its content, and previewing it
+ * away leaves the model with nothing. Accepting both keeps this correct
+ * whichever of the two type vocabularies the caller's map uses.
+ */
+function isImageLikeType(type: string | undefined): boolean {
+  return type === "image" || type === "svg";
+}
+
+/**
+ * Infer a routing type from a caller-declared mimetype.
+ *
+ * Only images matter here — this exists so the eager/lazy decision can read a
+ * mimetype hint — and "application/octet-stream" is deliberately ignored,
+ * because it is the opaque sentinel a caller sends when it knows nothing, not
+ * a claim about content.
+ */
+function inferFileTypeFromMimetype(mimetype?: string): string | undefined {
+  if (!mimetype) {
+    return undefined;
+  }
+  const normalized = mimetype.split(";")[0].trim().toLowerCase();
+  if (normalized === "image/svg+xml") {
+    return "svg";
+  }
+  return normalized.startsWith("image/") ? "image" : undefined;
 }
 
 /**

--- a/test/continuous-test-suite-multimodal-sdk.ts
+++ b/test/continuous-test-suite-multimodal-sdk.ts
@@ -34,14 +34,18 @@ import {
   Skip,
 } from "./helpers/harness.js";
 import {
+  findImageMagick,
   hasFfmpeg,
   makeAudioFile,
+  makeNumberImage,
   makeVideoFile,
 } from "./helpers/mediaFixtures.js";
 import { hasPackage, makeDocx, makeXlsx } from "./helpers/officeFixtures.js";
 import { FileDetector } from "../src/lib/utils/fileDetector.js";
+import { redactUrlsInText } from "../src/lib/utils/logSanitize.js";
 import { buildMultimodalMessagesArray } from "../src/lib/utils/messageBuilder.js";
 import { NeuroLink } from "../src/lib/neurolink.js";
+import { SIZE_TIER_THRESHOLDS } from "../src/lib/types/index.js";
 
 const { test, runSuite } = defineSuite("Multimodal through the SDK");
 
@@ -192,6 +196,46 @@ async function generateNonEmpty(
   return last;
 }
 
+/**
+ * Assert on a live reply without putting the reply in the failure message.
+ *
+ * `defineSuite`'s `test()` classifies a thrown error as SKIP — not FAIL — when
+ * its message matches `isExpectedProviderError()`, and that check reads the
+ * message text. An assertion that quotes model output can therefore be
+ * downgraded to a green skip the moment the model happens to say "timeout",
+ * "not found" or any other provider-ish phrase, which is precisely the
+ * false-green this suite exists to prevent.
+ *
+ * The reply is still printed — diagnosing a multimodal failure without seeing
+ * what came back is miserable — just to stderr rather than into the message
+ * the harness inspects.
+ */
+function formatReply(reply: string): string {
+  // Redacted because the reply is provider output: a model asked to describe an
+  // attachment can echo a signed URL back, and this goes to a CI log.
+  return redactUrlsInText(reply.slice(0, 300).replace(/\s+/g, " "));
+}
+
+function assertReply(condition: boolean, summary: string, reply: string): void {
+  if (!condition) {
+    console.error(`      ↳ model reply: ${formatReply(reply)}`);
+  }
+  assert(condition, summary);
+}
+
+/** `assertIncludes` counterpart to {@link assertReply}, for the same reason. */
+function assertIncludesReply(
+  haystack: string,
+  needle: string,
+  summary: string,
+  reply: string,
+): void {
+  if (!haystack.includes(needle)) {
+    console.error(`      ↳ model reply: ${formatReply(reply)}`);
+  }
+  assertIncludes(haystack, needle, summary);
+}
+
 // --- VIDEO-026 (#498) / AUDIO-030 (#483): FileDetector on real bytes ---------
 //
 // The detector is the first thing every multimodal call hits. These assert it
@@ -308,15 +352,17 @@ await test("audio reaches the model via input.files", async () => {
     provider: PROVIDER,
     maxTokens: 512,
   });
-  assert(
+  assertReply(
     !content.includes("NOTHING_RECEIVED"),
-    `the model reported receiving nothing; got: ${content.slice(0, 200)}`,
+    `the model reported receiving nothing`,
+    content,
   );
   // Only obtainable by reading the container header.
-  assertIncludes(
+  assertIncludesReply(
     content.toLowerCase(),
     "tone.mp3",
-    `the model described the actual file; got: ${content.slice(0, 200)}`,
+    `the model described the actual file`,
+    content,
   );
 });
 
@@ -339,14 +385,16 @@ await test("audio reaches the model as a Buffer via input.files", async () => {
     provider: PROVIDER,
     maxTokens: 512,
   });
-  assert(
+  assertReply(
     !content.includes("NOTHING_RECEIVED"),
-    `buffer input reached the model; got: ${content.slice(0, 200)}`,
+    `buffer input reached the model`,
+    content,
   );
   // Word-bounded so a stray "7" inside a larger number cannot satisfy it.
-  assert(
+  assertReply(
     new RegExp(`\\b${ODD_SECONDS}\\b`).test(content),
-    `the model read the real duration (${ODD_SECONDS}s) from the buffer; got: ${content.slice(0, 200)}`,
+    `the model read the real duration (${ODD_SECONDS}s) from the buffer`,
+    content,
   );
 });
 
@@ -367,13 +415,15 @@ await test("input.audioFiles delivers audio (regression for #1259)", async () =>
     provider: PROVIDER,
     maxTokens: 512,
   });
-  assert(
+  assertReply(
     !content.includes("NOTHING_RECEIVED"),
-    `audioFiles reached the model; got: ${content.slice(0, 200)}`,
+    `audioFiles reached the model`,
+    content,
   );
-  assert(
+  assertReply(
     new RegExp(`\\b${ODD_SECONDS}\\b`).test(content),
-    `the model read the real duration (${ODD_SECONDS}s) via audioFiles; got: ${content.slice(0, 200)}`,
+    `the model read the real duration (${ODD_SECONDS}s) via audioFiles`,
+    content,
   );
 });
 
@@ -401,10 +451,11 @@ await test("generate() reads content out of a .docx", async () => {
   });
   // Asserting on content the model could only know by reading the file is the
   // difference between "the call succeeded" and "the document arrived".
-  assertIncludes(
+  assertIncludesReply(
     result.content.toUpperCase(),
     "FALCON",
-    `docx content reached the model; got: ${result.content.slice(0, 160)}`,
+    `docx content reached the model`,
+    result.content,
   );
 });
 
@@ -433,10 +484,11 @@ await test("generate() reads cell values out of an .xlsx", async () => {
     maxTokens: 512,
     timeout: LIVE_TIMEOUT_MS,
   });
-  assertIncludes(
+  assertIncludesReply(
     result.content,
     "4242",
-    `xlsx cell reached the model; got: ${result.content.slice(0, 160)}`,
+    `xlsx cell reached the model`,
+    result.content,
   );
 });
 
@@ -454,18 +506,20 @@ await test("video reaches the model via input.files", async () => {
     provider: PROVIDER,
     maxTokens: 512,
   });
-  assert(
+  assertReply(
     !content.includes("NOTHING_RECEIVED"),
-    `the model reported seeing nothing; got: ${content.slice(0, 200)}`,
+    `the model reported seeing nothing`,
+    content,
   );
   // Asking for a specific fact rather than a free-form description: the model's
   // prose varies run to run (an earlier version asserted on whichever details it
   // happened to mention, and flaked). 320x240 is the fixture's real resolution,
   // obtainable only from the probed stream, and no refusal contains it.
-  assertIncludes(
+  assertIncludesReply(
     content,
     "320x240",
-    `the model read the real resolution; got: ${content.slice(0, 200)}`,
+    `the model read the real resolution`,
+    content,
   );
 });
 
@@ -481,14 +535,16 @@ await test("input.videoFiles delivers video (regression for #1259)", async () =>
     provider: PROVIDER,
     maxTokens: 512,
   });
-  assert(
+  assertReply(
     !content.includes("NOTHING_RECEIVED"),
-    `videoFiles reached the model; got: ${content.slice(0, 200)}`,
+    `videoFiles reached the model`,
+    content,
   );
-  assertIncludes(
+  assertIncludesReply(
     content,
     "320x240",
-    `the model read the real resolution via videoFiles; got: ${content.slice(0, 200)}`,
+    `the model read the real resolution via videoFiles`,
+    content,
   );
 });
 
@@ -526,10 +582,11 @@ await test("stream() carries a document through the same path as generate()", as
   }
   // generate() and stream() share MessageBuilder but not the whole path, so a
   // document that works in one can still be dropped in the other.
-  assertIncludes(
+  assertIncludesReply(
     text.toUpperCase(),
     "ORCHID",
-    `docx content reached the model via stream(); got: ${text.slice(0, 160)}`,
+    `docx content reached the model via stream()`,
+    text,
   );
 });
 
@@ -552,20 +609,12 @@ await test("mixed multimodal input keeps every part", async () => {
     timeout: LIVE_TIMEOUT_MS,
   });
   const upper = content.toUpperCase();
-  assertIncludes(
-    upper,
-    "PELICAN",
-    `spreadsheet part survived; got: ${content.slice(0, 200)}`,
-  );
+  assertIncludesReply(upper, "PELICAN", `spreadsheet part survived`, content);
   // The filename, not the word "AUDIO": a refusal such as "no audio file is
   // attached" contains "AUDIO" too, so that assertion passed whether or not
   // the audio ever arrived. Same false-pass shape this file's header warns
   // about — it survived one round of fixing those and was caught in review.
-  assertIncludes(
-    upper,
-    "TONE.MP3",
-    `audio part survived; got: ${content.slice(0, 200)}`,
-  );
+  assertIncludesReply(upper, "TONE.MP3", `audio part survived`, content);
 });
 
 await test("stream() file parity on the configured provider (regression for #1258)", async () => {
@@ -594,12 +643,209 @@ await test("stream() file parity on the configured provider (regression for #125
   for await (const chunk of result.stream) {
     text += typeof chunk === "string" ? chunk : (chunk.content ?? "");
   }
-  assertIncludes(
+  assertIncludesReply(
     text.toUpperCase(),
     "MERIDIAN",
-    `docx content reached the model via stream() on ${PROVIDER}; got: ${text.slice(0, 160)}`,
+    `docx content reached the model via stream() on ${PROVIDER}`,
+    text,
   );
 });
+
+// --- Images above the lazy-reference threshold ------------------------------
+//
+// `SIZE_TIER_THRESHOLDS.TINY_MAX` (10 KB) decides between eager processing and
+// lazy reference registration. For text that trade is sound; for an image it
+// was fatal — the file was previewed into ~98 characters and never attached,
+// so the model answered about a file it had never seen. Every image fixture in
+// the suites happened to sit under 10 KB, which is why this shipped.
+//
+// The number rendered into each image is the assertion: it has no prior, so a
+// correct answer cannot be produced without the pixels.
+
+const IMAGE_TOKEN_SMALL = "5182";
+const IMAGE_TOKEN_LARGE = "7391";
+
+function requireImageMagick(): void {
+  if (!findImageMagick()) {
+    throw new Skip("ImageMagick unavailable — cannot render image fixtures");
+  }
+}
+
+const READ_THE_NUMBER =
+  "What number is written in this image? Answer with the digits only. " +
+  "If no image reached you, reply exactly: NOTHING_RECEIVED";
+
+await test("an image under the lazy threshold reaches the model", async () => {
+  requireImageMagick();
+  requireLive();
+  const file = await makeNumberImage(dir, "tiny.png", IMAGE_TOKEN_SMALL);
+  assert(
+    fs.statSync(file).size < SIZE_TIER_THRESHOLDS.TINY_MAX,
+    "fixture is below the tier threshold, where images were never dropped",
+  );
+  const nl = new NeuroLink();
+  const content = await generateNonEmpty(nl, {
+    input: { text: READ_THE_NUMBER, files: [file] },
+    provider: PROVIDER,
+    maxTokens: 256,
+  });
+  assertReply(
+    new RegExp(`\\b${IMAGE_TOKEN_SMALL}\\b`).test(content),
+    `the model read the number off the image`,
+    content,
+  );
+});
+
+await test("an image ABOVE the lazy threshold still reaches the model", async () => {
+  // The regression this suite exists to catch. On release an 11 KB PNG and a
+  // 19 KB JPEG both came back NOTHING_RECEIVED.
+  requireImageMagick();
+  requireLive();
+  const file = await makeNumberImage(dir, "big.png", IMAGE_TOKEN_LARGE, true);
+  assert(
+    fs.statSync(file).size > SIZE_TIER_THRESHOLDS.TINY_MAX,
+    "fixture is above the tier threshold, the size that used to be routed lazily and lose its pixels",
+  );
+  const nl = new NeuroLink();
+  const content = await generateNonEmpty(nl, {
+    input: { text: READ_THE_NUMBER, files: [file] },
+    provider: PROVIDER,
+    maxTokens: 256,
+  });
+  assertReply(
+    !content.includes("NOTHING_RECEIVED"),
+    `the image reached the model rather than being previewed away`,
+    content,
+  );
+  assertReply(
+    new RegExp(`\\b${IMAGE_TOKEN_LARGE}\\b`).test(content),
+    `the model read the number off the large image`,
+    content,
+  );
+});
+
+await test("a large JPEG reaches the model too", async () => {
+  // PNG and JPEG take different processing branches; the release failure hit
+  // both, so both are pinned.
+  requireImageMagick();
+  requireLive();
+  const source = await makeNumberImage(
+    dir,
+    "big-src.png",
+    IMAGE_TOKEN_LARGE,
+    true,
+  );
+  const jpeg = path.join(dir, "big.jpg");
+  const magick = findImageMagick();
+  if (!magick) {
+    throw new Skip("ImageMagick unavailable");
+  }
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  await promisify(execFile)(magick, [source, "-quality", "92", jpeg]);
+  assert(
+    fs.statSync(jpeg).size > SIZE_TIER_THRESHOLDS.TINY_MAX,
+    "the jpeg fixture is above the tier threshold",
+  );
+  const nl = new NeuroLink();
+  const content = await generateNonEmpty(nl, {
+    input: { text: READ_THE_NUMBER, files: [jpeg] },
+    provider: PROVIDER,
+    maxTokens: 256,
+  });
+  assertReply(
+    new RegExp(`\\b${IMAGE_TOKEN_LARGE}\\b`).test(content),
+    `the model read the number off the large jpeg`,
+    content,
+  );
+});
+
+await test("an extension-less upload is classified from its mimetype", async () => {
+  // The eager/lazy decision read `filename` alone, so a `FileWithMetadata`
+  // whose name carries no extension — the entire reason that shape exists, for
+  // Slack/Curator-style uploads that arrive as bytes plus a declared mimetype
+  // — was classified as unknown and sent down the lazy path, losing its pixels.
+  // Caught in review rather than by a test, which is why this one exists.
+  requireImageMagick();
+  requireLive();
+  const source = await makeNumberImage(
+    dir,
+    "no-ext-src.png",
+    IMAGE_TOKEN_LARGE,
+    true,
+  );
+  const buffer = fs.readFileSync(source);
+  assert(
+    buffer.length > SIZE_TIER_THRESHOLDS.TINY_MAX,
+    "the fixture is above the tier threshold, the size that used to be routed lazily and lose its pixels",
+  );
+  const nl = new NeuroLink();
+  const content = await generateNonEmpty(nl, {
+    input: {
+      text: READ_THE_NUMBER,
+      files: [{ buffer, filename: "screenshot", mimetype: "image/png" }],
+    },
+    provider: PROVIDER,
+    maxTokens: 256,
+  });
+  assertReply(
+    !content.includes("NOTHING_RECEIVED"),
+    "the extension-less image reached the model",
+    content,
+  );
+  assertReply(
+    new RegExp(`\\b${IMAGE_TOKEN_LARGE}\\b`).test(content),
+    "the model read the number off the extension-less image",
+    content,
+  );
+});
+
+await test("a mislabelled filename loses to the declared mimetype", async () => {
+  // The two declarations on a `FileWithMetadata` were read as a `??` chain, so
+  // the first *recognised* one won outright: a name ending `.pdf` beat a
+  // `mimetype` of `image/png` and the pixels went down the lazy path. Naming is
+  // the least trustworthy field on that shape, which is why it cannot veto.
+  requireImageMagick();
+  requireLive();
+  const source = await makeNumberImage(
+    dir,
+    "mislabelled-src.png",
+    IMAGE_TOKEN_LARGE,
+    true,
+  );
+  const buffer = fs.readFileSync(source);
+  assert(
+    buffer.length > SIZE_TIER_THRESHOLDS.TINY_MAX,
+    "the fixture is above the tier threshold, the size that used to be routed lazily and lose its pixels",
+  );
+  const nl = new NeuroLink();
+  const content = await generateNonEmpty(nl, {
+    input: {
+      text: READ_THE_NUMBER,
+      files: [{ buffer, filename: "upload.pdf", mimetype: "image/png" }],
+    },
+    provider: PROVIDER,
+    maxTokens: 256,
+  });
+  assertReply(
+    !content.includes("NOTHING_RECEIVED"),
+    "the mislabelled image reached the model",
+    content,
+  );
+  assertReply(
+    new RegExp(`\\b${IMAGE_TOKEN_LARGE}\\b`).test(content),
+    "the model read the number off the mislabelled image",
+    content,
+  );
+});
+
+// HEIC, HEIF, ICO and JPEG 2000 are deliberately NOT asserted end-to-end here.
+// The extension→type entries this change adds for them are necessary but not
+// sufficient: `ImageProcessor.validateImageFormat` rejects those MIME types at
+// intake ("Invalid MIME type: image/heic is not in allowed list") before the
+// eager path is ever reached. Fixing that allowlist is a separate change, and
+// asserting the end-to-end result here would pin a failure this commit cannot
+// cause or cure. Their coverage lives with that fix.
 
 try {
   fs.rmSync(dir, { recursive: true, force: true });

--- a/test/helpers/mediaFixtures.ts
+++ b/test/helpers/mediaFixtures.ts
@@ -140,3 +140,86 @@ export function makeCorruptFile(dir: string, name: string): string {
   fs.writeFileSync(out, Buffer.from("not really media, just ascii", "utf8"));
   return out;
 }
+
+/**
+ * Render a number into an image of a chosen byte size.
+ *
+ * Two properties matter and neither is incidental.
+ *
+ * The *content* is a number the model cannot guess. Asking "describe this
+ * image" is worthless — a model that received nothing still produces plausible
+ * prose — and asking about a property with a strong prior (dimensions, a
+ * common colour) is answerable without looking. A four-digit token has no
+ * prior, so a correct answer can only have come from the pixels.
+ *
+ * The *size* is chosen relative to `SIZE_TIER_THRESHOLDS.TINY_MAX` (10 KB).
+ * Files under it are processed eagerly; files over it take the lazy
+ * reference path. An image on the wrong side of that line silently became a
+ * ~98-character text preview and never reached the model at all — and the
+ * reason that shipped is that every image fixture in the suites happened to be
+ * a few kilobytes. `bigPixels` pushes the encode over the threshold so the
+ * lazy path is actually exercised.
+ *
+ * @param label - Digits rendered into the image; keep it un-guessable.
+ * @param bigPixels - When true, render large enough to exceed TINY_MAX.
+ */
+export async function makeNumberImage(
+  dir: string,
+  name: string,
+  label: string,
+  bigPixels = false,
+): Promise<string> {
+  const magick = findImageMagick();
+  if (!magick) {
+    throw new Error("ImageMagick unavailable");
+  }
+  const out = path.join(dir, name);
+  const size = bigPixels ? "1600x900" : "200x100";
+  const pointsize = bigPixels ? "220" : "48";
+  await execFileAsync(magick, [
+    "-size",
+    size,
+    "xc:white",
+    "-fill",
+    "black",
+    "-pointsize",
+    pointsize,
+    "-gravity",
+    "center",
+    "-annotate",
+    "0",
+    label,
+    out,
+  ]);
+  return out;
+}
+
+/**
+ * Locate ImageMagick: `IMAGEMAGICK_PATH` first, then the usual install roots.
+ *
+ * Mirrors `findFfmpeg`'s env-override-then-fixed-paths order, so an unusual
+ * install can be pointed at rather than making the caller skip. It stops short
+ * of `findFfmpeg`'s bare-name PATH fallback on purpose: that one is safe
+ * because `hasFfmpeg()` proves the binary runs before anything relies on it,
+ * and there is no equivalent probe here — returning "magick" on a machine
+ * without it would turn a clean skip into a spawn failure mid-fixture.
+ */
+export function findImageMagick(): string | null {
+  const explicit = process.env.IMAGEMAGICK_PATH;
+  if (explicit && fs.existsSync(explicit)) {
+    return explicit;
+  }
+
+  for (const candidate of [
+    "/opt/homebrew/bin/magick",
+    "/usr/local/bin/magick",
+    "/usr/bin/magick",
+    "/opt/homebrew/bin/convert",
+    "/usr/bin/convert",
+  ]) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## The bug

Files over `SIZE_TIER_THRESHOLDS.TINY_MAX` (10 KB) are registered as lazy references and a short textual preview is injected instead of the file. For text-shaped input that trade is sound. For an image it is fatal: the preview is ~98 characters of prose, the pixels never reach the model, and the model then answers confidently about a file it has never seen.

10 KB is far below any real photo, so this affected essentially every image attached by path — an ordinary JPEG, not just unusual formats. Measured on `release`, asking *"what number is written in this image?"*:

| fixture | size | answer |
|---|---|---|
| `tiny.png` | 1.6 KB | `7391` — under the threshold, eager, correct |
| `big.png` | 11 KB | `NOTHING_RECEIVED` |
| `big.jpg` | 19 KB | `NOTHING_RECEIVED` |

## The fix

Images are always processed eagerly. This costs no extra memory: `tryRegisterFileReference` already calls `getFileBuffer()` and reads the whole file to register it — the lazy path was never lazy about *reading*, only about processing.

The eager/lazy decision reads an extension→type map that previously existed only for token estimation, where a missing entry costs a slightly-off guess. It now decides whether a file's bytes survive, so a missing entry drops the photo — and HEIC, HEIF, ICO, JPEG 2000, APNG and SVG were all missing. **HEIC is what an iPhone writes by default.** Those entries are added here.

Note HEIC/HEIF/ICO/JP2 additionally need the intake allowlist in `ImageProcessor.validateImageFormat` widened before they work end-to-end — a separate change — so this PR does not assert them.

## Why audio and video are left alone here

For audio the reason is not the one it looks like: an audio message is a metadata block (duration, codec, sample rate) on **both** paths, so making it eager changes nothing about what the model receives. That audio content never arrives at all is a separate, larger gap.

## Tests

Three end-to-end tests through `new NeuroLink()` that attach a rendered, un-guessable number and assert the model reads it back. Each asserts which side of the threshold its fixture lands on *before* the call, so they cannot drift back into testing only the easy path.

Verified to **fail without the fix and pass with it** — with the fix reverted, the two above-threshold tests fail and the sub-threshold control stays green.

- `pnpm run check` — 4815 files, 0 errors
- `pnpm run lint` — 0 errors
- `pnpm run build` — publint clean
- `test:multimodal:sdk` — 18/18 live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition for JPE, APNG, HEIC, HEIF, ICO, JP2, and JPX image formats.
  * SVG files are detected from their content, even without a reliable filename or MIME type.
  * Large images are processed correctly using filename, MIME type, metadata, and content signals.
  * Extensionless image uploads are supported when a valid MIME type is provided.

* **Bug Fixes**
  * Improved handling of misleading filenames and oversized image files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->