### PR TITLE
fix(cli): stop setup --list/--status from chaining into an interactive prompt

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -323,13 +323,17 @@ function printGenericProviderSetup(
  */
 export async function handleSetup(argv: SetupArgs): Promise<void> {
   try {
-    // Handle specific flags
+    // Handle specific flags. `--list`/`--status` are documented as one-shot,
+    // non-interactive informational commands (see the `setup --list` /
+    // `setup --status` examples in setupCommandFactory.ts) — pass
+    // interactive: false so they print and return instead of chaining into
+    // the wizard's follow-up inquirer prompt below.
     if (argv.list) {
-      return await showProviderList();
+      return await showProviderList(false);
     }
 
     if (argv.status) {
-      return await showProviderStatus();
+      return await showProviderStatus(false);
     }
 
     if (argv.provider && argv.provider !== "auto") {
@@ -739,9 +743,15 @@ async function showSetupCompletion(providerId: string): Promise<void> {
 }
 
 /**
- * Show detailed provider information
+ * Show detailed provider information.
+ *
+ * @param interactive - When true (the default, used by the interactive
+ * wizard's "learn more" menu choice), follows up with a prompt offering to
+ * launch the setup wizard. When false (used by the direct `setup --list`
+ * flag), returns immediately after printing so the command exits cleanly
+ * without waiting on stdin.
  */
-async function showProviderList(): Promise<void> {
+async function showProviderList(interactive = true): Promise<void> {
   logger.always(chalk.blue("📚 NeuroLink Supported AI Providers"));
   logger.always("");
 
@@ -782,6 +792,10 @@ async function showProviderList(): Promise<void> {
   logger.always("• neurolink setup --provider bedrock");
   logger.always("");
 
+  if (!interactive) {
+    return;
+  }
+
   const { action } = await inquirer.prompt([
     {
       type: "select",
@@ -800,9 +814,15 @@ async function showProviderList(): Promise<void> {
 }
 
 /**
- * Show provider status with detailed information
+ * Show provider status with detailed information.
+ *
+ * @param interactive - When true (the default, used by the interactive
+ * wizard's "check status" menu choice), follows up with a prompt offering to
+ * set up another provider. When false (used by the direct `setup --status`
+ * flag), returns immediately after printing so the command exits cleanly
+ * without waiting on stdin.
  */
-async function showProviderStatus(): Promise<void> {
+async function showProviderStatus(interactive = true): Promise<void> {
   const spinner = ora("🔍 Checking all AI provider configurations...").start();
 
   try {
@@ -908,6 +928,10 @@ async function showProviderStatus(): Promise<void> {
       }
       logger.always("• Check performance: neurolink provider status");
       logger.always("");
+    }
+
+    if (!interactive) {
+      return;
     }
 
     const { setupAnother } = await inquirer.prompt([

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -10222,6 +10222,96 @@ exit 127
       );
     },
   },
+  // `setup --list`/`setup --status` are documented (setupCommandFactory.ts
+  // examples) as one-shot, non-interactive informational commands, but
+  // showProviderList()/showProviderStatus() unconditionally chained into an
+  // interactive wizard's follow-up inquirer.prompt() regardless of how they
+  // were reached. With stdin closed (no TTY, matching CI/scripts) that
+  // trailing prompt either threw immediately ("User force closed the
+  // prompt", caught by handleSetup's outer catch -> exit 1 for --list) or,
+  // once real background provider-probe network calls were keeping the
+  // event loop alive, never resolved at all (--status hung indefinitely).
+  // The fix threads an `interactive` flag through both functions so a
+  // direct `--list`/`--status` invocation returns right after printing.
+  {
+    name: "CLI setup: --list prints the provider list and exits cleanly (no hang, no force-closed prompt)",
+    category: "cli",
+    fn: async () => {
+      const { existsSync } = await import("node:fs");
+      if (!existsSync(CLI_DIST_PATH)) {
+        return true; // dist not built in this run — covered by CI's built CLI.
+      }
+      const { spawnSync } = await import("node:child_process");
+      const r = spawnSync(
+        process.execPath,
+        [CLI_DIST_PATH, "setup", "--list"],
+        {
+          encoding: "utf8",
+          env: { ...process.env, NO_COLOR: "1" },
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 10_000,
+        },
+      );
+      const combined = `${r.stdout}${r.stderr}`;
+      return (
+        r.status === 0 &&
+        r.signal === null &&
+        /NeuroLink Supported AI Providers/.test(combined) &&
+        /Quick Start Recommendations/.test(combined) &&
+        !/Ready to set up a provider/.test(combined) &&
+        !/force closed/.test(combined)
+      );
+    },
+  },
+  {
+    name: "CLI setup: --status prints provider status and exits cleanly with no credentials (no hang, no force-closed prompt)",
+    category: "cli",
+    fn: async () => {
+      const { existsSync, mkdtempSync, rmSync } = await import("node:fs");
+      if (!existsSync(CLI_DIST_PATH)) {
+        return true;
+      }
+      const { spawnSync } = await import("node:child_process");
+      // Isolated cwd (no .env file) with a minimal, hand-built env (no
+      // spread of process.env) so no ambient or repo-local provider
+      // credential can sneak in — getProviderStatus() probes real
+      // providers, so any credential here would turn this into a live
+      // network test and defeat the point of the regression guard.
+      const dir = mkdtempSync(pathJoin(tmpdir(), "cli-setup-status-"));
+      try {
+        const env = {
+          PATH: process.env.PATH ?? "",
+          HOME: process.env.HOME ?? "",
+          NO_COLOR: "1",
+        };
+        const start = Date.now();
+        const r = spawnSync(
+          process.execPath,
+          [CLI_DIST_PATH, "setup", "--status"],
+          {
+            encoding: "utf8",
+            cwd: dir,
+            env,
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 20_000,
+          },
+        );
+        const elapsed = Date.now() - start;
+        const combined = `${r.stdout}${r.stderr}`;
+        return (
+          r.status === 0 &&
+          r.signal === null &&
+          elapsed < 15_000 && // regression guard: a re-introduced hang must fail fast, not stall CI
+          /NeuroLink Provider Status/.test(combined) &&
+          /provider\(s\) working/.test(combined) &&
+          !/Would you like to set up another provider/.test(combined) &&
+          !/force closed/.test(combined)
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
 ];
 
 // ============================================================================


### PR DESCRIPTION
`neurolink setup --list` exits 1. `neurolink setup --status` hangs indefinitely. Both are documented as one-shot non-interactive flags, and both are broken in exactly the contexts those flags exist for — scripts and CI.

## One cause, two symptoms

`showProviderList()` and `showProviderStatus()` each print their output and then unconditionally chain into a trailing `inquirer.prompt()`, whether they were reached from the interactive wizard menu or from the direct `--list`/`--status` flags.

With stdin closed, that trailing prompt behaves differently in each path:

- `--list` throws `ExitPromptError` immediately, which `handleSetup`'s outer catch turns into exit 1.
- `--status` hangs, because background provider probes keep the event loop alive and the prompt never resolves. Confirmed still hanging past 90s and 180s before the fix — measured, not assumed.

## Fix

Threads an `interactive` parameter (defaulting to true) through both functions and skips the trailing prompt when it is false; the `--list`/`--status` branches pass false. The wizard menu call sites are untouched, so interactive behavior is unchanged.

No `process.exit()` was added — both functions already return cleanly once the prompt is out of the way, so the fix removes the blocker rather than forcing the process down.

## Tests

Two tests added to the existing CLI-subprocess suite, driving `node dist/cli/index.js`: `--list` exits 0 and prints providers; `--status` exits 0 within a bounded time, asserting on elapsed duration so a regression to hanging fails the test instead of stalling CI.

The `--status` test runs in a fresh temporary cwd with a hand-built environment rather than an inherited one, because `.env` and `.neurolink.config` both resolve from cwd — so it is genuinely credential-free rather than merely env-var-free.

Verified failing before the fix: with the source change stashed and rebuilt, exactly those two tests fail (278/280) and nothing else. After: 280/280.

## Noted, not fixed

`getProviderStatus()` bounds each provider probe to 5s with `Promise.race`, but never cancels the losing promise — no `AbortSignal` reaches `provider.generate()`. With real credentials and a genuinely slow provider, `--status` can still take a long time even with this fix. That is a provider-lifecycle concern rather than a CLI one and belongs in its own change.