### PR TITLE
fix(ci): stop installing ffmpeg in jobs that never use it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,47 +24,21 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      # Installed from the runner's package index rather than a third-party
-      # action that downloads release assets from another repository. That
-      # action has broken this pipeline twice: first when the 8.1 asset was
-      # published corrupt, then again when the 7.1 pin added to work around
-      # it stopped resolving. Neither failure was caused by anything in this
-      # repository, and both blocked every open pull request. apt carries a
-      # version new enough for what the suites exercise, and it cannot be
-      # invalidated by an upstream release being moved or rebuilt.
-      - name: Install ffmpeg
-        timeout-minutes: 15
-        run: |
-          if command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
-            exit 0
-          fi
-          export DEBIAN_FRONTEND=noninteractive
-          # Runners boot with unattended-upgrades holding the dpkg lock, and a
-          # plain apt-get waits on that lock forever. On 2026-08-18 this step
-          # sat in_progress for 90 minutes on two open PRs, leaving the quality
-          # gate permanently "pending" with nothing to re-run against. Bound
-          # every wait so a contended lock fails fast, and let the step
-          # deadline catch anything the bounds miss.
-          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
-          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
-          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          for attempt in 1 2 3; do
-            sudo apt-get $APT_OPTS update && break
-            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
-            sleep 5
-          done
-          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
-
-      - name: Verify ffmpeg installation
-        run: |
-          echo "🎬 Verifying ffmpeg installation..."
-          ffmpeg -version || {
-            echo "❌ ffmpeg installation failed!"
-            echo "apt-get install ffmpeg did not produce a working binary."
-            exit 1
-          }
-          echo "✅ ffmpeg installed successfully"
+      # ffmpeg is deliberately NOT installed in this workflow. Nothing these
+      # jobs run needs it: no package script invokes it, and src/ shells out to
+      # ffmpeg only at runtime (frame extraction, video merge, audio playback),
+      # never during install, lint, typecheck, build or pack. provider-safety-net
+      # has always built and run its suites without it.
+      #
+      # Removed after the apt install broke CI three ways in one day: a corrupt
+      # published asset, a version pin that stopped resolving, and an Ubuntu
+      # mirror returning Ign: for every index while apt sat for 14 minutes.
+      # Because build-check is a required check, each of those blocked every
+      # open pull request on a dependency none of these jobs use.
+      #
+      # If a job here ever runs a suite that genuinely exercises media, install
+      # ffmpeg in THAT job only, and bound every wait (DPkg::Lock::Timeout,
+      # Acquire::*::Timeout) plus a step timeout-minutes.
 
       - name: Install dependencies
         run: pnpm install
@@ -215,48 +189,6 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
-      # Installed from the runner's package index rather than a third-party
-      # action that downloads release assets from another repository. That
-      # action has broken this pipeline twice: first when the 8.1 asset was
-      # published corrupt, then again when the 7.1 pin added to work around
-      # it stopped resolving. Neither failure was caused by anything in this
-      # repository, and both blocked every open pull request. apt carries a
-      # version new enough for what the suites exercise, and it cannot be
-      # invalidated by an upstream release being moved or rebuilt.
-      - name: Install ffmpeg
-        timeout-minutes: 15
-        run: |
-          if command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
-            exit 0
-          fi
-          export DEBIAN_FRONTEND=noninteractive
-          # Runners boot with unattended-upgrades holding the dpkg lock, and a
-          # plain apt-get waits on that lock forever. On 2026-08-18 this step
-          # sat in_progress for 90 minutes on two open PRs, leaving the quality
-          # gate permanently "pending" with nothing to re-run against. Bound
-          # every wait so a contended lock fails fast, and let the step
-          # deadline catch anything the bounds miss.
-          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
-          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
-          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          for attempt in 1 2 3; do
-            sudo apt-get $APT_OPTS update && break
-            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
-            sleep 5
-          done
-          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
-
-      - name: Verify ffmpeg installation
-        run: |
-          echo "🎬 Verifying ffmpeg installation..."
-          ffmpeg -version || {
-            echo "❌ ffmpeg installation failed!"
-            echo "apt-get install ffmpeg did not produce a working binary."
-            exit 1
-          }
-          echo "✅ ffmpeg installed successfully"
-
       - name: Install dependencies
         run: pnpm i
 
@@ -314,48 +246,6 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-
-      # Installed from the runner's package index rather than a third-party
-      # action that downloads release assets from another repository. That
-      # action has broken this pipeline twice: first when the 8.1 asset was
-      # published corrupt, then again when the 7.1 pin added to work around
-      # it stopped resolving. Neither failure was caused by anything in this
-      # repository, and both blocked every open pull request. apt carries a
-      # version new enough for what the suites exercise, and it cannot be
-      # invalidated by an upstream release being moved or rebuilt.
-      - name: Install ffmpeg
-        timeout-minutes: 15
-        run: |
-          if command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
-            exit 0
-          fi
-          export DEBIAN_FRONTEND=noninteractive
-          # Runners boot with unattended-upgrades holding the dpkg lock, and a
-          # plain apt-get waits on that lock forever. On 2026-08-18 this step
-          # sat in_progress for 90 minutes on two open PRs, leaving the quality
-          # gate permanently "pending" with nothing to re-run against. Bound
-          # every wait so a contended lock fails fast, and let the step
-          # deadline catch anything the bounds miss.
-          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
-          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
-          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          for attempt in 1 2 3; do
-            sudo apt-get $APT_OPTS update && break
-            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
-            sleep 5
-          done
-          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
-
-      - name: Verify ffmpeg installation
-        run: |
-          echo "🎬 Verifying ffmpeg installation..."
-          ffmpeg -version || {
-            echo "❌ ffmpeg installation failed!"
-            echo "apt-get install ffmpeg did not produce a working binary."
-            exit 1
-          }
-          echo "✅ ffmpeg installed successfully"
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,45 +31,21 @@ jobs:
           cache: "pnpm"
           registry-url: https://registry.npmjs.org/
 
-      # Installed from the runner's package index rather than a third-party
-      # action that downloads release assets from another repository. That
-      # action broke this workflow twice — first a corrupt 8.1 asset, then
-      # the 7.1 pin added to work around it — and because this is the
-      # publish workflow, each break silently stopped releases from going
-      # out while CI still looked healthy. ci.yml was moved off it already.
-      - name: Install ffmpeg
-        timeout-minutes: 15
-        run: |
-          if command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
-            exit 0
-          fi
-          export DEBIAN_FRONTEND=noninteractive
-          # Runners boot with unattended-upgrades holding the dpkg lock, and a
-          # plain apt-get waits on that lock forever. On 2026-08-18 this step
-          # sat in_progress for 90 minutes on two open PRs, leaving the quality
-          # gate permanently "pending" with nothing to re-run against. Bound
-          # every wait so a contended lock fails fast, and let the step
-          # deadline catch anything the bounds miss.
-          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
-          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
-          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          for attempt in 1 2 3; do
-            sudo apt-get $APT_OPTS update && break
-            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
-            sleep 5
-          done
-          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
-
-      - name: Verify ffmpeg installation
-        run: |
-          echo "🎬 Verifying ffmpeg installation..."
-          ffmpeg -version || {
-            echo "❌ ffmpeg installation failed!"
-            echo "apt-get install ffmpeg did not produce a working binary."
-            exit 1
-          }
-          echo "✅ ffmpeg installed successfully"
+      # ffmpeg is deliberately NOT installed in this workflow. Nothing these
+      # jobs run needs it: no package script invokes it, and src/ shells out to
+      # ffmpeg only at runtime (frame extraction, video merge, audio playback),
+      # never during install, lint, typecheck, build or pack. provider-safety-net
+      # has always built and run its suites without it.
+      #
+      # Removed after the apt install broke CI three ways in one day: a corrupt
+      # published asset, a version pin that stopped resolving, and an Ubuntu
+      # mirror returning Ign: for every index while apt sat for 14 minutes.
+      # Because build-check is a required check, each of those blocked every
+      # open pull request on a dependency none of these jobs use.
+      #
+      # If a job here ever runs a suite that genuinely exercises media, install
+      # ffmpeg in THAT job only, and bound every wait (DPkg::Lock::Timeout,
+      # Acquire::*::Timeout) plus a step timeout-minutes.
 
       - name: Install dependencies
         run: pnpm i
@@ -106,46 +82,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
-
-      # Installed from the runner's package index rather than a third-party
-      # action that downloads release assets from another repository. That
-      # action broke this workflow twice — first a corrupt 8.1 asset, then
-      # the 7.1 pin added to work around it — and because this is the
-      # publish workflow, each break silently stopped releases from going
-      # out while CI still looked healthy. ci.yml was moved off it already.
-      - name: Install ffmpeg
-        timeout-minutes: 15
-        run: |
-          if command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
-            exit 0
-          fi
-          export DEBIAN_FRONTEND=noninteractive
-          # Runners boot with unattended-upgrades holding the dpkg lock, and a
-          # plain apt-get waits on that lock forever. On 2026-08-18 this step
-          # sat in_progress for 90 minutes on two open PRs, leaving the quality
-          # gate permanently "pending" with nothing to re-run against. Bound
-          # every wait so a contended lock fails fast, and let the step
-          # deadline catch anything the bounds miss.
-          sudo systemctl stop unattended-upgrades.service >/dev/null 2>&1 || true
-          APT_OPTS="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=3"
-          APT_OPTS="$APT_OPTS -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          for attempt in 1 2 3; do
-            sudo apt-get $APT_OPTS update && break
-            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s"
-            sleep 5
-          done
-          sudo apt-get $APT_OPTS install -y --no-install-recommends ffmpeg
-
-      - name: Verify ffmpeg installation
-        run: |
-          echo "🎬 Verifying ffmpeg installation..."
-          ffmpeg -version || {
-            echo "❌ ffmpeg installation failed!"
-            echo "apt-get install ffmpeg did not produce a working binary."
-            exit 1
-          }
-          echo "✅ ffmpeg installed successfully"
 
       - name: Upgrade npm for native OIDC publish support
         run: |


### PR DESCRIPTION
**`release` is red right now, and every open PR with it.** This removes the cause rather than tuning it again.

## What's happening

`apt-get update` sat for **fourteen minutes with no output** while `azure.archive.ubuntu.com` returned `Ign:` for every index, then hit the step deadline:

```
04:39:12  Ign:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages
04:39:12  Ign:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages
04:39:12  Get:5  https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
04:53:47  ##[error]The action 'Install ffmpeg' has timed out after 15 minutes
```

That is the **third distinct way this one install has broken CI in a single day**:

| | Failure |
|---|---|
| 1 | A corrupt published asset from the downloader we used before |
| 2 | The version pin added to work around it stopped resolving |
| 3 | A step deadline too tight for a slow mirror — then the mirror itself failing |

Each of my last two fixes replaced one failure mode with another, because the dependency itself was the problem.

## None of it was ever needed

- **No package script invokes ffmpeg.** Checked every entry in `scripts`.
- **Nothing installs it as a dependency**, and no install hook needs it.
- **`src/` shells out to ffmpeg only at runtime** — frame extraction, video merging, audio playback — never during install, lint, typecheck, build or pack, which is all these jobs do.

The proof was already sitting in the same file: **`provider-safety-net` has never installed ffmpeg**, and it runs `pnpm run build` plus three test suites without trouble.

So five jobs were paying for a tool none of them invoke, on the most failure-prone step in the pipeline, reached over a network that has now failed three different ways. And since `build-check` became a required check, each of those failures blocks *every* open PR rather than one job.

## Change

Removed from all five: `test`, `build-check`, `quality-gate`, and both `release.yml` jobs. Net **−204 / +30** lines.

A comment in each workflow records why it's absent and what to do if a job ever genuinely needs it — install it in that job alone, and bound every wait.

## Verification

- Both workflows parse as valid YAML; every job and its remaining steps intact (`test` 10, `provider-safety-net` 9, `build-check` 7, `proxy-performance` 5, `quality-gate` 12, `semantic-release-validation` 5; release `test` 5, `release` 10).
- No `ffmpeg` step remains in any job — only the explanatory comments.
- This PR's own CI is the test: the same jobs now run without the step.
