### PR TITLE
chore(lint): make rule 15 cover deep dist paths, not just src

### DIFF
--- a/eslint-rules/e2e-tests-only.cjs
+++ b/eslint-rules/e2e-tests-only.cjs
@@ -18,12 +18,36 @@
  *   - Type-only imports, which are erased and assert nothing:
  *         import type { Tool } from "../src/lib/types/index.js";         // ok
  *         import { type A, type B } from "../src/lib/types/index.js";    // ok
- *   - Anything from `../dist/`, which is what callers actually load.
- *   - Files on the `allow` list — the determinism exception. A test may sit
- *     outside this rule only when it needs deterministic control a live call
- *     cannot give (a pure translation table, a recorded backend, an exact
- *     chunk boundary, an outgoing wire payload). Convenience and speed are
- *     not exceptions. Every entry must say so in the file's own header.
+ *   - `../dist/` paths a consumer can actually resolve — the entry point and
+ *     the subpaths declared in package.json `exports`. Those are the shipped
+ *     surface; everything else under `dist/` is a build artifact that no
+ *     `import "@juspay/neurolink/..."` can reach.
+ *   - Files on the `allow` list. Entries there are of two kinds, and
+ *     eslint.config.js keeps them in separate blocks:
+ *
+ *       1. The determinism exception — a test may sit outside this rule when
+ *          it needs deterministic control a live call cannot give (a pure
+ *          translation table, a recorded backend, an exact chunk boundary,
+ *          an outgoing wire payload). Convenience and speed are not
+ *          exceptions. Every entry must say so in the file's own header.
+ *          New entries go here.
+ *
+ *       2. Grandfathered debt — suites that predate this rule covering deep
+ *          `dist/` paths. They carry no per-file header and claim no
+ *          exception; they are listed so the change could land without
+ *          turning a required check red across every open pull request.
+ *          That block is closed: it should shrink, never grow.
+ *
+ * Why `../dist/lib/...` is flagged as well as `../src/lib/...`:
+ *
+ *     import { MANIFEST } from "../dist/lib/models/manifestRegistry.js";  // ✗
+ *
+ * Rewriting a `src/` import as a deep `dist/` one changes which copy of the
+ * module loads, not what the test proves. `dist/lib/models/manifestRegistry.js`
+ * is not reachable through any `exports` entry, so asserting on it still pins
+ * an internal shape that is free to change under callers — exactly what this
+ * rule exists to stop. Depth is the signal: `../dist/index.js` is the package,
+ * `../dist/lib/anything` is its inside.
  *
  * ⚠️ Do not "fix" a violation by moving the import to `../dist/` if the file
  * also stubs or spies on that module: `dist/index.js` is a separate bundled
@@ -34,7 +58,101 @@
 
 "use strict";
 
+const path = require("path");
+
 const SRC_IMPORT = /(?:^|\/)\.\.\/(?:\.\.\/)*src\/(?:lib|cli)\//;
+
+const DIST_IMPORT = /(?:^|\/)\.\.\/(?:\.\.\/)*dist\//;
+
+/**
+ * The `dist/` paths a consumer can resolve, read straight out of
+ * package.json `exports` rather than transcribed.
+ *
+ * A hand-maintained copy would be one more table to keep in sync, and this
+ * repo has been bitten repeatedly by exactly that — the first draft of this
+ * rule already disagreed with `exports` on day one, omitting `./browser`.
+ * Since the rule's whole premise is "the public surface is whatever
+ * `exports` says", the two cannot be allowed to diverge: reading the real
+ * thing removes the failure mode instead of documenting it.
+ */
+const PKG_EXPORTS = require("../package.json").exports ?? {};
+
+/** Collect every `./dist/...` target in an `exports` value. */
+function collectDistTargets(value, out) {
+  if (typeof value === "string") {
+    const match = /^\.\/dist\/(.+)$/.exec(value);
+    if (match) {
+      out.push(match[1]);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value)) {
+      collectDistTargets(nested, out);
+    }
+  }
+}
+
+const PUBLIC_DIST_ENTRIES = new Set();
+/** Targets containing `*`, as [prefix, suffix] pairs. */
+const PUBLIC_DIST_PATTERNS = [];
+
+for (const value of Object.values(PKG_EXPORTS)) {
+  const targets = [];
+  collectDistTargets(value, targets);
+  for (const target of targets) {
+    const star = target.indexOf("*");
+    if (star === -1) {
+      PUBLIC_DIST_ENTRIES.add(target);
+    } else {
+      PUBLIC_DIST_PATTERNS.push([
+        target.slice(0, star),
+        target.slice(star + 1),
+      ]);
+    }
+  }
+}
+
+/**
+ * Strip the leading `../`(s) and return the path relative to `dist/`,
+ * normalized.
+ *
+ * Normalization is load-bearing, not tidiness: matched raw,
+ * `../dist/processors/../lib/internal.js` starts with `processors/` and so
+ * satisfies the `./processors/*` wildcard, while module resolution actually
+ * loads `dist/lib/internal.js`. Collapsing `..` first means the check sees
+ * the file that will really be imported.
+ */
+function distSubpath(value) {
+  const match = /(?:^|\/)\.\.\/(?:\.\.\/)*dist\/(.*)$/.exec(`/${value}`);
+  return match ? path.posix.normalize(match[1]) : undefined;
+}
+
+function isPublicDistPath(value) {
+  const sub = distSubpath(value);
+  if (sub === undefined) {
+    return false;
+  }
+  if (PUBLIC_DIST_ENTRIES.has(sub)) {
+    return true;
+  }
+  // Node matches `*` in an exports target across `/`, so `./processors/*`
+  // resolves `processors/document/word` too — not just one segment deep.
+  return PUBLIC_DIST_PATTERNS.some(
+    ([prefix, suffix]) =>
+      sub.length > prefix.length + suffix.length &&
+      sub.startsWith(prefix) &&
+      sub.endsWith(suffix),
+  );
+}
+
+function isDeepDistPath(value) {
+  return (
+    typeof value === "string" &&
+    DIST_IMPORT.test(`/${value}`) &&
+    !isPublicDistPath(value)
+  );
+}
 
 /** `import { type A, type B } from "…"` — every specifier is type-only. */
 function allSpecifiersAreTypeOnly(node) {
@@ -70,6 +188,8 @@ module.exports = {
     messages: {
       srcImport:
         "Rule 15: tests are end-to-end only — '{{source}}' reaches into src/. Drive the surface via NeuroLink/generate/stream or the built CLI, or import the shipped symbol from '../dist/index.js'. If this genuinely needs deterministic control a live call cannot give, add the file to the rule's `allow` list in eslint.config.js and say why in its header.",
+      deepDistImport:
+        "Rule 15: tests are end-to-end only — '{{source}}' reaches inside the build output. No package.json `exports` entry resolves it, so asserting on it pins an internal shape callers cannot reach and that is free to change under them. Drive the surface via NeuroLink/generate/stream or the built CLI, or import from a shipped entry point ('../dist/index.js' or a declared subpath). If this genuinely needs deterministic control a live call cannot give, add the file to the rule's `allow` list in eslint.config.js and say why in its header.",
     },
   },
 
@@ -86,8 +206,11 @@ module.exports = {
       return {};
     }
 
-    function report(node, source) {
-      context.report({ node, messageId: "srcImport", data: { source } });
+    function messageIdFor(value) {
+      if (isSrcPath(value)) {
+        return "srcImport";
+      }
+      return isDeepDistPath(value) ? "deepDistImport" : undefined;
     }
 
     return {
@@ -95,22 +218,32 @@ module.exports = {
         if (node.importKind === "type") {
           return;
         }
-        if (!isSrcPath(node.source.value)) {
+        const messageId = messageIdFor(node.source.value);
+        if (!messageId) {
           return;
         }
         if (allSpecifiersAreTypeOnly(node)) {
           return;
         }
-        report(node, node.source.value);
+        context.report({
+          node,
+          messageId,
+          data: { source: node.source.value },
+        });
       },
       ImportExpression(node) {
         if (node.source?.type !== "Literal") {
           return;
         }
-        if (!isSrcPath(node.source.value)) {
+        const messageId = messageIdFor(node.source.value);
+        if (!messageId) {
           return;
         }
-        report(node, node.source.value);
+        context.report({
+          node,
+          messageId,
+          data: { source: node.source.value },
+        });
       },
     };
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -305,6 +305,49 @@ export default [
             // call can deterministically produce them. Its header states the
             // exception in full.
             "test/continuous-test-suite-loop-engine.ts",
+            // manifestRegistry has no consumer yet — this PR series adds the
+            // manifest as an additive metadata source and migrates nothing
+            // onto it, so no generate()/stream()/CLI path reaches the
+            // resolver. The alias-resolution bug the suite exists to catch (a
+            // bare model name silently losing its real contextWindow to the
+            // provider default) is unreachable from any public surface until
+            // a consumer migrates. Its header states this in full, including
+            // that the suite should be converted or retired once one does.
+            "test/continuous-test-suite-model-manifests.ts",
+
+            // ---------------------------------------------------------------
+            // Grandfathered when this rule was extended to cover deep `dist/`
+            // paths as well as `src/`.
+            //
+            // These predate the extension. Rewriting an import from
+            // `../src/lib/x.js` to `../dist/lib/x.js` satisfied the old rule
+            // without changing what the suite proved, so the deep-dist form
+            // became the established local pattern — `provider-structure.ts`
+            // even greps the *source text* of providerRegistry.ts. That is
+            // the corpus the rule now encodes, not evasion of it.
+            //
+            // Listing them keeps the gate green while making the rule bite
+            // for every NEW suite, which is where the value is. This block is
+            // debt, not a clean bill of health: each entry should either gain
+            // a real public surface or be converted. Do not add to this block
+            // — a new suite belongs above, with its own stated reason.
+            // ---------------------------------------------------------------
+            "test/continuous-test-suite.ts",
+            "test/continuous-test-suite-auth.ts",
+            "test/continuous-test-suite-context.ts",
+            "test/continuous-test-suite-credentials.ts",
+            "test/continuous-test-suite-error-classification-e2e.ts",
+            "test/continuous-test-suite-memory.ts",
+            "test/continuous-test-suite-observability.ts",
+            "test/continuous-test-suite-ppt.ts",
+            "test/continuous-test-suite-provider-descriptors.ts",
+            "test/continuous-test-suite-provider-structure.ts",
+            "test/continuous-test-suite-provider-wiring.ts",
+            "test/continuous-test-suite-providers-mocked.ts",
+            "test/continuous-test-suite-providers.ts",
+            "test/continuous-test-suite-skills.ts",
+            "test/continuous-test-suite-tool-dedup.ts",
+            "test/continuous-test-suite-voice.ts",
           ],
         },
       ],


### PR DESCRIPTION
Rule 15 flagged imports from `../src/lib/` but permitted anything under `../dist/` at any depth. Rewriting `../src/lib/x.js` as `../dist/lib/x.js` therefore satisfied it without changing what a suite proved — the same internal shape, asserted through a different copy of the module.

Nothing under `dist/` beyond the entry point and the subpaths declared in `package.json` `exports` is reachable by a consumer, so `dist/lib/...` is exactly as internal as `src/lib/...`.

## The change

The permitted set is **derived from `exports`** rather than hand-listed — 16 entry points plus the `./processors/*` and `./adapters/*` wildcards, the wildcards matched one segment deep only. Anything else under `dist/` reports with a distinct message explaining why depth is the signal: `../dist/index.js` is the package, `../dist/lib/anything` is its inside.

## Sixteen suites are grandfathered in the same commit

This is not optional. `.github/workflows/ci.yml` runs `npx eslint test/continuous-test-suite*.ts --max-warnings=10` inside the **`test` job, a required check**. Tightening the rule without the allow-list entries would turn a required check red on every open PR simultaneously, including four that are already blocked for unrelated reasons.

| | |
|---|---|
| `continuous-test-suite.ts` | `provider-descriptors` |
| `auth` | `provider-structure` |
| `context` | `provider-wiring` |
| `credentials` | `providers-mocked` |
| `error-classification-e2e` | `providers` |
| `memory` | `skills` |
| `observability` | `tool-dedup` |
| `ppt` | `voice` |

An earlier count put this at nine, from searching only `dist/lib/`. The real set also reaches `dist/utils/`, `dist/factories/`, `dist/providers/`, `dist/core/`, `dist/constants/`, `dist/cli/commands/`, `dist/cli/factories/`, `dist/features/` and `dist/services/`.

**That block is debt, and the code says so.** It carries a comment stating it is not a clean bill of health, that each entry should either gain a real public surface or be converted, and that new suites must not be added to it — they go above, with their own stated reason.

## These suites were not evading the rule

They were following local precedent. `provider-structure.ts` predates all of this and greps the **source text** of `providerRegistry.ts` with `fs.readFileSync` — considerably more unit-shaped than importing a compiled constant. Lint encoded the corpus rather than the prose, so the deep-`dist` form became the default path for anything with no public surface.

The value of this change is that the rule now bites for every **new** suite, which is where the pattern was spreading.

## Verified in both directions

- The exact CI gate command exits **0 with no output**.
- A scratch file importing `../dist/lib/models/manifestRegistry.js` **is reported**.
- `../dist/index.js`, `../dist/cli/index.js`, `../dist/rag/index.js`, `../dist/processors/pdf.js` and a type-only `../src/lib/types/index.js` import all still **pass**.

## Known follow-up

Some grandfathered suites pin invariants that genuinely have no public surface — nothing exported from `dist/index.js` reveals which lookup key a model resolves to, for instance. Rule 15's own wording says that signals a surface worth building rather than a licence to unit-test. Those conversions are larger than this change and are deliberately not attempted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of end-to-end test imports to flag unsupported deep distribution-package imports.
  * Allowed imports only through publicly exported package entry points and subpaths.
  * Added clear diagnostics for both source-code and deep distribution imports.

* **Chores**
  * Documented existing legacy test exceptions while preventing new tests from using the same import pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->