### PR TITLE
fix(proxy): ignore stale quota cooldowns

### DIFF
--- a/src/lib/proxy/accountQuota.ts
+++ b/src/lib/proxy/accountQuota.ts
@@ -52,10 +52,11 @@ export function getUnifiedRateLimitStatus(
 
 /**
  * Whether Anthropic explicitly permits a request to use overage after a
- * subscription window is exhausted. Fresh responses require all three
- * provider signals. Older persisted snapshots predate the raw fallback and
- * upgrade-path fields, but retain a positive fallback percentage together with
- * an allowed overage status, which is the equivalent provider state.
+ * subscription window is exhausted. An active overage signal is authoritative;
+ * otherwise fresh responses require explicit fallback and upgrade-path signals.
+ * Older persisted snapshots predate those raw fields, but retain a positive
+ * fallback percentage together with an allowed overage status, which is the
+ * equivalent provider state.
  */
 export function isQuotaOverageAvailable(
   quota:
@@ -64,6 +65,7 @@ export function isQuotaOverageAvailable(
         | "fallbackPercentage"
         | "fallbackStatus"
         | "overageStatus"
+        | "overageInUse"
         | "upgradePaths"
       >
     | null
@@ -71,6 +73,9 @@ export function isQuotaOverageAvailable(
 ): boolean {
   if (quota?.overageStatus?.trim().toLowerCase() !== "allowed") {
     return false;
+  }
+  if (quota.overageInUse === true) {
+    return true;
   }
   const explicitFallback = quota.fallbackStatus?.trim().toLowerCase();
   const hasExplicitOveragePath = (quota.upgradePaths ?? "")
@@ -124,6 +129,9 @@ export function parseQuotaHeaders(
     upgradePaths: getHeader(headers, `${P}unified-upgrade-paths`),
     overageStatus:
       getHeader(headers, `${P}unified-overage-status`) ?? "unknown",
+    overageInUse:
+      getHeader(headers, `${P}unified-overage-in-use`)?.trim().toLowerCase() ===
+      "true",
     lastUpdated: Date.now(),
     source: "headers",
   };

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -144,6 +144,9 @@ function routingCandidateValue(
         candidate[field] !== undefined &&
         !isNullableString(candidate[field]),
     ) ||
+    ("quotaStale" in candidate &&
+      candidate.quotaStale !== undefined &&
+      typeof candidate.quotaStale !== "boolean") ||
     ("overageEligible" in candidate &&
       candidate.overageEligible !== undefined &&
       typeof candidate.overageEligible !== "boolean") ||
@@ -165,6 +168,7 @@ function routingCandidateValue(
     usable: candidate.usable as boolean,
     saturated: candidate.saturated as boolean,
     quotaObserved: candidate.quotaObserved as boolean,
+    quotaStale: candidate.quotaStale === true,
     quotaLastUpdated: candidate.quotaLastUpdated as number | null,
     quotaAgeMs: candidate.quotaAgeMs as number | null,
     coolingActive: candidate.coolingActive as boolean,

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -234,6 +234,10 @@ function fetchAnthropicUpstream(
 
 const accountRuntimeState = new Map<string, RuntimeAccountState>();
 
+/** Persisted quota is advisory after a restart. Older snapshots cannot reject
+ * an account or create a new cooldown because the provider may have reset it. */
+const QUOTA_SNAPSHOT_FRESHNESS_MS = 15 * 60 * 1000;
+
 /** Shared across requests so a concurrent burst gets at most two retries for
  *  the account/window, rather than every request starting its own retry chain. */
 const transientRateLimitRetryBudgets = new Map<
@@ -903,8 +907,9 @@ function reconcileCooldownFromQuota(
  * proxy restart: all accounts tie, selection falls back to token-store
  * enumeration order, and the first account served becomes self-reinforcing
  * (it alone has data) — starving the others regardless of their resets.
- * Never overwrites fresher in-memory quota; stale disk snapshots degrade
- * gracefully because past reset timestamps are ignored by resetEpochToMs.
+ * Never overwrites fresher in-memory quota. Persisted quota cannot create or
+ * clear a cooldown: only an existing cooldown or fresh upstream response
+ * headers can change admission state.
  */
 async function seedRuntimeQuotasFromDisk(
   accounts: ProxyPassthroughAccount[],
@@ -928,22 +933,6 @@ async function seedRuntimeQuotasFromDisk(
       ) {
         state.coolingUntil = persistedCooldown.coolingUntil;
         state.coolingReason = persistedCooldown.reason;
-      }
-      if (state.quota) {
-        const cooldownUpdate = reconcileCooldownFromQuota(
-          state,
-          state.quota,
-          now,
-        );
-        if (cooldownUpdate?.kind === "cooled") {
-          await saveAccountCooldown(
-            account.key,
-            cooldownUpdate.coolingUntil,
-            cooldownUpdate.coolingReason,
-          );
-        } else if (cooldownUpdate?.kind === "cleared") {
-          await clearAccountCooldown(account.key, cooldownUpdate.coolingUntil);
-        }
       }
     }
   } catch {
@@ -1179,51 +1168,64 @@ function accountSortMetrics(
 ): ProxyAccountSortMetrics {
   const st = accountRuntimeState.get(accountKey);
   const q = st?.quota;
+  const quotaLastUpdated =
+    q && Number.isFinite(q.lastUpdated) ? q.lastUpdated : null;
+  const quotaAgeMs =
+    quotaLastUpdated === null ? null : Math.max(0, now - quotaLastUpdated);
+  const quotaStale =
+    quotaAgeMs !== null && quotaAgeMs > QUOTA_SNAPSHOT_FRESHNESS_MS;
+  const routingQuota = quotaStale ? undefined : q;
   const coolingActive = !!st?.coolingUntil && now < st.coolingUntil;
   // resetEpochToMs returns undefined for absent OR passed resets, so a
   // ticking window is exactly "reset !== undefined".
-  const weeklyReset = resetEpochToMs(q?.weeklyResetAt, now);
-  const sessionReset = resetEpochToMs(q?.sessionResetAt, now);
+  const weeklyReset = resetEpochToMs(routingQuota?.weeklyResetAt, now);
+  const sessionReset = resetEpochToMs(routingQuota?.sessionResetAt, now);
   const sessionTicking = sessionReset !== undefined;
   const weeklyTicking = weeklyReset !== undefined;
-  const sessionUsed = q ? (sessionTicking ? (q.sessionUsed ?? 0) : 0) : null;
-  const weeklyUsed = q ? (weeklyTicking ? (q.weeklyUsed ?? null) : 0) : null;
-  const sessionStatus = q
+  const sessionUsed = routingQuota
     ? sessionTicking
-      ? (q.sessionStatus ?? "unknown")
-      : "allowed"
+      ? (routingQuota.sessionUsed ?? 0)
+      : 0
     : null;
-  const weeklyStatus = q
+  const weeklyUsed = routingQuota
     ? weeklyTicking
-      ? (q.weeklyStatus ?? "unknown")
+      ? (routingQuota.weeklyUsed ?? null)
+      : 0
+    : null;
+  const sessionStatus = routingQuota
+    ? sessionTicking
+      ? (routingQuota.sessionStatus ?? "unknown")
       : "allowed"
     : null;
-  const overageEligible = isQuotaOverageAvailable(q);
+  const weeklyStatus = routingQuota
+    ? weeklyTicking
+      ? (routingQuota.weeklyStatus ?? "unknown")
+      : "allowed"
+    : null;
+  const overageEligible = isQuotaOverageAvailable(routingQuota);
   const saturated =
     sessionStatus === "throttled" ||
     (sessionTicking && (sessionUsed ?? 0) >= sessionSoftLimit);
-  const quotaLastUpdated =
-    q && Number.isFinite(q.lastUpdated) ? q.lastUpdated : null;
   return {
     usable:
       !coolingActive &&
       weeklyStatus !== "rejected" &&
       (sessionStatus !== "rejected" || overageEligible) &&
-      (q?.unifiedStatus?.trim().toLowerCase() !== "rejected" ||
+      (routingQuota?.unifiedStatus?.trim().toLowerCase() !== "rejected" ||
         overageEligible),
-    saturated,
-    hasQuota: !!q,
+    saturated: !quotaStale && saturated,
+    hasQuota: !!routingQuota,
+    quotaStale,
     quotaLastUpdated,
-    quotaAgeMs:
-      quotaLastUpdated === null ? null : Math.max(0, now - quotaLastUpdated),
+    quotaAgeMs,
     coolingActive,
     coolingReason: st?.coolingReason ?? null,
     coolingUntil: st?.coolingUntil ?? 0,
-    unifiedStatus: q?.unifiedStatus ?? null,
-    fallbackStatus: q?.fallbackStatus ?? null,
-    upgradePaths: q?.upgradePaths ?? null,
+    unifiedStatus: routingQuota?.unifiedStatus ?? null,
+    fallbackStatus: routingQuota?.fallbackStatus ?? null,
+    upgradePaths: routingQuota?.upgradePaths ?? null,
     overageEligible,
-    overageStatus: q?.overageStatus ?? null,
+    overageStatus: routingQuota?.overageStatus ?? null,
     sessionStatus,
     sessionUsed,
     sessionResetBucket: sessionTicking
@@ -1408,6 +1410,7 @@ function buildRoutingDecision(args: {
       usable: metrics.usable,
       saturated: metrics.saturated,
       quotaObserved: metrics.hasQuota,
+      quotaStale: metrics.quotaStale,
       quotaLastUpdated: metrics.quotaLastUpdated,
       quotaAgeMs: metrics.quotaAgeMs,
       coolingActive: metrics.coolingActive,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -527,6 +527,7 @@ export type ProxyAccountRoutingCandidate = {
   usable: boolean;
   saturated: boolean;
   quotaObserved: boolean;
+  quotaStale: boolean;
   quotaLastUpdated: number | null;
   quotaAgeMs: number | null;
   coolingActive: boolean;
@@ -567,6 +568,7 @@ export type ProxyAccountSortMetrics = {
   usable: boolean;
   saturated: boolean;
   hasQuota: boolean;
+  quotaStale: boolean;
   quotaLastUpdated: number | null;
   quotaAgeMs: number | null;
   coolingActive: boolean;
@@ -1102,6 +1104,8 @@ export type AccountQuota = {
   upgradePaths?: string;
   /** "allowed" | "rejected" */
   overageStatus: string;
+  /** Whether Anthropic reports that paid overage is actively serving traffic. */
+  overageInUse?: boolean;
   /** Epoch ms when we last captured this data */
   lastUpdated: number;
   /** Dynamic per-plan limit buckets from the usage API `limits[]` array

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -1728,6 +1728,25 @@ describe("authoritative unified rate-limit handling", () => {
     ).toBe(false);
   });
 
+  it("recognizes an active provider overage credit path without a fallback header", () => {
+    const quota = parseQuotaHeaders(
+      new Headers({
+        "anthropic-ratelimit-unified-5h-utilization": "1.0",
+        "anthropic-ratelimit-unified-7d-utilization": "0.4",
+        "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+        "anthropic-ratelimit-unified-overage-status": "allowed",
+        "anthropic-ratelimit-unified-overage-in-use": "true",
+      }),
+    );
+
+    expect(quota).toMatchObject({
+      fallbackStatus: "unknown",
+      overageStatus: "allowed",
+      overageInUse: true,
+    });
+    expect(isQuotaOverageAvailable(quota)).toBe(true);
+  });
+
   it("keeps absent upgrade paths nullable for routing diagnostics", () => {
     const quota = parseQuotaHeaders(
       new Headers({
@@ -1888,7 +1907,7 @@ describe("cooldown persistence", () => {
     expect(await loadAccountCooldowns()).not.toHaveProperty("anthropic:a");
   });
 
-  it("clears a legacy session cooldown when persisted quota permits overage", async () => {
+  it("does not clear an existing cooldown from persisted quota alone", async () => {
     const dir = await mkdtemp(join(tmpdir(), "neurolink-overage-seed-"));
     tempDirs.push(dir);
     const cooldownPath = join(dir, "account-cooldowns.json");
@@ -1926,10 +1945,71 @@ describe("cooldown persistence", () => {
     ]);
 
     expect(__testHooks.getAccountRuntimeState("anthropic:a")).toMatchObject({
-      coolingUntil: undefined,
-      coolingReason: undefined,
+      coolingUntil,
+      coolingReason: "session",
     });
+    expect(await loadAccountCooldowns()).toHaveProperty("anthropic:a");
+  });
+
+  it("does not create a cooldown or reject routing from a stale quota snapshot", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-stale-quota-"));
+    tempDirs.push(dir);
+    const cooldownPath = join(dir, "account-cooldowns.json");
+    const quotaPath = join(dir, "account-quotas.json");
+    const now = Date.now();
+
+    initAccountCooldown(cooldownPath);
+    initAccountQuota(quotaPath);
+    await saveAccountQuota("a", {
+      unifiedStatus: "rejected",
+      sessionUsed: 1,
+      sessionStatus: "rejected",
+      sessionResetAt: Math.floor((now + 60 * 60_000) / 1000),
+      weeklyUsed: 1,
+      weeklyStatus: "rejected",
+      weeklyResetAt: Math.floor((now + 24 * 60 * 60_000) / 1000),
+      fallbackPercentage: 0.5,
+      fallbackStatus: "unknown",
+      overageStatus: "allowed",
+      lastUpdated: now - 16 * 60_000,
+    });
+    await flushAccountQuotaStateForTests();
+
+    __testHooks.resetAllRuntimeState();
+    initAccountCooldown(cooldownPath);
+    initAccountQuota(quotaPath);
+    await __testHooks.seedRuntimeQuotasFromDisk([
+      {
+        key: "anthropic:a",
+        label: "a",
+        token: "test-token",
+        type: "oauth",
+      },
+    ]);
+
+    const runtimeState = __testHooks.getAccountRuntimeState("anthropic:a");
+    expect(runtimeState).not.toHaveProperty("coolingUntil");
+    expect(runtimeState).not.toHaveProperty("coolingReason");
     expect(await loadAccountCooldowns()).not.toHaveProperty("anthropic:a");
+    expect(
+      __testHooks.buildQuotaRoutingDecision(
+        [
+          {
+            key: "anthropic:a",
+            label: "a",
+            token: "test-token",
+            type: "oauth",
+          },
+        ],
+        now,
+        "anthropic:a",
+      )?.candidates[0],
+    ).toMatchObject({
+      usable: true,
+      quotaObserved: false,
+      quotaStale: true,
+      unifiedStatus: null,
+    });
   });
 
   it("preserves concurrent first writes while the persisted cache loads", async () => {


### PR DESCRIPTION
## Root cause

The worker rehydrated `account-quotas.json` after a restart, then treated persisted `rejected` quota statuses as current upstream evidence. This could create fresh cooldowns from stale snapshots without sending a request. In the observed incident, the configured NeuroLink account snapshot was five days old and was immediately cooled despite having current availability.

## Changes

- Startup quota hydration no longer creates or clears account cooldowns. Only persisted cooldowns and fresh upstream headers affect admission state.
- Quota snapshots older than 15 minutes are retained for diagnostics but are excluded from routing, saturation, and usability decisions.
- Routing evidence now marks such records with `quotaStale: true`; offline analysis accepts historical records that do not contain the new field.
- Parse Anthropic `unified-overage-in-use`; when paired with `overage-status: allowed`, it keeps the account eligible even when the fallback header is absent.

## Validation

- `pnpm exec vitest run test/proxyReliabilityHardening.test.ts test/proxyAnalysis.test.ts test/proxyUpdaterFallback.test.ts test/proxyUsageStatsPersistence.test.ts` (163 passing)
- `pnpm run test:proxy-limit-headers` (18 passing)
- `pnpm exec prettier --check ...`
- `pnpm exec tsc --noEmit`
- `git diff --check`

No live proxy files, processes, configuration, or traffic were touched for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota handling when paid overage is actively in use.
  * Prevented outdated quota snapshots from incorrectly blocking account routing.
  * Preserved active cooldowns when restoring persisted quota information.
  * Improved compatibility with legacy quota data.
  * Ensured invalid quota freshness values do not affect routing decisions.

* **Improvements**
  * Added quota freshness indicators and age information to routing decisions.
  * More accurately reports account availability, utilization, and saturation using current quota data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->