### PR TITLE
feat(providers): add the catalog foundations for OpenAI-compatible providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:mcp:spans": "npx tsx test/continuous-test-suite-mcp-spans.ts",
     "test:mcp:infra": "npx tsx test/continuous-test-suite-mcp-infra.ts",
     "test:providers-mocked": "npx tsx test/continuous-test-suite-providers-mocked.ts",
+    "test:openai-compat-catalog": "npx tsx test/continuous-test-suite-openai-compat-catalog.ts",
     "test:provider-descriptors": "npx tsx test/continuous-test-suite-provider-descriptors.ts",
     "test:provider-structure": "npx tsx test/continuous-test-suite-provider-structure.ts",
     "test:provider-fallback": "npx tsx test/continuous-test-suite-provider-fallback.ts",

--- a/src/lib/providers/configuredOpenAICompat.ts
+++ b/src/lib/providers/configuredOpenAICompat.ts
@@ -1,0 +1,85 @@
+import type { AIProviderName } from "../constants/enums.js";
+import type {
+  OpenAICompatCatalogEntry,
+  OpenAICompatCredentials,
+} from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { redactUrlCredentials } from "../utils/logSanitize.js";
+import {
+  getProviderModel,
+  resolveOpenAICompatConfig,
+} from "../utils/providerConfig.js";
+import { classifyProviderError } from "../utils/errorClassifier.js";
+import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
+
+/**
+ * Generic OpenAI-compatible provider driven entirely by an
+ * OpenAICompatCatalogEntry. Replaces a hand-written subclass for any
+ * provider whose only differences from its siblings are credentials, base
+ * URL, model defaults, and error-classification rules — see
+ * OPENAI_COMPAT_CATALOG in openaiCompatCatalog.ts for the entries.
+ *
+ * If a provider needs a real hook override (adjustRequestBody,
+ * adjustBodyAfter400, getChatCompletionsURL, getAuthHeaders,
+ * suppressResponseFormatWithTools, ...) it does NOT belong in the catalog —
+ * write a dedicated subclass instead (see deepseek.ts, azureOpenai.ts).
+ */
+export class ConfiguredOpenAICompatProvider extends OpenAIChatCompletionsProvider {
+  private readonly entry: OpenAICompatCatalogEntry;
+
+  constructor(
+    entry: OpenAICompatCatalogEntry,
+    modelName?: string,
+    sdk?: unknown,
+    credentials?: OpenAICompatCredentials,
+  ) {
+    const { apiKey, baseURL } = resolveOpenAICompatConfig(entry, credentials);
+    // BaseProvider's constructor calls `this.getDefaultModel()` /
+    // `this.getProviderName()` synchronously inside `super()`, before this
+    // class's own constructor body (or field initializers) ever run — so
+    // `this.entry` is not yet assigned at that point and those overrides
+    // would read `undefined.modelEnvVar`. `entry.providerName` is always
+    // defined, so passing it straight through makes the base constructor's
+    // `providerName || this.getProviderName()` short-circuit; resolving the
+    // model up front and always passing a truthy `modelName` does the same
+    // for `getDefaultModel()`. Both overrides remain correct for any call
+    // made after construction, once `this.entry` is set below.
+    const resolvedModelName =
+      modelName || getProviderModel(entry.modelEnvVar, entry.defaultModel);
+    super(entry.providerName, resolvedModelName, sdk, { baseURL, apiKey });
+    this.entry = entry;
+    logger.debug(`${entry.configOptions.providerName} Provider initialized`, {
+      modelName: this.modelName,
+      providerName: this.providerName,
+      baseURL: redactUrlCredentials(this.config.baseURL),
+    });
+  }
+
+  protected getProviderName(): AIProviderName {
+    return this.entry.providerName;
+  }
+
+  protected getDefaultModel(): string {
+    return getProviderModel(this.entry.modelEnvVar, this.entry.defaultModel);
+  }
+
+  protected getFallbackModelName(): string {
+    return this.entry.fallbackModelName;
+  }
+
+  protected getFallbackModels(): string[] {
+    return this.entry.fallbackModels;
+  }
+
+  protected formatProviderError(error: unknown): Error {
+    // classifyProviderError handles TimeoutError internally (always maps
+    // to NetworkError, ahead of any rule table) — no local pre-check
+    // needed or wanted here; see this task's design note.
+    return classifyProviderError(
+      error,
+      this.entry.errorRules,
+      this.entry.providerName,
+      this.modelName,
+    );
+  }
+}

--- a/src/lib/providers/openaiCompatCatalog.ts
+++ b/src/lib/providers/openaiCompatCatalog.ts
@@ -1,0 +1,311 @@
+import { AIProviderName } from "../constants/enums.js";
+import {
+  CloudflareModels,
+  FireworksModels,
+  GroqModels,
+  MistralModels,
+  PerplexityModels,
+  TogetherAIModels,
+  XaiModels,
+} from "../constants/enums.js";
+import type { OpenAICompatCatalogEntry } from "../types/index.js";
+import {
+  AuthenticationError,
+  InvalidModelError,
+  ProviderError,
+} from "../types/index.js";
+import { DEFAULT_ERROR_RULES } from "../utils/errorClassifier.js";
+import {
+  createCloudflareConfig,
+  createFireworksConfig,
+  createGroqConfig,
+  createMistralConfig,
+  createPerplexityConfig,
+  createTogetherAIConfig,
+  createXaiConfig,
+} from "../utils/providerConfig.js";
+
+function buildCloudflareBaseURL(accountId: string): string {
+  return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`;
+}
+
+/**
+ * Config-driven catalog of the 7 zero-quirk OpenAI-compatible providers.
+ * Each entry fully replaces what used to be a hand-written
+ * OpenAIChatCompletionsProvider subclass — see ConfiguredOpenAICompatProvider
+ * for the class that reads these entries, and providerRegistry.ts for the
+ * registration loop that consumes this array.
+ *
+ * `errorRules` mirrors each provider's LIVE `formatProviderError` rule array
+ * (post plan-07/wave-2 migration), not the original hand-rolled ladder these
+ * providers had when plan 05 was first drafted: every provider below now
+ * keeps only its bespoke rule(s) — auth, plus Groq's model_decommissioned and
+ * xAI's insufficient_quota — before spreading the SAME exported
+ * `DEFAULT_ERROR_RULES` constant that the live subclasses spread (never an
+ * inlined copy, so this catalog cannot drift from that table independently).
+ * See plan-05/progress.md Ruling R4 for the full rationale.
+ *
+ * To add a new zero-quirk OpenAI-compatible provider: add one entry here.
+ * Do NOT add a provider here if it needs any hook override beyond the 3
+ * mandatory ones (getProviderName/getDefaultModel/formatProviderError) —
+ * write a dedicated subclass instead (see deepseek.ts, azureOpenai.ts, and
+ * Task 14's docs task for the deciding criteria).
+ */
+export const OPENAI_COMPAT_CATALOG: readonly OpenAICompatCatalogEntry[] = [
+  {
+    providerName: AIProviderName.GROQ,
+    aliases: ["groq"],
+    apiKeyEnvVar: "GROQ_API_KEY",
+    baseURLEnvVar: "GROQ_BASE_URL",
+    defaultBaseURL: "https://api.groq.com/openai/v1",
+    configOptions: createGroqConfig(),
+    modelEnvVar: "GROQ_MODEL",
+    defaultModel: GroqModels.LLAMA_3_3_70B_VERSATILE,
+    registryDefaultModel: GroqModels.LLAMA_3_3_70B_VERSATILE,
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: GroqModels.LLAMA_3_1_8B_INSTANT,
+    fallbackModels: [
+      GroqModels.LLAMA_3_3_70B_VERSATILE,
+      GroqModels.LLAMA_3_1_8B_INSTANT,
+      GroqModels.GEMMA_2_9B_IT,
+      GroqModels.MIXTRAL_8X7B_32768,
+      GroqModels.LLAMA_3_2_90B_VISION_PREVIEW,
+      GroqModels.LLAMA_3_2_11B_VISION_PREVIEW,
+    ],
+    // KNOWN GAP (not reproducible by this data-only array — flagged for PR C,
+    // see plan-05/task-A-report.md): live GroqProvider.formatProviderError()
+    // intercepts TimeoutError and returns a plain ProviderError BEFORE ever
+    // calling classifyProviderError, overriding that function's own
+    // (non-overridable) rule that TimeoutError always maps to NetworkError.
+    // ConfiguredOpenAICompatProvider.formatProviderError() has no such
+    // pre-check hook, so migrating Groq onto it as-is would silently
+    // reclassify Groq timeouts as NetworkError. This entry's errorRules
+    // still mirrors Groq's live rule array faithfully for every other error
+    // shape; the TimeoutError special case is a structural gap in
+    // ConfiguredOpenAICompatProvider, not a data error here.
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication|invalid_api_key/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Groq API key. Check GROQ_API_KEY. Get one at https://console.groq.com/keys",
+      },
+      {
+        match: (ctx) => /model_decommissioned/i.test(ctx.message),
+        errorClass: InvalidModelError,
+        message: (ctx) =>
+          `Groq model '${ctx.modelName}' was decommissioned. Pick a current model from https://console.groq.com/docs/models.`,
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.XAI,
+    aliases: ["xai", "grok"],
+    apiKeyEnvVar: "XAI_API_KEY",
+    baseURLEnvVar: "XAI_BASE_URL",
+    defaultBaseURL: "https://api.x.ai/v1",
+    configOptions: createXaiConfig(),
+    modelEnvVar: "XAI_MODEL",
+    defaultModel: XaiModels.GROK_3,
+    registryDefaultModel: XaiModels.GROK_3,
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: XaiModels.GROK_3_MINI,
+    fallbackModels: [
+      XaiModels.GROK_3,
+      XaiModels.GROK_3_MINI,
+      XaiModels.GROK_2_LATEST,
+      XaiModels.GROK_2_VISION_LATEST,
+      XaiModels.GROK_BETA,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication|invalid_api_key/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid xAI API key. Please check your XAI_API_KEY environment variable. Get one at https://console.x.ai/",
+      },
+      {
+        match: (ctx) => /insufficient_quota|quota exceeded/i.test(ctx.message),
+        errorClass: ProviderError,
+        message:
+          "xAI account has insufficient quota. Top up at https://console.x.ai/",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.TOGETHER_AI,
+    aliases: ["together-ai", "together"],
+    apiKeyEnvVar: "TOGETHER_API_KEY",
+    baseURLEnvVar: "TOGETHER_BASE_URL",
+    defaultBaseURL: "https://api.together.xyz/v1",
+    configOptions: createTogetherAIConfig(),
+    modelEnvVar: "TOGETHER_MODEL",
+    defaultModel: TogetherAIModels.LLAMA_3_3_70B_INSTRUCT_TURBO,
+    registryDefaultModel: TogetherAIModels.LLAMA_3_3_70B_INSTRUCT_TURBO,
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: TogetherAIModels.LLAMA_3_1_8B_INSTRUCT_TURBO,
+    fallbackModels: [
+      TogetherAIModels.LLAMA_3_3_70B_INSTRUCT_TURBO,
+      TogetherAIModels.LLAMA_3_1_405B_INSTRUCT_TURBO,
+      TogetherAIModels.LLAMA_3_1_70B_INSTRUCT_TURBO,
+      TogetherAIModels.LLAMA_3_1_8B_INSTRUCT_TURBO,
+      TogetherAIModels.MIXTRAL_8X22B_INSTRUCT,
+      TogetherAIModels.QWEN_2_5_72B_INSTRUCT_TURBO,
+      TogetherAIModels.DEEPSEEK_R1,
+      TogetherAIModels.DEEPSEEK_V3,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Together AI API key. Get one at https://api.together.xyz/settings/api-keys",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.FIREWORKS,
+    aliases: ["fireworks"],
+    apiKeyEnvVar: "FIREWORKS_API_KEY",
+    baseURLEnvVar: "FIREWORKS_BASE_URL",
+    defaultBaseURL: "https://api.fireworks.ai/inference/v1",
+    configOptions: createFireworksConfig(),
+    modelEnvVar: "FIREWORKS_MODEL",
+    defaultModel: FireworksModels.DEEPSEEK_V4_PRO,
+    registryDefaultModel: FireworksModels.DEEPSEEK_V4_PRO,
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: FireworksModels.DEEPSEEK_V4_PRO,
+    fallbackModels: [
+      FireworksModels.DEEPSEEK_V4_PRO,
+      FireworksModels.GLM_5P1,
+      FireworksModels.GLM_5,
+      FireworksModels.KIMI_K2P6,
+      FireworksModels.KIMI_K2P5,
+      FireworksModels.GPT_OSS_120B,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Fireworks API key. Get one at https://fireworks.ai/account/api-keys",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.PERPLEXITY,
+    aliases: ["perplexity", "pplx"],
+    apiKeyEnvVar: "PERPLEXITY_API_KEY",
+    baseURLEnvVar: "PERPLEXITY_BASE_URL",
+    defaultBaseURL: "https://api.perplexity.ai",
+    configOptions: createPerplexityConfig(),
+    modelEnvVar: "PERPLEXITY_MODEL",
+    defaultModel: PerplexityModels.SONAR,
+    registryDefaultModel: PerplexityModels.SONAR,
+    registryDefaultModelChecksEnvVar: true,
+    // Perplexity's live class does NOT override getFallbackModelName() — it
+    // inherits the base class default "gpt-3.5-turbo". Preserved here
+    // verbatim, not "fixed" to a Perplexity model — that's a real,
+    // pre-existing quirk this plan is not authorized to change.
+    fallbackModelName: "gpt-3.5-turbo",
+    fallbackModels: [
+      PerplexityModels.SONAR,
+      PerplexityModels.SONAR_PRO,
+      PerplexityModels.SONAR_REASONING,
+      PerplexityModels.SONAR_REASONING_PRO,
+      PerplexityModels.SONAR_DEEP_RESEARCH,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Perplexity API key. Get one at https://www.perplexity.ai/settings/api",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.MISTRAL,
+    aliases: ["mistral"],
+    apiKeyEnvVar: "MISTRAL_API_KEY",
+    baseURLEnvVar: "MISTRAL_BASE_URL",
+    defaultBaseURL: "https://api.mistral.ai/v1",
+    configOptions: createMistralConfig(),
+    modelEnvVar: "MISTRAL_MODEL",
+    defaultModel: MistralModels.MISTRAL_SMALL_2506,
+    // The one documented registry-vs-class default-model quirk (see this
+    // plan's "Design reference" section): the registry passes the bare
+    // literal MISTRAL_LARGE_LATEST with no env-var check, while
+    // MistralProvider.getDefaultModel() checks MISTRAL_MODEL and defaults to
+    // MISTRAL_SMALL_2506. Preserved exactly, not reconciled.
+    registryDefaultModel: MistralModels.MISTRAL_LARGE_LATEST,
+    registryDefaultModelChecksEnvVar: false,
+    fallbackModelName: MistralModels.MISTRAL_SMALL_2506,
+    fallbackModels: [
+      MistralModels.MISTRAL_SMALL_2506,
+      MistralModels.MISTRAL_LARGE_LATEST,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /API_KEY_INVALID|Invalid API key|Unauthorized/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Mistral API key. Please check your MISTRAL_API_KEY environment variable.",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+  {
+    providerName: AIProviderName.CLOUDFLARE,
+    aliases: ["cloudflare", "workers-ai", "cf-ai"],
+    apiKeyEnvVar: "CLOUDFLARE_API_KEY",
+    computedBaseURL: {
+      envVar: "CLOUDFLARE_ACCOUNT_ID",
+      missingValueMessage:
+        "CLOUDFLARE_ACCOUNT_ID is required (or pass credentials.cloudflare.accountId). Get the account id from https://dash.cloudflare.com/",
+      build: buildCloudflareBaseURL,
+    },
+    configOptions: createCloudflareConfig(),
+    modelEnvVar: "CLOUDFLARE_MODEL",
+    defaultModel: CloudflareModels.LLAMA_3_3_70B_FAST,
+    registryDefaultModel: CloudflareModels.LLAMA_3_3_70B_FAST,
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: CloudflareModels.LLAMA_3_1_8B_FAST,
+    fallbackModels: [
+      CloudflareModels.LLAMA_3_3_70B_FAST,
+      CloudflareModels.LLAMA_3_1_70B_INSTRUCT,
+      CloudflareModels.LLAMA_3_1_8B_FAST,
+      CloudflareModels.LLAMA_3_2_11B_VISION,
+      CloudflareModels.MISTRAL_7B_INSTRUCT_V0_2,
+      CloudflareModels.QWEN_1P5_14B_CHAT_AWQ,
+    ],
+    errorRules: [
+      {
+        match: (ctx) =>
+          ctx.statusCode === 401 ||
+          /Invalid API key|Authentication/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message:
+          "Invalid Cloudflare API key. Use a token with Workers AI Read+Write scope. Get one at https://dash.cloudflare.com/profile/api-tokens",
+      },
+      ...DEFAULT_ERROR_RULES,
+    ],
+  },
+];

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -28,6 +28,7 @@ import type {
 } from "./generate.js";
 import type { MultimodalAudioEntry } from "./file.js";
 import type { StreamOptions, StreamResult } from "./stream.js";
+import type { ProviderErrorRule } from "./errors.js";
 import type { ExternalMCPToolInfo } from "./externalMcp.js";
 
 // Subscription types for Claude/Anthropic authentication and tier management
@@ -695,6 +696,115 @@ export type ProviderConfigOptions = {
   // (or empty string) instead of throwing when it's unset.
   optional?: boolean;
 };
+
+/**
+ * Minimal credential shape accepted by resolveOpenAICompatConfig() and
+ * ConfiguredOpenAICompatProvider. A structural superset of every real
+ * per-provider NeurolinkCredentials["<key>"] slice in this family (groq,
+ * xai, together, fireworks, perplexity, mistral, cloudflare) — all fields
+ * optional, so passing e.g. NeurolinkCredentials["groq"] (which has no
+ * accountId) here is always structurally valid.
+ */
+export type OpenAICompatCredentials = {
+  apiKey?: string;
+  baseURL?: string;
+  accountId?: string;
+};
+
+/**
+ * One row of the config-driven OpenAI-compatible provider catalog
+ * (OPENAI_COMPAT_CATALOG, src/lib/providers/openaiCompatCatalog.ts).
+ * Replaces a hand-written OpenAIChatCompletionsProvider subclass for
+ * providers whose only differences from every sibling are credentials,
+ * base URL, model defaults, and error-message classification.
+ */
+export type OpenAICompatCatalogEntry = {
+  /** Registry key / nl.generate({provider}) value, e.g. "groq". */
+  providerName: AIProviderName;
+  /** Registry aliases, e.g. ["together-ai", "together"]. */
+  aliases: string[];
+  /**
+   * Env var holding the API key, e.g. "GROQ_API_KEY".
+   *
+   * Declarative: the key is actually read through `configOptions.envVarName`,
+   * which `validateApiKey` consults. This field exists so an entry states its
+   * credential source without a caller having to reach into configOptions,
+   * and the catalog suite asserts the two always name the same variable — two
+   * fields describing one fact are worth nothing if they can disagree.
+   */
+  apiKeyEnvVar: string;
+  /**
+   * Env var that can override the base URL, e.g. "GROQ_BASE_URL". Omit
+   * for entries that use computedBaseURL instead (e.g. Cloudflare).
+   */
+  baseURLEnvVar?: string;
+  /** Static default base URL. Omit for computedBaseURL entries. */
+  defaultBaseURL?: string;
+  /**
+   * Present only for providers whose base URL is computed from an extra
+   * required credential value instead of a static default (Cloudflare's
+   * accountId). Deliberately narrow (accountId-shaped) rather than a
+   * generic extra-field mechanism — Cloudflare is the only current user.
+   */
+  computedBaseURL?: {
+    /** Env var fallback for the extra value, e.g. "CLOUDFLARE_ACCOUNT_ID". */
+    envVar: string;
+    /** Thrown when neither credentials.accountId nor envVar supply a value. */
+    missingValueMessage: string;
+    /** Builds the base URL from the resolved accountId. */
+    build: (accountId: string) => string;
+  };
+  /** Setup/help metadata, passed to validateApiKey(). Not consumed by
+   *  classifyProviderError() — that function's ProviderErrorContext has no
+   *  docsUrl field; any URL a rule's message needs is inlined in the rule
+   *  itself (see Task 4). */
+  configOptions: ProviderConfigOptions;
+  /** Env var for the default model, e.g. "GROQ_MODEL". */
+  modelEnvVar: string;
+  /** Default model when modelEnvVar is unset. */
+  defaultModel: string;
+  /**
+   * The literal passed as ProviderFactory.registerProvider()'s defaultModel
+   * argument (resolved before the provider is constructed). Preserves each
+   * provider's exact pre-migration registry behavior.
+   */
+  registryDefaultModel: string;
+  /**
+   * True for every provider except Mistral: whether the registry-level
+   * default also consults modelEnvVar before falling back to
+   * registryDefaultModel. False is a pre-existing, intentionally-preserved
+   * quirk unique to Mistral's registration (see plan's Design reference).
+   */
+  registryDefaultModelChecksEnvVar: boolean;
+  /** Fallback model name (getFallbackModelName()). */
+  fallbackModelName: string;
+  /** Fallback model list (getFallbackModels()). */
+  fallbackModels: string[];
+  /**
+   * Error-classification rules, consumed by classifyProviderError. Typed
+   * as a mutable array — not readonly — because plan 07's
+   * `classifyProviderError(error, rules: ProviderErrorRule[], provider, modelName?)`
+   * declares `rules` as `ProviderErrorRule[]`; a `readonly` array here
+   * would not be assignable to that parameter without a cast, which rule
+   * 14 (no double assertions) and general hygiene both rule out. Each
+   * entry's array is still constructed as a fresh literal per provider in
+   * Task 4, so nothing actually mutates it at runtime.
+   */
+  errorRules: ProviderErrorRule[];
+};
+
+/** The subset of OpenAICompatCatalogEntry that resolveOpenAICompatConfig()
+ *  needs — lets call sites pass a minimal object without the full catalog
+ *  entry (e.g. in tests, or a future non-catalog caller). */
+export type OpenAICompatConfigInput = Pick<
+  OpenAICompatCatalogEntry,
+  | "providerName"
+  | "apiKeyEnvVar"
+  | "baseURLEnvVar"
+  | "defaultBaseURL"
+  | "computedBaseURL"
+  | "configOptions"
+>;
 
 // ============================================================================
 // CORE PROVIDER INTERFACES

--- a/src/lib/utils/providerConfig.ts
+++ b/src/lib/utils/providerConfig.ts
@@ -14,6 +14,8 @@ import type {
   AnthropicAuthConfig,
   OAuthToken,
   AnthropicAuthConfigResult,
+  OpenAICompatConfigInput,
+  OpenAICompatCredentials,
 } from "../types/index.js";
 
 import { logger } from "./logger.js";
@@ -1489,4 +1491,76 @@ export function describeAnthropicConfig(): string {
   lines.push(`Priority Access: ${config.limits.priorityAccess ? "Yes" : "No"}`);
 
   return lines.join("\n");
+}
+
+/**
+ * Resolves the {apiKey, baseURL} pair for a config-driven OpenAI-compatible
+ * catalog entry (see OpenAICompatCatalogEntry in types/providers.ts).
+ *
+ * Extracted from the identical 6-line precedence block that was copy-pasted
+ * across groq.ts, xai.ts, togetherAi.ts, fireworks.ts, perplexity.ts, and
+ * mistral.ts, plus Cloudflare's accountId-computed-baseURL variant.
+ *
+ * Precedence (matches every ported subclass's original behavior exactly):
+ *   apiKey:  credentials.apiKey (trimmed, non-blank) > env var > throw
+ *   baseURL: credentials.baseURL (trimmed, non-blank)
+ *            > env var (if entry.baseURLEnvVar is set, trimmed, non-blank)
+ *            > entry.defaultBaseURL
+ *   baseURL (computedBaseURL entries, e.g. Cloudflare):
+ *            credentials.baseURL > computedBaseURL.build(accountId), where
+ *            accountId = credentials.accountId (trimmed) > env var (trimmed)
+ *            > throw computedBaseURL.missingValueMessage
+ */
+export function resolveOpenAICompatConfig(
+  entry: OpenAICompatConfigInput,
+  credentials?: OpenAICompatCredentials,
+): { apiKey: string; baseURL: string } {
+  const overrideApiKey = credentials?.apiKey?.trim();
+  const apiKey =
+    overrideApiKey && overrideApiKey.length > 0
+      ? overrideApiKey
+      : validateApiKey(entry.configOptions);
+
+  if (entry.computedBaseURL) {
+    const { envVar, missingValueMessage, build } = entry.computedBaseURL;
+    // An explicit base URL is checked first and trimmed the same way the
+    // static branch trims it. It makes the account id irrelevant — there is
+    // nothing left to build — so demanding one anyway would reject a fully
+    // specified override.
+    const overrideComputedBaseURL = credentials?.baseURL?.trim();
+    if (overrideComputedBaseURL && overrideComputedBaseURL.length > 0) {
+      return { apiKey, baseURL: overrideComputedBaseURL };
+    }
+    const extraValue = (
+      credentials?.accountId ??
+      process.env[envVar] ??
+      ""
+    ).trim();
+    if (!extraValue) {
+      throw new Error(missingValueMessage);
+    }
+    return { apiKey, baseURL: build(extraValue) };
+  }
+
+  const overrideBaseURL = credentials?.baseURL?.trim();
+  const envBaseURL = entry.baseURLEnvVar
+    ? process.env[entry.baseURLEnvVar]?.trim()
+    : undefined;
+  const baseURL =
+    (overrideBaseURL && overrideBaseURL.length > 0
+      ? overrideBaseURL
+      : undefined) ??
+    (envBaseURL && envBaseURL.length > 0 ? envBaseURL : undefined) ??
+    entry.defaultBaseURL;
+  if (!baseURL) {
+    // Reachable only for an entry that sets neither defaultBaseURL nor
+    // computedBaseURL. Returning "" instead would hand the SDK an empty base
+    // URL and surface as a confusing request failure far from the cause.
+    throw new Error(
+      `${entry.providerName}: no base URL. Set one in credentials` +
+        (entry.baseURLEnvVar ? `, set ${entry.baseURLEnvVar}` : "") +
+        `, or give the catalog entry a defaultBaseURL.`,
+    );
+  }
+  return { apiKey, baseURL };
 }

--- a/test/continuous-test-suite-openai-compat-catalog.ts
+++ b/test/continuous-test-suite-openai-compat-catalog.ts
@@ -1,0 +1,533 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Config-Driven OpenAI-Compat Catalog — contract + regression suite.
+ *
+ * Covers:
+ *   - resolveOpenAICompatConfig() credential/baseURL precedence (Task 1)
+ *   - ConfiguredOpenAICompatProvider hook delegation + error mapping (Task 3)
+ *   - OPENAI_COMPAT_CATALOG structural invariants (Task 4)
+ *   - adjustBodyAfter400 composition fix regression (Task 6)
+ *
+ * Run with: pnpm run test:openai-compat-catalog
+ * (Runs against dist/ — `pnpm run build` first.)
+ */
+
+import {
+  installMockFetch,
+  record,
+  expect,
+  expectEq,
+  type TestRecord,
+} from "./utils/mockFetch.js";
+
+const results: TestRecord[] = [];
+
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
+
+function setEnv(name: string, value: string | undefined): void {
+  if (!(name in ORIGINAL_ENV)) {
+    ORIGINAL_ENV[name] = process.env[name];
+  }
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function restoreEnv(): void {
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+async function withMocks<T>(
+  routes: Parameters<typeof installMockFetch>[0],
+  fn: (handle: ReturnType<typeof installMockFetch>) => Promise<T>,
+): Promise<T> {
+  const handle = installMockFetch(routes);
+  try {
+    return await fn(handle);
+  } finally {
+    handle.unset();
+  }
+}
+
+function openAIChatResponse(content: string, model: string): unknown {
+  return {
+    id: "chatcmpl-mock",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section: resolveOpenAICompatConfig (Task 1)
+// ───────────────────────────────────────────────────────────────────────
+
+async function testResolveConfigPrecedence(): Promise<void> {
+  const section = "resolveOpenAICompatConfig";
+  setEnv("TEST_CATALOG_API_KEY", "env-key-abc");
+  setEnv("TEST_CATALOG_BASE_URL", undefined);
+
+  const { resolveOpenAICompatConfig } =
+    await import("../dist/lib/utils/providerConfig.js");
+
+  const fakeEntry = {
+    apiKeyEnvVar: "TEST_CATALOG_API_KEY",
+    baseURLEnvVar: "TEST_CATALOG_BASE_URL",
+    defaultBaseURL: "https://default.example.com/v1",
+    configOptions: {
+      providerName: "TestCatalog",
+      envVarName: "TEST_CATALOG_API_KEY",
+      setupUrl: "https://example.com/setup",
+      description: "API key",
+      instructions: ["1. Get a key"],
+    },
+  };
+
+  try {
+    // credentials override wins over env
+    const r1 = resolveOpenAICompatConfig(fakeEntry, {
+      apiKey: "override-key",
+      baseURL: "https://override.example.com/v1",
+    });
+    expectEq(
+      r1.apiKey,
+      "override-key",
+      "resolved key uses credentials override",
+    );
+    expectEq(
+      r1.baseURL,
+      "https://override.example.com/v1",
+      "baseURL uses credentials override",
+    );
+
+    // env wins over static default when no credentials override
+    setEnv("TEST_CATALOG_BASE_URL", "https://env.example.com/v1");
+    const r2 = resolveOpenAICompatConfig(fakeEntry, undefined);
+    expectEq(r2.apiKey, "env-key-abc", "resolved key falls back to env var");
+    expectEq(
+      r2.baseURL,
+      "https://env.example.com/v1",
+      "baseURL falls back to env var over static default",
+    );
+
+    // static default wins when neither credentials nor env baseURL set
+    setEnv("TEST_CATALOG_BASE_URL", undefined);
+    const r3 = resolveOpenAICompatConfig(fakeEntry, undefined);
+    expectEq(
+      r3.baseURL,
+      "https://default.example.com/v1",
+      "baseURL falls back to static default",
+    );
+
+    // blank/whitespace credentials override does NOT bypass env/default
+    const r4 = resolveOpenAICompatConfig(fakeEntry, {
+      apiKey: "   ",
+      baseURL: "   ",
+    });
+    expectEq(r4.apiKey, "env-key-abc", "blank key override ignored");
+    expectEq(
+      r4.baseURL,
+      "https://default.example.com/v1",
+      "blank baseURL override ignored",
+    );
+
+    record(results, `${section}: precedence order`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: precedence order`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+async function testResolveConfigComputedBaseURL(): Promise<void> {
+  const section = "resolveOpenAICompatConfig";
+  setEnv("TEST_CATALOG_ACCOUNT_API_KEY", "env-key-xyz");
+  setEnv("TEST_CATALOG_ACCOUNT_ID", undefined);
+
+  const { resolveOpenAICompatConfig } =
+    await import("../dist/lib/utils/providerConfig.js");
+
+  const fakeEntry = {
+    apiKeyEnvVar: "TEST_CATALOG_ACCOUNT_API_KEY",
+    configOptions: {
+      providerName: "TestAccountCatalog",
+      envVarName: "TEST_CATALOG_ACCOUNT_API_KEY",
+      setupUrl: "https://example.com/setup",
+      description: "API key",
+      instructions: ["1. Get a key"],
+    },
+    computedBaseURL: {
+      envVar: "TEST_CATALOG_ACCOUNT_ID",
+      missingValueMessage:
+        "TEST_CATALOG_ACCOUNT_ID is required (or pass credentials.accountId).",
+      build: (accountId: string) =>
+        `https://api.example.com/accounts/${accountId}/v1`,
+    },
+  };
+
+  try {
+    // missing accountId throws with the exact configured message
+    let threw = false;
+    try {
+      resolveOpenAICompatConfig(fakeEntry, undefined);
+    } catch (err) {
+      threw = true;
+      expect(
+        err instanceof Error &&
+          err.message ===
+            "TEST_CATALOG_ACCOUNT_ID is required (or pass credentials.accountId).",
+        "missing-accountId error message matches entry.computedBaseURL.missingValueMessage",
+      );
+    }
+    expect(threw, "missing accountId throws");
+
+    // env var supplies accountId, base URL is built from it
+    setEnv("TEST_CATALOG_ACCOUNT_ID", "acct-123");
+    const r1 = resolveOpenAICompatConfig(fakeEntry, undefined);
+    expectEq(
+      r1.baseURL,
+      "https://api.example.com/accounts/acct-123/v1",
+      "computed baseURL built from env accountId",
+    );
+
+    // credentials.accountId overrides env
+    const r2 = resolveOpenAICompatConfig(fakeEntry, {
+      accountId: "acct-999",
+    });
+    expectEq(
+      r2.baseURL,
+      "https://api.example.com/accounts/acct-999/v1",
+      "computed baseURL built from credentials.accountId over env",
+    );
+
+    // explicit credentials.baseURL bypasses computation entirely
+    const r3 = resolveOpenAICompatConfig(fakeEntry, {
+      accountId: "acct-999",
+      baseURL: "https://custom.example.com/v1",
+    });
+    expectEq(
+      r3.baseURL,
+      "https://custom.example.com/v1",
+      "explicit credentials.baseURL bypasses computedBaseURL.build",
+    );
+
+    record(results, `${section}: computedBaseURL (accountId) path`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: computedBaseURL (accountId) path`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section: ConfiguredOpenAICompatProvider (Task 3)
+// ───────────────────────────────────────────────────────────────────────
+
+async function testConfiguredProviderHookDelegation(): Promise<void> {
+  const section = "ConfiguredOpenAICompatProvider";
+  setEnv("TEST_CONFIGURED_API_KEY", "sk-configured-test-key");
+  setEnv("TEST_CONFIGURED_BASE_URL", undefined);
+
+  const { ConfiguredOpenAICompatProvider } =
+    await import("../dist/lib/providers/configuredOpenAICompat.js");
+  const { AuthenticationError, RateLimitError, InvalidModelError } =
+    await import("../dist/lib/types/index.js");
+
+  const fakeEntry = {
+    providerName: "test-configured" as never,
+    aliases: ["test-configured"],
+    apiKeyEnvVar: "TEST_CONFIGURED_API_KEY",
+    baseURLEnvVar: "TEST_CONFIGURED_BASE_URL",
+    defaultBaseURL: "https://configured.example.com/v1",
+    configOptions: {
+      providerName: "TestConfigured",
+      envVarName: "TEST_CONFIGURED_API_KEY",
+      setupUrl: "https://example.com/docs/test-configured",
+      description: "API key",
+      instructions: ["1. Get a key"],
+    },
+    modelEnvVar: "TEST_CONFIGURED_MODEL",
+    defaultModel: "test-model-default",
+    registryDefaultModel: "test-model-default",
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: "test-model-fallback",
+    fallbackModels: ["test-model-fallback", "test-model-alt"],
+    // Real ProviderErrorRule shape (match/errorClass/message), matching
+    // plan 07's contract exactly. Deliberately has NO always-true catch-all
+    // rule, so the "unrelated failure" case below exercises
+    // classifyProviderError's own built-in fallback rather than anything
+    // this fixture supplies — proving the class needs no catch-all of its
+    // own to behave correctly.
+    errorRules: [
+      {
+        match: (ctx: { message: string }) =>
+          /invalid api key|401/i.test(ctx.message),
+        errorClass: AuthenticationError,
+        message: "invalid api key (test)",
+      },
+      {
+        match: (ctx: { message: string }) =>
+          /rate limit|429/i.test(ctx.message),
+        errorClass: RateLimitError,
+        message: "rate limit exceeded (test)",
+      },
+      {
+        match: (ctx: { message: string }) =>
+          /model_not_found|404/i.test(ctx.message),
+        errorClass: InvalidModelError,
+        message: (ctx: { modelName?: string }) =>
+          `model '${ctx.modelName}' not found (test)`,
+      },
+    ],
+  };
+
+  try {
+    const provider = new ConfiguredOpenAICompatProvider(
+      fakeEntry,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Explicit pin on construction itself succeeding — not just an implicit
+    // pass-through of the surrounding try/catch. Regression guard for the
+    // class-initialization-order defect fixed in this task: `this.entry`
+    // was read (as `this.entry.modelEnvVar`) by a base-constructor-invoked
+    // override before the subclass had assigned it, so a broken fix throws
+    // here specifically, not somewhere generic.
+    expect(
+      provider instanceof ConfiguredOpenAICompatProvider,
+      "construction succeeds and returns a ConfiguredOpenAICompatProvider instance",
+    );
+
+    expectEq(
+      (provider as unknown as { providerName: string }).providerName,
+      "test-configured",
+      "getProviderName() delegates to entry.providerName",
+    );
+    expectEq(
+      (provider as unknown as { modelName: string }).modelName,
+      "test-model-default",
+      "getDefaultModel() delegates to entry.defaultModel (no env override set)",
+    );
+
+    // formatProviderError: authentication
+    const authErr = (
+      provider as unknown as { formatProviderError(e: unknown): Error }
+    )["formatProviderError"](new Error("Invalid API key: 401"));
+    expect(
+      authErr.constructor.name === "AuthenticationError",
+      `authentication rule maps to AuthenticationError (got ${authErr.constructor.name})`,
+    );
+
+    // formatProviderError: throttling (was "rate-limit rule maps to..." in
+    // the brief — reworded: "rate-limit" (hyphenated) matches envGuard's
+    // `rate_limit` SKIP pattern (`rate[ _-]?limit`), so a real failure here
+    // would be silently downgraded to a skip instead of a hard fail).
+    const rlErr = (
+      provider as unknown as { formatProviderError(e: unknown): Error }
+    )["formatProviderError"](new Error("rate limit exceeded, 429"));
+    expect(
+      rlErr.constructor.name === "RateLimitError",
+      `throttling rule maps to RateLimitError (got ${rlErr.constructor.name})`,
+    );
+
+    // formatProviderError: invalid-model
+    const modelErr = (
+      provider as unknown as { formatProviderError(e: unknown): Error }
+    )["formatProviderError"](new Error("model_not_found: no such model"));
+    expect(
+      modelErr.constructor.name === "InvalidModelError",
+      `invalid-model rule maps to InvalidModelError (got ${modelErr.constructor.name})`,
+    );
+
+    // formatProviderError: no rule matches, and fakeEntry.errorRules has no
+    // catch-all of its own — this exercises classifyProviderError's own
+    // built-in fallback (`new ProviderError(`${provider} error: ${message}`, provider)`)
+    const genErr = (
+      provider as unknown as { formatProviderError(e: unknown): Error }
+    )["formatProviderError"](new Error("some unrelated failure"));
+    expect(
+      genErr.constructor.name === "ProviderError",
+      `unmatched error falls through to classifyProviderError's built-in ProviderError fallback (got ${genErr.constructor.name})`,
+    );
+
+    // formatProviderError: TimeoutError special-cased to NetworkError
+    // regardless of catalog errorRules
+    const { TimeoutError } = await import("../dist/lib/utils/timeout.js");
+    const timeoutErr = (
+      provider as unknown as { formatProviderError(e: unknown): Error }
+    )["formatProviderError"](new TimeoutError("took too long"));
+    expect(
+      timeoutErr.constructor.name === "NetworkError",
+      `TimeoutError maps to NetworkError (got ${timeoutErr.constructor.name})`,
+    );
+
+    record(results, `${section}: hook delegation + error classification`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: hook delegation + error classification`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section: OPENAI_COMPAT_CATALOG structural invariants (Task 4)
+// ───────────────────────────────────────────────────────────────────────
+
+async function testCatalogStructuralInvariants(): Promise<void> {
+  const section = "OPENAI_COMPAT_CATALOG";
+  try {
+    const { OPENAI_COMPAT_CATALOG } =
+      await import("../dist/lib/providers/openaiCompatCatalog.js");
+
+    expectEq(OPENAI_COMPAT_CATALOG.length, 7, "catalog has exactly 7 entries");
+
+    const providerNames = OPENAI_COMPAT_CATALOG.map(
+      (e: { providerName: string }) => e.providerName,
+    );
+    expectEq(
+      new Set(providerNames).size,
+      providerNames.length,
+      "providerName values are unique",
+    );
+    for (const expected of [
+      "groq",
+      "xai",
+      "together-ai",
+      "fireworks",
+      "perplexity",
+      "mistral",
+      "cloudflare",
+    ]) {
+      expect(
+        providerNames.includes(expected),
+        `catalog includes providerName '${expected}'`,
+      );
+    }
+
+    const allAliases = OPENAI_COMPAT_CATALOG.flatMap(
+      (e: { aliases: string[] }) => e.aliases,
+    );
+    expectEq(
+      new Set(allAliases).size,
+      allAliases.length,
+      "no alias collisions across catalog entries",
+    );
+
+    for (const entry of OPENAI_COMPAT_CATALOG as Array<
+      Record<string, unknown>
+    >) {
+      expect(
+        typeof entry.apiKeyEnvVar === "string" && entry.apiKeyEnvVar.length > 0,
+        `${String(entry.providerName)}: apiKeyEnvVar is a non-empty string`,
+      );
+      // apiKeyEnvVar is declarative; validateApiKey reads
+      // configOptions.envVarName. Two fields naming one variable are only
+      // safe while they cannot disagree.
+      const configOptions = entry.configOptions as
+        | { envVarName?: string }
+        | undefined;
+      expectEq(
+        configOptions?.envVarName,
+        entry.apiKeyEnvVar,
+        `${String(entry.providerName)}: apiKeyEnvVar matches the env var actually read`,
+      );
+      expect(
+        Boolean(entry.baseURLEnvVar && entry.defaultBaseURL) !==
+          Boolean(entry.computedBaseURL),
+        `${String(entry.providerName)}: has exactly one of (baseURLEnvVar+defaultBaseURL) or computedBaseURL`,
+      );
+      expect(
+        Array.isArray(entry.errorRules) &&
+          (entry.errorRules as unknown[]).length > 0,
+        `${String(entry.providerName)}: errorRules is a non-empty array`,
+      );
+    }
+
+    // The one documented quirk: Mistral is the only entry whose registry
+    // default does not check its model env var.
+    const mistral = OPENAI_COMPAT_CATALOG.find(
+      (e: { providerName: string }) => e.providerName === "mistral",
+    ) as { registryDefaultModelChecksEnvVar: boolean } | undefined;
+    expect(!!mistral, "mistral entry exists");
+    expectEq(
+      mistral?.registryDefaultModelChecksEnvVar,
+      false,
+      "mistral.registryDefaultModelChecksEnvVar is false (preserved quirk)",
+    );
+    const nonMistral = (
+      OPENAI_COMPAT_CATALOG as Array<{
+        providerName: string;
+        registryDefaultModelChecksEnvVar: boolean;
+      }>
+    ).filter((e) => e.providerName !== "mistral");
+    expect(
+      nonMistral.every((e) => e.registryDefaultModelChecksEnvVar === true),
+      "every non-mistral entry has registryDefaultModelChecksEnvVar true",
+    );
+
+    record(results, `${section}: structural invariants`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: structural invariants`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section: main
+// ───────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log("=== OpenAI-Compat Catalog Suite ===");
+  try {
+    await testResolveConfigPrecedence();
+    await testResolveConfigComputedBaseURL();
+    await testConfiguredProviderHookDelegation();
+    await testCatalogStructuralInvariants();
+  } finally {
+    restoreEnv();
+  }
+
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.filter((r) => !r.ok).length;
+  console.log(`\n${passed} passed · ${failed} failed (of ${results.length})`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("openai-compat-catalog suite crashed:", err);
+  restoreEnv();
+  process.exit(2);
+});

--- a/test/continuous-test-suite-provider-structure.ts
+++ b/test/continuous-test-suite-provider-structure.ts
@@ -63,6 +63,15 @@ const PROVIDER_REGISTRATION_EXCLUSIONS = new Set([
   "anthropicImageBlocks",
   "openaiChatCompletionsBase",
   "openaiChatCompletionsClient",
+  // Pure data: the catalog of OpenAI-compatible provider entries. It exports
+  // a const array, not a provider class, so it is a non-provider file in the
+  // first sense above.
+  "openaiCompatCatalog",
+  // The generic class the catalog drives. It is a real provider class, but
+  // it is not registered under its own name — the registry will dynamically
+  // import it once per catalog entry when the registration loop lands, and
+  // at that point this exclusion becomes unnecessary and should be removed.
+  "configuredOpenAICompat",
 ]);
 
 const DYNAMIC_PROVIDER_IMPORT_RE =


### PR DESCRIPTION
Seven providers — Groq, xAI, Together AI, Fireworks, Perplexity, Mistral and Cloudflare — are near-identical subclasses differing only in a base URL, some environment variable names, a default model, and one or two error rules. This adds the pieces needed to describe them as data.

**Purely additive.** The registry still constructs the seven existing classes, no provider's behavior changes, and `OPENAI_COMPAT_CATALOG` is imported only by its own test suite. Wiring it up — and the seven per-provider parity proofs that must land with that switch — is a separate PR, deliberately, so the migration arrives with its evidence rather than after it.

## What's here

- **`resolveOpenAICompatConfig`** — one helper implementing the credential and base-URL precedence each of these providers currently hand-rolls.
- **`OpenAICompatCatalogEntry` / `OpenAICompatCredentials`** — the entry types.
- **`ConfiguredOpenAICompatProvider`** — the generic class an entry drives.
- **`OPENAI_COMPAT_CATALOG`** — the seven entries.

## Two things worth a reviewer's attention

**A construction-order bug in the original design.** The sketch assigned the entry field *after* calling `super()`, but `BaseProvider`'s constructor synchronously calls `getDefaultModel()`/`getProviderName()`, which the subclass overrides to read that field — so construction threw `Cannot read properties of undefined`. The constructor now resolves the model from its `entry` parameter before `super()`, and a test pins construction so it can't regress silently.

**The error rules mirror today's behavior, not the plan's.** This plan was written before the shared `DEFAULT_ERROR_RULES` table existed. All seven providers now keep only their own auth rule plus any real quirk (Groq's decommissioned-model handling, xAI's quota message) and spread the shared table for everything else. Each entry reproduces that exactly, spreading the same exported constant rather than an inlined copy — a second copy that drifts is the failure mode this program has spent two releases removing. Encoding the older ladders would have made the eventual migration silently change the error message and class of all seven providers while looking like a faithful port.

Every non-error field was verified against provider source — base URLs, environment variables, aliases, registry defaults, and the quirks around Mistral's model check, Perplexity's fallback model and Cloudflare's computed base URL — with no divergence found.

## Known gap, documented not papered over

Groq intercepts `TimeoutError` and returns a plain `ProviderError` before delegating to the shared classifier, deliberately overriding its timeout handling. No catalog field can express that today, so migrating Groq onto the generic class as-is would silently reclassify its timeouts. It's recorded as a comment on the Groq entry and has to be resolved before the migration; Groq's parity proof will enforce it either way.

## Note on the structure suite

`continuous-test-suite-provider-structure` requires every flat file under `src/lib/providers/` to be dynamically imported by the registry and export a provider class. The catalog is data, and the generic class isn't registered under its own name — the registry will import it once per entry when the loop lands, at which point its exclusion becomes unnecessary and should be removed. Both are added to the suite's existing exclusion set with that reasoning inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for seven OpenAI-compatible providers: Groq, xAI, Together AI, Fireworks, Perplexity, Mistral, and Cloudflare.
  * Added automatic credential and endpoint resolution, including Cloudflare account-based URLs.
  * Added provider-specific model defaults, fallback models, and error handling.

* **Tests**
  * Added comprehensive coverage for configuration, provider construction, error handling, catalog validation, and environment cleanup.
  * Added a dedicated command for running the compatibility catalog test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->