### PR TITLE
fix(proxy): attribute runtime errors internally

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -124,6 +124,7 @@ import packageJson from "../../../package.json" with { type: "json" };
 const _require = createRequire(import.meta.url);
 const PROXY_VERSION = packageJson.version;
 const PROXY_INTERNAL_ACCOUNT_LABEL = "proxy/internal";
+const PROXY_INTERNAL_ACCOUNT_TYPE = "internal";
 
 const PROXY_TELEMETRY_SCRIPT_PATH = fileURLToPath(
   new URL(
@@ -1706,13 +1707,18 @@ export async function createProxyStartApp(params: {
   ): Promise<void> => {
     const clientMessage = options?.clientMessage ?? errorMessage;
     const clientErrorType = options?.clientErrorType ?? errorType;
-    recordFinalError(status, undefined, undefined, {
-      requestId: metadata.requestId,
-      errorType,
-      errorCode: options?.errorCode,
-      terminalOutcome: "handler_error",
-      message: errorMessage,
-    });
+    recordFinalError(
+      status,
+      PROXY_INTERNAL_ACCOUNT_LABEL,
+      PROXY_INTERNAL_ACCOUNT_TYPE,
+      {
+        requestId: metadata.requestId,
+        errorType,
+        errorCode: options?.errorCode,
+        terminalOutcome: "handler_error",
+        message: errorMessage,
+      },
+    );
     await Promise.all([
       logRequest({
         timestamp: new Date().toISOString(),

--- a/test/proxyUpdaterFallback.test.ts
+++ b/test/proxyUpdaterFallback.test.ts
@@ -40,6 +40,7 @@ import { openProxyWorkerLog } from "../src/lib/proxy/workerLog.js";
 import { __testHooks as openAIProxyTestHooks } from "../src/lib/server/routes/openaiProxyRoutes.js";
 import {
   getStats,
+  getTerminalErrors,
   recordAttempt,
   recordAttemptError,
   recordFinalError,
@@ -224,6 +225,11 @@ describe("proxy runtime error finalization", () => {
       error: { type: "api_error", message: "Proxy internal error" },
     });
     expect(getStats()).toMatchObject({ totalRequests: 1, totalErrors: 1 });
+    expect(getTerminalErrors().recent.at(-1)).toMatchObject({
+      account: "proxy/internal",
+      accountType: "internal",
+      errorType: "unhandled_proxy_error",
+    });
     expect(getProxyActivitySnapshot().activeRequests).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- persist top-level runtime failures under `proxy/internal` instead of leaving the terminal journal account unset
- keep account rows and durable terminal details consistent
- add a regression assertion for the generic 502 path

## Validation
- `pnpm exec vitest run test/proxyUpdaterFallback.test.ts test/proxyReliabilityHardening.test.ts`
- `pnpm exec prettier --check src/cli/commands/proxy.ts test/proxyUpdaterFallback.test.ts`
- `pnpm exec eslint src/cli/commands/proxy.ts test/proxyUpdaterFallback.test.ts` (existing max-lines warnings only)
- `pnpm exec tsc --noEmit --project tsconfig.cli.json`
- `git diff --check`

No live proxy process, configuration, or traffic was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for unexpected proxy failures by assigning a clear internal account identity and error type.
  * Terminal errors from failed adapters are now recorded consistently for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->