### PR TITLE
fix(lint): allow-list the codex suite so rule 15 stops blocking every commit

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -279,6 +279,14 @@ export default [
             // produces, and module-export-shape checks. Its header already
             // states the exception and the all-src module graph.
             "test/continuous-test-suite-error-classifier-contract.ts",
+            // Account ordering, 429 cooldown planning and refresh-failure
+            // classification, which would otherwise need a specific sequence
+            // of 429s and token-endpoint failures across several real ChatGPT
+            // accounts to provoke. Its header states the exception in full,
+            // including that `__testHooks` should shrink as the logic gains a
+            // real surface. Its last two cases drive the built CLI and are
+            // deliberately outside the exception.
+            "test/continuous-test-suite-codex.ts",
           ],
         },
       ],


### PR DESCRIPTION
**`pnpm run lint` fails on `release` right now, and `pre-commit.sh` runs lint across the whole repo — so no commit can land on any branch forked from current release.** Found when a fresh worktree could not commit unrelated work.

Two changes merged in a racing order:

- `a634f8ae` added `test/continuous-test-suite-codex.ts`, which imports `codexOAuth`, `codexAccountUsage`, `codexProxyRoutes`' `__testHooks` and `tokenStore` from `src/`.
- `f84d18b1` then added the lint rule enforcing rule 15 — without adding that file to the rule's `allow` list.

Neither is wrong on its own. Together they leave the gate red.

## Why allow-listing is the right fix here, not a workaround

The suite already carries a complete determinism-exception header, written before the rule existed. It covers account ordering, 429 cooldown planning, upstream header construction, quota parsing and refresh-failure classification — decisions that would otherwise need a specific sequence of 429s and token-endpoint failures provoked across several real ChatGPT accounts. Its header also notes that `__testHooks` is test-only and should shrink as the logic gains a real surface, and that its last two cases deliberately sit *outside* the exception because they drive the built CLI.

In other words the author made and documented exactly the case the rule asks for; the entry simply never reached the list. This adds it, with a comment summarising that justification so the list stays self-explaining.

One line of config. No test or source behavior changes. `pnpm run lint`: 0 errors.

(If the Codex owners would rather refactor the suite onto a shipped surface than keep the exemption, that is a better long-term answer — but it should not gate every unrelated commit in the meantime.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added the continuous test suite to the end-to-end test allowlist.
  * Documented coverage for deterministic account ordering, cooldown behavior, refresh failures, and command-line interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->