### PR TITLE
feat(tools): add provider onboarding scaffolding and a completeness gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -63,6 +63,22 @@ If yes, describe:
 - Migration path for users
 - Deprecation warnings added?
 
+## New Provider Onboarding
+
+**Does this PR add a new provider or a new aggregator-served model?** Pick a tier per `docs/provider-integration/tiers/README.md`:
+
+- [ ] N/A — no provider/model change
+- [ ] Tier 1 — aggregator passthrough only (LiteLLM/OpenRouter model id, no new `AIProviderName` member — see `docs/provider-integration/tiers/tier-1-aggregator-passthrough.md`). **No manifest and no mocked-contract section required**: `pnpm run verify:provider-onboarding` only gates providers that add an `AIProviderName` member, which Tier 1 never does.
+- [ ] Tier 2/3/4 — adds a new `AIProviderName` member — complete the checklist below
+
+If Tier 2/3/4:
+
+- [ ] Tier selected (2/3/4) per `docs/provider-integration/tiers/README.md`
+- [ ] Manifest added at `docs/provider-integration/manifests/<name>.json` (`tier4Justification` filled in if Tier 4)
+- [ ] Mocked-contract test section added to `test/continuous-test-suite-providers-mocked.ts`
+- [ ] `pnpm run test:providers-mocked` passes locally
+- [ ] `pnpm run verify:provider-onboarding` passes locally
+
 ## Testing
 
 **How has this been tested?**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Error classifier contract tests (TimeoutError classification per provider, no API keys required)
         run: pnpm run test:error-classifier-contract
 
+      - name: 🧩 Provider Onboarding Completeness
+        run: pnpm run verify:provider-onboarding
+
   # action-smoke-test:
   #   name: GitHub Action Smoke Test
   #   runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ NEUROLINK_SDK_GAPS.md
 .yama/state/
 .yama/analytics/
 .yama/reports/
+.scaffold-output/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,30 +163,33 @@ User input (text + files)
 
 ## Key Files
 
-| File                                               | Purpose                                                            |
-| -------------------------------------------------- | ------------------------------------------------------------------ |
-| `src/lib/neurolink.ts`                             | Main SDK class — orchestrates everything                           |
-| `src/lib/factories/providerRegistry.ts`            | Provider registration (use dynamic imports here)                   |
-| `src/lib/core/baseProvider.ts`                     | Base class all providers extend; central `stream()` tool merge     |
-| `src/lib/utils/messageBuilder.ts`                  | Constructs messages; handles all file types                        |
-| `src/lib/adapters/providerImageAdapter.ts`         | Per-provider multimodal formatting + vision capability map         |
-| `src/lib/adapters/tts/`                            | TTS provider handlers (Google TTS, Cartesia); new handlers go here |
-| `src/lib/mcp/toolRegistry.ts`                      | Tool management + MCP server registry                              |
-| `src/lib/mcp/mcpClientFactory.ts`                  | Creates MCP clients for all transport types                        |
-| `src/lib/processors/registry/ProcessorRegistry.ts` | Selects file processor by MIME type + priority                     |
-| `src/lib/types/index.ts`                           | Main type exports (start here for any type lookup)                 |
-| `src/lib/types/providers.ts`                       | `AIProvider` type                                                  |
-| `src/lib/types/mcp.ts`                             | `MCPTransportType` and MCP config types                            |
-| `src/lib/constants/enums.ts`                       | `AIProviderName` enum                                              |
-| `src/lib/constants/contextWindows.ts`              | Per-provider, per-model context window sizes                       |
-| `src/lib/context/contextCompactor.ts`              | Multi-stage context reduction orchestrator                         |
-| `src/lib/context/budgetChecker.ts`                 | Pre-call budget validation                                         |
-| `src/lib/rag/ragIntegration.ts`                    | `prepareRAGTool()` — auto RAG setup for generate/stream            |
-| `src/cli/factories/commandFactory.ts`              | All CLI command options and flag definitions                       |
-| `src/lib/server/routes/agentRoutes.ts`             | HTTP server routes including `/api/agent/embed`                    |
-| `src/lib/server/routes/claudeProxyRoutes.ts`       | Anthropic pool engine — account routing, retry, SSE relay          |
-| `src/lib/server/routes/codexProxyRoutes.ts`        | Codex (ChatGPT) pool engine — `/backend-api/codex/responses`       |
-| `src/lib/auth/codexOAuth.ts`                       | Codex OAuth: `auth.json` import, refresh, account-id resolution    |
+| File                                               | Purpose                                                                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/neurolink.ts`                             | Main SDK class — orchestrates everything                                                                                 |
+| `src/lib/factories/providerRegistry.ts`            | Provider registration (use dynamic imports here)                                                                         |
+| `src/lib/core/baseProvider.ts`                     | Base class all providers extend; central `stream()` tool merge                                                           |
+| `src/lib/utils/messageBuilder.ts`                  | Constructs messages; handles all file types                                                                              |
+| `src/lib/adapters/providerImageAdapter.ts`         | Per-provider multimodal formatting + vision capability map                                                               |
+| `src/lib/adapters/tts/`                            | TTS provider handlers (Google TTS, Cartesia); new handlers go here                                                       |
+| `src/lib/mcp/toolRegistry.ts`                      | Tool management + MCP server registry                                                                                    |
+| `src/lib/mcp/mcpClientFactory.ts`                  | Creates MCP clients for all transport types                                                                              |
+| `src/lib/processors/registry/ProcessorRegistry.ts` | Selects file processor by MIME type + priority                                                                           |
+| `src/lib/types/index.ts`                           | Main type exports (start here for any type lookup)                                                                       |
+| `src/lib/types/providers.ts`                       | `AIProvider` type, `NeurolinkCredentials`, `ProviderDescriptor` type                                                     |
+| `src/lib/factories/providerDescriptors.ts`         | `PROVIDER_DESCRIPTORS` — single source of truth for provider metadata (aliases, credentials key, env vars, tool support) |
+| `src/lib/providers/openaiCompatCatalog.ts`         | `OPENAI_COMPAT_CATALOG` — data rows for zero-quirk OpenAI-wire-compatible providers (Tier 2 onboarding)                  |
+| `docs/provider-integration/tiers/README.md`        | Tiered new-provider onboarding guide — start here for any new provider                                                   |
+| `src/lib/types/mcp.ts`                             | `MCPTransportType` and MCP config types                                                                                  |
+| `src/lib/constants/enums.ts`                       | `AIProviderName` enum (the actual location — not `types/providers.ts`)                                                   |
+| `src/lib/constants/contextWindows.ts`              | Per-provider, per-model context window sizes                                                                             |
+| `src/lib/context/contextCompactor.ts`              | Multi-stage context reduction orchestrator                                                                               |
+| `src/lib/context/budgetChecker.ts`                 | Pre-call budget validation                                                                                               |
+| `src/lib/rag/ragIntegration.ts`                    | `prepareRAGTool()` — auto RAG setup for generate/stream                                                                  |
+| `src/cli/factories/commandFactory.ts`              | All CLI command options and flag definitions                                                                             |
+| `src/lib/server/routes/agentRoutes.ts`             | HTTP server routes including `/api/agent/embed`                                                                          |
+| `src/lib/server/routes/claudeProxyRoutes.ts`       | Anthropic pool engine — account routing, retry, SSE relay                                                                |
+| `src/lib/server/routes/codexProxyRoutes.ts`        | Codex (ChatGPT) pool engine — `/backend-api/codex/responses`                                                             |
+| `src/lib/auth/codexOAuth.ts`                       | Codex OAuth: `auth.json` import, refresh, account-id resolution                                                          |
 
 ### Proxy pool engines
 
@@ -395,26 +398,14 @@ waits forever on the dpkg lock that `unattended-upgrades` holds.
 
 ### Adding a New Provider
 
-1. Create `src/lib/providers/yourProvider.ts` — extend `BaseProvider`
-2. Add name to `AIProviderName` enum in `src/lib/constants/enums.ts`
-3. Add model constants to `src/lib/models/`
-4. Register in `ProviderRegistry.registerAllProviders()` using a dynamic import:
+**Start at `docs/provider-integration/tiers/README.md`** — it routes you to one of four tiers by actual effort required, not a one-size-fits-all checklist:
 
-   ```typescript
-   ProviderFactory.registerProvider(
-     AIProviderName.YOUR_PROVIDER,
-     async (modelName?, _providerName?, sdk?) => {
-       const { YourProvider } = await import("../providers/yourProvider.js");
-       return new YourProvider(modelName, sdk as NeuroLink | undefined);
-     },
-     YourModels.DEFAULT,
-     ["alias1", "alias2"],
-   );
-   ```
+- **Tier 1 — aggregator passthrough** (a model already served by LiteLLM/OpenRouter): zero code, just a model id. See `tiers/tier-1-aggregator-passthrough.md`.
+- **Tier 2 — catalog entry** (OpenAI-wire-compatible, zero behavioral quirks — most new providers): one `AIProviderName` enum member + one `OpenAICompatCatalogEntry` row in `src/lib/providers/openaiCompatCatalog.ts` + one `ProviderDescriptor` row in `src/lib/factories/providerDescriptors.ts` + a `NeurolinkCredentials` slice in `src/lib/types/providers.ts` + one dynamic `ProviderFactory.registerProvider()` block in `src/lib/factories/providerRegistry.ts` + one mocked-contract test section + a manifest. ~1 hour. See `tiers/tier-2-catalog-entry.md` for the full checklist.
+- **Tier 3 — adapter-based native** (own SDK/wire format, still a normal HTTP request/response lifecycle): a `src/lib/providers/<name>.ts` class extending `BaseProvider`, days. See `tiers/tier-3-adapter-native.md`.
+- **Tier 4 — full custom** (SageMaker-class: non-HTTP protocol or SDK-signed auth): everything Tier 3 needs plus a custom lifecycle, and a written `tier4Justification` in its manifest. See `tiers/tier-4-full-custom.md`.
 
-5. If multimodal: add vision capabilities to `ProviderImageAdapter.VISION_CAPABILITIES`
-6. Add to CLI provider choices in `src/cli/factories/commandFactory.ts`
-7. Add tests to the most relevant `test/continuous-test-suite-*.ts` (e.g. `-providers.ts`), or create a new suite `test/continuous-test-suite-<name>.ts` and add a matching `test:<name>` script in `package.json`
+`AIProviderName` lives in `src/lib/constants/enums.ts` (not `src/lib/types/providers.ts`). Tier 2+ providers — every tier that adds an `AIProviderName` member — must end with a manifest at `docs/provider-integration/manifests/<name>.json` and a green `pnpm run verify:provider-onboarding`; this is a required CI gate, not optional. Tier 1 adds no `AIProviderName` member, so neither the manifest nor the gate applies to it — see `tiers/tier-1-aggregator-passthrough.md`. Use `pnpm run scaffold:provider` (`tools/scaffold-provider.ts`) to generate starting-point snippets instead of copy-pasting from an existing provider by hand.
 
 ### Adding a New File Processor
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
     "test:mcp:spans": "npx tsx test/continuous-test-suite-mcp-spans.ts",
     "test:mcp:infra": "npx tsx test/continuous-test-suite-mcp-infra.ts",
     "test:providers-mocked": "npx tsx test/continuous-test-suite-providers-mocked.ts",
+    "scaffold:provider": "npx tsx tools/scaffold-provider.ts",
+    "verify:provider-onboarding": "npx tsx tools/verify-provider-onboarding.ts",
     "test:openai-compat-catalog": "npx tsx test/continuous-test-suite-openai-compat-catalog.ts",
     "test:provider-descriptors": "npx tsx test/continuous-test-suite-provider-descriptors.ts",
     "test:provider-structure": "npx tsx test/continuous-test-suite-provider-structure.ts",

--- a/tools/provider-onboarding-marker.ts
+++ b/tools/provider-onboarding-marker.ts
@@ -1,0 +1,214 @@
+/**
+ * Single source of truth for the "mocked-contract section" marker that
+ * tools/verify-provider-onboarding.ts greps for in
+ * test/continuous-test-suite-providers-mocked.ts.
+ *
+ * Both tools/scaffold-provider.ts (which tells a contributor what to
+ * write) and tools/verify-provider-onboarding.ts (which checks what they
+ * wrote) import the same builder from here, so the two can never drift
+ * into checking for two different literals again — that drift is exactly
+ * what made the CI gate fail for every scaffolded provider before this
+ * module existed.
+ *
+ * A later regression showed that isn't enough on its own: the scaffold
+ * used to spell out the marker literal inside a documentation comment
+ * (telling the contributor what to write), and the verifier matched
+ * against raw source — including comments — so an untouched placeholder
+ * satisfied the gate. `isMockedSectionSatisfied` below is now the single
+ * function both the verifier and any test of it call; it strips comments
+ * before matching, so only executable syntax can satisfy the gate. The
+ * scaffold, in turn, is responsible for never reproducing the literal
+ * `<MOCKED_SECTION_FIELD>: "<name>"` shape in generated prose (see
+ * mockedTestSectionSnippet in scaffold-provider.ts) — belt and braces,
+ * since either safeguard alone is fragile.
+ */
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The object-literal property name a mocked-contract section must set.
+ * Exported on its own (rather than only inline inside the template
+ * literals below) so generated documentation can name the field without
+ * reproducing the full `field: "value"` shape that satisfies the gate.
+ */
+export const MOCKED_SECTION_FIELD = "provider";
+
+/**
+ * The literal text a mocked-contract section must contain. Every existing
+ * section satisfies this already, whether via an `OpenAICompatSpec` entry
+ * (`{ provider: "groq", ... }`) or a hand-written `nl.generate({ provider:
+ * "openai", ... })` call — both forms are plain object-literal properties
+ * with this exact shape.
+ */
+export function mockedSectionMarker(provider: string): string {
+  return `${MOCKED_SECTION_FIELD}: "${provider}"`;
+}
+
+/** RegExp the verifier uses to detect the marker in the test-suite source. */
+export function mockedSectionPattern(provider: string): RegExp {
+  return new RegExp(`${MOCKED_SECTION_FIELD}:\\s*"${escapeRegExp(provider)}"`);
+}
+
+type StripMode =
+  | "code"
+  | "line-comment"
+  | "block-comment"
+  | "string-single"
+  | "string-double"
+  | "template";
+
+/**
+ * Strips line comments and block comments from TypeScript source, leaving
+ * string and template-literal contents untouched — including a
+ * double-slash inside a URL like `"https://example.com"`, which a naive
+ * per-line "strip everything after two slashes" approach would mistake
+ * for a comment and corrupt. Tracks quote/template state (with a
+ * brace-depth stack for `${...}`
+ * template interpolation, so a `}` that closes an interpolation returns
+ * to template mode rather than leaking out of it) so only text actually
+ * outside a string is removed.
+ *
+ * Not a full TS parser — it does not need to be. It only has to be
+ * correct enough that a marker literal sitting inside a comment never
+ * survives to match `mockedSectionPattern`, while a marker literal
+ * sitting in real code (or inside a string/template) always does.
+ */
+export function stripComments(source: string): string {
+  let out = "";
+  let mode: StripMode = "code";
+  // Depth of unmatched `{` seen since the most recent `${` while inside a
+  // template literal, one entry per nested template-interpolation level.
+  const templateInterpolationDepth: number[] = [];
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+    const next = i + 1 < n ? source[i + 1] : "";
+
+    if (mode === "line-comment") {
+      if (ch === "\n") {
+        out += ch;
+        mode = "code";
+      }
+      i += 1;
+      continue;
+    }
+
+    if (mode === "block-comment") {
+      if (ch === "*" && next === "/") {
+        i += 2;
+        mode = "code";
+        continue;
+      }
+      if (ch === "\n") {
+        out += ch; // preserve newlines so line numbers stay roughly aligned
+      }
+      i += 1;
+      continue;
+    }
+
+    if (mode === "string-single" || mode === "string-double") {
+      const quote = mode === "string-single" ? "'" : '"';
+      if (ch === "\\" && i + 1 < n) {
+        out += ch + source[i + 1];
+        i += 2;
+        continue;
+      }
+      out += ch;
+      if (ch === quote) {
+        mode = "code";
+      }
+      i += 1;
+      continue;
+    }
+
+    if (mode === "template") {
+      if (ch === "\\" && i + 1 < n) {
+        out += ch + source[i + 1];
+        i += 2;
+        continue;
+      }
+      if (ch === "`") {
+        out += ch;
+        mode = "code";
+        i += 1;
+        continue;
+      }
+      if (ch === "$" && next === "{") {
+        out += "${";
+        templateInterpolationDepth.push(0);
+        mode = "code";
+        i += 2;
+        continue;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    // mode === "code"
+    if (templateInterpolationDepth.length > 0) {
+      const top = templateInterpolationDepth.length - 1;
+      if (ch === "{") {
+        templateInterpolationDepth[top] += 1;
+      } else if (ch === "}") {
+        if (templateInterpolationDepth[top] === 0) {
+          templateInterpolationDepth.pop();
+          out += ch;
+          mode = "template";
+          i += 1;
+          continue;
+        }
+        templateInterpolationDepth[top] -= 1;
+      }
+    }
+    if (ch === "/" && next === "/") {
+      mode = "line-comment";
+      i += 2;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      mode = "block-comment";
+      i += 2;
+      continue;
+    }
+    if (ch === "'") {
+      out += ch;
+      mode = "string-single";
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      out += ch;
+      mode = "string-double";
+      i += 1;
+      continue;
+    }
+    if (ch === "`") {
+      out += ch;
+      mode = "template";
+      i += 1;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * The one function both the verifier and any test of it should call: is
+ * `provider`'s mocked-contract marker present in *executable* source
+ * (comments stripped first)? This is what "matching function" means in
+ * this repo's provider-onboarding docs/reviews — call this, not
+ * `mockedSectionPattern(...).test(rawSource)`.
+ */
+export function isMockedSectionSatisfied(
+  source: string,
+  provider: string,
+): boolean {
+  return mockedSectionPattern(provider).test(stripComments(source));
+}

--- a/tools/scaffold-provider.ts
+++ b/tools/scaffold-provider.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env tsx
+/**
+ * Provider scaffolding tool (Tier 1-4 onboarding).
+ *
+ * Given {name, tier, baseURL, envVar, defaultModel, aliases}, generates
+ * the boilerplate snippets an engineer splices into the real source
+ * files, plus a manifest stub and the tier-specific manual checklist.
+ * Never edits repo source directly — everything lands under --out
+ * (default .scaffold-output/<name>/) for review before copy-paste.
+ *
+ * Usage:
+ *   npx tsx tools/scaffold-provider.ts --name=cerebras --tier=2 \
+ *     --baseURL=https://api.cerebras.ai/v1 --envVar=CEREBRAS_API_KEY \
+ *     --defaultModel=llama3.1-70b --aliases=cerebras-ai
+ *
+ * pnpm script: pnpm run scaffold:provider -- --name=... --tier=... ...
+ *
+ * See docs/provider-integration/tiers/README.md for what each tier means.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { MOCKED_SECTION_FIELD } from "./provider-onboarding-marker.js";
+
+type ScaffoldTier = 1 | 2 | 3 | 4;
+
+// Documented format (see docs/provider-integration and the --name usage
+// string below): lowercase kebab-case, e.g. "together-ai", "lm-studio".
+// Enforced before anything is derived from `name` — the derived envVar
+// becomes a TypeScript identifier fragment and `out` becomes a real
+// filesystem path joined with it, so an unvalidated name (e.g. "../..")
+// can escape the output directory or produce unsafe generated code.
+const NAME_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+type ScaffoldInput = {
+  name: string;
+  tier: ScaffoldTier;
+  baseURL?: string;
+  envVar: string;
+  defaultModel: string;
+  aliases: readonly string[];
+  out: string;
+};
+
+function toConstantCase(name: string): string {
+  return name.toUpperCase().replace(/-/g, "_");
+}
+
+function toPascalCase(name: string): string {
+  return name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+function toCamelCase(name: string): string {
+  return name.replace(/-([a-z])/g, (_match, char: string) =>
+    char.toUpperCase(),
+  );
+}
+
+function parseArgs(argv: readonly string[]): ScaffoldInput {
+  const flags = new Map<string, string>();
+  for (const arg of argv) {
+    const match = /^--([a-zA-Z]+)=(.*)$/.exec(arg);
+    if (match) {
+      flags.set(match[1], match[2]);
+    }
+  }
+  const name = flags.get("name");
+  const tierRaw = flags.get("tier");
+  const defaultModel = flags.get("defaultModel");
+  if (!name || !tierRaw || !defaultModel) {
+    console.error(
+      "Usage: npx tsx tools/scaffold-provider.ts --name=<kebab> --tier=<1|2|3|4> --defaultModel=<id> [--baseURL=<url>] [--envVar=<ENV_NAME>] [--aliases=a,b,c] [--out=<dir>]",
+    );
+    process.exit(1);
+  }
+  if (!NAME_PATTERN.test(name)) {
+    console.error(
+      `--name must be lowercase kebab-case (e.g. "together-ai"): got "${name}"`,
+    );
+    process.exit(1);
+  }
+  const tierNum = Number(tierRaw);
+  if (![1, 2, 3, 4].includes(tierNum)) {
+    console.error(`--tier must be 1, 2, 3, or 4 (got "${tierRaw}")`);
+    process.exit(1);
+  }
+  const tier = tierNum as ScaffoldTier;
+  return {
+    name,
+    tier,
+    baseURL: flags.get("baseURL"),
+    envVar: flags.get("envVar") ?? `${toConstantCase(name)}_API_KEY`,
+    defaultModel,
+    aliases: (flags.get("aliases") ?? "").split(",").filter(Boolean),
+    out: flags.get("out") ?? join(".scaffold-output", name),
+  };
+}
+
+function enumEntrySnippet(input: ScaffoldInput): string {
+  return `  ${toConstantCase(input.name)} = "${input.name}",\n`;
+}
+
+function descriptorSnippet(input: ScaffoldInput): string {
+  const constant = toConstantCase(input.name);
+  const camelKey = toCamelCase(input.name);
+  const aliasesLiteral = input.aliases.map((a) => `"${a}"`).join(", ");
+  return `  {
+    name: AIProviderName.${constant},
+    aliases: [${aliasesLiteral}] as const,
+    credentialsKey: "${camelKey}",
+    envVars: {
+      apiKey: "${input.envVar}",
+      baseURL: "${constant}_BASE_URL",
+      model: "${constant}_MODEL",
+    },
+    defaultModel: "${input.defaultModel}",
+    toolSupport: "native",
+    localRuntime: false,
+    healthCheck: "env-only",
+  },
+`;
+}
+
+function catalogEntrySnippet(input: ScaffoldInput): string {
+  const constant = toConstantCase(input.name);
+  const baseURLLiteral = input.baseURL ? `"${input.baseURL}"` : "undefined";
+  return `  {
+    provider: AIProviderName.${constant},
+    defaultBaseURL: ${baseURLLiteral},
+    envBaseURLVar: "${constant}_BASE_URL",
+    defaultModel: "${input.defaultModel}",
+    fallbackModels: ["${input.defaultModel}"],
+  },
+`;
+}
+
+// NOTE: tools/** is excluded from `pnpm run check` (see this plan's
+// Global Constraints), so a wrong classifyProviderError call shape in
+// this template would never surface as a type error in CI — it would
+// only fail once a human copies the generated snippet into real src/
+// code and runs `pnpm run check` against *that*. The call below MUST
+// match the real signature exactly: classifyProviderError(error, rules,
+// provider: string, modelName?: string) — positional, not an object
+// third argument. The rules array below is typed as a plain (mutable)
+// ProviderErrorRule[], not readonly — classifyProviderError's `rules`
+// parameter and DEFAULT_ERROR_RULES are both declared as mutable
+// ProviderErrorRule[] in src/lib/utils/errorClassifier.ts, and a
+// `readonly ProviderErrorRule[]` is not assignable to that parameter
+// type, so declaring it readonly here would hand every Tier 3/4 author
+// a guaranteed compile error unrelated to their own TODOs.
+function providerClassSnippet(input: ScaffoldInput): string {
+  const className = `${toPascalCase(input.name)}Provider`;
+  const constant = toConstantCase(input.name);
+  const camelKey = toCamelCase(input.name);
+  return `import { AIProviderName } from "../constants/enums.js";
+import { BaseProvider } from "../core/baseProvider.js";
+import { classifyProviderError, DEFAULT_ERROR_RULES } from "../utils/errorClassifier.js";
+import type { NeurolinkCredentials, ProviderErrorRule } from "../types/index.js";
+import type { NeuroLink } from "../neurolink.js";
+
+const ${constant}_ERROR_RULES: ProviderErrorRule[] = [
+  ...DEFAULT_ERROR_RULES,
+  // Add provider-specific rules here.
+];
+
+export class ${className} extends BaseProvider {
+  constructor(
+    modelName?: string,
+    sdk?: NeuroLink,
+    _region?: string,
+    credentials?: NeurolinkCredentials["${camelKey}"],
+  ) {
+    super(modelName ?? "${input.defaultModel}", AIProviderName.${constant}, sdk);
+    // TODO: resolve apiKey/baseURL from credentials -> env -> default,
+    // build the wire client, implement executeStream()/doGenerate().
+  }
+
+  formatProviderError(error: unknown): Error {
+    return classifyProviderError(error, ${constant}_ERROR_RULES, "${input.name}", this.modelName);
+  }
+}
+`;
+}
+
+function mockedTestSectionSnippet(input: ScaffoldInput): string {
+  return `// --- ${toPascalCase(input.name)} (Tier ${input.tier}) ---
+// TODO: this comment block is a placeholder, not a test — it must be
+// replaced, not pasted in as-is. Copy the nearest existing section in
+// test/continuous-test-suite-providers-mocked.ts (e.g. the groq or xai
+// section) and adapt it:
+// 1. installMockFetch a route for POST <baseURL>/chat/completions
+// 2. assert the Authorization header and request body shape
+// 3. assert the happy-path response is parsed correctly
+// 4. assert a 401 response maps to a friendly auth error
+//
+// REQUIRED: the copied section must keep its "${MOCKED_SECTION_FIELD}"
+// field (an OpenAICompatSpec entry, or the option object passed to
+// nl.generate()) set to this provider's name, as real executable code —
+// not described in a comment. tools/verify-provider-onboarding.ts strips
+// comments before checking, so this placeholder does not and cannot
+// satisfy the gate on its own; only a finished section copied from an
+// existing one does.
+`;
+}
+
+function manifestJson(input: ScaffoldInput): string {
+  const base: Record<string, unknown> = {
+    provider: input.name,
+    tier: input.tier,
+    addedInPR: "",
+    addedDate: new Date().toISOString().slice(0, 10),
+    filesTouched: [],
+    mockedContractSection: `LLM ${input.name}`,
+    manualTestStatus: "not-tested",
+  };
+  if (input.tier === 4) {
+    base.tier4Justification = "";
+  }
+  return `${JSON.stringify(base, null, 2)}\n`;
+}
+
+function tierDocFor(tier: ScaffoldTier): string {
+  switch (tier) {
+    case 1:
+      return "tiers/tier-1-aggregator-passthrough.md";
+    case 2:
+      return "tiers/tier-2-catalog-entry.md";
+    case 3:
+      return "tiers/tier-3-adapter-native.md";
+    case 4:
+      return "tiers/tier-4-full-custom.md";
+  }
+}
+
+function manualChecklist(input: ScaffoldInput): string {
+  const doc = tierDocFor(input.tier);
+  if (input.tier === 1) {
+    return `# Manual checklist for "${input.name}" (Tier 1)
+
+Full guide: docs/provider-integration/${doc}
+
+Tier 1 is a usage change, not an integration change — no files are
+generated under this directory for Tier 1.
+
+- [ ] Confirm the aggregator (litellm/openrouter) actually serves the
+      model
+- [ ] No AIProviderName enum change, no PROVIDER_DESCRIPTORS change, no
+      OPENAI_COMPAT_CATALOG change
+- [ ] Optional: friendlier default alias in MODEL_ALIASES /
+      DEFAULT_MODEL_ALIASES (src/lib/models/modelRegistry.ts)
+- [ ] Optional: document a dedicated env var in
+      docs/getting-started/environment-variables.md
+- [ ] Manually smoke-test the model end-to-end
+- [ ] No manifest file required — verify-provider-onboarding only gates
+      new AIProviderName members
+`;
+  }
+  const camelKey = toCamelCase(input.name);
+  const catalogOrClassLine =
+    input.tier === 2
+      ? "- [ ] Splice catalog-entry.ts.snippet into OPENAI_COMPAT_CATALOG (src/lib/providers/openaiCompatCatalog.ts)"
+      : "- [ ] Move provider-class.ts.snippet to src/lib/providers/<name>.ts and fill in the TODOs";
+  return `# Manual checklist for "${input.name}" (Tier ${input.tier})
+
+Full guide: docs/provider-integration/${doc}
+
+Generated files under this directory are STARTING POINTS, not finished
+code — review every TODO before copy-pasting into src/.
+
+- [ ] Splice enum-entry.ts.snippet into src/lib/constants/enums.ts
+${catalogOrClassLine}
+- [ ] Splice descriptor-entry.ts.snippet into PROVIDER_DESCRIPTORS (src/lib/factories/providerDescriptors.ts)
+- [ ] Add a NeurolinkCredentials["${camelKey}"] slice in src/lib/types/providers.ts
+- [ ] Add one ProviderFactory.registerProvider() block in src/lib/factories/providerRegistry.ts (dynamic import — Critical Rule 1)
+- [ ] Move mocked-test-section.ts.snippet into test/continuous-test-suite-providers-mocked.ts and finish the TODOs
+- [ ] Fill in manifest.json (addedInPR, filesTouched) and move it to docs/provider-integration/manifests/${input.name}.json
+- [ ] pnpm run check && pnpm run lint && pnpm run test:providers-mocked && pnpm run verify:provider-onboarding
+`;
+}
+
+function main(): void {
+  const input = parseArgs(process.argv.slice(2));
+  mkdirSync(input.out, { recursive: true });
+
+  if (input.tier !== 1) {
+    writeFileSync(
+      join(input.out, "enum-entry.ts.snippet"),
+      enumEntrySnippet(input),
+    );
+    writeFileSync(
+      join(input.out, "descriptor-entry.ts.snippet"),
+      descriptorSnippet(input),
+    );
+  }
+  if (input.tier === 2) {
+    writeFileSync(
+      join(input.out, "catalog-entry.ts.snippet"),
+      catalogEntrySnippet(input),
+    );
+  }
+  if (input.tier === 3 || input.tier === 4) {
+    writeFileSync(
+      join(input.out, "provider-class.ts.snippet"),
+      providerClassSnippet(input),
+    );
+  }
+  if (input.tier !== 1) {
+    writeFileSync(
+      join(input.out, "mocked-test-section.ts.snippet"),
+      mockedTestSectionSnippet(input),
+    );
+    writeFileSync(join(input.out, "manifest.json"), manifestJson(input));
+  }
+  const checklist = manualChecklist(input);
+  writeFileSync(join(input.out, "MANUAL-CHECKLIST.md"), checklist);
+
+  console.log(
+    `Scaffolded "${input.name}" (Tier ${input.tier}) -> ${input.out}`,
+  );
+  console.log(checklist);
+}
+
+main();

--- a/tools/verify-provider-onboarding.ts
+++ b/tools/verify-provider-onboarding.ts
@@ -1,0 +1,341 @@
+#!/usr/bin/env tsx
+/**
+ * Provider Onboarding Completeness gate.
+ *
+ * For every AIProviderName member NOT in LEGACY_PROVIDERS (i.e. every
+ * provider added after this gate existed), asserts the four required
+ * onboarding artifacts landed together:
+ *   1. A ProviderDescriptor entry (PROVIDER_DESCRIPTORS)
+ *   2. Either an OpenAICompatCatalogEntry OR a concrete, registered
+ *      provider class (catalog-or-class)
+ *   3. A mocked-contract test section in
+ *      test/continuous-test-suite-providers-mocked.ts — matched with
+ *      comments stripped first (see isMockedSectionSatisfied in
+ *      provider-onboarding-marker.ts), so a scaffold placeholder that only
+ *      *describes* the marker in a comment does not satisfy this check.
+ *   4. A manifest file at docs/provider-integration/manifests/<name>.json
+ *      (with tier4Justification present when tier === 4)
+ *
+ * Zero network I/O, zero API keys, source-only — does not require
+ * `pnpm run build` first (see docs/provider-integration/tiers/README.md
+ * and this repo's tools/README notes on why: PROVIDER_DESCRIPTORS and
+ * OPENAI_COMPAT_CATALOG are pure-data modules, safe to import directly
+ * from src/ via tsx's on-the-fly TS loader — the same mechanism
+ * src/lib/factories/providerRegistry.ts already relies on for every
+ * provider's dynamic import).
+ *
+ * Run with: pnpm run verify:provider-onboarding
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isMockedSectionSatisfied } from "./provider-onboarding-marker.js";
+
+const REPO_ROOT = process.cwd();
+
+// Snapshot of AIProviderName members that predate this gate (August
+// 2026). The gate does NOT retroactively require manifests/mocked
+// sections for these — see ADR-0003 and the manifests/README.md ratchet
+// note. Do not add to this list; it's a frozen baseline, not a way to
+// exempt a new provider from the gate.
+const LEGACY_PROVIDERS: ReadonlySet<string> = new Set([
+  "bedrock",
+  "openai",
+  "openai-compatible",
+  "openrouter",
+  "vertex",
+  "anthropic",
+  "azure",
+  "google-ai",
+  "huggingface",
+  "ollama",
+  "mistral",
+  "litellm",
+  "sagemaker",
+  "deepseek",
+  "nvidia-nim",
+  "lm-studio",
+  "llamacpp",
+  "xai",
+  "groq",
+  "cohere",
+  "together-ai",
+  "fireworks",
+  "perplexity",
+  "cloudflare",
+  "replicate",
+  "voyage",
+  "jina",
+  "stability",
+  "ideogram",
+  "recraft",
+]);
+
+type ProviderManifest = {
+  provider: string;
+  tier: 1 | 2 | 3 | 4;
+  addedDate: string;
+  mockedContractSection: string;
+  tier4Justification?: string;
+};
+
+type CheckResult = { provider: string; ok: boolean; problems: string[] };
+
+async function loadEnumMemberMap(): Promise<Readonly<Record<string, string>>> {
+  const mod = (await import("../src/lib/constants/enums.js")) as {
+    AIProviderName: Record<string, string>;
+  };
+  return mod.AIProviderName;
+}
+
+function loadEnumMembers(
+  enumMemberMap: Readonly<Record<string, string>>,
+): ReadonlySet<string> {
+  return new Set(Object.values(enumMemberMap).filter((v) => v !== "auto"));
+}
+
+async function loadDescriptors(): Promise<ReadonlySet<string>> {
+  const mod = (await import("../src/lib/factories/providerDescriptors.js")) as {
+    PROVIDER_DESCRIPTORS: ReadonlyArray<{ name: string }>;
+  };
+  return new Set(mod.PROVIDER_DESCRIPTORS.map((d) => d.name));
+}
+
+async function loadCatalog(): Promise<ReadonlySet<string>> {
+  const mod = (await import("../src/lib/providers/openaiCompatCatalog.js")) as {
+    OPENAI_COMPAT_CATALOG: ReadonlyArray<{ provider: string }>;
+  };
+  return new Set(mod.OPENAI_COMPAT_CATALOG.map((c) => c.provider));
+}
+
+function loadNativeProviderNames(
+  enumMemberMap: Readonly<Record<string, string>>,
+): ReadonlySet<string> {
+  // Every AIProviderName that has its own registerProvider() block whose
+  // dynamic-import target is a real file (or folder/index.ts) in
+  // src/lib/providers/ counts as "catalog-or-class" covered even without
+  // a catalog row (Tier 3/4).
+  //
+  // The registry pairs a *kebab-case* enum value (AIProviderName.<MEMBER>)
+  // with a *camelCase* import path (e.g. AIProviderName.OPENAI_COMPATIBLE
+  // = "openai-compatible" imports "../providers/openaiCompatible.js";
+  // AIProviderName.NVIDIA_NIM = "nvidia-nim" imports
+  // "../providers/nvidiaNim/index.js"). Comparing the raw file basename
+  // to the provider identity string never matches, so instead: split the
+  // registry source into one chunk per registerProvider() call, resolve
+  // each chunk's own <MEMBER> to its real enum value via enumMemberMap,
+  // and pair it with that same chunk's own import target (not a
+  // file-basename lookup against the whole file's enum-value set).
+  const registrySource = readFileSync(
+    join(REPO_ROOT, "src/lib/factories/providerRegistry.ts"),
+    "utf8",
+  );
+  const providersDir = join(REPO_ROOT, "src/lib/providers");
+  const entries = readdirSync(providersDir, { withFileTypes: true });
+  const flatFiles = new Set(
+    entries
+      .filter((e) => e.isFile() && e.name.endsWith(".ts"))
+      .map((e) => e.name.replace(/\.ts$/, "")),
+  );
+  const folders = new Set(
+    entries
+      .filter(
+        (e) =>
+          e.isDirectory() && existsSync(join(providersDir, e.name, "index.ts")),
+      )
+      .map((e) => e.name),
+  );
+
+  const memberRe = /AIProviderName\.(\w+)/;
+  // Matches both flat `providers/<name>.js` and folder
+  // `providers/<name>/index.js` import forms.
+  const importRe =
+    /await import\("\.\.\/providers\/([\w-]+)(?:\/index)?\.js"\)/;
+  const blocks = registrySource.split(
+    /(?=ProviderFactory\.registerProvider\()/,
+  );
+
+  const covered = new Set<string>();
+  for (const block of blocks) {
+    const memberMatch = memberRe.exec(block);
+    const importMatch = importRe.exec(block);
+    if (!memberMatch || !importMatch) {
+      continue;
+    }
+    const base = importMatch[1];
+    if (!flatFiles.has(base) && !folders.has(base)) {
+      continue;
+    }
+    const value = enumMemberMap[memberMatch[1]];
+    if (value) {
+      covered.add(value);
+    }
+  }
+  return covered;
+}
+
+type MockedSectionCheck = { found: boolean; readError?: string };
+
+function checkMockedSection(provider: string): MockedSectionCheck {
+  let source: string;
+  try {
+    source = readFileSync(
+      join(REPO_ROOT, "test/continuous-test-suite-providers-mocked.ts"),
+      "utf8",
+    );
+  } catch (err) {
+    return {
+      found: false,
+      readError: err instanceof Error ? err.message : String(err),
+    };
+  }
+  return { found: isMockedSectionSatisfied(source, provider) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type ManifestCheck = { manifest: ProviderManifest | null; problem?: string };
+
+function loadManifest(provider: string): ManifestCheck {
+  const path = join(
+    REPO_ROOT,
+    "docs/provider-integration/manifests",
+    `${provider}.json`,
+  );
+  if (!existsSync(path)) {
+    return { manifest: null };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    return {
+      manifest: null,
+      problem: `could not read manifest: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      manifest: null,
+      problem: `manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return { manifest: null, problem: "manifest is not a JSON object" };
+  }
+  if (
+    typeof parsed.provider !== "string" ||
+    typeof parsed.tier !== "number" ||
+    typeof parsed.addedDate !== "string" ||
+    typeof parsed.mockedContractSection !== "string"
+  ) {
+    return {
+      manifest: null,
+      problem:
+        "manifest missing required field(s) (provider, tier, addedDate, mockedContractSection)",
+    };
+  }
+  if (parsed.provider !== provider) {
+    return {
+      manifest: null,
+      problem: `manifest "provider" field is "${parsed.provider}", expected "${provider}" (manifest copied from another provider?)`,
+    };
+  }
+  if (!Number.isInteger(parsed.tier) || parsed.tier < 1 || parsed.tier > 4) {
+    return {
+      manifest: null,
+      problem: `manifest "tier" must be an integer 1-4 (got ${JSON.stringify(parsed.tier)})`,
+    };
+  }
+
+  const manifest: ProviderManifest = {
+    provider: parsed.provider,
+    tier: parsed.tier as 1 | 2 | 3 | 4,
+    addedDate: parsed.addedDate,
+    mockedContractSection: parsed.mockedContractSection,
+    ...(typeof parsed.tier4Justification === "string"
+      ? { tier4Justification: parsed.tier4Justification }
+      : {}),
+  };
+  return { manifest };
+}
+
+async function main(): Promise<void> {
+  const enumMemberMap = await loadEnumMemberMap();
+  const [descriptors, catalog] = await Promise.all([
+    loadDescriptors(),
+    loadCatalog(),
+  ]);
+  const enumMembers = loadEnumMembers(enumMemberMap);
+  const nativeClasses = loadNativeProviderNames(enumMemberMap);
+
+  const results: CheckResult[] = [];
+  for (const provider of [...enumMembers].sort()) {
+    if (LEGACY_PROVIDERS.has(provider)) {
+      continue;
+    }
+    const problems: string[] = [];
+    if (!descriptors.has(provider)) {
+      problems.push("missing ProviderDescriptor entry (PROVIDER_DESCRIPTORS)");
+    }
+    if (!catalog.has(provider) && !nativeClasses.has(provider)) {
+      problems.push(
+        "no OpenAICompatCatalogEntry and no registered provider class (catalog-or-class)",
+      );
+    }
+    const mockedSection = checkMockedSection(provider);
+    if (mockedSection.readError) {
+      problems.push(
+        `could not read test/continuous-test-suite-providers-mocked.ts: ${mockedSection.readError}`,
+      );
+    } else if (!mockedSection.found) {
+      problems.push(
+        "no mocked-contract section in continuous-test-suite-providers-mocked.ts",
+      );
+    }
+    const { manifest, problem: manifestProblem } = loadManifest(provider);
+    if (!manifest) {
+      problems.push(
+        manifestProblem ??
+          `missing/invalid manifest at docs/provider-integration/manifests/${provider}.json`,
+      );
+    } else if (manifest.tier === 4 && !manifest.tier4Justification) {
+      problems.push("tier-4 manifest missing tier4Justification");
+    }
+    results.push({ provider, ok: problems.length === 0, problems });
+  }
+
+  const failures = results.filter((r) => !r.ok);
+  for (const r of results) {
+    console.log(`${r.ok ? "✓" : "✗"} ${r.provider}`);
+    for (const p of r.problems) {
+      console.log(`    - ${p}`);
+    }
+  }
+  if (results.length === 0) {
+    console.log("No new (post-legacy) providers to check.");
+  } else {
+    console.log(
+      `\n${results.length - failures.length}/${results.length} new providers fully onboarded.`,
+    );
+  }
+  if (failures.length > 0) {
+    console.error(
+      `\nProvider Onboarding Completeness FAILED for: ${failures.map((f) => f.provider).join(", ")}`,
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("verify-provider-onboarding crashed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adding a provider means touching an enum, a descriptor, either a catalog row or a provider class, a mocked contract section, and a manifest. Miss one and nothing fails loudly — the provider just misbehaves later, in a way that looks like a bug in the provider rather than a missing registration.

Two tools close that gap.

**`scaffold-provider`** emits tier-appropriate snippets and a manual checklist into a scratch directory. It never writes to real source, so it cannot half-apply a change.

**`verify-provider-onboarding`** walks every name in `AIProviderName` and checks each has the pieces its tier requires. Providers predating the convention sit in a frozen legacy list, so the gate ratchets forward without demanding a bulk migration first. It is source-only — no network, no credentials, no provider construction — and runs in `provider-safety-net` alongside the other structural checks, **not** behind `continue-on-error`, so it can actually fail a build.

## Three corrections to the original design

Each verified against the tree rather than assumed:

- **The scaffolded error-rules array was typed `readonly`**, but the classifier's parameter and `DEFAULT_ERROR_RULES` are both mutable, so a readonly array is not assignable there. `tools/` is excluded from typechecking, so this would have shipped a snippet **guaranteed to fail compilation** for whoever pasted it — silently, since nothing typechecks the template.
- **The CI step was to be inserted after a job step that no longer exists.** Placed in `provider-safety-net` instead, which is the same zero-network structural category and one of the required checks.
- **A Tier 1 checklist line read "No manifest.json required"**, which the design's own verification grep then flagged against itself, for containing the very string it searched for.

A fourth premise did not hold: the CLAUDE.md staleness this was meant to fix had already been corrected upstream. The replacement text was applied anyway since it is accurate regardless, and a duplicate table row that would otherwise have been introduced was caught.

## Verified against the four required checks

- **`test`**: format, eslint, `validate:all`, build, CLI smoke — clean
- **`provider-safety-net`**: build, providers-mocked 54/54, provider-structure 2/2, error-classifier-contract 40/40, and the new gate (clean — "No new (post-legacy) providers to check", expected until someone adds one)
- **`build-check`**: `prepack` clean
- **Single commit**: yes

The gate was deliberately broken — by dropping a provider from the legacy list — to confirm it fails rather than passing vacuously, then reverted.

## Depends on #1356

CLAUDE.md now links to `docs/provider-integration/tiers/README.md`, which #1356 introduces. **Merge #1356 first.** This PR also resolves two review findings on #1356 that flag its checklists for referencing tooling that did not yet exist — it exists here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider scaffolding tool that generates tier-specific integration files, manifests, and checklists.
  * Added automated onboarding verification for required provider metadata, tests, and manifests.
  * Added provider onboarding and specialized provider test scripts.
  * Updated the package version.

* **Documentation**
  * Added tiered provider onboarding requirements to contribution guidance and pull request templates.

* **Chores**
  * Enhanced CI with onboarding and extended provider test checks.
  * Excluded generated scaffolding output from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->