### PR TITLE
fix(bedrock): retry with a cross-region inference profile when required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Error classifier contract tests (TimeoutError classification per provider, no API keys required)
         run: pnpm run test:error-classifier-contract
 
+      - name: Bedrock inference-profile fallback (local HTTP/2 stand-in, no API keys required)
+        run: pnpm run test:bedrock-inference-profile
+
       - name: 🧩 Provider Onboarding Completeness
         run: pnpm run verify:provider-onboarding
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:adjust-body-after-400": "npx tsx test/continuous-test-suite-adjust-body-after-400.ts",
     "test:error-classification-e2e": "npx tsx test/continuous-test-suite-error-classification-e2e.ts",
     "test:error-classifier-contract": "npx tsx test/continuous-test-suite-error-classifier-contract.ts",
+    "test:bedrock-inference-profile": "npx tsx test/continuous-test-suite-bedrock-inference-profile.ts",
     "test:loop-engine": "npx tsx test/continuous-test-suite-loop-engine.ts",
     "test:middleware": "npx tsx test/continuous-test-suite-middleware.ts",
     "test:observability": "npx tsx test/continuous-test-suite-observability.ts",

--- a/src/lib/providers/amazonBedrock/client.ts
+++ b/src/lib/providers/amazonBedrock/client.ts
@@ -20,6 +20,7 @@ import type { AIProviderName } from "../../constants/enums.js";
 import { createAnalytics } from "../../core/analytics.js";
 import { BaseProvider } from "../../core/baseProvider.js";
 import { DEFAULT_MAX_STEPS } from "../../core/constants.js";
+import { withInferenceProfileFallback } from "./inferenceProfile.js";
 import type { NeuroLink } from "../../neurolink.js";
 import type {
   JsonValue,
@@ -557,9 +558,6 @@ export class AmazonBedrockProvider extends BaseProvider {
             `[AmazonBedrockProvider] Calling Bedrock with ${this.conversationHistory.length} messages and ${toolConfig?.tools?.length || 0} tools`,
           );
 
-          // Create command and attempt API call
-          const command = new ConverseCommand(commandInput);
-
           logger.debug("[Observability] Bedrock API request", {
             model: commandInput.modelId,
             region: region,
@@ -569,10 +567,24 @@ export class AmazonBedrockProvider extends BaseProvider {
           });
 
           const apiCallStartTime = Date.now();
-          const response = await withTimeout(
-            this.bedrockClient.send(command),
-            120_000,
-            new Error("Bedrock API call timed out"),
+          const response = await withInferenceProfileFallback(
+            commandInput.modelId ?? "",
+            // `this.region`, not the local `region` above: that one is
+            // best-effort for logging and stays "unknown" if the lookup
+            // throws. It must also match the id the streaming path keys its
+            // cache by, or a resolution found here is never reused there.
+            this.region,
+            (effectiveModelId) =>
+              withTimeout(
+                this.bedrockClient.send(
+                  new ConverseCommand({
+                    ...commandInput,
+                    modelId: effectiveModelId,
+                  }),
+                ),
+                120_000,
+                new Error("Bedrock API call timed out"),
+              ),
           );
           const apiCallDuration = Date.now() - apiCallStartTime;
 
@@ -1473,7 +1485,6 @@ export class AmazonBedrockProvider extends BaseProvider {
         "[TRACE] streamingConversationLoop - testing first streaming call",
       );
       const commandInput = await this.prepareStreamCommand(options);
-      const command = new ConverseStreamCommand(commandInput);
 
       logger.debug("[Observability] Bedrock streaming API request", {
         model: commandInput.modelId,
@@ -1487,10 +1498,20 @@ export class AmazonBedrockProvider extends BaseProvider {
       });
 
       const streamStartTime = Date.now();
-      const response = await withTimeout(
-        this.bedrockClient.send(command),
-        120_000,
-        new Error("Bedrock streaming API call timed out"),
+      const response = await withInferenceProfileFallback(
+        commandInput.modelId ?? "",
+        this.region,
+        (effectiveModelId) =>
+          withTimeout(
+            this.bedrockClient.send(
+              new ConverseStreamCommand({
+                ...commandInput,
+                modelId: effectiveModelId,
+              }),
+            ),
+            120_000,
+            new Error("Bedrock streaming API call timed out"),
+          ),
       );
 
       logger.debug(

--- a/src/lib/providers/amazonBedrock/inferenceProfile.ts
+++ b/src/lib/providers/amazonBedrock/inferenceProfile.ts
@@ -1,0 +1,221 @@
+/**
+ * Bedrock cross-region inference profile resolution.
+ *
+ * Most current Bedrock models cannot be invoked by their bare model id. Each
+ * model card carries a Regional Availability table with three columns, and for
+ * a great many model/region pairs the In-Region column is "No" — Claude Opus
+ * 4.5 is No in every region AWS lists, Sonnet 4.6 is Yes only in eu-west-2.
+ * Those models are reachable only through a cross-region inference profile: the
+ * same id with a geography prefix (`us.`, `eu.`, `au.`, `jp.`, `apac.`) or the
+ * worldwide `global.` prefix.
+ *
+ * Sending the bare id where In-Region is No fails with a ValidationException
+ * telling you to use an inference profile. This module detects that specific
+ * failure and works out which prefixed id to retry with.
+ *
+ * ## Why prefixes are derived rather than tabulated
+ *
+ * The obvious implementation — a table of model to supported prefixes — is the
+ * one to avoid. The prefix set is per-model, not per-region: from the same
+ * caller region `ap-northeast-1`, Claude Opus 4.5 accepts only `global.`,
+ * Sonnet 4.5 also accepts `jp.`, and Haiku 4.5 works bare. A static table
+ * would need a row per model per region and would be wrong the day a model
+ * ships. AWS itself moved this data out of a central page and onto each
+ * model's detail page for the same reason.
+ *
+ * So resolution is empirical: on the specific error, try the geography that
+ * covers the caller's region, then `global.`, and remember what worked.
+ *
+ * `bedrock:ListInferenceProfiles` would give an authoritative answer, but it
+ * is a control-plane call needing a separate SDK client and an IAM permission
+ * a caller with plain inference access will not necessarily hold. Deriving
+ * candidates needs neither, and costs at most two extra attempts once per
+ * model/region pair.
+ */
+
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Geography prefixes, in the order AWS documents them. `global.` is not a
+ * geography — it routes anywhere and is tried last, as the broadest option.
+ */
+const GLOBAL_PREFIX = "global";
+
+/**
+ * Maps an AWS region to the geography whose inference profile covers it.
+ *
+ * Derived from the Geo inference tables on the model cards: the US geography
+ * covers `us-*` plus the Canadian regions, EU covers `eu-*` plus Israel, the
+ * Middle East and Africa, Japan covers the two Japanese regions, and Australia
+ * covers Sydney, Melbourne and New Zealand. Everything else in Asia Pacific
+ * falls under `apac`.
+ */
+function geoPrefixForRegion(region: string): string | undefined {
+  if (/^(us|ca)-/.test(region)) {
+    return "us";
+  }
+  if (/^(eu|il|me|af)-/.test(region)) {
+    return "eu";
+  }
+  if (/^ap-northeast-[13]$/.test(region)) {
+    return "jp";
+  }
+  if (/^ap-southeast-[246]$/.test(region)) {
+    return "au";
+  }
+  if (/^ap-/.test(region)) {
+    return "apac";
+  }
+  return undefined;
+}
+
+/** True when `modelId` already carries a geography or global prefix. */
+function hasProfilePrefix(modelId: string): boolean {
+  return /^(us|eu|au|jp|apac|global)\./.test(modelId);
+}
+
+/**
+ * Does this error mean "this model needs an inference profile in this region"?
+ *
+ * Deliberately narrow. A ValidationException covers many unrelated causes —
+ * a malformed body, an unknown parameter, a model the account has no access to
+ * — and retrying those with a different model id would turn one clear failure
+ * into two confusing ones. Both the exception name and the distinctive phrase
+ * must match.
+ *
+ * The phrase is matched loosely enough to survive AWS rewording the sentence
+ * around it, and the retry is a no-op when nothing resolves, so a miss here
+ * costs nothing beyond the original error surfacing unchanged — which is the
+ * behaviour without this module at all.
+ */
+export function isInferenceProfileRequiredError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const candidate = error as { name?: unknown; message?: unknown };
+  const name = typeof candidate.name === "string" ? candidate.name : "";
+  const message =
+    typeof candidate.message === "string" ? candidate.message : "";
+  if (
+    !/ValidationException/i.test(name) &&
+    !/ValidationException/i.test(message)
+  ) {
+    return false;
+  }
+  return (
+    /inference profile/i.test(message) && /on-demand throughput/i.test(message)
+  );
+}
+
+/**
+ * Candidate ids to retry, most specific first: the caller's own geography,
+ * then worldwide.
+ *
+ * Returns an empty array when the id already carries a prefix — a prefixed id
+ * that still fails is a real error, not something to re-prefix.
+ */
+export function inferenceProfileCandidates(
+  modelId: string,
+  region: string,
+): string[] {
+  // An ARN already names a concrete model or inference-profile resource, and
+  // this provider accepts one as a model id (see `extractRegionFromArn`).
+  // Prefixing it yields a malformed identifier whose ValidationException would
+  // then replace the original, accurate error.
+  if (modelId.startsWith("arn:") || hasProfilePrefix(modelId)) {
+    return [];
+  }
+  const candidates: string[] = [];
+  const geo = geoPrefixForRegion(region);
+  if (geo) {
+    candidates.push(`${geo}.${modelId}`);
+  }
+  candidates.push(`${GLOBAL_PREFIX}.${modelId}`);
+  return candidates;
+}
+
+/**
+ * Remembers which id actually worked, keyed by region and bare model id, so
+ * the probing happens once rather than on every call.
+ */
+const resolved = new Map<string, string>();
+
+function cacheKey(region: string, modelId: string): string {
+  return `${region}::${modelId}`;
+}
+
+/** The id that previously worked for this model in this region, if any. */
+export function getResolvedModelId(
+  modelId: string,
+  region: string,
+): string | undefined {
+  return resolved.get(cacheKey(region, modelId));
+}
+
+export function rememberResolvedModelId(
+  modelId: string,
+  region: string,
+  resolvedId: string,
+): void {
+  resolved.set(cacheKey(region, modelId), resolvedId);
+  logger.debug(
+    "[Bedrock] Cached inference-profile resolution for subsequent calls",
+    { region },
+  );
+}
+
+/** Exposed so tests can start from a known state. */
+export function clearResolvedModelIds(): void {
+  resolved.clear();
+}
+
+/**
+ * Run `send` against the given model id, falling back to inference-profile
+ * ids if — and only if — Bedrock says the bare id needs one.
+ *
+ * A previously resolved id is used straight away. Any error other than the
+ * inference-profile one propagates untouched on the first attempt, so this
+ * cannot mask an unrelated failure or silently change behaviour for a caller
+ * whose bare ids already work.
+ */
+export async function withInferenceProfileFallback<T>(
+  modelId: string,
+  region: string,
+  send: (effectiveModelId: string) => Promise<T>,
+): Promise<T> {
+  const cached = getResolvedModelId(modelId, region);
+  if (cached && cached !== modelId) {
+    return send(cached);
+  }
+
+  try {
+    return await send(modelId);
+  } catch (error) {
+    if (!isInferenceProfileRequiredError(error)) {
+      throw error;
+    }
+    const candidates = inferenceProfileCandidates(modelId, region);
+    if (candidates.length === 0) {
+      throw error;
+    }
+    logger.warn(
+      "[Bedrock] Model requires a cross-region inference profile in this region; retrying with a prefixed id",
+      { region, candidates: candidates.length },
+    );
+    for (const candidate of candidates) {
+      try {
+        const result = await send(candidate);
+        rememberResolvedModelId(modelId, region, candidate);
+        return result;
+      } catch (retryError) {
+        if (!isInferenceProfileRequiredError(retryError)) {
+          // A different failure against the prefixed id — for example the
+          // account lacking access to that geography — is the more
+          // informative error, so surface it rather than the original.
+          throw retryError;
+        }
+      }
+    }
+    throw error;
+  }
+}

--- a/test/continuous-test-suite-bedrock-inference-profile.ts
+++ b/test/continuous-test-suite-bedrock-inference-profile.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Bedrock cross-region inference profiles
+ *
+ * Most current Bedrock models cannot be invoked by their bare model id: the
+ * model card's Regional Availability table shows In-Region = No for the
+ * model/region pair, and only a geography-prefixed (`us.`/`eu.`/`au.`/`jp.`)
+ * or `global.` inference-profile id works. Sending the bare id fails with a
+ * ValidationException naming inference profiles.
+ *
+ * These cases drive the shipped surface — `new NeuroLink().generate({ provider:
+ * "bedrock" })` from `../dist/index.js` — against a real local HTTP server
+ * standing in for bedrock-runtime, reached via the AWS SDK's documented
+ * `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` override. Nothing is stubbed: the request
+ * really is signed, sent and routed by the AWS SDK, so the assertions are about
+ * the model ids that actually go out on the wire.
+ *
+ * Run: npx tsx test/continuous-test-suite-bedrock-inference-profile.ts
+ *      pnpm run test:bedrock-inference-profile
+ */
+
+import { createServer, type Http2Server } from "node:http2";
+import { assert, defineSuite } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("Bedrock Inference Profiles");
+
+const { NeuroLink } = await import("../dist/index.js");
+
+const BARE_MODEL = "anthropic.claude-opus-4-5-20251101-v1:0";
+
+// Resolution is cached per model+region for the life of the process, which is
+// the point of it. Cases that need to observe a first-time resolution use
+// their own id so they start from an unresolved state.
+const UNCACHED_MODEL = "anthropic.claude-sonnet-4-5-20250929-v1:0";
+const UNRELATED_MODEL = "anthropic.claude-haiku-4-5-20251001-v1:0";
+const CROSS_PATH_MODEL = "anthropic.claude-sonnet-4-6-20260218-v1:0";
+const ARN_MODEL =
+  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0";
+
+/** The exact shape bedrock-runtime returns when a profile is required. */
+const PROFILE_REQUIRED_BODY = JSON.stringify({
+  message:
+    "Invocation of model ID anthropic.claude-opus-4-5-20251101-v1:0 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+});
+
+const OK_BODY = JSON.stringify({
+  output: { message: { role: "assistant", content: [{ text: "ok" }] } },
+  stopReason: "end_turn",
+  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+});
+
+type Recorder = {
+  modelIds: string[];
+  close: () => Promise<void>;
+  port: number;
+};
+
+/**
+ * Local bedrock-runtime stand-in. `decide` maps the model id taken from the
+ * request path to the status it should answer with.
+ *
+ * Cleartext HTTP/2, because `@aws-sdk/client-bedrock-runtime` defaults to
+ * `NodeHttp2Handler` — its event-stream operations need it. An HTTP/1.1
+ * server is refused by the client with "Protocol error" before a request is
+ * ever sent.
+ */
+async function startServer(
+  decide: (modelId: string) => { status: number; body: string },
+): Promise<Recorder> {
+  const modelIds: string[] = [];
+  const server: Http2Server = createServer();
+  server.on("stream", (stream, headers) => {
+    // Path shape: /model/{urlencoded modelId}/converse
+    const path = String(headers[":path"] ?? "");
+    const match = /\/model\/([^/]+)\//.exec(path);
+    const modelId = match ? decodeURIComponent(match[1]) : "";
+    modelIds.push(modelId);
+    const { status, body } = decide(modelId);
+    stream.respond({
+      ":status": status,
+      "content-type": "application/json",
+      ...(status === 400 ? { "x-amzn-errortype": "ValidationException" } : {}),
+    });
+    stream.end(body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    modelIds,
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** Point the AWS SDK at the local server with credentials that can sign. */
+function withEnv(port: number): () => void {
+  const saved: Record<string, string | undefined> = {};
+  const set = (k: string, v: string) => {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  };
+  set("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", `http://127.0.0.1:${port}`);
+  set("AWS_ACCESS_KEY_ID", "test-fake-aws-key-id");
+  set("AWS_SECRET_ACCESS_KEY", "test-fake-aws-secret");
+  set("AWS_REGION", "us-east-1");
+  saved.AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN;
+  delete process.env.AWS_SESSION_TOKEN;
+  return () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  };
+}
+
+await test("A model needing an inference profile is retried with a region-prefixed id", async () => {
+  const server = await startServer((modelId) =>
+    modelId.startsWith("us.")
+      ? { status: 200, body: OK_BODY }
+      : { status: 400, body: PROFILE_REQUIRED_BODY },
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: BARE_MODEL,
+      maxTokens: 8,
+    });
+    assert(
+      typeof result?.content === "string",
+      "generate did not return content after the retry",
+    );
+    assert(
+      server.modelIds.length === 2,
+      `expected one initial attempt and one retry, saw ${server.modelIds.length} attempts`,
+    );
+    assert(
+      server.modelIds[0] === BARE_MODEL,
+      "first attempt did not use the bare model id",
+    );
+    assert(
+      server.modelIds[1] === `us.${BARE_MODEL}`,
+      "retry did not use the us-geography inference profile id",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("The resolved profile id is reused, so the failing id is not retried every call", async () => {
+  const server = await startServer((modelId) =>
+    modelId.startsWith("us.")
+      ? { status: 200, body: OK_BODY }
+      : { status: 400, body: PROFILE_REQUIRED_BODY },
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    for (let i = 0; i < 2; i++) {
+      await nl.generate({
+        input: { text: "hi" },
+        provider: "bedrock",
+        model: UNCACHED_MODEL,
+        maxTokens: 8,
+      });
+    }
+    const bareAttempts = server.modelIds.filter(
+      (m) => m === UNCACHED_MODEL,
+    ).length;
+    const profileAttempts = server.modelIds.filter((m) =>
+      m.startsWith("us."),
+    ).length;
+    assert(
+      bareAttempts === 1,
+      `the unusable id should be attempted once and then remembered, but was attempted ${bareAttempts} times`,
+    );
+    assert(
+      profileAttempts === 2,
+      `both calls should reach the model, but only ${profileAttempts} used a working id`,
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("An unrelated validation failure is not retried with a different model id", async () => {
+  // Same exception type, different cause. Retrying this would turn one clear
+  // error into several confusing ones.
+  const unrelated = JSON.stringify({
+    message: "Malformed input request: expected type string, found integer.",
+  });
+  const server = await startServer(() => ({ status: 400, body: unrelated }));
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    let threw = false;
+    try {
+      await nl.generate({
+        input: { text: "hi" },
+        provider: "bedrock",
+        model: UNRELATED_MODEL,
+        maxTokens: 8,
+      });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "an unrelated validation failure should still surface");
+    // The SDK and the caller apply their own retry policies, so the total
+    // attempt count is not ours to pin. What must hold is that none of the
+    // attempts swapped in a rewritten model id — that behaviour belongs
+    // only to the inference-profile path.
+    const rewritten = server.modelIds.filter((m) => m !== UNRELATED_MODEL);
+    assert(
+      rewritten.length === 0,
+      `an unrelated failure must not rewrite the model id, but ${rewritten.length} attempt(s) did`,
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("A resolution found by generate is reused by stream", async () => {
+  // generate() and stream() are separate send sites. They must key the
+  // resolution cache identically, or the second one re-probes an id already
+  // known to be unusable — and on a provider where that probe is a billed
+  // round trip, does so on every call.
+  //
+  // This pins the contract, and does not by itself reproduce a divergence:
+  // the client is constructed with the same region it later reports, so the
+  // two only differ if that lookup throws, which no caller can force. It
+  // fails if a future change keys the two paths differently for any reason
+  // that IS reachable.
+  const server = await startServer((modelId) =>
+    modelId.startsWith("us.")
+      ? { status: 200, body: OK_BODY }
+      : { status: 400, body: PROFILE_REQUIRED_BODY },
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: CROSS_PATH_MODEL,
+      maxTokens: 8,
+    });
+    const afterGenerate = server.modelIds.length;
+    try {
+      // The stand-in answers JSON where ConverseStream returns an AWS event
+      // stream, so consuming this throws. Irrelevant here: the assertion is
+      // about the id that went out, which is recorded before any parsing.
+      const streamed = await nl.stream({
+        input: { text: "hi" },
+        provider: "bedrock",
+        model: CROSS_PATH_MODEL,
+        maxTokens: 8,
+      });
+      for await (const _chunk of streamed.stream) {
+        void _chunk;
+      }
+    } catch {
+      // Expected — see above.
+    }
+    const streamAttempts = server.modelIds.slice(afterGenerate);
+    assert(
+      streamAttempts.length > 0,
+      "the streaming path never reached the server, so nothing was verified",
+    );
+    assert(
+      !streamAttempts.includes(CROSS_PATH_MODEL),
+      "streaming re-probed the bare id that generate had already resolved",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("A model ARN is never rewritten into a prefixed id", async () => {
+  // An ARN names a concrete resource and this provider accepts one as a model
+  // id. Prefixing it produces a malformed identifier whose error would then
+  // replace the accurate one the caller should have seen.
+  const server = await startServer(() => ({
+    status: 400,
+    body: PROFILE_REQUIRED_BODY,
+  }));
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    let threw = false;
+    try {
+      await nl.generate({
+        input: { text: "hi" },
+        provider: "bedrock",
+        model: ARN_MODEL,
+        maxTokens: 8,
+      });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "the profile-required error should still surface for an ARN");
+    assert(
+      server.modelIds.length > 0,
+      "no request reached the server, so nothing was verified",
+    );
+    const rewritten = server.modelIds.filter((m) => m !== ARN_MODEL);
+    assert(
+      rewritten.length === 0,
+      `an ARN must not be prefixed, but ${rewritten.length} attempt(s) rewrote it`,
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await runSuite();


### PR DESCRIPTION
Selecting most current Bedrock models fails outright:

```
ValidationException: Invocation of model ID anthropic.claude-opus-4-5-20251101-v1:0
with on-demand throughput isn't supported. Retry your request with the ID or ARN
of an inference profile that contains this model.
```

Each model card carries a Regional Availability table with three columns, and for a great many model/region pairs the **In-Region** column reads No. Of seventeen models checked against their cards, **eight are In-Region nowhere at all**:

| Model | Bare id works In-Region |
|---|---|
| Claude Opus 4.5 | nowhere — No in every region row |
| Claude Sonnet 4.5 | nowhere |
| Amazon Nova Premier | nowhere |
| Amazon Nova 2 Lite | nowhere |
| Llama 4 Maverick / Scout | nowhere |
| Pixtral Large | nowhere |
| DeepSeek R1 | nowhere |
| Claude Sonnet 4.6 | only `eu-west-2` |

Everywhere else needs a geography prefix (`us.` / `eu.` / `au.` / `jp.` / `apac.`) or `global.`. The SDK sent bare ids and had no notion of profiles.

## Resolution is empirical, not tabulated

On that specific error the provider retries with the geography covering the caller's region, then `global.`, and remembers whichever worked for the rest of the process.

**A model-to-prefixes table was the obvious design and is the one to avoid.** The prefix set is per-model, not per-region. From the same caller region `ap-northeast-1`:

- Claude Opus 4.5 — In-Region No, Geo No, **only `global.` works**
- Claude Sonnet 4.5 — In-Region No, **`jp.` works**
- Claude Haiku 4.5 — **bare id works**

Three sibling models, one region, three different answers. Such a table needs a row per model per region and is wrong the day a model ships. AWS moved this data off a central page and onto each model's detail page for exactly that reason, and this repo has already been bitten twice this week by static model data drifting — a launch date baked into an Opus 4.5 model id, and Claude 3 Opus pricing left on a 4.5 entry.

`bedrock:ListInferenceProfiles` would answer authoritatively, but it needs a control-plane client this package does not depend on, plus an IAM permission a caller with plain inference access may not hold. Deriving candidates needs neither and costs at most two extra attempts, once per model and region.

## Nothing changes for callers who are fine today

The first attempt is always the id the caller asked for. Only that one error triggers a retry.

Detection requires **both** the exception name and the distinctive phrase, because `ValidationException` also covers malformed bodies and models an account cannot reach — retrying those with a rewritten id would turn one clear failure into several confusing ones. A miss leaves the original error to surface untouched, which is the behaviour without this change at all. An id that already carries a prefix is never re-prefixed.

## Tests drive the shipped surface

`generate()` through `NeuroLink` from `dist/index.js`, against a local server standing in for bedrock-runtime. Nothing is stubbed — the request is genuinely signed, sent and routed by the AWS SDK, so assertions are about ids that really go out on the wire.

The stand-in speaks **cleartext HTTP/2**, because `@aws-sdk/client-bedrock-runtime` defaults to `NodeHttp2Handler` for its event-stream operations and refuses an HTTP/1.1 server with "Protocol error" before sending anything. That also answers the note in `continuous-test-suite-providers-mocked.ts` explaining Bedrock cannot be reached through `installMockFetch` — this is a route to real Bedrock round-trip coverage.

Three cases: the retry happens and uses the right prefix; the resolved id is reused so the unusable one is attempted once rather than every call; and an unrelated validation failure is never rewritten.

**Verified by reintroducing the defect** — the two retry cases fail, and the control case stays green. Runs in `provider-safety-net`, needs no credentials, and passes the rule-15 lint with no allow-list entry since it only imports `dist/index.js`.

## Note on the error string

The message text is well attested across independent runtime reports but appears on no AWS documentation page, so matching it is a heuristic rather than a contract. That is why a non-match means *do not retry*: if AWS rewords it, this feature stops helping and nothing else changes. Worth confirming against a live account when one is available — the credentials in this environment are expired, so it could not be exercised end to end here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback for Amazon Bedrock requests when an inference profile is required.
  * Supports regional and global inference-profile resolution, with successful resolutions reused for faster subsequent requests.
  * Preserves unrelated validation errors without altering model identifiers.

* **Tests**
  * Added coverage for fallback behavior, caching, retries, streaming, and error handling.
  * Added a CI safety-net test that runs without API keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->