### PR TITLE
ci(release): install ffmpeg from apt, matching ci.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release, matching ci.yml. The unpinned default
-          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
-          # the download 404s and fails the job at extract ("xz: (stdin): File
-          # format not recognized"). Revert once upstream publishes it.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -87,13 +83,9 @@ jobs:
           cache: "pnpm"
 
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release, matching ci.yml. The unpinned default
-          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
-          # the download 404s and fails the job at extract ("xz: (stdin): File
-          # format not recognized"). Revert once upstream publishes it.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |


### PR DESCRIPTION
`050af574` moved **ci.yml** off `AnimMouse/setup-ffmpeg` and onto the runner's own apt. **release.yml kept the action in both of its jobs**, still pinned to `version: "7.1"`.

## Why that pin is broken

The action downloads from `BtbN/FFmpeg-Builds`, whose asset list rotates. Checked against the API just now — the `latest` release carries:

```
ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz
ffmpeg-n9.0-latest-linux64-gpl-9.0.tar.xz
```

No `n7.1` at all. The request 404s, the action pipes the HTML error page into `tar`, and the job dies with:

```
xz: (stdin): File format not recognized
tar: Error is not recoverable: exiting now
```

which names neither ffmpeg nor the missing version — it just looks like a corrupt download.

**This has now failed twice the same way.** The `7.1` pin was itself the fix for a corrupt `8.1` asset; the comment it carries says *"Revert once upstream publishes it."* Moving the pin again would just queue up the third occurrence, so this drops the dependency instead.

## Why it matters more here than in ci.yml

`release.yml` is what runs semantic-release on a push to `release`. This would have failed the **next publish**, not a PR — and at a point where the failure looks like a packaging problem rather than a CI one.

## The change

Both jobs now use the same two lines ci.yml already uses:

```yaml
- name: Install ffmpeg
  run: |
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends ffmpeg
```

The `Verify ffmpeg installation` step after each is untouched and still fails the job loudly if ffmpeg is somehow absent, so this doesn't trade a noisy failure for a silent one.

Both workflow files parse as valid YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and release workflows to install required media-processing tools through the system package manager.
  * Preserved existing verification and release steps while simplifying workflow setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->