### PR TITLE
fix(ci): bound every apt wait so the ffmpeg install cannot hang a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,27 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          export DEBIAN_FRONTEND=noninteractive
+          # Runners boot with unattended-upgrades holding the dpkg lock, and a
+          # plain apt-get waits on that lock forever. On 2026-08-18 this step
+          # sat in_progress for 90 minutes on two open PRs, leaving the quality
+          # gate permanently "pending" with nothing to re-run against. Bound
+          # every wait so a contended lock fails fast, and let the step
+          # deadline catch anything the bounds miss.
+          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
+            sleep 5
+          done
+          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
+            install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -205,9 +223,27 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          export DEBIAN_FRONTEND=noninteractive
+          # Runners boot with unattended-upgrades holding the dpkg lock, and a
+          # plain apt-get waits on that lock forever. On 2026-08-18 this step
+          # sat in_progress for 90 minutes on two open PRs, leaving the quality
+          # gate permanently "pending" with nothing to re-run against. Bound
+          # every wait so a contended lock fails fast, and let the step
+          # deadline catch anything the bounds miss.
+          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
+            sleep 5
+          done
+          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
+            install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -286,9 +322,27 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          export DEBIAN_FRONTEND=noninteractive
+          # Runners boot with unattended-upgrades holding the dpkg lock, and a
+          # plain apt-get waits on that lock forever. On 2026-08-18 this step
+          # sat in_progress for 90 minutes on two open PRs, leaving the quality
+          # gate permanently "pending" with nothing to re-run against. Bound
+          # every wait so a contended lock fails fast, and let the step
+          # deadline catch anything the bounds miss.
+          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
+            sleep 5
+          done
+          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
+            install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,27 @@ jobs:
       # publish workflow, each break silently stopped releases from going
       # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          export DEBIAN_FRONTEND=noninteractive
+          # Runners boot with unattended-upgrades holding the dpkg lock, and a
+          # plain apt-get waits on that lock forever. On 2026-08-18 this step
+          # sat in_progress for 90 minutes on two open PRs, leaving the quality
+          # gate permanently "pending" with nothing to re-run against. Bound
+          # every wait so a contended lock fails fast, and let the step
+          # deadline catch anything the bounds miss.
+          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
+            sleep 5
+          done
+          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
+            install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -95,9 +113,27 @@ jobs:
       # publish workflow, each break silently stopped releases from going
       # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+            exit 0
+          fi
+          export DEBIAN_FRONTEND=noninteractive
+          # Runners boot with unattended-upgrades holding the dpkg lock, and a
+          # plain apt-get waits on that lock forever. On 2026-08-18 this step
+          # sat in_progress for 90 minutes on two open PRs, leaving the quality
+          # gate permanently "pending" with nothing to re-run against. Bound
+          # every wait so a contended lock fails fast, and let the step
+          # deadline catch anything the bounds miss.
+          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
+            sleep 5
+          done
+          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
+            install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |


### PR DESCRIPTION
## What happened

On 2026-08-18 the **Install ffmpeg** step sat `in_progress` for over **90 minutes** on #1354 and #1353.

That step normally completes in seconds, and the job it gates — 🛡️ Code Quality & Security Gate — finishes in about **2m40s** (see #1344, #1341, #1337). Because the step never returned, the gate stayed permanently **pending** rather than failing, so there was nothing to re-run against and every step behind it (`Build Validation`, `ESLint Quality Report`, `TypeScript Compiler Check`, …) never started. Both PRs looked indefinitely un-mergeable for a reason that had nothing to do with their code.

## Cause

apt, not ffmpeg. GitHub runners boot with `unattended-upgrades` holding the dpkg lock, and a plain `apt-get` blocks on that lock with **no deadline**. A slow or stuck upgrade run wedges the step until the job hits its six-hour limit.

## Fix

Bound every wait rather than trusting the defaults:

| Change | Why |
|---|---|
| `timeout-minutes: 5` on the step | A hang becomes a fast, visible failure that can be re-run, not an invisible stall |
| `-o DPkg::Lock::Timeout=60` | apt gives up on a contended lock instead of waiting forever |
| `-o Acquire::Retries=3` + 3-attempt loop around `update` | A flaky mirror retries instead of failing the build |
| Stop `unattended-upgrades` first | Removes the usual lock holder |
| Skip install when `ffmpeg` is already present | No apt call at all on images that ship it |

## Scope

All five install steps: the three CI jobs (`test`, `build-check`, `quality-gate`) and both `release.yml` jobs, which carry the identical hazard and would stall a release the same way.

## Verification

- Both workflow files parse as valid YAML; all five steps carry `timeout-minutes: 5`.
- The new step body passes `bash -n`.
- The real proof is this PR's own CI: the same three jobs now run the patched step. `Install ffmpeg` completing quickly here is the regression test.

No source, test or dependency changes — workflow YAML only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test, build, quality, and release workflows for more reliable completion.
  * Added safeguards to prevent setup steps from hanging indefinitely.
  * Existing tool installations are now detected and reused when available.
  * Added retry and timeout handling to better withstand temporary package service or system-lock issues.
  * These changes help reduce failed or stalled checks and releases without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->