### PR TITLE
fix(proxy): harden quota routing and transport retries

### DIFF
--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -50,6 +50,11 @@ function printAnalysis(
     logger.always(
       `    Attempts: ${report.attempts.total}, ${report.attempts.errors} errors${report.attempts.errors > 0 ? ` ${JSON.stringify(report.attempts.errorTypes)}` : ""}`,
     );
+    if (Object.keys(report.attempts.transportScopes).length > 0) {
+      logger.always(
+        `    Transport scopes: ${JSON.stringify(report.attempts.transportScopes)}`,
+      );
+    }
   }
   logger.always(
     report.coverage.lifecycle
@@ -81,6 +86,15 @@ function printAnalysis(
     logger.always(
       `    Selection reasons: ${JSON.stringify(report.routing.selectionReasons)}`,
     );
+    const productionQuotaProbes =
+      report.routing.selectionReasons.quota_probe ?? 0;
+    if (productionQuotaProbes > 0) {
+      logger.always(
+        chalk.yellow(
+          `    WARNING: ${productionQuotaProbes} production request(s) were selected for quota discovery`,
+        ),
+      );
+    }
     logger.always(
       `    Initial accounts: ${JSON.stringify(report.routing.initialAccounts)}`,
     );

--- a/src/lib/proxy/accountQuotaRefreshCoordinator.ts
+++ b/src/lib/proxy/accountQuotaRefreshCoordinator.ts
@@ -1,0 +1,132 @@
+import type {
+  AccountUsageFetchResult,
+  ProxyPassthroughAccount,
+  ProxyQuotaRefreshRunResult,
+  ProxyQuotaRefreshMetrics,
+  ProxyQuotaRefreshRuntimeState,
+} from "../types/index.js";
+
+const FAILURE_BACKOFF_MS = [30_000, 2 * 60_000, 10 * 60_000] as const;
+const MAX_FAILURE_BACKOFF_MS = 30 * 60_000;
+
+export class AccountQuotaRefreshCoordinator {
+  private readonly inFlight = new Map<
+    string,
+    Promise<ProxyQuotaRefreshRunResult>
+  >();
+  private readonly states = new Map<string, ProxyQuotaRefreshRuntimeState>();
+  private metrics: ProxyQuotaRefreshMetrics = {
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    coalesced: 0,
+    backoffSuppressed: 0,
+    triggerDeduplicated: 0,
+  };
+
+  getState(accountKey: string): ProxyQuotaRefreshRuntimeState {
+    const state = this.states.get(accountKey);
+    return state
+      ? { ...state, inFlight: this.inFlight.has(accountKey) }
+      : { inFlight: false, consecutiveFailures: 0, coalesced: 0 };
+  }
+
+  /**
+   * Run one refresh per account. `trigger` must identify the quota window or
+   * handoff condition so repeated requests deduplicate without hiding a later
+   * reset window.
+   */
+  run(
+    account: ProxyPassthroughAccount,
+    trigger: string,
+    fetcher: (
+      candidate: ProxyPassthroughAccount,
+    ) => Promise<AccountUsageFetchResult>,
+    options: { force?: boolean; now?: number } = {},
+  ): Promise<ProxyQuotaRefreshRunResult> {
+    const existing = this.inFlight.get(account.key);
+    if (existing) {
+      const state = this.getOrCreateState(account.key);
+      state.coalesced += 1;
+      this.metrics.coalesced += 1;
+      return existing;
+    }
+
+    const now = options.now ?? Date.now();
+    const state = this.getOrCreateState(account.key);
+    if (!options.force && state.lastCompletedTrigger === trigger) {
+      this.metrics.triggerDeduplicated += 1;
+      return Promise.resolve({ kind: "not_due" });
+    }
+    if (!options.force && now < (state.nextEligibleAt ?? 0)) {
+      this.metrics.backoffSuppressed += 1;
+      return Promise.resolve({
+        kind: "backoff",
+        nextEligibleAt: state.nextEligibleAt ?? now,
+      });
+    }
+
+    state.lastAttemptAt = now;
+    this.metrics.attempted += 1;
+    const task = fetcher(account)
+      .catch(
+        (error: unknown): AccountUsageFetchResult => ({
+          ok: false,
+          reason: "network",
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      )
+      .then((result): ProxyQuotaRefreshRunResult => {
+        const completedAt = options.now ?? Date.now();
+        if (result.ok === false) {
+          this.metrics.failed += 1;
+          state.consecutiveFailures += 1;
+          state.lastFailureReason = result.reason;
+          const backoffBase =
+            FAILURE_BACKOFF_MS[Math.max(0, state.consecutiveFailures - 1)] ??
+            MAX_FAILURE_BACKOFF_MS;
+          const jitter = 0.9 + Math.random() * 0.2;
+          state.nextEligibleAt = completedAt + Math.round(backoffBase * jitter);
+        } else {
+          this.metrics.succeeded += 1;
+          state.lastSuccessAt = completedAt;
+          state.nextEligibleAt = undefined;
+          state.consecutiveFailures = 0;
+          state.lastFailureReason = undefined;
+          state.lastCompletedTrigger = trigger;
+        }
+        return { kind: "completed", result, startedAt: now };
+      })
+      .finally(() => {
+        this.inFlight.delete(account.key);
+      });
+    this.inFlight.set(account.key, task);
+    return task;
+  }
+
+  clear(): void {
+    this.inFlight.clear();
+    this.states.clear();
+    this.metrics = {
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      coalesced: 0,
+      backoffSuppressed: 0,
+      triggerDeduplicated: 0,
+    };
+  }
+
+  getMetrics(): ProxyQuotaRefreshMetrics {
+    return { ...this.metrics };
+  }
+
+  private getOrCreateState(accountKey: string): ProxyQuotaRefreshRuntimeState {
+    let state = this.states.get(accountKey);
+    if (!state) {
+      state = { inFlight: false, consecutiveFailures: 0, coalesced: 0 };
+      this.states.set(accountKey, state);
+    }
+    return state;
+  }
+}

--- a/src/lib/proxy/accountUsage.ts
+++ b/src/lib/proxy/accountUsage.ts
@@ -1,15 +1,15 @@
 /**
  * On-Demand Account Usage Fetch
  *
- * Manual refetch path for account limits: queries Anthropic's OAuth usage
- * endpoint (the same call Claude Code's /usage makes) to get FRESH session /
- * weekly / model-scoped windows for an account without consuming any tokens
- * and without starting a 5h session window.
+ * Lightweight account-limit refresh: queries Anthropic's OAuth usage endpoint
+ * (the same call Claude Code's /usage makes) to get fresh session / weekly /
+ * model-scoped windows without consuming tokens or starting a 5h session.
  *
  * This complements — never replaces — the passive header capture in
  * accountQuota.ts: `usageToQuota` normalizes the endpoint payload into the
  * same `AccountQuota` shape so refreshed data flows through the existing
- * save/merge/cooldown chain.
+ * save/merge/cooldown chain. Manual refresh and adaptive proxy prewarming use
+ * the same transport through the route-owned single-flight coordinator.
  *
  * Only OAuth (Bearer) accounts have subscription windows; api_key accounts
  * are skipped and keep their header-derived absolute limits.

--- a/src/lib/proxy/providerTransportCoordinator.ts
+++ b/src/lib/proxy/providerTransportCoordinator.ts
@@ -1,0 +1,201 @@
+import type {
+  ProxyProviderTransportPermit,
+  ProxyProviderTransportProbeOutcome,
+} from "../types/index.js";
+import { TimeoutError, withTimeout } from "../utils/async/withTimeout.js";
+
+const SHARED_TRANSPORT_BACKOFF_MS = 250;
+const RECOVERY_PROBE_WAIT_TIMEOUT_MS = 30_000;
+
+export class ProviderTransportCoordinator {
+  private generation = 0;
+  private degraded = false;
+  private backoffUntil = 0;
+  private lastErrorCode: string | null = null;
+  private lastTransportScope:
+    | "shared_provider_transport"
+    | "connection_transport" = "shared_provider_transport";
+  private probe:
+    | {
+        generation: number;
+        promise: Promise<ProxyProviderTransportProbeOutcome>;
+        resolve: (outcome: ProxyProviderTransportProbeOutcome) => void;
+      }
+    | undefined;
+
+  async acquire(signal?: AbortSignal): Promise<ProxyProviderTransportPermit> {
+    if (!this.degraded) {
+      return { allowed: true, probe: false, generation: this.generation };
+    }
+
+    const waitMs = Math.max(0, this.backoffUntil - Date.now());
+    if (waitMs > 0) {
+      await this.wait(waitMs, signal);
+    }
+    if (!this.degraded) {
+      return { allowed: true, probe: false, generation: this.generation };
+    }
+    if (this.probe) {
+      const outcome = await this.waitForProbe(this.probe.promise, signal);
+      if (outcome === "recovered") {
+        return { allowed: true, probe: false, generation: this.generation };
+      }
+      if (outcome === "abandoned") {
+        return this.acquire(signal);
+      }
+      return {
+        allowed: false,
+        errorCode: this.lastErrorCode,
+        transportScope: this.lastTransportScope,
+      };
+    }
+
+    let resolveProbe!: (outcome: ProxyProviderTransportProbeOutcome) => void;
+    const promise = new Promise<ProxyProviderTransportProbeOutcome>(
+      (resolve) => {
+        resolveProbe = resolve;
+      },
+    );
+    this.probe = {
+      generation: this.generation,
+      promise,
+      resolve: resolveProbe,
+    };
+    return { allowed: true, probe: true, generation: this.generation };
+  }
+
+  reportSuccess(permit: ProxyProviderTransportPermit): void {
+    if (!permit.allowed || permit.generation !== this.generation) {
+      return;
+    }
+    if (permit.probe && this.probe?.generation !== permit.generation) {
+      return;
+    }
+    this.degraded = false;
+    this.backoffUntil = 0;
+    this.lastErrorCode = null;
+    this.lastTransportScope = "shared_provider_transport";
+    if (permit.probe && this.probe?.generation === permit.generation) {
+      this.probe.resolve("recovered");
+      this.probe = undefined;
+    }
+  }
+
+  reportTransportFailure(
+    errorCode: string | undefined,
+    transportScope: "shared_provider_transport" | "connection_transport",
+    permit: ProxyProviderTransportPermit,
+  ): void {
+    if (!permit.allowed || permit.generation !== this.generation) {
+      return;
+    }
+    if (permit.probe && this.probe?.generation !== permit.generation) {
+      return;
+    }
+    this.degraded = true;
+    this.backoffUntil = Date.now() + SHARED_TRANSPORT_BACKOFF_MS;
+    this.lastErrorCode = errorCode ?? null;
+    this.lastTransportScope = transportScope;
+    if (permit.probe && this.probe?.generation === permit.generation) {
+      this.probe.resolve("failed");
+      this.probe = undefined;
+    }
+    this.generation += 1;
+  }
+
+  reportProbeAbandoned(permit: ProxyProviderTransportPermit): void {
+    if (
+      !permit.allowed ||
+      !permit.probe ||
+      permit.generation !== this.generation ||
+      this.probe?.generation !== permit.generation
+    ) {
+      return;
+    }
+    this.probe.resolve("abandoned");
+    this.probe = undefined;
+    this.generation += 1;
+  }
+
+  clear(): void {
+    this.probe?.resolve("failed");
+    this.probe = undefined;
+    this.generation += 1;
+    this.degraded = false;
+    this.backoffUntil = 0;
+    this.lastErrorCode = null;
+    this.lastTransportScope = "shared_provider_transport";
+  }
+
+  private async wait(ms: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw signal.reason;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
+      const onAbort = (): void => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        reject(signal?.reason);
+      };
+      timeoutRef.current = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      timeoutRef.current.unref?.();
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  private async waitForProbe(
+    probe: Promise<ProxyProviderTransportProbeOutcome>,
+    signal?: AbortSignal,
+  ): Promise<ProxyProviderTransportProbeOutcome> {
+    const boundedProbe = withTimeout(
+      probe,
+      RECOVERY_PROBE_WAIT_TIMEOUT_MS,
+      "Anthropic transport recovery probe timed out",
+    );
+    try {
+      return await this.waitForProbeOrAbort(boundedProbe, signal);
+    } catch (error) {
+      if (error instanceof TimeoutError && this.probe?.promise === probe) {
+        this.probe.resolve("failed");
+        this.probe = undefined;
+        this.generation += 1;
+        this.backoffUntil = Date.now() + SHARED_TRANSPORT_BACKOFF_MS;
+        return "failed";
+      }
+      throw error;
+    }
+  }
+
+  private waitForProbeOrAbort(
+    probe: Promise<ProxyProviderTransportProbeOutcome>,
+    signal?: AbortSignal,
+  ): Promise<ProxyProviderTransportProbeOutcome> {
+    if (!signal) {
+      return probe;
+    }
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    return new Promise<ProxyProviderTransportProbeOutcome>(
+      (resolve, reject) => {
+        const onAbort = (): void => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+        probe.then(
+          (result) => {
+            signal.removeEventListener("abort", onAbort);
+            resolve(result);
+          },
+          (error: unknown) => {
+            signal.removeEventListener("abort", onAbort);
+            reject(error);
+          },
+        );
+      },
+    );
+  }
+}

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -39,6 +39,19 @@ const ROUTING_MODES = new Set<string>(PROXY_ACCOUNT_ROUTING_MODES);
 const ROUTING_REASONS = new Set<string>(PROXY_ACCOUNT_ROUTING_REASONS);
 const ROUTING_ACCOUNT_TYPES = new Set<string>(PROXY_ACCOUNT_TYPES);
 const COOLING_REASONS = new Set<string>(ACCOUNT_COOLING_REASONS);
+const QUOTA_FRESHNESS_VALUES = new Set([
+  "unknown",
+  "fresh",
+  "stale_known",
+  "refresh_due",
+]);
+const QUOTA_REFRESH_REASONS = new Set([
+  "startup_unknown",
+  "handoff_prewarm",
+  "ambiguous_snapshot",
+  "manual",
+]);
+const QUOTA_SATURATION_KINDS = new Set(["none", "soft", "hard"]);
 const MAX_RETAINED_ROUTING_RECORDS = 200;
 const MAX_ROUTING_RECORDS_BEFORE_COMPACTION = MAX_RETAINED_ROUTING_RECORDS * 2;
 
@@ -150,6 +163,40 @@ function routingCandidateValue(
     ("overageEligible" in candidate &&
       candidate.overageEligible !== undefined &&
       typeof candidate.overageEligible !== "boolean") ||
+    ("quotaFreshness" in candidate &&
+      candidate.quotaFreshness !== undefined &&
+      (typeof candidate.quotaFreshness !== "string" ||
+        !QUOTA_FRESHNESS_VALUES.has(candidate.quotaFreshness))) ||
+    ("refreshNeeded" in candidate &&
+      candidate.refreshNeeded !== undefined &&
+      typeof candidate.refreshNeeded !== "boolean") ||
+    ("refreshInFlight" in candidate &&
+      candidate.refreshInFlight !== undefined &&
+      typeof candidate.refreshInFlight !== "boolean") ||
+    ("refreshReason" in candidate &&
+      candidate.refreshReason !== undefined &&
+      candidate.refreshReason !== null &&
+      (typeof candidate.refreshReason !== "string" ||
+        !QUOTA_REFRESH_REASONS.has(candidate.refreshReason))) ||
+    [
+      "lastRefreshAttemptAt",
+      "lastRefreshSuccessAt",
+      "nextRefreshEligibleAt",
+    ].some(
+      (field) =>
+        field in candidate &&
+        candidate[field] !== undefined &&
+        !isNullableFiniteNumber(candidate[field]),
+    ) ||
+    ("saturationKind" in candidate &&
+      candidate.saturationKind !== undefined &&
+      (typeof candidate.saturationKind !== "string" ||
+        !QUOTA_SATURATION_KINDS.has(candidate.saturationKind))) ||
+    ("softLimitOverrideReason" in candidate &&
+      candidate.softLimitOverrideReason !== undefined &&
+      candidate.softLimitOverrideReason !== null &&
+      candidate.softLimitOverrideReason !== "overage" &&
+      candidate.softLimitOverrideReason !== "weekly_expiry") ||
     !(
       candidate.coolingReason === null ||
       (typeof candidate.coolingReason === "string" &&
@@ -169,6 +216,24 @@ function routingCandidateValue(
     saturated: candidate.saturated as boolean,
     quotaObserved: candidate.quotaObserved as boolean,
     quotaStale: candidate.quotaStale === true,
+    quotaFreshness:
+      candidate.quotaFreshness as ProxyAccountRoutingCandidate["quotaFreshness"],
+    refreshNeeded:
+      candidate.refreshNeeded as ProxyAccountRoutingCandidate["refreshNeeded"],
+    refreshReason:
+      candidate.refreshReason as ProxyAccountRoutingCandidate["refreshReason"],
+    refreshInFlight:
+      candidate.refreshInFlight as ProxyAccountRoutingCandidate["refreshInFlight"],
+    lastRefreshAttemptAt:
+      candidate.lastRefreshAttemptAt as ProxyAccountRoutingCandidate["lastRefreshAttemptAt"],
+    lastRefreshSuccessAt:
+      candidate.lastRefreshSuccessAt as ProxyAccountRoutingCandidate["lastRefreshSuccessAt"],
+    nextRefreshEligibleAt:
+      candidate.nextRefreshEligibleAt as ProxyAccountRoutingCandidate["nextRefreshEligibleAt"],
+    saturationKind:
+      candidate.saturationKind as ProxyAccountRoutingCandidate["saturationKind"],
+    softLimitOverrideReason:
+      candidate.softLimitOverrideReason as ProxyAccountRoutingCandidate["softLimitOverrideReason"],
     quotaLastUpdated: candidate.quotaLastUpdated as number | null,
     quotaAgeMs: candidate.quotaAgeMs as number | null,
     coolingActive: candidate.coolingActive as boolean,
@@ -700,6 +765,7 @@ export async function analyzeProxyLogs(
   let totalAttemptErrors = 0;
   const attemptErrorTypes: Record<string, number> = {};
   const attemptErrorCodes: Record<string, number> = {};
+  const attemptTransportScopes: Record<string, number> = {};
   let attemptRateLimits = 0;
   let transientRateLimits = 0;
   let quotaRateLimits = 0;
@@ -736,6 +802,10 @@ export async function analyzeProxyLogs(
           if (errorCode) {
             increment(attemptErrorCodes, errorCode);
           }
+        }
+        const transportScope = stringValue(record.transportScope);
+        if (transportScope) {
+          increment(attemptTransportScopes, transportScope);
         }
         const requestAttempts = attemptsByRequest.get(requestId) ?? {
           count: 0,
@@ -991,6 +1061,7 @@ export async function analyzeProxyLogs(
       errors: totalAttemptErrors,
       errorTypes: attemptErrorTypes,
       errorCodes: attemptErrorCodes,
+      transportScopes: attemptTransportScopes,
     },
     rateLimits: {
       attemptRateLimits,

--- a/src/lib/proxy/routingEvidence.ts
+++ b/src/lib/proxy/routingEvidence.ts
@@ -18,6 +18,9 @@ export const PROXY_ACCOUNT_ROUTING_REASONS = [
   "insertion_order",
   "availability",
   "cooldown_recovery",
+  "quota_evidence",
+  // Retained for backwards-compatible analysis of pre-fix logs. New routing
+  // decisions must never select a production request for quota discovery.
   "quota_probe",
   "session_headroom",
   "session_reset",

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -45,6 +45,8 @@ import {
   listAnthropicAccountsForUsage,
   usageToQuota,
 } from "../../proxy/accountUsage.js";
+import { AccountQuotaRefreshCoordinator } from "../../proxy/accountQuotaRefreshCoordinator.js";
+import { ProviderTransportCoordinator } from "../../proxy/providerTransportCoordinator.js";
 import {
   buildProxyLimitHeaders,
   summarizePoolHeadroom,
@@ -108,6 +110,7 @@ import type {
   AccountAdmissionState,
   AccountCooldownPlan,
   AccountQuota,
+  AccountUsageFetchResult,
   AnthropicAttemptLogger,
   AnthropicAuthRetryResult,
   AnthropicLoopState,
@@ -234,9 +237,12 @@ function fetchAnthropicUpstream(
 }
 
 const accountRuntimeState = new Map<string, RuntimeAccountState>();
+const accountQuotaRefreshCoordinator = new AccountQuotaRefreshCoordinator();
+const providerTransportCoordinator = new ProviderTransportCoordinator();
 
-/** Persisted quota is advisory after a restart. Older snapshots cannot reject
- * an account or create a new cooldown because the provider may have reset it. */
+/** Snapshot age is diagnostic and controls lightweight refresh eligibility. It
+ * must never discard known healthy routing evidence or trigger a user request
+ * on another account solely to rediscover quota. */
 const QUOTA_SNAPSHOT_FRESHNESS_MS = 15 * 60 * 1000;
 
 /** Shared across requests so a concurrent burst gets at most two retries for
@@ -954,6 +960,87 @@ const lastUsageFetchAt = new Map<string, number>();
 let limitsRefreshInFlight: Promise<ProxyLimitsRefreshResponse> | null = null;
 const USAGE_REFRESH_CONCURRENCY = 4;
 
+async function applyAccountUsageResult(
+  account: ProxyPassthroughAccount,
+  fetchResult: AccountUsageFetchResult,
+  observedAt: number,
+  prior?: AccountQuota | null,
+): Promise<AccountQuota | null> {
+  if (fetchResult.ok === false) {
+    return null;
+  }
+  const state = getOrCreateRuntimeState(account.key);
+  const quota = usageToQuota(fetchResult.usage, {
+    now: observedAt,
+    prior: state.quota ?? prior ?? null,
+  });
+  if (!quota) {
+    return null;
+  }
+  // The usage payload cannot be newer than the request that fetched it. A
+  // passive response captured after that request started wins, including its
+  // cooldown decision and persisted snapshot.
+  if (quota.lastUpdated < (state.quota?.lastUpdated ?? 0)) {
+    return state.quota ?? null;
+  }
+  state.quota = quota;
+  const cooldownUpdate = reconcileCooldownFromQuota(state, quota, Date.now());
+  if (cooldownUpdate?.kind === "cooled") {
+    await saveAccountCooldown(
+      account.key,
+      cooldownUpdate.coolingUntil,
+      cooldownUpdate.coolingReason,
+    ).catch(() => {
+      // Non-fatal: the cooldown is already active in memory.
+    });
+  } else if (cooldownUpdate?.kind === "cleared") {
+    await clearAccountCooldown(account.key, cooldownUpdate.coolingUntil).catch(
+      () => {
+        // Non-fatal: the next successful response will reconcile again.
+      },
+    );
+  }
+  await saveAccountQuota(account.label, quota).catch(() => {
+    // Non-fatal: quota persistence is best-effort.
+  });
+  return quota;
+}
+
+async function fetchValidatedAccountUsage(
+  account: ProxyPassthroughAccount,
+): Promise<AccountUsageFetchResult> {
+  const result = await fetchAccountUsage(account);
+  if (result.ok === false) {
+    return result;
+  }
+  const recognizable = usageToQuota(result.usage, {
+    now: Date.now(),
+    prior: accountRuntimeState.get(account.key)?.quota ?? null,
+  });
+  return recognizable
+    ? result
+    : {
+        ok: false,
+        reason: "parse",
+        error: "usage payload had no recognizable limit windows",
+      };
+}
+
+async function refreshAccountQuotaInBackground(
+  account: ProxyPassthroughAccount,
+  trigger: string,
+): Promise<void> {
+  const refresh = await accountQuotaRefreshCoordinator.run(
+    account,
+    trigger,
+    fetchValidatedAccountUsage,
+  );
+  if (refresh.kind !== "completed" || refresh.result.ok === false) {
+    return;
+  }
+  await applyAccountUsageResult(account, refresh.result, refresh.startedAt);
+}
+
 /**
  * Fetch fresh limits from Anthropic's usage endpoint for every eligible OAuth
  * account and write them through the exact same chain the passive header
@@ -1016,6 +1103,7 @@ async function refreshAccountLimits(
       results: accounts.map((account) =>
         buildResult(account, "snapshot", null),
       ),
+      refreshMetrics: accountQuotaRefreshCoordinator.getMetrics(),
     };
   }
 
@@ -1041,7 +1129,17 @@ async function refreshAccountLimits(
       // Isolate failures per account: an unexpected rejection must not abort
       // the Promise.all sweep and turn the whole /limits response into a 502.
       try {
-        const fetchResult = await fetchAccountUsage(account);
+        const refresh = await accountQuotaRefreshCoordinator.run(
+          account,
+          `manual:${account.key}`,
+          fetchValidatedAccountUsage,
+          { force: true },
+        );
+        if (refresh.kind !== "completed") {
+          results[index] = buildResult(account, "throttled", null);
+          continue;
+        }
+        const fetchResult = refresh.result;
         // `=== false` (not `!ok`) — the react-hooks sub-build compiles this
         // file without strictNullChecks, where negated boolean-discriminant
         // narrowing does not apply.
@@ -1054,12 +1152,12 @@ async function refreshAccountLimits(
           );
           continue;
         }
-        const state = getOrCreateRuntimeState(account.key);
-        const capturedAt = Date.now();
-        const quota = usageToQuota(fetchResult.usage, {
-          now: capturedAt,
-          prior: state.quota ?? persisted[account.label] ?? null,
-        });
+        const quota = await applyAccountUsageResult(
+          account,
+          fetchResult,
+          refresh.startedAt,
+          persisted[account.label] ?? null,
+        );
         if (!quota) {
           results[index] = buildResult(
             account,
@@ -1069,35 +1167,6 @@ async function refreshAccountLimits(
           );
           continue;
         }
-        // Guard against a passive header capture that landed mid-fetch: never
-        // replace a fresher runtime snapshot with an older reading.
-        if (quota.lastUpdated >= (state.quota?.lastUpdated ?? 0)) {
-          state.quota = quota;
-        }
-        const cooldownUpdate = reconcileCooldownFromQuota(
-          state,
-          quota,
-          capturedAt,
-        );
-        if (cooldownUpdate?.kind === "cooled") {
-          await saveAccountCooldown(
-            account.key,
-            cooldownUpdate.coolingUntil,
-            cooldownUpdate.coolingReason,
-          ).catch(() => {
-            // Non-fatal: cooldown is already active in memory.
-          });
-        } else if (cooldownUpdate?.kind === "cleared") {
-          await clearAccountCooldown(
-            account.key,
-            cooldownUpdate.coolingUntil,
-          ).catch(() => {
-            // Non-fatal: the next successful response will reconcile again.
-          });
-        }
-        await saveAccountQuota(account.label, quota).catch(() => {
-          // Non-fatal: quota persistence is best-effort
-        });
         results[index] = buildResult(account, "refreshed", quota);
       } catch (err) {
         results[index] = buildResult(
@@ -1115,7 +1184,12 @@ async function refreshAccountLimits(
       () => worker(),
     ),
   );
-  return { fetchedAt, snapshot: false, results };
+  return {
+    fetchedAt,
+    snapshot: false,
+    results,
+    refreshMetrics: accountQuotaRefreshCoordinator.getMetrics(),
+  };
 }
 
 /** Quota-aware selection is on by default; disable with
@@ -1173,9 +1247,33 @@ function accountSortMetrics(
     q && Number.isFinite(q.lastUpdated) ? q.lastUpdated : null;
   const quotaAgeMs =
     quotaLastUpdated === null ? null : Math.max(0, now - quotaLastUpdated);
+  const refreshState = accountQuotaRefreshCoordinator.getState(accountKey);
   const quotaStale =
     quotaAgeMs !== null && quotaAgeMs > QUOTA_SNAPSHOT_FRESHNESS_MS;
-  const routingQuota = quotaStale ? undefined : q;
+  const normalizeStatus = (status: string): string =>
+    status.trim().toLowerCase();
+  const rawOverageEligible = isQuotaOverageAvailable(q);
+  const observedStatuses = [
+    q?.unifiedStatus,
+    q?.sessionStatus,
+    q?.weeklyStatus,
+  ].filter((status): status is string => !!status?.trim());
+  const staleHardOrAmbiguous =
+    quotaStale &&
+    !!q &&
+    !rawOverageEligible &&
+    observedStatuses.some((status) => normalizeStatus(status) !== "allowed");
+  const quotaFreshness = !q
+    ? ("unknown" as const)
+    : !quotaStale
+      ? ("fresh" as const)
+      : staleHardOrAmbiguous
+        ? ("refresh_due" as const)
+        : ("stale_known" as const);
+  // A stale rejection is advisory after restart and cannot quarantine an
+  // account. Keep it as evidence, rank it behind known-healthy accounts, and
+  // refresh it through the usage endpoint before relying on the old status.
+  const routingQuota = staleHardOrAmbiguous ? undefined : q;
   const coolingActive = !!st?.coolingUntil && now < st.coolingUntil;
   // resetEpochToMs returns undefined for absent OR passed resets, so a
   // ticking window is exactly "reset !== undefined".
@@ -1204,19 +1302,52 @@ function accountSortMetrics(
       : "allowed"
     : null;
   const overageEligible = isQuotaOverageAvailable(routingQuota);
-  const saturated =
-    sessionStatus === "throttled" ||
-    (sessionTicking && (sessionUsed ?? 0) >= sessionSoftLimit);
+  const hardSaturated =
+    !overageEligible &&
+    (sessionStatus === "rejected" ||
+      sessionStatus === "throttled" ||
+      weeklyStatus === "rejected" ||
+      weeklyStatus === "throttled" ||
+      routingQuota?.unifiedStatus?.trim().toLowerCase() === "rejected" ||
+      (sessionTicking && (sessionUsed ?? 0) >= 1) ||
+      (weeklyTicking && (weeklyUsed ?? 0) >= 1));
+  const softSaturated =
+    !hardSaturated &&
+    !overageEligible &&
+    sessionTicking &&
+    (sessionUsed ?? 0) >= sessionSoftLimit;
+  const saturated = hardSaturated || softSaturated;
   return {
-    usable:
-      !coolingActive &&
-      weeklyStatus !== "rejected" &&
-      (sessionStatus !== "rejected" || overageEligible) &&
-      (routingQuota?.unifiedStatus?.trim().toLowerCase() !== "rejected" ||
-        overageEligible),
-    saturated: !quotaStale && saturated,
-    hasQuota: !!routingQuota,
+    usable: !coolingActive && !hardSaturated,
+    saturated,
+    hasQuota: !!q,
+    quotaEvidenceRank:
+      quotaFreshness === "fresh" || quotaFreshness === "stale_known"
+        ? 0
+        : quotaFreshness === "refresh_due"
+          ? 1
+          : 2,
     quotaStale,
+    quotaFreshness,
+    refreshNeeded:
+      quotaFreshness === "unknown" || quotaFreshness === "refresh_due",
+    refreshReason:
+      quotaFreshness === "unknown"
+        ? "startup_unknown"
+        : quotaFreshness === "refresh_due"
+          ? "ambiguous_snapshot"
+          : null,
+    refreshInFlight: refreshState.inFlight,
+    lastRefreshAttemptAt: refreshState.lastAttemptAt ?? null,
+    lastRefreshSuccessAt: refreshState.lastSuccessAt ?? null,
+    nextRefreshEligibleAt: refreshState.nextEligibleAt ?? null,
+    saturationKind: hardSaturated ? "hard" : softSaturated ? "soft" : "none",
+    softLimitOverrideReason:
+      overageEligible &&
+      sessionTicking &&
+      (sessionUsed ?? 0) >= sessionSoftLimit
+        ? "overage"
+        : null,
     quotaLastUpdated,
     quotaAgeMs,
     coolingActive,
@@ -1262,8 +1393,8 @@ function compareAccountRoutingFactors(
       au === bu ? "insertion_order" : "cooldown_recovery",
     ];
   }
-  if (ma.hasQuota !== mb.hasQuota) {
-    return [ma.hasQuota ? 1 : -1, "quota_probe"];
+  if (ma.quotaEvidenceRank !== mb.quotaEvidenceRank) {
+    return [ma.quotaEvidenceRank - mb.quotaEvidenceRank, "quota_evidence"];
   }
   if (ma.saturated !== mb.saturated) {
     return [ma.saturated ? 1 : -1, "session_headroom"];
@@ -1329,9 +1460,8 @@ function orderAccountsByQuotaWithMetrics(
  * temporarily demoted until that session resets.
  *
  * Priority among usable accounts:
- *   1. no quota data yet — probe first: one request reveals its windows and
- *      self-corrects the ordering. (Ranking unknowns last would starve them
- *      forever: never picked → never observed → never comparable.)
+ *   1. known healthy quota before unknown or ambiguous stale evidence. Quota
+ *      discovery is handled by a lightweight usage GET, never a user request.
  *   2. session headroom before session-saturated (>= soft limit or
  *      "throttled") — do not re-hammer an urgent weekly account while its 5h
  *      capacity is temporarily unavailable.
@@ -1360,6 +1490,103 @@ function orderAccountsByQuota(
     sessionSoftLimit,
     sessionResetToleranceMs,
   ).orderedAccounts;
+}
+
+function scheduleAdaptiveQuotaRefreshes(
+  accounts: ProxyPassthroughAccount[],
+  orderedAccounts: ProxyPassthroughAccount[],
+  sessionSoftLimit: number,
+  routingMetrics?: ReadonlyMap<string, ProxyAccountSortMetrics>,
+): void {
+  for (const account of accounts) {
+    if (account.type !== "oauth") {
+      continue;
+    }
+    const metrics =
+      routingMetrics?.get(account.key) ??
+      accountSortMetrics(
+        account.key,
+        Date.now(),
+        sessionSoftLimit,
+        getSessionResetToleranceMs(),
+      );
+    if (metrics.quotaFreshness === "unknown") {
+      void refreshAccountQuotaInBackground(
+        account,
+        `startup-unknown:${account.key}`,
+      ).catch((error) => {
+        logger.debug(
+          `[proxy] background quota discovery failed account=${account.label}: ${describeTransportError(error)}`,
+        );
+      });
+    } else if (metrics.quotaFreshness === "refresh_due") {
+      void refreshAccountQuotaInBackground(
+        account,
+        `ambiguous:${metrics.quotaLastUpdated ?? 0}`,
+      ).catch((error) => {
+        logger.debug(
+          `[proxy] ambiguous quota refresh failed account=${account.label}: ${describeTransportError(error)}`,
+        );
+      });
+    }
+  }
+
+  const active = orderedAccounts[0];
+  const candidate = orderedAccounts[1];
+  if (!active || !candidate || candidate.type !== "oauth") {
+    return;
+  }
+  const activeQuota = accountRuntimeState.get(active.key)?.quota;
+  if (!activeQuota) {
+    return;
+  }
+  const sessionPrewarmAt = Math.max(0, sessionSoftLimit - 0.05);
+  const needsPrewarm =
+    (activeQuota.sessionUsed ?? 0) >= sessionPrewarmAt ||
+    (activeQuota.weeklyUsed ?? 0) >= 0.9;
+  if (!needsPrewarm) {
+    return;
+  }
+  const trigger = [
+    "handoff",
+    active.key,
+    activeQuota.sessionResetAt ?? 0,
+    activeQuota.weeklyResetAt ?? 0,
+    candidate.key,
+  ].join(":");
+  void refreshAccountQuotaInBackground(candidate, trigger).catch((error) => {
+    logger.debug(
+      `[proxy] quota handoff prewarm failed account=${candidate.label}: ${describeTransportError(error)}`,
+    );
+  });
+}
+
+function scheduleHandoffQuotaRefresh(
+  current: ProxyPassthroughAccount,
+  candidate: ProxyPassthroughAccount | undefined,
+  handoffEpoch: number,
+  sessionSoftLimit: number,
+): void {
+  if (!candidate || candidate.type !== "oauth") {
+    return;
+  }
+  const metrics = accountSortMetrics(
+    candidate.key,
+    Date.now(),
+    sessionSoftLimit,
+    getSessionResetToleranceMs(),
+  );
+  if (metrics.quotaFreshness === "fresh") {
+    return;
+  }
+  void refreshAccountQuotaInBackground(
+    candidate,
+    `hard-handoff:${current.key}:${handoffEpoch}:${candidate.key}`,
+  ).catch((error) => {
+    logger.debug(
+      `[proxy] hard-handoff quota refresh failed account=${candidate.label}: ${describeTransportError(error)}`,
+    );
+  });
 }
 
 function buildRoutingDecision(args: {
@@ -1412,6 +1639,15 @@ function buildRoutingDecision(args: {
       saturated: metrics.saturated,
       quotaObserved: metrics.hasQuota,
       quotaStale: metrics.quotaStale,
+      quotaFreshness: metrics.quotaFreshness,
+      refreshNeeded: metrics.refreshNeeded,
+      refreshReason: metrics.refreshReason,
+      refreshInFlight: metrics.refreshInFlight,
+      lastRefreshAttemptAt: metrics.lastRefreshAttemptAt,
+      lastRefreshSuccessAt: metrics.lastRefreshSuccessAt,
+      nextRefreshEligibleAt: metrics.nextRefreshEligibleAt,
+      saturationKind: metrics.saturationKind,
+      softLimitOverrideReason: metrics.softLimitOverrideReason,
       quotaLastUpdated: metrics.quotaLastUpdated,
       quotaAgeMs: metrics.quotaAgeMs,
       coolingActive: metrics.coolingActive,
@@ -1491,7 +1727,10 @@ function selectClaudeProxyAccountOrder(args: {
   sessionSoftLimit: number;
   sessionResetToleranceMs: number;
   setRoutingDecision: (decision: ProxyAccountRoutingDecision) => void;
-}): ProxyPassthroughAccount[] {
+}): {
+  orderedAccounts: ProxyPassthroughAccount[];
+  metricsByKey: Map<string, ProxyAccountSortMetrics>;
+} {
   const {
     enabledAccounts,
     accountStrategy,
@@ -1582,7 +1821,7 @@ function selectClaudeProxyAccountOrder(args: {
   if (routingDecision) {
     setRoutingDecision(routingDecision);
   }
-  return orderedAccounts;
+  return { orderedAccounts, metricsByKey };
 }
 
 // ---------------------------------------------------------------------------
@@ -3142,7 +3381,7 @@ async function loadClaudeProxyAccounts(args: {
     return { response: buildLoggedClaudeError(401, reauthMsg) };
   }
 
-  const orderedAccounts = selectClaudeProxyAccountOrder({
+  const { orderedAccounts, metricsByKey } = selectClaudeProxyAccountOrder({
     enabledAccounts,
     accountStrategy,
     primaryAccountKey,
@@ -3151,6 +3390,18 @@ async function loadClaudeProxyAccounts(args: {
     sessionResetToleranceMs,
     setRoutingDecision,
   });
+  if (
+    accountStrategy === "fill-first" &&
+    quotaRoutingEnabled &&
+    enabledAccounts.length > 1
+  ) {
+    scheduleAdaptiveQuotaRefreshes(
+      enabledAccounts,
+      orderedAccounts,
+      sessionSoftLimit,
+      metricsByKey,
+    );
+  }
 
   const normalizedAnthropicBody = normalizeClaudeRequestForAnthropic(body);
   const bodyStr = JSON.stringify(normalizedAnthropicBody);
@@ -3667,6 +3918,8 @@ function buildClaudeAnthropicFailureResponse(args: {
   sawTransientFailure: boolean;
   sawRateLimit: boolean;
   lastError: unknown;
+  lastTransportErrorCode?: string;
+  lastTransportScope?: "shared_provider_transport" | "connection_transport";
   fallbackFailureMessage?: string;
   orderedAccounts: ProxyPassthroughAccount[];
   buildLoggedClaudeError: ClaudeLoggedErrorBuilder;
@@ -3695,6 +3948,8 @@ function buildClaudeAnthropicFailureResponse(args: {
     sawTransientFailure,
     sawRateLimit,
     lastError,
+    lastTransportErrorCode,
+    lastTransportScope,
     fallbackFailureMessage,
     orderedAccounts,
     buildLoggedClaudeError,
@@ -3758,7 +4013,13 @@ function buildClaudeAnthropicFailureResponse(args: {
     const fallbackSuffix = fallbackFailureMessage
       ? ` Fallback also failed: ${fallbackFailureMessage}`
       : "";
-    const msg = `All Anthropic accounts failed due to transient upstream/network errors. Last error: ${
+    const transportDescription =
+      lastTransportScope === "shared_provider_transport"
+        ? "shared Anthropic network"
+        : lastTransportScope === "connection_transport"
+          ? "Anthropic connection"
+          : null;
+    const msg = `${transportDescription ? `${transportDescription} failure prevented safe cross-account rotation` : "All Anthropic accounts failed due to transient upstream/network errors"}. Last error${lastTransportErrorCode ? ` (${lastTransportErrorCode})` : ""}: ${
       lastError instanceof Error
         ? lastError.message
         : String(lastError ?? "unknown")
@@ -3769,6 +4030,12 @@ function buildClaudeAnthropicFailureResponse(args: {
       502,
       msg,
       fallbackFailureMessage ? "fallback_exhausted" : "transient_error",
+      {
+        ...(lastTransportErrorCode
+          ? { errorCode: lastTransportErrorCode }
+          : {}),
+        ...(lastTransportScope ? { transportScope: lastTransportScope } : {}),
+      },
     );
   }
 
@@ -6021,6 +6288,7 @@ function createClaudeRequestRuntimeContext(args: {
               ? "stream_error"
               : "handler_error",
         message: errorMessage,
+        errorCode: extra?.errorCode,
       });
     } else {
       recordFinalSuccess(finalAccountLabel, finalAccountType);
@@ -6040,6 +6308,10 @@ function createClaudeRequestRuntimeContext(args: {
       responseTimeMs: Date.now() - requestStartTime,
       ...(errorType ? { errorType } : {}),
       ...(errorMessage ? { errorMessage } : {}),
+      ...(extra?.errorCode ? { errorCode: extra.errorCode } : {}),
+      ...(extra?.transportScope
+        ? { transportScope: extra.transportScope }
+        : {}),
       ...(extra?.inputTokens !== undefined
         ? { inputTokens: extra.inputTokens }
         : {}),
@@ -6072,6 +6344,7 @@ function createClaudeRequestRuntimeContext(args: {
       extra?.accountType ?? "final",
       errorType,
       message,
+      extra,
     );
     logProxyBody({
       phase: "client_response",
@@ -6137,6 +6410,9 @@ function createAnthropicAttemptLogger(args: {
       ...(errorType ? { errorType } : {}),
       ...(errorMessage ? { errorMessage } : {}),
       ...(extra?.errorCode ? { errorCode: extra.errorCode } : {}),
+      ...(extra?.transportScope
+        ? { transportScope: extra.transportScope }
+        : {}),
       ...(extra?.inputTokens !== undefined
         ? { inputTokens: extra.inputTokens }
         : {}),
@@ -6467,6 +6743,7 @@ async function fetchAnthropicAccountResponse(args: {
     });
   } catch (fetchErr) {
     const retryable = isRetryableNetworkError(fetchErr);
+    const transportScope = classifyNetworkTransportScope(fetchErr);
     // Every dispatched upstream request is an attempt, including terminal
     // transport failures. Record it once before preserving the throw behavior.
     sawNetworkError = true;
@@ -6481,6 +6758,7 @@ async function fetchAnthropicAccountResponse(args: {
     logAttempt(502, "network_error", errorMessage, {
       retryable,
       errorCode,
+      transportScope,
     });
     tracer?.setError("network_error", errorMessage);
     if (retryable) {
@@ -6493,6 +6771,8 @@ async function fetchAnthropicAccountResponse(args: {
     return {
       continueLoop: true,
       retrySameAccount: true,
+      transportScope,
+      errorCode,
       lastError,
       sawRateLimit,
       sawNetworkError,
@@ -6760,6 +7040,17 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     let rateLimitSameAccountRetries = 0;
 
     while (true) {
+      const transportPermit = await providerTransportCoordinator.acquire(
+        ctx.abortSignal,
+      );
+      if (transportPermit.allowed === false) {
+        loopState.sawNetworkError = true;
+        loopState.lastTransportErrorCode =
+          transportPermit.errorCode ?? undefined;
+        loopState.lastTransportScope = transportPermit.transportScope;
+        loopState.lastError = `Anthropic transport recovery probe failed (${transportPermit.errorCode ?? "unknown"})`;
+        break accountLoop;
+      }
       loopState.attemptNumber += 1;
       if (tracer && loopState.attemptNumber === 1 && acctSelectionSpan) {
         tracer.setAccountSelection({
@@ -6804,6 +7095,9 @@ async function handleAnthropicRoutedClaudeRequest(args: {
         !preparedAttempt.finalBodyStr ||
         preparedAttempt.fetchStartMs === undefined
       ) {
+        if (transportPermit.probe) {
+          providerTransportCoordinator.reportProbeAbandoned(transportPermit);
+        }
         continue accountLoop;
       }
 
@@ -6826,31 +7120,55 @@ async function handleAnthropicRoutedClaudeRequest(args: {
       if (!admissionLease) {
         // A later account may be immediately available. Preserve the routing
         // order but do not leave a request queued behind a busy first choice.
+        if (transportPermit.probe) {
+          providerTransportCoordinator.reportProbeAbandoned(transportPermit);
+        }
         continue accountLoop;
       }
       let admissionTransferredToStream = false;
       try {
-        const fetchResult = await fetchAnthropicAccountResponse({
-          url,
-          headers: preparedAttempt.headers,
-          finalBodyStr: preparedAttempt.finalBodyStr,
-          account,
-          accountState,
-          enabledAccounts,
-          orderedAccounts,
-          tracer,
-          logAttempt,
-          logProxyBody,
-          fetchStartMs: preparedAttempt.fetchStartMs,
-          attemptNumber: loopState.attemptNumber,
-          currentLastError: loopState.lastError,
-          currentSawRateLimit: loopState.sawRateLimit,
-          currentSawNetworkError: loopState.sawNetworkError,
-          upstreamSpan: preparedAttempt.upstreamSpan,
-        });
+        let fetchResult: AnthropicUpstreamFetchResult;
+        try {
+          fetchResult = await fetchAnthropicAccountResponse({
+            url,
+            headers: preparedAttempt.headers,
+            finalBodyStr: preparedAttempt.finalBodyStr,
+            account,
+            accountState,
+            enabledAccounts,
+            orderedAccounts,
+            tracer,
+            logAttempt,
+            logProxyBody,
+            fetchStartMs: preparedAttempt.fetchStartMs,
+            attemptNumber: loopState.attemptNumber,
+            currentLastError: loopState.lastError,
+            currentSawRateLimit: loopState.sawRateLimit,
+            currentSawNetworkError: loopState.sawNetworkError,
+            upstreamSpan: preparedAttempt.upstreamSpan,
+          });
+        } catch (error) {
+          if (transportPermit.probe) {
+            providerTransportCoordinator.reportProbeAbandoned(transportPermit);
+          }
+          throw error;
+        }
+        if (fetchResult.transportScope) {
+          providerTransportCoordinator.reportTransportFailure(
+            fetchResult.errorCode,
+            fetchResult.transportScope,
+            transportPermit,
+          );
+        } else {
+          providerTransportCoordinator.reportSuccess(transportPermit);
+        }
         loopState.lastError = fetchResult.lastError;
         loopState.sawRateLimit = fetchResult.sawRateLimit;
         loopState.sawNetworkError = fetchResult.sawNetworkError;
+        if (fetchResult.transportScope) {
+          loopState.lastTransportScope = fetchResult.transportScope;
+          loopState.lastTransportErrorCode = fetchResult.errorCode;
+        }
         if (fetchResult.terminalError) {
           return finalizeAnthropicTerminalFetchError({
             terminalError: fetchResult.terminalError,
@@ -6934,6 +7252,14 @@ async function handleAnthropicRoutedClaudeRequest(args: {
             logger.always(
               `[proxy] account=${account.label} rate-limited (${plan.reason}); cooling ~${minutesUntil(plan.coolingUntil, Date.now())}m until ${new Date(plan.coolingUntil).toISOString()}, rotating`,
             );
+            if (plan.rotateImmediately) {
+              scheduleHandoffQuotaRefresh(
+                account,
+                effectiveAccounts[accountIndex + 1],
+                plan.coolingUntil,
+                sessionSoftLimit,
+              );
+            }
             continue accountLoop;
           }
           // Transient error retry (network errors, 529 overloaded)
@@ -6951,10 +7277,16 @@ async function handleAnthropicRoutedClaudeRequest(args: {
             await sleep(delayMs);
             continue;
           }
-          if (fetchResult.retrySameAccount) {
+          if (fetchResult.retrySameAccount && !fetchResult.transportScope) {
             logger.always(
               `[proxy] exhausted transient same-account retries for account=${account.label}; rotating`,
             );
+          }
+          if (fetchResult.transportScope) {
+            logger.always(
+              `[proxy] Anthropic ${fetchResult.transportScope} failure code=${fetchResult.errorCode ?? "unknown"}; suppressing cross-account rotation after ${transientSameAccountRetries + 1} attempts`,
+            );
+            break accountLoop;
           }
           continue accountLoop;
         }
@@ -7208,6 +7540,8 @@ async function handleAnthropicRoutedClaudeRequest(args: {
     sawTransientFailure: loopState.sawTransientFailure,
     sawRateLimit: loopState.sawRateLimit,
     lastError: loopState.lastError,
+    lastTransportErrorCode: loopState.lastTransportErrorCode,
+    lastTransportScope: loopState.lastTransportScope,
     fallbackFailureMessage: loopState.fallbackFailureMessage,
     orderedAccounts,
     buildLoggedClaudeError,
@@ -7808,11 +8142,21 @@ function isRetryableNetworkError(error: unknown): boolean {
       // The Anthropic host is fixed, so ENOTFOUND can be a transient resolver
       // outage. Keep it inside the existing bounded same-account retry budget.
       "ENOTFOUND",
+      "EAI_AGAIN",
       "EHOSTUNREACH",
       "UND_ERR_CONNECT_TIMEOUT",
       "UND_ERR_CONNECT",
     ].includes(code)
   );
+}
+
+function classifyNetworkTransportScope(
+  error: unknown,
+): "shared_provider_transport" | "connection_transport" {
+  const code = getErrorCode(error);
+  return code === "ENOTFOUND" || code === "EAI_AGAIN"
+    ? "shared_provider_transport"
+    : "connection_transport";
 }
 
 const TRANSIENT_HTTP_STATUSES = new Set([
@@ -7985,15 +8329,21 @@ export const __testHooks = {
   planCooldownFor429,
   reconcileCooldownFromQuota,
   refreshAccountLimits,
+  applyAccountUsageResult,
   clearLimitsRefreshStateForTests: (): void => {
     lastUsageFetchAt.clear();
     limitsRefreshInFlight = null;
+    accountQuotaRefreshCoordinator.clear();
   },
   isRetryableNetworkError,
   isPermanentRefreshFailure,
   getStreamFailureDetails,
   trackUpstreamReadableStream,
   orderAccountsByQuota,
+  scheduleAdaptiveQuotaRefreshes,
+  scheduleHandoffQuotaRefresh,
+  getQuotaRefreshState: (key: string) =>
+    accountQuotaRefreshCoordinator.getState(key),
   buildQuotaRoutingDecision: (
     accounts: ProxyPassthroughAccount[],
     now: number,
@@ -8048,6 +8398,8 @@ export const __testHooks = {
     transientRateLimitRetryBudgets.clear();
     transientCooldownAdmissionSchedules.clear();
     accountAdmissionStates.clear();
+    accountQuotaRefreshCoordinator.clear();
+    providerTransportCoordinator.clear();
     primaryAccountIndex = 0;
     lastKnownAccountCount = 0;
   },

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -518,6 +518,43 @@ export type ProxyAccountRoutingReason =
 
 export type ProxyAccountType = (typeof PROXY_ACCOUNT_TYPES)[number];
 
+export type ProxyQuotaFreshness =
+  | "unknown"
+  | "fresh"
+  | "stale_known"
+  | "refresh_due";
+
+export type ProxyQuotaRefreshReason =
+  | "startup_unknown"
+  | "handoff_prewarm"
+  | "ambiguous_snapshot"
+  | "manual";
+
+export type ProxyQuotaSaturationKind = "none" | "soft" | "hard";
+
+export type ProxyTransportScope =
+  | "shared_provider_transport"
+  | "connection_transport"
+  | "account_specific";
+
+export type ProxyNetworkTransportScope = Exclude<
+  ProxyTransportScope,
+  "account_specific"
+>;
+
+export type ProxyProviderTransportProbeOutcome =
+  | "recovered"
+  | "failed"
+  | "abandoned";
+
+export type ProxyProviderTransportPermit =
+  | { allowed: true; probe: boolean; generation: number }
+  | {
+      allowed: false;
+      errorCode: string | null;
+      transportScope: ProxyNetworkTransportScope;
+    };
+
 export type ProxyAccountRoutingCandidate = {
   account: string;
   accountType: ProxyAccountType;
@@ -528,6 +565,15 @@ export type ProxyAccountRoutingCandidate = {
   saturated: boolean;
   quotaObserved: boolean;
   quotaStale: boolean;
+  quotaFreshness?: ProxyQuotaFreshness;
+  refreshNeeded?: boolean;
+  refreshReason?: ProxyQuotaRefreshReason | null;
+  refreshInFlight?: boolean;
+  lastRefreshAttemptAt?: number | null;
+  lastRefreshSuccessAt?: number | null;
+  nextRefreshEligibleAt?: number | null;
+  saturationKind?: ProxyQuotaSaturationKind;
+  softLimitOverrideReason?: "overage" | "weekly_expiry" | null;
   quotaLastUpdated: number | null;
   quotaAgeMs: number | null;
   coolingActive: boolean;
@@ -568,7 +614,17 @@ export type ProxyAccountSortMetrics = {
   usable: boolean;
   saturated: boolean;
   hasQuota: boolean;
+  quotaEvidenceRank: number;
   quotaStale: boolean;
+  quotaFreshness: ProxyQuotaFreshness;
+  refreshNeeded: boolean;
+  refreshReason: ProxyQuotaRefreshReason | null;
+  refreshInFlight: boolean;
+  lastRefreshAttemptAt: number | null;
+  lastRefreshSuccessAt: number | null;
+  nextRefreshEligibleAt: number | null;
+  saturationKind: ProxyQuotaSaturationKind;
+  softLimitOverrideReason: "overage" | "weekly_expiry" | null;
   quotaLastUpdated: number | null;
   quotaAgeMs: number | null;
   coolingActive: boolean;
@@ -605,6 +661,8 @@ export type RequestLogEntry = {
   errorMessage?: string;
   /** Low-level transport code such as ETIMEDOUT or EADDRNOTAVAIL. */
   errorCode?: string;
+  /** Whether changing credentials can affect this transport failure. */
+  transportScope?: ProxyTransportScope;
   inputTokens?: number;
   outputTokens?: number;
   cacheCreationTokens?: number;
@@ -637,6 +695,8 @@ export type RequestAttemptLogEntry = {
   errorMessage?: string;
   /** Low-level transport code such as ETIMEDOUT or EADDRNOTAVAIL. */
   errorCode?: string;
+  /** Whether changing credentials can affect this transport failure. */
+  transportScope?: ProxyTransportScope;
   /** Whether this failed attempt may be retried without changing the request. */
   retryable?: boolean;
   /** Distinguishes short-lived admission throttles from exhausted quota windows. */
@@ -680,6 +740,8 @@ export type ClaudeFinalRequestLogger = (
     outputTokens?: number;
     cacheCreationTokens?: number;
     cacheReadTokens?: number;
+    errorCode?: string;
+    transportScope?: ProxyTransportScope;
   },
 ) => void;
 
@@ -691,6 +753,8 @@ export type ClaudeLoggedErrorBuilder = (
     account?: string;
     accountType?: string;
     attempt?: number;
+    errorCode?: string;
+    transportScope?: ProxyTransportScope;
   },
 ) => ClaudeErrorResponse;
 
@@ -718,6 +782,7 @@ export type AnthropicAttemptLogger = (
     retryable?: boolean;
     /** Low-level transport code such as ETIMEDOUT or EADDRNOTAVAIL. */
     errorCode?: string;
+    transportScope?: ProxyTransportScope;
     rateLimitKind?: "transient" | "quota";
     cooldownReason?: "transient" | "session" | "weekly" | "unified";
     /** Override for nested retries whose attempt starts after this logger. */
@@ -741,6 +806,8 @@ export type AnthropicLoopState = {
   authCooldownMessage: string | null;
   fallbackFailureMessage?: string;
   attemptNumber: number;
+  lastTransportErrorCode?: string;
+  lastTransportScope?: ProxyNetworkTransportScope;
 };
 
 export type AnthropicUpstreamBody = {
@@ -887,6 +954,8 @@ export type TransientRateLimitRetryBudget = {
 export type AnthropicUpstreamFetchResult = {
   continueLoop: boolean;
   retrySameAccount?: boolean;
+  transportScope?: ProxyNetworkTransportScope;
+  errorCode?: string;
   /** When set, the caller should wait this many ms before retrying (from upstream retry-after). */
   retryAfterMs?: number;
   /** Set on a genuine 429: how long / why to cool this account before rotating. */
@@ -1194,6 +1263,36 @@ export type AccountUsageFetchResult =
       status?: number;
     };
 
+export type ProxyQuotaRefreshRuntimeState = {
+  inFlight: boolean;
+  lastAttemptAt?: number;
+  lastSuccessAt?: number;
+  nextEligibleAt?: number;
+  consecutiveFailures: number;
+  lastFailureReason?: string;
+  lastCompletedTrigger?: string;
+  coalesced: number;
+};
+
+export type ProxyQuotaRefreshMetrics = {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  coalesced: number;
+  backoffSuppressed: number;
+  triggerDeduplicated: number;
+};
+
+export type ProxyQuotaRefreshRunResult =
+  | {
+      kind: "completed";
+      result: AccountUsageFetchResult;
+      /** Lower bound for the freshness of the returned usage snapshot. */
+      startedAt: number;
+    }
+  | { kind: "backoff"; nextEligibleAt: number }
+  | { kind: "not_due" };
+
 /** Per-account result inside a GET /limits response. */
 export type ProxyLimitsAccountResult = {
   /** Account label (quota-store key). */
@@ -1215,6 +1314,8 @@ export type ProxyLimitsRefreshResponse = {
   /** True when served from stored state without contacting Anthropic. */
   snapshot: boolean;
   results: ProxyLimitsAccountResult[];
+  /** Process-local refresh activity; contains no credentials or response body. */
+  refreshMetrics?: ProxyQuotaRefreshMetrics;
 };
 
 /**
@@ -1781,6 +1882,7 @@ export type ProxyAnalysisReport = {
     errors: number;
     errorTypes: Record<string, number>;
     errorCodes: Record<string, number>;
+    transportScopes: Record<string, number>;
   };
   rateLimits: {
     attemptRateLimits: number;

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1647,16 +1647,16 @@ async function testOrderAccountsByQuota(): Promise<boolean | null> {
     return false;
   }
 
-  // Probe-first: an account with NO quota data must sort before known
-  // accounts (one request reveals its windows). Ranking it last would starve
-  // it forever: never picked → never observed → never comparable.
+  // Unknown quota must not displace known healthy accounts. The adaptive
+  // refresh coordinator discovers unknown windows through the lightweight
+  // usage endpoint instead of sending production traffic as a probe.
   const d: Acct = { key: "anthropic:d", label: "d", token: "t", type: "oauth" };
   const probeOrdered = __testHooks
     .orderAccountsByQuota([a, b, d] as never, now, undefined)
     .map((x: { label: string }) => x.label);
-  if (probeOrdered.join(",") !== "d,b,a") {
+  if (probeOrdered.join(",") !== "b,a,d") {
     log(
-      `orderAccountsByQuota: expected d,b,a (unknown probed first), got ${probeOrdered.join(",")}`,
+      `orderAccountsByQuota: expected b,a,d (known healthy before unknown), got ${probeOrdered.join(",")}`,
       "red",
     );
     __testHooks.resetAllRuntimeState();
@@ -1680,7 +1680,7 @@ async function testOrderAccountsByQuota(): Promise<boolean | null> {
 
   __testHooks.resetAllRuntimeState();
   log(
-    "orderAccountsByQuota: soonest-reset-first + probe-first + primary tie-break passed",
+    "orderAccountsByQuota: soonest-reset-first + known-before-unknown + primary tie-break passed",
     "green",
   );
   return true;

--- a/test/proxyAnalysis.test.ts
+++ b/test/proxyAnalysis.test.ts
@@ -179,6 +179,7 @@ describe("offline proxy log analysis", () => {
         attemptDurationMs: 25,
         errorType: "transport_error",
         errorCode: "ETIMEDOUT",
+        transportScope: "connection_transport",
       },
     ]);
 
@@ -278,6 +279,7 @@ describe("offline proxy log analysis", () => {
       errors: 3,
       errorTypes: { http_429: 2, transport_error: 1 },
       errorCodes: { ETIMEDOUT: 1 },
+      transportScopes: { connection_transport: 1 },
     });
     expect(report.rateLimits).toEqual({
       attemptRateLimits: 3,

--- a/test/proxyReliabilityHardening.test.ts
+++ b/test/proxyReliabilityHardening.test.ts
@@ -26,6 +26,8 @@ import {
   parseQuotaHeaders,
   saveAccountQuota,
 } from "../src/lib/proxy/accountQuota.js";
+import { AccountQuotaRefreshCoordinator } from "../src/lib/proxy/accountQuotaRefreshCoordinator.js";
+import { ProviderTransportCoordinator } from "../src/lib/proxy/providerTransportCoordinator.js";
 import {
   resolveProxyPaths,
   resolveProxyUsageStatsPath,
@@ -110,12 +112,17 @@ describe("weekly-expiry quota routing", () => {
   const quota = (
     now: number,
     overrides: Partial<{
+      unifiedStatus: string | undefined;
       sessionUsed: number;
       sessionStatus: string;
       sessionResetAt: number;
       weeklyUsed: number;
       weeklyStatus: string;
       weeklyResetAt: number;
+      fallbackPercentage: number;
+      fallbackStatus: string;
+      overageStatus: string;
+      upgradePaths: string;
     }>,
   ) => ({
     unifiedStatus: "allowed",
@@ -272,7 +279,7 @@ describe("weekly-expiry quota routing", () => {
     ).toBeUndefined();
   });
 
-  it("temporarily demotes an urgent weekly account at the session soft limit", () => {
+  it("keeps an urgent weekly account first at the soft limit when overage is available", () => {
     const now = Date.UTC(2026, 6, 17, 12, 0, 0);
     const nowSec = Math.floor(now / 1000);
     setQuota("urgent@example.com", now, {
@@ -280,6 +287,44 @@ describe("weekly-expiry quota routing", () => {
       sessionResetAt: nowSec + 30 * 60,
       weeklyUsed: 0.4,
       weeklyResetAt: nowSec + 12 * 60 * 60,
+      fallbackStatus: "available",
+      overageStatus: "allowed",
+      upgradePaths: "overage",
+    });
+    setQuota("later@example.com", now, {
+      sessionUsed: 0.2,
+      sessionResetAt: nowSec + 2 * 60 * 60,
+      weeklyUsed: 0.2,
+      weeklyResetAt: nowSec + 3 * 24 * 60 * 60,
+    });
+
+    expect(order(["urgent@example.com", "later@example.com"], now)).toEqual([
+      "urgent@example.com",
+      "later@example.com",
+    ]);
+    expect(
+      decision(["urgent@example.com", "later@example.com"], now),
+    ).toMatchObject({
+      initialAccount: "urgent@example.com",
+      selectionReason: "weekly_reset",
+    });
+    expect(
+      order(["urgent@example.com", "later@example.com"], now + 31 * 60 * 1000),
+    ).toEqual(["urgent@example.com", "later@example.com"]);
+  });
+
+  it("temporarily demotes a soft-limited account without a continuation path", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    const nowSec = Math.floor(now / 1000);
+    setQuota("urgent@example.com", now, {
+      sessionUsed: 0.98,
+      sessionResetAt: nowSec + 30 * 60,
+      weeklyUsed: 0.4,
+      weeklyResetAt: nowSec + 12 * 60 * 60,
+      fallbackPercentage: 0,
+      fallbackStatus: "unavailable",
+      overageStatus: "unavailable",
+      upgradePaths: "",
     });
     setQuota("later@example.com", now, {
       sessionUsed: 0.2,
@@ -298,12 +343,9 @@ describe("weekly-expiry quota routing", () => {
       initialAccount: "later@example.com",
       selectionReason: "session_headroom",
     });
-    expect(
-      order(["urgent@example.com", "later@example.com"], now + 31 * 60 * 1000),
-    ).toEqual(["urgent@example.com", "later@example.com"]);
   });
 
-  it("probes an account with no quota snapshot before observed accounts", () => {
+  it("keeps unknown accounts behind observed healthy accounts", () => {
     const now = Date.UTC(2026, 6, 17, 12, 0, 0);
     setQuota("observed@example.com", now, {
       weeklyUsed: 0.1,
@@ -313,21 +355,239 @@ describe("weekly-expiry quota routing", () => {
     expect(
       decision(["observed@example.com", "unknown@example.com"], now),
     ).toMatchObject({
-      initialAccount: "unknown@example.com",
-      selectionReason: "quota_probe",
+      initialAccount: "observed@example.com",
+      selectionReason: "quota_evidence",
       candidates: [
-        expect.objectContaining({
-          account: "unknown@example.com",
-          quotaObserved: false,
-          quotaLastUpdated: null,
-          quotaAgeMs: null,
-        }),
         expect.objectContaining({
           account: "observed@example.com",
           quotaObserved: true,
+          quotaFreshness: "fresh",
+        }),
+        expect.objectContaining({
+          account: "unknown@example.com",
+          quotaObserved: false,
+          quotaFreshness: "unknown",
+          quotaLastUpdated: null,
+          quotaAgeMs: null,
         }),
       ],
     });
+  });
+
+  it("keeps stale-known healthy quota ordered after the old 15-minute boundary", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    const observedAt = now - 16 * 60 * 1000;
+    setQuota("urgent@example.com", observedAt, {
+      weeklyUsed: 0.4,
+      weeklyResetAt: Math.floor(now / 1000) + 12 * 60 * 60,
+    });
+    setQuota("later@example.com", now, {
+      weeklyUsed: 0.1,
+      weeklyResetAt: Math.floor(now / 1000) + 3 * 24 * 60 * 60,
+    });
+
+    const routingDecision = decision(
+      ["urgent@example.com", "later@example.com"],
+      now,
+    );
+    expect(routingDecision).toMatchObject({
+      initialAccount: "urgent@example.com",
+      selectionReason: "weekly_reset",
+    });
+    expect(routingDecision?.candidates[0]).toMatchObject({
+      account: "urgent@example.com",
+      quotaObserved: true,
+      quotaStale: true,
+      quotaFreshness: "stale_known",
+    });
+  });
+
+  it("keeps stale allowed windows usable when optional status fields are absent", () => {
+    const now = Date.UTC(2026, 6, 17, 12, 0, 0);
+    const observedAt = now - 16 * 60 * 1000;
+    setQuota("urgent@example.com", observedAt, {
+      unifiedStatus: undefined,
+      overageStatus: "unavailable",
+      fallbackPercentage: 0,
+      weeklyUsed: 0.4,
+      weeklyResetAt: Math.floor(now / 1000) + 12 * 60 * 60,
+    });
+
+    expect(decision(["urgent@example.com"], now)?.candidates[0]).toMatchObject({
+      usable: true,
+      quotaFreshness: "stale_known",
+      refreshNeeded: false,
+    });
+  });
+
+  it("does not let an older usage refresh overwrite passive quota evidence", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-quota-race-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+    const now = Date.now();
+    const candidate = account("race@example.com");
+    setQuota(candidate.label, now, {
+      overageStatus: "unavailable",
+      fallbackPercentage: 0,
+      sessionUsed: 0.2,
+      weeklyUsed: 0.3,
+    });
+
+    const result = await __testHooks.applyAccountUsageResult(
+      candidate,
+      {
+        ok: true,
+        usage: {
+          five_hour: { utilization: 100 },
+          seven_day: { utilization: 100 },
+        },
+      },
+      now - 1,
+    );
+
+    expect(result).toMatchObject({ lastUpdated: now, sessionUsed: 0.2 });
+    const runtimeState = __testHooks.getAccountRuntimeState(candidate.key);
+    expect(runtimeState).toMatchObject({
+      quota: { lastUpdated: now, sessionUsed: 0.2, weeklyUsed: 0.3 },
+    });
+    expect(runtimeState?.coolingUntil).toBeUndefined();
+  });
+
+  it("does not refresh a healthy idle account merely because its evidence is old", async () => {
+    const now = Date.now();
+    const observedAt = now - 16 * 60 * 1000;
+    setQuota("active@example.com", observedAt, {
+      sessionUsed: 0.2,
+      weeklyUsed: 0.3,
+      weeklyResetAt: Math.floor(now / 1000) + 24 * 60 * 60,
+    });
+    setQuota("idle@example.com", observedAt, {
+      sessionUsed: 0.1,
+      weeklyUsed: 0.1,
+      weeklyResetAt: Math.floor(now / 1000) + 3 * 24 * 60 * 60,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected quota refresh"));
+
+    __testHooks.scheduleAdaptiveQuotaRefreshes(
+      [account("active@example.com"), account("idle@example.com")],
+      [account("active@example.com"), account("idle@example.com")],
+      0.97,
+    );
+    await Promise.resolve();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("prewarms the next account once per active reset window", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-quota-prewarm-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+    const now = Date.now();
+    const nowSec = Math.floor(now / 1000);
+    setQuota("active@example.com", now, {
+      sessionUsed: 0.92,
+      sessionResetAt: nowSec + 60 * 60,
+      weeklyUsed: 0.4,
+      weeklyResetAt: nowSec + 24 * 60 * 60,
+    });
+    setQuota("next@example.com", now - 16 * 60 * 1000, {
+      sessionUsed: 0.1,
+      sessionResetAt: nowSec + 2 * 60 * 60,
+      weeklyUsed: 0.1,
+      weeklyResetAt: nowSec + 3 * 24 * 60 * 60,
+    });
+
+    let resolveFetch!: (response: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const accounts = [
+      account("active@example.com"),
+      account("next@example.com"),
+    ];
+
+    for (let index = 0; index < 100; index += 1) {
+      __testHooks.scheduleAdaptiveQuotaRefreshes(accounts, accounts, 0.97);
+    }
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/api/oauth/usage");
+    expect(__testHooks.getQuotaRefreshState(accounts[1].key)).toMatchObject({
+      inFlight: true,
+      coalesced: 99,
+    });
+
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          five_hour: {
+            utilization: 10,
+            resets_at: new Date(now + 2 * 60 * 60_000).toISOString(),
+          },
+          seven_day: {
+            utilization: 10,
+            resets_at: new Date(now + 3 * 24 * 60 * 60_000).toISOString(),
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(__testHooks.getQuotaRefreshState(accounts[1].key).inFlight).toBe(
+        false,
+      ),
+    );
+
+    __testHooks.scheduleAdaptiveQuotaRefreshes(accounts, accounts, 0.97);
+    await Promise.resolve();
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes stale candidate evidence during a hard quota handoff", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-quota-handoff-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+    const now = Date.now();
+    const nowSec = Math.floor(now / 1000);
+    setQuota("next@example.com", now - 16 * 60 * 1000, {
+      sessionUsed: 0.1,
+      sessionResetAt: nowSec + 2 * 60 * 60,
+      weeklyUsed: 0.1,
+      weeklyResetAt: nowSec + 3 * 24 * 60 * 60,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          five_hour: {
+            utilization: 10,
+            resets_at: new Date(now + 2 * 60 * 60_000).toISOString(),
+          },
+          seven_day: {
+            utilization: 10,
+            resets_at: new Date(now + 3 * 24 * 60 * 60_000).toISOString(),
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const current = account("active@example.com");
+    const candidate = account("next@example.com");
+
+    __testHooks.scheduleHandoffQuotaRefresh(
+      current,
+      candidate,
+      now + 60_000,
+      0.97,
+    );
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce());
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/api/oauth/usage");
   });
 
   it("reports the exact comparator factor that selected the first account", () => {
@@ -752,6 +1012,7 @@ describe("upstream attempt classification and retry amplification", () => {
       {
         retryable: true,
         errorCode: "EADDRNOTAVAIL",
+        transportScope: "connection_transport",
       },
     );
     expect(getStats()).toMatchObject({ totalAttemptErrors: 1 });
@@ -772,6 +1033,8 @@ describe("upstream attempt classification and retry amplification", () => {
       continueLoop: true,
       retrySameAccount: true,
       sawNetworkError: true,
+      transportScope: "shared_provider_transport",
+      errorCode: "ENOTFOUND",
     });
     expect(logAttempt).toHaveBeenCalledWith(
       502,
@@ -780,7 +1043,394 @@ describe("upstream attempt classification and retry amplification", () => {
       {
         retryable: true,
         errorCode: "ENOTFOUND",
+        transportScope: "shared_provider_transport",
       },
+    );
+  });
+
+  it("coalesces concurrent quota refreshes and deduplicates a completed trigger", async () => {
+    const coordinator = new AccountQuotaRefreshCoordinator();
+    const account = fetchArgs(vi.fn(), vi.fn()).account;
+    let resolveFetch:
+      | ((value: { ok: true; usage: Record<string, never> }) => void)
+      | undefined;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<{ ok: true; usage: Record<string, never> }>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const refreshes = Array.from({ length: 100 }, () =>
+      coordinator.run(account, "handoff:window-1", fetcher),
+    );
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(coordinator.getState(account.key)).toMatchObject({
+      inFlight: true,
+      coalesced: 99,
+    });
+    resolveFetch?.({ ok: true, usage: {} });
+    await expect(Promise.all(refreshes)).resolves.toHaveLength(100);
+    await expect(
+      coordinator.run(account, "handoff:window-1", fetcher),
+    ).resolves.toEqual({ kind: "not_due" });
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(coordinator.getMetrics()).toEqual({
+      attempted: 1,
+      succeeded: 1,
+      failed: 0,
+      coalesced: 99,
+      backoffSuppressed: 0,
+      triggerDeduplicated: 1,
+    });
+  });
+
+  it("backs off a failed quota refresh without erasing its trigger eligibility", async () => {
+    const coordinator = new AccountQuotaRefreshCoordinator();
+    const account = fetchArgs(vi.fn(), vi.fn()).account;
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: false as const,
+      reason: "network" as const,
+      error: "resolver unavailable",
+    });
+
+    await expect(
+      coordinator.run(account, "startup-unknown", fetcher, { now: 1_000 }),
+    ).resolves.toMatchObject({
+      kind: "completed",
+      result: { ok: false, reason: "network" },
+    });
+    await expect(
+      coordinator.run(account, "startup-unknown", fetcher, { now: 2_000 }),
+    ).resolves.toEqual({ kind: "backoff", nextEligibleAt: 31_000 });
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(coordinator.getMetrics()).toEqual({
+      attempted: 1,
+      succeeded: 0,
+      failed: 1,
+      coalesced: 0,
+      backoffSuppressed: 1,
+      triggerDeduplicated: 0,
+    });
+
+    await coordinator.run(account, "startup-unknown", fetcher, {
+      now: 31_000,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts a transport backoff waiter without a timer reference error", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const coordinator = new ProviderTransportCoordinator();
+      const initial = await coordinator.acquire();
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        initial,
+      );
+
+      const controller = new AbortController();
+      const waiting = coordinator.acquire(controller.signal);
+      controller.abort(new Error("request cancelled"));
+
+      await expect(waiting).rejects.toThrow("request cancelled");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds recovery-probe waiters and releases a stale probe", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const coordinator = new ProviderTransportCoordinator();
+      const initial = await coordinator.acquire();
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        initial,
+      );
+
+      const ownerPromise = coordinator.acquire();
+      await vi.advanceTimersByTimeAsync(250);
+      const owner = await ownerPromise;
+      expect(owner).toEqual({ allowed: true, probe: true, generation: 1 });
+
+      const waiterPromise = coordinator.acquire();
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(waiterPromise).resolves.toMatchObject({
+        allowed: false,
+        errorCode: "ENOTFOUND",
+        transportScope: "shared_provider_transport",
+      });
+
+      coordinator.reportSuccess(owner);
+      const nextOwnerPromise = coordinator.acquire();
+      await vi.advanceTimersByTimeAsync(250);
+      await expect(nextOwnerPromise).resolves.toEqual({
+        allowed: true,
+        probe: true,
+        generation: 2,
+      });
+      coordinator.reportProbeAbandoned(await nextOwnerPromise);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let an older success release a newer recovery probe", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const coordinator = new ProviderTransportCoordinator();
+      const olderPermit = await coordinator.acquire();
+      const failingPermit = await coordinator.acquire();
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        failingPermit,
+      );
+
+      const probePromise = coordinator.acquire();
+      await vi.advanceTimersByTimeAsync(250);
+      const probe = await probePromise;
+      expect(probe).toEqual({ allowed: true, probe: true, generation: 1 });
+
+      const waiter = coordinator.acquire();
+      coordinator.reportSuccess(olderPermit);
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        probe,
+      );
+
+      await expect(waiter).resolves.toMatchObject({
+        allowed: false,
+        errorCode: "ENOTFOUND",
+        transportScope: "shared_provider_transport",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hands an abandoned recovery probe to a waiter without failing it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const coordinator = new ProviderTransportCoordinator();
+      const initial = await coordinator.acquire();
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        initial,
+      );
+
+      const ownerPromise = coordinator.acquire();
+      await vi.advanceTimersByTimeAsync(250);
+      const owner = await ownerPromise;
+      const waiter = coordinator.acquire();
+      coordinator.reportProbeAbandoned(owner);
+
+      const replacement = await waiter;
+      expect(replacement).toEqual({
+        allowed: true,
+        probe: true,
+        generation: 2,
+      });
+      coordinator.reportTransportFailure(
+        "ENOTFOUND",
+        "shared_provider_transport",
+        replacement,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds shared DNS retries per request without rotating credentials", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-dns-budget-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const accountKeys = [
+      "anthropic:first@example.com",
+      "anthropic:second@example.com",
+      "anthropic:third@example.com",
+    ];
+    vi.spyOn(tokenStore, "pruneExpired").mockResolvedValue(undefined);
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue(accountKeys);
+    vi.spyOn(tokenStore, "isDisabled").mockResolvedValue(false);
+    vi.spyOn(tokenStore, "loadTokens").mockImplementation(async (key) => ({
+      accessToken: `${key.split(":")[1]}-token`,
+      refreshToken: "test-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    }));
+
+    const attemptedTokens: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      attemptedTokens.push(
+        (init?.headers as Record<string, string>).authorization,
+      );
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "ENOTFOUND" },
+      });
+    });
+
+    const route = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      false,
+      accountKeys[0],
+      {
+        runtimeConfigProvider: () => ({
+          generation: 1,
+          strategy: "fill-first",
+          modelRouter: undefined,
+          passthrough: false,
+          primaryAccountKey: accountKeys[0],
+          accountAllowlist: undefined,
+          quotaRoutingEnabled: false,
+          sessionSoftLimit: 0.97,
+          sessionResetToleranceMs: 15 * 60 * 1000,
+        }),
+      },
+    ).routes.find(
+      (candidate) =>
+        candidate.method === "POST" && candidate.path === "/v1/messages",
+    );
+    expect(route).toBeDefined();
+
+    const result = await route!.handler({
+      requestId: "dns-budget",
+      method: "POST",
+      path: "/v1/messages",
+      headers: {},
+      query: {},
+      params: {},
+      body: {
+        model: "claude-test",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      },
+      neurolink: {},
+      toolRegistry: {},
+      timestamp: Date.now(),
+      metadata: {},
+    } as never);
+
+    expect(attemptedTokens).toEqual([
+      "Bearer first@example.com-token",
+      "Bearer first@example.com-token",
+      "Bearer first@example.com-token",
+    ]);
+    expect(JSON.stringify(result)).toContain("shared Anthropic network");
+    expect(JSON.stringify(result)).not.toContain("shared_provider_transport");
+    expect(JSON.stringify(result)).toContain("ENOTFOUND");
+    expect(getTerminalErrors().recent[0]).toMatchObject({
+      errorCode: "ENOTFOUND",
+    });
+  });
+
+  it("uses one recovery probe for a concurrent DNS outage", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "neurolink-dns-half-open-"));
+    tempDirs.push(dir);
+    initAccountCooldown(join(dir, "cooldowns.json"));
+    initAccountQuota(join(dir, "quotas.json"));
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const accountKeys = [
+      "anthropic:first@example.com",
+      "anthropic:second@example.com",
+      "anthropic:third@example.com",
+    ];
+    vi.spyOn(tokenStore, "pruneExpired").mockResolvedValue(undefined);
+    vi.spyOn(tokenStore, "listByPrefix").mockResolvedValue(accountKeys);
+    vi.spyOn(tokenStore, "isDisabled").mockResolvedValue(false);
+    vi.spyOn(tokenStore, "loadTokens").mockImplementation(async (key) => ({
+      accessToken: `${key.split(":")[1]}-token`,
+      refreshToken: "test-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      tokenType: "Bearer",
+    }));
+
+    const fetchError = Object.assign(new TypeError("fetch failed"), {
+      cause: { code: "ENOTFOUND" },
+    });
+    const attemptedTokens: string[] = [];
+    const rejectInitial: Array<(error: Error) => void> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      attemptedTokens.push(
+        (init?.headers as Record<string, string>).authorization,
+      );
+      if (rejectInitial.length < 10) {
+        return new Promise<Response>((_resolve, reject) => {
+          rejectInitial.push(reject);
+        });
+      }
+      throw fetchError;
+    });
+
+    const route = createClaudeProxyRoutes(
+      undefined,
+      "",
+      "fill-first",
+      false,
+      accountKeys[0],
+      {
+        runtimeConfigProvider: () => ({
+          generation: 1,
+          strategy: "fill-first",
+          modelRouter: undefined,
+          passthrough: false,
+          primaryAccountKey: accountKeys[0],
+          accountAllowlist: undefined,
+          quotaRoutingEnabled: false,
+          sessionSoftLimit: 0.97,
+          sessionResetToleranceMs: 15 * 60 * 1000,
+        }),
+      },
+    ).routes.find(
+      (candidate) =>
+        candidate.method === "POST" && candidate.path === "/v1/messages",
+    );
+    expect(route).toBeDefined();
+
+    const requests = Array.from({ length: 10 }, (_, index) =>
+      route!.handler({
+        requestId: `dns-half-open-${index}`,
+        method: "POST",
+        path: "/v1/messages",
+        headers: {},
+        query: {},
+        params: {},
+        body: {
+          model: "claude-test",
+          max_tokens: 16,
+          messages: [{ role: "user", content: "hello" }],
+        },
+        neurolink: {},
+        toolRegistry: {},
+        timestamp: Date.now(),
+        metadata: {},
+      } as never),
+    );
+    await vi.waitFor(() => expect(rejectInitial).toHaveLength(10));
+    for (const reject of rejectInitial) {
+      reject(fetchError);
+    }
+    await Promise.all(requests);
+
+    expect(attemptedTokens).toHaveLength(12);
+    expect(new Set(attemptedTokens)).toEqual(
+      new Set(["Bearer first@example.com-token"]),
     );
   });
 
@@ -801,6 +1451,7 @@ describe("upstream attempt classification and retry amplification", () => {
       {
         retryable: false,
         errorCode: "ERR_INVALID_URL",
+        transportScope: "connection_transport",
       },
     );
     expect(getStats()).toMatchObject({ totalAttemptErrors: 1 });
@@ -1645,6 +2296,7 @@ describe("upstream attempt classification and retry amplification", () => {
     for (const code of [
       "EADDRNOTAVAIL",
       "ENOTFOUND",
+      "EAI_AGAIN",
       "ECONNREFUSED",
       "EHOSTUNREACH",
       "UND_ERR_CONNECT_TIMEOUT",
@@ -2016,9 +2668,9 @@ describe("cooldown persistence", () => {
       )?.candidates[0],
     ).toMatchObject({
       usable: true,
-      quotaObserved: false,
+      quotaObserved: true,
       quotaStale: true,
-      unifiedStatus: null,
+      quotaFreshness: "refresh_due",
     });
   });
 


### PR DESCRIPTION
## Description

Hardens Claude proxy account selection and transport retry behavior using the failure patterns observed in proxy logs.

The proxy no longer sends a production request to an unknown account merely to discover quota. Known healthy quota remains usable after the old 15-minute age threshold, while unknown or ambiguous evidence is refreshed through Anthropic's lightweight OAuth usage endpoint with per-account single-flight, trigger deduplication, and bounded failure backoff.

Fill-first routing continues to spend the weekly allowance that expires first. A session at the soft limit is demoted only when it has no explicit overage/fallback continuation path; overage-enabled accounts retain expiry-first priority.

Pre-response transport failures are classified separately from account failures. DNS and connection failures receive bounded same-account retries and do not rotate the same request across credentials. Concurrent DNS outages share a half-open recovery probe to prevent retry amplification.

## Changes Made

- Add adaptive quota refresh coordination with no timers and no user-payload probes.
- Preserve known healthy stale quota and rank unknown or ambiguous evidence behind it.
- Prewarm the next account near session or weekly handoff boundaries.
- Keep earliest weekly expiry first when overage or fallback is explicitly available.
- Add shared transport retry coordination and truthful terminal attribution.
- Add quota-refresh and transport-scope evidence to status and log analysis.
- Retain legacy `quota_probe` parsing only to flag old log records.
- Update the isolated proxy E2E contract for known-before-unknown routing.

## Testing

- [x] `pnpm run check`
- [x] `pnpm run lint` (0 errors; repository-wide warnings unchanged)
- [x] `pnpm run build` including React hooks, CLI, browser bundle, and publint
- [x] `pnpm run validate`
- [x] `pnpm run validate:env`
- [x] `pnpm run validate:security`
- [x] `pnpm run test:proxy:vitest` - 266 passed
- [x] Focused reliability and analysis Vitest - 110 passed
- [x] `pnpm run test:bugfixes` - 275 passed
- [x] `pnpm run test:proxy` - 20 passed, 6 credential-dependent tests skipped
- [x] `pnpm run test:proxy-usage-refresh` - 25 passed
- [x] `pnpm run test:proxy-terminal-errors` - 5 passed
- [x] `pnpm run proxy:performance` - all budgets passed

The proxy E2E ran on port 9876 under a temporary isolated HOME with provider credentials removed. No live proxy process, config, token store, launchd service, or production endpoint was touched.

### Concurrency proof

- 100 concurrent quota refresh calls produce one usage request.
- 10 concurrent DNS-failing proxy requests produce 12 upstream attempts total, all against the initially selected credential, instead of rotating across three accounts.

### Performance proof

- Transport path added p95: 2.038 ms (budget: 5 ms).
- Lifecycle hot-path p95: 9.667 us (budget: 500 us).
- Response tracking added p95: 53.167 us (budget: 1000 us).
- Rolling handoff: 0 concurrent failures and active stream preserved.

## Dependencies and deployment

No dependency or configuration migration is required. The behavior is scoped to the Claude proxy routing path. Existing response and body logging behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved proxy account routing with fresher quota information, saturation status, and soft-limit handling.
  * Added coordinated quota refreshes, adaptive background updates, and refresh metrics.
  * Added shared transport recovery for connection and DNS failures, including controlled retries and recovery probes.
  * Expanded proxy diagnostics with transport-scope details in logs, errors, and analysis reports.
* **Bug Fixes**
  * Prevented unknown quota data from being prioritized over known healthy accounts.
  * Improved handling of stale quota data, transient transport failures, and unsafe account rotation.
  * Added warnings when production requests are selected for quota discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->