### PR TITLE
fix(proxy): align update check status field

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -3816,7 +3816,7 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
         updaterRunning: false,
         latestVersion: updateState?.lastCheckVersion || null,
         lastDetectedVersion: updateState?.lastCheckVersion || null,
-        lastUpdateCheckAt: updateState?.lastCheckAt ?? null,
+        lastCheckAt: updateState?.lastCheckAt ?? null,
         installedVersion:
           updateState?.installedVersion ??
           updateState?.lastUpdateVersion ??
@@ -4025,9 +4025,9 @@ export const proxyStatusCommand: CommandModule<object, ProxyStatusArgs> = {
             `  ${chalk.bold("Latest:")}     ${chalk.cyan(`v${status.latestVersion}`)}`,
           );
         }
-        if (status.latestVersion && status.lastUpdateCheckAt) {
+        if (status.latestVersion && status.lastCheckAt) {
           logger.always(
-            `  ${chalk.bold("Last update check:")} ${chalk.cyan(status.lastUpdateCheckAt)}`,
+            `  ${chalk.bold("Last update check:")} ${chalk.cyan(status.lastCheckAt)}`,
           );
         }
         if (status.installedVersion) {


### PR DESCRIPTION
## Summary
- rename the status-only `lastUpdateCheckAt` field to `lastCheckAt`
- align CLI JSON terminology with persisted updater state and existing status API terminology
- preserve the text output and all updater/proxy behavior

## Verification
- `pnpm exec prettier --check src/cli/commands/proxy.ts`
- `pnpm exec eslint src/cli/commands/proxy.ts` (0 errors; existing file-length warnings only)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- read-only local-source `proxy status` invocation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the proxy status output to use the correct latest check timestamp label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->