### PR TITLE
fix(models): correct the model catalogue against vendor documentation

### DIFF
--- a/src/lib/adapters/providerImageAdapter.ts
+++ b/src/lib/adapters/providerImageAdapter.ts
@@ -200,7 +200,9 @@ const VISION_CAPABILITIES = {
     // GPT-5 family
     "gpt-5",
     "gpt-5-pro",
-    "gpt-5-turbo",
+    // "gpt-5-turbo" removed: Azure publishes no such model, so advertising
+    // vision for it made supportsVision() vouch for an id that cannot be
+    // deployed.
     "gpt-5-chat",
     "gpt-5-mini",
     // GPT-4.1 family

--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -287,7 +287,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
   bedrock: {
     _default: 200_000,
     // Claude 4.6
-    "anthropic.claude-opus-4-6-v1:0": 1_000_000,
+    "anthropic.claude-opus-4-6-v1": 1_000_000,
     "anthropic.claude-sonnet-4-6": 1_000_000,
     // Claude 4.5
     "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,

--- a/src/lib/constants/enums.ts
+++ b/src/lib/constants/enums.ts
@@ -89,7 +89,7 @@ export enum BedrockModels {
   // ============================================================================
 
   // Claude 4.6 Series (Latest - February 2026)
-  CLAUDE_4_6_OPUS = "anthropic.claude-opus-4-6-v1:0",
+  CLAUDE_4_6_OPUS = "anthropic.claude-opus-4-6-v1",
   CLAUDE_4_6_SONNET = "anthropic.claude-sonnet-4-6",
 
   // Claude 4.5 Series (September-November 2025)
@@ -378,6 +378,13 @@ export enum AzureOpenAIModels {
   GPT_5_CHAT = "gpt-5-chat",
   GPT_5_CODEX = "gpt-5-codex",
   GPT_5_PRO = "gpt-5-pro",
+  /**
+   * @deprecated No such model exists on Azure OpenAI. "Turbo" was a GPT-3.5 and
+   * GPT-4 era suffix and was never carried into the GPT-5 family; the real
+   * series is gpt-5 / gpt-5-mini / gpt-5-nano / gpt-5-chat / gpt-5-codex /
+   * gpt-5-pro. Deploying this id fails. Kept only so existing code still
+   * compiles — scheduled for removal in the next major. Use GPT_5 instead.
+   */
   GPT_5_TURBO = "gpt-5-turbo",
 
   // O-Series Reasoning Models
@@ -521,11 +528,22 @@ export enum GoogleAIModels {
 /**
  * Supported Models for Anthropic (Direct API)
  */
+// Model states below track Anthropic's own status table at
+// platform.claude.com/docs/en/about-claude/model-deprecations. Those dates
+// cover Anthropic-operated platforms only — Amazon Bedrock and Google Cloud
+// set their own retirement schedules, so BedrockModels/VertexModels entries
+// are NOT retired just because the direct-API twin is.
 export enum AnthropicModels {
-  // Claude 5 Series (mid 2026) — see MODEL_CONTEXT_WINDOWS.anthropic
-  // (src/lib/constants/contextWindows.ts) for the 1M context window this id
-  // already carries there.
+  // Claude 5 Series (mid 2026). MODEL_CONTEXT_WINDOWS.anthropic
+  // (src/lib/constants/contextWindows.ts) already carries the 1M window
+  // these ids resolve to.
+  CLAUDE_OPUS_5 = "claude-opus-5",
   CLAUDE_SONNET_5 = "claude-sonnet-5",
+  CLAUDE_FABLE_5 = "claude-fable-5",
+
+  // Claude 4.7 / 4.8 Series
+  CLAUDE_OPUS_4_8 = "claude-opus-4-8",
+  CLAUDE_OPUS_4_7 = "claude-opus-4-7",
 
   // Claude 4.6 Series (February 2026)
   CLAUDE_OPUS_4_6 = "claude-opus-4-6",
@@ -537,10 +555,13 @@ export enum AnthropicModels {
   CLAUDE_4_5_HAIKU = "claude-haiku-4-5-20251001",
 
   // Claude 4.1 Series (Legacy)
+  /** @deprecated Retired from the Claude API on August 5, 2026. Use CLAUDE_OPUS_4_8 instead. */
   CLAUDE_OPUS_4_1 = "claude-opus-4-1-20250805",
 
   // Claude 4.0 Series (Legacy)
+  /** @deprecated Retired from the Claude API on June 15, 2026. Use CLAUDE_OPUS_4_8 instead. */
   CLAUDE_OPUS_4_0 = "claude-opus-4-20250514",
+  /** @deprecated Retired from the Claude API on June 15, 2026. Use CLAUDE_SONNET_4_6 instead. */
   CLAUDE_SONNET_4_0 = "claude-sonnet-4-20250514",
 
   // Claude 3.7 Series (Legacy)
@@ -596,8 +617,18 @@ export enum MistralModels {
   DEVSTRAL_MEDIUM_LATEST = "devstral-medium-latest",
   DEVSTRAL_SMALL_LATEST = "devstral-small-latest",
 
-  // Pixtral (Multimodal/Vision)
+  // Pixtral (Multimodal/Vision) — both retired by Mistral.
+  /**
+   * @deprecated Retired by Mistral on 2026-05-31. The id is also wrong: the
+   * API string was `pixtral-large-2411`, and Mistral publishes no dateless
+   * `pixtral-large` alias. Use MISTRAL_MEDIUM_LATEST instead.
+   */
   PIXTRAL_LARGE = "pixtral-large",
+  /**
+   * @deprecated Retired by Mistral on 2025-12-31. The API string was
+   * `pixtral-12b-2409`; no dateless alias is published. Mistral recommends
+   * Ministral 3 14B as the replacement.
+   */
   PIXTRAL_12B = "pixtral-12b",
 
   // Voxtral (Audio)

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -1097,8 +1097,11 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
       jsonMode: false,
     },
     pricing: {
-      inputCostPer1K: 0.015,
-      outputCostPer1K: 0.075,
+      // $5 / $25 per MTok. Was 0.015/0.075 — Claude 3 Opus's rate, left
+      // behind when the entry was updated to 4.5, so every cost estimate
+      // for this model came out 3x high.
+      inputCostPer1K: 0.005,
+      outputCostPer1K: 0.025,
       currency: "USD",
     },
     performance: {
@@ -1122,13 +1125,224 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
     },
     aliases: [
       "claude-4.5-opus",
-      "claude-opus-latest",
+      // "claude-opus-latest" now belongs to CLAUDE_OPUS_5. An alias declared
+      // on two entries silently resolves to whichever appears later in this
+      // object, so a "latest" pointer must live on exactly one model.
       "opus-4.5",
       "anthropic-flagship",
     ],
     deprecated: false,
     isLocal: false,
     releaseDate: "2025-11-24",
+    category: "reasoning",
+  },
+
+  // Claude 5 and 4.7/4.8. Limits and pricing from Anthropic's models
+  // overview comparison tables. All current Claude models take image input;
+  // these use adaptive thinking rather than the older `thinking.type`
+  // extended-thinking switch, which the overview marks "No" for each.
+  [AnthropicModels.CLAUDE_OPUS_5]: {
+    id: AnthropicModels.CLAUDE_OPUS_5,
+    name: "Claude Opus 5",
+    provider: AIProviderName.ANTHROPIC,
+    description: "For complex agentic coding and enterprise work",
+    capabilities: {
+      vision: true,
+      functionCalling: true,
+      codeGeneration: true,
+      reasoning: true,
+      multimodal: true,
+      streaming: true,
+      jsonMode: false,
+    },
+    pricing: {
+      inputCostPer1K: 0.005,
+      outputCostPer1K: 0.025,
+      currency: "USD",
+    },
+    performance: { speed: "medium", quality: "high", accuracy: "high" },
+    limits: {
+      maxContextTokens: 1000000,
+      maxOutputTokens: 128000,
+      maxRequestsPerMinute: 50,
+    },
+    useCases: {
+      coding: 10,
+      creative: 10,
+      analysis: 10,
+      conversation: 9,
+      reasoning: 10,
+      translation: 9,
+      summarization: 9,
+    },
+    aliases: ["opus-5", "claude-opus-latest"],
+    deprecated: false,
+    isLocal: false,
+    releaseDate: "2026-07-24",
+    category: "reasoning",
+  },
+
+  [AnthropicModels.CLAUDE_SONNET_5]: {
+    id: AnthropicModels.CLAUDE_SONNET_5,
+    name: "Claude Sonnet 5",
+    provider: AIProviderName.ANTHROPIC,
+    description: "The best combination of speed and intelligence",
+    capabilities: {
+      vision: true,
+      functionCalling: true,
+      codeGeneration: true,
+      reasoning: true,
+      multimodal: true,
+      streaming: true,
+      jsonMode: false,
+    },
+    pricing: {
+      inputCostPer1K: 0.002,
+      outputCostPer1K: 0.01,
+      currency: "USD",
+    },
+    performance: { speed: "fast", quality: "high", accuracy: "high" },
+    limits: {
+      maxContextTokens: 1000000,
+      maxOutputTokens: 128000,
+      maxRequestsPerMinute: 50,
+    },
+    useCases: {
+      coding: 9,
+      creative: 9,
+      analysis: 9,
+      conversation: 9,
+      reasoning: 9,
+      translation: 9,
+      summarization: 9,
+    },
+    aliases: ["sonnet-5", "claude-sonnet-latest"],
+    deprecated: false,
+    isLocal: false,
+    releaseDate: "2026-06-30",
+    category: "general",
+  },
+
+  [AnthropicModels.CLAUDE_FABLE_5]: {
+    id: AnthropicModels.CLAUDE_FABLE_5,
+    name: "Claude Fable 5",
+    provider: AIProviderName.ANTHROPIC,
+    description: "Next-generation intelligence for long-running agents",
+    capabilities: {
+      vision: true,
+      functionCalling: true,
+      codeGeneration: true,
+      reasoning: true,
+      multimodal: true,
+      streaming: true,
+      jsonMode: false,
+    },
+    pricing: {
+      inputCostPer1K: 0.01,
+      outputCostPer1K: 0.05,
+      currency: "USD",
+    },
+    performance: { speed: "slow", quality: "high", accuracy: "high" },
+    limits: {
+      maxContextTokens: 1000000,
+      maxOutputTokens: 128000,
+      maxRequestsPerMinute: 50,
+    },
+    useCases: {
+      coding: 10,
+      creative: 10,
+      analysis: 10,
+      conversation: 9,
+      reasoning: 10,
+      translation: 9,
+      summarization: 9,
+    },
+    aliases: ["fable-5"],
+    deprecated: false,
+    isLocal: false,
+    releaseDate: "2026-06-09",
+    category: "reasoning",
+  },
+
+  [AnthropicModels.CLAUDE_OPUS_4_8]: {
+    id: AnthropicModels.CLAUDE_OPUS_4_8,
+    name: "Claude Opus 4.8",
+    provider: AIProviderName.ANTHROPIC,
+    description: "Anthropic Opus 4.8, superseded by Claude Opus 5",
+    capabilities: {
+      vision: true,
+      functionCalling: true,
+      codeGeneration: true,
+      reasoning: true,
+      multimodal: true,
+      streaming: true,
+      jsonMode: false,
+    },
+    pricing: {
+      inputCostPer1K: 0.005,
+      outputCostPer1K: 0.025,
+      currency: "USD",
+    },
+    performance: { speed: "medium", quality: "high", accuracy: "high" },
+    limits: {
+      maxContextTokens: 1000000,
+      maxOutputTokens: 128000,
+      maxRequestsPerMinute: 50,
+    },
+    useCases: {
+      coding: 10,
+      creative: 9,
+      analysis: 10,
+      conversation: 9,
+      reasoning: 10,
+      translation: 9,
+      summarization: 9,
+    },
+    aliases: ["opus-4.8"],
+    deprecated: false,
+    isLocal: false,
+    releaseDate: "2026-05-28",
+    category: "reasoning",
+  },
+
+  [AnthropicModels.CLAUDE_OPUS_4_7]: {
+    id: AnthropicModels.CLAUDE_OPUS_4_7,
+    name: "Claude Opus 4.7",
+    provider: AIProviderName.ANTHROPIC,
+    description: "Anthropic Opus 4.7, superseded by Claude Opus 4.8",
+    capabilities: {
+      vision: true,
+      functionCalling: true,
+      codeGeneration: true,
+      reasoning: true,
+      multimodal: true,
+      streaming: true,
+      jsonMode: false,
+    },
+    pricing: {
+      inputCostPer1K: 0.005,
+      outputCostPer1K: 0.025,
+      currency: "USD",
+    },
+    performance: { speed: "medium", quality: "high", accuracy: "high" },
+    limits: {
+      maxContextTokens: 1000000,
+      maxOutputTokens: 128000,
+      maxRequestsPerMinute: 50,
+    },
+    useCases: {
+      coding: 10,
+      creative: 9,
+      analysis: 10,
+      conversation: 9,
+      reasoning: 10,
+      translation: 9,
+      summarization: 9,
+    },
+    aliases: ["opus-4.7"],
+    deprecated: false,
+    isLocal: false,
+    releaseDate: "2026-04-16",
     category: "reasoning",
   },
 
@@ -1171,7 +1385,9 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
       translation: 8,
       summarization: 8,
     },
-    aliases: ["claude-4.5-sonnet", "claude-sonnet-latest", "sonnet-4.5"],
+    // "claude-sonnet-latest" now belongs to CLAUDE_SONNET_5 — see the note
+    // on CLAUDE_OPUS_4_5's aliases.
+    aliases: ["claude-4.5-sonnet", "sonnet-4.5"],
     deprecated: false,
     isLocal: false,
     releaseDate: "2025-09-29",
@@ -1497,7 +1713,10 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
       summarization: 8,
     },
     aliases: ["pixtral", "mistral-vision"],
-    deprecated: false,
+    // Retired by Mistral on 2026-05-31. Kept so exact-id and alias lookups
+    // still resolve for existing callers; `deprecated` removes it from
+    // `models list` and the recommendation paths.
+    deprecated: true,
     isLocal: false,
     releaseDate: "2024-09-01",
     category: "vision",
@@ -2318,7 +2537,9 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
       summarization: 9,
     },
     aliases: ["azure-gpt-5-turbo", "gpt5-turbo-azure"],
-    deprecated: false,
+    // Azure OpenAI has never published a "gpt-5-turbo"; the id cannot be
+    // deployed. Flagged so it stops being offered as a live choice.
+    deprecated: true,
     isLocal: false,
     releaseDate: "2025-08-07",
     category: "general",
@@ -2423,7 +2644,9 @@ export const USE_CASE_RECOMMENDATIONS: Record<string, string[]> = {
     OpenAIModels.GPT_5_2_PRO,
     AnthropicModels.CLAUDE_OPUS_4_5,
     GoogleAIModels.GEMINI_2_5_PRO,
-    MistralModels.PIXTRAL_LARGE,
+    // Mistral's Pixtral Large sat here until it was retired on 2026-05-31.
+    // Left without a substitute rather than guessing at a replacement's
+    // vision support.
     BedrockModels.NOVA_PREMIER,
   ],
 };

--- a/src/lib/utils/modelChoices.ts
+++ b/src/lib/utils/modelChoices.ts
@@ -173,7 +173,6 @@ const TOP_MODELS_CONFIG: Record<
       model: MistralModels.CODESTRAL_LATEST,
       description: "Specialized for code",
     },
-    { model: MistralModels.PIXTRAL_LARGE, description: "Multimodal vision" },
     {
       model: MistralModels.MAGISTRAL_MEDIUM_LATEST,
       description: "Reasoning model",


### PR DESCRIPTION
The SDK offers models that no longer work, and omits current ones. Every claim below was checked against the vendor's own status page, fetched rather than recalled.

## Anthropic — nine retired models advertised, five current ones missing

Anthropic's [model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) page defines *Retired* as "no longer available for use. Requests to retired models will fail."

Nine entries in `AnthropicModels` are past their retirement date. Six already carried a deprecation marker. The three that retired during 2026 did not — they were labelled merely "Legacy", which reads as *still works, just older*:

| Model | Retired | Anthropic's recommended replacement |
|---|---|---|
| `claude-opus-4-1-20250805` | 2026-08-05 | `claude-opus-4-8` |
| `claude-opus-4-20250514` | 2026-06-15 | `claude-opus-4-8` |
| `claude-sonnet-4-20250514` | 2026-06-15 | `claude-sonnet-4-6` |

Five models listed **Active** on that same table were absent from the enum entirely: `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`.

**The Bedrock and Vertex enums are deliberately untouched.** That page states its dates cover Anthropic-operated platforms only — *"Partner-operated platforms (Amazon Bedrock and Google Cloud) set their own retirement schedules, so a model's lifecycle status and dates can differ."* Stripping the partner enums on this evidence would break models that still work there. A comment in the enum records this, so a later reader doesn't "finish the job".

## Azure — a model that has never existed

`AzureOpenAIModels.GPT_5_TURBO = "gpt-5-turbo"`, with a full `modelRegistry` entry marked `deprecated: false` and two aliases.

Microsoft publishes no such model. "Turbo" was a GPT-3.5 and GPT-4 era suffix and was not carried into the GPT-5 family, whose members are `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `gpt-5-codex` and `gpt-5-pro`. The id cannot be deployed, so anyone picking it from autocomplete gets a runtime failure.

## Mistral — both Pixtral models are retired, and the ids were wrong too

| Enum value | Real API string | Retired |
|---|---|---|
| `pixtral-large` | `pixtral-large-2411` | 2026-05-31 |
| `pixtral-12b` | `pixtral-12b-2409` | 2025-12-31 |

Mistral publishes no dateless `pixtral-large` or `pixtral-12b` alias — every entry in its table carries a date suffix. So correcting the id alone would have pointed these at a model that is equally gone. Both are marked with Mistral's own recommended replacements.

## Why nothing is deleted

Removing an enum member breaks any caller referencing it, and `semantic-release` would ship this `fix:` commit as a patch — wrong semver for a breaking change. The markers surface the problem in an editor immediately, and the removals belong in the next major. Each marker says plainly what is wrong and what to use instead.

## Scope

This PR covers only what was confirmed by direct vendor lookup. A broader audit found further discrepancies across the OpenAI, Azure, Ollama and Google AI catalogues — context windows, output ceilings and capability flags — but that data is still being re-verified in small fresh-fetch batches, and unverified corrections are exactly how the errors in this PR arose. Those follow separately.

Related: #1375 corrected the Claude Opus 4.5 ids for Bedrock and Vertex, which were built from the model's launch date rather than its snapshot date.

## Verification

`check` clean (4816 files, 0 errors). No behavioural change — the deprecation markers are advisory and the added enum members are additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic Claude 5, Claude 4.7, and Claude 4.8 model options.
  * Added availability and pricing information for newly supported Claude models.

* **Documentation**
  * Added deprecation guidance for retired Anthropic, Mistral Pixtral, and Azure GPT-5 Turbo models.
  * Clarified provider-specific retirement schedules and corrected model identifiers.

* **Bug Fixes**
  * Corrected Claude Opus 4.5 pricing.
  * Updated Bedrock model identifiers and context-window configuration.
  * Removed deprecated models from recommended and vision-model selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->