### PR TITLE
fix(proxy): diagnose updater health probe failures

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -44,6 +44,7 @@ import type {
   ModelRouterInterface,
   PersistedAccountCooldown,
   ProxyGuardArgs,
+  ProxyHealthProbe,
   ProxyNeurolinkRuntime,
   ProxySpinner,
   ProxyStartApp,
@@ -839,19 +840,60 @@ async function clearOpenCodeProxySettings(
   return hadNeurolink;
 }
 
-async function isProxyHealthy(
+export async function probeProxyHealth(
   host: string,
   port: number,
   timeoutMs: number,
-): Promise<boolean> {
+): Promise<ProxyHealthProbe> {
+  const startedAt = Date.now();
   try {
     const response = await fetch(`http://${host}:${port}/health`, {
       signal: AbortSignal.timeout(timeoutMs),
     });
-    return response.ok;
-  } catch {
-    return false;
+    return {
+      healthy: response.ok,
+      durationMs: Date.now() - startedAt,
+      failure: response.ok ? null : "http_status",
+      statusCode: response.status,
+      errorCode: null,
+    };
+  } catch (error) {
+    const candidate = error as {
+      cause?: unknown;
+      code?: unknown;
+      name?: unknown;
+    };
+    const cause = candidate?.cause as { code?: unknown } | undefined;
+    const errorCode =
+      typeof candidate?.code === "string"
+        ? candidate.code
+        : typeof cause?.code === "string"
+          ? cause.code
+          : typeof candidate?.name === "string"
+            ? candidate.name
+            : null;
+    const isTimeout =
+      candidate?.name === "TimeoutError" || candidate?.name === "AbortError";
+    return {
+      healthy: false,
+      durationMs: Date.now() - startedAt,
+      failure: isTimeout ? "timeout" : "network",
+      statusCode: null,
+      errorCode,
+    };
   }
+}
+
+function formatProxyHealthProbe(probe: ProxyHealthProbe): string {
+  const details = [
+    `reason=${probe.failure ?? "none"}`,
+    `durationMs=${probe.durationMs}`,
+    probe.statusCode === null ? null : `status=${probe.statusCode}`,
+    probe.errorCode === null
+      ? null
+      : `errorCode=${sanitizeForLog(probe.errorCode)}`,
+  ].filter((detail): detail is string => detail !== null);
+  return details.join(" ");
 }
 
 async function getProxyRuntimeActivity(
@@ -4859,23 +4901,27 @@ export const proxyGuardCommand: CommandModule<object, ProxyGuardArgs> = {
     const startedAt = Date.now();
     let parentStatus = getProcessStatus(parentPid);
     let consecutiveUnhealthy = 0;
+    let lastUnhealthyProbe: ProxyHealthProbe | null = null;
 
     // Keep monitoring for as long as the parent can affect Claude settings.
     while (true) {
-      const healthy = await isProxyHealthy(host, port, 1_500);
+      const healthProbe = await probeProxyHealth(host, port, 1_500);
+      const healthy = healthProbe.healthy;
 
       if (healthy) {
         if (updaterOnly && consecutiveUnhealthy >= failureThreshold) {
           logger.always(
-            `[updater] proxy health recovered after ${consecutiveUnhealthy} failed checks`,
+            `[updater] proxy health recovered after ${consecutiveUnhealthy} failed checks; ${formatProxyHealthProbe(lastUnhealthyProbe ?? healthProbe)}`,
           );
         }
         consecutiveUnhealthy = 0;
+        lastUnhealthyProbe = null;
       } else {
         consecutiveUnhealthy += 1;
+        lastUnhealthyProbe = healthProbe;
         if (updaterOnly && consecutiveUnhealthy === failureThreshold) {
           logger.always(
-            `[updater] proxy health unavailable after ${consecutiveUnhealthy} checks; worker remains active`,
+            `[updater] proxy health unavailable after ${consecutiveUnhealthy} checks; worker remains active; ${formatProxyHealthProbe(healthProbe)}`,
           );
         }
       }

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -2154,6 +2154,15 @@ export type UpdateCheckResult = {
   updateAvailable: boolean;
 };
 
+/** Result of one local proxy health probe by the updater or fail-open guard. */
+export type ProxyHealthProbe = {
+  healthy: boolean;
+  durationMs: number;
+  failure: "http_status" | "network" | "timeout" | null;
+  statusCode: number | null;
+  errorCode: string | null;
+};
+
 /** Parsed major.minor.patch components of a semver string. */
 export type SemVer = {
   major: number;

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -32,6 +32,7 @@ import { markProxyReady } from "../src/lib/proxy/proxyHealth.js";
 import { __testHooks } from "../src/lib/server/routes/claudeProxyRoutes.js";
 import {
   createProxyStartApp,
+  probeProxyHealth,
   sanitizeProxyStatusTerminalErrorMessage,
 } from "../src/cli/commands/proxy.js";
 import { StateFileManager } from "../src/cli/utils/serverUtils.js";
@@ -112,6 +113,68 @@ describe("proxy runtime activity", () => {
 
     expect(upstreamReason).toBe(reason);
     expect(getProxyActivitySnapshot().activeRequests).toBe(0);
+  });
+});
+
+describe("proxy updater health probes", () => {
+  it("reports a healthy response with its status and duration", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const result = await probeProxyHealth("127.0.0.1", 55669, 1_500);
+
+    expect(result.healthy).toBe(true);
+    expect(result.failure).toBeNull();
+    expect(result.statusCode).toBe(200);
+    expect(result.errorCode).toBeNull();
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("preserves non-OK HTTP status without treating it as a transport failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+
+    await expect(
+      probeProxyHealth("127.0.0.1", 55669, 1_500),
+    ).resolves.toMatchObject({
+      healthy: false,
+      failure: "http_status",
+      statusCode: 503,
+      errorCode: null,
+    });
+  });
+
+  it("preserves the low-level network code from a fetch cause", async () => {
+    const error = Object.assign(new TypeError("fetch failed"), {
+      cause: { code: "ENOTFOUND" },
+    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
+
+    await expect(
+      probeProxyHealth("127.0.0.1", 55669, 1_500),
+    ).resolves.toMatchObject({
+      healthy: false,
+      failure: "network",
+      statusCode: null,
+      errorCode: "ENOTFOUND",
+    });
+  });
+
+  it("classifies an aborted health request as a timeout", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new DOMException("The operation timed out", "TimeoutError"),
+    );
+
+    await expect(
+      probeProxyHealth("127.0.0.1", 55669, 1_500),
+    ).resolves.toMatchObject({
+      healthy: false,
+      failure: "timeout",
+      statusCode: null,
+      errorCode: "TimeoutError",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- classify updater health probes as HTTP status, timeout, or network failure
- record elapsed time, HTTP status, and safe low-level network code in threshold and recovery logs
- preserve the existing health decision and updater-only no-replacement behavior

## Verification
- `pnpm exec vitest run test/proxyUpdaterFallback.test.ts test/proxyReliabilityHardening.test.ts` (134 passed)
- `pnpm exec prettier --check src/cli/commands/proxy.ts src/lib/types/proxy.ts test/proxyUpdaterFallback.test.ts`
- `pnpm exec eslint src/cli/commands/proxy.ts src/lib/types/proxy.ts test/proxyUpdaterFallback.test.ts` (0 errors; existing file-length warnings only)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed proxy health diagnostics, including response status, check duration, failure category, and transport error codes.
  * Proxy recovery and failure messages now provide clearer diagnostic details.

* **Bug Fixes**
  * Improved handling and reporting of non-success responses, network failures, nested connection errors, and timeouts.

* **Tests**
  * Added coverage for successful checks, HTTP failures, network errors, and cancelled requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->