### PR TITLE
feat(tts): stream buffered audio incrementally

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,14 +7,14 @@ by [`docs/guides/migration-guide.md`](./guides/migration-guide.md) and the
 auto-generated changelog (see the
 [GitHub releases page](https://github.com/juspay/neurolink/releases)).
 
-Three breaking changes shipped across 9.94.x–9.95.x. Each is intentional and
-stays as shipped — this document exists so downstream consumers know what
-changed and how to adapt.
+Three breaking changes shipped across 9.94.x–9.95.x, and a fourth is registered
+below before release. Each is intentional — this document exists so downstream
+consumers know what changed and how to adapt.
 
 ## Policy
 
 Per this repository's `CLAUDE.md` (Critical Rule 5), the public SDK API must
-not break existing callers. The three breaking changes below shipped in
+not break existing callers. The first three breaking changes below shipped in
 9.94.x–9.95.x without an accompanying migration path and are documented here
 retroactively. Going forward, any breaking change **must** ship its migration
 path in the same release that introduces it — not documented after the fact.
@@ -194,3 +194,19 @@ function handleBatch(argv: BatchCommandArgs) {
   unchanged — this is a type-only rename of the property NeuroLink's own
   `batch` command handler reads internally; end users invoking
   `neurolink batch <promptsFile>` on the command line see no difference.
+
+---
+
+## 4. `stream()` synthesizes whenever `tts.enabled` is set (unreleased)
+
+**Who is affected:** SDK callers using `stream()` with `tts.enabled: true`
+without setting `useAiResponse: true`.
+
+**What changed:** those callers now receive incremental `tts_audio` chunks and
+the aggregate `streamResult.audio`. `useAiResponse` continues to choose input
+versus response synthesis for `generate()`; it no longer gates synthesis for
+`stream()`.
+
+**How to adapt:** disable TTS for a text-only stream by omitting `tts` or setting
+`tts.enabled: false`. Keep `tts.enabled: true` when streamed response audio is
+desired; no `useAiResponse` value is required on that path.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2473,6 +2473,7 @@ console.log(result.content);
 - [AudioInputSpec](type-aliases/AudioInputSpec.md)
 - [AudioChunk](type-aliases/AudioChunk.md)
 - [StreamChunk](type-aliases/StreamChunk.md)
+- [ProviderStreamChunk](type-aliases/ProviderStreamChunk.md)
 - [StreamOptions](type-aliases/StreamOptions.md)
 - [StreamResult](type-aliases/StreamResult.md)
 - [EnhancedStreamProvider](type-aliases/EnhancedStreamProvider.md)

--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -6,7 +6,7 @@
 
 # Class: NeuroLink
 
-Defined in: [neurolink.ts:607](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L607)
+Defined in: [neurolink.ts:608](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L608)
 
 ## Constructors
 
@@ -14,7 +14,7 @@ Defined in: [neurolink.ts:607](https://github.com/juspay/neurolink/blob/release/
 
 > **new NeuroLink**(`config?`): `NeuroLink`
 
-Defined in: [neurolink.ts:1252](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1252)
+Defined in: [neurolink.ts:1253](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1253)
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: [neurolink.ts:1252](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **conversationMemory?**: `ConversationMemoryManager` \| `RedisConversationMemoryManager` \| `null`
 
-Defined in: [neurolink.ts:710](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L710)
+Defined in: [neurolink.ts:711](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L711)
 
 ## Accessors
 
@@ -42,7 +42,7 @@ Defined in: [neurolink.ts:710](https://github.com/juspay/neurolink/blob/release/
 
 > **get** **tasks**(): `TaskManager`
 
-Defined in: [neurolink.ts:1413](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1413)
+Defined in: [neurolink.ts:1414](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1414)
 
 TaskManager — scheduled and self-running tasks.
 Lazy-initialized on first access. Configurable via constructor `tasks` option.
@@ -61,7 +61,7 @@ lazily inside TaskManager on first operation.
 
 > **generate**(`optionsOrPrompt`): `Promise`\<[`GenerateResult`](../type-aliases/GenerateResult.md)\>
 
-Defined in: [neurolink.ts:4244](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L4244)
+Defined in: [neurolink.ts:4245](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L4245)
 
 Generate AI response with comprehensive feature support.
 
@@ -191,7 +191,7 @@ When HITL approval is denied
 
 > **getSkillsManager**(): [`SkillsManager`](SkillsManager.md) \| `null`
 
-Defined in: [neurolink.ts:2224](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L2224)
+Defined in: [neurolink.ts:2225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L2225)
 
 Programmatic access to the skills subsystem (search/list/get/mutations).
 Returns null when skills are not configured or failed to initialize.
@@ -206,7 +206,7 @@ Returns null when skills are not configured or failed to initialize.
 
 > **getObservabilityConfig**(): [`ObservabilityConfig`](../type-aliases/ObservabilityConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:3456](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3456)
+Defined in: [neurolink.ts:3457](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3457)
 
 Get observability configuration
 
@@ -220,7 +220,7 @@ Get observability configuration
 
 > **isTelemetryEnabled**(): `boolean`
 
-Defined in: [neurolink.ts:3464](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3464)
+Defined in: [neurolink.ts:3465](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3465)
 
 Check if Langfuse telemetry is enabled
 Centralized utility to avoid duplication across providers
@@ -235,7 +235,7 @@ Centralized utility to avoid duplication across providers
 
 > **getTelemetryStatus**(): `object`
 
-Defined in: [neurolink.ts:3476](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3476)
+Defined in: [neurolink.ts:3477](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3477)
 
 Get comprehensive telemetry status including Langfuse, OTel, and exporter health
 
@@ -289,7 +289,7 @@ Get comprehensive telemetry status including Langfuse, OTel, and exporter health
 
 > **getMetrics**(): [`MetricsSummary`](../type-aliases/MetricsSummary.md)
 
-Defined in: [neurolink.ts:3531](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3531)
+Defined in: [neurolink.ts:3532](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3532)
 
 Get aggregated observability metrics (latency, tokens, cost, success rate)
 
@@ -303,7 +303,7 @@ Get aggregated observability metrics (latency, tokens, cost, success rate)
 
 > **getSpans**(): [`SpanData`](../type-aliases/SpanData.md)[]
 
-Defined in: [neurolink.ts:3538](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3538)
+Defined in: [neurolink.ts:3539](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3539)
 
 Get all recorded spans
 
@@ -317,7 +317,7 @@ Get all recorded spans
 
 > **getTraces**(): [`TraceView`](../type-aliases/TraceView.md)[]
 
-Defined in: [neurolink.ts:3545](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3545)
+Defined in: [neurolink.ts:3546](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3546)
 
 Get traces (spans grouped by traceId with parent-child hierarchy)
 
@@ -331,7 +331,7 @@ Get traces (spans grouped by traceId with parent-child hierarchy)
 
 > **resetMetrics**(): `void`
 
-Defined in: [neurolink.ts:3552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3552)
+Defined in: [neurolink.ts:3553](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3553)
 
 Reset all collected metrics and spans
 
@@ -345,7 +345,7 @@ Reset all collected metrics and spans
 
 > **recordMetricsSpan**(`span`): `void`
 
-Defined in: [neurolink.ts:3559](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3559)
+Defined in: [neurolink.ts:3560](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3560)
 
 Record a span for metrics tracking
 
@@ -365,7 +365,7 @@ Record a span for metrics tracking
 
 > **getProviderMetrics**(`options?`): `Promise`\<[`ProviderMetricsResult`](../type-aliases/ProviderMetricsResult.md)\>
 
-Defined in: [neurolink.ts:3570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3570)
+Defined in: [neurolink.ts:3571](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3571)
 
 Get provider metrics analysis
 Retrieves aggregated performance, token usage, latency, and success rates per provider.
@@ -390,7 +390,7 @@ Comprehensive provider metrics result
 
 > **getCostAnalysis**(`options?`): `Promise`\<[`CostAnalysisResult`](../type-aliases/CostAnalysisResult.md)\>
 
-Defined in: [neurolink.ts:3585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3585)
+Defined in: [neurolink.ts:3586](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3586)
 
 Get cost analysis breakdown
 Analyzes AI generation costs across requested groups and provides future projections.
@@ -415,7 +415,7 @@ Detailed cost analysis breakdown
 
 > **getTeamAnalytics**(`options?`): `Promise`\<[`TeamAnalyticsResult`](../type-aliases/TeamAnalyticsResult.md)\>
 
-Defined in: [neurolink.ts:3598](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3598)
+Defined in: [neurolink.ts:3599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3599)
 
 Get team-wide usage analytics
 Retrieves request counts, unique active users, provider breakdown, and quality scoring.
@@ -440,7 +440,7 @@ Comprehensive team analytics report
 
 > **initializeLangfuseObservability**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:3640](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3640)
+Defined in: [neurolink.ts:3641](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3641)
 
 Public method to initialize Langfuse observability
 This method can be called externally to ensure Langfuse is properly initialized
@@ -455,7 +455,7 @@ This method can be called externally to ensure Langfuse is properly initialized
 
 > **shutdown**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:3670](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3670)
+Defined in: [neurolink.ts:3671](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3671)
 
 Gracefully shutdown NeuroLink and all MCP connections
 
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6286)
+Defined in: [neurolink.ts:6287](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6287)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8658](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8658)
+Defined in: [neurolink.ts:8659](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8659)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:8739](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8739)
+Defined in: [neurolink.ts:8742](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8742)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -550,7 +550,9 @@ const result = await neurolink.stream({
 
 // Consume the stream
 for await (const chunk of result.stream) {
-  process.stdout.write(chunk.content);
+  if ("content" in chunk) {
+    process.stdout.write(chunk.content);
+  }
 }
 
 // Advanced streaming with options
@@ -586,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9625](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9625)
+Defined in: [neurolink.ts:9632](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9632)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -611,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9643)
+Defined in: [neurolink.ts:9650](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9650)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -625,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12069)
+Defined in: [neurolink.ts:12061](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12061)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -831,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12085)
+Defined in: [neurolink.ts:12077](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12077)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -854,7 +856,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12096](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12096)
+Defined in: [neurolink.ts:12088](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12088)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -872,7 +874,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12107](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12107)
+Defined in: [neurolink.ts:12099](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12099)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -896,7 +898,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12124](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12124)
+Defined in: [neurolink.ts:12116](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12116)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -922,7 +924,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12169](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12169)
+Defined in: [neurolink.ts:12161](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12161)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -974,7 +976,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12248)
+Defined in: [neurolink.ts:12240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12240)
 
 Emit tool start event with execution tracking
 
@@ -1010,7 +1012,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12299](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12299)
+Defined in: [neurolink.ts:12291](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12291)
 
 Emit tool end event with execution summary
 
@@ -1062,7 +1064,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12380](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12380)
+Defined in: [neurolink.ts:12372](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12372)
 
 Get current tool execution contexts for stream metadata
 
@@ -1076,7 +1078,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12387](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12387)
+Defined in: [neurolink.ts:12379](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12379)
 
 Get tool execution history
 
@@ -1090,7 +1092,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12394](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12394)
+Defined in: [neurolink.ts:12386](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12386)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1104,7 +1106,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12410](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12410)
+Defined in: [neurolink.ts:12402](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12402)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1150,7 +1152,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12551](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12551)
+Defined in: [neurolink.ts:12543](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12543)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1173,7 +1175,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12566](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12566)
+Defined in: [neurolink.ts:12558](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12558)
 
 Get the current tool execution context
 
@@ -1189,7 +1191,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12575](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12575)
+Defined in: [neurolink.ts:12567](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12567)
 
 Clear the tool execution context
 
@@ -1203,7 +1205,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12587](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12587)
+Defined in: [neurolink.ts:12579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12579)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1228,7 +1230,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12610](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12610)
+Defined in: [neurolink.ts:12602](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12602)
 
 Unregister a custom tool
 
@@ -1252,7 +1254,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12628](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12628)
+Defined in: [neurolink.ts:12620](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12620)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1277,7 +1279,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:12641](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12641)
+Defined in: [neurolink.ts:12633](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12633)
 
 Get all registered tool middlewares
 
@@ -1291,7 +1293,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12648](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12648)
+Defined in: [neurolink.ts:12640](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12640)
 
 Flush any pending batched tool calls immediately
 
@@ -1305,7 +1307,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12657](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12657)
+Defined in: [neurolink.ts:12649](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12649)
 
 Get the current MCP enhancements configuration
 
@@ -1319,7 +1321,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12680)
+Defined in: [neurolink.ts:12672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12672)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1369,7 +1371,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:12716](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12716)
+Defined in: [neurolink.ts:12708](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12708)
 
 Get all registered custom tools
 
@@ -1385,7 +1387,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12854](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12854)
+Defined in: [neurolink.ts:12846](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12846)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1414,7 +1416,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:12898](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12898)
+Defined in: [neurolink.ts:12890](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12890)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1437,7 +1439,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12925](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12925)
+Defined in: [neurolink.ts:12917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12917)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1467,7 +1469,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12941](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12941)
+Defined in: [neurolink.ts:12933](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12933)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1483,7 +1485,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:12953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12953)
+Defined in: [neurolink.ts:12945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12945)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1564,7 +1566,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:13957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13957)
+Defined in: [neurolink.ts:13949](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13949)
 
 ##### Returns
 
@@ -1576,7 +1578,7 @@ Defined in: [neurolink.ts:13957](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14139](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14139)
+Defined in: [neurolink.ts:14131](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14131)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1599,7 +1601,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14320](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14320)
+Defined in: [neurolink.ts:14312](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14312)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1623,7 +1625,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14352](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14352)
+Defined in: [neurolink.ts:14344](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14344)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1647,7 +1649,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14361](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14361)
+Defined in: [neurolink.ts:14353](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14353)
 
 Get list of all available AI provider names
 
@@ -1663,7 +1665,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14371](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14371)
+Defined in: [neurolink.ts:14363](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14363)
 
 Validate if a provider name is supported
 
@@ -1687,7 +1689,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14384)
+Defined in: [neurolink.ts:14376](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14376)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1703,7 +1705,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14454](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14454)
+Defined in: [neurolink.ts:14446](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14446)
 
 List all configured MCP servers with their status
 
@@ -1719,7 +1721,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14469](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14469)
+Defined in: [neurolink.ts:14461](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14461)
 
 Test connectivity to a specific MCP server
 
@@ -1743,7 +1745,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14510)
+Defined in: [neurolink.ts:14502](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14502)
 
 Check if a provider has the required environment variables configured
 
@@ -1767,7 +1769,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14536](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14536)
+Defined in: [neurolink.ts:14528](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14528)
 
 Perform comprehensive health check on a specific provider
 
@@ -1811,7 +1813,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14582](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14582)
+Defined in: [neurolink.ts:14574](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14574)
 
 Check health of all supported providers
 
@@ -1849,7 +1851,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14626](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14626)
+Defined in: [neurolink.ts:14618](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14618)
 
 Get a summary of provider health across all supported providers
 
@@ -1865,7 +1867,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:14673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14673)
+Defined in: [neurolink.ts:14665](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14665)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1887,7 +1889,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:14684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14684)
+Defined in: [neurolink.ts:14676](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14676)
 
 Get execution metrics for all tools
 
@@ -1903,7 +1905,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:14728](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14728)
+Defined in: [neurolink.ts:14720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14720)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1926,7 +1928,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:14741](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14741)
+Defined in: [neurolink.ts:14733](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14733)
 
 Get circuit breaker status for all tools
 
@@ -1942,7 +1944,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:14776](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14776)
+Defined in: [neurolink.ts:14768](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14768)
 
 Reset circuit breaker for a specific tool
 
@@ -1964,7 +1966,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:14793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14793)
+Defined in: [neurolink.ts:14785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14785)
 
 Clear all tool execution metrics
 
@@ -1978,7 +1980,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:14802](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14802)
+Defined in: [neurolink.ts:14794](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14794)
 
 Get comprehensive tool health report
 
@@ -1994,7 +1996,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14957)
+Defined in: [neurolink.ts:14949](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14949)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2011,7 +2013,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:14977](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14977)
+Defined in: [neurolink.ts:14969](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14969)
 
 Get conversation memory statistics (public API)
 
@@ -2025,7 +2027,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15004)
+Defined in: [neurolink.ts:14996](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14996)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2049,7 +2051,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15060](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15060)
+Defined in: [neurolink.ts:15052](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15052)
 
 Clear conversation history for a specific session (public API)
 
@@ -2069,7 +2071,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15086](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15086)
+Defined in: [neurolink.ts:15078](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15078)
 
 Clear all conversation history (public API)
 
@@ -2083,7 +2085,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15114](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15114)
+Defined in: [neurolink.ts:15106](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15106)
 
 List all conversation sessions with metadata (public API)
 
@@ -2107,7 +2109,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15163](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15163)
+Defined in: [neurolink.ts:15155](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15155)
 
 Export a single session with full history and metadata (public API)
 
@@ -2143,7 +2145,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15248)
+Defined in: [neurolink.ts:15240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15240)
 
 Export all sessions for a user (public API)
 
@@ -2179,7 +2181,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15312](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15312)
+Defined in: [neurolink.ts:15304](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15304)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2227,7 +2229,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15382](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15382)
+Defined in: [neurolink.ts:15374](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15374)
 
 Check if tool execution storage is available.
 
@@ -2248,7 +2250,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15392](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15392)
+Defined in: [neurolink.ts:15384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15384)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2277,7 +2279,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15433](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15433)
+Defined in: [neurolink.ts:15425](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15425)
 
 Replace the entire messages array for a session.
 
@@ -2311,7 +2313,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15481](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15481)
+Defined in: [neurolink.ts:15473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15473)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2348,7 +2350,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15512](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15512)
+Defined in: [neurolink.ts:15504](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15504)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2379,7 +2381,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15599)
+Defined in: [neurolink.ts:15591](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15591)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2404,7 +2406,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:15651](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15651)
+Defined in: [neurolink.ts:15643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15643)
 
 List all external MCP servers
 
@@ -2420,7 +2422,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:15680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15680)
+Defined in: [neurolink.ts:15672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15672)
 
 Get external MCP server status
 
@@ -2444,7 +2446,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:15694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15694)
+Defined in: [neurolink.ts:15686](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15686)
 
 Execute a tool from an external MCP server
 
@@ -2488,7 +2490,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15791)
+Defined in: [neurolink.ts:15783](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15783)
 
 Get all tools from external MCP servers
 
@@ -2504,7 +2506,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15800](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15800)
+Defined in: [neurolink.ts:15792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15792)
 
 Get tools from a specific external MCP server
 
@@ -2528,7 +2530,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:15809](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15809)
+Defined in: [neurolink.ts:15801](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15801)
 
 Test connection to an external MCP server
 
@@ -2552,7 +2554,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:15837](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15837)
+Defined in: [neurolink.ts:15829](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15829)
 
 Get external MCP server manager statistics
 
@@ -2592,7 +2594,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15852](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15852)
+Defined in: [neurolink.ts:15844](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15844)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2607,7 +2609,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15890](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15890)
+Defined in: [neurolink.ts:15882](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15882)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2638,7 +2640,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15918](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15918)
+Defined in: [neurolink.ts:15910](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15910)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2676,7 +2678,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15941](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15941)
+Defined in: [neurolink.ts:15933](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15933)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2705,7 +2707,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15966](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15966)
+Defined in: [neurolink.ts:15958](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15958)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2735,7 +2737,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15993](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15993)
+Defined in: [neurolink.ts:15985](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15985)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2767,7 +2769,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16021](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16021)
+Defined in: [neurolink.ts:16013](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16013)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2844,7 +2846,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16062](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16062)
+Defined in: [neurolink.ts:16054](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16054)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2925,7 +2927,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16101](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16101)
+Defined in: [neurolink.ts:16093](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16093)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -2955,7 +2957,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16123](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16123)
+Defined in: [neurolink.ts:16115](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16115)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -2996,7 +2998,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16162](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16162)
+Defined in: [neurolink.ts:16154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16154)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3037,7 +3039,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16185](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16185)
+Defined in: [neurolink.ts:16177](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16177)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3069,7 +3071,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16424](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16424)
+Defined in: [neurolink.ts:16416](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16416)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3120,7 +3122,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:16516](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16516)
+Defined in: [neurolink.ts:16508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16508)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3222,7 +3224,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:16654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16654)
+Defined in: [neurolink.ts:16646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16646)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3291,7 +3293,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:16740](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16740)
+Defined in: [neurolink.ts:16732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16732)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3352,7 +3354,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:16786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16786)
+Defined in: [neurolink.ts:16778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16778)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3378,7 +3380,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:16809](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16809)
+Defined in: [neurolink.ts:16801](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16801)
 
 Get details of a specific evaluation preset.
 
@@ -3414,7 +3416,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:16859](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16859)
+Defined in: [neurolink.ts:16851](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16851)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3466,7 +3468,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:16921](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16921)
+Defined in: [neurolink.ts:16913](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16913)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3540,7 +3542,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:16953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16953)
+Defined in: [neurolink.ts:16945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16945)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3580,7 +3582,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17042](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17042)
+Defined in: [neurolink.ts:17034](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17034)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3630,7 +3632,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17061](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17061)
+Defined in: [neurolink.ts:17053](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17053)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3663,7 +3665,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17077](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17077)
+Defined in: [neurolink.ts:17069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17069)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3688,7 +3690,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17095](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17095)
+Defined in: [neurolink.ts:17087](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17087)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3726,7 +3728,7 @@ The registered tool name
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:17117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17117)
+Defined in: [neurolink.ts:17109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17109)
 
 Execute an agent network with the given input.
 
@@ -3771,7 +3773,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:17141](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17141)
+Defined in: [neurolink.ts:17133](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17133)
 
 Stream agent network execution with real-time events.
 
@@ -3815,7 +3817,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:17165](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17165)
+Defined in: [neurolink.ts:17157](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17157)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -3843,7 +3845,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:17184](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17184)
+Defined in: [neurolink.ts:17176](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17176)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -3871,7 +3873,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:17202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17202)
+Defined in: [neurolink.ts:17194](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17194)
 
 Create a MessageBus for inter-agent communication.
 
@@ -3899,7 +3901,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17217](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17217)
+Defined in: [neurolink.ts:17209](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17209)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -3915,7 +3917,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:17404](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17404)
+Defined in: [neurolink.ts:17396](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17396)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -3932,7 +3934,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:17412](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17412)
+Defined in: [neurolink.ts:17404](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17404)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -3957,7 +3959,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:17463](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17463)
+Defined in: [neurolink.ts:17455](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17455)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -3986,7 +3988,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:17505](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17505)
+Defined in: [neurolink.ts:17497](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17497)
 
 Check if a session needs compaction.
 
@@ -4014,7 +4016,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17542](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17542)
+Defined in: [neurolink.ts:17534](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17534)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4036,7 +4038,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:17590](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17590)
+Defined in: [neurolink.ts:17582](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17582)
 
 Get the currently configured authentication provider
 
@@ -4050,7 +4052,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17631)
+Defined in: [neurolink.ts:17623](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17623)
 
 Set the current authentication context for request handling.
 
@@ -4077,7 +4079,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:17646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17646)
+Defined in: [neurolink.ts:17638](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17638)
 
 Get the current authentication context.
 
@@ -4093,7 +4095,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17654)
+Defined in: [neurolink.ts:17646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17646)
 
 Clear the current authentication context
 
@@ -4107,7 +4109,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:17668](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17668)
+Defined in: [neurolink.ts:17660](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17660)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/classes/TTSError.md
+++ b/docs/api/classes/TTSError.md
@@ -6,7 +6,7 @@
 
 # Class: TTSError
 
-Defined in: [utils/ttsProcessor.ts:36](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L36)
+Defined in: [utils/ttsProcessor.ts:131](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L131)
 
 TTS Error class for text-to-speech specific errors
 
@@ -20,7 +20,7 @@ TTS Error class for text-to-speech specific errors
 
 > **new TTSError**(`options`): `TTSError`
 
-Defined in: [utils/ttsProcessor.ts:37](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L37)
+Defined in: [utils/ttsProcessor.ts:132](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L132)
 
 #### Parameters
 

--- a/docs/api/classes/TTSProcessor.md
+++ b/docs/api/classes/TTSProcessor.md
@@ -6,7 +6,7 @@
 
 # Class: TTSProcessor
 
-Defined in: [utils/ttsProcessor.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L76)
+Defined in: [utils/ttsProcessor.ts:171](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L171)
 
 TTS processor class for orchestrating text-to-speech operations
 
@@ -41,7 +41,7 @@ if (TTSProcessor.supports("google-ai")) {
 
 > `static` **registerHandler**(`providerName`, `handler`): `void`
 
-Defined in: [utils/ttsProcessor.ts:116](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L116)
+Defined in: [utils/ttsProcessor.ts:211](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L211)
 
 Register a TTS handler for a specific provider
 
@@ -83,7 +83,7 @@ TTSProcessor.registerHandler('google-ai', googleHandler);
 
 > `static` **getHandler**(`providerName`): [`TTSHandler`](../type-aliases/TTSHandler.md) \| `undefined`
 
-Defined in: [utils/ttsProcessor.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L136)
+Defined in: [utils/ttsProcessor.ts:231](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L231)
 
 Get a registered TTS handler by provider name.
 
@@ -111,7 +111,7 @@ Handler instance or undefined if not registered
 
 > `static` **listProviders**(): `string`[]
 
-Defined in: [utils/ttsProcessor.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L143)
+Defined in: [utils/ttsProcessor.ts:238](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L238)
 
 List the names of all registered providers.
 
@@ -125,7 +125,7 @@ List the names of all registered providers.
 
 > `static` **clearHandlers**(): `void`
 
-Defined in: [utils/ttsProcessor.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L151)
+Defined in: [utils/ttsProcessor.ts:246](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L246)
 
 Removes every registered TTS handler. Primarily for test isolation —
 production code should not need to call this.
@@ -140,7 +140,7 @@ production code should not need to call this.
 
 > `static` **supports**(`providerName`): `boolean`
 
-Defined in: [utils/ttsProcessor.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L168)
+Defined in: [utils/ttsProcessor.ts:263](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L263)
 
 Check if a provider is supported (has a registered TTS handler)
 
@@ -172,7 +172,7 @@ if (TTSProcessor.supports("google-ai")) {
 
 > `static` **synthesize**(`text`, `provider`, `options`): `Promise`\<[`TTSResult`](../type-aliases/TTSResult.md)\>
 
-Defined in: [utils/ttsProcessor.ts:218](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L218)
+Defined in: [utils/ttsProcessor.ts:313](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L313)
 
 Synthesize speech from text using a registered TTS provider
 
@@ -231,3 +231,44 @@ const result = await TTSProcessor.synthesize("Hello, world!", "google-ai", {
 console.log(`Generated ${result.size} bytes of ${result.format} audio`);
 // Save to file or play the audio buffer
 ```
+
+---
+
+### synthesizeStream()
+
+> `static` **synthesizeStream**(`textChunks`, `provider`, `options`, `shouldStop?`): `AsyncGenerator`\<[`TTSChunk`](../type-aliases/TTSChunk.md)\>
+
+Defined in: [utils/ttsProcessor.ts:465](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L465)
+
+Incrementally synthesize sentence-buffered text chunks.
+
+Text is flushed at a sentence boundary after `streamingBufferSize`
+characters, or hard-split before the provider's maximum text length.
+Each segment goes through `synthesize()`, preserving the existing handler
+registry, validation, error normalization, and telemetry seam.
+
+The most recent successful audio chunk is held until another succeeds or
+the input ends, so exactly one real audio chunk carries `isFinal: true`
+without emitting a separate empty terminator chunk.
+
+#### Parameters
+
+##### textChunks
+
+`AsyncIterable`\<`string`\>
+
+##### provider
+
+`string`
+
+##### options
+
+[`TTSOptions`](../type-aliases/TTSOptions.md)
+
+##### shouldStop?
+
+() => `boolean`
+
+#### Returns
+
+`AsyncGenerator`\<[`TTSChunk`](../type-aliases/TTSChunk.md)\>

--- a/docs/api/functions/isTTSResult.md
+++ b/docs/api/functions/isTTSResult.md
@@ -8,7 +8,7 @@
 
 > **isTTSResult**(`value`): `value is TTSResult`
 
-Defined in: [types/tts.ts:223](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L223)
+Defined in: [types/tts.ts:232](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L232)
 
 Type guard to check if an object is a TTSResult
 

--- a/docs/api/functions/isValidTTSOptions.md
+++ b/docs/api/functions/isValidTTSOptions.md
@@ -8,7 +8,7 @@
 
 > **isValidTTSOptions**(`options`): `options is TTSOptions`
 
-Defined in: [types/tts.ts:240](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L240)
+Defined in: [types/tts.ts:249](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L249)
 
 Type guard to check if TTSOptions are valid
 

--- a/docs/api/type-aliases/AISDKUsage.md
+++ b/docs/api/type-aliases/AISDKUsage.md
@@ -8,7 +8,7 @@
 
 > **AISDKUsage** = `object`
 
-Defined in: [types/stream.ts:912](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L912)
+Defined in: [types/stream.ts:944](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L944)
 
 Raw usage data from Vercel AI SDK.
 
@@ -26,7 +26,7 @@ extractTokenUsage() in tokenUtils.ts already handles both shapes.
 
 > `optional` **promptTokens?**: `number`
 
-Defined in: [types/stream.ts:914](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L914)
+Defined in: [types/stream.ts:946](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L946)
 
 #### Deprecated
 
@@ -38,7 +38,7 @@ AI SDK v4 name — use inputTokens
 
 > `optional` **completionTokens?**: `number`
 
-Defined in: [types/stream.ts:916](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L916)
+Defined in: [types/stream.ts:948](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L948)
 
 #### Deprecated
 
@@ -50,7 +50,7 @@ AI SDK v4 name — use outputTokens
 
 > `optional` **totalTokens?**: `number`
 
-Defined in: [types/stream.ts:918](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L918)
+Defined in: [types/stream.ts:950](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L950)
 
 #### Deprecated
 
@@ -62,7 +62,7 @@ AI SDK v4 name — use totalTokens
 
 > `optional` **inputTokens?**: `number`
 
-Defined in: [types/stream.ts:920](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L920)
+Defined in: [types/stream.ts:952](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L952)
 
 AI SDK v6 name for prompt / input tokens
 
@@ -72,6 +72,6 @@ AI SDK v6 name for prompt / input tokens
 
 > `optional` **outputTokens?**: `number`
 
-Defined in: [types/stream.ts:922](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L922)
+Defined in: [types/stream.ts:954](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L954)
 
 AI SDK v6 name for completion / output tokens

--- a/docs/api/type-aliases/AudioChunk.md
+++ b/docs/api/type-aliases/AudioChunk.md
@@ -8,7 +8,7 @@
 
 > **AudioChunk** = `object`
 
-Defined in: [types/stream.ts:157](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L157)
+Defined in: [types/stream.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L158)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/stream.ts:157](https://github.com/juspay/neurolink/blob/relea
 
 > **data**: `Buffer`
 
-Defined in: [types/stream.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L158)
+Defined in: [types/stream.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L159)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/stream.ts:158](https://github.com/juspay/neurolink/blob/relea
 
 > **sampleRateHz**: `number`
 
-Defined in: [types/stream.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L159)
+Defined in: [types/stream.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L160)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/stream.ts:159](https://github.com/juspay/neurolink/blob/relea
 
 > **channels**: `number`
 
-Defined in: [types/stream.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L160)
+Defined in: [types/stream.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L161)
 
 ---
 
@@ -40,4 +40,4 @@ Defined in: [types/stream.ts:160](https://github.com/juspay/neurolink/blob/relea
 
 > **encoding**: [`PCMEncoding`](PCMEncoding.md)
 
-Defined in: [types/stream.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L161)
+Defined in: [types/stream.ts:162](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L162)

--- a/docs/api/type-aliases/AudioFormat.md
+++ b/docs/api/type-aliases/AudioFormat.md
@@ -8,7 +8,7 @@
 
 > **AudioFormat** = [`TTSAudioFormat`](TTSAudioFormat.md)
 
-Defined in: [types/tts.ts:169](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L169)
+Defined in: [types/tts.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L178)
 
 ## Deprecated
 

--- a/docs/api/type-aliases/AudioInputSpec.md
+++ b/docs/api/type-aliases/AudioInputSpec.md
@@ -8,7 +8,7 @@
 
 > **AudioInputSpec** = `object`
 
-Defined in: [types/stream.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L150)
+Defined in: [types/stream.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L151)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/stream.ts:150](https://github.com/juspay/neurolink/blob/relea
 
 > **frames**: `AsyncIterable`\<`Buffer`\>
 
-Defined in: [types/stream.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L151)
+Defined in: [types/stream.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L152)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/stream.ts:151](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **sampleRateHz?**: `number`
 
-Defined in: [types/stream.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L152)
+Defined in: [types/stream.ts:153](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L153)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/stream.ts:152](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **encoding?**: [`PCMEncoding`](PCMEncoding.md)
 
-Defined in: [types/stream.ts:153](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L153)
+Defined in: [types/stream.ts:154](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L154)
 
 ---
 
@@ -40,4 +40,4 @@ Defined in: [types/stream.ts:153](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **channels?**: `1`
 
-Defined in: [types/stream.ts:154](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L154)
+Defined in: [types/stream.ts:155](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L155)

--- a/docs/api/type-aliases/AudioSaveResult.md
+++ b/docs/api/type-aliases/AudioSaveResult.md
@@ -8,7 +8,7 @@
 
 > **AudioSaveResult** = `object`
 
-Defined in: [types/tts.ts:137](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L137)
+Defined in: [types/tts.ts:146](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L146)
 
 Result of saving audio to file
 
@@ -18,7 +18,7 @@ Result of saving audio to file
 
 > **success**: `boolean`
 
-Defined in: [types/tts.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L139)
+Defined in: [types/tts.ts:148](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L148)
 
 Whether the save was successful
 
@@ -28,7 +28,7 @@ Whether the save was successful
 
 > **path**: `string`
 
-Defined in: [types/tts.ts:141](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L141)
+Defined in: [types/tts.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L150)
 
 Full path to the saved file
 
@@ -38,7 +38,7 @@ Full path to the saved file
 
 > **size**: `number`
 
-Defined in: [types/tts.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L143)
+Defined in: [types/tts.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L152)
 
 File size in bytes
 
@@ -48,6 +48,6 @@ File size in bytes
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tts.ts:145](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L145)
+Defined in: [types/tts.ts:154](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L154)
 
 Error message if failed

--- a/docs/api/type-aliases/CartesiaMessage.md
+++ b/docs/api/type-aliases/CartesiaMessage.md
@@ -8,7 +8,7 @@
 
 > **CartesiaMessage** = `object`
 
-Defined in: [types/tts.ts:293](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L293)
+Defined in: [types/tts.ts:310](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L310)
 
 Message envelope received from the Cartesia TTS WebSocket.
 
@@ -18,7 +18,7 @@ Message envelope received from the Cartesia TTS WebSocket.
 
 > `optional` **data?**: `string`
 
-Defined in: [types/tts.ts:294](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L294)
+Defined in: [types/tts.ts:311](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L311)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tts.ts:294](https://github.com/juspay/neurolink/blob/release/
 
 > `optional` **done?**: `boolean`
 
-Defined in: [types/tts.ts:295](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L295)
+Defined in: [types/tts.ts:312](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L312)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/tts.ts:295](https://github.com/juspay/neurolink/blob/release/
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tts.ts:296](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L296)
+Defined in: [types/tts.ts:313](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L313)

--- a/docs/api/type-aliases/EnhancedStreamProvider.md
+++ b/docs/api/type-aliases/EnhancedStreamProvider.md
@@ -8,7 +8,7 @@
 
 > **EnhancedStreamProvider** = `object`
 
-Defined in: [types/stream.ts:859](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L859)
+Defined in: [types/stream.ts:891](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L891)
 
 Enhanced provider type with stream method
 
@@ -18,7 +18,7 @@ Enhanced provider type with stream method
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](StreamResult.md)\>
 
-Defined in: [types/stream.ts:860](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L860)
+Defined in: [types/stream.ts:892](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L892)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/stream.ts:860](https://github.com/juspay/neurolink/blob/relea
 
 > **getName**(): `string`
 
-Defined in: [types/stream.ts:861](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L861)
+Defined in: [types/stream.ts:893](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L893)
 
 #### Returns
 
@@ -48,7 +48,7 @@ Defined in: [types/stream.ts:861](https://github.com/juspay/neurolink/blob/relea
 
 > **isAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [types/stream.ts:862](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L862)
+Defined in: [types/stream.ts:894](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L894)
 
 #### Returns
 

--- a/docs/api/type-aliases/Gender.md
+++ b/docs/api/type-aliases/Gender.md
@@ -8,7 +8,7 @@
 
 > **Gender** = [`TTSGender`](TTSGender.md)
 
-Defined in: [types/tts.ts:175](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L175)
+Defined in: [types/tts.ts:184](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L184)
 
 ## Deprecated
 

--- a/docs/api/type-aliases/GoogleAudioEncoding.md
+++ b/docs/api/type-aliases/GoogleAudioEncoding.md
@@ -8,6 +8,6 @@
 
 > **GoogleAudioEncoding** = `"MP3"` \| `"LINEAR16"` \| `"OGG_OPUS"`
 
-Defined in: [types/tts.ts:218](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L218)
+Defined in: [types/tts.ts:227](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L227)
 
 Valid Google TTS audio formats

--- a/docs/api/type-aliases/PCMEncoding.md
+++ b/docs/api/type-aliases/PCMEncoding.md
@@ -8,7 +8,7 @@
 
 > **PCMEncoding** = `"PCM16LE"`
 
-Defined in: [types/stream.ts:148](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L148)
+Defined in: [types/stream.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L149)
 
 Stream function options type - Primary method for streaming content
 Future-ready for multi-modal capabilities while maintaining text focus

--- a/docs/api/type-aliases/ProgressCallback.md
+++ b/docs/api/type-aliases/ProgressCallback.md
@@ -8,7 +8,7 @@
 
 > **ProgressCallback** = (`progress`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/stream.ts:84](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L84)
+Defined in: [types/stream.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L85)
 
 Progress callback for streaming operations
 

--- a/docs/api/type-aliases/ProviderStreamChunk.md
+++ b/docs/api/type-aliases/ProviderStreamChunk.md
@@ -1,0 +1,13 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / ProviderStreamChunk
+
+# Type Alias: ProviderStreamChunk
+
+> **ProviderStreamChunk** = \{ `content`: `string`; \} \| \{ `type`: `"audio"`; `audio`: [`AudioChunk`](AudioChunk.md); \} \| \{ `type`: `"tts_audio"`; `audio`: [`TTSChunk`](TTSChunk.md); \} \| \{ `type`: `"image"`; `imageOutput`: \{ `base64`: `string`; \}; \}
+
+Defined in: [types/stream.ts:225](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L225)
+
+Provider-level chunks accepted by NeuroLink's core streaming pipeline.

--- a/docs/api/type-aliases/ResponseMetadata.md
+++ b/docs/api/type-aliases/ResponseMetadata.md
@@ -8,7 +8,7 @@
 
 > **ResponseMetadata** = `object`
 
-Defined in: [types/stream.ts:944](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L944)
+Defined in: [types/stream.ts:976](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L976)
 
 Response metadata from stream
 
@@ -18,7 +18,7 @@ Response metadata from stream
 
 > `optional` **id?**: `string`
 
-Defined in: [types/stream.ts:945](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L945)
+Defined in: [types/stream.ts:977](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L977)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:945](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **model?**: `string`
 
-Defined in: [types/stream.ts:946](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L946)
+Defined in: [types/stream.ts:978](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L978)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:946](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **timestamp?**: `number` \| `Date`
 
-Defined in: [types/stream.ts:947](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L947)
+Defined in: [types/stream.ts:979](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L979)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/stream.ts:947](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/stream.ts:948](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L948)
+Defined in: [types/stream.ts:980](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L980)

--- a/docs/api/type-aliases/StreamAnalyticsCollector.md
+++ b/docs/api/type-aliases/StreamAnalyticsCollector.md
@@ -8,7 +8,7 @@
 
 > **StreamAnalyticsCollector** = `object`
 
-Defined in: [types/stream.ts:929](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L929)
+Defined in: [types/stream.ts:961](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L961)
 
 Stream analytics collector type
 
@@ -18,7 +18,7 @@ Stream analytics collector type
 
 > **collectUsage**(`result`): `Promise`\<[`TokenUsage`](TokenUsage.md)\>
 
-Defined in: [types/stream.ts:930](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L930)
+Defined in: [types/stream.ts:962](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L962)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/stream.ts:930](https://github.com/juspay/neurolink/blob/relea
 
 > **collectMetadata**(`result`): `Promise`\<[`ResponseMetadata`](ResponseMetadata.md)\>
 
-Defined in: [types/stream.ts:931](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L931)
+Defined in: [types/stream.ts:963](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L963)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [types/stream.ts:931](https://github.com/juspay/neurolink/blob/relea
 
 > **createAnalytics**(`provider`, `model`, `result`, `startTime`, `context?`): `Promise`\<[`AnalyticsData`](AnalyticsData.md)\>
 
-Defined in: [types/stream.ts:932](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L932)
+Defined in: [types/stream.ts:964](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L964)
 
 #### Parameters
 

--- a/docs/api/type-aliases/StreamChunk.md
+++ b/docs/api/type-aliases/StreamChunk.md
@@ -8,7 +8,7 @@
 
 > **StreamChunk** = \{ `type`: `"text"`; `content`: `string`; \} \| \{ `type`: `"tts_audio"`; `audio`: [`TTSChunk`](TTSChunk.md); \}
 
-Defined in: [types/stream.ts:207](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L207)
+Defined in: [types/stream.ts:208](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L208)
 
 Stream chunk type using discriminated union for type safety
 

--- a/docs/api/type-aliases/StreamOptions.md
+++ b/docs/api/type-aliases/StreamOptions.md
@@ -8,7 +8,7 @@
 
 > **StreamOptions** = `object`
 
-Defined in: [types/stream.ts:223](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L223)
+Defined in: [types/stream.ts:231](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L231)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/stream.ts:223](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **useKnowledgeGrounding?**: `boolean`
 
-Defined in: [types/stream.ts:228](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L228)
+Defined in: [types/stream.ts:236](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L236)
 
 Opt this stream call into the knowledge grounding configured on the
 NeuroLink instance. Defaults to `false` when omitted.
@@ -27,7 +27,7 @@ NeuroLink instance. Defaults to `false` when omitted.
 
 > `optional` **knowledgeContext?**: [`KnowledgeRequestScope`](KnowledgeRequestScope.md)
 
-Defined in: [types/stream.ts:235](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L235)
+Defined in: [types/stream.ts:243](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L243)
 
 Enabled integrations used to scope knowledge retrieval for this turn.
 Used only when `useKnowledgeGrounding` is true and knowledge grounding is
@@ -39,7 +39,7 @@ enabled on the NeuroLink instance.
 
 > **input**: `object`
 
-Defined in: [types/stream.ts:237](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L237)
+Defined in: [types/stream.ts:245](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L245)
 
 #### text?
 
@@ -101,7 +101,7 @@ images: [
 
 > `optional` **output?**: `object`
 
-Defined in: [types/stream.ts:266](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L266)
+Defined in: [types/stream.ts:274](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L274)
 
 #### format?
 
@@ -129,7 +129,7 @@ Defined in: [types/stream.ts:266](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **csvOptions?**: [`CSVProcessorOptions`](CSVProcessorOptions.md)
 
-Defined in: [types/stream.ts:276](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L276)
+Defined in: [types/stream.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L284)
 
 ---
 
@@ -137,7 +137,7 @@ Defined in: [types/stream.ts:276](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **pdfOptions?**: `object`
 
-Defined in: [types/stream.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L279)
+Defined in: [types/stream.ts:287](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L287)
 
 PDF processing options (#258).
 
@@ -174,7 +174,7 @@ not sent to the model at all. Defaults to PDF_LIMITS.DEFAULT_MAX_PAGES (20).
 
 > `optional` **videoOptions?**: `object`
 
-Defined in: [types/stream.ts:298](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L298)
+Defined in: [types/stream.ts:306](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L306)
 
 #### frames?
 
@@ -206,7 +206,7 @@ Not implemented yet (#433) — warns rather than silently doing nothing.
 
 > `optional` **tts?**: [`TTSOptions`](TTSOptions.md)
 
-Defined in: [types/stream.ts:348](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L348)
+Defined in: [types/stream.ts:356](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L356)
 
 Text-to-Speech (TTS) configuration for streaming
 
@@ -252,7 +252,7 @@ const result = await neurolink.stream({
 
 > `optional` **stt?**: [`STTOptions`](STTOptions.md) & `object`
 
-Defined in: [types/stream.ts:355](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L355)
+Defined in: [types/stream.ts:363](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L363)
 
 Speech-to-Text (STT) configuration for streaming
 
@@ -274,7 +274,7 @@ When enabled, audio from `stt.audio` is transcribed before streaming begins.
 
 > `optional` **thinkingConfig?**: `object`
 
-Defined in: [types/stream.ts:397](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L397)
+Defined in: [types/stream.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L405)
 
 Thinking/reasoning configuration for extended thinking models
 
@@ -342,7 +342,7 @@ const result = await neurolink.stream({
 
 > `optional` **provider?**: [`AIProviderName`](../enumerations/AIProviderName.md) \| `string`
 
-Defined in: [types/stream.ts:407](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L407)
+Defined in: [types/stream.ts:415](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L415)
 
 ---
 
@@ -350,7 +350,7 @@ Defined in: [types/stream.ts:407](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **model?**: `string`
 
-Defined in: [types/stream.ts:408](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L408)
+Defined in: [types/stream.ts:416](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L416)
 
 ---
 
@@ -358,7 +358,7 @@ Defined in: [types/stream.ts:408](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **region?**: `string`
 
-Defined in: [types/stream.ts:409](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L409)
+Defined in: [types/stream.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L417)
 
 ---
 
@@ -366,7 +366,7 @@ Defined in: [types/stream.ts:409](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/stream.ts:410](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L410)
+Defined in: [types/stream.ts:418](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L418)
 
 ---
 
@@ -374,7 +374,7 @@ Defined in: [types/stream.ts:410](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/stream.ts:411](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L411)
+Defined in: [types/stream.ts:419](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L419)
 
 ---
 
@@ -382,7 +382,7 @@ Defined in: [types/stream.ts:411](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **topP?**: `number`
 
-Defined in: [types/stream.ts:413](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L413)
+Defined in: [types/stream.ts:421](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L421)
 
 Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
@@ -392,7 +392,7 @@ Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
 > `optional` **topK?**: `number`
 
-Defined in: [types/stream.ts:415](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L415)
+Defined in: [types/stream.ts:423](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L423)
 
 Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini models only)
 
@@ -402,7 +402,7 @@ Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini
 
 > `optional` **stopSequences?**: `string`[]
 
-Defined in: [types/stream.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L417)
+Defined in: [types/stream.ts:425](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L425)
 
 Stop sequences that will halt generation when encountered.
 
@@ -412,7 +412,7 @@ Stop sequences that will halt generation when encountered.
 
 > `optional` **systemPrompt?**: `string`
 
-Defined in: [types/stream.ts:418](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L418)
+Defined in: [types/stream.ts:426](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L426)
 
 ---
 
@@ -420,7 +420,7 @@ Defined in: [types/stream.ts:418](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **schema?**: [`ValidationSchema`](ValidationSchema.md)
 
-Defined in: [types/stream.ts:419](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L419)
+Defined in: [types/stream.ts:427](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L427)
 
 ---
 
@@ -428,7 +428,7 @@ Defined in: [types/stream.ts:419](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **tools?**: `Record`\<`string`, `Tool`\>
 
-Defined in: [types/stream.ts:420](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L420)
+Defined in: [types/stream.ts:428](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L428)
 
 ---
 
@@ -436,7 +436,7 @@ Defined in: [types/stream.ts:420](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **timeout?**: `number` \| `string`
 
-Defined in: [types/stream.ts:421](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L421)
+Defined in: [types/stream.ts:429](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L429)
 
 ---
 
@@ -444,7 +444,7 @@ Defined in: [types/stream.ts:421](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **turnTimeoutMs?**: `number`
 
-Defined in: [types/stream.ts:423](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L423)
+Defined in: [types/stream.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L431)
 
 Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs.
 
@@ -454,7 +454,7 @@ Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutM
 
 > `optional` **stallTimeoutMs?**: `number`
 
-Defined in: [types/stream.ts:425](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L425)
+Defined in: [types/stream.ts:433](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L433)
 
 Max time with no progress before the turn ends as "stalled" (ms). Native Vertex loops only — see GenerateOptions.stallTimeoutMs.
 
@@ -464,7 +464,7 @@ Max time with no progress before the turn ends as "stalled" (ms). Native Vertex 
 
 > `optional` **wrapupTimeLeadMs?**: `number`
 
-Defined in: [types/stream.ts:427](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L427)
+Defined in: [types/stream.ts:435](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L435)
 
 Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs.
 
@@ -474,7 +474,7 @@ Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptio
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/stream.ts:429](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L429)
+Defined in: [types/stream.ts:437](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L437)
 
 Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeoutMs.
 
@@ -484,7 +484,7 @@ Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeou
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/stream.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L431)
+Defined in: [types/stream.ts:439](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L439)
 
 AbortSignal for external cancellation of the AI call
 
@@ -494,7 +494,7 @@ AbortSignal for external cancellation of the AI call
 
 > `optional` **toolExecutionCapture?**: [`ToolExecutionCaptureOptions`](ToolExecutionCaptureOptions.md)
 
-Defined in: [types/stream.ts:433](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L433)
+Defined in: [types/stream.ts:441](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L441)
 
 Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
@@ -504,7 +504,7 @@ Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
 > `optional` **disableTools?**: `boolean`
 
-Defined in: [types/stream.ts:434](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L434)
+Defined in: [types/stream.ts:442](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L442)
 
 ---
 
@@ -512,7 +512,7 @@ Defined in: [types/stream.ts:434](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **disableToolCallRepair?**: `boolean`
 
-Defined in: [types/stream.ts:436](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L436)
+Defined in: [types/stream.ts:444](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L444)
 
 Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled).
 
@@ -522,7 +522,7 @@ Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (r
 
 > `optional` **maxSteps?**: `number`
 
-Defined in: [types/stream.ts:437](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L437)
+Defined in: [types/stream.ts:445](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L445)
 
 ---
 
@@ -530,7 +530,7 @@ Defined in: [types/stream.ts:437](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolChoice?**: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>
 
-Defined in: [types/stream.ts:443](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L443)
+Defined in: [types/stream.ts:451](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L451)
 
 Tool choice configuration for streaming generation.
 Mirrors generate() so translated/fallback requests can preserve forced tool use.
@@ -541,7 +541,7 @@ Mirrors generate() so translated/fallback requests can preserve forced tool use.
 
 > `optional` **prepareStep?**: (`options`) => `PromiseLike`\<\{ `toolChoice?`: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>; `activeTools?`: `Record`\<`string`, `Tool`\>; \} \| `undefined`\>
 
-Defined in: [types/stream.ts:448](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L448)
+Defined in: [types/stream.ts:456](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L456)
 
 Optional callback that runs before each stream step in a multi-step generation.
 
@@ -575,7 +575,7 @@ Optional callback that runs before each stream step in a multi-step generation.
 
 > `optional` **toolFilter?**: `string`[]
 
-Defined in: [types/stream.ts:462](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L462)
+Defined in: [types/stream.ts:470](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L470)
 
 Include only these tools by name (whitelist). If set, only matching tools are available.
 
@@ -585,7 +585,7 @@ Include only these tools by name (whitelist). If set, only matching tools are av
 
 > `optional` **enabledToolNames?**: `string`[]
 
-Defined in: [types/stream.ts:469](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L469)
+Defined in: [types/stream.ts:477](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L477)
 
 Filter available tools by name.
 Used by dynamic arguments to dynamically select which tools to enable.
@@ -597,7 +597,7 @@ Merged into `toolFilter` before tool filtering runs.
 
 > `optional` **excludeTools?**: `string`[]
 
-Defined in: [types/stream.ts:472](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L472)
+Defined in: [types/stream.ts:480](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L480)
 
 Exclude these tools by name (blacklist). Applied after toolFilter.
 
@@ -607,7 +607,7 @@ Exclude these tools by name (blacklist). Applied after toolFilter.
 
 > `optional` **disableToolCache?**: `boolean`
 
-Defined in: [types/stream.ts:475](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L475)
+Defined in: [types/stream.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L483)
 
 Disable tool result caching for this request (overrides global mcp.cache.enabled)
 
@@ -617,7 +617,7 @@ Disable tool result caching for this request (overrides global mcp.cache.enabled
 
 > `optional` **disableInternalFallback?**: `boolean`
 
-Defined in: [types/stream.ts:481](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L481)
+Defined in: [types/stream.ts:489](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L489)
 
 Disable NeuroLink's internal provider fallback for this request.
 Used by the Claude proxy so the proxy itself can own fallback order.
@@ -628,7 +628,7 @@ Used by the Claude proxy so the proxy itself can own fallback order.
 
 > `optional` **fallbackOnMaxSteps?**: `boolean`
 
-Defined in: [types/stream.ts:493](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L493)
+Defined in: [types/stream.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L501)
 
 Whether a turn that ended at the caller's own `maxSteps` bound may still
 trigger the internal no-output provider fallback. Reaching `maxSteps` is
@@ -645,7 +645,7 @@ the existing fallback behaviour.
 
 > `optional` **skipToolPromptInjection?**: `boolean`
 
-Defined in: [types/stream.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L501)
+Defined in: [types/stream.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L509)
 
 Skip injecting tool schemas into the system prompt.
 When true, tools are ONLY passed natively via the provider's `tools` parameter,
@@ -658,7 +658,7 @@ Default: false (backward compatible — tool schemas are injected into system pr
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/stream.ts:504](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L504)
+Defined in: [types/stream.ts:512](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L512)
 
 ---
 
@@ -666,7 +666,7 @@ Defined in: [types/stream.ts:504](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/stream.ts:505](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L505)
+Defined in: [types/stream.ts:513](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L513)
 
 ---
 
@@ -674,7 +674,7 @@ Defined in: [types/stream.ts:505](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **context?**: [`UnknownRecord`](UnknownRecord.md)
 
-Defined in: [types/stream.ts:506](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L506)
+Defined in: [types/stream.ts:514](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L514)
 
 ---
 
@@ -682,7 +682,7 @@ Defined in: [types/stream.ts:506](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/stream.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L509)
+Defined in: [types/stream.ts:517](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L517)
 
 ---
 
@@ -690,7 +690,7 @@ Defined in: [types/stream.ts:509](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/stream.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L510)
+Defined in: [types/stream.ts:518](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L518)
 
 ---
 
@@ -698,7 +698,7 @@ Defined in: [types/stream.ts:510](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/stream.ts:511](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L511)
+Defined in: [types/stream.ts:519](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L519)
 
 #### role
 
@@ -714,7 +714,7 @@ Defined in: [types/stream.ts:511](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **factoryConfig?**: `object`
 
-Defined in: [types/stream.ts:514](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L514)
+Defined in: [types/stream.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L522)
 
 #### domainType?
 
@@ -742,7 +742,7 @@ Defined in: [types/stream.ts:514](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **streaming?**: `object`
 
-Defined in: [types/stream.ts:528](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L528)
+Defined in: [types/stream.ts:536](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L536)
 
 #### enabled?
 
@@ -770,7 +770,7 @@ Defined in: [types/stream.ts:528](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/stream.ts:537](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L537)
+Defined in: [types/stream.ts:545](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L545)
 
 ---
 
@@ -778,7 +778,7 @@ Defined in: [types/stream.ts:537](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/stream.ts:540](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L540)
+Defined in: [types/stream.ts:548](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L548)
 
 ---
 
@@ -786,7 +786,7 @@ Defined in: [types/stream.ts:540](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflow?**: `string`
 
-Defined in: [types/stream.ts:543](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L543)
+Defined in: [types/stream.ts:551](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L551)
 
 ---
 
@@ -794,7 +794,7 @@ Defined in: [types/stream.ts:543](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflowConfig?**: [`WorkflowConfig`](WorkflowConfig.md)
 
-Defined in: [types/stream.ts:544](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L544)
+Defined in: [types/stream.ts:552](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L552)
 
 ---
 
@@ -802,7 +802,7 @@ Defined in: [types/stream.ts:544](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **enableSummarization?**: `boolean`
 
-Defined in: [types/stream.ts:546](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L546)
+Defined in: [types/stream.ts:554](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L554)
 
 ---
 
@@ -810,7 +810,7 @@ Defined in: [types/stream.ts:546](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **maxBudgetUsd?**: `number`
 
-Defined in: [types/stream.ts:561](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L561)
+Defined in: [types/stream.ts:569](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L569)
 
 Maximum cumulative cost (USD) for this session.
 Once the session spend reaches this limit, subsequent stream() calls
@@ -831,7 +831,7 @@ const result = await neurolink.stream({
 
 > `optional` **rag?**: [`RAGConfig`](RAGConfig.md)
 
-Defined in: [types/stream.ts:581](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L581)
+Defined in: [types/stream.ts:589](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L589)
 
 RAG (Retrieval-Augmented Generation) configuration.
 
@@ -857,7 +857,7 @@ const stream = await neurolink.stream({
 
 > `optional` **fallbackProvider?**: `string`
 
-Defined in: [types/stream.ts:594](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L594)
+Defined in: [types/stream.ts:602](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L602)
 
 BZ-1341: Override fallback provider name (takes precedence over env/model config).
 
@@ -867,7 +867,7 @@ BZ-1341: Override fallback provider name (takes precedence over env/model config
 
 > `optional` **fallbackModel?**: `string`
 
-Defined in: [types/stream.ts:596](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L596)
+Defined in: [types/stream.ts:604](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L604)
 
 BZ-1341: Override fallback model name (takes precedence over env/model config).
 
@@ -877,7 +877,7 @@ BZ-1341: Override fallback model name (takes precedence over env/model config).
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/stream.ts:599](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L599)
+Defined in: [types/stream.ts:607](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L607)
 
 Callback invoked when streaming completes successfully.
 
@@ -887,7 +887,7 @@ Callback invoked when streaming completes successfully.
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/stream.ts:602](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L602)
+Defined in: [types/stream.ts:610](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L610)
 
 Callback invoked when streaming encounters an error.
 
@@ -897,7 +897,7 @@ Callback invoked when streaming encounters an error.
 
 > `optional` **onChunk?**: [`OnChunkCallback`](OnChunkCallback.md)
 
-Defined in: [types/stream.ts:605](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L605)
+Defined in: [types/stream.ts:613](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L613)
 
 Callback invoked for each streaming chunk.
 
@@ -907,7 +907,7 @@ Callback invoked for each streaming chunk.
 
 > `optional` **requestContext?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/stream.ts:608](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L608)
+Defined in: [types/stream.ts:616](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L616)
 
 Pre-validated user context for the request
 
@@ -917,7 +917,7 @@ Pre-validated user context for the request
 
 > `optional` **auth?**: `object`
 
-Defined in: [types/stream.ts:611](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L611)
+Defined in: [types/stream.ts:619](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L619)
 
 Raw auth token — validated by configured auth provider
 
@@ -931,7 +931,7 @@ Raw auth token — validated by configured auth provider
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/stream.ts:618](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L618)
+Defined in: [types/stream.ts:626](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L626)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -943,7 +943,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **providerFallback?**: (`error`) => `Promise`\<\{ `provider?`: `string`; `model?`: `string`; \} \| `null`\>
 
-Defined in: [types/stream.ts:630](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L630)
+Defined in: [types/stream.ts:638](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L638)
 
 Curator P2-3: per-call fallback callback. Overrides any
 instance-level `providerFallback` set on `new NeuroLink({...})`.
@@ -970,7 +970,7 @@ Return `{ provider, model }` to retry, `null` to bubble.
 
 > `optional` **modelChain?**: `string`[]
 
-Defined in: [types/stream.ts:640](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L640)
+Defined in: [types/stream.ts:648](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L648)
 
 Curator P2-3: per-call ordered model chain. Overrides any
 instance-level `modelChain`. Without an explicit `providerFallback`
@@ -983,7 +983,7 @@ other failures (network, 5xx, timeouts) bubble immediately.
 
 > `optional` **memory?**: `object`
 
-Defined in: [types/stream.ts:649](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L649)
+Defined in: [types/stream.ts:657](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L657)
 
 Per-call memory control.
 
@@ -1023,7 +1023,7 @@ Primary user is still determined by context.userId.
 
 > `optional` **piiDetection?**: `object`
 
-Defined in: [types/stream.ts:665](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L665)
+Defined in: [types/stream.ts:673](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L673)
 
 PII detection — scans and optionally redacts PII from input before the LLM call.
 
@@ -1057,7 +1057,7 @@ PII detection — scans and optionally redacts PII from input before the LLM cal
 
 > `optional` **responseValidation?**: `object`
 
-Defined in: [types/stream.ts:686](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L686)
+Defined in: [types/stream.ts:694](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L694)
 
 Response validation — validates accumulated stream content after completion.
 
@@ -1117,7 +1117,7 @@ Response validation — validates accumulated stream content after completion.
 
 > `optional` **inputValidation?**: `object`
 
-Defined in: [types/stream.ts:704](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L704)
+Defined in: [types/stream.ts:712](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L712)
 
 Input validation — validates input text before any processing.
 
@@ -1143,7 +1143,7 @@ Input validation — validates input text before any processing.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/stream.ts:712](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L712)
+Defined in: [types/stream.ts:720](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L720)
 
 #### Deprecated
 
@@ -1155,7 +1155,7 @@ Use `piiDetection`, `responseValidation`, and `inputValidation` instead.
 
 > `optional` **skills?**: [`SkillsCallOptions`](SkillsCallOptions.md)
 
-Defined in: [types/stream.ts:720](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L720)
+Defined in: [types/stream.ts:728](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L728)
 
 Per-call skills control. Only effective when the instance was
 constructed with `skills.enabled: true`. Lets a call disable the

--- a/docs/api/type-aliases/StreamResult.md
+++ b/docs/api/type-aliases/StreamResult.md
@@ -8,7 +8,7 @@
 
 > **StreamResult** = `object`
 
-Defined in: [types/stream.ts:727](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L727)
+Defined in: [types/stream.ts:735](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L735)
 
 Stream function result type - Primary output format for streaming
 Future-ready for multi-modal outputs while maintaining text focus
@@ -19,7 +19,7 @@ Future-ready for multi-modal outputs while maintaining text focus
 
 > `optional` **knowledge?**: [`KnowledgeGroundingMetadata`](KnowledgeGroundingMetadata.md)
 
-Defined in: [types/stream.ts:729](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L729)
+Defined in: [types/stream.ts:737](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L737)
 
 Knowledge-grounding diagnostics for this turn (present only when grounding ran).
 
@@ -29,7 +29,7 @@ Knowledge-grounding diagnostics for this turn (present only when grounding ran).
 
 > **stream**: `AsyncIterable`\<\{ `content`: `string`; `reasoning?`: `string`; \} \| [`StreamNoOutputSentinel`](StreamNoOutputSentinel.md) \| \{ `type`: `"audio"`; `audio`: [`AudioChunk`](AudioChunk.md); \} \| \{ `type`: `"tts_audio"`; `audio`: [`TTSChunk`](TTSChunk.md); \} \| \{ `type`: `"image"`; `imageOutput`: \{ `base64`: `string`; \}; \} \| \{ `content`: `string`; `type?`: `"preliminary"` \| `"final"`; \}\>
 
-Defined in: [types/stream.ts:730](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L730)
+Defined in: [types/stream.ts:738](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L738)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [types/stream.ts:730](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **provider?**: `string`
 
-Defined in: [types/stream.ts:745](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L745)
+Defined in: [types/stream.ts:753](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L753)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [types/stream.ts:745](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **model?**: `string`
 
-Defined in: [types/stream.ts:746](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L746)
+Defined in: [types/stream.ts:754](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L754)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [types/stream.ts:746](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **usage?**: [`TokenUsage`](TokenUsage.md)
 
-Defined in: [types/stream.ts:749](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L749)
+Defined in: [types/stream.ts:757](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L757)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [types/stream.ts:749](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/stream.ts:752](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L752)
+Defined in: [types/stream.ts:760](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L760)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [types/stream.ts:752](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **stopReason?**: [`GenerateStopReason`](GenerateStopReason.md)
 
-Defined in: [types/stream.ts:760](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L760)
+Defined in: [types/stream.ts:768](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L768)
 
 Why the agentic turn ended (see GenerateStopReason). For background-loop
 streams (native Vertex paths) prefer `metadata.stopReason` after draining
@@ -82,7 +82,7 @@ wrapper spreads can snapshot it before the loop finishes.
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/stream.ts:762](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L762)
+Defined in: [types/stream.ts:770](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L770)
 
 Verbatim provider finish/stop reason for the turn's terminal model call.
 
@@ -92,7 +92,7 @@ Verbatim provider finish/stop reason for the turn's terminal model call.
 
 > `optional` **toolCalls?**: [`StreamToolCall`](StreamToolCall.md)[]
 
-Defined in: [types/stream.ts:765](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L765)
+Defined in: [types/stream.ts:773](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L773)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [types/stream.ts:765](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolResults?**: [`StreamToolResult`](StreamToolResult.md)[]
 
-Defined in: [types/stream.ts:766](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L766)
+Defined in: [types/stream.ts:774](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L774)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [types/stream.ts:766](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolEvents?**: `AsyncIterable`\<[`ToolExecutionEvent`](ToolExecutionEvent.md)\>
 
-Defined in: [types/stream.ts:769](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L769)
+Defined in: [types/stream.ts:777](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L777)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [types/stream.ts:769](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolExecutions?**: [`ToolExecutionSummary`](ToolExecutionSummary.md)[]
 
-Defined in: [types/stream.ts:770](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L770)
+Defined in: [types/stream.ts:778](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L778)
 
 ---
 
@@ -124,7 +124,7 @@ Defined in: [types/stream.ts:770](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolsUsed?**: `string`[]
 
-Defined in: [types/stream.ts:771](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L771)
+Defined in: [types/stream.ts:779](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L779)
 
 ---
 
@@ -132,7 +132,7 @@ Defined in: [types/stream.ts:771](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/stream.ts:774](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L774)
+Defined in: [types/stream.ts:782](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L782)
 
 #### streamId?
 
@@ -212,7 +212,7 @@ Defined in: [types/stream.ts:774](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **analytics?**: [`AnalyticsData`](AnalyticsData.md) \| `Promise`\<[`AnalyticsData`](AnalyticsData.md)\>
 
-Defined in: [types/stream.ts:804](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L804)
+Defined in: [types/stream.ts:812](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L812)
 
 ---
 
@@ -220,7 +220,7 @@ Defined in: [types/stream.ts:804](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **evaluation?**: [`EvaluationData`](EvaluationData.md) \| `Promise`\<[`EvaluationData`](EvaluationData.md)\>
 
-Defined in: [types/stream.ts:805](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L805)
+Defined in: [types/stream.ts:813](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L813)
 
 ---
 
@@ -228,7 +228,7 @@ Defined in: [types/stream.ts:805](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **events?**: `object`[]
 
-Defined in: [types/stream.ts:808](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L808)
+Defined in: [types/stream.ts:816](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L816)
 
 #### Index Signature
 
@@ -252,7 +252,7 @@ Defined in: [types/stream.ts:808](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflow?**: `object`
 
-Defined in: [types/stream.ts:816](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L816)
+Defined in: [types/stream.ts:824](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L824)
 
 #### originalResponse
 
@@ -320,7 +320,7 @@ Defined in: [types/stream.ts:816](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **transcription?**: [`STTResult`](STTResult.md)
 
-Defined in: [types/stream.ts:844](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L844)
+Defined in: [types/stream.ts:852](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L852)
 
 STT transcription result (when stt option is used)
 
@@ -330,10 +330,39 @@ STT transcription result (when stt option is used)
 
 > `optional` **audio?**: `Promise`\<[`TTSResult`](TTSResult.md) \| `undefined`\>
 
-Defined in: [types/stream.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L853)
+Defined in: [types/stream.ts:878](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L878)
 
-TTS Mode 2 result (when `tts.enabled && tts.useAiResponse`).
-Resolves with the synthesized audio after the stream completes;
-resolves to undefined if TTS was not enabled or synthesis failed.
-The same audio is also yielded as a final chunk on `stream` for callers
-that prefer to consume it inline.
+Streaming TTS result (when `tts.enabled`). `stream()` synthesizes the AI
+response incrementally; `useAiResponse` continues to select input vs
+response synthesis for non-streaming generation.
+Resolves with the synthesized audio after the caller drains `stream` to
+completion; like other stream-final fields, it remains pending while the
+lazy stream is unconsumed. It resolves with the aggregate of whatever
+segments were synthesized: a synthesis failure part-way through still
+resolves with the earlier segments rather than discarding them. It resolves
+to undefined only when no segment was produced — TTS was not enabled, no
+handler resolved for the requested provider, the model stream errored, every
+synthesis failed, or the caller stopped draining `stream` before it ended
+(an abandoned stream settles undefined rather than a partial aggregate).
+Audio is also yielded incrementally as ordered
+`tts_audio` chunks. Each chunk, including the final one, contains only its
+own buffered segment. The aggregate is a byte concatenation of those
+independently synthesized segments, so what it is depends on the format's
+framing: for frame- or sample-stream formats (`mp3`, `mpeg`, `mpga`,
+`pcm16`) it is one playable stream; for header-bearing container formats
+(`wav`, `flac`, `m4a`, `mp4`, `webm`) it is not a valid file, because each
+segment carries its own header; for `ogg`/`opus` it is a chained stream that
+some decoders read only through its first segment. Use the individual chunk
+buffers when each segment must be a valid container file.
+
+---
+
+### ttsMetadata?
+
+> `optional` **ttsMetadata?**: [`TTSMetadata`](TTSMetadata.md)
+
+Defined in: [types/stream.ts:885](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L885)
+
+Outcome metadata for streaming TTS synthesis. This is a mutable reference
+whose success and latency fields are finalized asynchronously; read it
+after draining `stream`.

--- a/docs/api/type-aliases/StreamTextResult.md
+++ b/docs/api/type-aliases/StreamTextResult.md
@@ -8,7 +8,7 @@
 
 > **StreamTextResult** = `object`
 
-Defined in: [types/stream.ts:872](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L872)
+Defined in: [types/stream.ts:904](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L904)
 
 Stream text result from AI SDK (compatible with both v4 and v6)
 
@@ -22,7 +22,7 @@ This type accepts either shape so callers don't need casts.
 
 > **textStream**: `AsyncIterable`\<`string`\>
 
-Defined in: [types/stream.ts:873](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L873)
+Defined in: [types/stream.ts:905](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L905)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/stream.ts:873](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **fullStream?**: `AsyncIterable`\<`unknown`\>
 
-Defined in: [types/stream.ts:874](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L874)
+Defined in: [types/stream.ts:906](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L906)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/stream.ts:874](https://github.com/juspay/neurolink/blob/relea
 
 > **text**: `PromiseLike`\<`string`\>
 
-Defined in: [types/stream.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L875)
+Defined in: [types/stream.ts:907](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L907)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/stream.ts:875](https://github.com/juspay/neurolink/blob/relea
 
 > **usage**: `PromiseLike`\<[`AISDKUsage`](AISDKUsage.md) \| `undefined`\>
 
-Defined in: [types/stream.ts:876](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L876)
+Defined in: [types/stream.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L908)
 
 ---
 
@@ -54,7 +54,7 @@ Defined in: [types/stream.ts:876](https://github.com/juspay/neurolink/blob/relea
 
 > **response**: `PromiseLike`\<\{ `id?`: `string`; `model?`: `string`; `timestamp?`: `number` \| `Date`; \} \| `undefined`\>
 
-Defined in: [types/stream.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L877)
+Defined in: [types/stream.ts:909](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L909)
 
 ---
 
@@ -62,7 +62,7 @@ Defined in: [types/stream.ts:877](https://github.com/juspay/neurolink/blob/relea
 
 > **finishReason**: `PromiseLike`\<`"stop"` \| `"length"` \| `"content-filter"` \| `"tool-calls"` \| `"error"` \| `"other"` \| `"unknown"`\>
 
-Defined in: [types/stream.ts:885](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L885)
+Defined in: [types/stream.ts:917](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L917)
 
 ---
 
@@ -70,7 +70,7 @@ Defined in: [types/stream.ts:885](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolResults?**: `PromiseLike`\<[`StreamToolResult`](StreamToolResult.md)[] \| `ReadonlyArray`\<`unknown`\>\>
 
-Defined in: [types/stream.ts:898](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L898)
+Defined in: [types/stream.ts:930](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L930)
 
 Tool results. Accepts both NeuroLink StreamToolResult[] and AI SDK TypedToolResult[],
 since the analytics collector passes them through as `unknown` anyway.
@@ -81,6 +81,6 @@ since the analytics collector passes them through as `unknown` anyway.
 
 > `optional` **toolCalls?**: `PromiseLike`\<[`StreamToolCall`](StreamToolCall.md)[] \| `ReadonlyArray`\<`unknown`\>\>
 
-Defined in: [types/stream.ts:902](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L902)
+Defined in: [types/stream.ts:934](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L934)
 
 Tool calls. Accepts both NeuroLink StreamToolCall[] and AI SDK TypedToolCall[].

--- a/docs/api/type-aliases/StreamToolCall.md
+++ b/docs/api/type-aliases/StreamToolCall.md
@@ -8,7 +8,7 @@
 
 > **StreamToolCall** = `object`
 
-Defined in: [types/stream.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L91)
+Defined in: [types/stream.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L92)
 
 Type for tool execution calls (AI SDK compatible)
 
@@ -18,7 +18,7 @@ Type for tool execution calls (AI SDK compatible)
 
 > `optional` **type?**: `"tool-call"`
 
-Defined in: [types/stream.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L92)
+Defined in: [types/stream.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L93)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:92](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **toolCallId?**: `string`
 
-Defined in: [types/stream.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L93)
+Defined in: [types/stream.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L94)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:93](https://github.com/juspay/neurolink/blob/releas
 
 > **toolName**: `string`
 
-Defined in: [types/stream.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L94)
+Defined in: [types/stream.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L95)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/stream.ts:94](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **parameters?**: [`UnknownRecord`](UnknownRecord.md)
 
-Defined in: [types/stream.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L95)
+Defined in: [types/stream.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L96)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/stream.ts:95](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **args?**: [`UnknownRecord`](UnknownRecord.md)
 
-Defined in: [types/stream.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L96)
+Defined in: [types/stream.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L97)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/stream.ts:96](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **id?**: `string`
 
-Defined in: [types/stream.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L97)
+Defined in: [types/stream.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L98)

--- a/docs/api/type-aliases/StreamToolResult.md
+++ b/docs/api/type-aliases/StreamToolResult.md
@@ -8,7 +8,7 @@
 
 > **StreamToolResult** = `object`
 
-Defined in: [types/stream.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L103)
+Defined in: [types/stream.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L104)
 
 Type for tool execution results - Enhanced for type safety
 
@@ -18,7 +18,7 @@ Type for tool execution results - Enhanced for type safety
 
 > **toolName**: `string`
 
-Defined in: [types/stream.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L104)
+Defined in: [types/stream.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L105)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:104](https://github.com/juspay/neurolink/blob/relea
 
 > **status**: `"success"` \| `"failure"`
 
-Defined in: [types/stream.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L105)
+Defined in: [types/stream.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L106)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:105](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **output?**: [`JsonValue`](JsonValue.md)
 
-Defined in: [types/stream.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L106)
+Defined in: [types/stream.ts:107](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L107)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/stream.ts:106](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **error?**: `string`
 
-Defined in: [types/stream.ts:107](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L107)
+Defined in: [types/stream.ts:108](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L108)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/stream.ts:107](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **id?**: `string`
 
-Defined in: [types/stream.ts:108](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L108)
+Defined in: [types/stream.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L109)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/stream.ts:108](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **executionTime?**: `number`
 
-Defined in: [types/stream.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L109)
+Defined in: [types/stream.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L110)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/stream.ts:109](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **metadata?**: `object` & `object`
 
-Defined in: [types/stream.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L110)
+Defined in: [types/stream.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L111)
 
 #### Type Declaration
 

--- a/docs/api/type-aliases/StreamingMetadata.md
+++ b/docs/api/type-aliases/StreamingMetadata.md
@@ -8,7 +8,7 @@
 
 > **StreamingMetadata** = `object`
 
-Defined in: [types/stream.ts:59](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L59)
+Defined in: [types/stream.ts:60](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L60)
 
 Streaming metadata for performance tracking
 
@@ -18,7 +18,7 @@ Streaming metadata for performance tracking
 
 > **startTime**: `number`
 
-Defined in: [types/stream.ts:60](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L60)
+Defined in: [types/stream.ts:61](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L61)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:60](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **endTime?**: `number`
 
-Defined in: [types/stream.ts:61](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L61)
+Defined in: [types/stream.ts:62](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L62)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:61](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **totalDuration?**: `number`
 
-Defined in: [types/stream.ts:62](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L62)
+Defined in: [types/stream.ts:63](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L63)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/stream.ts:62](https://github.com/juspay/neurolink/blob/releas
 
 > **averageChunkSize**: `number`
 
-Defined in: [types/stream.ts:63](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L63)
+Defined in: [types/stream.ts:64](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L64)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/stream.ts:63](https://github.com/juspay/neurolink/blob/releas
 
 > **maxChunkSize**: `number`
 
-Defined in: [types/stream.ts:64](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L64)
+Defined in: [types/stream.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L65)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/stream.ts:64](https://github.com/juspay/neurolink/blob/releas
 
 > **minChunkSize**: `number`
 
-Defined in: [types/stream.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L65)
+Defined in: [types/stream.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L66)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/stream.ts:65](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **throughputBytesPerSecond?**: `number`
 
-Defined in: [types/stream.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L66)
+Defined in: [types/stream.ts:67](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L67)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/stream.ts:66](https://github.com/juspay/neurolink/blob/releas
 
 > **streamingProvider**: `string`
 
-Defined in: [types/stream.ts:67](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L67)
+Defined in: [types/stream.ts:68](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L68)
 
 ---
 
@@ -82,4 +82,4 @@ Defined in: [types/stream.ts:67](https://github.com/juspay/neurolink/blob/releas
 
 > **modelUsed**: `string`
 
-Defined in: [types/stream.ts:68](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L68)
+Defined in: [types/stream.ts:69](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L69)

--- a/docs/api/type-aliases/StreamingOptions.md
+++ b/docs/api/type-aliases/StreamingOptions.md
@@ -8,7 +8,7 @@
 
 > **StreamingOptions** = `object`
 
-Defined in: [types/stream.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L74)
+Defined in: [types/stream.ts:75](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L75)
 
 Options for AI requests with unified provider configuration
 
@@ -18,7 +18,7 @@ Options for AI requests with unified provider configuration
 
 > **providers**: [`AIModelProviderConfig`](AIModelProviderConfig.md)[]
 
-Defined in: [types/stream.ts:75](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L75)
+Defined in: [types/stream.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L76)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:75](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/stream.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L76)
+Defined in: [types/stream.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L77)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:76](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/stream.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L77)
+Defined in: [types/stream.ts:78](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L78)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/stream.ts:77](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **systemPrompt?**: `string`
 
-Defined in: [types/stream.ts:78](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L78)
+Defined in: [types/stream.ts:79](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L79)

--- a/docs/api/type-aliases/StreamingProgressData.md
+++ b/docs/api/type-aliases/StreamingProgressData.md
@@ -8,7 +8,7 @@
 
 > **StreamingProgressData** = `object`
 
-Defined in: [types/stream.ts:46](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L46)
+Defined in: [types/stream.ts:47](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L47)
 
 Progress tracking and metadata for streaming operations
 
@@ -18,7 +18,7 @@ Progress tracking and metadata for streaming operations
 
 > **chunkCount**: `number`
 
-Defined in: [types/stream.ts:47](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L47)
+Defined in: [types/stream.ts:48](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L48)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:47](https://github.com/juspay/neurolink/blob/releas
 
 > **totalBytes**: `number`
 
-Defined in: [types/stream.ts:48](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L48)
+Defined in: [types/stream.ts:49](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L49)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:48](https://github.com/juspay/neurolink/blob/releas
 
 > **chunkSize**: `number`
 
-Defined in: [types/stream.ts:49](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L49)
+Defined in: [types/stream.ts:50](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L50)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/stream.ts:49](https://github.com/juspay/neurolink/blob/releas
 
 > **elapsedTime**: `number`
 
-Defined in: [types/stream.ts:50](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L50)
+Defined in: [types/stream.ts:51](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L51)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/stream.ts:50](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **estimatedRemaining?**: `number`
 
-Defined in: [types/stream.ts:51](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L51)
+Defined in: [types/stream.ts:52](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L52)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/stream.ts:51](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **streamId?**: `string`
 
-Defined in: [types/stream.ts:52](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L52)
+Defined in: [types/stream.ts:53](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L53)
 
 ---
 
@@ -66,4 +66,4 @@ Defined in: [types/stream.ts:52](https://github.com/juspay/neurolink/blob/releas
 
 > **phase**: `"initializing"` \| `"streaming"` \| `"processing"` \| `"complete"` \| `"error"`
 
-Defined in: [types/stream.ts:53](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L53)
+Defined in: [types/stream.ts:54](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L54)

--- a/docs/api/type-aliases/TTSChunk.md
+++ b/docs/api/type-aliases/TTSChunk.md
@@ -8,7 +8,7 @@
 
 > **TTSChunk** = `object`
 
-Defined in: [types/tts.ts:273](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L273)
+Defined in: [types/tts.ts:290](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L290)
 
 TTS audio chunk for streaming Text-to-Speech output
 
@@ -21,7 +21,7 @@ Used in StreamChunk type to deliver audio alongside text content.
 
 > **data**: `Buffer`
 
-Defined in: [types/tts.ts:275](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L275)
+Defined in: [types/tts.ts:292](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L292)
 
 Audio data chunk as Buffer
 
@@ -31,7 +31,7 @@ Audio data chunk as Buffer
 
 > **format**: [`TTSAudioFormat`](TTSAudioFormat.md)
 
-Defined in: [types/tts.ts:277](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L277)
+Defined in: [types/tts.ts:294](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L294)
 
 Audio format of this chunk
 
@@ -41,7 +41,7 @@ Audio format of this chunk
 
 > **index**: `number`
 
-Defined in: [types/tts.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L279)
+Defined in: [types/tts.ts:296](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L296)
 
 Chunk sequence number (0-indexed)
 
@@ -51,7 +51,7 @@ Chunk sequence number (0-indexed)
 
 > **isFinal**: `boolean`
 
-Defined in: [types/tts.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L281)
+Defined in: [types/tts.ts:298](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L298)
 
 Whether this is the final audio chunk
 
@@ -61,7 +61,7 @@ Whether this is the final audio chunk
 
 > `optional` **cumulativeSize?**: `number`
 
-Defined in: [types/tts.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L283)
+Defined in: [types/tts.ts:300](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L300)
 
 Cumulative audio size in bytes so far
 
@@ -71,7 +71,7 @@ Cumulative audio size in bytes so far
 
 > `optional` **estimatedDuration?**: `number`
 
-Defined in: [types/tts.ts:285](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L285)
+Defined in: [types/tts.ts:302](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L302)
 
 Estimated total duration in seconds (if available)
 
@@ -81,7 +81,7 @@ Estimated total duration in seconds (if available)
 
 > `optional` **voice?**: `string`
 
-Defined in: [types/tts.ts:287](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L287)
+Defined in: [types/tts.ts:304](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L304)
 
 Voice used for generation
 
@@ -91,6 +91,6 @@ Voice used for generation
 
 > `optional` **sampleRate?**: `number`
 
-Defined in: [types/tts.ts:289](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L289)
+Defined in: [types/tts.ts:306](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L306)
 
 Sample rate in Hz

--- a/docs/api/type-aliases/TTSGender.md
+++ b/docs/api/type-aliases/TTSGender.md
@@ -8,6 +8,6 @@
 
 > **TTSGender** = `"male"` \| `"female"` \| `"neutral"`
 
-Defined in: [types/tts.ts:157](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L157)
+Defined in: [types/tts.ts:166](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L166)
 
 Allowed genders for TTS voices

--- a/docs/api/type-aliases/TTSOptions.md
+++ b/docs/api/type-aliases/TTSOptions.md
@@ -28,9 +28,12 @@ Enable TTS output
 
 > `optional` **useAiResponse?**: `boolean`
 
-Defined in: [types/tts.ts:86](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L86)
+Defined in: [types/tts.ts:89](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L89)
 
 Use the AI-generated response for TTS instead of the input text
+
+This switch applies to non-streaming generation. `stream()` always
+synthesizes the streamed AI response incrementally when TTS is enabled.
 
 When false or undefined (default): TTS will synthesize the input text/prompt directly without calling AI generation
 When true: TTS will synthesize the AI-generated response after generation completes
@@ -67,7 +70,7 @@ const result = await neurolink.generate({
 
 > `optional` **voice?**: `string`
 
-Defined in: [types/tts.ts:88](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L88)
+Defined in: [types/tts.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L91)
 
 Voice identifier (e.g., "en-US-Neural2-C")
 
@@ -77,7 +80,7 @@ Voice identifier (e.g., "en-US-Neural2-C")
 
 > `optional` **format?**: [`TTSAudioFormat`](TTSAudioFormat.md)
 
-Defined in: [types/tts.ts:90](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L90)
+Defined in: [types/tts.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L93)
 
 Audio format (default: mp3)
 
@@ -87,7 +90,7 @@ Audio format (default: mp3)
 
 > `optional` **speed?**: `number`
 
-Defined in: [types/tts.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L92)
+Defined in: [types/tts.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L95)
 
 Speaking rate 0.25-4.0 (default: 1.0)
 
@@ -97,7 +100,7 @@ Speaking rate 0.25-4.0 (default: 1.0)
 
 > `optional` **pitch?**: `number`
 
-Defined in: [types/tts.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L94)
+Defined in: [types/tts.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L97)
 
 Voice pitch adjustment -20.0 to 20.0 semitones (default: 0.0)
 
@@ -107,7 +110,7 @@ Voice pitch adjustment -20.0 to 20.0 semitones (default: 0.0)
 
 > `optional` **volumeGainDb?**: `number`
 
-Defined in: [types/tts.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L96)
+Defined in: [types/tts.ts:99](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L99)
 
 Volume gain in dB -96.0 to 16.0 (default: 0.0)
 
@@ -117,7 +120,7 @@ Volume gain in dB -96.0 to 16.0 (default: 0.0)
 
 > `optional` **quality?**: [`TTSQuality`](TTSQuality.md)
 
-Defined in: [types/tts.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L98)
+Defined in: [types/tts.ts:101](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L101)
 
 Audio quality (default: standard)
 
@@ -127,7 +130,7 @@ Audio quality (default: standard)
 
 > `optional` **output?**: `string`
 
-Defined in: [types/tts.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L100)
+Defined in: [types/tts.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L103)
 
 Output file path (optional)
 
@@ -137,7 +140,7 @@ Output file path (optional)
 
 > `optional` **play?**: `boolean`
 
-Defined in: [types/tts.ts:102](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L102)
+Defined in: [types/tts.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L105)
 
 Auto-play audio after generation (default: false)
 
@@ -147,6 +150,18 @@ Auto-play audio after generation (default: false)
 
 > `optional` **provider?**: [`TTSProviderName`](TTSProviderName.md)
 
-Defined in: [types/tts.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L104)
+Defined in: [types/tts.ts:107](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L107)
 
 Override TTS provider (e.g., "elevenlabs", "openai-tts", "azure-tts")
+
+---
+
+### streamingBufferSize?
+
+> `optional` **streamingBufferSize?**: `number`
+
+Defined in: [types/tts.ts:113](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L113)
+
+Minimum buffered text length before incremental stream synthesis flushes
+at a sentence boundary. The provider's maximum text length remains a hard
+upper bound. Defaults to 120 characters.

--- a/docs/api/type-aliases/TTSResult.md
+++ b/docs/api/type-aliases/TTSResult.md
@@ -8,7 +8,7 @@
 
 > **TTSResult** = `object`
 
-Defined in: [types/tts.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L110)
+Defined in: [types/tts.ts:119](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L119)
 
 TTS audio result returned from generation
 
@@ -18,7 +18,7 @@ TTS audio result returned from generation
 
 > **buffer**: `Buffer`
 
-Defined in: [types/tts.ts:112](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L112)
+Defined in: [types/tts.ts:121](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L121)
 
 Audio data as Buffer
 
@@ -28,7 +28,7 @@ Audio data as Buffer
 
 > **format**: [`TTSAudioFormat`](TTSAudioFormat.md)
 
-Defined in: [types/tts.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L114)
+Defined in: [types/tts.ts:123](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L123)
 
 Audio format
 
@@ -38,7 +38,7 @@ Audio format
 
 > **size**: `number`
 
-Defined in: [types/tts.ts:116](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L116)
+Defined in: [types/tts.ts:125](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L125)
 
 Audio file size in bytes
 
@@ -48,7 +48,7 @@ Audio file size in bytes
 
 > `optional` **duration?**: `number`
 
-Defined in: [types/tts.ts:118](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L118)
+Defined in: [types/tts.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L127)
 
 Duration in seconds (if available)
 
@@ -58,7 +58,7 @@ Duration in seconds (if available)
 
 > `optional` **voice?**: `string`
 
-Defined in: [types/tts.ts:120](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L120)
+Defined in: [types/tts.ts:129](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L129)
 
 Voice used for generation
 
@@ -68,7 +68,7 @@ Voice used for generation
 
 > `optional` **sampleRate?**: `number`
 
-Defined in: [types/tts.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L122)
+Defined in: [types/tts.ts:131](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L131)
 
 Sample rate in Hz
 
@@ -78,7 +78,7 @@ Sample rate in Hz
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/tts.ts:124](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L124)
+Defined in: [types/tts.ts:133](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L133)
 
 Performance and request metadata
 

--- a/docs/api/type-aliases/TTSVoice.md
+++ b/docs/api/type-aliases/TTSVoice.md
@@ -8,7 +8,7 @@
 
 > **TTSVoice** = `object`
 
-Defined in: [types/tts.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L180)
+Defined in: [types/tts.ts:189](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L189)
 
 TTS voice information
 
@@ -18,7 +18,7 @@ TTS voice information
 
 > **id**: `string`
 
-Defined in: [types/tts.ts:182](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L182)
+Defined in: [types/tts.ts:191](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L191)
 
 Voice identifier
 
@@ -28,7 +28,7 @@ Voice identifier
 
 > **name**: `string`
 
-Defined in: [types/tts.ts:184](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L184)
+Defined in: [types/tts.ts:193](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L193)
 
 Display name
 
@@ -38,7 +38,7 @@ Display name
 
 > **languageCode**: `string`
 
-Defined in: [types/tts.ts:186](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L186)
+Defined in: [types/tts.ts:195](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L195)
 
 Primary language code (e.g., "en-US")
 
@@ -48,7 +48,7 @@ Primary language code (e.g., "en-US")
 
 > **languageCodes**: `string`[]
 
-Defined in: [types/tts.ts:188](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L188)
+Defined in: [types/tts.ts:197](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L197)
 
 All supported language codes
 
@@ -58,7 +58,7 @@ All supported language codes
 
 > **gender**: [`TTSGender`](TTSGender.md)
 
-Defined in: [types/tts.ts:190](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L190)
+Defined in: [types/tts.ts:199](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L199)
 
 TTSGender
 
@@ -68,7 +68,7 @@ TTSGender
 
 > `optional` **type?**: [`TTSVoiceType`](TTSVoiceType.md)
 
-Defined in: [types/tts.ts:192](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L192)
+Defined in: [types/tts.ts:201](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L201)
 
 Voice type
 
@@ -78,7 +78,7 @@ Voice type
 
 > `optional` **description?**: `string`
 
-Defined in: [types/tts.ts:194](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L194)
+Defined in: [types/tts.ts:203](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L203)
 
 Voice description (optional)
 
@@ -88,6 +88,6 @@ Voice description (optional)
 
 > `optional` **naturalSampleRateHertz?**: `number`
 
-Defined in: [types/tts.ts:196](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L196)
+Defined in: [types/tts.ts:205](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L205)
 
 Natural sample rate in Hz (optional)

--- a/docs/api/type-aliases/TTSVoiceType.md
+++ b/docs/api/type-aliases/TTSVoiceType.md
@@ -8,6 +8,6 @@
 
 > **TTSVoiceType** = `"standard"` \| `"wavenet"` \| `"neural"` \| `"chirp"` \| `"unknown"`
 
-Defined in: [types/tts.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L149)
+Defined in: [types/tts.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L158)
 
 Allowed TTS voice types

--- a/docs/api/type-aliases/ToolCallResults.md
+++ b/docs/api/type-aliases/ToolCallResults.md
@@ -8,6 +8,6 @@
 
 > **ToolCallResults** = [`StreamToolResult`](StreamToolResult.md)[]
 
-Defined in: [types/stream.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L122)
+Defined in: [types/stream.ts:123](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L123)
 
 Tool Call Results Array - High Reusability

--- a/docs/api/type-aliases/ToolCalls.md
+++ b/docs/api/type-aliases/ToolCalls.md
@@ -8,6 +8,6 @@
 
 > **ToolCalls** = [`StreamToolCall`](StreamToolCall.md)[]
 
-Defined in: [types/stream.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L127)
+Defined in: [types/stream.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L128)
 
 Tool Calls Array - High Reusability

--- a/docs/api/type-aliases/VoiceType.md
+++ b/docs/api/type-aliases/VoiceType.md
@@ -8,7 +8,7 @@
 
 > **VoiceType** = [`TTSVoiceType`](TTSVoiceType.md)
 
-Defined in: [types/tts.ts:172](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L172)
+Defined in: [types/tts.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L181)
 
 ## Deprecated
 

--- a/docs/api/variables/TTS_ERROR_CODES.md
+++ b/docs/api/variables/TTS_ERROR_CODES.md
@@ -8,7 +8,7 @@
 
 > `const` **TTS_ERROR_CODES**: `object`
 
-Defined in: [utils/ttsProcessor.ts:24](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L24)
+Defined in: [utils/ttsProcessor.ts:29](https://github.com/juspay/neurolink/blob/release/src/lib/utils/ttsProcessor.ts#L29)
 
 TTS-specific error codes
 

--- a/docs/api/variables/VALID_AUDIO_FORMATS.md
+++ b/docs/api/variables/VALID_AUDIO_FORMATS.md
@@ -8,6 +8,6 @@
 
 > `const` **VALID_AUDIO_FORMATS**: readonly [`TTSAudioFormat`](../type-aliases/TTSAudioFormat.md)[]
 
-Defined in: [types/tts.ts:200](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L200)
+Defined in: [types/tts.ts:209](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L209)
 
 Valid audio formats as an array for runtime validation

--- a/docs/api/variables/VALID_TTS_QUALITIES.md
+++ b/docs/api/variables/VALID_TTS_QUALITIES.md
@@ -8,6 +8,6 @@
 
 > `const` **VALID_TTS_QUALITIES**: readonly [`TTSQuality`](../type-aliases/TTSQuality.md)[]
 
-Defined in: [types/tts.ts:215](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L215)
+Defined in: [types/tts.ts:224](https://github.com/juspay/neurolink/blob/release/src/lib/types/tts.ts#L224)
 
 Valid TTS quality levels as an array for runtime validation

--- a/docs/features/tts.md
+++ b/docs/features/tts.md
@@ -255,10 +255,9 @@ const result = await neurolink.generate({
 > **Note:** when `useAiResponse: true`, NeuroLink synthesizes the chat
 > provider's text response. If your chat provider has no TTS counterpart
 > (e.g. `anthropic`, `bedrock`), set `tts.provider` explicitly — otherwise
-> stream Mode 2 will throw `No TTS provider resolved for stream Mode 2`
-> after text generation completes. Chat providers that double as TTS
-> handlers (e.g. `google-ai`, `vertex`) auto-resolve when `tts.provider`
-> is omitted.
+> streaming continues as text-only and logs a provider-resolution warning.
+> Chat providers that double as TTS handlers (e.g. `google-ai`, `vertex`)
+> auto-resolve when `tts.provider` is omitted.
 
 **Use cases:**
 
@@ -646,39 +645,56 @@ audioFiles.forEach((item, index) => {
 
 ### 7. Streaming Text + Audio
 
-Stream AI-generated text and convert to audio:
+Mode 2 can synthesize sentence-buffered audio while the text response is still
+streaming. `stream()` synthesizes whenever `tts.enabled` is set;
+`useAiResponse` selects input-versus-response synthesis for `generate()` and
+does not apply to `stream()`. `streamingBufferSize` sets the minimum number of
+buffered characters before a completed sentence is flushed (default: 120). A
+provider's `maxTextLength` remains a hard boundary; handlers without an override
+use the 3,000-character default.
+
+If one segment fails, NeuroLink keeps the text stream and already-yielded audio,
+attempts the remaining segments, and resolves `streamResult.audio` from the
+surviving chunks. After the stream is drained, `streamResult.ttsMetadata` reports
+`success: false` and a structured, sanitized `error` identifying the failed
+segment count and positions. The first segment failure supplies the error detail.
 
 ```typescript
 async function streamAndSpeak(prompt: string, voice: string) {
-  // Step 1: Stream AI response
   const streamResult = await neurolink.stream({
     input: { text: prompt },
     provider: "google-ai",
     model: "gemini-2.0-flash-exp",
+    tts: {
+      enabled: true,
+      provider: "google-ai",
+      voice,
+      streamingBufferSize: 80,
+    },
   });
 
   let fullText = "";
   for await (const chunk of streamResult.stream) {
-    fullText += chunk.content;
-    process.stdout.write(chunk.content);
+    if ("content" in chunk) {
+      fullText += chunk.content;
+      process.stdout.write(chunk.content);
+    } else if ("type" in chunk && chunk.type === "tts_audio") {
+      // Chunks are ordered by index. cumulativeSize grows monotonically,
+      // and exactly the last successful audio chunk has isFinal=true.
+      playAudioChunk(chunk.audio.data);
+    }
   }
 
-  console.log("\n\nConverting to audio...");
-
-  // Step 2: Convert complete text to audio
-  const ttsResult = await neurolink.generate({
-    input: { text: fullText },
-    provider: "google-ai",
-    tts: {
-      enabled: true,
-      voice,
-      play: true,
-    },
-  });
-
+  // After stream iteration, audio resolves to the concatenated TTS result.
+  // That aggregate is a byte concatenation of the independently synthesized
+  // segments: one playable stream for mp3/mpeg/mpga/pcm16, but NOT a valid
+  // file for header-bearing containers (wav, flac, m4a, mp4, webm), and a
+  // chained stream for ogg/opus that some decoders read only through its first
+  // segment. Use the per-chunk `chunk.audio.data` buffers when each segment
+  // must stand alone.
   return {
     text: fullText,
-    audio: ttsResult.audio,
+    audio: await streamResult.audio,
   };
 }
 
@@ -688,6 +704,13 @@ const result = await streamAndSpeak(
   "en-US-Neural2-C",
 );
 ```
+
+The buffering heuristic recognizes `.`, `!`, or `?` followed by whitespace or
+the end of a text chunk. Short sentences remain buffered until the configured
+boundary or stream completion. Text without sentence punctuation is hard-split
+at the provider limit, so repeated synthesis calls never exceed that cap. The
+same chunk ordering and finality rules apply when a provider falls back to
+synthetic streaming.
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -317,6 +317,12 @@ export default [
             // a consumer migrates. Its header states this in full, including
             // that the suite should be converted or retired once one does.
             "test/continuous-test-suite-model-manifests.ts",
+            // Direct `synthesizeStream` access covers only the
+            // handler-synthesis seam: provider/default text caps,
+            // surrogate-safe splits, and final-chunk failure isolation.
+            // Sentence carry-over and flush behaviour drive the public
+            // `stream()` surface instead.
+            "test/continuous-test-suite-tts-unit.ts",
 
             // ---------------------------------------------------------------
             // Grandfathered when this rule was extended to cover deep `dist/`

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1,7 +1,7 @@
 import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { directAgentTools } from "../agent/directTools.js";
 import type { AIProviderName } from "../constants/enums.js";
-import { isImageGenerationModel } from "../core/constants.js";
+import { isImageGenerationModel } from "./constants.js";
 import type { EvaluationData } from "../index.js";
 import { MiddlewareFactory } from "../middleware/factory.js";
 import { modelSupports } from "../models/modelRegistry.js";
@@ -18,7 +18,9 @@ import type {
   AIProvider,
   AnalyticsData,
   EnhancedGenerateResult,
+  TTSChunk,
   TTSMetadata,
+  TTSResult,
   TextGenerationOptions,
   TextGenerationResult,
   StandardRecord,
@@ -44,6 +46,7 @@ import {
 } from "../utils/lifecycleCallbacks.js";
 import { resolveLifecycleTimeoutMs } from "../utils/lifecycleTimeout.js";
 import { logger } from "../utils/logger.js";
+import { interleaveTTSStream } from "../utils/ttsStream.js";
 import {
   TimeoutError as AsyncTimeoutError,
   withTimeoutFn,
@@ -663,6 +666,80 @@ export abstract class BaseProvider implements AIProvider {
   }
 
   /**
+   * Build the fake-stream output and apply the same incremental TTS wrapper
+   * used by the standard NeuroLink stream path.
+   */
+  private createFakeStreamingOutput(
+    result: EnhancedGenerateResult | null,
+    options: StreamOptions,
+    onTTSComplete?: (result: TTSResult | undefined) => void,
+  ): AsyncIterable<
+    | { content: string }
+    | {
+        type: "image";
+        imageOutput: NonNullable<EnhancedGenerateResult["imageOutput"]>;
+      }
+    | { type: "tts_audio"; audio: TTSChunk }
+  > {
+    const incrementalTTS = options.tts?.enabled === true;
+    const source = (async function* () {
+      if (result?.content) {
+        const words = result.content.split(/(\s+)/);
+        let buffer = "";
+
+        for (let i = 0; i < words.length; i++) {
+          buffer += words[i];
+          const shouldYield =
+            i === words.length - 1 ||
+            buffer.length > 50 ||
+            /[.!?;,]\s*$/.test(buffer);
+          if (shouldYield && buffer.trim()) {
+            yield { content: buffer };
+            buffer = "";
+            await new Promise((resolve) => {
+              setTimeout(resolve, Math.random() * 9 + 1);
+            });
+          }
+        }
+
+        if (buffer.trim()) {
+          yield { content: buffer };
+        }
+      }
+
+      if (result?.imageOutput) {
+        yield { type: "image" as const, imageOutput: result.imageOutput };
+      }
+
+      if (result?.audio && !incrementalTTS) {
+        yield {
+          type: "tts_audio" as const,
+          audio: {
+            data: result.audio.buffer,
+            format: result.audio.format,
+            index: 0,
+            isFinal: true,
+            cumulativeSize: result.audio.size,
+            voice: result.audio.voice,
+            sampleRate: result.audio.sampleRate,
+          },
+        };
+      }
+    })();
+
+    if (!incrementalTTS || !options.tts) {
+      return source;
+    }
+
+    return interleaveTTSStream({
+      stream: source,
+      provider: options.tts.provider ?? options.provider ?? this.providerName,
+      options: options.tts,
+      onComplete: onTTSComplete,
+    });
+  }
+
+  /**
    * Execute fake streaming - extracted method for reusability
    */
   private async executeFakeStreaming(
@@ -705,10 +782,10 @@ export abstract class BaseProvider implements AIProvider {
         skipToolPromptInjection: options.skipToolPromptInjection,
         timeout: options.timeout,
         stt: options.stt,
-        // Forward TTS options too — without this, the fake-streaming fallback
-        // path silently drops `tts` and the resulting StreamResult never
-        // produces a `tts_audio` chunk even when synthesis was requested.
-        tts: options.tts,
+        // Streaming TTS is synthesized incrementally by
+        // createFakeStreamingOutput; do not let generate() perform a duplicate
+        // input- or whole-response synthesis first.
+        tts: options.tts?.enabled ? undefined : options.tts,
       };
 
       logger.debug(`Calling generate for fake streaming`, {
@@ -728,66 +805,49 @@ export abstract class BaseProvider implements AIProvider {
         timestamp: Date.now(),
       });
 
+      const incrementalTTS = options.tts?.enabled === true;
+      const ttsProvider =
+        options.tts?.provider ?? options.provider ?? this.providerName;
+      const ttsStartedAt = Date.now();
+      let resolveAudio: ((value: TTSResult | undefined) => void) | undefined;
+      let audioSettled = false;
+      const audio = incrementalTTS
+        ? new Promise<TTSResult | undefined>((resolve) => {
+            resolveAudio = resolve;
+          }).catch(() => undefined)
+        : undefined;
+      const ttsMetadata: TTSMetadata | undefined = incrementalTTS
+        ? {
+            attempted: TTSProcessor.supports(ttsProvider),
+            success: false,
+          }
+        : result?.ttsMetadata;
+      const onTTSComplete = incrementalTTS
+        ? (
+            ttsResult: TTSResult | undefined,
+            error?: NonNullable<TTSMetadata["error"]>,
+          ) => {
+            if (audioSettled) {
+              return;
+            }
+            audioSettled = true;
+            if (ttsMetadata) {
+              ttsMetadata.success =
+                error === undefined && ttsResult !== undefined;
+              if (error) {
+                ttsMetadata.error = error;
+              } else {
+                delete ttsMetadata.error;
+              }
+              ttsMetadata.latency = Date.now() - ttsStartedAt;
+            }
+            resolveAudio?.(ttsResult);
+          }
+        : undefined;
+
       // Create a synthetic stream from the generate result that simulates progressive delivery
       return {
-        stream: (async function* () {
-          if (result?.content) {
-            // Split content into words for more natural streaming
-            const words = result.content.split(/(\s+)/); // Keep whitespace
-            let buffer = "";
-
-            for (let i = 0; i < words.length; i++) {
-              buffer += words[i];
-
-              // Yield chunks of roughly 5-10 words or at punctuation
-              const shouldYield =
-                i === words.length - 1 || // Last word
-                buffer.length > 50 || // Buffer getting long
-                /[.!?;,]\s*$/.test(buffer); // End of sentence/clause
-
-              if (shouldYield && buffer.trim()) {
-                yield { content: buffer };
-                buffer = "";
-
-                // Small delay to simulate streaming (1-10ms)
-                await new Promise((resolve) => {
-                  setTimeout(resolve, Math.random() * 9 + 1);
-                });
-              }
-            }
-
-            // Yield all remaining content
-            if (buffer.trim()) {
-              yield { content: buffer };
-            }
-          }
-
-          // 🔧 CRITICAL FIX: Yield image output if present
-          if (result?.imageOutput) {
-            yield {
-              type: "image" as const,
-              imageOutput: result.imageOutput,
-            };
-          }
-
-          // Yield synthesized audio so callers using stream() with tts.enabled
-          // still receive a tts_audio chunk on the fake-streaming fallback
-          // path (matches the discriminator used by the real streaming path).
-          if (result?.audio) {
-            yield {
-              type: "tts_audio" as const,
-              audio: {
-                data: result.audio.buffer,
-                format: result.audio.format,
-                index: 0,
-                isFinal: true,
-                cumulativeSize: result.audio.size,
-                voice: result.audio.voice,
-                sampleRate: result.audio.sampleRate,
-              },
-            };
-          }
-        })(),
+        stream: this.createFakeStreamingOutput(result, options, onTTSComplete),
         usage: result?.usage,
         provider: result?.provider,
         model: result?.model,
@@ -810,6 +870,8 @@ export abstract class BaseProvider implements AIProvider {
         // 🔧 FIX: Include analytics and evaluation from generate result
         analytics: result?.analytics,
         evaluation: result?.evaluation,
+        audio,
+        ttsMetadata,
       };
     } catch (error) {
       logger.error(

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -103,7 +103,7 @@ import type {
   MCPServerCategory,
   MCPServerInfo,
   MCPStatus,
-  AudioChunk,
+  ProviderStreamChunk,
   StreamOptions,
   StreamResult,
   StreamToolCall,
@@ -238,8 +238,8 @@ import { tracers } from "./telemetry/tracers.js";
 // Voice integration imports
 import type {
   STTResult,
+  TTSMetadata,
   TTSResult,
-  TTSChunk,
   TTSOptions,
   SessionExport,
   SessionListItem,
@@ -264,6 +264,7 @@ import {
   hasLifecycleErrorFired,
   markLifecycleErrorFired,
 } from "./utils/lifecycleCallbacks.js";
+import { interleaveTTSStream } from "./utils/ttsStream.js";
 import { resolveLifecycleTimeoutMs } from "./utils/lifecycleTimeout.js";
 import { cloneOptionsForCallIsolation } from "./utils/cloneOptions.js";
 import {
@@ -8714,7 +8715,9 @@ Current user's request: ${currentInput}`;
    *
    * // Consume the stream
    * for await (const chunk of result.stream) {
-   *   process.stdout.write(chunk.content);
+   *   if ("content" in chunk) {
+   *     process.stdout.write(chunk.content);
+   *   }
    * }
    *
    * // Advanced streaming with options
@@ -9093,19 +9096,19 @@ Current user's request: ${currentInput}`;
           .thinking?.thinkingLevel,
       );
 
-      // TTS Mode 2 deferred: stream() emits text first, then synthesizes the
-      // accumulated response into a single audio chunk at end-of-stream and
-      // resolves `streamResult.audio` with the same TTSResult. The resolver is
+      // Streaming TTS deferred: stream() always synthesizes the streamed AI
+      // response when TTS is enabled, regardless of generate()'s
+      // input-vs-response `useAiResponse` switch. It resolves
+      // `streamResult.audio` with the aggregate TTSResult. The resolver is
       // plumbed explicitly through the params bag (M11: previously a
       // `_streamTtsResolve` cast on the caller's options object — fragile if
       // the same options object was reused across concurrent stream() calls).
       const ttsOptions = options.tts;
-      const wantsStreamTtsMode2 = !!(
-        ttsOptions?.enabled && ttsOptions?.useAiResponse
-      );
+      const wantsStreamTtsMode2 = ttsOptions?.enabled === true;
       let resolveStreamTtsAudio:
         | ((value: TTSResult | undefined) => void)
         | undefined;
+      let streamTtsMetadata: TTSMetadata | undefined;
       const streamTtsAudioPromise = wantsStreamTtsMode2
         ? new Promise<TTSResult | undefined>((resolve) => {
             resolveStreamTtsAudio = resolve;
@@ -9123,6 +9126,9 @@ Current user's request: ${currentInput}`;
             streamId,
             originalPrompt,
             ttsResolver: resolveStreamTtsAudio,
+            ttsMetadataSink: (metadata) => {
+              streamTtsMetadata = metadata;
+            },
           }),
         ),
       );
@@ -9131,6 +9137,7 @@ Current user's request: ${currentInput}`;
       }
       if (streamTtsAudioPromise) {
         streamResult.audio = streamTtsAudioPromise;
+        streamResult.ttsMetadata = streamTtsMetadata;
       }
       return streamResult;
     } catch (error) {
@@ -9818,14 +9825,16 @@ Current user's request: ${currentInput}`;
     streamId: string;
     originalPrompt: string;
     /**
-     * Resolver for `streamResult.audio` Promise (TTS Mode 2). Set when the
-     * caller requested `tts.enabled && tts.useAiResponse`. Always resolved
+     * Resolver for the streaming `streamResult.audio` Promise. Set when the
+     * caller requested `tts.enabled`. Always resolved
      * exactly once: with the synthesised TTSResult on success, or `undefined`
      * on synthesis failure / non-Mode-2 path / stream error. Plumbed
      * explicitly via this params bag (M11) instead of via a side-channel
      * cast on the caller's options object.
      */
     ttsResolver?: (value: TTSResult | undefined) => void;
+    /** Receives the mutable streaming-TTS metadata reference before return. */
+    ttsMetadataSink?: (value: TTSMetadata | undefined) => void;
   }): Promise<StreamResult> {
     const {
       options,
@@ -9836,6 +9845,7 @@ Current user's request: ${currentInput}`;
       streamId,
       originalPrompt,
       ttsResolver,
+      ttsMetadataSink,
     } = params;
 
     logger.debug("[NeuroLink] Running standard stream request", {
@@ -9876,6 +9886,18 @@ Current user's request: ${currentInput}`;
         analytics: streamAnalytics,
         metadata: providerStreamMetadata,
       } = await this.createMCPStream(enhancedOptions);
+      let streamedTTSResult: TTSResult | undefined;
+      const { stream: incrementalStream, ttsMetadata: streamTtsMetadata } =
+        await this.createIncrementalTTSStream({
+          stream: mcpStream,
+          ttsOptions: enhancedOptions.tts,
+          providerName,
+          fallbackProvider: enhancedOptions.provider,
+          onComplete: (result) => {
+            streamedTTSResult = result;
+          },
+        });
+      ttsMetadataSink?.(streamTtsMetadata);
       const streamState = {
         finishReason: streamFinishReason ?? "stop",
         toolCalls: streamToolCalls,
@@ -9932,7 +9954,7 @@ Current user's request: ${currentInput}`;
         // NoOutputGeneratedError, and we want fallback to fire there.
         let realOutputChunks = 0;
         try {
-          for await (const chunk of mcpStream) {
+          for await (const chunk of incrementalStream) {
             chunkCount++;
             const isNoOutputSentinel =
               chunk !== null &&
@@ -9997,7 +10019,7 @@ Current user's request: ${currentInput}`;
             streamState.toolCalls.length === 0 &&
             streamState.toolResults.length === 0
           ) {
-            yield* self.handleStreamFallback(
+            const fallbackStream = self.handleStreamFallback(
               metadata,
               streamState,
               originalPrompt,
@@ -10007,24 +10029,21 @@ Current user's request: ${currentInput}`;
                 accumulatedContent += content;
               },
             );
+            const { stream: incrementalFallback } =
+              await self.createIncrementalTTSStream({
+                stream: fallbackStream,
+                ttsOptions: enhancedOptions.tts,
+                providerName,
+                fallbackProvider: enhancedOptions.provider,
+                ttsMetadata: streamTtsMetadata,
+                onComplete: (result) => {
+                  streamedTTSResult = result;
+                },
+              });
+            yield* incrementalFallback;
           }
 
-          // TTS Mode 2 for stream(): synthesize the accumulated response
-          // and yield ONE final audio chunk so callers iterating the stream
-          // get the audio inline; also resolve `streamResult.audio` so the
-          // ergonomic `await result.audio` pattern works post-iteration.
-          // m5: synthesis logic lives in a dedicated helper to keep this
-          // generator under the max-lines-per-function lint budget.
-          const ttsModeResult = await self.synthesizeStreamModeTwo({
-            ttsOptions: enhancedOptions.tts,
-            providerName,
-            fallbackProvider: enhancedOptions.provider,
-            accumulatedContent,
-            ttsResolver,
-          });
-          if (ttsModeResult.audioChunk) {
-            yield ttsModeResult.audioChunk;
-          }
+          ttsResolver?.(streamedTTSResult);
 
           resolvedUsage = streamUsage;
           if (!resolvedUsage && streamAnalytics) {
@@ -10295,6 +10314,7 @@ Current user's request: ${currentInput}`;
         providerMetadata: providerStreamMetadata,
       });
     } catch (error) {
+      ttsResolver?.(undefined);
       if (options.disableInternalFallback) {
         throw error;
       }
@@ -10309,92 +10329,84 @@ Current user's request: ${currentInput}`;
     }
   }
 
-  /**
-   * TTS Mode 2 synthesis helper for the stream() pipeline.
-   *
-   * m5 — extracted from runStandardStreamRequest so the surrounding generator
-   * stays under the max-lines-per-function lint budget. Behaviour preserved
-   * exactly:
-   * - When Mode 2 is enabled (`tts.enabled && tts.useAiResponse`) AND the
-   *   model produced non-empty content: synthesises one final audio buffer
-   *   and returns it as an `audioChunk` for the caller to `yield`. Resolves
-   *   `ttsResolver` with the `TTSResult`.
-   * - When Mode 2 is enabled but synthesis fails: logs a warning and resolves
-   *   `ttsResolver` with `undefined`.
-   * - When Mode 2 is requested but skipped (empty content / wrong mode):
-   *   resolves `ttsResolver` with `undefined` early so callers awaiting
-   *   `result.audio` unblock before the surrounding `finally` cleanup
-   *   completes (Issue 7 latency micro-opt — the finally block also resolves
-   *   defensively, so this is a redundant early signal, not a coverage fix).
-   */
-  private async synthesizeStreamModeTwo(params: {
+  /** Wrap one provider stream with incremental TTS synthesis. */
+  private async createIncrementalTTSStream(params: {
+    stream: AsyncIterable<ProviderStreamChunk>;
     ttsOptions: TTSOptions | undefined;
     providerName: string;
     fallbackProvider?: string;
-    accumulatedContent: string;
-    ttsResolver?: (value: TTSResult | undefined) => void;
-  }): Promise<{ audioChunk?: { type: "tts_audio"; audio: TTSChunk } }> {
-    const {
-      ttsOptions,
-      providerName,
-      fallbackProvider,
-      accumulatedContent,
-      ttsResolver,
-    } = params;
+    ttsMetadata?: TTSMetadata;
+    onComplete: (value: TTSResult | undefined) => void;
+  }): Promise<{
+    stream: AsyncIterable<ProviderStreamChunk>;
+    ttsMetadata?: TTSMetadata;
+  }> {
+    const { stream, ttsOptions, providerName, fallbackProvider, onComplete } =
+      params;
 
-    if (
-      !ttsOptions?.enabled ||
-      !ttsOptions.useAiResponse ||
-      accumulatedContent.trim().length === 0
-    ) {
-      ttsResolver?.(undefined);
-      return {};
+    if (!ttsOptions?.enabled) {
+      onComplete(undefined);
+      return { stream };
     }
 
-    try {
-      const { TTSProcessor } = await import("./utils/ttsProcessor.js");
-      // ttsOptions.provider takes precedence; otherwise fall back to the
-      // chat provider ID ONLY when it happens to be a registered TTS handler
-      // (e.g. "google-ai" works for both LLM and TTS). For LLM-only IDs like
-      // "anthropic", we'd otherwise complete generation and then fail synth —
-      // surface that mismatch up front instead.
-      const candidate = ttsOptions.provider ?? fallbackProvider ?? providerName;
-      const ttsProvider =
-        candidate && TTSProcessor.supports(candidate) ? candidate : undefined;
-      if (!ttsProvider) {
-        throw new Error(
-          `No TTS provider resolved for stream Mode 2 (set tts.provider explicitly — chat provider "${candidate ?? "<unset>"}" is not a registered TTS handler)`,
-        );
+    const { TTSProcessor } = await import("./utils/ttsProcessor.js");
+    const concreteFallback =
+      fallbackProvider === "auto" ? undefined : fallbackProvider;
+    const candidate = ttsOptions.provider ?? concreteFallback ?? providerName;
+    const ttsProvider =
+      candidate && TTSProcessor.supports(candidate) ? candidate : undefined;
+    const ttsMetadata = params.ttsMetadata ?? {
+      attempted: ttsProvider !== undefined,
+      success: false,
+    };
+    ttsMetadata.attempted = ttsProvider !== undefined;
+    ttsMetadata.success = false;
+    delete ttsMetadata.error;
+    delete ttsMetadata.latency;
+    const ttsStartedAt = Date.now();
+    let completionRecorded = false;
+    const recordCompletion = (
+      result: TTSResult | undefined,
+      error?: NonNullable<TTSMetadata["error"]>,
+    ) => {
+      if (completionRecorded) {
+        return;
       }
-      const ttsResult = await TTSProcessor.synthesize(
-        accumulatedContent,
-        ttsProvider,
-        ttsOptions,
-      );
-      ttsResolver?.(ttsResult);
-      return {
-        audioChunk: {
-          type: "tts_audio" as const,
-          audio: {
-            data: ttsResult.buffer,
-            format: ttsResult.format,
-            index: 0,
-            isFinal: true,
-            cumulativeSize: ttsResult.size,
-            voice: ttsResult.voice,
-            sampleRate: ttsResult.sampleRate,
-          },
-        },
-      };
-    } catch (ttsError) {
+      completionRecorded = true;
+      ttsMetadata.success = error === undefined && result !== undefined;
+      if (error) {
+        ttsMetadata.error = error;
+      } else {
+        delete ttsMetadata.error;
+      }
+      ttsMetadata.latency = Date.now() - ttsStartedAt;
+      onComplete(result);
+    };
+    if (!ttsProvider) {
       logger.warn(
-        `[NeuroLink.stream] Stream TTS Mode 2 synthesis failed: ${
-          ttsError instanceof Error ? ttsError.message : String(ttsError)
-        }`,
+        `[NeuroLink.stream] No TTS provider resolved for incremental streaming (set tts.provider explicitly — chat provider "${candidate ?? "<unset>"}" is not a registered TTS handler)`,
       );
-      ttsResolver?.(undefined);
-      return {};
+      recordCompletion(undefined);
+      return { stream, ttsMetadata };
     }
+
+    return {
+      stream: interleaveTTSStream({
+        stream,
+        provider: ttsProvider,
+        options: ttsOptions,
+        onComplete: recordCompletion,
+      }),
+      ttsMetadata,
+    };
+  }
+
+  /** Prevent provider fallback streams from duplicating outer streaming TTS. */
+  private deferProviderStreamTTS(options: StreamOptions): StreamOptions {
+    if (options.tts?.enabled) {
+      return { ...options, tts: undefined };
+    }
+    return options;
   }
 
   /**
@@ -10711,12 +10723,7 @@ Current user's request: ${currentInput}`;
     enhancedOptions: StreamOptions,
     providerName: string,
     appendContent: (content: string) => void,
-  ): AsyncGenerator<
-    | { content: string }
-    | { type: "audio"; audio: AudioChunk }
-    | { type: "tts_audio"; audio: TTSChunk }
-    | { type: "image"; imageOutput: { base64: string } }
-  > {
+  ): AsyncGenerator<ProviderStreamChunk> {
     metadata.fallbackAttempted = true;
     const errorMsg =
       "Stream completed with 0 chunks (possible guardrails block)";
@@ -10815,7 +10822,7 @@ Current user's request: ${currentInput}`;
             } as TextGenerationOptions);
 
       const fallbackResult = await fallbackProvider.stream({
-        ...enhancedOptions,
+        ...this.deferProviderStreamTTS(enhancedOptions),
         model: fallbackRoute.model,
         conversationMessages,
       });
@@ -11100,12 +11107,7 @@ Current user's request: ${currentInput}`;
    * Create MCP stream
    */
   private async createMCPStream(options: StreamOptions): Promise<{
-    stream: AsyncIterable<
-      | { content: string }
-      | { type: "audio"; audio: AudioChunk }
-      | { type: "tts_audio"; audio: TTSChunk }
-      | { type: "image"; imageOutput: { base64: string } }
-    >;
+    stream: AsyncIterable<ProviderStreamChunk>;
     provider: string;
     usage?: { input: number; output: number; total: number };
     model?: string;
@@ -11442,7 +11444,7 @@ Current user's request: ${currentInput}`;
           );
 
           const poolStreamResult = await poolStreamProvider.stream({
-            ...options,
+            ...this.deferProviderStreamTTS(options),
             provider: poolStreamProviderName as AIProviderName,
             model: poolStreamModel,
             region: poolStreamRegion,
@@ -11532,7 +11534,7 @@ Current user's request: ${currentInput}`;
     // 🔧 FIX: Pass enhanced system prompt to real streaming
     // Tools will be accessed through the streamText call in executeStream
     const streamResult = await provider.stream({
-      ...options,
+      ...this.deferProviderStreamTTS(options),
       systemPrompt: enhancedSystemPrompt, // Use enhanced prompt with tool descriptions
       conversationMessages,
     });
@@ -11564,12 +11566,7 @@ Current user's request: ${currentInput}`;
    * Process stream result
    */
   private async processStreamResult(
-    _stream: AsyncIterable<
-      | { content: string }
-      | { type: "audio"; audio: AudioChunk }
-      | { type: "tts_audio"; audio: TTSChunk }
-      | { type: "image"; imageOutput: { base64: string } }
-    >,
+    _stream: AsyncIterable<ProviderStreamChunk>,
     _options: StreamOptions,
     _factoryResult: unknown,
   ): Promise<{
@@ -11617,12 +11614,7 @@ Current user's request: ${currentInput}`;
       analytics?: AnalyticsData;
       evaluation?: EvaluationData;
     },
-    stream: AsyncIterable<
-      | { content: string }
-      | { type: "audio"; audio: AudioChunk }
-      | { type: "tts_audio"; audio: TTSChunk }
-      | { type: "image"; imageOutput: { base64: string } }
-    >,
+    stream: AsyncIterable<ProviderStreamChunk>,
     config: {
       providerName: string;
       options: StreamOptions;

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -25,6 +25,7 @@ import type { StreamNoOutputSentinel } from "./noOutputSentinel.js";
 import type {
   AdditionalMemoryUser,
   GenerateStopReason,
+  TTSMetadata,
   ToolExecutionCaptureOptions,
 } from "./generate.js";
 import type {
@@ -219,6 +220,13 @@ export type StreamChunk =
       /** TTS audio chunk data */
       audio: TTSChunk;
     };
+
+/** Provider-level chunks accepted by NeuroLink's core streaming pipeline. */
+export type ProviderStreamChunk =
+  | { content: string }
+  | { type: "audio"; audio: AudioChunk }
+  | { type: "tts_audio"; audio: TTSChunk }
+  | { type: "image"; imageOutput: { base64: string } };
 
 export type StreamOptions = {
   /**
@@ -844,13 +852,37 @@ export type StreamResult = {
   transcription?: STTResult;
 
   /**
-   * TTS Mode 2 result (when `tts.enabled && tts.useAiResponse`).
-   * Resolves with the synthesized audio after the stream completes;
-   * resolves to undefined if TTS was not enabled or synthesis failed.
-   * The same audio is also yielded as a final chunk on `stream` for callers
-   * that prefer to consume it inline.
+   * Streaming TTS result (when `tts.enabled`). `stream()` synthesizes the AI
+   * response incrementally; `useAiResponse` continues to select input vs
+   * response synthesis for non-streaming generation.
+   * Resolves with the synthesized audio after the caller drains `stream` to
+   * completion; like other stream-final fields, it remains pending while the
+   * lazy stream is unconsumed. It resolves with the aggregate of whatever
+   * segments were synthesized: a synthesis failure part-way through still
+   * resolves with the earlier segments rather than discarding them. It resolves
+   * to undefined only when no segment was produced — TTS was not enabled, no
+   * handler resolved for the requested provider, the model stream errored, every
+   * synthesis failed, or the caller stopped draining `stream` before it ended
+   * (an abandoned stream settles undefined rather than a partial aggregate).
+   * Audio is also yielded incrementally as ordered
+   * `tts_audio` chunks. Each chunk, including the final one, contains only its
+   * own buffered segment. The aggregate is a byte concatenation of those
+   * independently synthesized segments, so what it is depends on the format's
+   * framing: for frame- or sample-stream formats (`mp3`, `mpeg`, `mpga`,
+   * `pcm16`) it is one playable stream; for header-bearing container formats
+   * (`wav`, `flac`, `m4a`, `mp4`, `webm`) it is not a valid file, because each
+   * segment carries its own header; for `ogg`/`opus` it is a chained stream that
+   * some decoders read only through its first segment. Use the individual chunk
+   * buffers when each segment must be a valid container file.
    */
   audio?: Promise<TTSResult | undefined>;
+
+  /**
+   * Outcome metadata for streaming TTS synthesis. This is a mutable reference
+   * whose success and latency fields are finalized asynchronously; read it
+   * after draining `stream`.
+   */
+  ttsMetadata?: TTSMetadata;
 };
 
 /**

--- a/src/lib/types/tts.ts
+++ b/src/lib/types/tts.ts
@@ -58,6 +58,9 @@ export type TTSOptions = {
   /**
    * Use the AI-generated response for TTS instead of the input text
    *
+   * This switch applies to non-streaming generation. `stream()` always
+   * synthesizes the streamed AI response incrementally when TTS is enabled.
+   *
    * When false or undefined (default): TTS will synthesize the input text/prompt directly without calling AI generation
    * When true: TTS will synthesize the AI-generated response after generation completes
    *
@@ -102,6 +105,12 @@ export type TTSOptions = {
   play?: boolean;
   /** Override TTS provider (e.g., "elevenlabs", "openai-tts", "azure-tts") */
   provider?: TTSProviderName;
+  /**
+   * Minimum buffered text length before incremental stream synthesis flushes
+   * at a sentence boundary. The provider's maximum text length remains a hard
+   * upper bound. Defaults to 120 characters.
+   */
+  streamingBufferSize?: number;
 };
 
 /**
@@ -258,6 +267,14 @@ export function isValidTTSOptions(options: unknown): options is TTSOptions {
   }
   if (opts.quality !== undefined) {
     if (!VALID_TTS_QUALITIES.includes(opts.quality)) {
+      return false;
+    }
+  }
+  if (opts.streamingBufferSize !== undefined) {
+    if (
+      !Number.isInteger(opts.streamingBufferSize) ||
+      opts.streamingBufferSize < 1
+    ) {
       return false;
     }
   }

--- a/src/lib/utils/ttsProcessor.ts
+++ b/src/lib/utils/ttsProcessor.ts
@@ -8,7 +8,12 @@
  */
 
 import { logger } from "./logger.js";
-import type { TTSOptions, TTSResult, TTSHandler } from "../types/index.js";
+import type {
+  TTSChunk,
+  TTSOptions,
+  TTSResult,
+  TTSHandler,
+} from "../types/index.js";
 import { ErrorCategory, ErrorSeverity } from "../constants/enums.js";
 import { NeuroLinkError } from "./errorHandling.js";
 import { HandlerRegistry } from "../core/handlerRegistry.js";
@@ -29,6 +34,96 @@ export const TTS_ERROR_CODES = {
   SYNTHESIS_FAILED: "TTS_SYNTHESIS_FAILED",
   INVALID_INPUT: "TTS_INVALID_INPUT",
 } as const;
+
+const DEFAULT_STREAMING_BUFFER_SIZE = 120;
+const SENTENCE_BOUNDARY = /[.!?]+(?:["')\]]+)?(?=\s|$)/g;
+
+/** Internal signal raised after all buffered segments have been attempted. */
+export class IncrementalTTSSynthesisError extends Error {
+  readonly firstError: unknown;
+  readonly failedSegments: readonly number[];
+
+  constructor(firstError: unknown, failedSegments: number[]) {
+    super(
+      `Incremental TTS failed for ${failedSegments.length} segment${failedSegments.length === 1 ? "" : "s"}`,
+    );
+    this.name = "IncrementalTTSSynthesisError";
+    this.firstError = firstError;
+    this.failedSegments = [...failedSegments];
+  }
+}
+
+function findSentenceEnds(text: string): number[] {
+  const ends: number[] = [];
+  for (const match of text.matchAll(SENTENCE_BOUNDARY)) {
+    ends.push((match.index ?? 0) + match[0].length);
+  }
+  return ends;
+}
+
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+
+/**
+ * Move a split index off the middle of a surrogate pair.
+ *
+ * The cap is measured in UTF-16 code units, so a hard split can land between
+ * the two halves of an astral character (emoji, rarer CJK). That would end one
+ * segment with a lone high surrogate and start the next with its low half, and
+ * providers receive U+FFFD instead of the character. Backing the split off by
+ * one code unit keeps the pair whole in the next segment.
+ *
+ * A split at index 1 is left alone: backing off would yield an empty segment
+ * with an unchanged remainder, and a cap that small cannot hold the pair anyway.
+ */
+function avoidSurrogateSplit(text: string, splitAt: number): number {
+  if (splitAt <= 1 || splitAt >= text.length) {
+    return splitAt;
+  }
+  const high = text.charCodeAt(splitAt - 1);
+  const low = text.charCodeAt(splitAt);
+  const splitsPair =
+    high >= HIGH_SURROGATE_START &&
+    high <= HIGH_SURROGATE_END &&
+    low >= LOW_SURROGATE_START &&
+    low <= LOW_SURROGATE_END;
+  return splitsPair ? splitAt - 1 : splitAt;
+}
+
+function takeBufferedSegment(
+  buffer: string,
+  flushBoundary: number,
+  maxTextLength: number,
+  inputComplete: boolean,
+): { segment: string; remainder: string } | undefined {
+  const cappedText = buffer.slice(0, maxTextLength);
+  const sentenceEnds = findSentenceEnds(cappedText);
+  let splitAt =
+    buffer.length >= flushBoundary ? sentenceEnds.at(-1) : undefined;
+
+  if (splitAt === undefined && buffer.length >= maxTextLength) {
+    splitAt = sentenceEnds.at(-1) ?? maxTextLength;
+  }
+
+  if (splitAt === undefined && inputComplete && buffer.trim()) {
+    splitAt = Math.min(buffer.length, maxTextLength);
+  }
+
+  if (splitAt === undefined) {
+    return undefined;
+  }
+
+  splitAt = avoidSurrogateSplit(buffer, splitAt);
+
+  const segment = buffer.slice(0, splitAt).trim();
+  const remainder = buffer.slice(splitAt).trimStart();
+  if (!segment) {
+    return { segment: "", remainder };
+  }
+  return { segment, remainder };
+}
 
 /**
  * TTS Error class for text-to-speech specific errors
@@ -352,6 +447,139 @@ export class TTSProcessor {
         },
         originalError: err instanceof Error ? err : undefined,
       });
+    }
+  }
+
+  /**
+   * Incrementally synthesize sentence-buffered text chunks.
+   *
+   * Text is flushed at a sentence boundary after `streamingBufferSize`
+   * characters, or hard-split before the provider's maximum text length.
+   * Each segment goes through `synthesize()`, preserving the existing handler
+   * registry, validation, error normalization, and telemetry seam.
+   *
+   * The most recent successful audio chunk is held until another succeeds or
+   * the input ends, so exactly one real audio chunk carries `isFinal: true`
+   * without emitting a separate empty terminator chunk.
+   */
+  static async *synthesizeStream(
+    textChunks: AsyncIterable<string>,
+    provider: string,
+    options: TTSOptions,
+    shouldStop?: () => boolean,
+  ): AsyncGenerator<TTSChunk> {
+    const handler = this.getHandler(provider);
+    const maxTextLength = Math.max(
+      1,
+      handler?.maxTextLength ?? this.DEFAULT_MAX_TEXT_LENGTH,
+    );
+    const requestedBoundary =
+      options.streamingBufferSize ?? DEFAULT_STREAMING_BUFFER_SIZE;
+    const flushBoundary = Math.min(
+      Math.max(1, Math.trunc(requestedBoundary)),
+      maxTextLength,
+    );
+    let buffer = "";
+    let chunkIndex = 0;
+    let cumulativeSize = 0;
+    let cumulativeDuration = 0;
+    let pendingChunk: TTSChunk | undefined;
+    let segmentNumber = 0;
+    let firstFailure: unknown;
+    const failedSegments: number[] = [];
+
+    const synthesizeSegment = async (
+      segment: string,
+    ): Promise<TTSChunk | undefined> => {
+      const currentSegment = ++segmentNumber;
+      try {
+        const result = await this.synthesize(segment, provider, options);
+        cumulativeSize += result.size;
+        cumulativeDuration += result.duration ?? 0;
+        return {
+          data: result.buffer,
+          format: result.format,
+          index: chunkIndex++,
+          isFinal: false,
+          cumulativeSize,
+          estimatedDuration: cumulativeDuration || undefined,
+          voice: result.voice,
+          sampleRate: result.sampleRate,
+        };
+      } catch (error) {
+        if (failedSegments.length === 0) {
+          firstFailure = error;
+        }
+        failedSegments.push(currentSegment);
+        logger.warn(
+          `[TTSProcessor] Incremental synthesis skipped a buffered segment: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return undefined;
+      }
+    };
+
+    for await (const textChunk of textChunks) {
+      if (shouldStop?.()) {
+        break;
+      }
+      buffer += textChunk;
+
+      while (!shouldStop?.()) {
+        const buffered = takeBufferedSegment(
+          buffer,
+          flushBoundary,
+          maxTextLength,
+          false,
+        );
+        if (!buffered) {
+          break;
+        }
+        buffer = buffered.remainder;
+        if (!buffered.segment) {
+          continue;
+        }
+
+        const chunk = await synthesizeSegment(buffered.segment);
+        if (chunk) {
+          if (pendingChunk) {
+            yield pendingChunk;
+          }
+          pendingChunk = chunk;
+        }
+      }
+    }
+
+    while (!shouldStop?.()) {
+      const buffered = takeBufferedSegment(
+        buffer,
+        flushBoundary,
+        maxTextLength,
+        true,
+      );
+      if (!buffered) {
+        break;
+      }
+      buffer = buffered.remainder;
+      if (!buffered.segment) {
+        continue;
+      }
+
+      const chunk = await synthesizeSegment(buffered.segment);
+      if (chunk) {
+        if (pendingChunk) {
+          yield pendingChunk;
+        }
+        pendingChunk = chunk;
+      }
+    }
+
+    if (pendingChunk) {
+      yield { ...pendingChunk, isFinal: true };
+    }
+    if (failedSegments.length > 0) {
+      throw new IncrementalTTSSynthesisError(firstFailure, failedSegments);
     }
   }
 }

--- a/src/lib/utils/ttsStream.ts
+++ b/src/lib/utils/ttsStream.ts
@@ -1,0 +1,290 @@
+import type {
+  TTSChunk,
+  TTSMetadata,
+  TTSOptions,
+  TTSResult,
+} from "../types/index.js";
+import { NeuroLinkError } from "./errorHandling.js";
+import { sanitizeErrorCause } from "./logSanitize.js";
+import { logger } from "./logger.js";
+import {
+  IncrementalTTSSynthesisError,
+  TTS_ERROR_CODES,
+  TTSProcessor,
+} from "./ttsProcessor.js";
+import { TimeoutError as AsyncTimeoutError } from "./async/withTimeout.js";
+
+function getStreamingTTSErrorDetails(
+  error: unknown,
+): NonNullable<TTSMetadata["error"]> {
+  const incrementalFailure =
+    error instanceof IncrementalTTSSynthesisError ? error : undefined;
+  const cause = incrementalFailure?.firstError ?? error;
+  const safeMessage = sanitizeErrorCause(cause).message;
+  let detail: NonNullable<TTSMetadata["error"]>;
+
+  if (cause instanceof AsyncTimeoutError) {
+    detail = {
+      code: TTS_ERROR_CODES.SYNTHESIS_FAILED,
+      message: safeMessage,
+      retriable: true,
+    };
+  } else if (cause instanceof NeuroLinkError) {
+    detail = {
+      code: cause.code,
+      message: safeMessage,
+      retriable: cause.retriable,
+    };
+  } else {
+    detail = {
+      code: TTS_ERROR_CODES.SYNTHESIS_FAILED,
+      message: safeMessage,
+    };
+  }
+
+  const failedSegments = incrementalFailure?.failedSegments;
+  const count = failedSegments?.length ?? 1;
+  const positions = failedSegments?.join(", ") ?? "unknown";
+  return {
+    ...detail,
+    message: `Incremental TTS failed for ${count} segment${count === 1 ? "" : "s"} (segment${count === 1 ? "" : "s"} ${positions}): ${detail.message}`,
+  };
+}
+
+class AsyncTextQueue implements AsyncIterableIterator<string> {
+  private readonly values: string[] = [];
+  private readonly waiters: Array<{
+    resolve: (result: IteratorResult<string>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private ended = false;
+  private failure: unknown;
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<string> {
+    return this;
+  }
+
+  next(): Promise<IteratorResult<string>> {
+    if (this.values.length > 0) {
+      const value = this.values.shift();
+      if (value !== undefined) {
+        return Promise.resolve({ value, done: false });
+      }
+    }
+    if (this.failure !== undefined) {
+      return Promise.reject(this.failure);
+    }
+    if (this.ended) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  push(value: string): void {
+    if (this.ended || this.failure !== undefined) {
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve({ value, done: false });
+      return;
+    }
+    this.values.push(value);
+  }
+
+  end(): void {
+    if (this.ended || this.failure !== undefined) {
+      return;
+    }
+    this.ended = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.resolve({ value: undefined, done: true });
+    }
+  }
+
+  fail(error: unknown): void {
+    if (this.ended || this.failure !== undefined) {
+      return;
+    }
+    this.failure = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
+  }
+}
+
+function sourceEvent<T>(iterator: AsyncIterator<T>) {
+  return iterator.next().then(
+    (result) => ({ kind: "source" as const, result }),
+    (error: unknown) => ({ kind: "source-error" as const, error }),
+  );
+}
+
+function audioEvent(iterator: AsyncIterator<TTSChunk>) {
+  return iterator.next().then(
+    (result) => ({ kind: "audio" as const, result }),
+    (error: unknown) => ({ kind: "audio-error" as const, error }),
+  );
+}
+
+function textFromChunk(chunk: unknown): string | undefined {
+  if (
+    chunk &&
+    typeof chunk === "object" &&
+    "content" in chunk &&
+    typeof chunk.content === "string" &&
+    chunk.content.length > 0
+  ) {
+    return chunk.content;
+  }
+  return undefined;
+}
+
+function aggregateTTSChunks(chunks: TTSChunk[]): TTSResult | undefined {
+  const last = chunks.at(-1);
+  if (!last) {
+    return undefined;
+  }
+  const buffer = Buffer.concat(chunks.map((chunk) => chunk.data));
+  return {
+    buffer,
+    format: last.format,
+    size: buffer.length,
+    duration: last.estimatedDuration,
+    voice: last.voice,
+    sampleRate: last.sampleRate,
+  };
+}
+
+/**
+ * Preserve source-stream backpressure while interleaving incremental TTS audio.
+ * Source chunks are yielded before their derived audio, and TTS failures degrade
+ * to the unchanged source stream.
+ */
+export async function* interleaveTTSStream<T>(params: {
+  stream: AsyncIterable<T>;
+  provider: string;
+  options: TTSOptions;
+  onComplete?: (
+    result: TTSResult | undefined,
+    error?: NonNullable<TTSMetadata["error"]>,
+  ) => void;
+}): AsyncGenerator<T | { type: "tts_audio"; audio: TTSChunk }> {
+  const { stream, provider, options, onComplete } = params;
+
+  if (!TTSProcessor.supports(provider)) {
+    try {
+      for await (const chunk of stream) {
+        yield chunk;
+      }
+    } finally {
+      onComplete?.(undefined);
+    }
+    return;
+  }
+
+  const textQueue = new AsyncTextQueue();
+  const sourceIterator = stream[Symbol.asyncIterator]();
+  let cancelled = false;
+  const audioIterator = TTSProcessor.synthesizeStream(
+    textQueue,
+    provider,
+    options,
+    () => cancelled,
+  )[Symbol.asyncIterator]();
+  const audioChunks: TTSChunk[] = [];
+  let nextSource: ReturnType<typeof sourceEvent<T>> | undefined =
+    sourceEvent(sourceIterator);
+  let nextAudio: ReturnType<typeof audioEvent> | undefined =
+    audioEvent(audioIterator);
+  let completed = false;
+  let preferAudio = false;
+
+  try {
+    while (nextSource || nextAudio) {
+      const event =
+        nextSource && nextAudio
+          ? await Promise.race(
+              preferAudio ? [nextAudio, nextSource] : [nextSource, nextAudio],
+            )
+          : nextSource
+            ? await nextSource
+            : nextAudio
+              ? await nextAudio
+              : undefined;
+      if (!event) {
+        break;
+      }
+
+      if (event.kind === "source-error") {
+        textQueue.fail(event.error);
+        throw event.error;
+      }
+      if (event.kind === "audio-error") {
+        textQueue.end();
+        const error = getStreamingTTSErrorDetails(event.error);
+        logger.warn(
+          `[TTSProcessor] Incremental stream disabled after an audio error: ${
+            event.error instanceof Error
+              ? event.error.message
+              : String(event.error)
+          }`,
+        );
+        nextAudio = undefined;
+        preferAudio = false;
+        completed = true;
+        onComplete?.(aggregateTTSChunks(audioChunks), error);
+        continue;
+      }
+      if (event.kind === "source") {
+        if (event.result.done) {
+          nextSource = undefined;
+          textQueue.end();
+          preferAudio = true;
+          continue;
+        }
+        const text = textFromChunk(event.result.value);
+        if (text) {
+          textQueue.push(text);
+        }
+        nextSource = sourceEvent(sourceIterator);
+        preferAudio = true;
+        yield event.result.value;
+        continue;
+      }
+
+      if (event.result.done) {
+        nextAudio = undefined;
+        completed = true;
+        onComplete?.(aggregateTTSChunks(audioChunks));
+        continue;
+      }
+      audioChunks.push(event.result.value);
+      nextAudio = audioEvent(audioIterator);
+      preferAudio = false;
+      yield { type: "tts_audio", audio: event.result.value };
+    }
+  } finally {
+    if (!completed) {
+      cancelled = true;
+    }
+    textQueue.end();
+    const releases: Promise<unknown>[] = [];
+    if (nextSource && sourceIterator.return) {
+      releases.push(
+        Promise.resolve().then(() => sourceIterator.return?.(undefined)),
+      );
+    }
+    if (nextAudio && audioIterator.return) {
+      releases.push(
+        Promise.resolve().then(() => audioIterator.return?.(undefined)),
+      );
+    }
+    await Promise.allSettled(releases);
+    if (!completed) {
+      onComplete?.(undefined);
+    }
+  }
+}

--- a/test/continuous-test-suite-tts-unit.ts
+++ b/test/continuous-test-suite-tts-unit.ts
@@ -1,94 +1,50 @@
 #!/usr/bin/env tsx
 /**
- * Continuous Test Suite: TTSProcessor (public surface).
+ * Continuous Test Suite: public TTS behavior plus deterministic chunking.
  *
- * Rule-15 rewrite. The previous version of this file called
- * `TTSProcessor.registerHandler()` / `.synthesize()` / `.supports()` /
- * `.getHandler()` / `.clearHandlers()` directly and asserted on their return
- * values — that is a unit test of an internal static class, not a test of
- * anything NeuroLink ships to a caller. Its own header claimed "stream() has
- * no options-surface hook to inject a stub" — that claim is wrong: `stream()`
- * accepts `tts.provider`, and a synthetic provider registered via
- * `TTSProcessor.registerHandler()` as *setup* is resolved through that same
- * option, so a stub handler can be driven end-to-end through the public
- * `NeuroLink#stream()` call. This file now does that.
+ * Covers TTS-027 (#527), and the no-key half of TTS-028 (#528).
  *
- * Public dispatch path exercised (src/lib/neurolink.ts,
- * `synthesizeStreamModeTwo`, called from `runStandardStreamRequest`):
- *   stream({ tts: { enabled: true, useAiResponse: true, provider } })
- *   -> gate: tts.enabled && tts.useAiResponse && accumulatedContent non-empty
- *   -> candidate = tts.provider ?? fallbackProvider ?? providerName
- *   -> TTSProcessor.supports(candidate) must be true, else no synthesis is
- *      attempted at all
- *   -> TTSProcessor.synthesize(accumulatedContent, candidate, tts) is called
- *   -> on success: one `{ type: "tts_audio", audio: TTSChunk }` chunk is
- *      yielded on the stream, and `streamResult.audio` resolves to the
- *      TTSResult
- *   -> on ANY failure (validation or handler throw): the error is caught
- *      inside `synthesizeStreamModeTwo` itself, logged via `logger.warn`,
- *      and swallowed — no `tts_audio` chunk is yielded, `streamResult.audio`
- *      resolves to `undefined`, and the text stream completes normally.
- *
- * Because an LLM response is required to reach TTS Mode 2 (`useAiResponse`
- * needs accumulated text), this suite points `provider: "openai-compatible"`
- * at a local HTTP server that streams a fixed SSE response — the same idiom
- * `test/continuous-test-suite-openai-compat-streaming-retry.ts` uses. No
- * external API keys or network calls are needed.
- *
- * registerHandler()/clearHandlers() appear ONLY as setup/teardown here (per
- * rule 15's guidance) — every assertion is about what `stream()` returned or
- * yielded, via a per-test synthetic provider name so nothing real is
- * disturbed, and the whole registry is snapshotted/restored around the run.
- *
- * ---------------------------------------------------------------------
- * Coverage dropped relative to the old unit suite (reported, not hidden):
- *
- * 1. registerHandler()'s own argument validation ("Provider name is
- *    required" / "Handler is required") — these guard the setup API
- *    itself; there is no public generate()/stream() call that can reach
- *    them, since only test *setup* calls registerHandler().
- * 2. supports()/getHandler() as directly-observed query methods — now only
- *    exercised indirectly, via the pass/fail shape of a stream() call.
- * 3. The specific TTSError CODE and message/context (EMPTY_TEXT,
- *    PROVIDER_NOT_SUPPORTED + availableProviders, TEXT_TOO_LONG,
- *    PROVIDER_NOT_CONFIGURED, SYNTHESIS_FAILED) are indistinguishable from
- *    the public surface: `synthesizeStreamModeTwo` catches every one of
- *    them identically and turns them all into the same observable outcome
- *    ("no tts_audio chunk; streamResult.audio resolves to undefined").
- *    This suite still reproduces each *trigger condition* (short
- *    maxTextLength, isConfigured:false, a throwing handler, an unresolved
- *    provider) and asserts the resulting graceful-degradation behavior,
- *    but cannot assert which TTSError code or message fired.
- * 4. EMPTY_TEXT specifically is structurally unreachable through stream():
- *    `synthesizeStreamModeTwo` already gates on non-empty accumulated
- *    content before ever calling `TTSProcessor.synthesize`.
- * 5. PROVIDER_NOT_SUPPORTED's `availableProviders` context is also
- *    unreachable at the synthesize() level from this call site:
- *    `synthesizeStreamModeTwo` only calls `TTSProcessor.synthesize` after
- *    `TTSProcessor.supports(candidate)` has already returned true.
- * 6. `TTSHandler.getVoices()` — no code path in NeuroLink's generate()/
- *    stream() ever calls a handler's `getVoices()`; it is reachable only by
- *    a consumer holding a handler reference directly (e.g. a client-side
- *    React hook, outside the SDK's own dispatch). Not exercised here.
- * 7. `clearHandlers()` wiping every registration is no longer asserted as a
- *    behavior in its own right — per rule 15 it may only be setup/teardown
- *    now, so it is used solely to restore the registry, not as a test
- *    subject.
+ * The direct `synthesizeStream` cases use the rule-15 determinism exception
+ * only for the handler-synthesis seam: exact provider text caps,
+ * surrogate-pair-safe splitting, and per-segment failure isolation. Sentence
+ * carry-over and configurable flushing drive the shipped `NeuroLink.stream()`
+ * surface through `makeTextStream` instead. The OpenAITTS format-mapping case
+ * deliberately reaches the private pure `mapFormat`/`effectiveFormat` methods
+ * so it can pin wire-format behavior without credentials or constructor side
+ * effects. The auto-provider case must stub the internal health selector before
+ * any public provider surface exists; that single exception keeps this suite
+ * credential-free and deterministic.
  *
  * Run: npx tsx test/continuous-test-suite-tts-unit.ts
- *      pnpm run test:tts:unit
  */
-import { createServer, type Server } from "node:http";
-import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
-import { TTSProcessor } from "../dist/index.js";
-import type {
-  NeuroLink,
-  StreamOptions,
-  TTSHandler,
-  TTSResult,
-} from "../dist/index.js";
 
-const { test, runSuite } = defineSuite("TTSProcessor (public surface)");
+import {
+  defineSuite,
+  assert,
+  assertEqual,
+  assertIncludes,
+  assertNotNull,
+} from "./helpers/harness.js";
+import {
+  AIProviderFactory,
+  NeuroLink,
+  OpenAITTS,
+  TTSProcessor,
+  TTSError,
+  TTS_ERROR_CODES,
+} from "../dist/index.js";
+import { ProviderHealthChecker } from "../dist/utils/providerHealth.js";
+import type {
+  AIProvider,
+  EnhancedGenerateResult,
+  StreamOptions,
+  StreamResult,
+  TTSChunk,
+  TTSHandler,
+} from "../dist/index.js";
+import { stub, withStubs } from "./helpers/stubs.js";
+
+const { test, runSuite } = defineSuite("TTSProcessor (unit)");
 
 // ---------------------------------------------------------------------------
 // Registry hygiene (rule 4): snapshot every handler registered before this
@@ -110,407 +66,1880 @@ function restoreTTSRegistry(snapshot: Array<readonly [string, TTSHandler]>) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Local SSE fixture server (openai-compatible streaming), same idiom as
-// continuous-test-suite-openai-compat-streaming-retry.ts.
-// ---------------------------------------------------------------------------
-
-function sseChunk(text: string): string {
-  return `data: ${JSON.stringify({
-    choices: [{ delta: { content: text }, finish_reason: null }],
-  })}\n\n`;
-}
-
-async function startFixedResponseServer(
-  text: string,
-): Promise<{ port: number; server: Server }> {
-  const server = createServer((_req, res) => {
-    res.writeHead(200, { "content-type": "text/event-stream" });
-    res.write(sseChunk(text));
-    res.write("data: [DONE]\n\n");
-    res.end();
-  });
-  await new Promise<void>((resolve) => server.listen(0, resolve));
-  const address = server.address();
-  const port = typeof address === "object" && address ? address.port : 0;
-  return { port, server };
-}
-
-const TOUCHED_ENV_VARS = [
-  "OPENAI_COMPATIBLE_BASE_URL",
-  "OPENAI_COMPATIBLE_API_KEY",
-] as const;
-
-function snapshotEnv(): Record<string, string | undefined> {
-  const snapshot: Record<string, string | undefined> = {};
-  for (const key of TOUCHED_ENV_VARS) {
-    snapshot[key] = process.env[key];
-  }
-  return snapshot;
-}
-
-function restoreEnv(snapshot: Record<string, string | undefined>): void {
-  for (const key of TOUCHED_ENV_VARS) {
-    const prior = snapshot[key];
-    if (prior === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = prior;
-    }
-  }
-}
-
-const ACCUMULATED_TEXT = "hello world";
-
-/**
- * Runs `nl.stream()` against the local fixed-response SSE server with the
- * given `tts` options, fully drains the stream, and returns everything a
- * caller of the public API can observe.
- */
-async function runTtsStream(
-  nl: NeuroLink,
-  tts: StreamOptions["tts"],
-): Promise<{
-  ttsAudioChunks: Array<{
-    type: "tts_audio";
-    audio: {
-      data: Buffer;
-      format: string;
-      index: number;
-      isFinal: boolean;
-      cumulativeSize?: number;
-      voice?: string;
-      sampleRate?: number;
-    };
-  }>;
-  textContent: string;
-  resolvedAudio: TTSResult | undefined;
-}> {
-  const envSnapshot = snapshotEnv();
-  const { port, server } = await startFixedResponseServer(ACCUMULATED_TEXT);
-  try {
-    process.env.OPENAI_COMPATIBLE_BASE_URL = `http://127.0.0.1:${port}`;
-    process.env.OPENAI_COMPATIBLE_API_KEY = "test-key";
-
-    const result = await nl.stream({
-      provider: "openai-compatible",
-      model: "gpt-4o-mini",
-      input: { text: "hi" },
-      maxSteps: 1,
-      tts,
-    } as Parameters<NeuroLink["stream"]>[0]);
-
-    let textContent = "";
-    const ttsAudioChunks: Array<{
-      type: "tts_audio";
-      audio: {
-        data: Buffer;
-        format: string;
-        index: number;
-        isFinal: boolean;
-        cumulativeSize?: number;
-        voice?: string;
-        sampleRate?: number;
-      };
-    }> = [];
-    for await (const chunk of result.stream) {
-      if (chunk && "content" in chunk && typeof chunk.content === "string") {
-        textContent += chunk.content;
-      }
-      if (
-        chunk &&
-        typeof chunk === "object" &&
-        "type" in chunk &&
-        (chunk as { type?: unknown }).type === "tts_audio"
-      ) {
-        ttsAudioChunks.push(chunk as (typeof ttsAudioChunks)[number]);
-      }
-    }
-
-    const resolvedAudio = await result.audio;
-    return { ttsAudioChunks, textContent, resolvedAudio };
-  } finally {
-    server.close();
-    restoreEnv(envSnapshot);
-  }
-}
-
-function makeStubHandler(overrides: Partial<TTSHandler> = {}): TTSHandler {
-  return {
+/** Records what it was asked to do so dispatch can be asserted, not inferred. */
+function makeStubHandler(overrides: Partial<TTSHandler> = {}) {
+  const calls: Array<{ text: string; options: unknown }> = [];
+  const audio = Buffer.from("fake-audio");
+  const handler = {
     isConfigured: () => true,
-    synthesize: async (): Promise<TTSResult> => ({
-      buffer: Buffer.from("stub-audio"),
-      format: "mp3",
-      size: 10,
-    }),
+    synthesize: async (text: string, options: unknown) => {
+      calls.push({ text, options });
+      return {
+        buffer: audio,
+        format: "mp3",
+        size: audio.length,
+        voice: "stub-voice",
+      };
+    },
+    getVoices: async () => [{ name: "stub-voice", languageCode: "en-US" }],
     ...overrides,
+  } as unknown as TTSHandler;
+  return { handler, calls };
+}
+
+const PROVIDER = "stub-tts-provider";
+
+function isTTSAudioChunk(
+  chunk: unknown,
+): chunk is { type: "tts_audio"; audio: TTSChunk } {
+  return (
+    chunk !== null &&
+    typeof chunk === "object" &&
+    "type" in chunk &&
+    chunk.type === "tts_audio" &&
+    "audio" in chunk
+  );
+}
+
+type ExecutableProvider = AIProvider & {
+  executeStream: (options: StreamOptions) => Promise<StreamResult>;
+};
+
+async function createOfflineProvider(
+  neurolink: NeuroLink,
+): Promise<ExecutableProvider> {
+  return (await AIProviderFactory.createProvider(
+    "openai",
+    "gpt-4o-mini",
+    false,
+    neurolink,
+    undefined,
+    { openai: { apiKey: "offline-test-key" } },
+  )) as ExecutableProvider;
+}
+
+function makeTextStream(...parts: string[]): StreamResult["stream"] {
+  return (async function* () {
+    for (const content of parts) {
+      yield { content };
+    }
+  })();
+}
+
+function makeGenerateResult(content: string): EnhancedGenerateResult {
+  return {
+    content,
+    provider: "openai",
+    model: "gpt-4o-mini",
+    usage: { input: 1, output: 1, total: 2 },
   };
 }
 
-let uniqueCounter = 0;
+let uniqueProviderCounter = 0;
+
 function uniqueProvider(label: string): string {
-  uniqueCounter += 1;
-  return `unit-test-tts-${label}-${uniqueCounter}`;
+  uniqueProviderCounter += 1;
+  return `unit-test-tts-${label}-${uniqueProviderCounter}`;
 }
 
-void runSuite(async () => {
-  const { NeuroLink, ProviderRegistry } = await import("../dist/index.js");
-  await ProviderRegistry.registerAllProviders();
+async function runPublicTtsStream(
+  tts: NonNullable<StreamOptions["tts"]>,
+  responseText: string | string[] = "hello world",
+): Promise<{
+  ttsAudioChunks: Array<{ type: "tts_audio"; audio: TTSChunk }>;
+  textContent: string;
+  resolvedAudio: Awaited<StreamResult["audio"]>;
+  ttsMetadata: StreamResult["ttsMetadata"];
+}> {
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const responseParts = Array.isArray(responseText)
+    ? responseText
+    : [responseText];
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: makeTextStream(...responseParts),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  const output: Array<unknown> = [];
+  let result: StreamResult | undefined;
 
-  const registrySnapshot = snapshotTTSRegistry();
-
-  function nl() {
-    return new NeuroLink({ conversationMemory: { enabled: false } });
-  }
-
-  try {
-    // -----------------------------------------------------------------
-    // Happy path: successful synthesis observed via the tts_audio chunk
-    // and streamResult.audio.
-    // -----------------------------------------------------------------
-
-    await test("stream() yields a tts_audio chunk and resolves streamResult.audio on successful synthesis", async () => {
-      const provider = uniqueProvider("success");
-      const expectedBuffer = Buffer.from("synth-output-bytes");
-      TTSProcessor.registerHandler(
-        provider,
-        makeStubHandler({
-          synthesize: async () => ({
-            buffer: expectedBuffer,
-            format: "wav",
-            size: expectedBuffer.length,
-            sampleRate: 24000,
-          }),
-        }),
-      );
-
-      const { ttsAudioChunks, textContent, resolvedAudio } = await runTtsStream(
-        nl(),
-        {
-          enabled: true,
-          useAiResponse: true,
-          provider,
-          voice: "test-voice",
-        },
-      );
-
-      assert(
-        textContent.includes(ACCUMULATED_TEXT),
-        "the underlying text stream still delivered the AI response",
-      );
-      assertEqual(
-        ttsAudioChunks.length,
-        1,
-        "exactly one tts_audio chunk was yielded",
-      );
-      const chunk = ttsAudioChunks[0];
-      assertEqual(chunk.type, "tts_audio", "chunk carries the tts_audio type");
-      assert(
-        chunk.audio.data.equals(expectedBuffer),
-        "chunk audio.data is the handler's buffer",
-      );
-      assertEqual(chunk.audio.format, "wav", "chunk audio.format");
-      assertEqual(chunk.audio.isFinal, true, "chunk audio.isFinal");
-      assertEqual(chunk.audio.sampleRate, 24000, "chunk audio.sampleRate");
-      assertEqual(
-        chunk.audio.voice,
-        "test-voice",
-        "chunk audio.voice falls back to the request's tts.voice when the handler omits it",
-      );
-
-      assert(!!resolvedAudio, "streamResult.audio resolved to a value");
-      assertEqual(
-        resolvedAudio?.format,
-        "wav",
-        "resolved audio.format matches the handler's result",
-      );
-      assertEqual(
-        resolvedAudio?.size,
-        expectedBuffer.length,
-        "resolved audio.size matches the handler's result",
-      );
-      assertEqual(
-        resolvedAudio?.voice,
-        "test-voice",
-        "resolved audio.voice also falls back to the request's tts.voice",
-      );
+  await withStubs([create, execute], async () => {
+    result = await neurolink.stream({
+      input: { text: "exercise public streaming TTS" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts,
     });
-
-    // -----------------------------------------------------------------
-    // Duplicate registration: the later registerHandler() call wins.
-    // -----------------------------------------------------------------
-
-    await test("re-registering a provider makes stream() dispatch to the later handler", async () => {
-      const provider = uniqueProvider("overwrite");
-      TTSProcessor.registerHandler(
-        provider,
-        makeStubHandler({
-          synthesize: async () => ({
-            buffer: Buffer.from("first-handler"),
-            format: "mp3",
-            size: 5,
-          }),
-        }),
-      );
-      TTSProcessor.registerHandler(
-        provider,
-        makeStubHandler({
-          synthesize: async () => ({
-            buffer: Buffer.from("second-handler"),
-            format: "mp3",
-            size: 6,
-          }),
-        }),
-      );
-
-      const { ttsAudioChunks } = await runTtsStream(nl(), {
-        enabled: true,
-        useAiResponse: true,
-        provider,
-      });
-
-      assertEqual(ttsAudioChunks.length, 1, "one tts_audio chunk was yielded");
-      assert(
-        ttsAudioChunks[0].audio.data.equals(Buffer.from("second-handler")),
-        "the later registration's handler produced the audio, not the first",
-      );
-    });
-
-    // -----------------------------------------------------------------
-    // Case-insensitive provider resolution.
-    // -----------------------------------------------------------------
-
-    await test("stream() resolves tts.provider case-insensitively against the registered name", async () => {
-      const mixedCaseProvider = `Unit-Test-TTS-Mixed-Case-${(uniqueCounter += 1)}`;
-      TTSProcessor.registerHandler(mixedCaseProvider, makeStubHandler());
-
-      const { ttsAudioChunks } = await runTtsStream(nl(), {
-        enabled: true,
-        useAiResponse: true,
-        provider: mixedCaseProvider.toUpperCase(),
-      });
-
-      assertEqual(
-        ttsAudioChunks.length,
-        1,
-        "synthesis still ran even though the requested provider casing differs from the registered casing",
-      );
-    });
-
-    // -----------------------------------------------------------------
-    // Graceful-degradation paths: each of these trigger conditions must
-    // still let the text stream complete normally, with no tts_audio
-    // chunk and streamResult.audio resolving to undefined. The specific
-    // TTSError code behind each is not observable here (see file header,
-    // item 3) — only the shared "synthesis did not happen" outcome is.
-    // -----------------------------------------------------------------
-
-    const degradationCases: Array<{
-      name: string;
-      register: (provider: string) => void;
-      tts: (provider: string) => Parameters<typeof runTtsStream>[1];
-    }> = [
-      {
-        name: "text longer than the handler's maxTextLength",
-        register: (provider) =>
-          TTSProcessor.registerHandler(
-            provider,
-            makeStubHandler({ maxTextLength: 3 }),
-          ),
-        tts: (provider) => ({ enabled: true, useAiResponse: true, provider }),
-      },
-      {
-        name: "an unconfigured provider",
-        register: (provider) =>
-          TTSProcessor.registerHandler(
-            provider,
-            makeStubHandler({ isConfigured: () => false }),
-          ),
-        tts: (provider) => ({ enabled: true, useAiResponse: true, provider }),
-      },
-      {
-        name: "a handler that throws during synthesis",
-        register: (provider) =>
-          TTSProcessor.registerHandler(
-            provider,
-            makeStubHandler({
-              synthesize: async () => {
-                throw new Error("synthesis boom");
-              },
-            }),
-          ),
-        tts: (provider) => ({ enabled: true, useAiResponse: true, provider }),
-      },
-      {
-        name: "a tts.provider that was never registered",
-        register: () => {
-          /* deliberately no registration */
-        },
-        tts: (provider) => ({ enabled: true, useAiResponse: true, provider }),
-      },
-    ];
-
-    for (const degradationCase of degradationCases) {
-      await test(`stream() degrades gracefully (no tts_audio, audio undefined) for: ${degradationCase.name}`, async () => {
-        const provider = uniqueProvider("degrade");
-        degradationCase.register(provider);
-
-        const { ttsAudioChunks, textContent, resolvedAudio } =
-          await runTtsStream(nl(), degradationCase.tts(provider));
-
-        assert(
-          textContent.includes(ACCUMULATED_TEXT),
-          "text stream still completed despite the TTS failure",
-        );
-        assertEqual(ttsAudioChunks.length, 0, "no tts_audio chunk was yielded");
-        assertEqual(
-          resolvedAudio,
-          undefined,
-          "streamResult.audio resolved to undefined",
-        );
-      });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
     }
+  });
 
-    // -----------------------------------------------------------------
-    // Mode 2 is gated off entirely when useAiResponse is not set: no
-    // synthesis attempt at all, confirmed by a handler that would blow up
-    // if it were ever invoked.
-    // -----------------------------------------------------------------
+  assertNotNull(result, "public stream returned a StreamResult");
+  const ttsAudioChunks = output.filter(isTTSAudioChunk);
+  const textContent = output
+    .map((chunk) =>
+      chunk !== null &&
+      typeof chunk === "object" &&
+      "content" in chunk &&
+      typeof chunk.content === "string"
+        ? chunk.content
+        : "",
+    )
+    .join("");
+  return {
+    ttsAudioChunks,
+    textContent,
+    resolvedAudio: await result.audio,
+    ttsMetadata: result.ttsMetadata,
+  };
+}
 
-    await test("stream() does not attempt synthesis when tts.useAiResponse is not set", async () => {
-      const provider = uniqueProvider("mode1-gate");
-      TTSProcessor.registerHandler(
-        provider,
-        makeStubHandler({
-          synthesize: async () => {
-            throw new Error(
-              "synthesize should not have been called — Mode 2 was not requested",
-            );
-          },
-        }),
-      );
+const registrySnapshot = snapshotTTSRegistry();
 
-      const { ttsAudioChunks, textContent, resolvedAudio } = await runTtsStream(
-        nl(),
-        { enabled: true, provider },
-      );
+await test("stream() yields a tts_audio chunk and resolves streamResult.audio on successful synthesis", async () => {
+  const provider = uniqueProvider("success");
+  const expectedBuffer = Buffer.from("synth-output-bytes");
+  const { handler } = makeStubHandler({
+    synthesize: async () => ({
+      buffer: expectedBuffer,
+      format: "wav",
+      size: expectedBuffer.length,
+      sampleRate: 24000,
+    }),
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(provider, handler);
 
-      assert(
-        textContent.includes(ACCUMULATED_TEXT),
-        "text stream still completed",
-      );
-      assertEqual(
-        ttsAudioChunks.length,
-        0,
-        "no tts_audio chunk was yielded when useAiResponse is unset",
-      );
-      assertEqual(
-        resolvedAudio,
-        undefined,
-        "streamResult.audio resolved to undefined when useAiResponse is unset",
-      );
+  const { ttsAudioChunks, textContent, resolvedAudio } =
+    await runPublicTtsStream({
+      enabled: true,
+      useAiResponse: true,
+      provider,
+      voice: "test-voice",
     });
-  } finally {
-    restoreTTSRegistry(registrySnapshot);
-  }
+
+  assert(
+    textContent.includes("hello world"),
+    "the underlying text stream still delivered the AI response",
+  );
+  assertEqual(
+    ttsAudioChunks.length,
+    1,
+    "exactly one tts_audio chunk was yielded",
+  );
+  const chunk = ttsAudioChunks[0];
+  assertEqual(chunk.type, "tts_audio", "chunk carries the tts_audio type");
+  assert(
+    chunk.audio.data.equals(expectedBuffer),
+    "chunk audio.data is the handler's buffer",
+  );
+  assertEqual(chunk.audio.format, "wav", "chunk audio.format is preserved");
+  assertEqual(chunk.audio.isFinal, true, "the only audio chunk is final");
+  assertEqual(
+    chunk.audio.sampleRate,
+    24000,
+    "chunk audio.sampleRate is preserved",
+  );
+  assertEqual(
+    chunk.audio.voice,
+    "test-voice",
+    "chunk audio.voice falls back to the request voice",
+  );
+  assertNotNull(resolvedAudio, "streamResult.audio resolved to a value");
+  assertEqual(
+    resolvedAudio.format,
+    "wav",
+    "resolved audio format matches the synthesized result",
+  );
+  assertEqual(
+    resolvedAudio.size,
+    expectedBuffer.length,
+    "resolved audio size matches the synthesized buffer",
+  );
+  assertEqual(
+    resolvedAudio.voice,
+    "test-voice",
+    "resolved audio voice matches the emitted chunk",
+  );
 });
+
+await test("re-registering a provider makes stream() dispatch to the later handler", async () => {
+  const provider = uniqueProvider("overwrite");
+  const first = makeStubHandler({
+    synthesize: async () => ({
+      buffer: Buffer.from("first-handler"),
+      format: "mp3",
+      size: 13,
+    }),
+  } as Partial<TTSHandler>);
+  const second = makeStubHandler({
+    synthesize: async () => ({
+      buffer: Buffer.from("second-handler"),
+      format: "mp3",
+      size: 14,
+    }),
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(provider, first.handler);
+  TTSProcessor.registerHandler(provider, second.handler);
+
+  const { ttsAudioChunks } = await runPublicTtsStream({
+    enabled: true,
+    useAiResponse: true,
+    provider,
+  });
+
+  assertEqual(ttsAudioChunks.length, 1, "one tts_audio chunk was yielded");
+  assert(
+    ttsAudioChunks[0].audio.data.equals(Buffer.from("second-handler")),
+    "the later registration produced the audio",
+  );
+});
+
+await test("stream() resolves tts.provider case-insensitively against the registered name", async () => {
+  const provider = uniqueProvider("Mixed-Case");
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(provider, handler);
+
+  const { ttsAudioChunks } = await runPublicTtsStream({
+    enabled: true,
+    useAiResponse: true,
+    provider: provider.toUpperCase(),
+  });
+
+  assertEqual(
+    ttsAudioChunks.length,
+    1,
+    "synthesis ran despite different requested provider casing",
+  );
+});
+
+const degradationCases: Array<{
+  name: string;
+  register: (provider: string) => void;
+}> = [
+  {
+    name: "an unconfigured provider",
+    register: (provider) => {
+      const { handler } = makeStubHandler({ isConfigured: () => false });
+      TTSProcessor.registerHandler(provider, handler);
+    },
+  },
+  {
+    name: "a handler that throws during synthesis",
+    register: (provider) => {
+      const { handler } = makeStubHandler({
+        synthesize: async () => {
+          throw new Error("synthesis boom");
+        },
+      } as Partial<TTSHandler>);
+      TTSProcessor.registerHandler(provider, handler);
+    },
+  },
+  {
+    name: "a tts.provider that was never registered",
+    register: () => {
+      // Deliberately no registration.
+    },
+  },
+];
+
+for (const degradationCase of degradationCases) {
+  await test(`stream() degrades gracefully (no tts_audio, audio undefined) for: ${degradationCase.name}`, async () => {
+    const provider = uniqueProvider("degrade");
+    degradationCase.register(provider);
+
+    const { ttsAudioChunks, textContent, resolvedAudio } =
+      await runPublicTtsStream({
+        enabled: true,
+        useAiResponse: true,
+        provider,
+      });
+
+    assert(
+      textContent.includes("hello world"),
+      "text stream still completed despite the TTS failure",
+    );
+    assertEqual(ttsAudioChunks.length, 0, "no tts_audio chunk was yielded");
+    assertEqual(
+      resolvedAudio,
+      undefined,
+      "streamResult.audio resolved to undefined",
+    );
+  });
+}
+
+// This replaces release's `text longer than the handler's maxTextLength`
+// degradation case. #516 hard-splits incremental stream() synthesis at
+// min(streamingBufferSize, maxTextLength) instead of raising TTS_TEXT_TOO_LONG;
+// non-streaming generate() still raises for over-cap text.
+await test("stream() splits over-cap text into multiple tts_audio chunks", async () => {
+  const provider = uniqueProvider("over-cap");
+  const { handler, calls } = makeStubHandler({ maxTextLength: 3 });
+  TTSProcessor.registerHandler(provider, handler);
+
+  const { ttsAudioChunks, textContent, resolvedAudio } =
+    await runPublicTtsStream(
+      { enabled: true, useAiResponse: true, provider },
+      "hello world",
+    );
+
+  assert(
+    textContent.includes("hello world"),
+    "the underlying text stream still completed",
+  );
+  assert(calls.length > 1, "over-cap text required multiple synthesize calls");
+  assert(
+    calls.every(({ text }) => text.length <= 3),
+    "every synthesize call stayed within the handler text cap",
+  );
+  assertEqual(
+    ttsAudioChunks.length,
+    calls.length,
+    "each capped segment yielded one tts_audio chunk",
+  );
+  assertNotNull(resolvedAudio, "split synthesis resolved aggregate audio");
+});
+
+// #516 accepts `options.tts?.enabled === true` for stream(). This replaces
+// release's pre-#516 useAiResponse gate test; generate() keeps its existing
+// input-vs-response Mode-1/Mode-2 switch.
+await test("stream() synthesizes when tts.enabled is set, without useAiResponse", async () => {
+  const provider = uniqueProvider("enabled-contract");
+  const { handler, calls } = makeStubHandler();
+  TTSProcessor.registerHandler(provider, handler);
+
+  const { ttsAudioChunks, resolvedAudio } = await runPublicTtsStream({
+    enabled: true,
+    provider,
+  });
+
+  assertEqual(calls.length, 1, "the TTS handler was called once");
+  assertEqual(
+    ttsAudioChunks.length,
+    1,
+    "tts.enabled yielded one audio chunk without useAiResponse",
+  );
+  assertNotNull(
+    resolvedAudio,
+    "streamResult.audio resolved without useAiResponse",
+  );
+});
+
+await test("registerHandler makes a provider resolvable", () => {
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  assertEqual(TTSProcessor.supports(PROVIDER), true, "supports() sees it");
+  assert(
+    TTSProcessor.getHandler(PROVIDER) !== undefined,
+    "getHandler() returns it",
+  );
+});
+
+await test("an unregistered provider is not claimed", () => {
+  assertEqual(
+    TTSProcessor.supports("provider-that-was-never-registered"),
+    false,
+    "supports() is false for unknown providers",
+  );
+  assertEqual(
+    TTSProcessor.getHandler("provider-that-was-never-registered"),
+    undefined,
+    "getHandler() returns undefined rather than throwing",
+  );
+});
+
+await test("synthesize dispatches to the registered handler", async () => {
+  const { handler, calls } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const result = await TTSProcessor.synthesize("hello world", PROVIDER, {});
+  assertEqual(calls.length, 1, "handler invoked exactly once");
+  assertEqual(calls[0].text, "hello world", "text forwarded verbatim");
+  assert(Buffer.isBuffer(result.buffer), "audio buffer returned");
+  assertEqual(result.size, result.buffer.length, "size matches the buffer");
+});
+
+await test("stream() buffers sentences across text chunk boundaries", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  const provider = uniqueProvider("sentence-carry");
+  TTSProcessor.registerHandler(provider, handler);
+
+  const { ttsAudioChunks: chunks } = await runPublicTtsStream(
+    { enabled: true, provider, streamingBufferSize: 10 },
+    ["First sentence", ". Second", " sentence! Tail"],
+  );
+  const audio = chunks.map((chunk) => chunk.audio);
+
+  assertEqual(calls.length, 3, "three buffered segments reach the handler");
+  assert(
+    calls.join("|") === "First sentence.|Second sentence!|Tail",
+    "buffered segments do not match the expected boundary split",
+  );
+  assertEqual(chunks.length, 3, "three buffered segments synthesized");
+  assertEqual(
+    audio.map((chunk) => chunk.index).join(","),
+    "0,1,2",
+    "chunk indexes are sequential",
+  );
+  assertEqual(
+    audio.map((chunk) => chunk.cumulativeSize).join(","),
+    "15,31,35",
+    "cumulative sizes are monotonic sums",
+  );
+  assertEqual(
+    audio.filter((chunk) => chunk.isFinal).length,
+    1,
+    "exactly one final chunk",
+  );
+  assertEqual(audio[2].isFinal, true, "only the last chunk is final");
+});
+
+await test("stream() honors the configurable flush boundary", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  const provider = uniqueProvider("flush-boundary");
+  TTSProcessor.registerHandler(provider, handler);
+
+  await runPublicTtsStream(
+    { enabled: true, provider, streamingBufferSize: 20 },
+    ["One. ", "Two. ", "Three."],
+  );
+
+  assertEqual(
+    calls.join("|"),
+    "One. Two. Three.",
+    "short sentences stay buffered until the configured boundary or stream end",
+  );
+});
+
+await test("synthesizeStream never exceeds the handler text cap", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    maxTextLength: 12,
+    synthesize: async (text: string) => {
+      calls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+
+  const chunks = [];
+  for await (const chunk of TTSProcessor.synthesizeStream(
+    (async function* () {
+      yield "x".repeat(25);
+    })(),
+    PROVIDER,
+    { streamingBufferSize: 50 },
+  )) {
+    chunks.push(chunk);
+  }
+
+  assertEqual(
+    calls.map((text) => text.length).join(","),
+    "12,12,1",
+    "handler calls respect the configured text cap",
+  );
+  assert(
+    calls.every((text) => text.length <= 12),
+    "every repeated synthesize call stays within the handler cap",
+  );
+  assertEqual(
+    chunks.filter((chunk) => chunk.isFinal).length,
+    1,
+    "exactly one capped chunk is final",
+  );
+  assertEqual(chunks.at(-1)?.isFinal, true, "the last capped chunk is final");
+});
+
+await test("synthesizeStream hard-splits at the default 3000-character cap", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+
+  for await (const _chunk of TTSProcessor.synthesizeStream(
+    (async function* () {
+      yield "x".repeat(3001);
+    })(),
+    PROVIDER,
+    { streamingBufferSize: 5000 },
+  )) {
+    // Drain the stream; handler call lengths are the assertion surface.
+  }
+
+  assertEqual(
+    calls.map((text) => text.length).join(","),
+    "3000,1",
+    "the default cap splits instead of throwing TTS_TEXT_TOO_LONG",
+  );
+});
+
+await test("synthesizeStream never hard-splits a surrogate pair at the cap", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+
+  // The emoji straddles the 3000-code-unit cap, and the text carries no
+  // sentence boundary, so the cap is the only available split point. A naive
+  // slice(0, 3000) ends one call with a lone high surrogate and starts the next
+  // with its low half — both halves reach the provider as U+FFFD.
+  const input = `${"x".repeat(2999)}\u{1F600}${"y".repeat(10)}`;
+  for await (const _chunk of TTSProcessor.synthesizeStream(
+    (async function* () {
+      yield input;
+    })(),
+    PROVIDER,
+    { streamingBufferSize: 5000 },
+  )) {
+    // Drain the stream; the synthesized text is the assertion surface.
+  }
+
+  const isHighSurrogate = (unit: number) => unit >= 0xd800 && unit <= 0xdbff;
+  const isLowSurrogate = (unit: number) => unit >= 0xdc00 && unit <= 0xdfff;
+
+  assertEqual(
+    calls.filter((text) => isHighSurrogate(text.charCodeAt(text.length - 1)))
+      .length,
+    0,
+    "no synthesize call ends on an unpaired high surrogate",
+  );
+  assertEqual(
+    calls.filter((text) => isLowSurrogate(text.charCodeAt(0))).length,
+    0,
+    "no synthesize call starts on an unpaired low surrogate",
+  );
+  assert(
+    calls.join("").replace(/\s+/g, "") === input.replace(/\s+/g, ""),
+    "keeping the pair intact still forwards every input character exactly once",
+  );
+});
+
+await test("synthesizeStream keeps one final chunk after a later segment fails", async () => {
+  const calls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      if (text === "Tail") {
+        throw new Error("offline tail failure");
+      }
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+
+  const chunks = [];
+  let failure: unknown;
+  try {
+    for await (const chunk of TTSProcessor.synthesizeStream(
+      (async function* () {
+        yield "First sentence. ";
+        yield "Second sentence! ";
+        yield "Tail";
+      })(),
+      PROVIDER,
+      { streamingBufferSize: 10 },
+    )) {
+      chunks.push(chunk);
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  assertEqual(calls.length, 3, "three attempted segments reach the handler");
+  assert(
+    calls.join("|") === "First sentence.|Second sentence!|Tail",
+    "attempted segments do not match the expected boundary split",
+  );
+  assertEqual(chunks.length, 2, "successful audio chunks are preserved");
+  assertEqual(
+    chunks.map((chunk) => chunk.index).join(","),
+    "0,1",
+    "successful chunk indexes remain sequential",
+  );
+  assertEqual(
+    chunks.filter((chunk) => chunk.isFinal).length,
+    1,
+    "exactly one surviving chunk is final",
+  );
+  assertEqual(
+    chunks.at(-1)?.isFinal,
+    true,
+    "the last surviving chunk is final",
+  );
+  assert(
+    failure instanceof Error && failure.name === "IncrementalTTSSynthesisError",
+    "the handler-synthesis seam reports the deferred segment failure",
+  );
+});
+
+await test("stream() reports a failed middle segment while retaining partial audio", async () => {
+  const provider = uniqueProvider("middle-failure");
+  const calls: string[] = [];
+  const leakedToken = "sk-live-segment-secret";
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      calls.push(text);
+      if (text === "Second sentence.") {
+        throw new Error(
+          `TTS request to https://host/v1/tts?api_key=${leakedToken}`,
+        );
+      }
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(provider, handler);
+
+  const { ttsAudioChunks, resolvedAudio, ttsMetadata } =
+    await runPublicTtsStream(
+      { enabled: true, provider, streamingBufferSize: 5 },
+      ["First sentence. ", "Second sentence. ", "Third sentence."],
+    );
+
+  assertEqual(calls.length, 3, "all three segments are still attempted");
+  assertEqual(
+    calls.join("|"),
+    "First sentence.|Second sentence.|Third sentence.",
+    "the middle segment is the only failed attempt",
+  );
+  assertEqual(ttsAudioChunks.length, 2, "both surviving chunks are delivered");
+  assertEqual(
+    ttsAudioChunks.map((chunk) => chunk.audio.index).join(","),
+    "0,1",
+    "failed segments do not manufacture an index gap",
+  );
+  assertNotNull(resolvedAudio, "the partial aggregate is still delivered");
+  assertEqual(ttsMetadata?.attempted, true, "metadata records the attempt");
+  assertEqual(
+    ttsMetadata?.success,
+    false,
+    "partial synthesis is not reported as fully successful",
+  );
+  assertEqual(
+    ttsMetadata?.error?.code,
+    TTS_ERROR_CODES.SYNTHESIS_FAILED,
+    "partial failure uses the structured synthesis error code",
+  );
+  assertIncludes(
+    ttsMetadata?.error?.message ?? "",
+    "1 segment",
+    "metadata reports the number of failed segments",
+  );
+  assertIncludes(
+    ttsMetadata?.error?.message ?? "",
+    "segment 2",
+    "metadata identifies the failed segment",
+  );
+  assert(
+    !ttsMetadata?.error?.message.includes(leakedToken),
+    "the public error does not expose provider URL credentials",
+  );
+});
+
+await test("NeuroLink.stream interleaves ordered TTS audio", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: (async function* () {
+      yield { content: "First sentence. " };
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      yield { content: "Second sentence. " };
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      yield { content: "Final tail." };
+    })(),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  const output: Array<unknown> = [];
+  let result: StreamResult | undefined;
+
+  await withStubs([create, execute], async () => {
+    result = await neurolink.stream({
+      input: { text: "speak three sentences" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: { enabled: true, provider: PROVIDER, streamingBufferSize: 5 },
+    });
+    assertNotNull(
+      result.ttsMetadata,
+      "primary stream exposes mutable TTS metadata before drain",
+    );
+    assertEqual(
+      result.ttsMetadata.attempted,
+      true,
+      "primary-stream metadata records the TTS attempt before drain",
+    );
+    assertEqual(
+      result.ttsMetadata.success,
+      false,
+      "primary-stream metadata remains pending before drain",
+    );
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  const audio = output.filter(isTTSAudioChunk).map((chunk) => chunk.audio);
+  const firstAudio = output.findIndex(isTTSAudioChunk);
+  let lastText = -1;
+  output.forEach((chunk, index) => {
+    if (chunk !== null && typeof chunk === "object" && "content" in chunk) {
+      lastText = index;
+    }
+  });
+  assertEqual(audio.length, 3, "one audio chunk per buffered sentence");
+  assert(
+    firstAudio < lastText,
+    "audio is interleaved before source completion",
+  );
+  assertEqual(
+    audio.map((chunk) => chunk.index).join(","),
+    "0,1,2",
+    "audio indexes preserve synthesis order",
+  );
+  assertEqual(
+    audio.filter((chunk) => chunk.isFinal).length,
+    1,
+    "the public stream exposes one final audio chunk",
+  );
+  const aggregate = await result?.audio;
+  assertEqual(
+    aggregate?.size,
+    audio.at(-1)?.cumulativeSize,
+    "the public aggregate matches the emitted audio",
+  );
+  assertEqual(
+    result?.ttsMetadata?.attempted,
+    true,
+    "primary-stream metadata records the TTS attempt after drain",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    true,
+    "primary-stream metadata records successful synthesis after drain",
+  );
+  assert(
+    typeof result?.ttsMetadata?.latency === "number",
+    "primary-stream metadata records synthesis latency after drain",
+  );
+});
+
+await test("NeuroLink.stream metadata records primary TTS failure", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async () => {
+      throw new Error("offline synthesis failure");
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: makeTextStream("Failure sentence."),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([create, execute], async () => {
+    result = await neurolink.stream({
+      input: { text: "synthesis should fail" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: { enabled: true, provider: PROVIDER },
+    });
+    for await (const _chunk of result.stream) {
+      // Drain the public stream to finalize the mutable metadata reference.
+    }
+  });
+
+  assertEqual(
+    result?.ttsMetadata?.attempted,
+    true,
+    "failed primary synthesis still records the attempt",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    false,
+    "failed primary synthesis records an unsuccessful outcome",
+  );
+  assert(
+    typeof result?.ttsMetadata?.latency === "number",
+    "failed primary synthesis records latency",
+  );
+  assertEqual(
+    result?.ttsMetadata?.error?.code,
+    TTS_ERROR_CODES.SYNTHESIS_FAILED,
+    "failed primary synthesis records a structured error",
+  );
+  assertIncludes(
+    result?.ttsMetadata?.error?.message ?? "",
+    "segment 1",
+    "total failure identifies the failed segment",
+  );
+});
+
+await test("NeuroLink.stream metadata records unsupported TTS", async () => {
+  const noHandler = "primary-tts-provider-without-a-handler";
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: makeTextStream("Text survives unsupported speech."),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([create, execute], async () => {
+    result = await neurolink.stream({
+      input: { text: "unsupported speech" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: { enabled: true, provider: noHandler },
+    });
+    for await (const _chunk of result.stream) {
+      // Drain the unchanged text stream.
+    }
+  });
+
+  assertEqual(
+    result?.ttsMetadata?.attempted,
+    false,
+    "unsupported primary TTS records that synthesis was not attempted",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    false,
+    "unsupported primary TTS records no successful synthesis",
+  );
+});
+
+await test("NeuroLink.stream metadata follows no-output fallback", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const primary = await createOfflineProvider(neurolink);
+  const fallback = await createOfflineProvider(neurolink);
+  const execute = stub(primary, "executeStream", async () => ({
+    stream: makeTextStream(),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const fallbackStream = stub(fallback, "stream", async () => ({
+    stream: makeTextStream("Fallback sentence."),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  let factoryCalls = 0;
+  const create = stub(AIProviderFactory, "createProvider", async () =>
+    ++factoryCalls === 1 ? primary : fallback,
+  );
+  const output: Array<unknown> = [];
+  let result: StreamResult | undefined;
+
+  await withStubs([create, execute, fallbackStream], async () => {
+    result = await neurolink.stream({
+      input: { text: "force no-output fallback" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      fallbackProvider: "openai",
+      fallbackModel: "gpt-4o-mini",
+      disableTools: true,
+      tts: { enabled: true, provider: PROVIDER },
+    });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  assert(
+    output.some(isTTSAudioChunk),
+    "no-output fallback emits TTS audio through the public stream",
+  );
+  assertEqual(
+    result?.ttsMetadata?.attempted,
+    true,
+    "no-output fallback metadata records the TTS attempt",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    true,
+    "no-output fallback metadata records successful synthesis",
+  );
+  assert(
+    typeof result?.ttsMetadata?.latency === "number",
+    "no-output fallback metadata records synthesis latency",
+  );
+});
+
+await test("NeuroLink.stream resolves auto to a concrete TTS provider", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const health = stub(
+    ProviderHealthChecker,
+    "getBestHealthyProvider",
+    async () => PROVIDER,
+  );
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: makeTextStream("Auto-selected sentence."),
+    provider: PROVIDER,
+    model: "offline-model",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  const output: Array<unknown> = [];
+
+  await withStubs([health, create, execute], async () => {
+    const result = await neurolink.stream({
+      input: { text: "auto provider" },
+      provider: "auto",
+      model: "offline-model",
+      disableTools: true,
+      tts: { enabled: true, streamingBufferSize: 5 },
+    });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  assertEqual(
+    output.filter(isTTSAudioChunk).length,
+    1,
+    "auto chat selection falls through to the concrete TTS provider",
+  );
+});
+
+await test("NeuroLink.stream preserves TTS through real-stream fallback", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({
+    conversationMemory: { enabled: false },
+  });
+  const provider = await createOfflineProvider(neurolink);
+  let generatedOptions: StreamOptions | string | undefined;
+  const execute = stub(provider, "executeStream", async () => {
+    throw new Error("real streaming unavailable in offline stub");
+  });
+  const generate = stub(provider, "generate", async (optionsOrPrompt) => {
+    generatedOptions = optionsOrPrompt as StreamOptions | string;
+    return makeGenerateResult("First sentence. Second sentence. Final tail.");
+  });
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  const output: Array<unknown> = [];
+  let result: StreamResult | undefined;
+
+  await withStubs([create, generate, execute], async () => {
+    result = await neurolink.stream({
+      input: { text: "offline" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      tts: { enabled: true, provider: PROVIDER, streamingBufferSize: 5 },
+    });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  const audio = output.filter(isTTSAudioChunk).map((chunk) => chunk.audio);
+  assert(audio.length > 1, "fallback emits multiple audio chunks");
+  assertEqual(
+    audio.filter((chunk) => chunk.isFinal).length,
+    1,
+    "fallback exposes one final audio chunk",
+  );
+  assert(
+    audio.every(
+      (chunk, index) =>
+        index === 0 ||
+        (chunk.cumulativeSize ?? 0) > (audio[index - 1].cumulativeSize ?? 0),
+    ),
+    "fallback cumulative sizes increase monotonically",
+  );
+  assertEqual(
+    typeof generatedOptions === "string"
+      ? generatedOptions
+      : generatedOptions?.tts,
+    undefined,
+    "fake generate skips duplicate whole-response Mode 2 synthesis",
+  );
+  assertEqual(
+    (await result?.audio)?.size,
+    audio.at(-1)?.cumulativeSize,
+    "fallback aggregate matches its emitted chunks",
+  );
+});
+
+await test("provider fake stream retains Mode 2 audio and metadata", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => {
+    throw new Error("real streaming unavailable in offline stub");
+  });
+  let generatedOptions: StreamOptions | string | undefined;
+  const generate = stub(provider, "generate", async (optionsOrPrompt) => {
+    generatedOptions = optionsOrPrompt as StreamOptions | string;
+    return makeGenerateResult("First sentence. Second sentence. Final tail.");
+  });
+  let result: StreamResult | undefined;
+  const output: Array<unknown> = [];
+
+  await withStubs([generate, execute], async () => {
+    result = await provider.stream({
+      input: { text: "offline" },
+      tts: {
+        enabled: true,
+        useAiResponse: true,
+        provider: PROVIDER,
+        streamingBufferSize: 5,
+      },
+    });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  const audioChunks = output
+    .filter(isTTSAudioChunk)
+    .map((chunk) => chunk.audio);
+  const aggregate = await result?.audio;
+  const metadata = result?.ttsMetadata;
+  assert(audioChunks.length > 1, "fake stream emits incremental audio");
+  assertEqual(
+    aggregate?.size,
+    audioChunks.at(-1)?.cumulativeSize,
+    "fake-stream aggregate is retained on StreamResult",
+  );
+  assertEqual(
+    metadata?.attempted,
+    true,
+    "fake-stream metadata records attempt",
+  );
+  assertEqual(metadata?.success, true, "fake-stream metadata records success");
+  assertEqual(
+    typeof generatedOptions === "string"
+      ? generatedOptions
+      : generatedOptions?.tts,
+    undefined,
+    "fake generation still avoids duplicate synthesis",
+  );
+});
+
+await test("provider fake stream records structured TTS failure metadata", async () => {
+  const { handler } = makeStubHandler({
+    synthesize: async () => {
+      throw new Error("offline fake-stream synthesis failure");
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => {
+    throw new Error("real streaming unavailable in offline stub");
+  });
+  const generate = stub(provider, "generate", async () =>
+    makeGenerateResult("Failure sentence."),
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([generate, execute], async () => {
+    result = await provider.stream({
+      input: { text: "offline" },
+      tts: { enabled: true, provider: PROVIDER },
+    });
+    for await (const _chunk of result.stream) {
+      // Drain the fake stream to finalize audio and metadata.
+    }
+  });
+
+  assertEqual(await result?.audio, undefined, "total failure has no aggregate");
+  assertEqual(
+    result?.ttsMetadata?.attempted,
+    true,
+    "fake-stream metadata records the synthesis attempt",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    false,
+    "fake-stream total failure records an unsuccessful outcome",
+  );
+  assertEqual(
+    result?.ttsMetadata?.error?.code,
+    TTS_ERROR_CODES.SYNTHESIS_FAILED,
+    "fake-stream total failure records a structured error",
+  );
+  assertIncludes(
+    result?.ttsMetadata?.error?.message ?? "",
+    "segment 1",
+    "fake-stream total failure identifies the failed segment",
+  );
+});
+
+await test("provider fake-stream audio follows the drain-first contract", async () => {
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => {
+    throw new Error("real streaming unavailable in offline stub");
+  });
+  const generate = stub(provider, "generate", async () =>
+    makeGenerateResult("Deferred sentence."),
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([generate, execute], async () => {
+    result = await provider.stream({
+      input: { text: "offline" },
+      tts: { enabled: true, provider: PROVIDER },
+    });
+    const audioPromise = result.audio;
+    assertNotNull(audioPromise, "Mode 2 exposes an audio promise");
+    assert(
+      typeof audioPromise.then === "function",
+      "Mode 2 audio is promise-like",
+    );
+    const timeout = Symbol("audio-timeout");
+    const beforeDrain = await Promise.race([
+      audioPromise,
+      new Promise<typeof timeout>((resolve) =>
+        setTimeout(() => resolve(timeout), 50),
+      ),
+    ]);
+    assertEqual(
+      beforeDrain,
+      timeout,
+      "lazy Mode 2 audio remains pending until the stream is drained",
+    );
+    for await (const _chunk of result.stream) {
+      // Drain the lazy stream to trigger synthesis and finalize the aggregate.
+    }
+    assert(
+      (await audioPromise)?.size !== undefined,
+      "Mode 2 audio settles with the aggregate after the stream is drained",
+    );
+  });
+});
+
+await test("Mode 2 audio resolves when setup falls back before iteration", async () => {
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const setupFailure = await createOfflineProvider(neurolink);
+  const setup = stub(setupFailure, "setupToolExecutor", () => {
+    throw new Error("offline setup failure");
+  });
+  const fallbackProvider = {
+    stream: async () => ({
+      stream: makeTextStream("fallback text"),
+      provider: "openai",
+      model: "gpt-4o-mini",
+    }),
+  } as unknown as AIProvider;
+  let factoryCalls = 0;
+  const create = stub(AIProviderFactory, "createProvider", async () =>
+    ++factoryCalls === 1 ? setupFailure : fallbackProvider,
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([create, setup], async () => {
+    result = await neurolink.stream({
+      input: { text: "offline" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      tts: { enabled: true, useAiResponse: true, provider: PROVIDER },
+    });
+    for await (const _chunk of result.stream) {
+      // Drain the fallback stream before observing the deferred audio result.
+    }
+  });
+
+  const timeout = Symbol("audio-timeout");
+  const audioPromise = result?.audio;
+  assertNotNull(
+    audioPromise,
+    "Mode 2 exposes a pending audio promise after setup failure",
+  );
+  assert(
+    typeof audioPromise.then === "function",
+    "Mode 2 setup-failure audio is promise-like",
+  );
+  const settled = await Promise.race([
+    audioPromise,
+    new Promise<typeof timeout>((resolve) =>
+      setTimeout(() => resolve(timeout), 50),
+    ),
+  ]);
+  assert(
+    settled !== timeout,
+    "Mode 2 audio promise settles after setup failure",
+  );
+  assertEqual(settled, undefined, "failed pre-iteration setup has no audio");
+});
+
+await test("consumer early-break stops queued TTS ingestion after one dispatched segment", async () => {
+  const providerName = uniqueProvider("queued-cancel");
+  const synthesizeCalls: string[] = [];
+  let releaseFirstSynthesis = () => {};
+  const firstSynthesisMayFinish = new Promise<void>((resolve) => {
+    releaseFirstSynthesis = resolve;
+  });
+  let releaseDispatchedSynthesis = () => {};
+  const dispatchedSynthesisMayFinish = new Promise<void>((resolve) => {
+    releaseDispatchedSynthesis = resolve;
+  });
+  let markDispatchedSynthesisStarted = () => {};
+  const dispatchedSynthesisStarted = new Promise<void>((resolve) => {
+    markDispatchedSynthesisStarted = resolve;
+  });
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      synthesizeCalls.push(text);
+      if (synthesizeCalls.length === 1) {
+        await firstSynthesisMayFinish;
+      }
+      if (synthesizeCalls.length === 3) {
+        markDispatchedSynthesisStarted();
+        await dispatchedSynthesisMayFinish;
+        throw new Error("already-dispatched synthesis failed after break");
+      }
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(providerName, handler);
+
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const sourceChunkCount = 8;
+  let sourceNexts = 0;
+  let sourceReturns = 0;
+  const source = {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next() {
+      sourceNexts++;
+      if (sourceNexts <= sourceChunkCount) {
+        return Promise.resolve({
+          done: false as const,
+          value: { content: `Queued sentence ${sourceNexts}. ` },
+        });
+      }
+      return new Promise<IteratorResult<{ content: string }>>(() => {});
+    },
+    async return() {
+      sourceReturns++;
+      releaseDispatchedSynthesis();
+      return { done: true as const, value: undefined };
+    },
+  };
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: source,
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  let sourceChunksSeen = 0;
+
+  await withStubs([create, execute], async () => {
+    const result = await neurolink.stream({
+      input: { text: "offline" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: {
+        enabled: true,
+        useAiResponse: true,
+        provider: providerName,
+        streamingBufferSize: 1,
+      },
+    });
+    for await (const chunk of result.stream) {
+      if (isTTSAudioChunk(chunk)) {
+        await dispatchedSynthesisStarted;
+        break;
+      }
+      sourceChunksSeen++;
+      if (sourceChunksSeen === sourceChunkCount) {
+        releaseFirstSynthesis();
+      }
+    }
+  });
+
+  assertEqual(
+    sourceChunksSeen,
+    sourceChunkCount,
+    "all later sentence chunks were queued before the consumer break",
+  );
+  assertEqual(sourceReturns, 1, "early-break closes the queued source once");
+  assertEqual(
+    synthesizeCalls.length,
+    3,
+    "two calls expose the first audio and one already-dispatched call is the post-cancel billing ceiling",
+  );
+  assertEqual(
+    synthesizeCalls.join("|"),
+    "Queued sentence 1.|Queued sentence 2.|Queued sentence 3.",
+    "queued sentences after the already-dispatched segment are never synthesized",
+  );
+});
+
+await test("consumer early-break releases source and audio iterators", async () => {
+  const synthesizeCalls: string[] = [];
+  const { handler } = makeStubHandler({
+    synthesize: async (text: string) => {
+      synthesizeCalls.push(text);
+      const buffer = Buffer.from(text);
+      return { buffer, format: "mp3", size: buffer.length };
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  let sourceReturns = 0;
+  let releaseSource = () => {};
+  const sourceMayAdvance = new Promise<void>((resolve) => {
+    releaseSource = resolve;
+  });
+  const source = (async function* () {
+    try {
+      yield { content: "First sentence. " };
+      yield { content: "Second sentence. tail remainder" };
+      await sourceMayAdvance;
+      yield { content: "not consumed" };
+    } finally {
+      sourceReturns++;
+    }
+  })();
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: source,
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  let audioReturns = 0;
+  const realSynthesizeStream = TTSProcessor.synthesizeStream.bind(TTSProcessor);
+  const synthesizeStream = stub(
+    TTSProcessor,
+    "synthesizeStream",
+    (...args: Parameters<typeof TTSProcessor.synthesizeStream>) => {
+      // yield* forwards next/return/throw to the real generator; an early
+      // consumer return() reaches finally with exhausted still false.
+      async function* countingWrapper() {
+        let exhausted = false;
+        try {
+          yield* realSynthesizeStream(...args);
+          exhausted = true;
+        } finally {
+          if (!exhausted) {
+            audioReturns++;
+          }
+        }
+      }
+      return countingWrapper();
+    },
+  );
+  let audioAfterBreak: Awaited<StreamResult["audio"]> = undefined;
+
+  await withStubs([create, execute, synthesizeStream], async () => {
+    const result = await neurolink.stream({
+      input: { text: "offline" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: {
+        enabled: true,
+        useAiResponse: true,
+        provider: PROVIDER,
+        streamingBufferSize: 10,
+      },
+    });
+    for await (const chunk of result.stream) {
+      if (isTTSAudioChunk(chunk)) {
+        releaseSource();
+        break;
+      }
+    }
+    audioAfterBreak = await result.audio;
+  });
+
+  assertEqual(sourceReturns, 1, "early-break closes the source iterator once");
+  assertEqual(audioReturns, 1, "early-break closes the audio iterator once");
+  assertEqual(
+    synthesizeCalls.length,
+    2,
+    "early-break does not bill an additional tail synthesis",
+  );
+  assertEqual(
+    audioAfterBreak,
+    undefined,
+    "early-break still settles streamResult.audio",
+  );
+});
+
+await test("unsupported fake-stream TTS does not attempt synthesis", async () => {
+  const noHandler = "tts-provider-without-a-handler";
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const execute = stub(provider, "executeStream", async () => {
+    throw new Error("real streaming unavailable in offline stub");
+  });
+  const generate = stub(provider, "generate", async () =>
+    makeGenerateResult("text survives unsupported speech"),
+  );
+  const synthesizeStream = stub(TTSProcessor, "synthesizeStream", () =>
+    (async function* () {
+      yield {
+        data: Buffer.alloc(0),
+        format: "mp3" as const,
+        index: 0,
+        isFinal: true,
+        cumulativeSize: 0,
+      };
+    })(),
+  );
+  const output: Array<unknown> = [];
+
+  await withStubs([synthesizeStream, generate, execute], async () => {
+    const result = await provider.stream({
+      input: { text: "offline" },
+      tts: {
+        enabled: true,
+        useAiResponse: true,
+        provider: noHandler,
+        streamingBufferSize: 5,
+      },
+    });
+    for await (const chunk of result.stream) {
+      output.push(chunk);
+    }
+  });
+
+  assertEqual(
+    synthesizeStream.callCount,
+    0,
+    "unsupported TTS bypasses the synthesis iterator",
+  );
+  assert(
+    output.some(
+      (chunk) =>
+        chunk !== null &&
+        typeof chunk === "object" &&
+        "content" in chunk &&
+        typeof chunk.content === "string" &&
+        chunk.content.length > 0,
+    ),
+    "unsupported TTS preserves text output",
+  );
+});
+
+await test("audio failure retains the already-emitted aggregate", async () => {
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const neurolink = new NeuroLink({ conversationMemory: { enabled: false } });
+  const provider = await createOfflineProvider(neurolink);
+  const partial = Buffer.from("partial-audio");
+  const synthesizeStream = stub(TTSProcessor, "synthesizeStream", () =>
+    (async function* () {
+      yield {
+        data: partial,
+        format: "mp3" as const,
+        index: 0,
+        isFinal: false,
+        cumulativeSize: partial.length,
+      };
+      throw new Error("later audio failure");
+    })(),
+  );
+  const execute = stub(provider, "executeStream", async () => ({
+    stream: makeTextStream("First sentence. "),
+    provider: "openai",
+    model: "gpt-4o-mini",
+  }));
+  const create = stub(
+    AIProviderFactory,
+    "createProvider",
+    async () => provider,
+  );
+  let result: StreamResult | undefined;
+
+  await withStubs([create, execute, synthesizeStream], async () => {
+    result = await neurolink.stream({
+      input: { text: "offline" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      tts: { enabled: true, useAiResponse: true, provider: PROVIDER },
+    });
+    for await (const _chunk of result.stream) {
+      // Drain through the graceful audio-error path.
+    }
+  });
+
+  assertEqual(
+    (await result?.audio)?.size,
+    partial.length,
+    "partial emitted audio remains available as the aggregate",
+  );
+  assertEqual(
+    result?.ttsMetadata?.success,
+    false,
+    "a later audio failure marks the aggregate as partial",
+  );
+  assertEqual(
+    result?.ttsMetadata?.error?.code,
+    TTS_ERROR_CODES.SYNTHESIS_FAILED,
+    "the later audio failure records a structured error",
+  );
+  assertIncludes(
+    result?.ttsMetadata?.error?.message ?? "",
+    "1 segment",
+    "the later audio failure records a failed-segment count",
+  );
+});
+
+await test("empty text is rejected before any handler runs", async () => {
+  const { handler, calls } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  try {
+    await TTSProcessor.synthesize("", PROVIDER, {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.EMPTY_TEXT,
+    "empty text raises TTS_EMPTY_TEXT",
+  );
+  // The point of validating first is not to spend a paid API call proving the
+  // input was empty.
+  assertEqual(calls.length, 0, "handler was never invoked");
+});
+
+await test("whitespace-only text counts as empty", async () => {
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  try {
+    await TTSProcessor.synthesize("   \n\t  ", PROVIDER, {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.EMPTY_TEXT,
+    "whitespace-only input is treated as empty",
+  );
+});
+
+await test("an unsupported provider raises a typed error", async () => {
+  let code: string | undefined;
+  let message = "";
+  try {
+    await TTSProcessor.synthesize("hello", "no-such-provider", {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+    message = err instanceof Error ? err.message : "";
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.PROVIDER_NOT_SUPPORTED,
+    "unknown provider raises TTS_PROVIDER_NOT_SUPPORTED",
+  );
+  assertIncludes(
+    message,
+    "no-such-provider",
+    "the error names the provider that was asked for",
+  );
+});
+
+await test("text beyond the handler's limit is rejected", async () => {
+  const { handler, calls } = makeStubHandler({
+    maxTextLength: 10,
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  try {
+    await TTSProcessor.synthesize("x".repeat(50), PROVIDER, {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.TEXT_TOO_LONG,
+    "over-long text raises TTS_TEXT_TOO_LONG",
+  );
+  assertEqual(calls.length, 0, "handler was never invoked");
+});
+
+await test("an unconfigured provider is rejected before synthesis", async () => {
+  // Registration and configuration are separate states: a handler can be
+  // registered at startup and only later discover it has no credentials.
+  // Failing here rather than inside the provider is what turns a vendor auth
+  // error into an actionable "set the API keys".
+  const { handler, calls } = makeStubHandler({
+    isConfigured: () => false,
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  try {
+    await TTSProcessor.synthesize("hello", PROVIDER, {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.PROVIDER_NOT_CONFIGURED,
+    "unconfigured provider raises TTS_PROVIDER_NOT_CONFIGURED",
+  );
+  assertEqual(calls.length, 0, "handler was never invoked");
+});
+
+await test("length is validated before configuration", async () => {
+  // Ordering is observable, so pin it: an over-long text sent to an
+  // unconfigured provider must report the text problem the caller can fix
+  // from the input, not a credentials problem that is beside the point.
+  const { handler } = makeStubHandler({
+    isConfigured: () => false,
+    maxTextLength: 10,
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  try {
+    await TTSProcessor.synthesize("x".repeat(50), PROVIDER, {});
+  } catch (err) {
+    code = err instanceof TTSError ? err.code : undefined;
+  }
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.TEXT_TOO_LONG,
+    "the text-length failure wins over the configuration failure",
+  );
+});
+
+await test("a handler failure surfaces as a typed TTSError", async () => {
+  // A raw vendor error escaping synthesize() would force every caller to
+  // string-match on provider-specific messages.
+  const { handler } = makeStubHandler({
+    synthesize: async () => {
+      throw new Error("upstream vendor exploded");
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  let code: string | undefined;
+  let isTyped = false;
+  let message = "";
+  try {
+    await TTSProcessor.synthesize("hello", PROVIDER, {});
+  } catch (err) {
+    isTyped = err instanceof TTSError;
+    code = err instanceof TTSError ? err.code : undefined;
+    message = err instanceof Error ? err.message : "";
+  }
+  assert(isTyped, "a raw handler error is wrapped rather than leaked");
+  assertEqual(
+    code,
+    TTS_ERROR_CODES.SYNTHESIS_FAILED,
+    "handler failure raises TTS_SYNTHESIS_FAILED",
+  );
+  // The original cause has to survive the wrapping, or the wrap has destroyed
+  // the only information that explains the failure.
+  assertIncludes(
+    message,
+    "upstream vendor exploded",
+    "the underlying reason is preserved in the wrapped error",
+  );
+});
+
+await test("a voice-resolution failure propagates rather than being swallowed", async () => {
+  // An empty voice list and a failed voice lookup are different outcomes; a
+  // handler that swallowed the error would render the second as the first,
+  // and a caller would show the user "no voices available" for what is really
+  // an outage.
+  const { handler } = makeStubHandler({
+    getVoices: async () => {
+      throw new Error("voice catalogue unavailable");
+    },
+  } as Partial<TTSHandler>);
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const resolved = TTSProcessor.getHandler(PROVIDER);
+  let message = "";
+  try {
+    await resolved?.getVoices?.("en-US");
+  } catch (err) {
+    message = err instanceof Error ? err.message : "";
+  }
+  assertIncludes(
+    message,
+    "voice catalogue unavailable",
+    "the failure reaches the caller instead of becoming an empty list",
+  );
+});
+
+await test("re-registering a provider replaces the previous handler", () => {
+  // Registration is a Map insert, so a second registration must win rather
+  // than silently keeping the first — otherwise a host that swaps credentials
+  // at runtime keeps using the stale handler.
+  const first = makeStubHandler();
+  const second = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, first.handler);
+  TTSProcessor.registerHandler(PROVIDER, second.handler);
+  assertEqual(
+    TTSProcessor.getHandler(PROVIDER),
+    second.handler,
+    "the later registration wins",
+  );
+});
+
+await test("getVoices reaches the handler", async () => {
+  const { handler } = makeStubHandler();
+  TTSProcessor.registerHandler(PROVIDER, handler);
+  const resolved = TTSProcessor.getHandler(PROVIDER);
+  assert(resolved !== undefined, "handler resolves");
+  const voices = await resolved?.getVoices?.("en-US");
+  assert(Array.isArray(voices) && voices.length > 0, "voices are returned");
+});
+
+// --- TTS-008 (#479): OpenAI format mapping -----------------------------------
+
+await test("#479: flac is a real OpenAI response_format and must not downgrade to mp3", async () => {
+  // Exercised off the prototype so no API key / constructor side effects are
+  // needed — mapFormat and effectiveFormat are pure.
+  const proto = OpenAITTS.prototype as unknown as {
+    mapFormat: (f: string) => string;
+    effectiveFormat: (f: string) => string;
+  };
+  const roundTrip = (f: string) => {
+    const wire = proto.mapFormat.call({}, f);
+    return { wire, back: proto.effectiveFormat.call({}, wire) };
+  };
+
+  // flac is BOTH a valid TTSAudioFormat and a documented OpenAI
+  // response_format, yet it used to fall through to the mp3 coercion branch —
+  // a caller asking for lossless silently received lossy.
+  assertEqual(roundTrip("flac").wire, "flac", "flac reaches the API as flac");
+  assertEqual(
+    roundTrip("flac").back,
+    "flac",
+    "TTSResult.format reports flac, not mp3",
+  );
+
+  // Unchanged mappings.
+  assertEqual(roundTrip("mp3").wire, "mp3", "mp3 unchanged");
+  assertEqual(roundTrip("wav").wire, "wav", "wav unchanged");
+  assertEqual(roundTrip("ogg").wire, "opus", "ogg still maps to opus");
+  assertEqual(roundTrip("pcm16").wire, "pcm", "pcm16 still maps to pcm");
+  assertEqual(
+    roundTrip("pcm16").back,
+    "pcm16",
+    "pcm round-trips back to pcm16 so callers do not mislabel raw bytes",
+  );
+
+  // m4a is in TTSAudioFormat (it is an STT input format) but OpenAI TTS cannot
+  // produce it — coercing to mp3 with a warning stays correct.
+  assertEqual(
+    roundTrip("m4a").wire,
+    "mp3",
+    "a format OpenAI genuinely cannot produce still coerces to mp3",
+  );
+});
+
+try {
+  await runSuite();
+} finally {
+  restoreTTSRegistry(registrySnapshot);
+}

--- a/test/continuous-test-suite-voice.ts
+++ b/test/continuous-test-suite-voice.ts
@@ -1772,12 +1772,12 @@ async function testStreamAudioPromise(sdk: NeuroLink): Promise<boolean | null> {
 async function testStreamTTSUseAiResponseFalse(
   sdk: NeuroLink,
 ): Promise<boolean | null> {
-  // T3: stream() + tts.useAiResponse:false → result.audio resolves to undefined
-  // (must not hang or throw — the resolver-on-finally guarantee from neurolink.ts).
-  logTest("T3: stream() + TTS Mode 1 audio Promise = undefined", "TESTING");
+  // T3: stream() synthesizes whenever tts.enabled is true; useAiResponse keeps
+  // its input-vs-response meaning for generate() and does not gate stream().
+  logTest("T3: stream() + TTS enabled audio Promise resolves", "TESTING");
   if (isCredentialsMissing()) {
     logTest(
-      "T3: stream() + TTS Mode 1 audio Promise = undefined",
+      "T3: stream() + TTS enabled audio Promise resolves",
       "SKIP",
       "creds missing",
     );
@@ -1804,16 +1804,17 @@ async function testStreamTTSUseAiResponseFalse(
         setTimeout(() => resolve("timeout"), 5000),
       ),
     ]);
-    const ok = audio === undefined;
+    const ok =
+      audio !== "timeout" && audio !== undefined && audio.buffer.length > 0;
     logTest(
-      "T3: stream() + TTS Mode 1 audio Promise = undefined",
+      "T3: stream() + TTS enabled audio Promise resolves",
       ok ? "PASS" : "FAIL",
-      `result=${audio === "timeout" ? "TIMEOUT" : typeof audio}`,
+      `result=${audio === "timeout" ? "TIMEOUT" : `bytes=${audio?.buffer.length ?? 0}`}`,
     );
     return ok;
   } catch (err) {
     logTest(
-      "T3: stream() + TTS Mode 1 audio Promise = undefined",
+      "T3: stream() + TTS enabled audio Promise resolves",
       "FAIL",
       err instanceof Error ? err.message : String(err),
     );
@@ -2142,7 +2143,7 @@ async function runAllTests(): Promise<void> {
       fn: () => testStreamAudioPromise(sharedSdk),
     },
     {
-      name: "T3: stream() + TTS Mode 1 audio Promise = undefined",
+      name: "T3: stream() + TTS enabled audio Promise resolves",
       fn: () => testStreamTTSUseAiResponseFalse(sharedSdk),
     },
     {


### PR DESCRIPTION
`stream()` with `tts.enabled` currently waits for the fully drained response and yields exactly one final `tts_audio` chunk, so audio only arrives after the text finishes. This adds `TTSProcessor.synthesizeStream()`, which buffers streamed text at sentence boundaries (default 120 characters, configurable via `TTSOptions.streamingBufferSize`) and synthesizes ordered segments through the existing `synthesize()` seam. Both the NeuroLink streaming wrapper and fake-stream fallback interleave `tts_audio` chunks with text; `streamResult.audio` still resolves after drain.

Streaming synthesis is enabled by `tts.enabled === true`; `useAiResponse` continues to select input-vs-response TTS for `generate()` and does not gate `stream()`. For stream text over a handler's `maxTextLength`, the effective segment cap is `min(streamingBufferSize, maxTextLength)`, so stream mode hard-splits and synthesizes segments instead of raising `TTS_TEXT_TOO_LONG`. `generate()` retains its existing over-length error.

`StreamResult.audio.buffer` is now a byte concatenation of independently synthesized segments. It is directly playable for `mp3`, `mpeg`, `mpga`, and `pcm16`; it is not a valid aggregate container for `wav`, `flac`, `m4a`, `mp4`, or `webm`; `ogg` and `opus` are chained streams, and some decoders may stop after the first segment.

Provider adapters are untouched. The `TTSChunk` contract remains sequential indexes, monotonic cumulative size, and exactly one `isFinal` chunk. The one-final-chunk behavior changes only on streaming paths; provider-native streaming (#481/#492/#505) and #465's full scope remain outside this slice.

Per-segment orchestration timeout is deferred: release's single synthesis call is equally unwrapped, while all six built-in handlers apply 30-second request timeouts. `wav`/`flac` aggregate re-headering and an `AbortSignal` for true zero-billing cancellation are also deferred. Early break stops queued ingestion, but at most one already-dispatched segment can still be billed.

Part of #516
