### PR TITLE
fix(archive): bound gzip decompression at the decoder

### DIFF
--- a/src/lib/processors/archive/ArchiveProcessor.ts
+++ b/src/lib/processors/archive/ArchiveProcessor.ts
@@ -183,6 +183,19 @@ const SINGLE_STREAM_TOOLS: Record<"bz2" | "xz" | "zst", string> = {
   zst: "zstd",
 };
 
+/**
+ * Whether a zlib rejection is the output bound firing rather than bad input.
+ *
+ * `maxOutputLength` aborts an inflate the moment its output would pass the cap,
+ * which is the whole point — but it surfaces as a plain `RangeError`, and a
+ * bomb reported as "failed to decompress" reads as a corrupt upload and invites
+ * the user to send it again. It will fail identically every time.
+ *
+ * Keyed on `code`, not the message: the message embeds a byte count.
+ */
+const isDecompressionBoundExceeded = (error: unknown): boolean =>
+  (error as NodeJS.ErrnoException | null)?.code === "ERR_BUFFER_TOO_LARGE";
+
 /** File extensions recognized as archive formats */
 const SUPPORTED_ARCHIVE_EXTENSIONS = [".zip", ".tar", ".gz", ".tgz", ".bz2", ".tbz2", ".jar", ".xz", ".txz", ".zst", ".tzst"] as const;
 
@@ -894,20 +907,16 @@ export class ArchiveProcessor extends BaseFileProcessor<ProcessedArchive> {
       const { promisify } = await import("util");
       const gunzip = promisify(zlib.gunzip);
 
-      const decompressed = await gunzip(buffer);
+      // Bounded at the decoder, matching the zstd path. Checking the length
+      // afterwards only reports a bomb once it has already been paid for: 40KB
+      // of gzip inflates to 40MB, and the allocation is the damage, not the
+      // number. `maxOutputLength` abandons the inflate at the cap instead, so
+      // the ceiling on memory is the limit rather than whatever the attacker
+      // chose. The overflow is classified in the catch below.
+      const decompressed = await gunzip(buffer, {
+        maxOutputLength: ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE,
+      });
       const tarBuffer = Buffer.from(decompressed);
-
-      // Security: check decompressed size
-      if (tarBuffer.length > ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE) {
-        return {
-          success: false,
-          entries: [],
-          securityWarnings: [],
-          error: this.createError(FileErrorCode.SECURITY_VALIDATION_FAILED, {
-            reason: `Decompressed TAR size (${this.formatSizeMB(tarBuffer.length)} MB) exceeds limit (${this.formatSizeMB(ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE)} MB)`,
-          }),
-        };
-      }
 
       // Security: check compression ratio
       if (buffer.length > 0) {
@@ -928,6 +937,16 @@ export class ArchiveProcessor extends BaseFileProcessor<ProcessedArchive> {
       const tarStream = await import("tar-stream");
       return await this.parseTarStream(tarStream, tarBuffer);
     } catch (error) {
+      if (isDecompressionBoundExceeded(error)) {
+        return {
+          success: false,
+          entries: [],
+          securityWarnings: [],
+          error: this.createError(FileErrorCode.SECURITY_VALIDATION_FAILED, {
+            reason: `Decompressed TAR size exceeds limit (${this.formatSizeMB(ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE)} MB)`,
+          }),
+        };
+      }
       // Check if the error is one we already created (security validation)
       if (
         error &&
@@ -1165,19 +1184,11 @@ export class ArchiveProcessor extends BaseFileProcessor<ProcessedArchive> {
       const { promisify } = await import("util");
       const gunzip = promisify(zlib.gunzip);
 
-      const decompressed = await gunzip(buffer);
-
-      // Security: check decompressed size
-      if (decompressed.length > ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE) {
-        return {
-          success: false,
-          entries: [],
-          securityWarnings: [],
-          error: this.createError(FileErrorCode.SECURITY_VALIDATION_FAILED, {
-            reason: `Decompressed size (${this.formatSizeMB(decompressed.length)} MB) exceeds limit (${this.formatSizeMB(ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE)} MB)`,
-          }),
-        };
-      }
+      // Bounded at the decoder — see the matching call in extractTarGzEntries.
+      // The overflow is classified in the catch below.
+      const decompressed = await gunzip(buffer, {
+        maxOutputLength: ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE,
+      });
 
       // Security: compression ratio
       if (buffer.length > 0) {
@@ -1229,6 +1240,16 @@ export class ArchiveProcessor extends BaseFileProcessor<ProcessedArchive> {
 
       return { success: true, entries, securityWarnings, contents };
     } catch (error) {
+      if (isDecompressionBoundExceeded(error)) {
+        return {
+          success: false,
+          entries: [],
+          securityWarnings: [],
+          error: this.createError(FileErrorCode.SECURITY_VALIDATION_FAILED, {
+            reason: `Decompressed size exceeds limit (${this.formatSizeMB(ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE)} MB)`,
+          }),
+        };
+      }
       return {
         success: false,
         entries: [],

--- a/test/continuous-test-suite-file-formats.ts
+++ b/test/continuous-test-suite-file-formats.ts
@@ -514,6 +514,81 @@ await test("a bytes-plus-name upload keeps the name detection routes on", async 
 });
 
 // Cleanup must precede runSuite(): it prints the summary and then calls
+await test("a gzip bomb is refused without being inflated first", async () => {
+  // The limit used to be applied to `decompressed.length`, which only exists
+  // once the whole thing has been inflated — so a 400KB upload claiming 400MB
+  // was rejected *after* allocating all 400MB. The verdict was always right;
+  // the cost was the bug. Now `maxOutputLength` abandons the inflate at the
+  // cap, so the ceiling is our limit rather than whatever the attacker picked.
+  const zlib = await import("node:zlib");
+  const { ArchiveProcessor } =
+    await import("../src/lib/processors/archive/ArchiveProcessor.js");
+  // `ARCHIVE_SECURITY` is module-private, so the limit is restated here. If it
+  // moves, this test still exercises the bound — it just stops being a 4x
+  // margin, and the assertion below says so rather than silently weakening.
+  const limit = 100 * 1024 * 1024;
+  const inflatedTarget = limit * 4;
+
+  // Streamed in chunks so building the fixture does not itself allocate the
+  // payload we are asserting never gets allocated.
+  const gz = zlib.createGzip();
+  const parts: Buffer[] = [];
+  gz.on("data", (c: Buffer) => parts.push(c));
+  const done = new Promise<void>((resolve) => gz.on("end", () => resolve()));
+  const chunk = Buffer.alloc(4 * 1024 * 1024, 0);
+  for (let written = 0; written < inflatedTarget; written += chunk.length) {
+    if (!gz.write(chunk)) {
+      await new Promise((r) => gz.once("drain", r));
+    }
+  }
+  gz.end();
+  gz.resume();
+  await done;
+  const bomb = Buffer.concat(parts);
+
+  global.gc?.();
+  const baseline = process.memoryUsage().rss;
+  let peak = baseline;
+  const sampler = setInterval(() => {
+    const rss = process.memoryUsage().rss;
+    if (rss > peak) {
+      peak = rss;
+    }
+  }, 5);
+
+  let result;
+  try {
+    result = (await new ArchiveProcessor().processFile({
+      id: "bomb",
+      name: "bomb.gz",
+      mimetype: "application/gzip",
+      size: bomb.length,
+      buffer: bomb,
+    } as never)) as { success?: boolean; error?: { code?: string } };
+  } finally {
+    clearInterval(sampler);
+  }
+
+  assert(
+    result.success !== true,
+    "the bomb was rejected rather than processed",
+  );
+  assert(
+    result.error?.code === "SECURITY_VALIDATION_FAILED",
+    "the rejection is classified as a security failure, not a corrupt-file error",
+  );
+
+  // The decisive check. Inflating to the cap costs the cap; inflating the whole
+  // payload costs four times it. A midpoint separates the two with wide margin
+  // in both directions (measured: 411MB unbounded vs 102MB bounded, cap 100MB).
+  const growthMb = (peak - baseline) / (1024 * 1024);
+  const ceilingMb = (inflatedTarget / (1024 * 1024)) * 0.5;
+  assert(
+    growthMb < ceilingMb,
+    "decompression stopped at the limit instead of materialising the whole payload",
+  );
+});
+
 // process.exit, so anything after it never runs.
 try {
   fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## The bug

`extractGzEntries` and `extractTarGzEntries` inflated a `.gz`/`.tar.gz` **in full** and then compared the result against `MAX_DECOMPRESSED_SIZE`:

```ts
const decompressed = await gunzip(buffer);        // allocate everything
if (decompressed.length > ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE) {  // then object
```

The verdict was always correct. The **cost** was the bug: a ~400KB upload that inflates to 400MB allocated all 400MB before a 100MB limit turned it away, so the memory ceiling was whatever the attacker chose rather than our limit.

This is the same decode-then-check shape as the base64 issue fixed in #1309 — and it is **live in `10.11.3`**, not confined to an unmerged branch.

## The fix

Both call sites now pass `maxOutputLength`, matching what the zstd path in the same file already did:

```ts
const decompressed = await gunzip(buffer, {
  maxOutputLength: ARCHIVE_SECURITY.MAX_DECOMPRESSED_SIZE,
});
```

Measured with a 400MB bomb driven through `ArchiveProcessor.processFile`:

| | peak RSS growth | reason reported |
| --- | --- | --- |
| `release` (`10.11.3`) | **411 MB** | `Decompressed size (400.00 MB) exceeds limit (100.00 MB)` |
| this branch | **102 MB** | `Decompressed size exceeds limit (100.00 MB)` |

Same rejection either way; the allocation is what changes. The bound stops the inflate at our limit instead of the attacker's number.

### Error classification

`maxOutputLength` surfaces as a bare `RangeError` (`code: ERR_BUFFER_TOO_LARGE`, verified empirically). Without handling, a bomb would report as `DECOMPRESSION_FAILED` — *"failed to decompress"* — which reads as a corrupt upload and invites the user to send it again, when it will fail identically every time. A `code`-keyed classifier keeps it as `SECURITY_VALIDATION_FAILED`, matching the existing `isMissingTool`/`isTooLarge` idiom in this file.

### Deliberate consequences

- **The post-inflate size checks are removed, not left in place.** With the bound at the same limit, `> MAX` became unreachable; dead code shaped like a security guard is worse than none.
- **The message no longer names the actual inflated size.** Reporting "400.00 MB" required having materialised 400MB — that number was only available *because* of the bug.

## Scope — what this does not do

This bounds a **single decompression**, not total process memory. Many concurrent requests can still each allocate up to the limit. That is a concurrency-level concern and deliberately out of scope here; flagging it so the fix is not read as more than it is.

The zip and tar entry-extraction paths were not audited for the same shape in this PR.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm run check` | 4819 files, 0 errors, 0 warnings |
| `prettier --check .` | clean |
| `test:file-formats` **with** fix | 60 passed / 9 skipped / PASS |
| `test:file-formats` **without** fix | `✗` **RESULT: FAIL** |

The regression test asserts on measured memory growth (2x margin either side of the observed 411MB/102MB split) plus the security classification — not on message text. Per the repo's harness guidance it was confirmed to report `✗` and fail against the unfixed code, rather than being downgraded to a skip.

Fixture is built by streaming chunks through gzip, so creating it does not itself allocate the payload the test asserts never gets allocated.

## Provenance

Found while replying to review threads on #1309. Yama flagged the **zstd** path as unbounded — it was already bounded, and gzip, which it cited as the correct example, was the one with the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against oversized decompressed archive contents.
  * TAR.GZ and GZIP extraction now stop safely when output exceeds configured limits and return a security validation error.
  * Prevented highly compressed files from consuming excessive memory during extraction.

* **Tests**
  * Added regression coverage verifying oversized compressed payloads are rejected without full inflation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->