### PR TITLE
chore(release): stop semantic-release pushing back to the branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,18 +6,54 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
-          { "type": "feat", "release": "minor" },
-          { "type": "fix", "release": "patch" },
-          { "type": "perf", "release": "patch" },
-          { "type": "revert", "release": "patch" },
-          { "type": "docs", "release": false },
-          { "type": "style", "release": false },
-          { "type": "refactor", "release": "patch" },
-          { "type": "test", "release": false },
-          { "type": "build", "release": "patch" },
-          { "type": "ci", "release": false },
-          { "type": "chore", "release": false },
-          { "breaking": true, "release": "major" }
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "revert",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": false
+          },
+          {
+            "type": "style",
+            "release": false
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": false
+          },
+          {
+            "type": "build",
+            "release": "patch"
+          },
+          {
+            "type": "ci",
+            "release": false
+          },
+          {
+            "type": "chore",
+            "release": false
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
         ],
         "parserOpts": {
           "headerPattern": "^(?:\\w+-\\d+:\\s*)?(\\w+!?)(\\([\\w\\$\\.\\-\\*\\s]*\\))?\\s*:(.*)$",
@@ -46,13 +82,6 @@
         "provenance": true
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Resolves the conflict between branch protection and publishing, so required status checks can be turned back on.

## The problem

Enabling required status checks on `release` blocked publishing entirely. `semantic-release` pushes its version-bump commit **directly** to the branch via `GITHUB_TOKEN`, and a direct push carries no check runs — so all four required checks read as missing and the push was declined:

```
GH013: Repository rule violations found for refs/heads/release
- 4 of 4 required status checks are expected.
! [remote rejected]   HEAD -> release (push declined due to repository rule violations)
```

The usual remedy is to let the Actions app bypass the ruleset. **That actor cannot be added at repository level** — GitHub requires it to belong to the owner organization (`Actor GitHub Actions integration must be part of the ruleset source or owner organization`). So without an org-level change, the choice was between protecting the branch and being able to release.

## The fix

Drop `@semantic-release/git`. Nothing then pushes to the protected branch, so no bypass is needed.

**Nothing that ships changes.** `@semantic-release/npm` rewrites `package.json` in the workspace before the tarball is packed, so all of these still carry the correct version:

| | Status |
|---|---|
| npm publish | ✅ unaffected |
| GitHub Packages publish | ✅ unaffected |
| Git tag | ✅ unaffected (core semantic-release, not the git plugin) |
| GitHub Release + notes | ✅ unaffected |
| CHANGELOG.md inside the published package | ✅ still generated and packed |

## What is genuinely lost

Stating this plainly rather than letting someone discover it later:

- **`CHANGELOG.md` is no longer committed to the repo.** It's still generated during the run, still ships inside the published package, and the notes remain on the GitHub Release — but a reader browsing the repository won't see it advance.
- **`package.json`'s version in git stops tracking the published version.** Nothing reads it to decide what to publish (semantic-release derives the next version from tags), but `--version` from a *git clone* will report whatever was last committed. The published package is unaffected.
- **The `chore(release): x.y.z [skip ci]` commits stop appearing** on the branch.

If the org later allows GitHub Actions as a bypass actor, this can be reverted and the plugin restored.

## Context

`release` keeps `deletion`, `non_fast_forward` and `required_linear_history` protection throughout. Required status checks were removed to unblock the `11.2.3` publish (which has since succeeded) and will be re-enabled once this lands.
