### PR TITLE
ci(policy): reject CI-skip directives in commit messages

### DIFF
--- a/.github/workflows/single-commit-enforcement.yml
+++ b/.github/workflows/single-commit-enforcement.yml
@@ -128,6 +128,47 @@ jobs:
 
           echo "✅ Commit message format is valid"
 
+      - name: Reject CI-Skip Directives
+        if: steps.validate.outputs.status == 'compliant'
+        run: |
+          COMMIT_HASH="${{ steps.validate.outputs.commit_hash }}"
+          # The format check above reads only the subject line (%s). GitHub reads
+          # the WHOLE message, body included, so a skip directive quoted in a body
+          # -- e.g. while documenting semantic-release's own commit template --
+          # silently suppresses every workflow for the resulting push. That has
+          # already happened once on `release`: the merge ran no CI at all, and
+          # nothing reported it, because a skipped run looks identical to a run
+          # that was never required.
+          FULL_MSG=$(git log -1 --pretty=format:%B "$COMMIT_HASH")
+
+          if echo "$FULL_MSG" | grep -qiE '\[(skip ci|ci skip|no ci|skip actions|actions skip)\]'; then
+            echo "❌ POLICY VIOLATION: commit message contains a CI-skip directive"
+            echo ""
+            echo "Offending line(s):"
+            echo "$FULL_MSG" | grep -niE '\[(skip ci|ci skip|no ci|skip actions|actions skip)\]' | sed 's/^/    /'
+            echo ""
+            echo "GitHub honours [skip ci], [ci skip], [no ci], [skip actions] and"
+            echo "[actions skip] anywhere in a commit message -- subject or body."
+            echo "Merging this would push a commit that runs no workflows at all,"
+            echo "including the checks required to protect this branch."
+            echo ""
+            echo "🔧 TO FIX:"
+            echo "  If you were quoting the directive rather than intending it,"
+            echo "  break up the literal text -- write 'skip-ci' or 'skip<space>ci'"
+            echo "  instead -- or move the explanation to the pull request body,"
+            echo "  which GitHub does not scan."
+            echo ""
+            echo "    git commit --amend"
+            echo "    git push --force-with-lease"
+            echo ""
+            echo "  If you genuinely need to skip CI, say so on the pull request"
+            echo "  and have someone merge it deliberately -- it should not be a"
+            echo "  side effect of how a commit message happens to be worded."
+            exit 1
+          fi
+
+          echo "✅ No CI-skip directives in commit message"
+
       - name: Check for Merge Commits
         if: steps.validate.outputs.status == 'compliant'
         run: |


### PR DESCRIPTION
## What happened

A pull request merged to `release` earlier today and **ran no workflows at all** — not CI, not the release job, nothing. Only an unrelated push-listener workflow fired.

The cause was a commit body that quoted a CI-skip directive while documenting semantic-release's own commit template. GitHub reads the **entire** commit message, not just the subject, so quoting one is indistinguishable from meaning it.

Nothing reported this, and nothing could have: **a suppressed run looks exactly like a run that was never required.** It surfaced only because the branch's check list looked implausibly short an hour later.

## Why the existing check missed it

This workflow's `Validate Commit Message Format` step reads `%s` — the subject line alone. The directive was in the body, so it was structurally invisible to that check.

## The fix

A new step reading `%B` (the full message), failing on any of the five spellings GitHub honours, case-insensitively:

`skip ci` · `ci skip` · `no ci` · `skip actions` · `actions skip` (each in square brackets)

The error message explains how to fix it — break up the literal text, or move the explanation to the PR body, which GitHub does not scan.

## Why this matters more than it used to

Required status checks are now active on `release`. A commit that suppresses its own workflows produces a push carrying **no checks at all** — precisely the condition that lets work reach the branch unverified. This closes that hole from the commit-message side.

It lives in the single-commit workflow rather than the quality gate because that job already resolves the real PR head commit for internal *and* external contributors, and is already a required check.

## Verification

Tested the step's script directly against real inputs:

| Input | Result |
|---|---|
| The actual commit that caused this | **fails** (exit 1) ✅ |
| A message discussing "CI" and "skipping" in ordinary prose | **passes** (exit 0) ✅ |
| All four other bracketed variants, incl. uppercase | **fail** ✅ |

Also confirmed **this PR's own commit message passes its own check** — worded to describe the directives rather than reproduce them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject commits containing CI-skip directives.
  * Reports the offending lines and provides remediation guidance when validation fails.
  * Supports case-insensitive detection across complete commit messages, including message bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->