### PR TITLE
ci(release): install ffmpeg from apt so publishes stop failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,21 +31,23 @@ jobs:
           cache: "pnpm"
           registry-url: https://registry.npmjs.org/
 
+      # Installed from the runner's package index rather than a third-party
+      # action that downloads release assets from another repository. That
+      # action broke this workflow twice — first a corrupt 8.1 asset, then
+      # the 7.1 pin added to work around it — and because this is the
+      # publish workflow, each break silently stopped releases from going
+      # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release, matching ci.yml. The unpinned default
-          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
-          # the download 404s and fails the job at extract ("xz: (stdin): File
-          # format not recognized"). Revert once upstream publishes it.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
           echo "🎬 Verifying ffmpeg installation..."
           ffmpeg -version || {
             echo "❌ ffmpeg installation failed!"
-            echo "Please check the setup-ffmpeg action configuration."
+            echo "apt-get install ffmpeg did not produce a working binary."
             exit 1
           }
           echo "✅ ffmpeg installed successfully"
@@ -86,21 +88,23 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
+      # Installed from the runner's package index rather than a third-party
+      # action that downloads release assets from another repository. That
+      # action broke this workflow twice — first a corrupt 8.1 asset, then
+      # the 7.1 pin added to work around it — and because this is the
+      # publish workflow, each break silently stopped releases from going
+      # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          # Pin to a known-good release, matching ci.yml. The unpinned default
-          # resolves to a version BtbN/FFmpeg-Builds has no Linux asset for, so
-          # the download 404s and fails the job at extract ("xz: (stdin): File
-          # format not recognized"). Revert once upstream publishes it.
-          version: "7.1"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
           echo "🎬 Verifying ffmpeg installation..."
           ffmpeg -version || {
             echo "❌ ffmpeg installation failed!"
-            echo "Please check the setup-ffmpeg action configuration."
+            echo "apt-get install ffmpeg did not produce a working binary."
             exit 1
           }
           echo "✅ ffmpeg installed successfully"


### PR DESCRIPTION
**Nothing has published since 11.1.0.** Two PRs have merged to `release` since then and neither produced a version.

`release.yml` still uses the third-party `AnimMouse/setup-ffmpeg` action that #1342 moved `ci.yml` off. It is failing identically — `xz: (stdin): File format not recognized` — which fails the `release` job before semantic-release ever runs.

This failure mode is worse than the CI one because it is silent. Pull requests merge, CI on `release` reports green, and no release goes out; you only notice by checking npm. Runs 32114361501 and 32117776035 both failed this way.

Same replacement as #1342: install from the runner's package index, in both jobs that need it, so an upstream release being moved, rebuilt or rate-limited can no longer stop a publish. Also updates the failure message, which still pointed at the removed action.

Once this lands, the two already-merged changes (`fix(cli)` setup flag forwarding, `fix(providers)` transport-error classification) should publish on the next release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test and release environments to install FFmpeg through the system package manager.
  * Improved verification messaging when FFmpeg installation is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->