### PR TITLE
fix(providers): classify transport errors, honor paired credentials, repair dead tests

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -41,10 +41,39 @@ if [[ "$BRANCH_NAME" != "HEAD" ]]; then
   echo "⏭️  Skipping tests (continuous test suites require API keys - run manually with pnpm test)"
 
   # Adding formatted files to git stage.
+  #
+  # `git diff --name-only` (worktree vs index) lists every file prettier just
+  # reformatted on disk, but ALSO any unrelated file with in-progress edits
+  # that were never staged for this commit. Re-adding that raw list sweeps
+  # unrelated WIP into the commit. Only files that are BOTH just-reformatted
+  # AND already staged for this commit (index vs HEAD) should be re-added.
+  #
+  # This protects files you never staged. It does NOT give you partial
+  # staging: for a file with both staged and unstaged hunks, prettier
+  # formats the whole worktree copy and the `git add` below stages all of
+  # it, unstaged hunks included — exactly as before this change. Fixing
+  # that means formatting the staged blob in isolation and re-applying the
+  # unstaged patch, which is a larger change than this one.
   echo "📝 Adding formatted files to git stage..."
-  files="$(git diff --name-only --diff-filter=d)"
-  if [[ -n "$files" ]]; then
-    git add -- $files
+  staged_files=()
+  while IFS= read -r -d '' f; do
+    staged_files+=("$f")
+  done < <(git diff --cached --name-only --diff-filter=d -z)
+
+  if [[ ${#staged_files[@]} -gt 0 ]]; then
+    files_to_add=()
+    while IFS= read -r -d '' f; do
+      for s in "${staged_files[@]}"; do
+        if [[ "$f" == "$s" ]]; then
+          files_to_add+=("$f")
+          break
+        fi
+      done
+    done < <(git diff --name-only --diff-filter=d -z)
+
+    if [[ ${#files_to_add[@]} -gt 0 ]]; then
+      git add -- "${files_to_add[@]}"
+    fi
   fi
 
   echo "🎉 All pre-commit checks passed!"

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -46,6 +46,7 @@ import {
   createTogetherAIConfig,
   createVoyageConfig,
   createXaiConfig,
+  satisfiesFallbacks,
 } from "../../lib/utils/providerConfig.js";
 
 // Provider information database
@@ -493,7 +494,7 @@ export async function checkExistingConfigurations(): Promise<string[]> {
     }
     const requiredOk =
       (extraRequired ?? []).every((v) => !!process.env[v]) ||
-      (extraRequiredFallbacks ?? []).some((v) => !!process.env[v]);
+      satisfiesFallbacks(extraRequiredFallbacks, process.env);
     if (requiredOk) {
       configured.push(p.id);
     }

--- a/src/lib/constants/networkErrorCodes.ts
+++ b/src/lib/constants/networkErrorCodes.ts
@@ -1,0 +1,21 @@
+/**
+ * Error codes that indicate a transient transport failure (dropped
+ * connection, socket reset, connect timeout) rather than a permanent
+ * misconfiguration. Shared between `proxy/proxyFetch.ts` (retry gating) and
+ * `utils/errorClassifier.ts` (NetworkError classification) so both stay in
+ * sync — a second hand-maintained copy would drift the two apart the same
+ * way the "5xx literal text vs statusCode" split did.
+ *
+ * undici's native `fetch()` wraps the real transport failure in
+ * `TypeError: fetch failed`, with the actionable code on `error.cause`
+ * (sometimes nested another level deep, e.g. a SocketError inside a
+ * ConnectTimeoutError) — never on the outer TypeError itself.
+ */
+export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);

--- a/src/lib/factories/providerDescriptors.ts
+++ b/src/lib/factories/providerDescriptors.ts
@@ -53,6 +53,9 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
     timeouts: { generateMs: 45_000, streamMs: 120_000 },
     autoSelectPriority: 7,
     apiKeyFormatPattern: API_KEY_FORMATS.bedrock,
+    // Falls back to the AWS SDK's own default credential chain (shared
+    // profile, IAM role) when these env vars are absent — see field JSDoc.
+    credentialsResolvedExternally: true,
   },
   {
     name: AIProviderName.OPENAI,
@@ -116,12 +119,14 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
       // priority than GOOGLE_APPLICATION_CREDENTIALS by the real gating
       // logic (hasGoogleCredentials() in googleVertex/client.ts and
       // googleVertex/utils.ts) — corrected here vs. the plan snippet, which
-      // omitted it.
+      // omitted it. GOOGLE_AUTH_CLIENT_EMAIL and GOOGLE_AUTH_PRIVATE_KEY are
+      // nested together because hasGoogleCredentials() only accepts them as
+      // a pair — either alone is not valid auth, unlike the other flat
+      // entries here which are each independently sufficient.
       extraRequiredFallbacks: [
         "GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK",
         "GOOGLE_SERVICE_ACCOUNT_KEY",
-        "GOOGLE_AUTH_CLIENT_EMAIL",
-        "GOOGLE_AUTH_PRIVATE_KEY",
+        ["GOOGLE_AUTH_CLIENT_EMAIL", "GOOGLE_AUTH_PRIVATE_KEY"],
       ],
     },
     defaultModel: VertexModels.CLAUDE_4_6_SONNET,
@@ -131,6 +136,9 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
     setupUrl: "https://console.cloud.google.com/",
     timeouts: { generateMs: 60_000, streamMs: 120_000 },
     autoSelectPriority: 3,
+    // OR-of-multiple-auth-paths (file / individual fields / base64 key) —
+    // not a flat AND-list of required env vars. See field JSDoc.
+    credentialsResolvedExternally: true,
   },
   {
     name: AIProviderName.ANTHROPIC,
@@ -268,6 +276,8 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
     setupUrl: "https://docs.litellm.ai/docs/proxy/quick_start",
     timeouts: { generateMs: 300_000, streamMs: 120_000 },
     autoSelectPriority: 1,
+    // Documented zero-config local proxy — see field JSDoc.
+    credentialsResolvedExternally: true,
   },
   {
     name: AIProviderName.SAGEMAKER,

--- a/src/lib/proxy/proxyFetch.ts
+++ b/src/lib/proxy/proxyFetch.ts
@@ -15,6 +15,7 @@ import type {
   ProxyEnvironmentSnapshot,
 } from "../types/index.js";
 import { createHash } from "node:crypto";
+import { TRANSIENT_NETWORK_CODES } from "../constants/networkErrorCodes.js";
 
 async function getLangfuseContext(): Promise<LangfuseContext | undefined> {
   try {
@@ -105,16 +106,6 @@ function extractHostname(url: string | URL | RequestInfo): string {
     return "[unknown]";
   }
 }
-
-/** Error codes classified as transient (module-scope: the retry path is hot). */
-const TRANSIENT_NETWORK_CODES = new Set([
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ECONNREFUSED",
-  "EPIPE",
-  "UND_ERR_SOCKET",
-  "UND_ERR_CONNECT_TIMEOUT",
-]);
 
 /**
  * Classify a fetch failure as a transient network error worth retrying.

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -2005,8 +2005,8 @@ export type ProviderDescriptor = {
     modelFallbacks?: readonly string[];
     /** Additional env vars required alongside apiKey (e.g. AWS secret key, Azure endpoint). */
     extraRequired?: readonly string[];
-    /** Alternate ways to satisfy extraRequired when it isn't a plain env-var list (e.g. Vertex's file-path-OR-individual-fields auth). */
-    extraRequiredFallbacks?: readonly string[];
+    /** Alternate ways to satisfy extraRequired when it isn't a plain env-var list (e.g. Vertex's file-path-OR-individual-fields auth). Each entry is either a single env var name (satisfied alone) or a nested array of names that must ALL be present together (e.g. Vertex's GOOGLE_AUTH_CLIENT_EMAIL + GOOGLE_AUTH_PRIVATE_KEY pair, which is only valid as a pair). Evaluate with `satisfiesFallbacks()` (providerConfig.ts) rather than re-deriving this logic at each call site. */
+    extraRequiredFallbacks?: readonly (string | readonly string[])[];
     /** True when the provider is usable with zero configuration (local runtime with a documented default URL, or a documented non-secret default like LiteLLM's "sk-anything"). */
     optional?: boolean;
   };
@@ -2029,6 +2029,21 @@ export type ProviderDescriptor = {
   autoSelectPriority?: number;
   /** Format-validation regex sourced from providerConfig.ts's API_KEY_FORMATS, when one exists for this provider. */
   apiKeyFormatPattern?: RegExp;
+  /**
+   * True when this provider's credentials are resolved by an external chain
+   * or its own config validator rather than by plain env-var presence, so
+   * its required-env-vars can't be expressed as "every one of these exact
+   * names must be literally set". Examples: Vertex accepts a service-account
+   * file OR individual client-email/private-key fields OR a base64 key
+   * (an OR, not an AND, of auth paths); Bedrock falls back to the AWS SDK's
+   * own default credential chain (shared profile, IAM role) with no env
+   * vars required at all; LiteLLM is a documented zero-config local proxy.
+   * `ProviderHealthChecker.getRequiredEnvironmentVariables()` returns `[]`
+   * for these providers and defers to `checkProviderSpecificConfig()`'s
+   * dedicated per-provider check instead of deriving a flat AND-list from
+   * `envVars`.
+   */
+  credentialsResolvedExternally?: boolean;
 };
 
 // =============================================================================

--- a/src/lib/utils/errorClassifier.ts
+++ b/src/lib/utils/errorClassifier.ts
@@ -22,28 +22,103 @@ import {
 } from "../types/index.js";
 import { TimeoutError } from "./timeout.js";
 import { duckTypedStatusCode } from "./providerRetry.js";
+import { TRANSIENT_NETWORK_CODES } from "../constants/networkErrorCodes.js";
+import { redactUrlsInText } from "./logSanitize.js";
+
+/** Bounded walk depth for `.cause` chains — matches the precedent in
+ * `proxy/proxyFetch.ts`'s `isTransientNetworkError`. Guards against
+ * pathological/cyclic `.cause` chains hanging classification. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Walk `error.cause` up to `MAX_CAUSE_DEPTH` links, guarded by a seen-set so
+ * a cyclic chain (`a.cause === a`, or a longer cycle) terminates instead of
+ * looping. Node's native `fetch` (undici) throws `TypeError: fetch failed`
+ * with the real transport error nested under `.cause` — sometimes another
+ * level deep (e.g. a SocketError inside a ConnectTimeoutError) — so a
+ * classifier that only reads the outer error's `.message`/`.code` never
+ * sees it.
+ */
+function collectCauseChain(error: unknown): Record<string, unknown>[] {
+  const chain: Record<string, unknown>[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (
+    current &&
+    typeof current === "object" &&
+    !seen.has(current) &&
+    chain.length < MAX_CAUSE_DEPTH
+  ) {
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    chain.push(record);
+    current = record.cause;
+  }
+  return chain;
+}
+
+function firstString(
+  chain: Record<string, unknown>[],
+  key: "name" | "code",
+): string | undefined {
+  for (const record of chain) {
+    if (typeof record[key] === "string") {
+      return record[key] as string;
+    }
+  }
+  return undefined;
+}
 
 function buildErrorContext(
   error: unknown,
   provider: string,
   modelName?: string,
 ): ProviderErrorContext {
-  const record =
-    error && typeof error === "object"
-      ? (error as Record<string, unknown>)
-      : undefined;
-  const message =
-    typeof record?.message === "string"
-      ? record.message
+  const chain = collectCauseChain(error);
+  const top = chain[0];
+  const topMessage =
+    typeof top?.message === "string"
+      ? top.message
       : error instanceof Error
         ? error.message
         : "Unknown error";
+
+  // Compose (never replace) the message: append the deepest cause's message
+  // when it differs from the top, so existing rules matching the outer text
+  // (e.g. "rate limit", "model not found") keep matching, while the real
+  // transport failure buried in .cause becomes visible to rules that need
+  // it (e.g. a nested "ECONNREFUSED").
+  // The nested message is redacted before it is composed in: an undici cause
+  // carries the full request URL, so a presigned token would otherwise reach
+  // a client-facing error message through this path. Only the nested text is
+  // scrubbed — the provider's own top-level message is left alone, since
+  // several providers deliberately name their base URL in it.
+  const deepest = chain[chain.length - 1];
+  const deepestMessage =
+    typeof deepest?.message === "string"
+      ? redactUrlsInText(deepest.message)
+      : undefined;
+  const message =
+    deepestMessage && deepestMessage !== topMessage
+      ? `${topMessage}: ${deepestMessage}`
+      : topMessage;
+
+  // errorCode/errorName/statusCode: prefer the outer error's own value,
+  // falling back to the first cause in the chain that has one.
+  let statusCode: number | undefined;
+  for (const record of chain) {
+    statusCode = duckTypedStatusCode(record);
+    if (statusCode !== undefined) {
+      break;
+    }
+  }
+
   return {
     error,
     message,
-    statusCode: duckTypedStatusCode(error),
-    errorName: typeof record?.name === "string" ? record.name : undefined,
-    errorCode: typeof record?.code === "string" ? record.code : undefined,
+    statusCode,
+    errorName: firstString(chain, "name"),
+    errorCode: firstString(chain, "code"),
     provider,
     modelName,
   };
@@ -111,17 +186,45 @@ export const DEFAULT_ERROR_RULES: ProviderErrorRule[] = [
         : `${ctx.provider} model not found.`,
   },
   {
+    // Message regex covers providers/SDKs that surface a code as text
+    // (e.g. AWS SDK wrapping "ECONNRESET" into its own message). errorCode
+    // covers undici's native fetch(), which wraps transport failures as
+    // `TypeError: fetch failed` and puts the *structured* code
+    // (ECONNREFUSED, UND_ERR_SOCKET, ...) on a nested `.cause` rather than
+    // in any message text — buildErrorContext's cause walk surfaces it here.
     match: (ctx) =>
       /ECONNRESET|ENOTFOUND|ECONNREFUSED|ETIMEDOUT|network|connection/i.test(
         ctx.message,
-      ),
+      ) ||
+      (ctx.errorCode !== undefined &&
+        TRANSIENT_NETWORK_CODES.has(ctx.errorCode)),
     errorClass: NetworkError,
     message: (ctx) => `Connection error: ${ctx.message}`,
   },
   {
+    // Batch J Task 3: the old `/\b5\d\d\b/` matched ANY bare 3-digit number
+    // in [500,599) anywhere in the message — e.g. "max_tokens (500) exceeds
+    // model limit" — with no relation to an actual HTTP status. Tightened to
+    // require the number sit in a status-shaped context: immediately next
+    // to "error" (either order) or "status"/"status code" (a common HTTP
+    // client wrapper phrase, e.g. axios's "Request failed with status code
+    // 500"), with a bounded gap so unrelated digits nearby can't bridge the
+    // match — or a named 5xx phrase that needs no digit at all ("bad
+    // gateway", "service unavailable", "gateway timeout", "server error",
+    // which already covers "... Internal Server Error"). This changes the
+    // MATCHED MESSAGE TEXT only, never the classified class: when no rule
+    // matches, `classifyProviderError`'s fallback also returns
+    // `ProviderError` (see above) — the same class this rule assigns — so
+    // narrowing this regex can only move a message between "${provider}
+    // server error: ..." and "${provider} error: ...", never between error
+    // classes.
     match: (ctx) =>
-      (ctx.statusCode !== undefined && ctx.statusCode >= 500) ||
-      /\b5\d\d\b|server error/i.test(ctx.message),
+      (ctx.statusCode !== undefined &&
+        ctx.statusCode >= 500 &&
+        ctx.statusCode <= 599) ||
+      /server error|bad gateway|service unavailable|gateway timeout|\berror\b\D{0,12}\b5\d\d\b|\b5\d\d\b\D{0,12}\berror\b|\bstatus(?:\s*code)?\b\D{0,12}\b5\d\d\b/i.test(
+        ctx.message,
+      ),
     errorClass: ProviderError,
     message: (ctx) => `${ctx.provider} server error: ${ctx.message}`,
   },

--- a/src/lib/utils/providerConfig.ts
+++ b/src/lib/utils/providerConfig.ts
@@ -222,6 +222,35 @@ export function hasProviderCredentials(envVars: string[]): boolean {
   return envVars.some((envVar) => !!process.env[envVar]);
 }
 
+/**
+ * Evaluates a `ProviderDescriptor.envVars.extraRequiredFallbacks`-shaped
+ * list against an env-var source. Each entry is either a single env var
+ * name (satisfied on its own) or a nested array of names that must ALL be
+ * present together (e.g. Vertex's GOOGLE_AUTH_CLIENT_EMAIL +
+ * GOOGLE_AUTH_PRIVATE_KEY pair, which is only valid auth as a pair).
+ * Returns true when at least one entry is satisfied. The single evaluation
+ * site for this shape — every consumer (providerUtils.ts, providerHealth.ts,
+ * setup.ts, environmentManager.ts) must call this instead of re-deriving the
+ * same `.some()`/`.every()` logic, so they can't drift out of sync with each
+ * other or with the real auth gate (hasGoogleCredentials()).
+ * @param env Explicit env-var source (`process.env`, or a parsed .env file) —
+ *   never hardcoded, so callers checking a file's contents (not the live
+ *   process env) can reuse this too.
+ */
+export function satisfiesFallbacks(
+  fallbacks: readonly (string | readonly string[])[] | undefined,
+  env: Record<string, string | undefined>,
+): boolean {
+  if (!fallbacks) {
+    return false;
+  }
+  return fallbacks.some((entry) =>
+    typeof entry === "string"
+      ? !!env[entry]
+      : entry.every((name) => !!env[name]),
+  );
+}
+
 // =============================================================================
 // PROVIDER-SPECIFIC CONFIGURATION CREATORS
 // =============================================================================

--- a/src/lib/utils/providerHealth.ts
+++ b/src/lib/utils/providerHealth.ts
@@ -11,7 +11,7 @@ import {
   AnthropicModels,
   BedrockModels,
 } from "../constants/enums.js";
-import { PROJECT_ID_FORMAT } from "./providerConfig.js";
+import { PROJECT_ID_FORMAT, satisfiesFallbacks } from "./providerConfig.js";
 import { basename } from "path";
 import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type {
@@ -284,7 +284,7 @@ export class ProviderHealthChecker {
 
       const hasValidAuth =
         (extraRequired ?? []).every((v) => !!process.env[v]) ||
-        (extraRequiredFallbacks ?? []).some((v) => !!process.env[v]);
+        satisfiesFallbacks(extraRequiredFallbacks, process.env);
 
       logger.debug("Vertex auth final result", { hasValidAuth });
 
@@ -488,48 +488,40 @@ export class ProviderHealthChecker {
   }
 
   /**
-   * Providers whose credential model can't be reduced to "every one of
-   * these exact env vars must be literally set" — the check in
-   * checkEnvironmentConfiguration() below ANDs every entry in the
-   * returned list together, which can't express Vertex's file-OR-
-   * individual-creds-OR-service-account auth, Bedrock's AWS SDK default
-   * provider chain (profile / IAM role, no env vars at all), or
-   * LiteLLM's documented zero-config local proxy. Their real requirement
-   * is validated by checkProviderSpecificConfig()'s dedicated per-provider
-   * checks instead — matches the original hand-written switch's
-   * deliberate `return []` for exactly these three. Naively deriving
-   * [apiKey, ...extraRequired] from the descriptor here (as for the other
-   * 27 providers) would make checkEnvironmentConfiguration() push a false
-   * "missing environment variables" issue — and therefore isHealthy=false
-   * — for legitimate fallback-based Vertex auth, AWS_PROFILE/IAM-role
-   * Bedrock auth, and unauthenticated local LiteLLM proxies. See
-   * hasProviderEnvVars() in providerUtils.ts for the equivalent OR-aware
-   * check used for auto-select gating.
-   */
-  private static readonly ENV_CHECK_DELEGATED_TO_SPECIFIC_CONFIG =
-    new Set<string>([
-      AIProviderName.VERTEX,
-      AIProviderName.BEDROCK,
-      AIProviderName.LITELLM,
-    ]);
-
-  /**
-   * Get required environment variables for a provider
+   * Get required environment variables for a provider.
+   *
+   * Returns `[]` for providers with `descriptor.credentialsResolvedExternally
+   * === true` (Vertex, Bedrock, LiteLLM) — the check in
+   * checkEnvironmentConfiguration() below ANDs every entry in the returned
+   * list together, which can't express Vertex's file-OR-individual-creds-
+   * OR-service-account auth, Bedrock's AWS SDK default provider chain
+   * (profile / IAM role, no env vars at all), or LiteLLM's documented
+   * zero-config local proxy. Their real requirement is validated by
+   * checkProviderSpecificConfig()'s dedicated per-provider checks instead.
+   * Naively deriving [apiKey, ...extraRequired] from the descriptor for
+   * these three (as for the other 27 providers) would make
+   * checkEnvironmentConfiguration() push a false "missing environment
+   * variables" issue — and therefore isHealthy=false — for legitimate
+   * fallback-based Vertex auth, AWS_PROFILE/IAM-role Bedrock auth, and
+   * unauthenticated local LiteLLM proxies. See hasProviderEnvVars() in
+   * providerUtils.ts for the equivalent OR-aware check used for
+   * auto-select gating. See `ProviderDescriptor.credentialsResolvedExternally`
+   * (types/providers.ts) for the field's full documentation.
    */
   static getRequiredEnvironmentVariables(providerName: string): string[] {
-    // Resolve the descriptor FIRST so the delegation-Set check below is
-    // keyed on the canonical, alias-resolved `descriptor.name` — not the
-    // raw, possibly-aliased `providerName` argument. Checking the raw
-    // input here would let documented aliases (e.g. "googleVertex" for
+    // Resolve the descriptor FIRST so the field check below is keyed on
+    // the canonical, alias-resolved `descriptor.credentialsResolvedExternally`
+    // — not the raw, possibly-aliased `providerName` argument. Checking the
+    // raw input here would let documented aliases (e.g. "googleVertex" for
     // vertex, "aws" for bedrock) skip the delegation and fall through to
     // the naive [apiKey, ...extraRequired] derivation below, reproducing
     // the exact false "missing environment variables" regression this
-    // Set exists to prevent.
+    // field exists to prevent.
     const descriptor = ProviderFactory.getDescriptor(providerName);
     if (!descriptor) {
       return [];
     }
-    if (this.ENV_CHECK_DELEGATED_TO_SPECIFIC_CONFIG.has(descriptor.name)) {
+    if (descriptor.credentialsResolvedExternally) {
       return [];
     }
     const { apiKey, extraRequired } = descriptor.envVars;
@@ -689,7 +681,7 @@ export class ProviderHealthChecker {
     }
 
     if (!hasValidAuth) {
-      hasValidAuth = this.checkIndividualGoogleCredentials(healthStatus);
+      hasValidAuth = this.checkExtraRequiredFallbackCredentials(healthStatus);
     }
 
     if (!hasValidAuth) {
@@ -697,7 +689,7 @@ export class ProviderHealthChecker {
         "Google Cloud authentication not configured or credentials file missing",
       );
       healthStatus.recommendations.push(
-        "Set either GOOGLE_APPLICATION_CREDENTIALS (valid file path), GOOGLE_SERVICE_ACCOUNT_KEY (base64), or both GOOGLE_AUTH_CLIENT_EMAIL and GOOGLE_AUTH_PRIVATE_KEY",
+        "Set either GOOGLE_APPLICATION_CREDENTIALS (valid file path), GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK, GOOGLE_SERVICE_ACCOUNT_KEY (base64), or both GOOGLE_AUTH_CLIENT_EMAIL and GOOGLE_AUTH_PRIVATE_KEY",
       );
     }
 
@@ -737,18 +729,26 @@ export class ProviderHealthChecker {
   }
 
   /**
-   * Check individual Google credentials
+   * Check Vertex's non-file auth fallbacks (GOOGLE_APPLICATION_CREDENTIALS_
+   * NEUROLINK, GOOGLE_SERVICE_ACCOUNT_KEY, or the GOOGLE_AUTH_CLIENT_EMAIL +
+   * GOOGLE_AUTH_PRIVATE_KEY pair) via the descriptor's extraRequiredFallbacks
+   * instead of a hand-maintained env-var list, so this stays in sync with
+   * the real gating logic (hasGoogleCredentials()) the same way
+   * checkApiKeyValidity()'s vertex branch does. The previous hand-rolled
+   * version only recognized GOOGLE_SERVICE_ACCOUNT_KEY or the email+key
+   * pair — missing GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK, the
+   * descriptor's documented first-priority fallback.
    */
-  private static checkIndividualGoogleCredentials(
+  private static checkExtraRequiredFallbackCredentials(
     healthStatus: ProviderHealthStatusOptions,
   ): boolean {
-    const hasServiceAccountKey = !!process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
-    const hasIndividualCredentials = !!(
-      process.env.GOOGLE_AUTH_CLIENT_EMAIL &&
-      process.env.GOOGLE_AUTH_PRIVATE_KEY
+    const descriptor = ProviderFactory.getDescriptor(AIProviderName.VERTEX);
+    const hasValidAuth = satisfiesFallbacks(
+      descriptor?.envVars.extraRequiredFallbacks,
+      process.env,
     );
 
-    if (hasServiceAccountKey || hasIndividualCredentials) {
+    if (hasValidAuth) {
       healthStatus.hasApiKey = true;
       return true;
     }

--- a/src/lib/utils/providerUtils.ts
+++ b/src/lib/utils/providerUtils.ts
@@ -15,6 +15,7 @@ import {
   API_KEY_FORMATS,
   API_KEY_LENGTHS,
   PROJECT_ID_FORMAT,
+  satisfiesFallbacks,
 } from "./providerConfig.js";
 import { DEFAULT_OLLAMA_MODEL } from "../providers/ollama/constants.js";
 import { ProviderFactory } from "../factories/providerFactory.js";
@@ -448,7 +449,7 @@ export function hasProviderEnvVars(provider: string): boolean {
   }
   return (
     (extraRequired ?? []).every((v) => !!process.env[v]) ||
-    (extraRequiredFallbacks ?? []).some((v) => !!process.env[v])
+    satisfiesFallbacks(extraRequiredFallbacks, process.env)
   );
 }
 

--- a/test/continuous-test-suite-context.ts
+++ b/test/continuous-test-suite-context.ts
@@ -3397,12 +3397,47 @@ async function test_6_8_fullstream_providers_gate_on_content_yielded(): Promise<
   const testName =
     "6.8 — REGRESSION: OpenRouter/LiteLLM gate post-stream NoOutput detect on contentYielded, not raw chunkCount";
   const fs = await import("node:fs/promises");
-  const targets = [
-    "dist/lib/providers/openRouter.js",
-    "dist/lib/providers/litellm.js",
-  ];
+
+  // OpenRouter and LiteLLM are directories in src (client.ts + index.ts),
+  // not flat files, so the compiled output is `.../openRouter/client.js`
+  // — never a flat `openRouter.js`. Both provider classes `extends
+  // OpenAIChatCompletionsProvider` and inherit its stream loop rather than
+  // reimplementing it, so `contentYielded` itself only appears in the
+  // shared base class's compiled output, not in either provider's own
+  // file. The base class also doesn't call a `detectPostStreamNoOutput`
+  // helper (that's a separate mechanism StreamHandler.ts uses for
+  // providers that don't extend this base) — it builds the sentinel
+  // inline via `buildNoOutputSentinel`/`stampNoOutputSpan`. So this test
+  // checks two things: the shared base class still gates on
+  // `contentYielded` (not raw chunk count) before emitting the sentinel,
+  // and each provider still inherits that gate rather than growing its
+  // own unguarded stream path.
+  const basePath = "dist/providers/openaiChatCompletionsBase.js";
+  const providerTargets: Record<string, string> = {
+    OpenRouter: "dist/providers/openRouter/client.js",
+    LiteLLM: "dist/providers/litellm/client.js",
+  };
   const issues: string[] = [];
-  for (const path of targets) {
+
+  let baseSrc = "";
+  try {
+    baseSrc = await fs.readFile(basePath, "utf-8");
+  } catch (err) {
+    issues.push(`cannot read ${basePath}: ${(err as Error).message}`);
+  }
+  if (baseSrc) {
+    const baseGatesOnContentYielded =
+      /contentYielded\s*===\s*0[\s\S]{0,400}?(buildNoOutputSentinel|stampNoOutputSpan)/.test(
+        baseSrc,
+      );
+    if (!baseGatesOnContentYielded) {
+      issues.push(
+        `${basePath}: 'contentYielded === 0 ... (buildNoOutputSentinel|stampNoOutputSpan)' pattern not found`,
+      );
+    }
+  }
+
+  for (const [name, path] of Object.entries(providerTargets)) {
     let src: string;
     try {
       src = await fs.readFile(path, "utf-8");
@@ -3410,24 +3445,18 @@ async function test_6_8_fullstream_providers_gate_on_content_yielded(): Promise<
       issues.push(`cannot read ${path}: ${(err as Error).message}`);
       continue;
     }
-    // Look for the production-fix gate. Both providers should reference
-    // `contentYielded` (the corrected counter). If either still uses
-    // `chunkCount` near `detectPostStreamNoOutput`, the gate is dead.
-    const usesContentYielded =
-      /contentYielded\s*===\s*0[\s\S]{0,400}?detectPostStreamNoOutput/.test(
-        src,
-      );
-    if (!usesContentYielded) {
+    if (!/extends\s+OpenAIChatCompletionsProvider/.test(src)) {
       issues.push(
-        `${path}: 'contentYielded === 0 ... detectPostStreamNoOutput' pattern not found`,
+        `${path}: ${name} no longer extends OpenAIChatCompletionsProvider — shared contentYielded gate is not inherited`,
       );
     }
   }
+
   if (issues.length === 0) {
     recordIssue06(
       testName,
       "PASS",
-      `both fullStream providers gate post-stream detect on contentYielded`,
+      `both fullStream providers inherit the shared base class's contentYielded-gated post-stream detect`,
     );
   } else {
     recordIssue06(testName, "FAIL", `bug-confirmed: ${issues.join("; ")}`);

--- a/test/continuous-test-suite-error-classification-e2e.ts
+++ b/test/continuous-test-suite-error-classification-e2e.ts
@@ -72,9 +72,13 @@ function handleMockRequest(
 ): void {
   hitCount++;
   if (destroySocketOnRequest) {
-    // Simulates a genuine ECONNRESET: abort the connection mid-flight
-    // instead of responding, so the client's http layer raises a real
-    // ECONNRESET, not a synthetic message string.
+    // Abort the connection mid-flight instead of responding. NOT a real
+    // ECONNRESET, contrary to what this comment used to claim: undici's
+    // native fetch() surfaces this as `TypeError: fetch failed` wrapping a
+    // `SocketError` with message "other side closed" and code
+    // `UND_ERR_SOCKET` on `.cause` — confirmed by live repro through the
+    // actual `createProxyFetch()` path. Never the literal "ECONNRESET"
+    // text or code.
     req.socket?.destroy();
     return;
   }
@@ -212,7 +216,14 @@ async function startMockServer(
 
 // A port nothing listens on: connecting here raises a real ECONNREFUSED
 // without needing to bind+close a real server (avoids a reuse race).
-const CLOSED_PORT_ORIGIN = "http://127.0.0.1:1";
+// Deliberately NOT port 1 — undici's Fetch-spec "bad ports" blocklist
+// rejects port 1 (plus a handful of other low ports) before attempting any
+// connection, yielding `.cause = Error("bad port")` with no `.code` at all,
+// which is a client-side misconfiguration, not a transient transport
+// failure — confirmed by live repro through the real `createProxyFetch()`
+// path. 65533 is outside that blocklist and produces a genuine
+// `.cause = Error("connect ECONNREFUSED ...")` with `code: "ECONNREFUSED"`.
+const CLOSED_PORT_ORIGIN = "http://127.0.0.1:65533";
 
 // ---------------------------------------------------------------------------
 // Env var snapshot/restore — cloned from providers-mocked.ts's pattern.
@@ -428,23 +439,27 @@ async function main(): Promise<void> {
         expectClass: RateLimitError,
       });
 
-      // File1 #7: real socket reset (not a synthetic message string) via
+      // File1 #7: real socket death (not a synthetic message string) via
       // req.socket.destroy(). Node's native fetch (undici) surfaces this as
-      // `TypeError: fetch failed` with the real ECONNRESET nested under
-      // `.cause`, not in the top-level `.message` — so DEFAULT_ERROR_RULES'
-      // NetworkError rule (which pattern-matches literal "ECONNRESET" text
-      // in the message) never actually fires for a real Node-fetch transport
-      // failure; it falls through to the generic-fallback ProviderError
-      // rule. No status code either -> also wrapped. Renamed from the
-      // original "-> NetworkError" expectation to reflect what a real socket
-      // reset actually classifies as through this provider's shared HTTP
-      // client (same "fetch failed" gap documented for openai-compatible's
-      // ECONNREFUSED case below).
+      // `TypeError: fetch failed` wrapping a `SocketError` with message
+      // "other side closed" and code `UND_ERR_SOCKET` on `.cause` — NOT the
+      // literal "ECONNRESET" text or code (confirmed by live repro through
+      // the real `createProxyFetch()` path). buildErrorContext() now walks
+      // that `.cause` chain (bounded, cycle-guarded) and composes the
+      // deepest cause's message in, and DEFAULT_ERROR_RULES' NetworkError
+      // rule matches `ctx.errorCode` against a shared transient-code set
+      // (TRANSIENT_NETWORK_CODES, also used by proxyFetch.ts's own retry
+      // gate) in addition to its message regex — so this now correctly
+      // classifies as NetworkError instead of falling through to the
+      // generic fallback. No status code either -> still wrapped by the
+      // provider-fallback loop, so instanceof identity doesn't survive;
+      // asserted via the rule's "Connection error" message text instead,
+      // matching the existing precedent for this exact wrapping behavior.
       setSocketDestroyHandler();
       await expectGenerateError({
-        name: "DEFAULT_ERROR_RULES via mistral: real ECONNRESET -> generic ProviderError (fetch failed, not NetworkError)",
+        name: "DEFAULT_ERROR_RULES via mistral: real socket death (UND_ERR_SOCKET) -> NetworkError",
         run: () => gen({ provider: "mistral", model: "mistral-large-latest" }),
-        messageIncludes: ["mistral error: fetch failed"],
+        messageIncludes: ["Connection error"],
       });
 
       // File1 #8: unmatched -> generic ProviderError
@@ -751,21 +766,29 @@ async function main(): Promise<void> {
       "test-fake-openai-compatible-credential",
     );
     setEnv("OPENAI_COMPATIBLE_BASE_URL", CLOSED_PORT_ORIGIN);
-    // No status code on a transport-level failure -> retryable -> wrapped
-    // (see the DEFAULT_ERROR_RULES mistral ECONNRESET case for rationale).
-    // Same underlying gap as that mistral case: Node's native fetch surfaces
-    // a closed-port ECONNREFUSED as `TypeError: fetch failed` with the real
-    // errno nested under `.cause`, not in the top-level `.message` that gets
-    // wrapped into the generic ProviderError -> the base URL is never
-    // actually present in `.message` to assert against. Renamed from the
-    // original "-> NetworkError naming the base URL" expectation (and that
-    // base-URL substring check dropped) to reflect what this transport
-    // failure actually classifies as; only the generic-fallback prefix is
-    // pinned here.
+    // CLOSED_PORT_ORIGIN now points at port 65533 (outside undici's Fetch-spec
+    // "bad ports" blocklist — see that constant's own comment), so this is a
+    // genuine closed-port connection attempt: Node's native fetch surfaces it
+    // as `TypeError: fetch failed` wrapping a real `Error("connect ECONNREFUSED
+    // ...")` with code `ECONNREFUSED` on `.cause` — confirmed by live repro
+    // through the real `createProxyFetch()` path. This provider never reaches
+    // DEFAULT_ERROR_RULES' generic NetworkError rule for this case: its own
+    // formatProviderError() (openaiCompatible/client.ts) checks a bespoke
+    // `/ECONNREFUSED|Failed to fetch/i` rule against ctx.message FIRST, naming
+    // the configured base URL. That rule already existed in wave 2, but never
+    // fired for this test because port 1's "bad port" cause carries no
+    // ECONNREFUSED text at all. buildErrorContext()'s new cause-walk now
+    // composes the deepest cause's message (which does contain "ECONNREFUSED")
+    // into ctx.message, so the provider's own rule matches and this correctly
+    // classifies as NetworkError. Still no status code, so the
+    // provider-fallback loop still wraps it and instanceof identity doesn't
+    // survive — asserted via the provider's bespoke message text (and the
+    // base URL it names) rather than "Connection error", which is
+    // DEFAULT_ERROR_RULES' generic rule 4 format and not what fires here.
     await expectGenerateError({
-      name: "openai-compatible: real ECONNREFUSED (closed port) -> generic ProviderError (wrapped, not NetworkError)",
+      name: "openai-compatible: real ECONNREFUSED (closed port) -> NetworkError naming the base URL",
       run: () => gen({ provider: "openai-compatible", model: "gpt-4o-mini" }),
-      messageIncludes: ["openai-compatible error:"],
+      messageIncludes: ["OpenAI Compatible endpoint not available", "65533"],
     });
 
     setEnv("OPENAI_COMPATIBLE_BASE_URL", mockOrigin);
@@ -1084,9 +1107,17 @@ async function main(): Promise<void> {
       messageIncludes: ["Anthropic rate limit exceeded"],
     });
 
+    // Real socket death (not a synthetic message string) via
+    // req.socket.destroy(). Node's native fetch (undici) surfaces this as
+    // `TypeError: fetch failed` wrapping a `SocketError` with message
+    // "other side closed" and code `UND_ERR_SOCKET` on `.cause` — NOT the
+    // literal "ECONNRESET" text or code, matching the mistral case above.
+    // Assertion is correct (buildErrorContext walks `.cause` and the
+    // NetworkError rule matches the transient errorCode set), only the old
+    // name lied about the mechanism.
     setSocketDestroyHandler();
     await expectGenerateError({
-      name: "anthropic: real ECONNRESET -> NetworkError",
+      name: "anthropic: real socket death (UND_ERR_SOCKET) -> NetworkError",
       run: () =>
         gen({ provider: "anthropic", model: "claude-3-5-sonnet-20241022" }),
       messageIncludes: ["Connection error"],

--- a/test/continuous-test-suite-error-classifier-contract.ts
+++ b/test/continuous-test-suite-error-classifier-contract.ts
@@ -197,6 +197,130 @@ void runSuite(async () => {
     );
   });
 
+  section("Batch J Task 1 — buildErrorContext's bounded .cause chain walk");
+
+  await test("buildErrorContext walks a nested .cause (two levels deep) so a transient errorCode still classifies as NetworkError", () => {
+    // Mirrors undici's real shape for a closed-port fetch: the outer
+    // TypeError carries no code, an intermediate wrapper carries no code
+    // either, and the actionable code lives on the innermost cause.
+    const innermost = Object.assign(new Error("refused by peer"), {
+      code: "ECONNREFUSED",
+    });
+    const middle = new Error("socket layer failure", { cause: innermost });
+    const outer = new TypeError("fetch failed", { cause: middle });
+    const result = classifyProviderError(outer, DEFAULT_ERROR_RULES, "acme");
+    assert(
+      result instanceof NetworkError,
+      "a transient code two levels down the cause chain was not surfaced to the rule table",
+    );
+  });
+
+  await test("a signed URL in a nested cause is redacted out of the composed message", () => {
+    // undici puts the full request URL in the cause's message, so composing
+    // it in raw would carry a presigned token into a client-facing error.
+    const innermost = new Error(
+      "request to https://storage.example.com/bucket/key?X-Amz-Signature=deadbeefsecret&X-Amz-Expires=900 failed",
+    );
+    const outer = new TypeError("fetch failed", { cause: innermost });
+    const result = classifyProviderError(outer, DEFAULT_ERROR_RULES, "acme");
+    assert(
+      !result.message.includes("deadbeefsecret"),
+      "the signature value from a nested cause reached the classified message",
+    );
+    assert(
+      !result.message.includes("X-Amz-Signature"),
+      "the signed query string from a nested cause reached the classified message",
+    );
+    // Compare the surviving host exactly rather than by substring: a
+    // substring check would also pass for an attacker-controlled host like
+    // storage.example.com.evil.test, and asserts nothing about what was
+    // actually kept.
+    const survivingUrl = result.message.match(/https?:\/\/[^\s]+/)?.[0];
+    assert(
+      survivingUrl !== undefined &&
+        new URL(survivingUrl).host === "storage.example.com",
+      "redaction did not leave the bare host, so nothing diagnostic survived",
+    );
+  });
+
+  await test("a cyclic .cause chain terminates classification instead of hanging", () => {
+    const a: Error & { cause?: unknown } = new Error("outer link");
+    const b: Error & { cause?: unknown } = Object.assign(
+      new Error("inner link"),
+      { code: "ETIMEDOUT" },
+    );
+    a.cause = b;
+    b.cause = a; // deliberate cycle
+    const start = Date.now();
+    const result = classifyProviderError(a, DEFAULT_ERROR_RULES, "acme");
+    const elapsedMs = Date.now() - start;
+    assert(
+      elapsedMs < 2000,
+      "classification of a cyclic cause chain took too long to return",
+    );
+    assert(
+      result instanceof NetworkError,
+      "a cyclic cause chain carrying a transient code was not classified before the walk was bounded off",
+    );
+  });
+
+  section("Batch J Task 3 — tightened rule-5 (5xx) message matching");
+
+  await test("rule 5 does NOT match an unrelated 3-digit number in message text (max_tokens limit)", () => {
+    const err = new Error("max_tokens (500) exceeds model limit");
+    const result = classifyProviderError(err, DEFAULT_ERROR_RULES, "acme");
+    assert(
+      result instanceof ProviderError,
+      "expected the generic no-match fallback (still ProviderError, per R4's class-invariance)",
+    );
+    assert(
+      !result.message.includes("server error"),
+      "the loose old regex would have misfired on the bare digits in '(500)' — tightened rule 5 must not label this a server error",
+    );
+  });
+
+  await test("rule 5 still matches a real textual 5xx message with no statusCode set (502 Bad Gateway)", () => {
+    const err = new Error("502 Bad Gateway");
+    const result = classifyProviderError(err, DEFAULT_ERROR_RULES, "acme");
+    assert(
+      result instanceof ProviderError,
+      "a real 502-shaped message should still classify as ProviderError",
+    );
+    assert(
+      result.message.includes("acme server error:"),
+      "a real 502-shaped message should still be labeled via rule 5's server-error message, not fall through to the generic no-match message",
+    );
+  });
+
+  await test("rule 5 still matches a real 5xx message wrapped by a generic HTTP client (status code phrasing)", () => {
+    const err = new Error("Request failed with status code 500");
+    const result = classifyProviderError(err, DEFAULT_ERROR_RULES, "acme");
+    assert(
+      result.message.includes("acme server error:"),
+      "a common HTTP-client wrapper phrase ('status code 5xx') should still trigger rule 5",
+    );
+  });
+
+  await test("rule 5's tightening does not change the classified CLASS even where it changes the message (a bare 3-digit number with no qualifying context)", () => {
+    const withoutContext = classifyProviderError(
+      new Error("value must be under 500"),
+      DEFAULT_ERROR_RULES,
+      "acme",
+    );
+    const withStatusCode = classifyProviderError(
+      Object.assign(new Error("value must be under 500"), {
+        status: 500,
+      }),
+      DEFAULT_ERROR_RULES,
+      "acme",
+    );
+    assert(
+      withoutContext instanceof ProviderError &&
+        withStatusCode instanceof ProviderError,
+      "R4: whether or not the message-only regex matches, the class must stay ProviderError — the no-match fallback and rule 5 share the same class",
+    );
+  });
+
   // ===========================================================================
   // Ported from continuous-test-suite-error-classifier-openai-compat.ts
   // (old File2) — Part A test-a (TimeoutError) x19 providers

--- a/test/continuous-test-suite-provider-descriptors.ts
+++ b/test/continuous-test-suite-provider-descriptors.ts
@@ -295,6 +295,236 @@ await runSuite(async () => {
     }
   });
 
+  logSection("apiKeyFormatPattern coverage (8 descriptors set it)");
+
+  await test("apiKeyFormatPattern: every field present on a descriptor is a real RegExp instance", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    for (const d of PROVIDER_DESCRIPTORS as Array<{
+      name: string;
+      apiKeyFormatPattern?: unknown;
+    }>) {
+      if (d.apiKeyFormatPattern !== undefined) {
+        assert(
+          d.apiKeyFormatPattern instanceof RegExp,
+          `${d.name} apiKeyFormatPattern is not a RegExp instance`,
+        );
+      }
+    }
+  });
+
+  await test("apiKeyFormatPattern: descriptors without the field simply omit it, never an empty/no-op pattern", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    // Every 30 canonical names, minus the 8 that legitimately set the field.
+    const withPattern = new Set([
+      "bedrock",
+      "openai",
+      "anthropic",
+      "azure",
+      "google-ai",
+      "huggingface",
+      "mistral",
+      "sagemaker",
+    ]);
+    let checkedAbsent = 0;
+    for (const d of PROVIDER_DESCRIPTORS as Array<{
+      name: string;
+      apiKeyFormatPattern?: unknown;
+    }>) {
+      if (!withPattern.has(d.name)) {
+        assert(
+          d.apiKeyFormatPattern === undefined,
+          `${d.name} unexpectedly carries an apiKeyFormatPattern field`,
+        );
+        checkedAbsent += 1;
+      }
+    }
+    // Sanity: the 30-descriptor set minus the 8 with-pattern entries is 22.
+    assertEqual(
+      checkedAbsent,
+      22,
+      "apiKeyFormatPattern absence count mismatch — descriptor roster may have changed",
+    );
+  });
+
+  // Realistic sample construction, never a real credential. Base units are
+  // built from mixed letters+digits (or uppercase-only for the AWS-shaped
+  // patterns, which are case-sensitive) and combined with .repeat()/.slice()
+  // so exact lengths are computed by the runtime rather than hand-counted —
+  // avoiding an off-by-one that would silently invalidate a positive case.
+  // Reject samples are derived from a REAL competing credential shape
+  // (a different provider's own prefix/format) wherever a realistic mix-up
+  // exists, rather than an arbitrary string that trivially fails.
+  const alnum = "A1b2C3d4E5f6"; // 12 chars, no hyphen/underscore
+  const mixedWithSeparators = "A1b2C3d4E5f6-Xy9Z_"; // 18 chars, incl. -/_
+  const awsUnit = "AKIA1B2C3D4"; // 11 chars, uppercase+digits only
+
+  const awsAccept = awsUnit.repeat(2).slice(0, 20);
+  const azureAccept = alnum.repeat(3).slice(0, 32);
+  const mistralAccept = "Q7wE9rT2yU4i".repeat(3).slice(0, 32);
+  const hfAccept = `hf_${alnum.repeat(4).slice(0, 37)}`;
+  const googleAiAccept = `AIza${mixedWithSeparators.repeat(2).slice(0, 35)}`;
+  const openaiAccept = `sk-${alnum.repeat(4)}`; // 48-char body, meets {48,}
+  // 108-char body (18 * 6), comfortably over the {95,} minimum.
+  const anthropicAccept = `sk-ant-${mixedWithSeparators.repeat(6)}`;
+
+  type PatternCase = {
+    provider: string;
+    accept: string;
+    rejectShape: string;
+  };
+  const patternCases: PatternCase[] = [
+    {
+      provider: "bedrock",
+      accept: awsAccept,
+      // Same 20-char shape, lowercased — the regex is uppercase-only, and a
+      // lowercased paste is a realistic real-world mistake.
+      rejectShape: awsAccept.toLowerCase(),
+    },
+    {
+      provider: "sagemaker",
+      // Same [A-Z0-9]{20} shape as bedrock, but this exercises SageMaker's
+      // OWN apiKeyFormatPattern field (API_KEY_FORMATS.aws), a distinct
+      // RegExp object from bedrock's (API_KEY_FORMATS.bedrock) even though
+      // the source pattern text is identical.
+      accept: awsAccept,
+      rejectShape: awsAccept.toLowerCase(),
+    },
+    {
+      provider: "openai",
+      accept: openaiAccept,
+      // Real-world mix-up: a "pk-" (publishable-key-style) prefix instead
+      // of "sk-", same body shape/length otherwise.
+      rejectShape: `pk-${alnum.repeat(4)}`,
+    },
+    {
+      provider: "anthropic",
+      accept: anthropicAccept,
+      // Real-world mix-up: an OpenAI-shaped "sk-..." key missing the
+      // "ant-" segment Anthropic requires.
+      rejectShape: openaiAccept,
+    },
+    {
+      provider: "azure",
+      accept: azureAccept,
+      // Same content, with a hyphen spliced in — Azure's key has no
+      // separators, unlike a resource/GUID string it's easily confused
+      // with. Also changes the length away from the required 32.
+      rejectShape: `${azureAccept.slice(0, 16)}-${azureAccept.slice(16)}`,
+    },
+    {
+      provider: "google-ai",
+      accept: googleAiAccept,
+      // Real-world mix-up: Google's own OAuth access-token prefix
+      // ("ya29.") instead of the API-key prefix ("AIza").
+      rejectShape: `ya29.${mixedWithSeparators.repeat(2).slice(0, 35)}`,
+    },
+    {
+      provider: "huggingface",
+      accept: hfAccept,
+      // Real-world mix-up: a GitHub personal-access-token prefix ("ghp_")
+      // instead of HuggingFace's ("hf_").
+      rejectShape: `ghp_${alnum.repeat(4).slice(0, 36)}`,
+    },
+    {
+      provider: "mistral",
+      accept: mistralAccept,
+      rejectShape: `${mistralAccept.slice(0, 16)}-${mistralAccept.slice(16)}`,
+    },
+  ];
+
+  await test("apiKeyFormatPattern: accepts a realistic well-formed sample per provider", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    const byName = new Map(
+      (
+        PROVIDER_DESCRIPTORS as Array<{
+          name: string;
+          apiKeyFormatPattern?: RegExp;
+        }>
+      ).map((d) => [d.name, d]),
+    );
+    for (const { provider, accept } of patternCases) {
+      const pattern = byName.get(provider)?.apiKeyFormatPattern;
+      assert(
+        pattern !== undefined,
+        `${provider} descriptor is missing its apiKeyFormatPattern field`,
+      );
+      assert(
+        pattern!.test(accept),
+        `${provider} apiKeyFormatPattern rejected a realistic well-formed sample`,
+      );
+    }
+  });
+
+  await test("apiKeyFormatPattern: rejects an empty string per provider", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    const byName = new Map(
+      (
+        PROVIDER_DESCRIPTORS as Array<{
+          name: string;
+          apiKeyFormatPattern?: RegExp;
+        }>
+      ).map((d) => [d.name, d]),
+    );
+    for (const { provider } of patternCases) {
+      const pattern = byName.get(provider)?.apiKeyFormatPattern;
+      assert(
+        pattern !== undefined && !pattern.test(""),
+        `${provider} apiKeyFormatPattern accepted an empty string`,
+      );
+    }
+  });
+
+  await test("apiKeyFormatPattern: rejects a wrong-prefix/wrong-shape sample per provider", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    const byName = new Map(
+      (
+        PROVIDER_DESCRIPTORS as Array<{
+          name: string;
+          apiKeyFormatPattern?: RegExp;
+        }>
+      ).map((d) => [d.name, d]),
+    );
+    for (const { provider, rejectShape } of patternCases) {
+      const pattern = byName.get(provider)?.apiKeyFormatPattern;
+      assert(
+        pattern !== undefined && !pattern.test(rejectShape),
+        `${provider} apiKeyFormatPattern accepted a wrong-shape sample`,
+      );
+    }
+  });
+
+  await test("apiKeyFormatPattern: completes well under a second against a 10k-char pathological input (ReDoS guard)", async () => {
+    const { PROVIDER_DESCRIPTORS } = await import("../dist/index.js");
+    const byName = new Map(
+      (
+        PROVIDER_DESCRIPTORS as Array<{
+          name: string;
+          apiKeyFormatPattern?: RegExp;
+        }>
+      ).map((d) => [d.name, d]),
+    );
+    // Pathological-ish input: 10k chars that are almost-but-not-quite a
+    // match for several of these patterns at once (mixed prefix text
+    // followed by a long alnum run), to stress any backtracking, not just
+    // an unrelated random string.
+    const pathological = `sk-ant-AIzahf_${"A1b2C3d4E5f6".repeat(833)}`; // ~10k chars
+    assert(
+      pathological.length > 9_900,
+      "pathological ReDoS-guard fixture is shorter than intended",
+    );
+    for (const { provider } of patternCases) {
+      const pattern = byName.get(provider)?.apiKeyFormatPattern;
+      assert(pattern !== undefined, `${provider} descriptor pattern missing`);
+      const start = performance.now();
+      pattern!.test(pathological);
+      const elapsedMs = performance.now() - start;
+      assert(
+        elapsedMs < 500,
+        `${provider} apiKeyFormatPattern took too long against a pathological input (${elapsedMs.toFixed(1)}ms)`,
+      );
+    }
+  });
+
   logSection("providerUtils env-var checks cover all 30 providers");
 
   await test("hasProviderEnvVars recognizes a provider outside the old 10-case switch (regression)", async () => {
@@ -452,7 +682,11 @@ await runSuite(async () => {
     );
   });
 
-  await test("getRequiredEnvironmentVariables still delegates vertex/bedrock/litellm to their specific-config checks (regression)", async () => {
+  await test("getRequiredEnvironmentVariables still delegates vertex/bedrock/litellm to their specific-config checks via credentialsResolvedExternally (regression)", async () => {
+    // Was backed by a hand-maintained ENV_CHECK_DELEGATED_TO_SPECIFIC_CONFIG
+    // Set; now derived from descriptor.credentialsResolvedExternally. Same
+    // observable behavior — proven identical for all 30 providers + all
+    // aliases by a before/after capture across the refactor.
     const { ProviderHealthChecker } =
       await import("../dist/utils/providerHealth.js");
     for (const providerName of ["vertex", "bedrock", "litellm"] as const) {
@@ -464,13 +698,14 @@ await runSuite(async () => {
     }
   });
 
-  await test("getRequiredEnvironmentVariables resolves aliases before consulting the specific-config delegation set (regression)", async () => {
+  await test("getRequiredEnvironmentVariables resolves aliases before consulting the credentialsResolvedExternally delegation field (regression)", async () => {
     const { ProviderHealthChecker } =
       await import("../dist/utils/providerHealth.js");
     // "googleVertex" and "aws" are documented aliases for vertex/bedrock.
-    // The delegation check must key off the resolved descriptor name, not
-    // the raw alias string, or it silently skips delegation for aliased
-    // input and reports a false non-empty required-vars list.
+    // The delegation check must key off the resolved descriptor's
+    // credentialsResolvedExternally field, not the raw alias string, or it
+    // silently skips delegation for aliased input and reports a false
+    // non-empty required-vars list.
     assertEqual(
       ProviderHealthChecker.getRequiredEnvironmentVariables("googleVertex")
         .length,
@@ -602,7 +837,12 @@ await runSuite(async () => {
 
   logSection("setup.ts checkExistingConfigurations derived from descriptors");
 
-  await test("checkExistingConfigurations detects together via descriptor-driven logic (characterization)", async () => {
+  await test("checkExistingConfigurations: primary key alone is enough for a provider with no extraRequired (mistral)", async () => {
+    // Renamed from "...detects together via descriptor-driven logic
+    // (characterization)" — that name was a leftover from an earlier
+    // together-ai-flavored version of this test; it pins MISTRAL_API_KEY
+    // and asserts "mistral", not "together". Kept mistral (no fallbacks, no
+    // extraRequired) as the cleanest primary-key-only case.
     const savedMistral = process.env.MISTRAL_API_KEY;
     process.env.MISTRAL_API_KEY = "test-key-for-suite-only";
     try {
@@ -618,6 +858,151 @@ await runSuite(async () => {
         delete process.env.MISTRAL_API_KEY;
       } else {
         process.env.MISTRAL_API_KEY = savedMistral;
+      }
+    }
+  });
+
+  await test("checkExistingConfigurations: a fallback env var alone satisfies the primary-key check (anthropic OAuth token, no ANTHROPIC_API_KEY)", async () => {
+    const controlledVars = [
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_OAUTH_TOKEN",
+      "CLAUDE_OAUTH_TOKEN",
+      "ANTHROPIC_OAUTH_ACCESS_TOKEN",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      delete process.env.ANTHROPIC_API_KEY;
+      process.env.ANTHROPIC_OAUTH_TOKEN = "test-oauth-token-for-suite-only";
+      delete process.env.CLAUDE_OAUTH_TOKEN;
+      delete process.env.ANTHROPIC_OAUTH_ACCESS_TOKEN;
+      const { checkExistingConfigurations } =
+        await import("../dist/cli/commands/setup.js");
+      const configured = await checkExistingConfigurations();
+      assert(
+        configured.includes("anthropic"),
+        "anthropic should be detected from its OAuth fallback var alone",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
+      }
+    }
+  });
+
+  await test("checkExistingConfigurations: extraRequired vars are ANDed with the primary key, not treated as optional (bedrock)", async () => {
+    const controlledVars = [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      const { checkExistingConfigurations } =
+        await import("../dist/cli/commands/setup.js");
+
+      // Primary key alone, secret unset: extraRequired must block reporting.
+      process.env.AWS_ACCESS_KEY_ID = "test-access-key-for-suite-only";
+      delete process.env.AWS_SECRET_ACCESS_KEY;
+      const withoutSecret = await checkExistingConfigurations();
+      assert(
+        !withoutSecret.includes("bedrock"),
+        "bedrock should not be reported without its extraRequired secret var",
+      );
+
+      // Both present: now it should report.
+      process.env.AWS_SECRET_ACCESS_KEY = "test-secret-key-for-suite-only";
+      const withSecret = await checkExistingConfigurations();
+      assert(
+        withSecret.includes("bedrock"),
+        "bedrock should be reported once both its primary and extraRequired vars are set",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
+      }
+    }
+  });
+
+  await test("checkExistingConfigurations: vertex's nested extraRequiredFallbacks pair requires BOTH halves, not one (email+key, via the real setup.ts function)", async () => {
+    // Distinct from the hasProviderEnvVars pair tests further below — this
+    // drives the actual setup.ts checkExistingConfigurations() function
+    // (its own satisfiesFallbacks call site), not providerUtils.
+    const controlledVars = [
+      "GOOGLE_CLOUD_PROJECT_ID",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK",
+      "GOOGLE_SERVICE_ACCOUNT_KEY",
+      "GOOGLE_AUTH_CLIENT_EMAIL",
+      "GOOGLE_AUTH_PRIVATE_KEY",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      const { checkExistingConfigurations } =
+        await import("../dist/cli/commands/setup.js");
+
+      // Primary satisfied, extraRequired unset, only ONE half of the pair.
+      process.env.GOOGLE_CLOUD_PROJECT_ID = "test-project-for-suite-only";
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK;
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+      process.env.GOOGLE_AUTH_CLIENT_EMAIL = "test-email-for-suite-only";
+      delete process.env.GOOGLE_AUTH_PRIVATE_KEY;
+      const oneHalf = await checkExistingConfigurations();
+      assert(
+        !oneHalf.includes("vertex"),
+        "vertex should not be reported from the email half of the pair alone",
+      );
+
+      // Now both halves.
+      process.env.GOOGLE_AUTH_PRIVATE_KEY = "test-key-for-suite-only";
+      const bothHalves = await checkExistingConfigurations();
+      assert(
+        bothHalves.includes("vertex"),
+        "vertex should be reported once both halves of the email+key pair are set",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
+      }
+    }
+  });
+
+  await test("checkExistingConfigurations: a provider with no primary key set is not reported (openrouter)", async () => {
+    const saved = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    try {
+      const { checkExistingConfigurations } =
+        await import("../dist/cli/commands/setup.js");
+      const configured = await checkExistingConfigurations();
+      assert(
+        !configured.includes("openrouter"),
+        "openrouter should not be reported with no primary key var set",
+      );
+    } finally {
+      if (saved === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = saved;
       }
     }
   });
@@ -651,6 +1036,172 @@ await runSuite(async () => {
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       } else {
         process.env.GOOGLE_APPLICATION_CREDENTIALS = savedCredentials;
+      }
+    }
+  });
+
+  logSection(
+    "extraRequiredFallbacks paired-credential semantics (Vertex email+key)",
+  );
+
+  await test("satisfiesFallbacks: undefined fallbacks list is unsatisfied", async () => {
+    const { satisfiesFallbacks } =
+      await import("../dist/utils/providerConfig.js");
+    assert(
+      satisfiesFallbacks(undefined, {}) === false,
+      "an undefined fallbacks list should never be satisfied",
+    );
+  });
+
+  await test("satisfiesFallbacks: a flat string entry is satisfied alone", async () => {
+    const { satisfiesFallbacks } =
+      await import("../dist/utils/providerConfig.js");
+    assert(
+      satisfiesFallbacks(["SOME_VAR"], { SOME_VAR: "x" }) === true,
+      "a flat entry present in env should satisfy on its own",
+    );
+    assert(
+      satisfiesFallbacks(["SOME_VAR"], {}) === false,
+      "a flat entry absent from env should not satisfy",
+    );
+  });
+
+  await test("satisfiesFallbacks: a paired entry requires every name in the pair, not just one", async () => {
+    const { satisfiesFallbacks } =
+      await import("../dist/utils/providerConfig.js");
+    const pairFallback = [["EMAIL_VAR", "KEY_VAR"]] as const;
+    assert(
+      satisfiesFallbacks(pairFallback, { EMAIL_VAR: "e" }) === false,
+      "email half alone should not satisfy a paired entry",
+    );
+    assert(
+      satisfiesFallbacks(pairFallback, { KEY_VAR: "k" }) === false,
+      "key half alone should not satisfy a paired entry",
+    );
+    assert(
+      satisfiesFallbacks(pairFallback, { EMAIL_VAR: "e", KEY_VAR: "k" }) ===
+        true,
+      "both halves present together should satisfy a paired entry",
+    );
+  });
+
+  await test("satisfiesFallbacks: a flat entry later in the list still satisfies when an earlier paired entry doesn't", async () => {
+    const { satisfiesFallbacks } =
+      await import("../dist/utils/providerConfig.js");
+    const mixed = [["EMAIL_VAR", "KEY_VAR"], "SERVICE_ACCOUNT_VAR"] as const;
+    assert(
+      satisfiesFallbacks(mixed, { SERVICE_ACCOUNT_VAR: "s" }) === true,
+      "a satisfied flat entry should still win even when a preceding paired entry is unsatisfied",
+    );
+  });
+
+  await test("vertex descriptor: GOOGLE_AUTH_CLIENT_EMAIL alone (no private key) does not satisfy the paired fallback", async () => {
+    const controlledVars = [
+      "GOOGLE_CLOUD_PROJECT_ID",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK",
+      "GOOGLE_SERVICE_ACCOUNT_KEY",
+      "GOOGLE_AUTH_CLIENT_EMAIL",
+      "GOOGLE_AUTH_PRIVATE_KEY",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      process.env.GOOGLE_CLOUD_PROJECT_ID = "test-project-for-suite-only";
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK;
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+      process.env.GOOGLE_AUTH_CLIENT_EMAIL = "test-email-for-suite-only";
+      delete process.env.GOOGLE_AUTH_PRIVATE_KEY;
+      const { hasProviderEnvVars } =
+        await import("../dist/utils/providerUtils.js");
+      assert(
+        hasProviderEnvVars("vertex") === false,
+        "vertex should not be considered configured from the client email alone",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
+      }
+    }
+  });
+
+  await test("vertex descriptor: GOOGLE_AUTH_PRIVATE_KEY alone (no client email) does not satisfy the paired fallback", async () => {
+    const controlledVars = [
+      "GOOGLE_CLOUD_PROJECT_ID",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK",
+      "GOOGLE_SERVICE_ACCOUNT_KEY",
+      "GOOGLE_AUTH_CLIENT_EMAIL",
+      "GOOGLE_AUTH_PRIVATE_KEY",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      process.env.GOOGLE_CLOUD_PROJECT_ID = "test-project-for-suite-only";
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK;
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+      delete process.env.GOOGLE_AUTH_CLIENT_EMAIL;
+      process.env.GOOGLE_AUTH_PRIVATE_KEY = "test-key-for-suite-only";
+      const { hasProviderEnvVars } =
+        await import("../dist/utils/providerUtils.js");
+      assert(
+        hasProviderEnvVars("vertex") === false,
+        "vertex should not be considered configured from the private key alone",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
+      }
+    }
+  });
+
+  await test("vertex descriptor: GOOGLE_AUTH_CLIENT_EMAIL + GOOGLE_AUTH_PRIVATE_KEY together satisfy the paired fallback", async () => {
+    const controlledVars = [
+      "GOOGLE_CLOUD_PROJECT_ID",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK",
+      "GOOGLE_SERVICE_ACCOUNT_KEY",
+      "GOOGLE_AUTH_CLIENT_EMAIL",
+      "GOOGLE_AUTH_PRIVATE_KEY",
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const v of controlledVars) {
+      saved[v] = process.env[v];
+    }
+    try {
+      process.env.GOOGLE_CLOUD_PROJECT_ID = "test-project-for-suite-only";
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS_NEUROLINK;
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+      process.env.GOOGLE_AUTH_CLIENT_EMAIL = "test-email-for-suite-only";
+      process.env.GOOGLE_AUTH_PRIVATE_KEY = "test-key-for-suite-only";
+      const { hasProviderEnvVars } =
+        await import("../dist/utils/providerUtils.js");
+      assert(
+        hasProviderEnvVars("vertex") === true,
+        "vertex should be considered configured from the email+key pair together",
+      );
+    } finally {
+      for (const v of controlledVars) {
+        if (saved[v] === undefined) {
+          delete process.env[v];
+        } else {
+          process.env[v] = saved[v];
+        }
       }
     }
   });

--- a/tools/automation/environmentManager.ts
+++ b/tools/automation/environmentManager.ts
@@ -10,6 +10,7 @@ import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { PROVIDER_DESCRIPTORS } from "../../src/lib/factories/providerDescriptors.js";
+import { satisfiesFallbacks } from "../../src/lib/utils/providerConfig.js";
 
 class EnvironmentManager {
   envFile: string;
@@ -260,7 +261,7 @@ class EnvironmentManager {
         !!apiKey && (!!env[apiKey] || (fallbacks ?? []).some((v) => !!env[v]));
       const requiredOk =
         (extraRequired ?? []).every((v) => !!env[v]) ||
-        (extraRequiredFallbacks ?? []).some((v) => !!env[v]);
+        satisfiesFallbacks(extraRequiredFallbacks, env);
       providers[d.name] = hasPrimary && requiredOk;
     }
 


### PR DESCRIPTION
# Follow-ups from the provider overhaul: error classification, credential semantics, and test honesty

Seven small, independently reviewed commits clearing the backlog that accumulated across waves 1 and 2 (PRs #1335 and #1337), plus the real findings from #1337's bot review. Every commit passed the repo's pre-commit gate; each batch passed an independent spec-and-quality review.

## Correctness

**Transport failures were never classified as network errors.** `DEFAULT_ERROR_RULES`' NetworkError rule matches `ECONNRESET`/`ECONNREFUSED`/etc., but Node's native `fetch` throws `TypeError: fetch failed` and nests the real cause one level down, where nothing looked. So every bare-`fetch` provider fell through to a generic `ProviderError` on a dropped connection — the rule could not fire at all. `buildErrorContext` now walks the `.cause` chain (bounded to 5 links, cycle-guarded) and composes the messages, and the rule also matches structured error codes against the transient-code set that `proxyFetch` already maintained. That set now lives in one shared module instead of two copies that could drift.

Two tests in the end-to-end suite had been pinning the broken behavior on purpose; they now assert the fixed behavior. Both also turned out to describe mechanisms that never occur — see below.

**Vertex reported itself configured with half a credential.** `extraRequiredFallbacks` was a flat "any one of these suffices" list, which cannot express that `GOOGLE_AUTH_CLIENT_EMAIL` and `GOOGLE_AUTH_PRIVATE_KEY` are only valid together — so a machine with just the email reported Vertex as available, then failed at construction. The field now accepts a nested array meaning "all of these together", and Vertex uses it. Flat entries keep their exact prior meaning, so only Vertex's evaluation changed — and it changed to agree with `hasGoogleCredentials()`, the real auth gate, verified across all 32 combinations of the relevant variables. All five call sites (`hasProviderEnvVars`, two health checks, the CLI setup path, the environment manager) now share one helper rather than four hand-written checks that could drift apart again.

**A stray number could look like a server error.** The 5xx rule matched any bare 500-599 in a message, so `max_tokens (500) exceeds model limit` took the server-error branch. It now requires status-shaped context or a named 5xx phrase. No classified class changes — the rule's class is the same one the no-match fallback returns.

## Developer infrastructure

**`pre-commit.sh` swept unrelated work into commits.** Its "add formatted files" step re-staged every modified tracked file, not just the ones prettier had reformatted, so any in-progress edit sitting in the tree landed in whatever commit you made. This happened during wave 2 and had to be reverted. It now stages only files that are both reformatted and already part of the commit, NUL-delimited so filenames with spaces survive.

*Correction worth recording:* the commit body claims a `--cached`-only check would stop staging formatting fixes. Review disproved that — `format-staged` only ever formats staged files, so the two are equivalent today. The intersection is still the right shape, and stays correct if that scope ever widens.

**`dist/lib` is not a stale artifact.** Carried as a cleanup item since wave 2 on the assumption it was a `svelte-package` remnant. It isn't: it's tsc's `build:cli` output (its tsconfig has `rootDir: ./src` and includes `src/lib/**`, preserving the path segment), while the flat `dist/` comes from `svelte-package`. Both are regenerated by every build. Closed as a misdiagnosis, no work needed.

## Tests that were not testing what they claimed

This is the throughline. Six separate cases, every one surfaced by making a test drive the real shipped surface or by checking a claim against source:

- Context-suite test 6.8 has failed on every run since before this work began, and a path fix alone would not have revived it. It read flat `dist/lib/providers/openRouter.js` paths for providers that are directories — *and* its regex looked for a no-output detector those providers never call, since both inherit an inline sentinel from `OpenAIChatCompletionsProvider`. With correct paths it still would never have matched. Rewritten against the real mechanism and proven capable of failing.
- The anthropic transport test was named "real ECONNRESET" while using a socket-destroy handler that produces a `SocketError` with code `UND_ERR_SOCKET`. Renamed.
- The two end-to-end transport pins claimed `ECONNRESET` and `ECONNREFUSED`; one produced a socket error, the other pointed at port 1, which undici rejects via its bad-ports blocklist before attempting any connection. Fixed and re-pointed at a genuinely closed port.
- (In #1337) an OpenAI-compat retry test's "exactly 2 attempts" was satisfied by a `GET /models` auto-discovery probe eating the first attempt, so the retry under test never ran; and a `loadFromURL` retry test counted a HEAD pre-flight whose failure is never charged to the retry budget.

A follow-up sweep of both suites found no further instances.

## Coverage

`apiKeyFormatPattern` is populated on 8 descriptors and consumed at runtime with nothing testing the patterns, so a bad one would ship silently. Each is now asserted to be a real RegExp that accepts a well-formed synthetic sample, rejects an empty string, rejects a competing credential shape someone might plausibly paste instead (a Google OAuth token where an API key belongs, a GitHub token where a Hugging Face one does), and survives a 10k-character pathological input well inside half a second, so a future pattern cannot introduce catastrophic backtracking. No sample is a real credential.

`checkExistingConfigurations` goes from one characterization test to seven, now that it decides CLI-reported configuration from descriptor data — including one pinning Vertex's nested pair, which only became meaningful with the change above.

The display and delegation helpers flagged alongside it are deliberately left untested: they format console output or switch to a handler, so a test could only assert that a log was written or that a switch switches — constraining future refactoring without catching anything.

`providerHealth`'s hand-maintained delegation Set (bedrock, vertex, litellm return no required env vars, since their credentials come from an external chain, an OR of auth paths, or nothing) is folded into a documented descriptor field. Verified behavior-identical across all 30 providers and every alias.

## Known, not addressed here

`neurolink setup --provider X --check` and `--non-interactive` are silently dropped: `delegateToProviderSetup` hardcodes both to false and `handleSetup` never forwards the caller's values, even though 8 of the 9 dedicated handlers honor them when invoked directly. Confirmed user-visible and pre-existing since 2025-09-09 — it belongs in its own change rather than riding along here.

`test:context` still shows one failure, now a live-API summarization heuristic rather than 6.8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider credential detection, including paired fallback credentials and externally managed authentication.
  * More accurately classify transient network failures and nested error causes while reducing false server-error matches.
  * Improved setup and health checks across supported providers.
  * Added protection for sensitive URLs in nested error messages.

* **Tests**
  * Expanded coverage for credentials, authentication fallbacks, network errors, and cyclic error chains.
  * Updated integration checks for realistic transport failures and provider-specific messages.

* **Chores**
  * Improved pre-commit formatting behavior for staged, modified, and deleted files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->