### PR TITLE
fix(cli): forward setup --check and --non-interactive flags to provider delegation

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -332,7 +332,10 @@ export async function handleSetup(argv: SetupArgs): Promise<void> {
     }
 
     if (argv.provider && argv.provider !== "auto") {
-      return await delegateToProviderSetup(argv.provider);
+      return await delegateToProviderSetup(argv.provider, {
+        check: argv.check,
+        nonInteractive: argv.nonInteractive,
+      });
     }
 
     // Main setup wizard
@@ -611,11 +614,17 @@ async function runProviderSelection(): Promise<void> {
  */
 export async function delegateToProviderSetup(
   providerId: string,
-): Promise<void> {
-  const setupArgs = {
-    nonInteractive: false,
-    "non-interactive": false,
+  flags: { check?: boolean; nonInteractive?: boolean } = {
     check: false,
+    nonInteractive: false,
+  },
+): Promise<void> {
+  const nonInteractive = flags.nonInteractive ?? false;
+  const check = flags.check ?? false;
+  const setupArgs = {
+    nonInteractive,
+    "non-interactive": nonInteractive,
+    check,
     _: [] as (string | number)[],
     $0: "neurolink",
   };

--- a/src/lib/types/cli.ts
+++ b/src/lib/types/cli.ts
@@ -675,6 +675,8 @@ export type SetupArgs = {
   status?: boolean;
   interactive?: boolean;
   help?: boolean;
+  check?: boolean;
+  nonInteractive?: boolean;
 };
 
 /**

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -10103,6 +10103,125 @@ exit 127
       }
     },
   },
+  // ---------- setup command --check/--non-interactive flag forwarding ----------
+  // `neurolink setup --provider <p> --check` used to build its delegated
+  // provider-setup argv with `check`/`nonInteractive` hardcoded to `false`,
+  // silently dropping whatever the caller passed. With a credential already
+  // present, that meant `--check` still fell through to an interactive
+  // "do you want to reconfigure?" prompt instead of the check-only path — and
+  // with no TTY attached (stdio "ignore" below, matching how CI/scripts
+  // invoke the CLI), inquirer aborted with "User force closed the prompt"
+  // and the process exited non-zero. `stdio: ["ignore", ...]` gives stdin an
+  // immediate EOF, exactly like the failure mode this test targets — a
+  // hanging prompt would instead be caught by the `timeout` below.
+  {
+    name: "CLI setup: --provider <p> --check takes the check-only path (no interactive prompt, no hang)",
+    category: "cli",
+    fn: async () => {
+      const { spawnSync } = await import("node:child_process");
+      const { existsSync } = await import("node:fs");
+      const cli = "dist/cli/index.js";
+      if (!existsSync(cli)) {
+        return true; // dist not built in this run — covered by CI's built CLI.
+      }
+      // Force the "credential already present" branch deterministically,
+      // independent of whatever OPENAI_API_KEY happens to be set to in the
+      // ambient test environment — no network call is made either way, the
+      // check-only path only reads env vars.
+      const env = {
+        ...process.env,
+        NO_COLOR: "1",
+        OPENAI_API_KEY: "sk-test-fake-key-for-flag-forwarding-check",
+      };
+      const r = spawnSync(
+        process.execPath,
+        [cli, "setup", "--provider", "openai", "--check"],
+        {
+          encoding: "utf8",
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 10_000,
+        },
+      );
+      const combined = `${r.stdout}${r.stderr}`;
+      return (
+        r.status === 0 &&
+        r.signal === null &&
+        /OpenAI setup complete/.test(combined) &&
+        !/Do you want to reconfigure/.test(combined) &&
+        !/force closed/.test(combined)
+      );
+    },
+  },
+  {
+    name: "CLI setup: --provider <p> --check behaves the same as the dedicated `setup <p> --check` subcommand",
+    category: "cli",
+    fn: async () => {
+      const { spawnSync } = await import("node:child_process");
+      const { existsSync } = await import("node:fs");
+      const cli = "dist/cli/index.js";
+      if (!existsSync(cli)) {
+        return true;
+      }
+      const env = {
+        ...process.env,
+        NO_COLOR: "1",
+        OPENAI_API_KEY: "sk-test-fake-key-for-flag-forwarding-check",
+      };
+      const run = (args: string[]) =>
+        spawnSync(process.execPath, [cli, ...args], {
+          encoding: "utf8",
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 10_000,
+        });
+      const viaFlag = run(["setup", "--provider", "openai", "--check"]);
+      const viaSubcommand = run(["setup", "openai", "--check"]);
+      const combined = (r: { stdout: string; stderr: string }) =>
+        `${r.stdout}${r.stderr}`;
+      return (
+        viaFlag.status === 0 &&
+        viaSubcommand.status === 0 &&
+        /OpenAI setup complete/.test(combined(viaFlag)) &&
+        /OpenAI setup complete/.test(combined(viaSubcommand))
+      );
+    },
+  },
+  {
+    name: "CLI setup: --provider <p> --non-interactive skips the reconfigure prompt (no hang)",
+    category: "cli",
+    fn: async () => {
+      const { spawnSync } = await import("node:child_process");
+      const { existsSync } = await import("node:fs");
+      const cli = "dist/cli/index.js";
+      if (!existsSync(cli)) {
+        return true;
+      }
+      const env = {
+        ...process.env,
+        NO_COLOR: "1",
+        OPENAI_API_KEY: "sk-test-fake-key-for-flag-forwarding-check",
+      };
+      const r = spawnSync(
+        process.execPath,
+        [cli, "setup", "--provider", "openai", "--non-interactive"],
+        {
+          encoding: "utf8",
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 10_000,
+        },
+      );
+      const combined = `${r.stdout}${r.stderr}`;
+      return (
+        r.status === 0 &&
+        r.signal === null &&
+        /Using existing OpenAI configuration/.test(combined) &&
+        !/Do you want to reconfigure/.test(combined) &&
+        !/force closed/.test(combined)
+      );
+    },
+  },
 ];
 
 // ============================================================================


### PR DESCRIPTION
`neurolink setup --provider openai --check` ignores `--check`. It falls into the interactive "reconfigure?" prompt, and with no TTY — a script, a CI job — it crashes with `User force closed the prompt` and exits 1. `--non-interactive` is dropped the same way. Confirmed against the built CLI, not by reading.

The positional form `neurolink setup openai --check` works correctly, because it dispatches straight to the provider handler and never passes through `handleSetup`. That was the reference for correct behavior.

## Cause

Not a missing flag declaration — yargs accepts both flags today. The break is in the handler layer:

- `SetupArgs` had no `check`/`nonInteractive` fields, so `handleSetup` had no typed way to read what the user passed.
- `delegateToProviderSetup` hardcoded `check: false` and `nonInteractive: false` regardless of argv, then handed that to the per-provider handlers — which do honor the flags when they receive them.

Pre-existing since 2025-09-09.

## Fix

Adds the two fields to `SetupArgs`, forwards them from `handleSetup`, and gives `delegateToProviderSetup` a second parameter that defaults to the previous hardcoded values, so the interactive-wizard call site is byte-identical. The kebab-case `"non-interactive"` duplicate is kept in sync, because two handlers read that key rather than the camelCase one.

## Tests

Three tests added to the existing CLI-subprocess suite, driving `node dist/cli/index.js`: `--check` takes the check-only path without prompting or hanging; the flag form matches the dedicated positional subcommand's `--check`; and `--non-interactive` works on its own. They use a provider whose check path reads only env vars, a fixed fake key for determinism, and closed stdin so a regression reproduces the original hang rather than waiting on a terminal.

Verified failing before the fix: with the source change stashed and rebuilt, all three fail for real (275 passed / 3 failed, non-zero exit). After: 278/278.

## Noted, not changed

- `CLICommandFactory.createSetupCommand()` in `commandFactory.ts` is dead code — `parser.ts` registers the `setupCommandFactory` version and never calls it. Deleting it is a separate cleanup.
- `setup --list` exits 1 and `setup --status` hangs. Both are broken today, independent of this change, and confirmed unaffected by it.

CI on this branch will fail at `Install ffmpeg` until #1342 lands; that failure is unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed setup command flags so `--check` correctly performs a non-interactive validation without prompting or hanging.
  * Fixed `--non-interactive` to reuse existing provider configuration without prompting.
  * Ensured setup flags work consistently across supported command formats.

* **Tests**
  * Added regression coverage for setup validation and non-interactive configuration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->