### PR TITLE
feat(core): give BaseProvider a default executeStream via a doStream hook

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -26,7 +26,13 @@ import type {
   ValidationSchema,
   ZodUnknownSchema,
 } from "../types/index.js";
-import { isAbortError, NeuroLinkError } from "../utils/errorHandling.js";
+import {
+  ERROR_CODES,
+  isAbortError,
+  NeuroLinkError,
+} from "../utils/errorHandling.js";
+import { createAnalytics as buildAnalytics } from "./analytics.js";
+import { ErrorCategory, ErrorSeverity } from "../constants/enums.js";
 import {
   duckTypedStatusCode,
   extractRetryAfterMsFromError,
@@ -1928,12 +1934,108 @@ export abstract class BaseProvider implements AIProvider {
   // ===================
 
   /**
-   * Provider-specific streaming implementation (only used when tools are disabled)
+   * Opt-in streaming hook. A provider that produces an async iterable of text
+   * chunks plus promises for how the turn ended implements this and gets a
+   * working `executeStream` for free.
+   *
+   * Deliberately optional rather than abstract: every provider that already
+   * overrides `executeStream` directly — the older and still perfectly valid
+   * pattern — never needs it.
+   *
+   * `finishReason` and `usage` are promises because both are only knowable
+   * once the underlying stream has finished. Resolve them when it does; the
+   * default `executeStream` chains off them rather than waiting for a
+   * consumer, so they must settle even if nobody drains the stream.
    */
-  protected abstract executeStream(
+  protected doStream?(options: StreamOptions): Promise<{
+    stream: AsyncIterable<{ content: string }>;
+    finishReason: Promise<string>;
+    usage: Promise<{ inputTokens: number; outputTokens: number }>;
+    warnings?: string[];
+  }>;
+
+  /**
+   * Provider-specific streaming implementation (only used when tools are
+   * disabled).
+   *
+   * This used to be `protected abstract`, which meant a provider had exactly
+   * two options: write the whole adapter by hand, or not stream at all. The
+   * failure mode that produced was SageMaker's — a complete, working
+   * `doStream` sitting one property access away from an `executeStream` that
+   * unconditionally threw "not yet fully implemented". Providers that
+   * implement `doStream` now inherit a correct implementation, and providers
+   * that override this method are unaffected.
+   */
+  protected async executeStream(
     options: StreamOptions,
-    analysisSchema?: ValidationSchema,
-  ): Promise<StreamResult>;
+    _analysisSchema?: ValidationSchema,
+  ): Promise<StreamResult> {
+    if (!this.doStream) {
+      throw new NeuroLinkError({
+        code: ERROR_CODES.INVALID_CONFIGURATION,
+        message: `${this.providerName} cannot stream: it neither implements doStream() nor overrides executeStream()`,
+        category: ErrorCategory.CONFIGURATION,
+        severity: ErrorSeverity.CRITICAL,
+        retriable: false,
+        context: { provider: this.providerName, model: this.modelName },
+      });
+    }
+
+    const startTime = Date.now();
+    const { stream, finishReason, usage, warnings } =
+      await this.doStream(options);
+
+    if (warnings?.length) {
+      logger.warn(`[${this.providerName}] doStream reported warnings`, {
+        provider: this.providerName,
+        count: warnings.length,
+      });
+    }
+
+    // `metadata` is handed back by reference and filled in when the turn
+    // ends — the documented contract for background-loop streams, since a
+    // result-object spread would snapshot a top-level getter before the
+    // stream has produced anything.
+    const metadata: NonNullable<StreamResult["metadata"]> = {
+      startTime,
+      streamId: `${this.providerName}-${startTime}`,
+    };
+
+    // Chained off the provider's own promises rather than off the consumer
+    // draining the stream. Binding analytics to a stream iterator's finally
+    // block means a caller that awaits analytics without iterating waits
+    // forever, because a generator body does not run until it is iterated.
+    const analytics = (async () => {
+      const [resolvedFinishReason, resolvedUsage] = await Promise.all([
+        finishReason,
+        usage,
+      ]);
+      metadata.finishReason = resolvedFinishReason;
+      metadata.rawFinishReason = resolvedFinishReason;
+      return buildAnalytics(
+        this.providerName,
+        this.modelName || this.getDefaultModel(),
+        {
+          usage: {
+            input: resolvedUsage.inputTokens,
+            output: resolvedUsage.outputTokens,
+            total: resolvedUsage.inputTokens + resolvedUsage.outputTokens,
+          },
+          stopReason: resolvedFinishReason,
+        },
+        Date.now() - startTime,
+        { streamingMode: true },
+      );
+    })();
+
+    return {
+      stream,
+      model: this.modelName || this.getDefaultModel(),
+      provider: this.getProviderName(),
+      analytics,
+      metadata,
+    };
+  }
 
   /**
    * Get the provider name

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -9,8 +9,9 @@ import "dotenv/config";
  * `../src/...`. This is the deliberate, documented exception to rule 15's
  * "one module graph per suite, end-to-end tests only" mandate. The three
  * modules under test — `src/lib/core/streamChannel.ts`,
- * `src/lib/core/nativeToolFormat.ts` (added by Task 2), and
- * `src/lib/core/loopEngine.ts` (added by Task 3) — have no exported surface
+ * `src/lib/core/nativeToolFormat.ts` (added by Task 2),
+ * `src/lib/core/loopEngine.ts` (added by Task 3), and `BaseProvider`'s
+ * default `executeStream` (added by Task 5) — have no exported surface
  * at all: none of them is reachable through package.json's `exports` map
  * (`.`, `./client`, `./types`, `./cli`, `./server`, `./browser`, ... — no
  * entry resolves into `src/lib/core/`), and as of this PR nothing outside
@@ -33,6 +34,12 @@ import "dotenv/config";
  *     been pushed to the channel does NOT retry and surfaces the original,
  *     unwrapped error). No provider is wired to the engine yet, so there is
  *     no live call that could exercise this at all.
+ *   - `BaseProvider`'s default `executeStream`, which only exists for
+ *     subclasses that implement the optional `doStream` hook. `BaseProvider`
+ *     is abstract and never constructed by callers, so there is no shipped
+ *     surface that reaches the default at all until a provider adopts it
+ *     (Task 6, SageMaker). This suite builds minimal fake subclasses so the
+ *     contract is pinned before anything depends on it.
  *
  * No API keys, no network, no LLM.
  *
@@ -44,6 +51,9 @@ import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
 import { createStreamChannel } from "../src/lib/core/streamChannel.js";
 import { toNativeToolDeclarations } from "../src/lib/core/nativeToolFormat.js";
 import { runAgenticLoop } from "../src/lib/core/loopEngine.js";
+import { BaseProvider } from "../src/lib/core/baseProvider.js";
+import type { AIProviderName } from "../src/lib/constants/enums.js";
+import type { StreamOptions } from "../src/lib/types/index.js";
 import type {
   AgenticLoopAdapter,
   AgenticLoopStepResult,
@@ -646,6 +656,152 @@ await test("runAgenticLoop: a stream-only consumer observes the failure — the 
     resultRejected = true;
   }
   assert(resultRejected, "resultPromise also rejects for the same failure");
+});
+
+// ---------------------------------------------------------------------------
+// BaseProvider's default executeStream (Plan 08, Task 5)
+// ---------------------------------------------------------------------------
+
+/** The smallest subclass that satisfies BaseProvider's remaining abstracts. */
+abstract class FakeProviderBase extends BaseProvider {
+  protected getProviderName(): AIProviderName {
+    return "fake" as AIProviderName;
+  }
+  protected getDefaultModel(): string {
+    return "fake-model";
+  }
+  public getAISDKModel(): never {
+    throw new Error("not used by these cases");
+  }
+  protected formatProviderError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+class WorkingDoStreamProvider extends FakeProviderBase {
+  protected async doStream(_options: StreamOptions) {
+    async function* chunks() {
+      yield { content: "hello " };
+      yield { content: "world" };
+    }
+    return {
+      stream: chunks(),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 3, outputTokens: 2 }),
+      warnings: [],
+    };
+  }
+}
+
+class ThrowingDoStreamProvider extends FakeProviderBase {
+  protected async doStream(_options: StreamOptions): Promise<never> {
+    throw new Error("synthetic doStream failure");
+  }
+}
+
+/** Implements neither doStream nor an executeStream override. */
+class NoStreamProvider extends FakeProviderBase {}
+
+await test("the default executeStream streams a doStream provider's chunks", async () => {
+  const provider = new WorkingDoStreamProvider("fake-model");
+  const result = await provider.stream({ input: { text: "hi there" } });
+  let text = "";
+  for await (const chunk of result.stream) {
+    text += chunk.content ?? "";
+  }
+  assertEqual(
+    text,
+    "hello world",
+    "streamed text did not match doStream's chunks",
+  );
+});
+
+await test("the default executeStream reports finishReason and usage from doStream's promises", async () => {
+  const provider = new WorkingDoStreamProvider("fake-model");
+  const result = await provider.stream({ input: { text: "hi there" } });
+  for await (const chunk of result.stream) {
+    void chunk;
+  }
+  const analytics = await result.analytics;
+  assertEqual(
+    analytics?.tokenUsage?.output,
+    2,
+    "usage was not the value doStream's promise resolved to",
+  );
+  assertEqual(
+    result.metadata?.finishReason,
+    "stop",
+    "finishReason was not the value doStream's promise resolved to",
+  );
+});
+
+await test("analytics settles even when the consumer never drains the stream", async () => {
+  // Binding analytics to the stream iterator's finally block is the natural
+  // shape and the wrong one: a generator body does not run until iterated, so
+  // a caller that awaits analytics without consuming the stream waits
+  // forever. That exact bug shipped in the Bedrock provider and is pinned
+  // here so the shared default cannot reintroduce it.
+  const provider = new WorkingDoStreamProvider("fake-model");
+  const result = await provider.stream({ input: { text: "hi there" } });
+  // The timer is cleared rather than left pending: an uncleared timeout keeps
+  // the event loop alive and holds the suite open for its full duration after
+  // the assertion has already passed.
+  let timer: NodeJS.Timeout | undefined;
+  const settled = await Promise.race([
+    Promise.resolve(result.analytics).then(() => "SETTLED"),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve("TIMED_OUT"), 10_000);
+    }),
+  ]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+  assertEqual(settled, "SETTLED", "analytics never settled without a drain");
+});
+
+await test("a doStream rejection propagates instead of being swallowed", async () => {
+  const provider = new ThrowingDoStreamProvider("fake-model");
+  let threw = false;
+  try {
+    const result = await provider.stream({ input: { text: "hi" } });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+  } catch {
+    threw = true;
+  }
+  assert(
+    threw,
+    "a doStream rejection must propagate, not be silently swallowed",
+  );
+});
+
+await test("a provider with neither doStream nor an override never yields a silent empty stream", async () => {
+  // The default's throw is deliberately not asserted on here. `stream()`
+  // re-throws only a small allowlist (abort/timeout/401/403/quota/rate
+  // limit/authentication) and falls back to fake streaming for everything
+  // else, so this provider degrades through generate() rather than
+  // surfacing the configuration error — which is the intended behaviour,
+  // and why the default's message shows up in logs rather than to the
+  // caller. What must never happen is the third outcome: a clean, empty,
+  // apparently-successful stream that silently produces nothing.
+  const provider = new NoStreamProvider("fake-model");
+  let failed = false;
+  let chunkCount = 0;
+  try {
+    const result = await provider.stream({ input: { text: "hi" } });
+    for await (const chunk of result.stream) {
+      chunkCount++;
+      void chunk;
+    }
+  } catch {
+    failed = true;
+  }
+  assert(
+    failed || chunkCount > 0,
+    "a provider that cannot stream produced a silent empty success",
+  );
 });
 
 await runSuite();


### PR DESCRIPTION
Plan 08 Task 5. `executeStream` was `protected abstract`, so a provider had exactly two options: hand-write the whole adapter, or not stream at all.

The failure mode that produced is SageMaker's, which Task 6 migrates — a complete, working `doStream` sitting **one property access away** from an `executeStream` that unconditionally threw `"SageMaker streaming not yet fully implemented"`.

`executeStream` becomes a concrete default, and a new optional `doStream` hook is added. A provider that implements `doStream` inherits a correct implementation; a provider that overrides `executeStream` directly — the older and still valid pattern, used by Bedrock, Anthropic and Vertex — is untouched. Nothing becomes abstract that wasn't already, so no existing provider changes.

## Analytics is bound to the turn, not to the drain

Chained off the promises `doStream` returns rather than off the consumer draining the stream. Binding it to a stream iterator's `finally` block is the natural shape and the wrong one: a generator body doesn't run until it's iterated, so a caller that awaits analytics without consuming the stream waits forever.

That exact bug shipped in the Bedrock provider and was fixed there this week. A case pins it here so the shared default can't reintroduce it for every provider at once. Verified by mutation — making the analytics promise never settle fails that case and only that case.

## Four brief/code mismatches

Following the task brief literally would have produced something that cannot compile or pass:

| Brief says | Code actually has |
|---|---|
| `buildMessagesForStream` returns `{messages, systemPrompt?}` | async, returns `Promise<ModelMessage[]>` — the brief's `{...options, ...built}` would spread **array indices** in as object keys |
| `ERROR_CODES.NOT_IMPLEMENTED` | doesn't exist; `INVALID_CONFIGURATION` does |
| `new NeuroLinkError(msg, code, ctx)` | takes a single options object |
| `analytics.finishReason` / `analytics.usage` | `AnalyticsData` has `tokenUsage` and `stopReason` — both brief assertions could never have passed |

The default passes `options` straight through and lets the provider build its own messages, which is what an AI-SDK-shaped `doStream` already does. `finishReason` is surfaced on `metadata`, the documented mutable reference for background-loop streams.

## The brief's fifth case rested on a wrong premise

It asserted that a provider with neither hook "fails with a clear reason". It doesn't, and shouldn't: `stream()` re-throws only a small allowlist (abort/timeout/401/403/quota/rate limit/authentication) and falls back to fake streaming for everything else, so such a provider **degrades through `generate()`** — the intended behaviour. My first run of that case failed with `"nope"` from the fake's `getAISDKModel()`, which is an artifact of an incomplete fake, not a defect.

What's worth pinning is the third outcome — that it must never yield a clean empty stream that silently produces nothing — and that's what the case now asserts.

## Rule 15

The suite's determinism exception is extended to name the fourth module and say what determinism buys: `BaseProvider` is abstract and never constructed by callers, so nothing shipped reaches the default until a provider adopts it in Task 6. The contract is pinned before anything depends on it.

## Verification

| Suite | Result |
|---|---|
| `loop-engine` | 23 passed (5 new) |
| `providers-mocked` | 54 passed |
| `provider-structure` | 3 passed |
| `error-classifier-contract` | 40 passed |