### PR TITLE
fix(models): correct the Claude Opus 4.5 model ids for Bedrock and Vertex

### DIFF
--- a/docs/api/enumerations/BedrockModels.md
+++ b/docs/api/enumerations/BedrockModels.md
@@ -30,7 +30,7 @@ Defined in: [constants/enums.ts:76](https://github.com/juspay/neurolink/blob/ff5
 
 ### CLAUDE_4_5_OPUS
 
-> **CLAUDE_4_5_OPUS**: `"anthropic.claude-opus-4-5-20251124-v1:0"`
+> **CLAUDE_4_5_OPUS**: `"anthropic.claude-opus-4-5-20251101-v1:0"`
 
 Defined in: [constants/enums.ts:79](https://github.com/juspay/neurolink/blob/ff50c1e5a18abd666c68e6a6290bfe2015cb65b1/src/lib/constants/enums.ts#L79)
 

--- a/docs/api/enumerations/VertexModels.md
+++ b/docs/api/enumerations/VertexModels.md
@@ -30,7 +30,7 @@ Defined in: [constants/enums.ts:396](https://github.com/juspay/neurolink/blob/ff
 
 ### CLAUDE_4_5_OPUS
 
-> **CLAUDE_4_5_OPUS**: `"claude-opus-4-5@20251124"`
+> **CLAUDE_4_5_OPUS**: `"claude-opus-4-5@20251101"`
 
 Defined in: [constants/enums.ts:399](https://github.com/juspay/neurolink/blob/ff50c1e5a18abd666c68e6a6290bfe2015cb65b1/src/lib/constants/enums.ts#L399)
 

--- a/docs/getting-started/providers/aws-bedrock.md
+++ b/docs/getting-started/providers/aws-bedrock.md
@@ -251,7 +251,7 @@ const haiku35 = await ai.generate({
 | ------------------------------------------- | ----------------------- | ------- |
 | `anthropic.claude-opus-4-6-v1:0`            | Claude 4.6 Opus         | 1M      |
 | `anthropic.claude-sonnet-4-6`               | Claude 4.6 Sonnet       | 1M      |
-| `anthropic.claude-opus-4-5-20251124-v1:0`   | Claude 4.5 Opus         | 200K    |
+| `anthropic.claude-opus-4-5-20251101-v1:0`   | Claude 4.5 Opus         | 200K    |
 | `anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude 4.5 Sonnet       | 200K    |
 | `anthropic.claude-haiku-4-5-20251001-v1:0`  | Claude 4.5 Haiku        | 200K    |
 | `anthropic.claude-opus-4-1-20250805-v1:0`   | Claude 4.1 Opus         | 200K    |

--- a/src/lib/adapters/providerImageAdapter.ts
+++ b/src/lib/adapters/providerImageAdapter.ts
@@ -420,7 +420,7 @@ const VISION_CAPABILITIES = {
     "claude-opus-4-5",
     "claude-opus-4.5",
     "anthropic.claude-opus-4-5",
-    "anthropic.claude-opus-4-5-20251124-v1:0",
+    "anthropic.claude-opus-4-5-20251101-v1:0",
     "claude-haiku-4-5",
     "claude-haiku-4.5",
     "anthropic.claude-haiku-4-5",

--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -290,7 +290,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
     "anthropic.claude-opus-4-6-v1:0": 1_000_000,
     "anthropic.claude-sonnet-4-6": 1_000_000,
     // Claude 4.5
-    "anthropic.claude-opus-4-5-20251124-v1:0": 200_000,
+    "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
     "anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
     "anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
     // Claude legacy

--- a/src/lib/constants/enums.ts
+++ b/src/lib/constants/enums.ts
@@ -93,7 +93,7 @@ export enum BedrockModels {
   CLAUDE_4_6_SONNET = "anthropic.claude-sonnet-4-6",
 
   // Claude 4.5 Series (September-November 2025)
-  CLAUDE_4_5_OPUS = "anthropic.claude-opus-4-5-20251124-v1:0",
+  CLAUDE_4_5_OPUS = "anthropic.claude-opus-4-5-20251101-v1:0",
   CLAUDE_4_5_SONNET = "anthropic.claude-sonnet-4-5-20250929-v1:0",
   CLAUDE_4_5_HAIKU = "anthropic.claude-haiku-4-5-20251001-v1:0",
 
@@ -418,7 +418,7 @@ export enum VertexModels {
   CLAUDE_4_6_SONNET = "claude-sonnet-4-6",
 
   // Claude 4.5 Series (September-November 2025)
-  CLAUDE_4_5_OPUS = "claude-opus-4-5@20251124",
+  CLAUDE_4_5_OPUS = "claude-opus-4-5@20251101",
   CLAUDE_4_5_SONNET = "claude-sonnet-4-5@20250929",
   CLAUDE_4_5_HAIKU = "claude-haiku-4-5@20251001",
 

--- a/src/lib/constants/tokens.ts
+++ b/src/lib/constants/tokens.ts
@@ -156,7 +156,7 @@ export const PROVIDER_TOKEN_LIMITS = {
     "gemini-1.5-flash": 8192,
     // Claude 4.5 Series (September-November 2025)
     "claude-sonnet-4-5@20250929": 8192,
-    "claude-opus-4-5@20251124": 8192,
+    "claude-opus-4-5@20251101": 8192,
     "claude-haiku-4-5@20251001": 8192,
     // Claude 4 Series (May 2025)
     "claude-sonnet-4@20250514": 4096,

--- a/src/lib/providers/googleVertex/constants.ts
+++ b/src/lib/providers/googleVertex/constants.ts
@@ -9,7 +9,7 @@ export let cachedCredentialsPath: string | null = null;
 export const VERTEX_MODEL_ALIASES: Record<string, string> = {
   // Claude 4.x shorthand aliases → versioned names
   "claude-sonnet-4-5": "claude-sonnet-4-5@20250929",
-  "claude-opus-4-5": "claude-opus-4-5@20251124",
+  "claude-opus-4-5": "claude-opus-4-5@20251101",
   "claude-haiku-4-5": "claude-haiku-4-5@20251001",
   "claude-sonnet-4": "claude-sonnet-4@20250514",
   "claude-opus-4": "claude-opus-4@20250514",

--- a/test/continuous-test-suite-provider-structure.ts
+++ b/test/continuous-test-suite-provider-structure.ts
@@ -284,4 +284,80 @@ await test("Provider Registration Completeness", async () => {
   );
 });
 
+/**
+ * A per-model token-limit key that no enum value points at is dead config:
+ * either the key is stale, or the enum carries a different id for the same
+ * model and the limit is silently never applied.
+ *
+ * That second case is how Bedrock/Vertex Claude Opus 4.5 shipped with an
+ * unusable model id — the tables were keyed on the real id (…20251101…)
+ * while the enums emitted the launch date (…20251124…), so the enum value
+ * reached AWS as an invalid identifier and its token limit was never read.
+ * Nothing failed loudly, because an unmatched key just falls through to the
+ * provider default.
+ */
+/**
+ * Keys deliberately kept for model ids the enums no longer advertise but
+ * callers may still pass by hand. Unlike the failure this test guards
+ * against, none of these is a *disagreement* — no enum value names the same
+ * model under a different id.
+ */
+const KNOWN_UNREFERENCED_TOKEN_KEYS: Record<string, readonly string[]> = {
+  BEDROCK: [
+    // Regional inference-profile spelling ("us." prefix) of a bare id the
+    // enum already carries.
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    // On-demand id the enum does not carry at all, kept for callers who pass
+    // it directly. Not a regional variant.
+    "anthropic.claude-3-opus-20240229-v1:0",
+  ],
+  // Gemini 1.5 names the Vertex enum no longer advertises, still accepted
+  // when passed by hand.
+  VERTEX: ["gemini-1.5-pro", "gemini-1.5-flash"],
+};
+
+await test("Model id tables agree with the model enums", async () => {
+  const { BedrockModels, VertexModels, AnthropicModels } =
+    await import("../dist/lib/constants/enums.js");
+  const { PROVIDER_TOKEN_LIMITS } =
+    await import("../dist/lib/constants/tokens.js");
+
+  const surfaces = [
+    { table: "BEDROCK", models: BedrockModels },
+    { table: "VERTEX", models: VertexModels },
+    { table: "ANTHROPIC", models: AnthropicModels },
+  ] as const;
+
+  const orphans: string[] = [];
+  for (const { table, models } of surfaces) {
+    const limits = (
+      PROVIDER_TOKEN_LIMITS as unknown as Record<string, Record<string, number>>
+    )[table];
+    if (!limits) {
+      orphans.push(`${table}: no PROVIDER_TOKEN_LIMITS entry`);
+      continue;
+    }
+    const declared = new Set(Object.values(models) as string[]);
+    const allowed = new Set(KNOWN_UNREFERENCED_TOKEN_KEYS[table] ?? []);
+    for (const key of Object.keys(limits)) {
+      if (key === "default" || allowed.has(key) || declared.has(key)) {
+        continue;
+      }
+      orphans.push(`${table}.${key}`);
+    }
+  }
+
+  // The offending keys are printed, never interpolated into the assertion
+  // message: they contain provider names, and defineSuite downgrades a
+  // failure to SKIP when the message looks like a provider error.
+  if (orphans.length > 0) {
+    console.error("  unreachable token-limit keys:");
+    orphans.forEach((o) => console.error(`    ${o}`));
+  }
+  assert(
+    orphans.length === 0,
+    `${orphans.length} token-limit key(s) unreachable from any model enum (listed above)`,
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
Claude Opus 4.5 cannot be used on Bedrock or Vertex today. Both enums carry an identifier neither provider issues, so the request is rejected before it reaches the model:

```
ValidationException: The provided model identifier is invalid.
```

## Cause

The ids were built from the model's **launch date** (2025-11-24) rather than the **snapshot date** its id is derived from (2025-11-01):

| | Shipped | Correct |
|---|---|---|
| `BedrockModels.CLAUDE_4_5_OPUS` | `anthropic.claude-opus-4-5-20251124-v1:0` | `anthropic.claude-opus-4-5-20251101-v1:0` |
| `VertexModels.CLAUDE_4_5_OPUS` | `claude-opus-4-5@20251124` | `claude-opus-4-5@20251101` |

Both vendors document the November 1 form — AWS in the Claude Opus 4.5 model card's Programmatic Access table (including the `us.`/`eu.`/`global.` inference-profile ids), Google in the Vertex partner-model page. The direct Anthropic id already in this repo, `claude-opus-4-5-20251101`, uses the same date, which is what made these two the odd ones out.

## A second, quieter symptom

The lookup tables were already keyed on the **correct** id. Because the enums emitted a different string, those rows were unreachable:

- `PROVIDER_TOKEN_LIMITS.BEDROCK["anthropic.claude-opus-4-5-20251101-v1:0"]` was never read, so Bedrock Opus 4.5 resolved no max-output-token limit and silently fell back to the provider default.
- `MODEL_TOKEN_LIMITS` / `modelRouter`'s Vertex entry had the same split.

Fixing the enums makes those rows live for the first time.

## What changed

All six sites that carried the wrong date: both enums, the context-window table, the token-limit table, the Vertex model map, and the vision-capability list. `jsonMode` is not touched here — that lives in the manifest and is corrected in #1351.

## Regression guard

`test/continuous-test-suite-provider-structure.ts` gains a check that fails when a per-model token-limit key is unreachable from any model enum. That is exactly the shape this bug had: the table named the real model, the enum named something else, and nothing failed loudly because an unmatched key just falls through to the default.

The suite already runs on every PR via `provider-safety-net`, so this needs no new wiring.

**Verified the guard actually catches the defect** rather than merely passing: restoring the bad id makes the suite report

```
unreachable token-limit keys:
  BEDROCK.anthropic.claude-opus-4-5-20251101-v1:0
✗ Model id tables agree with the model enums
RESULT: FAIL
```

— a failure, not a skip. The offending keys are printed rather than interpolated into the assertion message, because they contain provider names and `defineSuite` downgrades a failure to SKIP when the message looks like a provider error.

Four keys are allow-listed as deliberate rather than broken, each with its reason in the source: two Bedrock spellings the enums cover under a different form, and two Gemini 1.5 names the Vertex enum no longer advertises but callers may still pass by hand.

## Verification

`check` clean (4816 files, 0 errors), `lint` clean, full build green, `provider-structure` 3/3.

## Note on discovery

This surfaced while checking a review finding on #1351. Both review bots reached the wrong conclusion on it — one explicitly advised keeping the Bedrock id — so the vendor documentation was read directly instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Claude 4.5 Opus model identifiers for Amazon Bedrock and Google Vertex AI to the `20251101` versions.
  - Preserved existing model capabilities, including Bedrock’s 200,000-token context window and Vertex AI’s 8,192-token limit.
  - Updated vision support and provider mappings to recognize the corrected identifiers.

- **Documentation**
  - Updated model listings and provider setup documentation with the current identifiers.

- **Tests**
  - Added validation to detect mismatches between supported models and token-limit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->