### PR TITLE
docs(sdk): document custom content ordering for multimodal API

### DIFF
--- a/docs/sdk/multimodal.md
+++ b/docs/sdk/multimodal.md
@@ -1,0 +1,34 @@
+# Multimodal Capabilities
+
+The NeuroLink SDK supports rich multimodal interactions, allowing you to pass images, files, and text to supported models.
+
+## Custom Content Ordering
+
+By default, the simple API will order the text before any attached images. This is convenient for many prompts, but it is not always the right sequence for multimodal tasks such as OCR, visual search, or side-by-side comparison.
+
+When you need a different order, construct a custom content array. The SDK preserves the exact array order you provide, so the model receives the content in the same sequence you define.
+
+Example: image-first ordering
+
+```typescript
+import { NeuroLink } from "neurolink";
+
+const sdk = new NeuroLink();
+
+const response = await sdk.generate({
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "image", image: "https://example.com/receipt.jpg" },
+        { type: "text", text: "Extract the total amount from this receipt." },
+      ],
+    },
+  ],
+  provider: "google-ai",
+});
+```
+
+This keeps the image first and the instruction second, which is useful when the model should interpret the visual input before following the text prompt. The same pattern also works for image-first or custom multi-part prompts that mix text and media in any order you need.
+
+> The simple API is still backward compatible, but when ordering matters, the custom `messages[].content` array is the explicit and flexible option.


### PR DESCRIPTION
Fixes #306

# Pull Request

## Description
This PR documents the custom multimodal content-ordering behavior for the SDK.

The simple API defaults to a text-first sequence, but advanced multimodal workflows such as OCR, visual search, and image comparison sometimes require the model to see the image before the instruction. This update explains how to use a custom `messages[].content` array to preserve the exact order of text and media elements.

## Related Issues
Fixes #306

## Type of Change
- [x] Documentation update

## Motivation and Context
The current simple API is text-first by default. Some workflows require image-first or custom ordering, but the SDK already supports that via a custom content array. This documentation makes the supported pattern explicit and preserves backward compatibility.

## Changes Made
- Created `docs/sdk/multimodal.md`
- Documented the default text-first behavior of the simple API
- Added a TypeScript example showing an image-first content array
- Clarified that `messages[].content` preserves the exact ordering of elements

## Breaking Changes
- [x] No breaking changes

## Testing
- [x] Manual testing completed

### Manual Testing Steps
1. Verified markdown formatting with `npx markdownlint-cli2 "docs/sdk/multimodal.md"`
2. Pushed the branch to the fork to create the PR

## Code Quality
- [x] Code follows the project's style guidelines
- [x] Code is properly formatted
- [x] Self-review of code completed
- [x] No hardcoded API keys or secrets

## Documentation
- [x] Documentation in /docs updated
- [x] Code examples added/updated

## Commit Message Format
- [x] Commit message follows format: `type(scope): description`

## Dependencies
- [x] No dependency changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment steps

## Pre-submission Checklist
- [x] Read and followed the Contributing Guidelines
- [x] Updated relevant documentation
- [x] Reviewed your own code for obvious issues
- [x] Ensured commit messages follow semantic format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for controlling text and image ordering in multimodal SDK requests.
  * Included an image-first generation example.
  * Clarified that the simple API remains backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->