### PR TITLE
fix(ci): give the ffmpeg install a realistic deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already present: $(ffmpeg -version | head -1)"
@@ -47,13 +47,14 @@ jobs:
           # every wait so a contended lock fails fast, and let the step
           # deadline catch anything the bounds miss.
           sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
+          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           for attempt in 1 2 3; do
-            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            sudo apt-get $APT_OPTS update && break
             echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
             sleep 5
           done
-          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
-            install -y --no-install-recommends ffmpeg
+          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -223,7 +224,7 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already present: $(ffmpeg -version | head -1)"
@@ -237,13 +238,14 @@ jobs:
           # every wait so a contended lock fails fast, and let the step
           # deadline catch anything the bounds miss.
           sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
+          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           for attempt in 1 2 3; do
-            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            sudo apt-get $APT_OPTS update && break
             echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
             sleep 5
           done
-          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
-            install -y --no-install-recommends ffmpeg
+          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -322,7 +324,7 @@ jobs:
       # version new enough for what the suites exercise, and it cannot be
       # invalidated by an upstream release being moved or rebuilt.
       - name: Install ffmpeg
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already present: $(ffmpeg -version | head -1)"
@@ -336,13 +338,14 @@ jobs:
           # every wait so a contended lock fails fast, and let the step
           # deadline catch anything the bounds miss.
           sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
+          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           for attempt in 1 2 3; do
-            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            sudo apt-get $APT_OPTS update && break
             echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
             sleep 5
           done
-          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
-            install -y --no-install-recommends ffmpeg
+          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       # publish workflow, each break silently stopped releases from going
       # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already present: $(ffmpeg -version | head -1)"
@@ -52,13 +52,14 @@ jobs:
           # every wait so a contended lock fails fast, and let the step
           # deadline catch anything the bounds miss.
           sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
+          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           for attempt in 1 2 3; do
-            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            sudo apt-get $APT_OPTS update && break
             echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
             sleep 5
           done
-          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
-            install -y --no-install-recommends ffmpeg
+          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |
@@ -113,7 +114,7 @@ jobs:
       # publish workflow, each break silently stopped releases from going
       # out while CI still looked healthy. ci.yml was moved off it already.
       - name: Install ffmpeg
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already present: $(ffmpeg -version | head -1)"
@@ -127,13 +128,14 @@ jobs:
           # every wait so a contended lock fails fast, and let the step
           # deadline catch anything the bounds miss.
           sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
+          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
+          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           for attempt in 1 2 3; do
-            sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 update && break
+            sudo apt-get $APT_OPTS update && break
             echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
             sleep 5
           done
-          sudo apt-get -o DPkg::Lock::Timeout=60 -o Acquire::Retries=3 \
-            install -y --no-install-recommends ffmpeg
+          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
 
       - name: Verify ffmpeg installation
         run: |


### PR DESCRIPTION
Regression fix for #1355, which I introduced a few hours ago. `build-check` and the `release` workflow are currently **failing on `release` itself** because of it.

## What went wrong

#1355 added `timeout-minutes: 5` to the ffmpeg install to stop it hanging. The log from the failing run shows apt was **not stuck — it was slow**:

```
03:56:05 Get:50 .../libflite1 amd64 2.2-6build3 [13.6 MB]
03:57:17 Get:51 .../libserd-0-0 ...          ← 72s for one package
03:57:25 Get:57 .../libplacebo338 [2654 kB]
03:57:37 ##[error]The action 'Install ffmpeg' has timed out after 5 minutes.
```

Steady progress, killed mid-download. A successful install on a healthy mirror takes about **2m50s**, so 5 minutes left almost no headroom.

**This is worse than the bug it replaced**, because `build-check` is now a required status check on `release`: instead of one stalled job, *every* PR fails whenever the Ubuntu mirror is having a slow day.

## Fix

`timeout-minutes: 5` → **15**, across all five install steps (3 CI jobs + 2 release jobs). That still bounds the original fault decisively — the hang it was added for ran past **90 minutes** — while leaving roughly 5× the normal install duration as headroom.

Also added `Acquire::http::Timeout=30` / `Acquire::https::Timeout=30`. The step deadline was always the backstop, not the fix; what actually addresses the hang is `DPkg::Lock::Timeout`, which stops apt waiting forever on the lock `unattended-upgrades` holds. The new download timeouts cover the case the retry loop couldn't see — a transfer that stalls *mid-download* now aborts and retries instead of creeping toward the deadline.

## Verification

- Both workflow files parse as valid YAML; all five steps carry `timeout-minutes: 15`.
- The step body passes `bash -n`.
- The real check is this PR's own CI — the same three jobs run the patched step. `Install ffmpeg` completing here is the regression test.

Workflow YAML only; no source, test or dependency changes.
