### PR TITLE
ci(test): run the extended suites in CI, non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,81 @@ jobs:
           pnpm pack
           ls -la dist/
 
+  # Deliberately NOT a required status check. These suites are new and this job
+  # exists so a regression in them is visible, not so it can block a merge on
+  # day one. Promote it to required once it has proven stable.
+  #
+  # It exists at all because the alternative was demonstrated: the OpenAI-compat
+  # catalog suite sat in no CI job, broke (it threw on any machine without
+  # GROQ_API_KEY), and nobody noticed — because nothing ran it. A suite wired
+  # into nothing is documentation, not a test.
+  extended-suites:
+    runs-on: ubuntu-latest
+    name: Extended Suites (non-blocking)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: SvelteKit sync
+        run: pnpm exec svelte-kit sync
+
+      # Every one of these suites imports from ../dist/index.js per rule 15, so
+      # the built output is a prerequisite rather than an optimisation.
+      - name: Build
+        run: pnpm run build
+
+      - name: Run extended suites
+        run: |
+          # No provider credentials are set in this job, and that is the point:
+          # each of these suites drives the public API against stubs, local
+          # fixtures or mocked fetch, so a suite that starts making real network
+          # calls fails here rather than silently costing money and flaking.
+          SUITES="
+            test:openai-compat-catalog
+            test:handler-registry
+            test:tts:unit
+            test:stt:unit
+            test:avatar:unit
+            test:music:unit
+            test:video:unit
+            test:realtime:unit
+          "
+          FAILED=""
+          for s in $SUITES; do
+            echo "::group::$s"
+            if pnpm run "$s"; then
+              echo "PASS $s"
+            else
+              echo "FAIL $s"
+              FAILED="$FAILED $s"
+            fi
+            echo "::endgroup::"
+          done
+
+          echo ""
+          echo "──────────────────────────────────────────────"
+          if [ -n "$FAILED" ]; then
+            # Every suite runs before failing, so one broken suite does not hide
+            # the state of the other seven.
+            echo "Failing suites:$FAILED"
+            exit 1
+          fi
+          echo "All extended suites passed."
+
   proxy-performance:
     name: Proxy Performance Gates
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:tts:unit": "npx tsx test/continuous-test-suite-tts-unit.ts",
     "test:stt:unit": "npx tsx test/continuous-test-suite-stt-unit.ts",
     "test:realtime:unit": "npx tsx test/continuous-test-suite-realtime-unit.ts",
+    "test:video:unit": "npx tsx test/continuous-test-suite-video-generation-unit.ts",
     "test:voice": "npx tsx test/continuous-test-suite-voice.ts",
     "test:avatar": "npx tsx test/continuous-test-suite-avatar.ts",
     "test:avatar:unit": "npx tsx test/continuous-test-suite-avatar-unit.ts",


### PR DESCRIPTION
Eight suites covering the media handler registry and the OpenAI-compat catalog **ran in no CI job at all**. This wires them in.

## Why this isn't theoretical

The catalog suite was **broken on `release`** — it constructed a provider with `undefined` credentials and threw on any machine without `GROQ_API_KEY` — and nobody noticed, because nothing ran it. A review thread claiming the fix had landed cited a commit that was never on the branch. A suite wired into nothing is documentation, not a test.

The video suite was worse: **it had no `package.json` script whatsoever**, so it couldn't be run by name even deliberately. That script (`test:video:unit`) is added here.

## Deliberately non-blocking

This is **not** a required status check. These suites were rewritten onto the public API very recently; the job exists so a regression is *visible*, not so it can block a merge on day one. Worth promoting to required once it's proven stable.

## Two load-bearing details

- **It runs `pnpm run build`.** Every suite imports from `../dist/index.js` per rule 15, so the built output is a prerequisite, not an optimisation.
- **No provider credentials are set, and that's the point.** Each suite drives the public API against stubs, local fixtures or mocked fetch. A suite that starts making real network calls fails here rather than silently costing money and flaking. (One draft of these suites *did* start making real API calls during development — this job is what would catch that.)

Every suite runs before the job fails, so one broken suite can't hide the state of the other seven.

## Suites covered

| Suite | Tests |
|---|---|
| `test:openai-compat-catalog` | 29 |
| `test:realtime:unit` | 19 |
| `test:stt:unit` | 11 |
| `test:avatar:unit` | 11 |
| `test:music:unit` | 10 |
| `test:handler-registry` | 9 |
| `test:video:unit` | 9 |
| `test:tts:unit` | 8 |
| **Total** | **106** |

## Verification

Simulated the job's exact loop locally against a clean build with credentials poisoned (`OPENAI_API_KEY=sk-invalid`, etc.): **all 8 suites pass, 106 tests, none failing.**

Also confirmed the runner script passes `bash -n`, every script name in the loop exists in `package.json`, both workflow files parse as valid YAML, and prettier is clean.
