### PR TITLE
fix(processors): report an oversized OpenDocument as too large, not failed

### DIFF
--- a/src/lib/processors/base/BaseFileProcessor.ts
+++ b/src/lib/processors/base/BaseFileProcessor.ts
@@ -103,6 +103,34 @@ function isDownloadTooLarge(error: unknown): boolean {
   );
 }
 
+/**
+ * Marker on the error raised when a processor refuses content for exceeding
+ * the size limit *after* the download — a ZIP entry that expands past the
+ * bound, say.
+ *
+ * Separate from DOWNLOAD_TOO_LARGE because the two fire at different stages,
+ * but it exists for the same reason. Without it a bound that fires reaches
+ * `buildProcessedResultWithResult` as a plain Error and becomes
+ * PROCESSING_FAILED, which is `retryable: true` — so a caller retries a
+ * deterministic refusal three times and gets the identical answer each time.
+ * FILE_TOO_LARGE is `retryable: false`, which is the truth about this failure.
+ */
+export const CONTENT_TOO_LARGE_CODE = "CONTENT_TOO_LARGE";
+
+/** An error that a processor's own size bound was exceeded. */
+export function contentTooLargeError(message: string): Error {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = CONTENT_TOO_LARGE_CODE;
+  return error;
+}
+
+/** Whether `error` is a processor size bound firing rather than a fault. */
+export function isContentTooLarge(error: unknown): boolean {
+  return (
+    (error as NodeJS.ErrnoException | null)?.code === CONTENT_TOO_LARGE_CODE
+  );
+}
+
 /** Node's signal that a zlib output bound was reached. */
 function isBufferTooLargeError(error: unknown): boolean {
   return (
@@ -454,6 +482,23 @@ export abstract class BaseFileProcessor<T extends ProcessedFileBase> {
       const result = await this.buildProcessedResult(buffer, fileInfo);
       return { success: true, data: result };
     } catch (error) {
+      // A size bound firing is a verdict, not a fault: PROCESSING_FAILED is
+      // retryable, and re-running a decompression that will hit the same
+      // ceiling is the one thing worth not doing three times.
+      if (isContentTooLarge(error)) {
+        return {
+          success: false,
+          // Same detail keys as the other FILE_TOO_LARGE sites, so anything
+          // reading them does not have to special-case where the verdict came
+          // from. `sizeMB` is absent on purpose: the decompressed size is the
+          // number this bound exists to never find out.
+          error: this.createError(FileErrorCode.FILE_TOO_LARGE, {
+            maxMB: this.config.maxSizeMB,
+            type: this.config.fileTypeName,
+            reason: error instanceof Error ? error.message : undefined,
+          }),
+        };
+      }
       return {
         success: false,
         error: this.createError(

--- a/src/lib/processors/document/OpenDocumentProcessor.ts
+++ b/src/lib/processors/document/OpenDocumentProcessor.ts
@@ -10,7 +10,11 @@
 import { createRequire } from "node:module";
 import * as zlib from "node:zlib";
 
-import { BaseFileProcessor } from "../base/BaseFileProcessor.js";
+import {
+  BaseFileProcessor,
+  contentTooLargeError,
+  isContentTooLarge,
+} from "../base/BaseFileProcessor.js";
 import { readZipEntryWithinLimit } from "../archive/zipEntryReader.js";
 import type {
   FileInfo,
@@ -99,8 +103,11 @@ export class OpenDocumentProcessor extends BaseFileProcessor<ProcessedOpenDocume
           zlib,
         );
         if (read.status === "too-large") {
-          throw new Error(
-            `content.xml exceeds the ${SIZE_LIMITS.DOCUMENT_MAX_MB}MB limit for OpenDocument content`,
+          // Coded, so the bound surfaces as FILE_TOO_LARGE (not retryable)
+          // rather than PROCESSING_FAILED (retryable). The file will be
+          // exactly as oversized on the next attempt.
+          throw contentTooLargeError(
+            `content.xml in "${this.getFilename(fileInfo)}" exceeds the ${SIZE_LIMITS.DOCUMENT_MAX_MB}MB limit for OpenDocument content`,
           );
         }
         if (read.status !== "ok") {
@@ -122,6 +129,13 @@ export class OpenDocumentProcessor extends BaseFileProcessor<ProcessedOpenDocume
         throw new Error("content.xml not found in OpenDocument archive");
       }
     } catch (error) {
+      // A size verdict passes through intact. Re-wrapping it as a plain Error
+      // drops the code, and the base class then reports PROCESSING_FAILED —
+      // which is retryable, so the caller would refetch and decompress a file
+      // guaranteed to be exactly as oversized.
+      if (isContentTooLarge(error)) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Failed to extract OpenDocument content: ${message}`, {
         cause: error,


### PR DESCRIPTION
Follow-up to #1327, from Copilot's and CodeRabbit's review on it. Both findings were real.

## The bound reported a retryable error

`OpenDocumentProcessor` threw a plain `Error` when `content.xml` exceeded the limit. That reaches `buildProcessedResultWithResult` and becomes **`PROCESSING_FAILED`, which is `retryable: true`** — so a caller retries a deterministic refusal, refetching and re-decompressing a file that will be exactly as oversized next time. `FILE_TOO_LARGE` is `retryable: false`, and it is already the verdict the download path gives for the same condition.

Worth being blunt about how this got in: the probe output in #1327 said `code=PROCESSING_FAILED` in plain text, in the same change whose commit message explained why that distinction matters on the download path. Measuring something and reading it are not the same thing.

`contentTooLargeError` / `isContentTooLarge` mirror the existing `DOWNLOAD_TOO_LARGE` pair — keyed on `code`, not message text — and the mapping lives in `buildProcessedResultWithResult` so it covers every processor rather than this one.

One wrinkle worth flagging: `OpenDocumentProcessor`'s own `catch` wrapped **every** error in a plain `Error`, which discarded the code and made the first version of this fix completely inert. It now rethrows a size verdict untouched.

## The bomb tests asserted only on memory

CodeRabbit's point, and it is the sharper of the two. A memory-only assertion **also passes when the processor never reads the bomb**. Rename the slide part and `PptxProcessor` extracts nothing, allocates nothing, and the test goes green while proving the opposite of what it claims.

That is not hypothetical — it is exactly how the first version of the pptx test behaved in #1327, with the bomb parked in `docProps/thumbnail.bin`, an entry the processor never opens. I fixed the fixture then but left the assertion open to the same trap returning.

Both bomb tests now pin the outcome: pptx asserts the refusal names the limit, odt asserts `FILE_TOO_LARGE`. The odt assertion caught the inert first attempt above, so it has already earned its place.

## Verification

- `pnpm run check` — 4821 files, 0 errors
- `prettier --check .` — clean
- `eslint` — 0 errors (50 pre-existing warnings)
- `test:office:security` — 9/9
- `test:archive:security` — 6/6, no regression from the `BaseFileProcessor` change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Files exceeding content-size limits now receive a clear “file too large” result.
  * Oversized OpenDocument files are handled consistently and include the affected filename.
  * Size-limit failures are no longer incorrectly treated as retryable processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->