### PR TITLE
fix(proxy): show update check timestamp in status

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -3816,6 +3816,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         updaterRunning: false,
         latestVersion: updateState?.lastCheckVersion || null,
         lastDetectedVersion: updateState?.lastCheckVersion || null,
+        lastUpdateCheckAt: updateState?.lastCheckAt ?? null,
         installedVersion:
           updateState?.installedVersion ??
           updateState?.lastUpdateVersion ??
@@ -4022,6 +4023,11 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         if (status.latestVersion) {
           logger.always(
             `  ${chalk.bold("Latest:")}     ${chalk.cyan(`v${status.latestVersion}`)}`,
+          );
+        }
+        if (status.latestVersion && status.lastUpdateCheckAt) {
+          logger.always(
+            `  ${chalk.bold("Last update check:")} ${chalk.cyan(status.lastUpdateCheckAt)}`,
           );
         }
         if (status.installedVersion) {


### PR DESCRIPTION
## Summary
- show the persisted update-check timestamp in `neurolink proxy status`
- render it only after a version was actually observed
- leave updater execution, package discovery, routing, retries, and live proxy behavior unchanged

## Verification
- `pnpm exec prettier --check src/cli/commands/proxy.ts`
- `pnpm exec eslint src/cli/commands/proxy.ts` (0 errors; existing file-length warnings only)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- read-only local-source `proxy status` invocation against the existing running proxy
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy status now shows when update information was last checked.
  * Text output includes this timestamp when a newer version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->