### PR TITLE
ci(workflows): install ffmpeg from apt instead of a third-party downloader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,21 +24,25 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
+      # Installed from the runner's package index rather than a third-party
+      # action that downloads release assets from another repository. That
+      # action has broken this pipeline twice: first when the 8.1 asset was
+      # published corrupt, then again when the 7.1 pin added to work around
+      # it stopped resolving. Neither failure was caused by anything in this
+      # repository, and both blocked every open pull request. apt carries a
+      # version new enough for what the suites exercise, and it cannot be
+      # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
-          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
-          # job at download ("xz: File format not recognized"). Revert once
-          # upstream republishes a valid 8.1 build.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
           echo "🎬 Verifying ffmpeg installation..."
           ffmpeg -version || {
             echo "❌ ffmpeg installation failed!"
-            echo "Please check the setup-ffmpeg action configuration."
+            echo "apt-get install ffmpeg did not produce a working binary."
             exit 1
           }
           echo "✅ ffmpeg installed successfully"
@@ -189,21 +193,25 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
+      # Installed from the runner's package index rather than a third-party
+      # action that downloads release assets from another repository. That
+      # action has broken this pipeline twice: first when the 8.1 asset was
+      # published corrupt, then again when the 7.1 pin added to work around
+      # it stopped resolving. Neither failure was caused by anything in this
+      # repository, and both blocked every open pull request. apt carries a
+      # version new enough for what the suites exercise, and it cannot be
+      # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
-          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
-          # job at download ("xz: File format not recognized"). Revert once
-          # upstream republishes a valid 8.1 build.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
           echo "🎬 Verifying ffmpeg installation..."
           ffmpeg -version || {
             echo "❌ ffmpeg installation failed!"
-            echo "Please check the setup-ffmpeg action configuration."
+            echo "apt-get install ffmpeg did not produce a working binary."
             exit 1
           }
           echo "✅ ffmpeg installed successfully"
@@ -266,21 +274,25 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
+      # Installed from the runner's package index rather than a third-party
+      # action that downloads release assets from another repository. That
+      # action has broken this pipeline twice: first when the 8.1 asset was
+      # published corrupt, then again when the 7.1 pin added to work around
+      # it stopped resolving. Neither failure was caused by anything in this
+      # repository, and both blocked every open pull request. apt carries a
+      # version new enough for what the suites exercise, and it cannot be
+      # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release. The default (latest → FFmpeg 8.1)
-          # BtbN/FFmpeg-Builds Linux asset is currently corrupt and fails the
-          # job at download ("xz: File format not recognized"). Revert once
-          # upstream republishes a valid 8.1 build.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
           echo "🎬 Verifying ffmpeg installation..."
           ffmpeg -version || {
             echo "❌ ffmpeg installation failed!"
-            echo "Please check the setup-ffmpeg action configuration."
+            echo "apt-get install ffmpeg did not produce a working binary."
             exit 1
           }
           echo "✅ ffmpeg installed successfully"


### PR DESCRIPTION
CI is currently red on every open pull request, and not because of anything in the code.

`AnimMouse/setup-ffmpeg` downloads release assets from another repository, and that dependency has now broken this pipeline twice:

1. The default (latest → 8.1) asset was published corrupt — jobs failed at download with `xz: File format not recognized`. The workaround pinned `version: "7.1"`, with a comment to revert once upstream republished.
2. The 7.1 pin has now stopped resolving too. The step exits 2 immediately after the release-id lookup, taking `test`, `build-check` and the quality gate down with it in about 20 seconds.

Reproduced on https://github.com/juspay/neurolink/pull/1341: all three jobs failed at `Install ffmpeg`, twice, including after a re-run.

This replaces all three copies of the step with an apt install. The version in the runner's package index is new enough for what the media suites exercise, the index is already on the image, and an upstream release being moved, rebuilt or rate-limited can no longer take the pipeline down.

The fix validates itself: if this PR's own CI goes green, the step works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the consistency of automated build, test, and quality checks.
  * Standardized media-processing tool setup across validation workflows.
  * Enhanced release verification reliability by simplifying the continuous integration environment.
  * Updated setup checks to provide clearer guidance when required tools are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->