### PR TITLE
fix(providers): make provider registration statically discoverable

### DIFF
--- a/src/lib/factories/providerRegistry.ts
+++ b/src/lib/factories/providerRegistry.ts
@@ -38,6 +38,47 @@ import {
 } from "../constants/enums.js";
 
 /**
+ * Static module -> provider-ID manifest for every provider registered below.
+ * Module names (file/dir under src/lib/providers/) intentionally differ from
+ * their canonical IDs (e.g. amazonBedrock -> "bedrock", googleVertex ->
+ * "vertex"); static scanners that cannot resolve the dynamic import() calls
+ * use this mapping to confirm a module is registered. Enforced at runtime so
+ * the registry cannot silently drift from this manifest.
+ */
+export const PROVIDER_MODULE_TO_ID: Readonly<Record<string, AIProviderName>> = {
+  amazonBedrock: AIProviderName.BEDROCK,
+  amazonSagemaker: AIProviderName.SAGEMAKER,
+  anthropic: AIProviderName.ANTHROPIC,
+  azureOpenai: AIProviderName.AZURE,
+  cloudflare: AIProviderName.CLOUDFLARE,
+  cohere: AIProviderName.COHERE,
+  deepseek: AIProviderName.DEEPSEEK,
+  fireworks: AIProviderName.FIREWORKS,
+  googleAiStudio: AIProviderName.GOOGLE_AI,
+  googleVertex: AIProviderName.VERTEX,
+  groq: AIProviderName.GROQ,
+  huggingFace: AIProviderName.HUGGINGFACE,
+  ideogram: AIProviderName.IDEOGRAM,
+  jina: AIProviderName.JINA,
+  litellm: AIProviderName.LITELLM,
+  llamaCpp: AIProviderName.LLAMACPP,
+  lmStudio: AIProviderName.LM_STUDIO,
+  mistral: AIProviderName.MISTRAL,
+  nvidiaNim: AIProviderName.NVIDIA_NIM,
+  ollama: AIProviderName.OLLAMA,
+  openAI: AIProviderName.OPENAI,
+  openaiCompatible: AIProviderName.OPENAI_COMPATIBLE,
+  openRouter: AIProviderName.OPENROUTER,
+  perplexity: AIProviderName.PERPLEXITY,
+  recraft: AIProviderName.RECRAFT,
+  replicate: AIProviderName.REPLICATE,
+  stability: AIProviderName.STABILITY,
+  togetherAi: AIProviderName.TOGETHER_AI,
+  voyage: AIProviderName.VOYAGE,
+  xai: AIProviderName.XAI,
+};
+
+/**
  * Provider Registry - registers all providers with the factory
  * This is where we migrate providers one by one to the new pattern
  */
@@ -91,10 +132,12 @@ export class ProviderRegistry {
    * (avoids circular dependencies; see CLAUDE.md).
    *
    * Not registered (by design): index.ts, providerTypeUtils.ts,
-   * anthropicBaseProvider.ts (legacy; anthropic.ts is live),
-   * googleNativeGemini3.ts (shared helpers). Filename != provider ID
-   * (e.g. amazonBedrock -> "bedrock"); static scanners that miss dynamic
-   * imports may false-positive (Pattern Analysis #1178).
+   * openaiChatCompletionsBase.ts, openaiChatCompletionsClient.ts,
+   * anthropicImageBlocks.ts (shared base/helper modules), anthropicBaseProvider.ts
+   * (legacy; anthropic.ts is live), googleNativeGemini3.ts (shared helpers).
+   * Filename != provider ID (e.g. amazonBedrock -> "bedrock"); the
+   * statically-scannable PROVIDER_MODULE_TO_ID manifest maps every registered
+   * module to its provider ID and is enforced below (Pattern Analysis #1178/#1317).
    */
   // eslint-disable-next-line max-lines-per-function
   private static async _doRegister(): Promise<void> {
@@ -743,6 +786,23 @@ export class ProviderRegistry {
         process.env.RECRAFT_MODEL || RecraftModels.RECRAFT_V3,
         ["recraft"],
       );
+
+      const unregistered = Object.entries(PROVIDER_MODULE_TO_ID).filter(
+        ([module, id]) => {
+          if (!ProviderFactory.hasProvider(id)) {
+            logger.error(
+              `[ProviderRegistry] drift: module "${module}" not registered as "${id}"`,
+            );
+            return true;
+          }
+          return false;
+        },
+      );
+      if (unregistered.length > 0) {
+        throw new Error(
+          `ProviderRegistry drift: ${unregistered.length} module(s) in PROVIDER_MODULE_TO_ID are not registered`,
+        );
+      }
 
       logger.debug("All AI providers registered successfully");
 

--- a/test/continuous-test-suite-provider-structure.ts
+++ b/test/continuous-test-suite-provider-structure.ts
@@ -238,6 +238,31 @@ await test("Provider Registration Completeness", async () => {
     "AUTO must not be registered as a concrete provider",
   );
 
+  const { PROVIDER_MODULE_TO_ID } =
+    await import("../dist/lib/factories/providerRegistry.js");
+  const manifestFailures: string[] = [];
+  for (const base of concreteProviders) {
+    if (!(base in PROVIDER_MODULE_TO_ID)) {
+      manifestFailures.push(
+        `module "${base}" missing from PROVIDER_MODULE_TO_ID`,
+      );
+    }
+  }
+  for (const [module, id] of Object.entries(PROVIDER_MODULE_TO_ID)) {
+    if (!ProviderFactory.hasProvider(id)) {
+      manifestFailures.push(
+        `manifest entry "${module}" -> "${id}" is not registered`,
+      );
+    }
+  }
+  if (manifestFailures.length > 0) {
+    console.error("ProviderRegistry manifest mismatches:", manifestFailures);
+  }
+  assert(
+    manifestFailures.length === 0,
+    `${manifestFailures.length} manifest mismatch(es)`,
+  );
+
   const claimedKeys = new Map<string, string>();
   const keyCollisions: string[] = [];
   for (const id of canonicalIds) {


### PR DESCRIPTION
## Summary

Resolves the Pattern Analysis `provider-registration` finding ([#1317](https://github.com/juspay/neurolink/issues/1317)) for the 10 provider modules the automated scanner flagged as "may not be registered in ProviderRegistry".

### Root cause

Every provider in `ProviderRegistry` is registered via a **dynamic `import()`** inside its factory function (required by CLAUDE.md Rule 1 to avoid circular dependencies). Provider module names intentionally differ from the canonical provider IDs they are registered under (e.g. `amazonBedrock` -> `"bedrock"`, `googleVertex` -> `"vertex"`, `nvidiaNim` -> `"nvidia-nim"`). Static scanners cannot resolve dynamic imports, so they cannot connect a provider module to its registration and flag these modules:

- `amazonBedrock.ts`, `amazonSagemaker.ts`, `azureOpenai.ts`, `googleAiStudio.ts`, `googleVertex.ts`, `lmStudio.ts`, `nvidiaNim.ts`, `openaiChatCompletionsBase.ts`, `openaiCompatible.ts`, `togetherAi.ts`

### Fix

1. **`src/lib/factories/providerRegistry.ts`** added `PROVIDER_MODULE_TO_ID`, an explicit statically-scannable manifest mapping every registered provider module (file/dir under `src/lib/providers/`) to its canonical provider ID. It is enforced at runtime inside `_doRegister()` with a drift guard: registration now fails loudly if any manifest module is not actually registered, so the manifest and the registry can never silently diverge.

2. **`test/continuous-test-suite-provider-structure.ts`** the "Provider Registration Completeness" test now also asserts that every concrete provider module is covered by `PROVIDER_MODULE_TO_ID` and that every manifest entry resolves to a registered provider.

### Design notes

- Keeps the required dynamic-import architecture (no static provider imports, no circular dependencies).
- Canonical provider IDs and the public SDK surface are unchanged.
- The manifest doubles as the authoritative module -> ID mapping for tooling that cannot resolve `import()`.

## Test report

| Check | Result |
| --- | --- |
| `eslint` on changed files (`providerRegistry.ts`, `provider-structure.ts`) | PASS (exit 0) |
| `tsc --noEmit` (changed files) | PASS no errors in changed files |
| `prettier --check` on changed files | PASS |
| Runtime registration + drift guard (`ProviderRegistry.registerAllProviders()`) | PASS 30/30 manifest entries registered, 30/30 canonical IDs resolvable, no drift detected |
| Manifest coverage vs `src/lib/providers/` modules | PASS 30/30 concrete modules covered |

> Note: a full `pnpm run check` / live provider suite cannot run in this environment because the local `node_modules` has a broken `zod` link (pre-existing, unrelated to this change); provider *creation* against live APIs also requires API keys. All registration-level behavior is verified above.

## Impact

- Self-contained: only the registry and its structure test are touched.
- No public API or behavior changes; the drift guard adds a startup-time invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved provider registration validation to detect missing or mismatched provider entries.
- Registration now reports configuration issues clearly and prevents incomplete provider setups.
- Added a centralized provider manifest to keep supported provider identifiers consistent.

## Tests
- Added coverage to verify that all supported providers are documented and successfully registered.
- Enhanced checks to report discrepancies between documented and registered providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->