### PR TITLE
refactor(amazonBedrock): migrate both native turn loops onto the engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Bedrock inference-profile fallback (local HTTP/2 stand-in, no API keys required)
         run: pnpm run test:bedrock-inference-profile
 
+      - name: Bedrock loop characterization (local HTTP/2 stand-in, no API keys required)
+        run: pnpm run test:bedrock-loop-characterization
+
       - name: 🧩 Provider Onboarding Completeness
         run: pnpm run verify:provider-onboarding
 

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ NEUROLINK_SDK_GAPS.md
 .yama/analytics/
 .yama/reports/
 .scaffold-output/
+
+# Subagent-driven-development scratch workspace (ledger, briefs, review packages)
+.superpowers/

--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "test:model-pool": "npx tsx test/continuous-test-suite-model-pool.ts",
     "test:vector-chroma": "npx tsx test/continuous-test-suite-vector-chroma.ts",
     "test:vector-pgvector": "npx tsx test/continuous-test-suite-vector-pgvector.ts",
-    "test:vector-pinecone": "npx tsx test/continuous-test-suite-vector-pinecone.ts"
+    "test:vector-pinecone": "npx tsx test/continuous-test-suite-vector-pinecone.ts",
+    "test:bedrock-loop-characterization": "tsx test/continuous-test-suite-bedrock-loop-characterization.ts"
   },
   "files": [
     "dist",

--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -83,6 +83,8 @@ export function runAgenticLoop<TConversation>(
     let conversation = initialConversation;
     let usage: AgenticLoopUsage = { inputTokens: 0, outputTokens: 0 };
     let finalText = "";
+    // The most recent step's text, kept only for the step-cap case below.
+    let lastStepText = "";
     let rawStopReason: string | undefined;
     const allToolCalls: AgenticLoopResult<TConversation>["toolCalls"] = [];
     const allToolExecutions: AgenticLoopResult<TConversation>["toolExecutions"] =
@@ -147,6 +149,7 @@ export function runAgenticLoop<TConversation>(
 
         usage = sumUsage(usage, stepResult.usage);
         rawStopReason = stepResult.rawStopReason;
+        lastStepText = stepResult.text || lastStepText;
 
         if (
           adapter.isMalformedStep?.(stepResult) &&
@@ -261,7 +264,14 @@ export function runAgenticLoop<TConversation>(
         hadToolCallsAtCap,
       );
       return {
-        text: finalText,
+        // `finalText` is only set by a step that asked for no tools, so a turn
+        // that runs out of steps mid-tool-call would otherwise return "" and
+        // throw away everything the model actually said. An empty result also
+        // reads as a failed generation to callers that retry on empty content,
+        // turning one capped turn into several. Fall back to the last step's
+        // text in that case only — when the loop ended normally, an empty
+        // final step genuinely means the model said nothing.
+        text: finalText || (hadToolCallsAtCap ? lastStepText : ""),
         toolCalls: allToolCalls,
         toolExecutions: allToolExecutions,
         usage,

--- a/src/lib/providers/amazonBedrock/client.ts
+++ b/src/lib/providers/amazonBedrock/client.ts
@@ -1,17 +1,12 @@
 import type {
   Tool as BedrockTool,
   ContentBlock,
-  ConverseCommandInput,
-  ConverseCommandOutput,
-  ConverseStreamCommandInput,
   Message,
   ToolConfiguration,
   ToolSpecification,
 } from "@aws-sdk/client-bedrock-runtime";
 import {
   BedrockRuntimeClient,
-  ConverseCommand,
-  ConverseStreamCommand,
   ImageFormat,
 } from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType } from "@smithy/types";
@@ -20,9 +15,12 @@ import type { AIProviderName } from "../../constants/enums.js";
 import { createAnalytics } from "../../core/analytics.js";
 import { BaseProvider } from "../../core/baseProvider.js";
 import { DEFAULT_MAX_STEPS } from "../../core/constants.js";
-import { withInferenceProfileFallback } from "./inferenceProfile.js";
+import { runAgenticLoop } from "../../core/loopEngine.js";
+import { createBedrockLoopAdapter } from "./loopAdapter.js";
 import type { NeuroLink } from "../../neurolink.js";
 import type {
+  AgenticLoopStepRequest,
+  AgenticLoopUsage,
   JsonValue,
   StreamOptions,
   StreamResult,
@@ -36,7 +34,6 @@ import type {
   MultimodalChatMessage,
   EnhancedGenerateResult,
   TextGenerationOptions,
-  BedrockContentBlock,
   BedrockMessage,
   ProviderErrorRule,
 } from "../../types/index.js";
@@ -47,10 +44,8 @@ import {
 } from "../../types/index.js";
 import { classifyProviderError } from "../../utils/errorClassifier.js";
 import { isAbortError, withTimeout } from "../../utils/errorHandling.js";
-import { emitToolEndFromStepFinish } from "../../utils/toolEndEmitter.js";
 import { logger } from "../../utils/logger.js";
 import { resolveSamplingParams } from "../../models/modelRegistry.js";
-import { calculateCost } from "../../utils/pricing.js";
 import { buildMultimodalMessagesArray } from "../../utils/messageBuilder.js";
 import { buildMultimodalOptions } from "../../utils/multimodalOptionsBuilder.js";
 import { convertZodToJsonSchema } from "../../utils/schemaConversion.js";
@@ -317,8 +312,10 @@ export class AmazonBedrockProvider extends BaseProvider {
     let text: string;
     let usage: { input: number; output: number; total: number };
     let finishReason: string | undefined;
+    let rawFinishReason: string | undefined;
     try {
-      ({ text, usage, finishReason } = await this.conversationLoop(options));
+      ({ text, usage, finishReason, rawFinishReason } =
+        await this.conversationLoop(options));
     } catch (error) {
       // Emit failure generation:end so Pipeline B records the failed generation
       const failEmitter = this.neurolink?.getEventEmitter();
@@ -366,6 +363,8 @@ export class AmazonBedrockProvider extends BaseProvider {
       usage,
       model: this.modelName || this.getDefaultModel(),
       provider: this.getProviderName(),
+      ...(finishReason !== undefined && { finishReason }),
+      ...(rawFinishReason !== undefined && { rawFinishReason }),
     };
   }
 
@@ -379,484 +378,93 @@ export class AmazonBedrockProvider extends BaseProvider {
       cacheCreationTokens?: number;
     };
     finishReason?: string;
+    rawFinishReason?: string;
   }> {
-    const maxIterations = 10; // Prevent infinite loops
-    let iteration = 0;
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCacheWriteTokens = 0;
-    let lastFinishReason: string | undefined;
-
-    while (iteration < maxIterations) {
-      iteration++;
-      logger.debug(
-        `[AmazonBedrockProvider] Conversation iteration ${iteration}`,
-      );
-
-      try {
-        logger.debug(`[AmazonBedrockProvider] About to call Bedrock API`);
-        const response = await this.callBedrock(options);
-        logger.debug(
-          `[AmazonBedrockProvider] Received Bedrock response`,
-          JSON.stringify(response, null, 2),
-        );
-
-        // Accumulate real token counts and capture the stop reason so
-        // Pipeline B (Langfuse) gets correct usage and finishReason.
-        // Converse follows the Anthropic additive convention: inputTokens is
-        // the UNCACHED remainder; cache reads/writes are reported separately.
-        totalInputTokens += response.usage?.inputTokens ?? 0;
-        totalOutputTokens += response.usage?.outputTokens ?? 0;
-        totalCacheReadTokens += response.usage?.cacheReadInputTokens ?? 0;
-        totalCacheWriteTokens += response.usage?.cacheWriteInputTokens ?? 0;
-        if (response.stopReason) {
-          lastFinishReason = response.stopReason;
-        }
-
-        const result = await this.handleBedrockResponse(response);
-        logger.debug(`[AmazonBedrockProvider] Handle response result:`, result);
-
-        if (result.shouldContinue) {
-          logger.debug(
-            `[AmazonBedrockProvider] Continuing conversation loop...`,
-          );
-        } else {
-          logger.debug(
-            `[AmazonBedrockProvider] Conversation completed with final text`,
-          );
-          logger.debug(
-            `[AmazonBedrockProvider] Returning final text: "${result.text}"`,
-          );
-          return {
-            text: result.text || "",
-            usage: {
-              input: totalInputTokens,
-              output: totalOutputTokens,
-              // Cache reads/writes are billed tokens reported separately
-              // from inputTokens — the total must include them.
-              total:
-                totalInputTokens +
-                totalCacheReadTokens +
-                totalCacheWriteTokens +
-                totalOutputTokens,
-              ...(totalCacheReadTokens > 0 && {
-                cacheReadTokens: totalCacheReadTokens,
-              }),
-              ...(totalCacheWriteTokens > 0 && {
-                cacheCreationTokens: totalCacheWriteTokens,
-              }),
-            },
-            finishReason: lastFinishReason,
-          };
-        }
-      } catch (error) {
-        logger.error(
-          `[AmazonBedrockProvider] Error in conversation loop:`,
-          error,
-        );
-        throw this.handleProviderError(error);
-      }
-    }
-
-    throw new Error("Conversation loop exceeded maximum iterations");
-  }
-
-  private async callBedrock(options: TextGenerationOptions) {
-    const startTime = Date.now();
-    return bedrockTracer.startActiveSpan(
-      "bedrock.generate",
-      {
-        kind: SpanKind.CLIENT,
-        attributes: {
-          "gen_ai.system": "aws.bedrock",
-          "gen_ai.request.model": this.modelName || this.getDefaultModel(),
-          "gen_ai.operation.name": "chat",
-        },
-      },
-      async (generateSpan) => {
-        logger.info(
-          `[AmazonBedrockProvider] Starting Bedrock API call at ${new Date().toISOString()}`,
-        );
-
-        try {
-          // Pre-call validation and logging
-          let region = "unknown";
-          try {
-            region =
-              typeof this.bedrockClient.config.region === "function"
-                ? await this.bedrockClient.config.region()
-                : (this.bedrockClient.config.region ?? "unknown");
-          } catch {
-            // Region lookup failed — not critical, only used for logging
-          }
-          logger.info(`[AmazonBedrockProvider] Client region: ${region}`);
-          logger.info(
-            `[AmazonBedrockProvider] Model: ${this.modelName || this.getDefaultModel()}`,
-          );
-          logger.info(
-            `[AmazonBedrockProvider] Conversation history length: ${this.conversationHistory.length}`,
-          );
-
-          // Get all available tools
-          const aiTools = await this.getAllTools();
-          const allTools = this.convertAISDKToolsToToolDefinitions(aiTools);
-          const toolConfig = this.formatToolsForBedrock(allTools);
-
-          // Registry-driven strip: models that reject sampling params
-          // (Sonnet 5 / Opus 4.7+ / Fable 5 Claude families on Bedrock)
-          // must not receive the legacy 0.7 default temperature.
-          const generateSampling = resolveSamplingParams(
-            this.providerName,
-            this.modelName || this.getDefaultModel(),
-            { temperature: options.temperature ?? 0.7 },
-            "bedrock.converse",
-          );
-
-          const commandInput: ConverseCommandInput = {
-            modelId: this.modelName || this.getDefaultModel(),
-            messages: this.convertToAWSMessages(this.conversationHistory),
-            system: [
-              {
-                text:
-                  options.systemPrompt ||
-                  "You are a helpful assistant with access to external tools. Use tools when necessary to provide accurate information.",
-              },
-            ],
-            inferenceConfig: {
-              maxTokens: options.maxTokens, // No default limit - unlimited unless specified
-              ...(generateSampling.temperature !== undefined && {
-                temperature: generateSampling.temperature,
-              }),
-            },
-          };
-
-          if (toolConfig) {
-            commandInput.toolConfig = toolConfig;
-            logger.info(
-              `[AmazonBedrockProvider] Tools configured: ${toolConfig.tools?.length || 0}`,
-            );
-          }
-
-          // Log command details for debugging
-          logger.info(`[AmazonBedrockProvider] Command input summary:`);
-          logger.info(`  - Model ID: ${commandInput.modelId}`);
-          logger.info(
-            `  - Messages count: ${commandInput.messages?.length || 0}`,
-          );
-          logger.info(
-            `  - System prompts: ${commandInput.system?.length || 0}`,
-          );
-          logger.info(
-            `  - Max tokens: ${commandInput.inferenceConfig?.maxTokens}`,
-          );
-          logger.info(
-            `  - Temperature: ${commandInput.inferenceConfig?.temperature}`,
-          );
-
-          logger.debug(
-            `[AmazonBedrockProvider] Calling Bedrock with ${this.conversationHistory.length} messages and ${toolConfig?.tools?.length || 0} tools`,
-          );
-
-          logger.debug("[Observability] Bedrock API request", {
-            model: commandInput.modelId,
-            region: region,
-            messageCount: commandInput.messages?.length || 0,
-            toolCount: commandInput.toolConfig?.tools?.length || 0,
-            maxTokens: commandInput.inferenceConfig?.maxTokens,
-          });
-
-          const apiCallStartTime = Date.now();
-          const response = await withInferenceProfileFallback(
-            commandInput.modelId ?? "",
-            // `this.region`, not the local `region` above: that one is
-            // best-effort for logging and stays "unknown" if the lookup
-            // throws. It must also match the id the streaming path keys its
-            // cache by, or a resolution found here is never reused there.
-            this.region,
-            (effectiveModelId) =>
-              withTimeout(
-                this.bedrockClient.send(
-                  new ConverseCommand({
-                    ...commandInput,
-                    modelId: effectiveModelId,
-                  }),
-                ),
-                120_000,
-                new Error("Bedrock API call timed out"),
-              ),
-          );
-          const apiCallDuration = Date.now() - apiCallStartTime;
-
-          logger.debug("[Observability] Bedrock API response", {
-            model: commandInput.modelId,
-            durationMs: apiCallDuration,
-            hasContent: !!response.output?.message?.content?.length,
-            stopReason: response.stopReason,
-            usage: response.usage
-              ? {
-                  inputTokens: response.usage.inputTokens,
-                  outputTokens: response.usage.outputTokens,
-                  totalTokens:
-                    (response.usage.inputTokens || 0) +
-                    (response.usage.outputTokens || 0),
-                }
-              : undefined,
-          });
-
-          logger.info(`[AmazonBedrockProvider] Bedrock API call successful`);
-          logger.info(
-            `[AmazonBedrockProvider] API call duration: ${apiCallDuration}ms`,
-          );
-
-          const totalDuration = Date.now() - startTime;
-          logger.info(
-            `[AmazonBedrockProvider] Total callBedrock duration: ${totalDuration}ms`,
-          );
-
-          generateSpan.setAttribute(
-            "gen_ai.response.stop_reason",
-            response.stopReason ?? "",
-          );
-          const spanCacheRead = response.usage?.cacheReadInputTokens ?? 0;
-          const spanCacheWrite = response.usage?.cacheWriteInputTokens ?? 0;
-          // Converse's inputTokens is only the UNCACHED remainder — the span
-          // attribute reports the FULL prompt (uncached + cache read/write)
-          // so telemetry matches the cache-inclusive pricing inputs below.
-          generateSpan.setAttribute(
-            "gen_ai.usage.input_tokens",
-            (response.usage?.inputTokens ?? 0) + spanCacheRead + spanCacheWrite,
-          );
-          generateSpan.setAttribute(
-            "gen_ai.usage.cache_read_input_tokens",
-            spanCacheRead,
-          );
-          generateSpan.setAttribute(
-            "gen_ai.usage.cache_creation_input_tokens",
-            spanCacheWrite,
-          );
-          generateSpan.setAttribute(
-            "gen_ai.usage.output_tokens",
-            response.usage?.outputTokens ?? 0,
-          );
-          const cost = calculateCost(this.providerName, this.modelName, {
-            input: response.usage?.inputTokens ?? 0,
-            output: response.usage?.outputTokens ?? 0,
-            total:
-              (response.usage?.inputTokens ?? 0) +
-              spanCacheRead +
-              spanCacheWrite +
-              (response.usage?.outputTokens ?? 0),
-            ...(spanCacheRead > 0 && { cacheReadTokens: spanCacheRead }),
-            ...(spanCacheWrite > 0 && {
-              cacheCreationTokens: spanCacheWrite,
-            }),
-          });
-          if (cost && cost > 0) {
-            generateSpan.setAttribute("neurolink.cost", cost);
-          }
-          generateSpan.setStatus({ code: SpanStatusCode.OK });
-          generateSpan.end();
-          return response;
-        } catch (error) {
-          const errorDuration = Date.now() - startTime;
-
-          // Extract AWS metadata for structured logging
-          const awsError =
-            error && typeof error === "object"
-              ? (error as Record<string, unknown>)
-              : null;
-          const metadata =
-            awsError?.$metadata && typeof awsError.$metadata === "object"
-              ? (awsError.$metadata as Record<string, unknown>)
-              : null;
-
-          logger.debug("[Observability] Bedrock API request failed", {
-            model: this.modelName || this.getDefaultModel(),
-            durationMs: errorDuration,
-            error: error instanceof Error ? error.message : String(error),
-            errorName: error instanceof Error ? error.name : undefined,
-            httpStatus: metadata?.httpStatusCode,
-            awsRequestId: metadata?.requestId,
-            awsErrorCode: awsError?.Code,
-          });
-
-          logger.error(
-            `[AmazonBedrockProvider] Bedrock API call failed after ${errorDuration}ms`,
-          );
-
-          if (error instanceof Error) {
-            logger.error(
-              `[AmazonBedrockProvider] Error: ${error.name} - ${error.message}`,
-            );
-          }
-
-          if (metadata) {
-            logger.error(`[AmazonBedrockProvider] AWS SDK metadata`, {
-              httpStatus: metadata.httpStatusCode,
-              requestId: metadata.requestId,
-              attempts: metadata.attempts,
-              totalRetryDelay: metadata.totalRetryDelay,
-            });
-          }
-
-          generateSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
-          });
-          generateSpan.recordException(
-            error instanceof Error ? error : new Error(String(error)),
-          );
-          generateSpan.end();
-          throw error;
-        }
-      },
-    ); // end bedrockTracer.startActiveSpan('bedrock.generate')
-  }
-
-  private async handleBedrockResponse(
-    response: ConverseCommandOutput,
-  ): Promise<{ shouldContinue: boolean; text?: string }> {
-    logger.debug(
-      `[AmazonBedrockProvider] Received response with stopReason: ${response.stopReason}`,
+    // The step cap is now the same `maxSteps || DEFAULT_MAX_STEPS` the
+    // streaming path has always used. It used to be a hardcoded 10 that
+    // ignored the caller's maxSteps entirely, and reaching it threw — which
+    // then propagated into NeuroLink's provider-level retry and ran the whole
+    // turn twice more, so a runaway tool loop cost thirty billed calls. The
+    // engine stops at the cap and returns what the turn produced.
+    const maxSteps = options.maxSteps || DEFAULT_MAX_STEPS;
+    const tools = await this.resolveTurnTools(
+      options.tools,
+      options.disableTools,
+    );
+    const toolConfig = this.formatToolsForBedrock(tools);
+    const sampling = resolveSamplingParams(
+      this.providerName,
+      this.modelName || this.getDefaultModel(),
+      { temperature: options.temperature ?? 0.7 },
+      "bedrock.converse",
     );
 
-    if (!response.output || !response.output.message) {
-      throw new Error("Invalid response structure from Bedrock API");
-    }
-
-    const assistantMessage = response.output.message;
-    const stopReason = response.stopReason;
-
-    // Add assistant message to conversation history
-    const bedrockAssistantMessage: BedrockMessage = {
-      role: "assistant",
-      content: (assistantMessage.content || []).map((item) => {
-        const bedrockItem: BedrockContentBlock = {};
-        if ("text" in item && item.text) {
-          bedrockItem.text = item.text;
-        }
-        if ("toolUse" in item && item.toolUse) {
-          bedrockItem.toolUse = {
-            toolUseId: item.toolUse.toolUseId || "",
-            name: item.toolUse.name || "",
-            input: (item.toolUse.input as Record<string, unknown>) || {},
-          };
-        }
-        if ("toolResult" in item && item.toolResult) {
-          bedrockItem.toolResult = {
-            toolUseId: item.toolResult.toolUseId || "",
-            content: (item.toolResult.content || []).map((c) => ({
-              text:
-                typeof c === "object" && "text" in c
-                  ? (c.text as string) || ""
-                  : "",
-            })),
-            status: item.toolResult.status || "unknown",
-          };
-        }
-        return bedrockItem;
+    const adapter = createBedrockLoopAdapter({
+      client: this.bedrockClient,
+      streaming: false,
+      region: this.region,
+      maxSteps,
+      buildCommandInput: (conversation) => ({
+        modelId: this.modelName || this.getDefaultModel(),
+        messages: this.convertToAWSMessages(conversation),
+        system: [
+          {
+            text:
+              options.systemPrompt ||
+              "You are a helpful assistant with access to external tools. Use tools when necessary to provide accurate information.",
+          },
+        ],
+        inferenceConfig: {
+          maxTokens: options.maxTokens,
+          ...(sampling.temperature !== undefined && {
+            temperature: sampling.temperature,
+          }),
+        },
+        ...(toolConfig ? { toolConfig } : {}),
       }),
-    };
-    this.conversationHistory.push(bedrockAssistantMessage);
+    });
 
-    if (stopReason === "end_turn" || stopReason === "stop_sequence") {
-      // Extract text from assistant message
-      const textContent = bedrockAssistantMessage.content
-        .filter((item: BedrockContentBlock) => item.text)
-        .map((item: BedrockContentBlock) => item.text)
-        .join(" ");
-
-      return { shouldContinue: false, text: textContent };
-    } else if (stopReason === "tool_use") {
-      logger.debug(
-        `[AmazonBedrockProvider] Tool use detected - executing tools immediately`,
+    try {
+      const { resultPromise } = runAgenticLoop(
+        adapter,
+        this.conversationHistory,
+        {
+          tools: this.toEngineTools(tools),
+          abortSignal: options.abortSignal,
+        },
       );
+      const result = await resultPromise;
+      this.conversationHistory = result.conversation;
 
-      // Execute all tool uses in the message
-      const toolResults = [];
-
-      for (const contentItem of bedrockAssistantMessage.content) {
-        if (contentItem.toolUse) {
-          logger.debug(
-            `[AmazonBedrockProvider] Executing tool: ${contentItem.toolUse.name}`,
-          );
-
-          try {
-            // Execute tool using BaseProvider's tool execution
-            logger.debug(
-              `[AmazonBedrockProvider] Debug toolUse.input:`,
-              JSON.stringify(contentItem.toolUse.input, null, 2),
-            );
-            const toolResult = await this.executeSingleTool(
-              contentItem.toolUse.name,
-              contentItem.toolUse.input || {},
-              contentItem.toolUse.toolUseId,
-            );
-
-            logger.debug(
-              `[AmazonBedrockProvider] Tool execution successful: ${contentItem.toolUse.name}`,
-            );
-
-            toolResults.push({
-              toolResult: {
-                toolUseId: contentItem.toolUse.toolUseId,
-                content: [{ text: String(toolResult) }],
-                status: "success",
-              },
-            });
-          } catch (error) {
-            logger.error(
-              `[AmazonBedrockProvider] Tool execution failed: ${contentItem.toolUse.name}`,
-              error,
-            );
-
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
-            // Still create toolResult for failed tools to maintain 1:1 mapping with toolUse blocks
-            toolResults.push({
-              toolResult: {
-                toolUseId: contentItem.toolUse.toolUseId,
-                content: [
-                  {
-                    text: `Error executing tool ${contentItem.toolUse.name}: ${errorMessage}`,
-                  },
-                ],
-                status: "error",
-              },
-            });
-          }
-        }
-      }
-
-      // Add tool results as user message
-      if (toolResults.length > 0) {
-        const userMessageWithToolResults: BedrockMessage = {
-          role: "user",
-          content: toolResults,
-        };
-        this.conversationHistory.push(userMessageWithToolResults);
-
-        logger.debug(
-          `[AmazonBedrockProvider] Added ${toolResults.length} tool results to conversation`,
-        );
-      }
-
-      return { shouldContinue: true };
-    } else if (stopReason === "max_tokens") {
-      // Max tokens reached — return what we have rather than continuing,
-      // since the model hit the configured limit.
-      const textContent = bedrockAssistantMessage.content
-        .filter((item: BedrockContentBlock) => item.text)
-        .map((item: BedrockContentBlock) => item.text)
-        .join(" ");
-
-      return { shouldContinue: false, text: textContent };
-    } else {
-      logger.warn(
-        `[AmazonBedrockProvider] Unrecognized stop reason "${stopReason}", ending conversation.`,
+      const input = result.usage.inputTokens;
+      const output = result.usage.outputTokens;
+      const cacheRead = result.usage.cacheReadTokens ?? 0;
+      const cacheWrite = result.usage.cacheWriteTokens ?? 0;
+      return {
+        text: result.text || "",
+        usage: {
+          input,
+          output,
+          // Cache reads/writes are billed tokens reported separately from
+          // inputTokens — the total must include them.
+          total: input + cacheRead + cacheWrite + output,
+          ...(cacheRead > 0 && { cacheReadTokens: cacheRead }),
+          ...(cacheWrite > 0 && { cacheCreationTokens: cacheWrite }),
+        },
+        // The MAPPED reason, matching the streaming path and every AI-SDK
+        // backed provider. This path previously surfaced Bedrock's raw value,
+        // so a turn stopped at the step cap reported "tool_use" here while
+        // the same turn reported "tool-calls" when streamed. The raw value is
+        // kept alongside rather than dropped.
+        finishReason: result.finishReason,
+        rawFinishReason: result.rawStopReason,
+      };
+    } catch (error) {
+      logger.error(
+        `[AmazonBedrockProvider] Error in conversation loop:`,
+        error,
       );
-      return { shouldContinue: false, text: "" };
+      throw this.handleProviderError(error);
     }
   }
 
@@ -902,7 +510,17 @@ export class AmazonBedrockProvider extends BaseProvider {
     }));
   }
 
+  /**
+   * `tools` is passed in rather than re-resolved from `getAllTools()`. That
+   * call returns only the provider's own registry, so resolving here meant a
+   * tool the caller passed to generate/stream could never execute — the
+   * streaming path advertised it to the model and then failed every call to
+   * it with "Tool not found", and the generate path never advertised it at
+   * all. The turn's full merged tool set is resolved once by the caller and
+   * handed down.
+   */
   private async executeSingleTool(
+    tools: Record<string, ToolDefinition<ToolArgs, JsonValue>>,
     toolName: string,
     args: Record<string, unknown>,
     _toolUseId?: string,
@@ -924,10 +542,6 @@ export class AmazonBedrockProvider extends BaseProvider {
               args,
             },
           );
-
-          // Use BaseProvider's tool execution mechanism
-          const aiTools = await this.getAllTools();
-          const tools = this.convertAISDKToolsToToolDefinitions(aiTools);
 
           if (!tools[toolName]) {
             throw new Error(`Tool not found: ${toolName}`);
@@ -1023,6 +637,54 @@ export class AmazonBedrockProvider extends BaseProvider {
         }
       },
     );
+  }
+
+  /**
+   * Resolve the turn's tools once: whatever the caller passed, else the
+   * provider's own registry. `BaseProvider.stream()` has already merged base
+   * tools into `options.tools` by the time it reaches the streaming path;
+   * the generate path has no such pre-merge, so it falls back here.
+   */
+  private async resolveTurnTools(
+    optionTools: unknown,
+    disableTools?: boolean,
+  ): Promise<Record<string, ToolDefinition<ToolArgs, JsonValue>>> {
+    // `generate()` reaches conversationLoop() without going through
+    // BaseProvider's tool preparation, so `options.tools` is undefined there
+    // and the getAllTools() fallback would hand the model the whole registry
+    // even when the caller asked for no tools at all.
+    if (disableTools) {
+      return {};
+    }
+    const aiTools =
+      (optionTools as Record<string, Tool> | undefined) ??
+      (await this.getAllTools());
+    return this.convertAISDKToolsToToolDefinitions(aiTools);
+  }
+
+  /**
+   * Present the resolved tools in the shape `runAgenticLoop` dispatches
+   * through. Execution still goes through `executeSingleTool`, so the tool
+   * span, the parameter defaults and the ToolResult unwrapping are unchanged
+   * — only which tools are reachable changes.
+   */
+  private toEngineTools(
+    tools: Record<string, ToolDefinition<ToolArgs, JsonValue>>,
+  ): Record<
+    string,
+    { execute: (args: Record<string, unknown>) => Promise<unknown> }
+  > {
+    const engineTools: Record<
+      string,
+      { execute: (args: Record<string, unknown>) => Promise<unknown> }
+    > = {};
+    for (const name of Object.keys(tools)) {
+      engineTools[name] = {
+        execute: (args: Record<string, unknown>) =>
+          this.executeSingleTool(tools, name, args),
+      };
+    }
+    return engineTools;
   }
 
   private convertAISDKToolsToToolDefinitions(
@@ -1464,884 +1126,243 @@ export class AmazonBedrockProvider extends BaseProvider {
     options: StreamOptions,
     streamSpan: Span,
   ): Promise<StreamResult> {
-    logger.debug("[TRACE] streamingConversationLoop ENTRY");
     const startTime = Date.now();
-    const maxIterations = options.maxSteps || DEFAULT_MAX_STEPS;
-    let iteration = 0;
+    const maxSteps = options.maxSteps || DEFAULT_MAX_STEPS;
 
-    // Shared counters updated by both the first-iteration inline loop and
-    // the processStreamResponse loop. Read by the final generation:end emit
-    // so Pipeline B (Langfuse) gets real token counts from Bedrock streams.
-    let streamTotalInputTokens = 0;
-    let streamTotalOutputTokens = 0;
-    let streamTotalCacheReadTokens = 0;
-    let streamTotalCacheWriteTokens = 0;
-    let streamLastStopReason: string | undefined;
-
-    // The REAL issue: ReadableStream errors don't bubble up to the caller
-    // So we need to make the first streaming call synchronously to test permissions
-    try {
-      logger.debug(
-        "[TRACE] streamingConversationLoop - testing first streaming call",
-      );
-      const commandInput = await this.prepareStreamCommand(options);
-
-      logger.debug("[Observability] Bedrock streaming API request", {
-        model: commandInput.modelId,
-        messageCount: commandInput.messages?.length || 0,
-        toolCount: commandInput.toolConfig?.tools?.length || 0,
-      });
-
-      streamSpan.addEvent("stream.api_call", {
-        "bedrock.message_count": commandInput.messages?.length || 0,
-        "bedrock.tool_count": commandInput.toolConfig?.tools?.length || 0,
-      });
-
-      const streamStartTime = Date.now();
-      const response = await withInferenceProfileFallback(
-        commandInput.modelId ?? "",
-        this.region,
-        (effectiveModelId) =>
-          withTimeout(
-            this.bedrockClient.send(
-              new ConverseStreamCommand({
-                ...commandInput,
-                modelId: effectiveModelId,
-              }),
-            ),
-            120_000,
-            new Error("Bedrock streaming API call timed out"),
-          ),
-      );
-
-      logger.debug(
-        "[Observability] Bedrock streaming API connection established",
-        {
-          model: commandInput.modelId,
-          durationMs: Date.now() - streamStartTime,
-          hasStream: !!response.stream,
-        },
-      );
-
-      // Process the first response immediately to avoid waste
-
-      const stream = new ReadableStream({
-        start: async (controller) => {
-          logger.debug(
-            "[TRACE] streamingConversationLoop - ReadableStream start() called",
-          );
-          try {
-            // Process the first response we already have, tracking all event types
-            let firstStopReason = "";
-            if (response.stream) {
-              const firstMessageContent: (BedrockContentBlock & {
-                _inputBuffer?: string;
-              })[] = [];
-              let firstText = "";
-
-              for await (const chunk of response.stream) {
-                if (chunk.contentBlockStart) {
-                  firstMessageContent.push({});
-                }
-
-                if (chunk.contentBlockDelta?.delta?.text) {
-                  const textDelta = chunk.contentBlockDelta.delta.text;
-                  firstText += textDelta;
-                  controller.enqueue({ content: textDelta });
-                }
-
-                if (chunk.contentBlockStart?.start?.toolUse) {
-                  const currentBlock =
-                    firstMessageContent[firstMessageContent.length - 1];
-                  currentBlock.toolUse = {
-                    name: chunk.contentBlockStart.start.toolUse.name || "",
-                    input: {},
-                    toolUseId:
-                      chunk.contentBlockStart.start.toolUse.toolUseId ||
-                      `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
-                  };
-                }
-
-                if (chunk.contentBlockDelta?.delta?.toolUse) {
-                  const currentBlock =
-                    firstMessageContent[firstMessageContent.length - 1];
-                  if (!currentBlock.toolUse) {
-                    currentBlock.toolUse = {
-                      name: "",
-                      input: {},
-                      toolUseId: `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
-                    };
-                  }
-                  const deltaInput =
-                    chunk.contentBlockDelta.delta.toolUse.input;
-                  if (!deltaInput) {
-                    // no input delta
-                  } else if (typeof deltaInput === "string") {
-                    currentBlock._inputBuffer =
-                      (currentBlock._inputBuffer || "") + deltaInput;
-                  } else if (
-                    typeof deltaInput === "object" &&
-                    !Array.isArray(deltaInput)
-                  ) {
-                    const currentInput = currentBlock.toolUse.input || {};
-                    currentBlock.toolUse.input = {
-                      ...currentInput,
-                      ...(deltaInput as Record<string, unknown>),
-                    } as Record<string, unknown>;
-                  }
-                }
-
-                if (chunk.contentBlockStop) {
-                  const currentBlock =
-                    firstMessageContent[firstMessageContent.length - 1];
-                  if (currentBlock?.toolUse && currentBlock._inputBuffer) {
-                    try {
-                      currentBlock.toolUse.input = JSON.parse(
-                        currentBlock._inputBuffer,
-                      );
-                    } catch {
-                      currentBlock.toolUse.input = {};
-                    }
-                    delete currentBlock._inputBuffer;
-                  }
-                  if (firstText && currentBlock && !currentBlock.toolUse) {
-                    currentBlock.text = firstText;
-                  }
-                  firstText = "";
-                }
-
-                if (chunk.messageStop) {
-                  firstStopReason = chunk.messageStop.stopReason || "end_turn";
-                  // Don't break — metadata chunk with usage comes after messageStop
-                  continue;
-                }
-
-                // Accumulate usage from Bedrock metadata chunk for Pipeline B.
-                // The metadata chunk is emitted after messageStop with aggregate usage.
-                if (chunk.metadata?.usage) {
-                  streamTotalInputTokens +=
-                    chunk.metadata.usage.inputTokens ?? 0;
-                  streamTotalOutputTokens +=
-                    chunk.metadata.usage.outputTokens ?? 0;
-                  // inputTokens excludes cache reads/writes (Converse follows
-                  // the Anthropic additive convention) — track them too.
-                  streamTotalCacheReadTokens +=
-                    chunk.metadata.usage.cacheReadInputTokens ?? 0;
-                  streamTotalCacheWriteTokens +=
-                    chunk.metadata.usage.cacheWriteInputTokens ?? 0;
-                  // Stream is effectively complete after metadata chunk
-                  break;
-                }
-              }
-
-              if (firstStopReason) {
-                streamLastStopReason = firstStopReason;
-              }
-
-              // Add first assistant message to conversation history
-              const firstAssistantMessage: BedrockMessage = {
-                role: "assistant",
-                content: firstMessageContent,
-              };
-              this.conversationHistory.push(firstAssistantMessage);
-
-              streamSpan.addEvent("stream.turn_complete", {
-                iteration: 0,
-                stop_reason: firstStopReason,
-              });
-
-              if (firstStopReason === "tool_use") {
-                const toolNames = firstMessageContent
-                  .flatMap((b) => (b.toolUse?.name ? [b.toolUse.name] : []))
-                  .join(", ");
-                streamSpan.addEvent("stream.tool_use", {
-                  iteration: 0,
-                  tool_names: toolNames,
-                });
-              }
-
-              // Handle the stop reason from the first response
-              const shouldContinue = await this.handleStreamStopReason(
-                firstStopReason,
-                firstAssistantMessage,
-                controller,
-                options,
-              );
-              if (!shouldContinue) {
-                streamSpan.setAttribute(
-                  "gen_ai.response.stop_reason",
-                  firstStopReason,
-                );
-                // Close the controller so downstream `for await` exits;
-                // see the close() comment near the bottom of this start()
-                // function for the spec rationale.
-                controller.close();
-                return;
-              }
-            }
-
-            // Continue with normal iterations if needed
-            while (iteration < maxIterations) {
-              iteration++;
-              logger.debug(
-                `[AmazonBedrockProvider] Streaming iteration ${iteration}`,
-              );
-
-              const commandInput = await this.prepareStreamCommand(options);
-              const { stopReason, assistantMessage, usage } =
-                await this.processStreamResponse(commandInput, controller);
-
-              // Accumulate real usage from Bedrock metadata chunks.
-              if (usage) {
-                streamTotalInputTokens += usage.input;
-                streamTotalOutputTokens += usage.output;
-                streamTotalCacheReadTokens += usage.cacheReadTokens ?? 0;
-                streamTotalCacheWriteTokens += usage.cacheCreationTokens ?? 0;
-              }
-              if (stopReason) {
-                streamLastStopReason = stopReason;
-              }
-
-              streamSpan.addEvent("stream.turn_complete", {
-                iteration,
-                stop_reason: stopReason,
-              });
-
-              if (stopReason === "tool_use") {
-                const toolNames = assistantMessage.content
-                  .flatMap((b) => (b.toolUse?.name ? [b.toolUse.name] : []))
-                  .join(", ");
-                streamSpan.addEvent("stream.tool_use", {
-                  iteration,
-                  tool_names: toolNames,
-                });
-              }
-
-              const shouldContinue = await this.handleStreamStopReason(
-                stopReason,
-                assistantMessage,
-                controller,
-                options,
-              );
-              if (!shouldContinue) {
-                streamSpan.setAttribute(
-                  "gen_ai.response.stop_reason",
-                  stopReason,
-                );
-                break;
-              }
-            }
-
-            if (iteration >= maxIterations) {
-              streamSpan.setAttribute(
-                "gen_ai.response.stop_reason",
-                "max_iterations",
-              );
-              controller.error(
-                new Error("Streaming conversation exceeded maximum iterations"),
-              );
-              return;
-            }
-            // CRITICAL: ReadableStream's start() returning does NOT auto-close
-            // the controller per the WHATWG Streams spec. Without this, the
-            // downstream `for await (const chunk of stream)` in
-            // convertToAsyncIterable never sees `done: true` and the
-            // consumer hangs forever — manifested as a 240s harness
-            // PER_TEST_TIMEOUT_SKIP for `[bedrock] stream tokens`. The first-
-            // iteration `return` path and the while-loop natural `break`
-            // path both reach here, so closing once at the bottom covers
-            // every non-error exit.
-            controller.close();
-          } catch (error) {
-            logger.debug(
-              "[TRACE] streamingConversationLoop - CATCH block hit in ReadableStream",
-            );
-            controller.error(error);
-          }
-        },
-      });
-
-      // Emit generation:end after the stream completes so Pipeline B (Langfuse)
-      // creates a GENERATION observation. Bedrock bypasses the Vercel AI SDK so
-      // experimental_telemetry is never injected; we emit the event manually.
-      const streamEmitter = this.neurolink?.getEventEmitter();
-      const streamAsyncIterable = this.convertToAsyncIterable(stream);
-      const self = this;
-
-      // Defer analytics resolution until the stream completes so we have
-      // real token counts aggregated from Bedrock metadata chunks.
-      let resolveAnalytics!: (
-        value: ReturnType<typeof createAnalytics>,
-      ) => void;
-      const analyticsPromise = new Promise<ReturnType<typeof createAnalytics>>(
-        (resolve) => {
-          resolveAnalytics = resolve;
-        },
-      );
-
-      const wrappedStreamIterable: AsyncIterable<{ content: string }> = {
-        async *[Symbol.asyncIterator]() {
-          let streamErrored = false;
-          try {
-            yield* streamAsyncIterable;
-          } catch (error) {
-            streamErrored = true;
-            throw error;
-          } finally {
-            const aggregatedUsage = {
-              input: streamTotalInputTokens,
-              output: streamTotalOutputTokens,
-              // Cache reads/writes are billed tokens reported separately
-              // from inputTokens — the total must include them.
-              total:
-                streamTotalInputTokens +
-                streamTotalCacheReadTokens +
-                streamTotalCacheWriteTokens +
-                streamTotalOutputTokens,
-              ...(streamTotalCacheReadTokens > 0 && {
-                cacheReadTokens: streamTotalCacheReadTokens,
-              }),
-              ...(streamTotalCacheWriteTokens > 0 && {
-                cacheCreationTokens: streamTotalCacheWriteTokens,
-              }),
-            };
-
-            // Resolve analytics with accumulated token counts from Bedrock
-            // metadata chunks so Pipeline A also reports real usage.
-            resolveAnalytics(
-              createAnalytics(
-                self.providerName,
-                self.modelName || self.getDefaultModel(),
-                { usage: aggregatedUsage },
-                Date.now() - startTime,
-                {
-                  requestId: `bedrock-stream-${Date.now()}`,
-                  streamingMode: true,
-                },
-              ),
-            );
-
-            if (streamEmitter) {
-              streamEmitter.emit("generation:end", {
-                provider: self.providerName,
-                responseTime: Date.now() - startTime,
-                timestamp: Date.now(),
-                result: {
-                  content: "",
-                  usage: aggregatedUsage,
-                  model: self.modelName || self.getDefaultModel(),
-                  provider: self.providerName,
-                  finishReason: streamErrored ? "error" : streamLastStopReason,
-                },
-                success: !streamErrored,
-              });
-            }
-          }
-        },
-      };
-
-      return {
-        stream: wrappedStreamIterable,
-        // No usage key here on purpose: the real aggregate resolves through
-        // `analytics` after the stream drains. A literal zero object is
-        // truthy and would block every downstream usage fallback.
-        model: this.modelName || this.getDefaultModel(),
-        provider: this.getProviderName(),
-        analytics: analyticsPromise,
-        metadata: {
-          startTime,
-          streamId: `bedrock-${Date.now()}`,
-        },
-      };
-    } catch (error: unknown) {
-      logger.debug(
-        "[TRACE] streamingConversationLoop - first streaming call FAILED, throwing",
-      );
-      throw error; // This will be caught by executeStream
-    }
-  }
-
-  private convertToAsyncIterable(
-    stream: ReadableStream,
-  ): AsyncIterable<{ content: string }> {
-    return {
-      async *[Symbol.asyncIterator]() {
-        const reader = stream.getReader();
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              break;
-            }
-            yield value;
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      },
-    };
-  }
-
-  private async prepareStreamCommand(
-    options: StreamOptions,
-  ): Promise<ConverseStreamCommandInput> {
-    // CRITICAL DEBUG: Log conversation history before conversion
-    if (logger.shouldLog("debug")) {
-      logger.debug(
-        `[AmazonBedrockProvider] BEFORE conversion - conversationHistory length: ${this.conversationHistory.length}`,
-      );
-      this.conversationHistory.forEach((msg, index) => {
-        logger.debug(
-          `[AmazonBedrockProvider] Message ${index}: role=${msg.role}, content=${JSON.stringify(msg.content)}`,
-        );
-      });
-    }
-
-    // Get all available tools
-    // BaseProvider.stream() pre-merges base tools + external tools into options.tools
-    const aiTools =
-      (options.tools as Record<string, Tool>) || (await this.getAllTools());
-    const allTools = this.convertAISDKToolsToToolDefinitions(aiTools);
-    const toolConfig = this.formatToolsForBedrock(allTools);
-
-    const convertedMessages = this.convertToAWSMessages(
-      this.conversationHistory,
+    // Resolved once for the whole turn. Bedrock has no mid-turn tool
+    // discovery, so nothing here would need re-resolving per step.
+    const tools = await this.resolveTurnTools(
+      options.tools,
+      options.disableTools,
     );
-    if (logger.shouldLog("debug")) {
-      logger.debug(
-        `[AmazonBedrockProvider] AFTER conversion - messages length: ${convertedMessages.length}`,
-      );
-      convertedMessages.forEach((msg, index) => {
-        logger.debug(
-          `[AmazonBedrockProvider] Converted Message ${index}: role=${msg.role}, content=${JSON.stringify(msg.content)}`,
-        );
-      });
-    }
-
-    // Registry-driven strip: models that reject sampling params (Sonnet 5 /
-    // Opus 4.7+ / Fable 5 Claude families on Bedrock) must not receive the
-    // legacy 0.7 default temperature.
-    const streamSampling = resolveSamplingParams(
+    const toolConfig = this.formatToolsForBedrock(tools);
+    const sampling = resolveSamplingParams(
       this.providerName,
       this.modelName || this.getDefaultModel(),
       { temperature: options.temperature ?? 0.7 },
       "bedrock.converseStream",
     );
 
-    const commandInput: ConverseStreamCommandInput = {
-      modelId: this.modelName || this.getDefaultModel(),
-      messages: convertedMessages,
-      system: [
-        {
-          text:
-            options.systemPrompt ||
-            "You are a helpful assistant with access to external tools. Use tools when necessary to provide accurate information.",
+    const baseAdapter = createBedrockLoopAdapter({
+      client: this.bedrockClient,
+      streaming: true,
+      region: this.region,
+      maxSteps,
+      buildCommandInput: (conversation) => ({
+        modelId: this.modelName || this.getDefaultModel(),
+        messages: this.convertToAWSMessages(conversation),
+        system: [
+          {
+            text:
+              options.systemPrompt ||
+              "You are a helpful assistant with access to external tools. Use tools when necessary to provide accurate information.",
+          },
+        ],
+        inferenceConfig: {
+          maxTokens: options.maxTokens,
+          ...(sampling.temperature !== undefined && {
+            temperature: sampling.temperature,
+          }),
         },
-      ],
-      inferenceConfig: {
-        maxTokens: options.maxTokens, // No default limit - unlimited unless specified
-        ...(streamSampling.temperature !== undefined && {
-          temperature: streamSampling.temperature,
-        }),
+        ...(toolConfig ? { toolConfig } : {}),
+      }),
+    });
+
+    // executeStream() falls back to non-streaming generate() when the first
+    // call fails on permissions, and that only works if the failure reaches it
+    // synchronously. The engine runs the turn in the background, so the first
+    // successful send reports separately.
+    //
+    // Success is the ONLY thing signalled here. The engine wraps every
+    // executeStep in withProviderRetry, so rejecting on a failed attempt
+    // would settle this promise on attempt one and never un-settle it: a
+    // retryable 429 would be reported as a dead turn even though the engine's
+    // own retry went on to succeed, and this method would throw while that
+    // retried — and billed — turn kept running in the background with its
+    // output discarded, with the fallback generate() billed on top. A
+    // terminal failure is taken from the turn's settled outcome instead,
+    // which by definition is reached only after the engine has stopped
+    // retrying.
+    let firstStepSucceeded = false;
+    let firstStepSent!: () => void;
+    const firstStep = new Promise<void>((resolve) => {
+      firstStepSent = () => {
+        firstStepSucceeded = true;
+        resolve();
+      };
+    });
+
+    const adapter = {
+      ...baseAdapter,
+      executeStep: async (
+        request: AgenticLoopStepRequest,
+        channel: { push(chunk: { content: string }): void },
+        signal: AbortSignal,
+      ) => {
+        const stepResult = await baseAdapter.executeStep(
+          request,
+          channel,
+          signal,
+        );
+        firstStepSent();
+        return stepResult;
       },
     };
 
-    if (toolConfig) {
-      commandInput.toolConfig = toolConfig;
-    }
-
-    logger.debug(
-      `[AmazonBedrockProvider] Calling Bedrock streaming with ${this.conversationHistory.length} messages`,
-    );
-
-    // DEBUG: Log exact conversation structure being sent to Bedrock
-    logger.debug(`[AmazonBedrockProvider] DEBUG - Conversation structure:`);
-    this.conversationHistory.forEach((msg, index) => {
-      logger.debug(
-        `  Message ${index} (${msg.role}): ${msg.content.length} content items`,
-      );
-      msg.content.forEach((item, itemIndex) => {
-        const keys = Object.keys(item);
-        logger.debug(`    Content ${itemIndex}: ${keys.join(", ")}`);
-      });
+    streamSpan.addEvent("stream.api_call", {
+      "bedrock.tool_count": toolConfig?.tools?.length ?? 0,
     });
 
-    return commandInput;
-  }
+    const { stream, resultPromise } = runAgenticLoop(
+      adapter,
+      this.conversationHistory,
+      {
+        tools: this.toEngineTools(tools),
+        abortSignal: options.abortSignal,
+      },
+    );
 
-  private async processStreamResponse(
-    commandInput: ConverseStreamCommandInput,
-    controller: ReadableStreamDefaultController,
-  ): Promise<{
-    stopReason: string;
-    assistantMessage: BedrockMessage;
-    usage?: {
+    // The stream surfaces the same failure, so this settled view exists only
+    // so the turn's outcome can be read without a second unhandled rejection.
+    const settled = resultPromise.then(
+      (result) => ({ result, error: undefined as unknown }),
+      (error: unknown) => ({ result: undefined, error }),
+    );
+
+    // A turn that ends without ever completing a step — an abort before the
+    // first request, or a failure the engine gave up retrying — would leave
+    // `firstStep` pending forever, so the settled outcome releases the wait
+    // too.
+    await Promise.race([firstStep, settled]);
+    if (!firstStepSucceeded) {
+      // The turn ended before any send succeeded. Surface its error here so
+      // executeStream's permission fallback still sees it synchronously.
+      const outcome = await settled;
+      if (outcome.error) {
+        throw outcome.error;
+      }
+    }
+
+    const streamEmitter = this.neurolink?.getEventEmitter();
+    const self = this;
+    const metadata: NonNullable<StreamResult["metadata"]> = {
+      startTime,
+      streamId: `bedrock-${Date.now()}`,
+    };
+
+    let resolveAnalytics!: (value: ReturnType<typeof createAnalytics>) => void;
+    const analyticsPromise = new Promise<ReturnType<typeof createAnalytics>>(
+      (resolve) => {
+        resolveAnalytics = resolve;
+      },
+    );
+
+    const usageFromOutcome = (
+      usage: AgenticLoopUsage | undefined,
+    ): {
       input: number;
       output: number;
       total: number;
       cacheReadTokens?: number;
       cacheCreationTokens?: number;
-    };
-  }> {
-    const command = new ConverseStreamCommand(commandInput);
-
-    logger.debug(
-      "[Observability] Bedrock streaming API request (continuation)",
-      {
-        model: commandInput.modelId,
-        messageCount: commandInput.messages?.length || 0,
-      },
-    );
-
-    const iterationStartTime = Date.now();
-    const response = await withTimeout(
-      this.bedrockClient.send(command),
-      120_000,
-      new Error("Bedrock streaming API call timed out"),
-    );
-
-    logger.debug(
-      "[Observability] Bedrock streaming API connection established (continuation)",
-      {
-        model: commandInput.modelId,
-        durationMs: Date.now() - iterationStartTime,
-      },
-    );
-
-    if (!response.stream) {
-      throw new Error("No stream returned from Bedrock");
-    }
-
-    const currentMessageContent: (BedrockContentBlock & {
-      _inputBuffer?: string;
-    })[] = [];
-    let stopReason = "";
-    let currentText = "";
-    let streamUsage:
-      | {
-          input: number;
-          output: number;
-          total: number;
-          cacheReadTokens?: number;
-          cacheCreationTokens?: number;
-        }
-      | undefined;
-
-    // Process streaming chunks
-    for await (const chunk of response.stream) {
-      if (chunk.contentBlockStart) {
-        // Starting a new content block
-        currentMessageContent.push({});
-      }
-
-      if (chunk.contentBlockDelta?.delta?.text) {
-        // Text delta - stream it to user
-        const textDelta = chunk.contentBlockDelta.delta.text;
-        currentText += textDelta;
-
-        controller.enqueue({
-          content: textDelta,
-        });
-      }
-
-      if (chunk.contentBlockStart?.start?.toolUse) {
-        // Tool use block starting - initialize tool information
-        const currentBlock =
-          currentMessageContent[currentMessageContent.length - 1];
-        currentBlock.toolUse = {
-          name: chunk.contentBlockStart.start.toolUse.name || "",
-          input: {}, // Initialize empty - will be populated by delta chunks
-          toolUseId:
-            chunk.contentBlockStart.start.toolUse.toolUseId ||
-            `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
-        };
-      }
-
-      if (chunk.contentBlockDelta?.delta?.toolUse) {
-        // Tool use delta - accumulate tool information
-        const currentBlock =
-          currentMessageContent[currentMessageContent.length - 1];
-        if (!currentBlock.toolUse) {
-          currentBlock.toolUse = {
-            name: "",
-            input: {},
-            toolUseId: `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
-          };
-        }
-        // Accumulate JSON string fragments into _inputBuffer.
-        // Bedrock sends toolUse.input as incremental JSON string fragments,
-        // not pre-parsed objects. We buffer them and parse at contentBlockStop.
-        if (chunk.contentBlockDelta.delta.toolUse.input) {
-          const deltaInput = chunk.contentBlockDelta.delta.toolUse.input;
-          if (typeof deltaInput === "string") {
-            currentBlock._inputBuffer =
-              (currentBlock._inputBuffer || "") + deltaInput;
-          } else if (
-            deltaInput &&
-            typeof deltaInput === "object" &&
-            !Array.isArray(deltaInput)
-          ) {
-            // Some SDK versions may deliver pre-parsed objects; merge directly
-            const currentInput = currentBlock.toolUse.input || {};
-            currentBlock.toolUse.input = {
-              ...currentInput,
-              ...(deltaInput as Record<string, unknown>),
-            } as Record<string, unknown>;
-          }
-        }
-      }
-
-      if (chunk.contentBlockStop) {
-        // Content block completed
-        const currentBlock =
-          currentMessageContent[currentMessageContent.length - 1];
-
-        // Parse accumulated JSON input buffer for tool-use blocks
-        if (currentBlock?.toolUse && currentBlock._inputBuffer) {
-          try {
-            currentBlock.toolUse.input = JSON.parse(currentBlock._inputBuffer);
-          } catch {
-            currentBlock.toolUse.input = {};
-          }
-          delete currentBlock._inputBuffer;
-        }
-
-        if (currentText && currentBlock && !currentBlock.toolUse) {
-          // Only add text to blocks that don't have toolUse
-          currentBlock.text = currentText;
-        }
-        currentText = "";
-      }
-
-      if (chunk.messageStop) {
-        stopReason = chunk.messageStop.stopReason || "end_turn";
-        // Don't break — metadata chunk with usage arrives after messageStop
-        continue;
-      }
-
-      // Bedrock ConverseStream emits a metadata chunk at the end with
-      // aggregate usage. Capture it for Pipeline B telemetry.
-      if (chunk.metadata?.usage) {
-        const input = chunk.metadata.usage.inputTokens ?? 0;
-        const output = chunk.metadata.usage.outputTokens ?? 0;
-        const cacheRead = chunk.metadata.usage.cacheReadInputTokens ?? 0;
-        const cacheWrite = chunk.metadata.usage.cacheWriteInputTokens ?? 0;
-        streamUsage = {
-          input,
-          output,
-          // Computed rather than trusting totalTokens: inputTokens excludes
-          // cache reads/writes (additive convention), and the total must
-          // count every billed component.
-          total: input + cacheRead + cacheWrite + output,
-          ...(cacheRead > 0 && { cacheReadTokens: cacheRead }),
-          ...(cacheWrite > 0 && { cacheCreationTokens: cacheWrite }),
-        };
-        // Stream is effectively complete after metadata chunk
-        break;
-      }
-    }
-
-    // Add assistant message to conversation history
-    const assistantMessage: BedrockMessage = {
-      role: "assistant",
-      content: currentMessageContent,
-    };
-    this.conversationHistory.push(assistantMessage);
-
-    return { stopReason, assistantMessage, usage: streamUsage };
-  }
-
-  private async handleStreamStopReason(
-    stopReason: string,
-    assistantMessage: BedrockMessage,
-    controller: ReadableStreamDefaultController,
-    options: StreamOptions,
-  ): Promise<boolean> {
-    if (stopReason === "end_turn" || stopReason === "stop_sequence") {
-      // Conversation completed
-      controller.close();
-      return false;
-    } else if (stopReason === "tool_use") {
-      logger.debug(
-        `[AmazonBedrockProvider] Tool use detected in streaming - executing tools`,
-      );
-
-      await this.executeStreamTools(assistantMessage.content, options);
-      return true; // Continue conversation loop
-    } else if (stopReason === "max_tokens") {
-      // Max tokens reached — close the stream rather than continuing,
-      // since the model hit the configured limit.
-      controller.close();
-      return false;
-    } else {
-      // Unknown stop reason - end conversation
-      controller.close();
-      return false;
-    }
-  }
-
-  private async executeStreamTools(
-    messageContent: BedrockContentBlock[],
-    options: StreamOptions,
-  ): Promise<void> {
-    // Execute all tool uses in the message - ensure 1:1 mapping like Bedrock-MCP-Connector
-    const toolResults = [];
-    let toolUseCount = 0;
-
-    // Track tool calls and results for storage (similar to Vertex onStepFinish)
-    const toolCalls: Array<{
-      type: string;
-      toolCallId: string;
-      toolName: string;
-      args: unknown;
-    }> = [];
-    const toolResultsForStorage: Array<{
-      type: string;
-      toolCallId: string;
-      toolName: string;
-      result: unknown;
-    }> = [];
-
-    // Count toolUse blocks first to ensure 1:1 mapping
-    for (const contentItem of messageContent) {
-      if (contentItem.toolUse) {
-        toolUseCount++;
-      }
-    }
-
-    logger.debug(
-      `[AmazonBedrockProvider] Found ${toolUseCount} toolUse blocks in assistant message`,
-    );
-
-    for (const contentItem of messageContent) {
-      if (contentItem.toolUse) {
-        logger.debug(
-          `[AmazonBedrockProvider] Executing tool: ${contentItem.toolUse.name}`,
-        );
-
-        // Track tool call
-        toolCalls.push({
-          type: "tool-call",
-          toolCallId: contentItem.toolUse.toolUseId,
-          toolName: contentItem.toolUse.name,
-          args: contentItem.toolUse.input || {},
-        });
-
-        try {
-          const toolResult = await this.executeSingleTool(
-            contentItem.toolUse.name,
-            contentItem.toolUse.input || {},
-            contentItem.toolUse.toolUseId,
-          );
-
-          logger.debug(
-            `[AmazonBedrockProvider] Tool execution successful: ${contentItem.toolUse.name}`,
-          );
-
-          // Track tool result for storage
-          toolResultsForStorage.push({
-            type: "tool-result",
-            toolCallId: contentItem.toolUse.toolUseId,
-            toolName: contentItem.toolUse.name,
-            result: toolResult,
-          });
-
-          // Ensure exact structure matching Bedrock-MCP-Connector
-          toolResults.push({
-            toolResult: {
-              toolUseId: contentItem.toolUse.toolUseId,
-              content: [{ text: String(toolResult) }],
-              status: "success",
-            },
-          });
-        } catch (error) {
-          logger.error(
-            `[AmazonBedrockProvider] Tool execution failed: ${contentItem.toolUse.name}`,
-            error,
-          );
-
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-
-          // Track failed tool result
-          toolResultsForStorage.push({
-            type: "tool-result",
-            toolCallId: contentItem.toolUse.toolUseId,
-            toolName: contentItem.toolUse.name,
-            result: { error: errorMessage },
-          });
-
-          toolResults.push({
-            toolResult: {
-              toolUseId: contentItem.toolUse.toolUseId,
-              content: [
-                {
-                  text: `Error executing tool ${contentItem.toolUse.name}: ${errorMessage}`,
-                },
-              ],
-              status: "error",
-            },
-          });
-        }
-      }
-    }
-
-    logger.debug(
-      `[AmazonBedrockProvider] Created ${toolResults.length} toolResult blocks for ${toolUseCount} toolUse blocks`,
-    );
-
-    // Validate 1:1 mapping before adding to conversation
-    if (toolResults.length !== toolUseCount) {
-      logger.error(
-        `[AmazonBedrockProvider] Mismatch: ${toolResults.length} toolResults vs ${toolUseCount} toolUse blocks`,
-      );
-      throw new Error(
-        `Tool mapping mismatch: ${toolResults.length} toolResults for ${toolUseCount} toolUse blocks`,
-      );
-    }
-
-    // Add tool results as user message - exact structure like Bedrock-MCP-Connector
-    if (toolResults.length > 0) {
-      const userMessageWithToolResults: BedrockMessage = {
-        role: "user",
-        content: toolResults,
+    } => {
+      const input = usage?.inputTokens ?? 0;
+      const output = usage?.outputTokens ?? 0;
+      const cacheRead = usage?.cacheReadTokens ?? 0;
+      const cacheWrite = usage?.cacheWriteTokens ?? 0;
+      return {
+        input,
+        output,
+        // Cache reads/writes are billed tokens reported separately from
+        // inputTokens — the total must include them.
+        total: input + cacheRead + cacheWrite + output,
+        ...(cacheRead > 0 && { cacheReadTokens: cacheRead }),
+        ...(cacheWrite > 0 && { cacheCreationTokens: cacheWrite }),
       };
-      this.conversationHistory.push(userMessageWithToolResults);
+    };
 
-      logger.debug(
-        `[AmazonBedrockProvider] Added ${toolResults.length} tool results to conversation (1:1 mapping validated)`,
+    // Bind analytics to the turn ending, not to the consumer draining the
+    // stream. A caller that awaits `result.analytics` without iterating
+    // `result.stream` would otherwise wait forever, because the generator
+    // body — and its finally block — never runs. Resolving twice is
+    // harmless; the first call wins.
+    void settled.then((outcome) => {
+      resolveAnalytics(
+        createAnalytics(
+          this.providerName,
+          this.modelName || this.getDefaultModel(),
+          { usage: usageFromOutcome(outcome.result?.usage) },
+          Date.now() - startTime,
+          {
+            requestId: `bedrock-stream-${Date.now()}`,
+            streamingMode: true,
+          },
+        ),
       );
+    });
 
-      // Emit tool:end for each completed tool result so Pipeline B
-      // captures telemetry for Bedrock-driven tool calls (gap S2).
-      emitToolEndFromStepFinish(
-        this.neurolink?.getEventEmitter(),
-        toolResultsForStorage.map((tr) => {
-          const hasError =
-            tr.result && typeof tr.result === "object" && "error" in tr.result;
-          return {
-            toolName: tr.toolName,
-            result: tr.result,
-            error: hasError
-              ? String((tr.result as Record<string, unknown>).error)
-              : undefined,
-          };
-        }),
-      );
+    const wrappedStreamIterable: AsyncIterable<{ content: string }> = {
+      async *[Symbol.asyncIterator]() {
+        let streamErrored = false;
+        try {
+          yield* stream;
+        } catch (error) {
+          streamErrored = true;
+          throw error;
+        } finally {
+          const outcome = await settled;
+          if (outcome.error) {
+            streamErrored = true;
+          }
+          const aggregatedUsage = usageFromOutcome(outcome.result?.usage);
 
-      // Store tool execution for analytics and debugging (similar to Vertex onStepFinish)
-      this.handleToolExecutionStorage(
-        toolCalls,
-        toolResultsForStorage,
-        options,
-        new Date(),
-      ).catch((error: unknown) => {
-        logger.warn("[AmazonBedrockProvider] Failed to store tool executions", {
-          provider: this.providerName,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-    }
+          if (outcome.result) {
+            self.conversationHistory = outcome.result.conversation;
+            metadata.finishReason = outcome.result.finishReason;
+            metadata.rawFinishReason = outcome.result.rawStopReason;
+            streamSpan.setAttribute(
+              "gen_ai.response.stop_reason",
+              outcome.result.rawStopReason ?? "unknown",
+            );
+          }
+
+          // Analytics is resolved off `settled` above, so it lands whether or
+          // not anyone drains the stream.
+
+          // Bedrock bypasses the Vercel AI SDK, so experimental_telemetry is
+          // never injected and generation:end is emitted by hand for
+          // Pipeline B (Langfuse).
+          if (streamEmitter) {
+            streamEmitter.emit("generation:end", {
+              provider: self.providerName,
+              responseTime: Date.now() - startTime,
+              timestamp: Date.now(),
+              result: {
+                content: "",
+                usage: aggregatedUsage,
+                model: self.modelName || self.getDefaultModel(),
+                provider: self.providerName,
+                finishReason: streamErrored
+                  ? "error"
+                  : outcome.result?.rawStopReason,
+              },
+              success: !streamErrored,
+            });
+          }
+        }
+      },
+    };
+
+    return {
+      stream: wrappedStreamIterable,
+      // No usage key here on purpose: the real aggregate resolves through
+      // `analytics` after the stream drains. A literal zero object is truthy
+      // and would block every downstream usage fallback.
+      model: this.modelName || this.getDefaultModel(),
+      provider: this.getProviderName(),
+      analytics: analyticsPromise,
+      metadata,
+    };
   }
 
   /**

--- a/src/lib/providers/amazonBedrock/loopAdapter.ts
+++ b/src/lib/providers/amazonBedrock/loopAdapter.ts
@@ -1,0 +1,425 @@
+/**
+ * Bedrock's adapter onto the shared agentic loop engine.
+ *
+ * Bedrock had two hand-rolled turn loops — one for `Converse`, one for
+ * `ConverseStream` — that between them duplicated the same content-block
+ * accumulation three times. Everything here is the wire-format half of that:
+ * issuing the right command, folding a response into blocks, serializing tool
+ * results back into the conversation, and mapping the stop reason. The turn
+ * loop itself, the step cap, tool dispatch and usage accumulation belong to
+ * `runAgenticLoop`.
+ *
+ * One adapter covers both operations because the two differ only in how a
+ * step's content blocks arrive: `ConverseStream` delivers them as events that
+ * are pushed to the consumer as they land, `Converse` returns them whole.
+ * Block accumulation, tool-call extraction and the conversation shape are
+ * identical, and were identical in the hand-rolled loops too — which is why
+ * they drifted apart in the details.
+ */
+
+import type {
+  ContentBlock,
+  ConverseCommandInput,
+  ConverseStreamCommandInput,
+} from "@aws-sdk/client-bedrock-runtime";
+import {
+  ConverseCommand,
+  ConverseStreamCommand,
+  type BedrockRuntimeClient,
+} from "@aws-sdk/client-bedrock-runtime";
+import type {
+  AgenticLoopAdapter,
+  AgenticLoopStepRequest,
+  AgenticLoopStepResult,
+  AgenticLoopToolCallResult,
+  BedrockContentBlock,
+  BedrockMessage,
+  BedrockPendingContentBlock,
+} from "../../types/index.js";
+import { withTimeout } from "../../utils/errorHandling.js";
+import { withInferenceProfileFallback } from "./inferenceProfile.js";
+
+const STEP_TIMEOUT_MS = 120_000;
+
+function newToolUseId(): string {
+  return `tool_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+}
+
+/**
+ * Finalize a block once its `contentBlockStop` arrives: parse whatever tool
+ * input accumulated, and attach the text a plain block collected.
+ *
+ * Attaching the text matters beyond this step. `buildToolResultMessages`
+ * replays these blocks back to the model as the assistant turn, so a text
+ * block left empty here silently drops the assistant's own words from the
+ * conversation on every subsequent step of the turn.
+ */
+function finalizeBlock(
+  block: BedrockPendingContentBlock | undefined,
+  text: string,
+): void {
+  if (!block) {
+    return;
+  }
+  if (block.toolUse && block._inputBuffer) {
+    try {
+      block.toolUse.input = JSON.parse(block._inputBuffer) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      block.toolUse.input = {};
+    }
+    delete block._inputBuffer;
+  }
+  if (text && !block.toolUse) {
+    block.text = text;
+  }
+}
+
+function toolCallsFrom(
+  blocks: BedrockPendingContentBlock[],
+): AgenticLoopStepResult<BedrockContentBlock[]>["toolCalls"] {
+  return blocks
+    .filter((b) => b.toolUse)
+    .map((b) => ({
+      id: b.toolUse?.toolUseId ?? newToolUseId(),
+      name: b.toolUse?.name ?? "",
+      args: (b.toolUse?.input as Record<string, unknown>) ?? {},
+    }));
+}
+
+/** Fold a `ConverseStream` event sequence into finished content blocks. */
+async function readStreamedStep(
+  response: { stream?: AsyncIterable<Record<string, never>> },
+  channel: { push(chunk: { content: string }): void },
+  signal: AbortSignal,
+): Promise<AgenticLoopStepResult<BedrockContentBlock[]>> {
+  const blocks: BedrockPendingContentBlock[] = [];
+  // Blocks are keyed by the index Bedrock stamps on every event rather than
+  // by arrival order, because a text block does not necessarily announce
+  // itself with `contentBlockStart` — the first thing seen for it can be a
+  // delta. Creating the block on whichever event arrives first is what keeps
+  // assistant text that precedes a tool call from being dropped: `raw` is
+  // replayed as the assistant turn on the next step, so a lost text block
+  // means the model stops seeing its own reasoning mid-turn.
+  const blocksByIndex = new Map<number, BedrockPendingContentBlock>();
+  const textByIndex = new Map<number, string>();
+  const blockFor = (index: number): BedrockPendingContentBlock => {
+    let block = blocksByIndex.get(index);
+    if (!block) {
+      block = {};
+      blocksByIndex.set(index, block);
+      blocks.push(block);
+    }
+    return block;
+  };
+  let text = "";
+  let rawStopReason: string | undefined;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+
+  if (response.stream) {
+    for await (const rawChunk of response.stream) {
+      if (signal.aborted) {
+        break;
+      }
+      const chunk = rawChunk as {
+        contentBlockStart?: {
+          contentBlockIndex?: number;
+          start?: { toolUse?: { name?: string; toolUseId?: string } };
+        };
+        contentBlockDelta?: {
+          contentBlockIndex?: number;
+          delta?: { text?: string; toolUse?: { input?: unknown } };
+        };
+        contentBlockStop?: { contentBlockIndex?: number };
+        messageStop?: { stopReason?: string };
+        metadata?: {
+          usage?: {
+            inputTokens?: number;
+            outputTokens?: number;
+            cacheReadInputTokens?: number;
+            cacheWriteInputTokens?: number;
+          };
+        };
+      };
+
+      if (chunk.contentBlockStart) {
+        blockFor(chunk.contentBlockStart.contentBlockIndex ?? 0);
+      }
+
+      if (chunk.contentBlockDelta?.delta?.text) {
+        const index = chunk.contentBlockDelta.contentBlockIndex ?? 0;
+        const delta = chunk.contentBlockDelta.delta.text;
+        blockFor(index);
+        text += delta;
+        textByIndex.set(index, (textByIndex.get(index) ?? "") + delta);
+        channel.push({ content: delta });
+      }
+
+      if (chunk.contentBlockStart?.start?.toolUse) {
+        const block = blockFor(chunk.contentBlockStart.contentBlockIndex ?? 0);
+        block.toolUse = {
+          name: chunk.contentBlockStart.start.toolUse.name ?? "",
+          input: {},
+          toolUseId:
+            chunk.contentBlockStart.start.toolUse.toolUseId ?? newToolUseId(),
+        };
+      }
+
+      if (chunk.contentBlockDelta?.delta?.toolUse) {
+        const block = blockFor(chunk.contentBlockDelta.contentBlockIndex ?? 0);
+        block.toolUse ??= {
+          name: "",
+          input: {},
+          toolUseId: newToolUseId(),
+        };
+        const deltaInput = chunk.contentBlockDelta.delta.toolUse.input;
+        if (typeof deltaInput === "string") {
+          block._inputBuffer = (block._inputBuffer ?? "") + deltaInput;
+        } else if (
+          typeof deltaInput === "object" &&
+          deltaInput !== null &&
+          !Array.isArray(deltaInput)
+        ) {
+          block.toolUse.input = {
+            ...(block.toolUse.input ?? {}),
+            ...(deltaInput as Record<string, unknown>),
+          };
+        }
+      }
+
+      if (chunk.contentBlockStop) {
+        const index = chunk.contentBlockStop.contentBlockIndex ?? 0;
+        finalizeBlock(blocksByIndex.get(index), textByIndex.get(index) ?? "");
+      }
+
+      if (chunk.messageStop) {
+        rawStopReason = chunk.messageStop.stopReason ?? "end_turn";
+        // Not a break: the metadata event carrying usage arrives after this.
+        continue;
+      }
+
+      if (chunk.metadata?.usage) {
+        inputTokens += chunk.metadata.usage.inputTokens ?? 0;
+        outputTokens += chunk.metadata.usage.outputTokens ?? 0;
+        // Converse follows the Anthropic additive convention — inputTokens is
+        // the uncached remainder, so cache reads/writes are counted apart.
+        cacheReadTokens += chunk.metadata.usage.cacheReadInputTokens ?? 0;
+        cacheWriteTokens += chunk.metadata.usage.cacheWriteInputTokens ?? 0;
+        break;
+      }
+    }
+  }
+
+  // Finalize anything the stream never closed. `contentBlockStop` is not
+  // guaranteed to arrive for every block: an abort breaks the loop, the
+  // metadata event breaks it, and a truncated stream simply ends. A block
+  // left unfinalized keeps `text` undefined and its tool input unparsed, and
+  // since `raw` is replayed as the assistant message — where an unrecognized
+  // block maps to `{ text: "" }`, which Bedrock rejects — that would fail the
+  // NEXT step of the turn rather than this one.
+  for (const [index, block] of blocksByIndex) {
+    finalizeBlock(block, textByIndex.get(index) ?? "");
+  }
+
+  // A block that opened and then received nothing carries no content at all,
+  // and `convertToAWSMessages` maps an unrecognized block to `{ text: "" }`,
+  // which Bedrock rejects. Drop them rather than replay them.
+  const usableBlocks = blocks.filter(
+    (block) => block.text || block.toolUse || block.image || block.document,
+  );
+
+  return {
+    text,
+    toolCalls: toolCallsFrom(usableBlocks),
+    usage: { inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens },
+    rawStopReason,
+    raw: usableBlocks as BedrockContentBlock[],
+  };
+}
+
+/** Fold a non-streaming `Converse` response into the same block shape. */
+function readGeneratedStep(response: {
+  output?: { message?: { content?: ContentBlock[] } };
+  stopReason?: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+  };
+}): AgenticLoopStepResult<BedrockContentBlock[]> {
+  const blocks: BedrockContentBlock[] = [];
+  let text = "";
+
+  for (const item of response.output?.message?.content ?? []) {
+    const block: BedrockContentBlock = {};
+    if ("text" in item && item.text) {
+      block.text = item.text;
+      text += text ? ` ${item.text}` : item.text;
+    }
+    if ("toolUse" in item && item.toolUse) {
+      block.toolUse = {
+        toolUseId: item.toolUse.toolUseId ?? newToolUseId(),
+        name: item.toolUse.name ?? "",
+        input: (item.toolUse.input as Record<string, unknown>) ?? {},
+      };
+    }
+    blocks.push(block);
+  }
+
+  return {
+    text,
+    toolCalls: toolCallsFrom(blocks),
+    usage: {
+      inputTokens: response.usage?.inputTokens ?? 0,
+      outputTokens: response.usage?.outputTokens ?? 0,
+      cacheReadTokens: response.usage?.cacheReadInputTokens ?? 0,
+      cacheWriteTokens: response.usage?.cacheWriteInputTokens ?? 0,
+    },
+    rawStopReason: response.stopReason,
+    raw: blocks,
+  };
+}
+
+export function createBedrockLoopAdapter(config: {
+  client: BedrockRuntimeClient;
+  /** `ConverseStream` when true, `Converse` when false. */
+  streaming: boolean;
+  /** The region the client was constructed with, for profile resolution. */
+  region: string;
+  maxSteps: number;
+  /**
+   * Build the request for one step. Synchronous by contract, so anything
+   * async (tool declarations in particular) is resolved once before the turn
+   * starts rather than per step. Bedrock has no mid-turn tool discovery, so
+   * there is nothing that would need re-resolving.
+   */
+  buildCommandInput: (
+    conversation: BedrockMessage[],
+    step: number,
+  ) => ConverseCommandInput & ConverseStreamCommandInput;
+}): AgenticLoopAdapter<BedrockMessage[], BedrockContentBlock[]> {
+  return {
+    providerLabel: "bedrock",
+    maxSteps: config.maxSteps,
+    // No toolFailureBreaker: Bedrock has never had strike counting — a failing
+    // tool becomes one error tool-result with no cross-step memory. Preserved.
+
+    buildStepRequest(
+      conversation: BedrockMessage[],
+      step: number,
+    ): AgenticLoopStepRequest {
+      return { raw: config.buildCommandInput(conversation, step) };
+    },
+
+    async executeStep(
+      request: AgenticLoopStepRequest,
+      channel: { push(chunk: { content: string }): void },
+      signal: AbortSignal,
+    ): Promise<AgenticLoopStepResult<BedrockContentBlock[]>> {
+      const commandInput = request.raw as ConverseCommandInput &
+        ConverseStreamCommandInput;
+
+      // Both sends go through the inference-profile fallback: most current
+      // Bedrock models are not invocable by their bare id in a given region
+      // and need a geography- or global-prefixed profile id instead. This is
+      // where the provider's two Converse call sites now live.
+      if (!config.streaming) {
+        const response = await withInferenceProfileFallback(
+          commandInput.modelId ?? "",
+          config.region,
+          (effectiveModelId) =>
+            withTimeout(
+              config.client.send(
+                new ConverseCommand({
+                  ...commandInput,
+                  modelId: effectiveModelId,
+                }),
+              ),
+              STEP_TIMEOUT_MS,
+              new Error("Bedrock API call timed out"),
+            ),
+        );
+        if (!response.output?.message) {
+          throw new Error("Invalid response structure from Bedrock API");
+        }
+        return readGeneratedStep(response);
+      }
+
+      const response = await withInferenceProfileFallback(
+        commandInput.modelId ?? "",
+        config.region,
+        (effectiveModelId) =>
+          withTimeout(
+            config.client.send(
+              new ConverseStreamCommand({
+                ...commandInput,
+                modelId: effectiveModelId,
+              }),
+            ),
+            STEP_TIMEOUT_MS,
+            new Error("Bedrock streaming API call timed out"),
+          ),
+      );
+      return readStreamedStep(
+        response as { stream?: AsyncIterable<Record<string, never>> },
+        channel,
+        signal,
+      );
+    },
+
+    buildToolResultMessages(
+      conversation: BedrockMessage[],
+      stepResult: AgenticLoopStepResult<BedrockContentBlock[]>,
+      toolResults: AgenticLoopToolCallResult[],
+    ): BedrockMessage[] {
+      const assistantMessage: BedrockMessage = {
+        role: "assistant",
+        content: stepResult.raw,
+      };
+      const toolResultMessage: BedrockMessage = {
+        role: "user",
+        content: toolResults.map((result) => ({
+          toolResult: {
+            toolUseId: result.id,
+            content: [
+              {
+                text: result.error
+                  ? `Error executing tool ${result.name}: ${result.error}`
+                  : String(
+                      typeof result.output === "string"
+                        ? result.output
+                        : JSON.stringify(result.output),
+                    ),
+              },
+            ],
+            status: result.error ? "error" : "success",
+          },
+        })),
+      };
+      return [...conversation, assistantMessage, toolResultMessage];
+    },
+
+    mapFinishReason(
+      rawStopReason: string | undefined,
+      hadToolCallsAtCap: boolean,
+    ): string {
+      switch (rawStopReason) {
+        case "end_turn":
+        case "stop_sequence":
+          return "stop";
+        case "max_tokens":
+          return "length";
+        case "tool_use":
+          return "tool-calls";
+        default:
+          return hadToolCallsAtCap ? "tool-calls" : "stop";
+      }
+    },
+  };
+}

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -1023,6 +1023,16 @@ export type BedrockContentBlock = {
 };
 
 /**
+ * A Bedrock content block still being assembled from a ConverseStream event
+ * sequence. `_inputBuffer` holds the partial tool-call JSON that arrives
+ * across several `contentBlockDelta` events and is parsed away at
+ * `contentBlockStop`, so it never appears on a finished block.
+ */
+export type BedrockPendingContentBlock = BedrockContentBlock & {
+  _inputBuffer?: string;
+};
+
+/**
  * Bedrock message structure
  */
 export type BedrockMessage = {

--- a/test/continuous-test-suite-bedrock-loop-characterization.ts
+++ b/test/continuous-test-suite-bedrock-loop-characterization.ts
@@ -1,0 +1,872 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Amazon Bedrock native-loop characterization
+ * (Plan 08, Task 4).
+ *
+ * Pins the observable behaviour of Bedrock's two hand-rolled turn loops —
+ * `conversationLoop` (generate) and `streamingConversationLoop` (stream) —
+ * so the migration onto `runAgenticLoop` can be shown not to change it.
+ *
+ * Everything here drives the shipped surface: `new NeuroLink()` from
+ * `../dist/index.js`, no imports out of `src/`, no stubbing. The provider's
+ * real AWS SDK client is pointed at a local server with the documented
+ * `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` variable, so requests are really signed
+ * with SigV4 and really routed, and the assertions are about the calls that
+ * actually go out on the wire.
+ *
+ * The stand-in speaks cleartext HTTP/2 because `@aws-sdk/client-bedrock-runtime`
+ * defaults to `NodeHttp2Handler` for its event-stream operations and refuses
+ * an HTTP/1.1 server with "Protocol error" before sending anything. Streaming
+ * responses are encoded in the real `vnd.amazon.eventstream` binary framing
+ * (see `encodeEventFrame`), so the SDK's own decoder is exercised too.
+ *
+ * Run: npx tsx test/continuous-test-suite-bedrock-loop-characterization.ts
+ *      pnpm run test:bedrock-loop-characterization
+ */
+
+import { createServer, type Http2Server } from "node:http2";
+import { crc32 } from "node:zlib";
+import { z } from "zod";
+import { assert, defineSuite } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, section, runSuite } = defineSuite(
+  "Bedrock loop characterization",
+);
+
+const { NeuroLink } = await import("../dist/index.js");
+
+// Already carries a geography prefix, so it is a concrete routable id under
+// any inference-profile resolution the provider may grow.
+const MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+type EventFrame = { type: string; payload: Record<string, unknown> };
+
+/**
+ * Encode one `:message-type: event` frame of the AWS event-stream framing:
+ * an 8-byte prelude and its CRC, the headers, the payload, and a CRC over
+ * everything before it. Verified byte-for-byte against
+ * `@smithy/eventstream-codec` for every frame type used below, which is why
+ * this can stay a local helper instead of promoting two transitive `@smithy`
+ * packages to explicit devDependencies.
+ */
+function encodeEventFrame(frame: EventFrame): Buffer {
+  const body = Buffer.from(JSON.stringify(frame.payload), "utf8");
+  const header = (name: string, value: string): Buffer => {
+    const n = Buffer.from(name, "utf8");
+    const v = Buffer.from(value, "utf8");
+    const len = Buffer.alloc(2);
+    len.writeUInt16BE(v.length);
+    return Buffer.concat([
+      Buffer.from([n.length]),
+      n,
+      Buffer.from([7]),
+      len,
+      v,
+    ]);
+  };
+  const headers = Buffer.concat([
+    header(":message-type", "event"),
+    header(":event-type", frame.type),
+    header(":content-type", "application/json"),
+  ]);
+  const totalLength = 12 + headers.length + body.length + 4;
+  const prelude = Buffer.alloc(8);
+  prelude.writeUInt32BE(totalLength, 0);
+  prelude.writeUInt32BE(headers.length, 4);
+  const preludeCrc = Buffer.alloc(4);
+  preludeCrc.writeUInt32BE(crc32(prelude));
+  const head = Buffer.concat([prelude, preludeCrc, headers, body]);
+  const messageCrc = Buffer.alloc(4);
+  messageCrc.writeUInt32BE(crc32(head));
+  return Buffer.concat([head, messageCrc]);
+}
+
+function textFrames(text: string): EventFrame[] {
+  return [
+    { type: "messageStart", payload: { role: "assistant" } },
+    {
+      type: "contentBlockDelta",
+      payload: { contentBlockIndex: 0, delta: { text } },
+    },
+    { type: "contentBlockStop", payload: { contentBlockIndex: 0 } },
+    { type: "messageStop", payload: { stopReason: "end_turn" } },
+    {
+      type: "metadata",
+      payload: { usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 } },
+    },
+  ];
+}
+
+function toolUseFrames(
+  name: string,
+  input: Record<string, unknown>,
+  toolUseId: string,
+): EventFrame[] {
+  return [
+    { type: "messageStart", payload: { role: "assistant" } },
+    {
+      type: "contentBlockStart",
+      payload: {
+        contentBlockIndex: 0,
+        start: { toolUse: { name, toolUseId } },
+      },
+    },
+    {
+      type: "contentBlockDelta",
+      payload: {
+        contentBlockIndex: 0,
+        delta: { toolUse: { input: JSON.stringify(input) } },
+      },
+    },
+    { type: "contentBlockStop", payload: { contentBlockIndex: 0 } },
+    { type: "messageStop", payload: { stopReason: "tool_use" } },
+    {
+      type: "metadata",
+      payload: { usage: { inputTokens: 12, outputTokens: 6, totalTokens: 18 } },
+    },
+  ];
+}
+
+/** Non-streaming Converse reply carrying a plain text turn. */
+function converseText(text: string): string {
+  return JSON.stringify({
+    output: { message: { role: "assistant", content: [{ text }] } },
+    stopReason: "end_turn",
+    usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+  });
+}
+
+/** Non-streaming Converse reply asking for one tool call. */
+function converseToolUse(
+  name: string,
+  input: Record<string, unknown>,
+  toolUseId: string,
+  text?: string,
+): string {
+  return JSON.stringify({
+    output: {
+      message: {
+        role: "assistant",
+        content: [
+          ...(text ? [{ text }] : []),
+          { toolUse: { name, toolUseId, input } },
+        ],
+      },
+    },
+    stopReason: "tool_use",
+    usage: { inputTokens: 12, outputTokens: 6, totalTokens: 18 },
+  });
+}
+
+type StandInCall = {
+  streaming: boolean;
+  modelId: string;
+  /** Parsed request body, so assertions can look at what was actually sent. */
+  body: Record<string, unknown>;
+};
+
+type StandIn = {
+  /** One entry per request that reached the server, in order. */
+  calls: StandInCall[];
+  port: number;
+  close: () => Promise<void>;
+};
+
+/** Names of the tools declared to the model on a given request. */
+function declaredToolNames(call: StandInCall | undefined): string[] {
+  const toolConfig = call?.body?.toolConfig as
+    | { tools?: Array<{ toolSpec?: { name?: string } }> }
+    | undefined;
+  return (toolConfig?.tools ?? [])
+    .map((t) => t.toolSpec?.name)
+    .filter((n): n is string => typeof n === "string");
+}
+
+/** Tool-result blocks carried back to the model on a given request. */
+function toolResults(
+  call: StandInCall | undefined,
+): Array<{ status?: string; content?: Array<{ text?: string }> }> {
+  const messages = (call?.body?.messages ?? []) as Array<{
+    content?: Array<{
+      toolResult?: { status?: string; content?: Array<{ text?: string }> };
+    }>;
+  }>;
+  return messages
+    .flatMap((m) => m.content ?? [])
+    .map((c) => c.toolResult)
+    .filter((r): r is NonNullable<typeof r> => !!r);
+}
+
+/**
+ * `reply` is called once per request with the zero-based request index and
+ * decides that request's response: event frames for a streaming call, a JSON
+ * string for a non-streaming one.
+ */
+async function startStandIn(
+  reply: (callIndex: number) => EventFrame[] | string,
+): Promise<StandIn> {
+  const calls: StandIn["calls"] = [];
+  const server: Http2Server = createServer();
+  server.on("stream", (stream, headers) => {
+    const path = String(headers[":path"] ?? "");
+    const match = /\/model\/([^/]+)\/(converse-stream|converse)/.exec(path);
+    const streaming = match?.[2] === "converse-stream";
+    const parts: Buffer[] = [];
+    stream.on("data", (c: Buffer) => parts.push(c));
+    stream.on("end", () => {
+      const parseBody = (): Record<string, unknown> => {
+        try {
+          return JSON.parse(Buffer.concat(parts).toString("utf8") || "{}");
+        } catch {
+          return {};
+        }
+      };
+      const body = parseBody();
+      const responseSpec = reply(calls.length);
+      calls.push({
+        streaming,
+        modelId: match ? decodeURIComponent(match[1]) : "",
+        body,
+      });
+      const response = responseSpec;
+      // A sentinel the reply function can return to make the stand-in answer
+      // with a retryable status instead of a body.
+      if (response === "RETRYABLE_503") {
+        stream.respond({ ":status": 503, "content-type": "application/json" });
+        stream.end(JSON.stringify({ message: "service unavailable" }));
+        return;
+      }
+      if (typeof response === "string") {
+        stream.respond({ ":status": 200, "content-type": "application/json" });
+        stream.end(response);
+        return;
+      }
+      stream.respond({
+        ":status": 200,
+        "content-type": "application/vnd.amazon.eventstream",
+      });
+      for (const frame of response) {
+        stream.write(encodeEventFrame(frame));
+      }
+      stream.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    calls,
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** Point the AWS SDK at the stand-in with credentials that can sign. */
+function withEnv(port: number): () => void {
+  const saved: Record<string, string | undefined> = {};
+  const set = (k: string, v: string) => {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  };
+  set("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", `http://127.0.0.1:${port}`);
+  set("AWS_ACCESS_KEY_ID", "test-fake-aws-key-id");
+  set("AWS_SECRET_ACCESS_KEY", "test-fake-aws-secret");
+  set("AWS_REGION", "us-east-1");
+  saved.AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN;
+  delete process.env.AWS_SESSION_TOKEN;
+  return () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  };
+}
+
+/**
+ * A built-in tool, so it resolves through the provider's own registry.
+ * The loop-mechanics cases below use this rather than a caller-supplied tool
+ * because caller-supplied tools do not currently execute on Bedrock at all —
+ * pinned separately in the "caller-supplied tools" section.
+ */
+const BUILT_IN_TOOL = "getCurrentTime";
+
+/** A caller-supplied tool, the kind an SDK consumer passes to generate/stream. */
+function customTool(counter: { calls: number }) {
+  return {
+    lookup: {
+      description: "look a value up",
+      inputSchema: z.object({}).passthrough(),
+      execute: async () => {
+        counter.calls++;
+        return { found: true };
+      },
+    },
+  };
+}
+
+section("streaming loop");
+
+await test("a text-only turn streams its text and stops after one call", async () => {
+  const server = await startStandIn(() => textFrames("hello from bedrock"));
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      text += chunk?.content ?? "";
+    }
+    assert(
+      text.includes("hello from bedrock"),
+      "the streamed text was not surfaced to the consumer",
+    );
+    assert(
+      server.calls.length === 1,
+      `a text-only turn should take exactly one call, took ${server.calls.length}`,
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("a tool_use turn runs the tool and finishes on the following turn", async () => {
+  const server = await startStandIn((i) =>
+    i === 0 ? toolUseFrames(BUILT_IN_TOOL, {}, "tool_1") : textFrames("done"),
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "what time is it" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      text += chunk?.content ?? "";
+    }
+    assert(
+      server.calls.length === 2,
+      `a tool round trip should take exactly two calls, took ${server.calls.length}`,
+    );
+    const results = toolResults(server.calls[1]);
+    assert(
+      results.length === 1,
+      `the follow-up call should carry exactly one tool result, carried ${results.length}`,
+    );
+    assert(
+      results[0]?.status === "success",
+      "the tool result sent back to the model was not a success",
+    );
+    assert(text.includes("done"), "the final turn's text was not surfaced");
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("the streaming cap is exactly maxSteps, and reaching it returns", async () => {
+  // Both halves of this were defects before the migration, and both were
+  // pinned here as such.
+  //
+  // The count was off by one: the old loop made its first Converse call
+  // inline, before `while (iteration < maxIterations)` was entered with
+  // `iteration` still 0, so maxSteps=3 bought 4 billed calls. The engine
+  // counts every step against one bound.
+  //
+  // Reaching the bound then threw, so the caller lost every tool result and
+  // every token already streamed. It now ends the turn and reports
+  // finishReason "tool-calls", which is what every other family does.
+  const server = await startStandIn((i) =>
+    toolUseFrames(BUILT_IN_TOOL, {}, `tool_${i}`),
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "keep going" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    assert(
+      server.calls.length === 3,
+      `maxSteps=3 should buy exactly 3 calls, but the turn made ${server.calls.length}`,
+    );
+    assert(
+      result.metadata?.finishReason === "tool-calls",
+      "a turn cut off at the step cap should report finishReason tool-calls",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+section("generate loop");
+
+await test("a text-only generate turn returns its text after one call", async () => {
+  const server = await startStandIn(() => converseText("generated answer"));
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+    });
+    assert(
+      typeof result?.content === "string" &&
+        result.content.includes("generated answer"),
+      "generate did not return the model's text",
+    );
+    assert(
+      server.calls.length === 1,
+      `a text-only generate should take exactly one call, took ${server.calls.length}`,
+    );
+    assert(
+      server.calls.every((c) => !c.streaming),
+      "the generate path should use the non-streaming Converse operation",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("a generate tool_use turn runs the tool and finishes on the following turn", async () => {
+  const server = await startStandIn((i) =>
+    i === 0
+      ? converseToolUse(BUILT_IN_TOOL, {}, "tool_1")
+      : converseText("generated done"),
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "what time is it" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+    });
+    assert(
+      server.calls.length === 2,
+      `a generate tool round trip should take exactly two calls, took ${server.calls.length}`,
+    );
+    const results = toolResults(server.calls[1]);
+    assert(
+      results.length === 1,
+      `the follow-up call should carry exactly one tool result, carried ${results.length}`,
+    );
+    assert(
+      typeof result?.content === "string" &&
+        result.content.includes("generated done"),
+      "the final turn's text was not returned",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("the generate cap honours maxSteps and keeps the model's text", async () => {
+  // The generate loop used to ignore `maxSteps` entirely, counting to a
+  // literal 10 and then throwing. The throw propagated into NeuroLink's own
+  // provider-level retry, which ran the whole turn twice more, so a runaway
+  // tool loop cost thirty billed model calls where the caller asked for
+  // three.
+  //
+  // The text assertion is the second half, and it is why the count is 3 and
+  // not 9. A turn that runs out of steps mid-tool-call has no "final" step,
+  // so the engine returned an empty string and discarded everything the
+  // model had said — and empty content reads as a failed generation to the
+  // retry layer, which then ran the turn three times over.
+  const server = await startStandIn(() =>
+    converseToolUse(BUILT_IN_TOOL, {}, "tool_x", "still working"),
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "keep going" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+    });
+    assert(
+      server.calls.length === 3,
+      `maxSteps=3 should buy exactly 3 calls, but the turn made ${server.calls.length}`,
+    );
+    assert(
+      typeof result?.content === "string" &&
+        result.content.includes("still working"),
+      "a turn stopped at the step cap should still return what the model said",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("assistant text emitted before a tool call survives into the next step", async () => {
+  // Bedrock does not necessarily announce a text block with
+  // `contentBlockStart` — the first event for it can be a delta. Keying
+  // blocks by arrival order therefore dropped any text that preceded a
+  // toolUse block from the assistant turn replayed on the following step:
+  // the consumer saw the text, but the model stopped seeing its own
+  // reasoning. Blocks are keyed by `contentBlockIndex` instead.
+  const server = await startStandIn((i) =>
+    i === 0
+      ? [
+          { type: "messageStart", payload: { role: "assistant" } },
+          {
+            type: "contentBlockDelta",
+            payload: { contentBlockIndex: 0, delta: { text: "let me check" } },
+          },
+          {
+            type: "contentBlockStop",
+            payload: { contentBlockIndex: 0 },
+          },
+          {
+            type: "contentBlockStart",
+            payload: {
+              contentBlockIndex: 1,
+              start: { toolUse: { name: BUILT_IN_TOOL, toolUseId: "tool_1" } },
+            },
+          },
+          {
+            type: "contentBlockDelta",
+            payload: {
+              contentBlockIndex: 1,
+              delta: { toolUse: { input: "{}" } },
+            },
+          },
+          {
+            type: "contentBlockStop",
+            payload: { contentBlockIndex: 1 },
+          },
+          { type: "messageStop", payload: { stopReason: "tool_use" } },
+          {
+            type: "metadata",
+            payload: {
+              usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+            },
+          },
+        ]
+      : textFrames("done"),
+  );
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "what time is it" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+    });
+    let streamed = "";
+    for await (const chunk of result.stream) {
+      streamed += chunk?.content ?? "";
+    }
+    assert(
+      streamed.includes("let me check"),
+      "the pre-tool-call text never reached the consumer",
+    );
+    const replayed = JSON.stringify(server.calls[1]?.body ?? {});
+    assert(
+      replayed.includes("let me check"),
+      "the pre-tool-call text was dropped from the conversation sent back to the model",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("disableTools declares no tools on either path", async () => {
+  // The generate path reaches its loop without BaseProvider's tool
+  // preparation, so `options.tools` is undefined there and the getAllTools()
+  // fallback would hand the model the whole registry even though the caller
+  // asked for none.
+  const generateServer = await startStandIn(() => converseText("no tools"));
+  let restore = withEnv(generateServer.port);
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      disableTools: true,
+    });
+    assert(
+      declaredToolNames(generateServer.calls[0]).length === 0,
+      "the generate path declared tools despite disableTools",
+    );
+  } finally {
+    restore();
+    await generateServer.close();
+  }
+
+  const streamServer = await startStandIn(() => textFrames("no tools"));
+  restore = withEnv(streamServer.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      disableTools: true,
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    assert(
+      declaredToolNames(streamServer.calls[0]).length === 0,
+      "the streaming path declared tools despite disableTools",
+    );
+  } finally {
+    restore();
+    await streamServer.close();
+  }
+});
+
+await test("analytics resolves for a caller that never drains the stream", async () => {
+  // `result.analytics` used to be resolved only inside the stream iterator's
+  // finally block, so a caller that awaited it without iterating waited
+  // forever — the generator body never runs.
+  const server = await startStandIn(() => textFrames("ignored"));
+  const restore = withEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+    });
+    // The timer is cleared rather than left pending: an uncleared timeout
+    // keeps the event loop alive and holds the whole suite open for its full
+    // duration after the assertion has already passed.
+    let timer: NodeJS.Timeout | undefined;
+    const analytics = await Promise.race([
+      Promise.resolve(result.analytics),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve("TIMED_OUT"), 15_000);
+      }),
+    ]).finally(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
+    assert(
+      analytics !== "TIMED_OUT",
+      "analytics never settled for a caller that did not drain the stream",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("generate and stream agree on the finish reason for the same turn", async () => {
+  // Both paths ran a turn to the step cap, and before this they disagreed:
+  // generate surfaced Bedrock's raw "tool_use" while stream surfaced the
+  // mapped "tool-calls". Callers that branch on finishReason would have had
+  // to special-case which method they called.
+  const generateServer = await startStandIn(() =>
+    converseToolUse(BUILT_IN_TOOL, {}, "tool_x", "still working"),
+  );
+  let restore = withEnv(generateServer.port);
+  let generateFinish: string | undefined;
+  let generateRaw: string | undefined;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "keep going" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 2,
+      disableTools: false,
+    });
+    generateFinish = result?.finishReason;
+    generateRaw = result?.rawFinishReason;
+  } finally {
+    restore();
+    await generateServer.close();
+  }
+
+  const streamServer = await startStandIn((i) =>
+    toolUseFrames(BUILT_IN_TOOL, {}, `tool_${i}`),
+  );
+  restore = withEnv(streamServer.port);
+  let streamFinish: string | undefined;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "keep going" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 2,
+      disableTools: false,
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    streamFinish = result.metadata?.finishReason;
+  } finally {
+    restore();
+    await streamServer.close();
+  }
+
+  assert(
+    generateFinish === "tool-calls",
+    "generate did not report the mapped finish reason for a capped turn",
+  );
+  assert(
+    generateFinish === streamFinish,
+    "generate and stream reported different finish reasons for the same turn shape",
+  );
+  assert(
+    generateRaw === "tool_use",
+    "the raw provider finish reason was dropped instead of kept alongside",
+  );
+});
+
+section("caller-supplied tools");
+
+// Before the migration, neither of these worked. Bedrock resolved tool
+// execution through `getAllTools()` — the provider's own registry — rather
+// than the tools the caller passed for this turn, so an SDK consumer's own
+// tool could never run: the streaming path declared it to the model and then
+// failed every call to it with "Tool not found", and the generate path never
+// declared it at all.
+
+await test("a caller's own tool is declared to the model on the streaming path", async () => {
+  const server = await startStandIn(() => textFrames("hi"));
+  const restore = withEnv(server.port);
+  const counter = { calls: 0 };
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      disableTools: false,
+      tools: customTool(counter),
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    assert(
+      declaredToolNames(server.calls[0]).includes("lookup"),
+      "the streaming path did not declare the caller's tool to the model",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("a caller's own tool executes, on both paths", async () => {
+  const streamServer = await startStandIn((i) =>
+    i === 0 ? toolUseFrames("lookup", {}, "tool_1") : textFrames("after"),
+  );
+  let restore = withEnv(streamServer.port);
+  const streamCounter = { calls: 0 };
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "look something up" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      tools: customTool(streamCounter),
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    assert(
+      streamCounter.calls === 1,
+      "the caller's tool did not execute on the streaming path",
+    );
+    const results = toolResults(streamServer.calls[1]);
+    assert(
+      results[0]?.status === "success",
+      "the streaming path sent back a failed tool result",
+    );
+  } finally {
+    restore();
+    await streamServer.close();
+  }
+
+  const generateServer = await startStandIn((i) =>
+    i === 0
+      ? converseToolUse("lookup", {}, "tool_1")
+      : converseText("generated after"),
+  );
+  restore = withEnv(generateServer.port);
+  const generateCounter = { calls: 0 };
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "look something up" },
+      provider: "bedrock",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      tools: customTool(generateCounter),
+    });
+    assert(
+      declaredToolNames(generateServer.calls[0]).includes("lookup"),
+      "the generate path did not declare the caller's tool to the model",
+    );
+    assert(
+      generateCounter.calls === 1,
+      "the caller's tool did not execute on the generate path",
+    );
+  } finally {
+    restore();
+    await generateServer.close();
+  }
+});
+
+await runSuite();


### PR DESCRIPTION
Plan 08 Task 4. Bedrock had two hand-rolled agentic turn loops — one for `Converse`, one for `ConverseStream` — and between them they duplicated the same content-block accumulation **three** times, because the streaming loop ran its first iteration inline and then again inside `processStreamResponse`. Both now call `runAgenticLoop`; everything wire-format-specific moves into a new `loopAdapter`.

**1411 lines deleted against 783 added**, and seven methods removed once nothing called them: `callBedrock`, `handleBedrockResponse`, `prepareStreamCommand`, `processStreamResponse`, `handleStreamStopReason`, `executeStreamTools`, `convertToAsyncIterable`.

## The characterization suite came first

It was written and committed against the **unmigrated** code, so the migration has a baseline it cannot quietly move. It drives the shipped surface only — `NeuroLink` from `dist/index.js`, nothing stubbed — and points the provider's real AWS SDK client at a local server via the documented `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` variable. Requests are really signed with SigV4 and really routed, and assertions are about calls that actually go out on the wire. The stand-in speaks cleartext HTTP/2 (the Bedrock client defaults to `NodeHttp2Handler` and refuses HTTP/1.1 before sending anything) and answers streaming calls in the real `vnd.amazon.eventstream` binary framing, so the SDK's own decoder runs too. Its frame encoder is a local helper, not a new dependency — verified byte-for-byte against `@smithy/eventstream-codec` for every frame type used.

The brief specified the opposite — import from `src/` and replace the private client's `send` — on the grounds that *"no endpoint/baseURL override exists, so there is no way to redirect its AWS SDK v3 client at a local mock server through the public dist surface."* That is not so, and the difference earns its keep: counting real requests pins the call count more directly than counting calls to a replaced method, the real path exercises signing and event-stream decoding a replaced `send` skips, and it needs no rule-15 allow-list entry.

## Four defects it found, none of them in the brief

Two of the brief's own three cases assert behaviour this code does not have, and could not have passed as written.

| | Before | After |
|---|---|---|
| A caller's own tools | never execute | execute on both paths |
| Streaming step cap | `maxSteps` + 1 calls | exactly `maxSteps` |
| Reaching either cap | throws, losing all output | returns, `finishReason: "tool-calls"` |
| Runaway generate turn | **30** billed calls | **3** |

**Callers' tools could not execute at all.** `executeSingleTool` resolved through `getAllTools()` — the provider's own registry — rather than the tools passed for this turn. The streaming path advertised the caller's tool to the model and then failed every call to it with `Tool not found`; the generate path never advertised it. It now takes the turn's merged tool set as an argument.

**The generate loop ignored `maxSteps`,** counting to a literal 10 and then throwing — and the throw propagated into NeuroLink's own provider-level retry, which ran the whole turn twice more.

## It also found a defect in the engine

Which is what migrating Bedrock first was for. `runAgenticLoop` only kept a step's text when that step requested no tools, so a turn that ran out of steps mid-tool-call returned an empty string and discarded everything the model had said. Empty content also reads as a failed generation to the retry layer — that is why the runaway count was 9 rather than 3. The engine now falls back to the last step's text in that case only; when a loop ends normally, an empty final step genuinely means the model said nothing.

## Preserved deliberately

The provider's first call was made synchronously so permission failures reach `executeStream`, which falls back to non-streaming `generate()` on them. The engine runs the turn in the background, so that guarantee is now explicit: the adapter reports its first step separately and `streamingConversationLoop` waits for it before returning. The wait is also released by the turn's own outcome, so an abort before the first request cannot leave it pending.

Rebased onto the cross-region inference-profile fix (#1380) that landed in between. That change wrapped the provider's two Converse send sites; this refactor moves both into the adapter, so the wrapping moved with them rather than being silently dropped — its suite still passes unmodified.

## Verification

| Suite | Result |
|---|---|
| `bedrock-loop-characterization` | 8 passed (and 8 passed pre-migration, with the four defects pinned as they were) |
| `bedrock-inference-profile` | 5 passed |
| `loop-engine` | 18 passed |
| `providers-mocked` | 54 passed |
| `provider-structure` | 3 passed |
| `error-classifier-contract` | 40 passed |

Sanity-checked against the harness skip hazard: a deliberately broken assertion reports a failure and a non-zero exit, not a skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for caller-supplied tools in Amazon Bedrock generation and streaming.
  * Improved multi-step tool interactions, usage metrics, finish reasons, and streaming responses.
  * Preserved the latest model text when execution reaches the configured step limit.

* **Bug Fixes**
  * Improved Bedrock fallback, timeout, cancellation, and error handling.

* **Tests**
  * Added comprehensive Bedrock coverage for text responses, tools, streaming, step limits, and finish reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->