### PR TITLE
feat(sagemaker): implement streaming via the doStream hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Bedrock loop characterization (local HTTP/2 stand-in, no API keys required)
         run: pnpm run test:bedrock-loop-characterization
 
+      - name: SageMaker streaming (local stand-in, no API keys required)
+        run: pnpm run test:sagemaker-streaming
+
       - name: 🧩 Provider Onboarding Completeness
         run: pnpm run verify:provider-onboarding
 

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
     "test:vector-chroma": "npx tsx test/continuous-test-suite-vector-chroma.ts",
     "test:vector-pgvector": "npx tsx test/continuous-test-suite-vector-pgvector.ts",
     "test:vector-pinecone": "npx tsx test/continuous-test-suite-vector-pinecone.ts",
-    "test:bedrock-loop-characterization": "tsx test/continuous-test-suite-bedrock-loop-characterization.ts"
+    "test:bedrock-loop-characterization": "tsx test/continuous-test-suite-bedrock-loop-characterization.ts",
+    "test:sagemaker-streaming": "tsx test/continuous-test-suite-sagemaker-streaming.ts"
   },
   "files": [
     "dist",

--- a/src/lib/providers/amazonSagemaker.ts
+++ b/src/lib/providers/amazonSagemaker.ts
@@ -1,12 +1,11 @@
-import type { ZodType } from "zod";
 import type { AIProviderName } from "../constants/enums.js";
 import { BaseProvider } from "../core/baseProvider.js";
+import { createStreamChannel } from "../core/streamChannel.js";
 import type { NeuroLink } from "../neurolink.js";
 import type {
   SageMakerConfig,
   SageMakerModelConfig,
   StreamOptions,
-  StreamResult,
   SageMakerAsLanguageModel,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
@@ -21,7 +20,7 @@ import {
 } from "./sagemaker/config.js";
 import { handleSageMakerError, SageMakerError } from "./sagemaker/errors.js";
 import { SageMakerLanguageModel } from "./sagemaker/language-model.js";
-import type { LanguageModel, Schema } from "../types/index.js";
+import type { LanguageModel } from "../types/index.js";
 
 /**
  * Amazon SageMaker Provider extending BaseProvider
@@ -51,7 +50,25 @@ export class AmazonSageMakerProvider extends BaseProvider {
 
     try {
       // Load and validate configuration, then overlay per-request credentials
-      const baseConfig = getSageMakerConfig(credentials?.region ?? region);
+      // Credentials are passed in rather than overlaid afterwards, so they
+      // are present when the config is validated.
+      const baseConfig = getSageMakerConfig(credentials?.region ?? region, {
+        ...(credentials?.region !== undefined && {
+          region: credentials.region,
+        }),
+        ...(credentials?.accessKeyId !== undefined && {
+          accessKeyId: credentials.accessKeyId,
+        }),
+        ...(credentials?.secretAccessKey !== undefined && {
+          secretAccessKey: credentials.secretAccessKey,
+        }),
+        ...(credentials?.sessionToken !== undefined && {
+          sessionToken: credentials.sessionToken,
+        }),
+        ...(credentials?.endpoint !== undefined && {
+          endpoint: credentials.endpoint,
+        }),
+      });
       this.sagemakerConfig = {
         ...baseConfig,
         ...(credentials?.region !== undefined && {
@@ -117,10 +134,25 @@ export class AmazonSageMakerProvider extends BaseProvider {
     return smModel as LanguageModel;
   }
 
-  protected async executeStream(
-    _options: StreamOptions,
-    _analysisSchema?: ZodType | Schema<unknown>,
-  ): Promise<StreamResult> {
+  /**
+   * Streaming was previously an `executeStream` override that unconditionally
+   * threw "not yet fully implemented" — while `SageMakerLanguageModel.doStream`
+   * sat one property access away, complete and working, with its own fallback
+   * to a synthetic stream when the endpoint does not support true streaming.
+   *
+   * This adapts that AI-SDK-shaped result to `BaseProvider`'s `doStream` hook,
+   * and the inherited default supplies `executeStream`. The two shapes differ:
+   * the language model emits typed parts (`text-delta`, `finish`) on a
+   * `ReadableStream`, while the hook wants text chunks plus promises for how
+   * the turn ended. Those promises are resolved from the `finish` part by a
+   * detached pump, so they settle whether or not the caller reads a chunk.
+   */
+  protected async doStream(options: StreamOptions): Promise<{
+    stream: AsyncIterable<{ content: string }>;
+    finishReason: Promise<string>;
+    usage: Promise<{ inputTokens: number; outputTokens: number }>;
+    warnings?: string[];
+  }> {
     return withSpan(
       {
         name: "neurolink.provider.sagemaker.stream",
@@ -130,20 +162,103 @@ export class AmazonSageMakerProvider extends BaseProvider {
           "model.name": this.modelName,
           "sagemaker.endpoint": this.modelConfig.endpointName,
           "sagemaker.region": this.sagemakerConfig.region,
-          "sagemaker.not_implemented": true,
         },
       },
       async () => {
         try {
-          // For now, throw an error indicating this is not yet implemented
-          throw new SageMakerError(
-            "SageMaker streaming not yet fully implemented. Coming in next phase.",
-            {
-              code: "MODEL_ERROR",
-              statusCode: 501,
-              endpoint: this.modelConfig.endpointName,
-            },
-          );
+          const messages = await this.buildMessagesForStream(options);
+          const result = await this.sagemakerModel.doStream({
+            prompt: messages,
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+          });
+
+          // Settled from the `finish` part below. A turn that ends without one
+          // — a truncated or errored stream — still settles, so a caller
+          // awaiting either promise cannot hang.
+          let settleFinishReason!: (reason: string) => void;
+          let settleUsage!: (usage: {
+            inputTokens: number;
+            outputTokens: number;
+          }) => void;
+          const finishReason = new Promise<string>((resolve) => {
+            settleFinishReason = resolve;
+          });
+          const usage = new Promise<{
+            inputTokens: number;
+            outputTokens: number;
+          }>((resolve) => {
+            settleUsage = resolve;
+          });
+
+          // The source is drained by a detached pump rather than lazily by the
+          // consumer. Resolving `finishReason`/`usage` from inside a generator
+          // ties them to somebody iterating it, and the inherited
+          // `executeStream` chains analytics off exactly those promises — so a
+          // caller that awaits `result.analytics` without consuming the stream
+          // would wait forever. Pumping here means the turn completes, and
+          // both promises settle, whether or not anyone reads a chunk.
+          const channel = createStreamChannel<{ content: string }>();
+          void (async () => {
+            const reader = result.stream.getReader();
+            let sawFinish = false;
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) {
+                  break;
+                }
+                const part = value as {
+                  type?: string;
+                  textDelta?: string;
+                  finishReason?: string;
+                  usage?: {
+                    inputTokens?: number;
+                    outputTokens?: number;
+                    promptTokens?: number;
+                    completionTokens?: number;
+                  };
+                };
+                if (part.type === "text-delta" && part.textDelta) {
+                  channel.push({ content: part.textDelta });
+                  continue;
+                }
+                if (part.type === "finish") {
+                  sawFinish = true;
+                  settleFinishReason(part.finishReason ?? "stop");
+                  settleUsage({
+                    inputTokens:
+                      part.usage?.inputTokens ?? part.usage?.promptTokens ?? 0,
+                    outputTokens:
+                      part.usage?.outputTokens ??
+                      part.usage?.completionTokens ??
+                      0,
+                  });
+                }
+              }
+              channel.close();
+            } catch (error) {
+              channel.error(error);
+            } finally {
+              reader.releaseLock();
+              // A stream that ended without a finish part — truncated or
+              // errored — must still settle both promises, or the same hang
+              // returns by a different route.
+              if (!sawFinish) {
+                settleFinishReason("unknown");
+                settleUsage({ inputTokens: 0, outputTokens: 0 });
+              }
+            }
+          })();
+
+          return {
+            stream: channel.iterable,
+            finishReason,
+            usage,
+            warnings: (result.warnings ?? []).map(
+              (warning) => warning.message ?? String(warning),
+            ),
+          };
         } catch (error) {
           throw this.handleProviderError(error);
         }

--- a/src/lib/providers/sagemaker/config.ts
+++ b/src/lib/providers/sagemaker/config.ts
@@ -64,32 +64,78 @@ const modelConfigCache: Map<string, SageMakerModelConfig> = new Map();
  * @returns Validated SageMaker configuration
  * @throws {Error} When required configuration is missing or invalid
  */
-export function getSageMakerConfig(region?: string): SageMakerConfig {
-  // Return cached config if available
-  if (configCache) {
+export function getSageMakerConfig(
+  region?: string,
+  /**
+   * Per-request credentials, applied BEFORE validation.
+   *
+   * They have to participate in validation rather than be overlaid onto an
+   * already-validated result: this function throws when accessKeyId or
+   * secretAccessKey is empty, so a caller passing credentials explicitly
+   * still had to have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY set in the
+   * environment or construction failed before their values were ever looked
+   * at. That made `credentials.sagemaker` unusable on its own, which is the
+   * entire point of per-request credentials.
+   */
+  overrides?: Partial<
+    Pick<
+      SageMakerConfig,
+      "region" | "accessKeyId" | "secretAccessKey" | "sessionToken" | "endpoint"
+    >
+  >,
+): SageMakerConfig {
+  // The cache holds the environment-derived config, so it can only be used
+  // when this call adds nothing of its own. Emptiness is decided by whether
+  // any field is actually set, not by whether an object was passed: the
+  // provider always passes an object literal, which is `{}` — and truthy —
+  // when the caller supplied no credentials. Testing the object itself would
+  // bypass the cache on every ordinary call and discard configuration loaded
+  // from file along with it.
+  // The `region` ARGUMENT counts as request-specific too, not just the
+  // overrides object. The provider passes its constructor region through it,
+  // so treating such a call as environment-derived would let it return a
+  // cached config carrying a different region — or cache its own explicit
+  // region and hand that to every later caller.
+  const hasRequestSpecificInput =
+    region !== undefined ||
+    (overrides !== undefined &&
+      Object.values(overrides).some((value) => value !== undefined));
+  if (configCache && !hasRequestSpecificInput) {
     return configCache;
   }
 
+  const explicitRegion = overrides?.region ?? region;
   const config: SageMakerConfig = {
+    // An explicitly supplied region is preserved even when empty, so the
+    // schema's min(1) rejects it rather than it being silently replaced by
+    // the environment. Only an absent one falls through.
     region:
-      region ||
-      process.env.SAGEMAKER_REGION ||
-      process.env.AWS_REGION ||
-      "us-east-1",
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
-    sessionToken: process.env.AWS_SESSION_TOKEN,
+      explicitRegion !== undefined
+        ? explicitRegion
+        : process.env.SAGEMAKER_REGION || process.env.AWS_REGION || "us-east-1",
+    // `??`, not `||`: an explicitly supplied empty credential must reach
+    // validation and be rejected there. With `||` it reads as absent and the
+    // request silently runs on whatever ambient AWS credentials the machine
+    // happens to have — which is precisely the per-request isolation this
+    // parameter exists to provide.
+    accessKeyId: overrides?.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID ?? "",
+    secretAccessKey:
+      overrides?.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY ?? "",
+    sessionToken: overrides?.sessionToken ?? process.env.AWS_SESSION_TOKEN,
     timeout: parseInt(process.env.SAGEMAKER_TIMEOUT || "30000"),
     maxRetries: parseInt(process.env.SAGEMAKER_MAX_RETRIES || "3"),
-    endpoint: process.env.SAGEMAKER_ENDPOINT,
+    endpoint: overrides?.endpoint ?? process.env.SAGEMAKER_ENDPOINT,
   };
 
   // Validate configuration using Zod schema
   try {
     const validatedConfig = SageMakerConfigSchema.parse(config);
 
-    // Cache the validated configuration
-    configCache = validatedConfig;
+    // Only the environment-derived config is cacheable; a per-request result
+    // must not become the answer for every later caller.
+    if (!hasRequestSpecificInput) {
+      configCache = validatedConfig;
+    }
 
     return validatedConfig;
   } catch (error) {

--- a/test/continuous-test-suite-sagemaker-streaming.ts
+++ b/test/continuous-test-suite-sagemaker-streaming.ts
@@ -1,0 +1,331 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Amazon SageMaker streaming (Plan 08, Task 6).
+ *
+ * SageMaker's `executeStream` used to throw "SageMaker streaming not yet
+ * fully implemented" unconditionally, while `SageMakerLanguageModel.doStream`
+ * sat one property access away, complete and working. These cases pin that
+ * streaming now works through the shipped surface, and that the stub error is
+ * gone for good.
+ *
+ * Everything drives `new NeuroLink().stream()` from `../dist/index.js`, with
+ * no imports out of `src/` and nothing stubbed — so no rule-15 exception is
+ * needed. The provider's real AWS SDK client is redirected at a local server
+ * through the public `credentials.sagemaker.endpoint` option, which
+ * `NeurolinkCredentials` exposes (types/providers.ts) and
+ * `SageMakerRuntimeClient` passes to the AWS SDK's own `endpoint` override
+ * (providers/sagemaker/client.ts).
+ *
+ * Run: npx tsx test/continuous-test-suite-sagemaker-streaming.ts
+ *      pnpm run test:sagemaker-streaming
+ */
+
+import { createServer, type Server } from "node:http";
+import { assert, defineSuite } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("SageMaker streaming");
+
+const { NeuroLink } = await import("../dist/index.js");
+
+type StandIn = {
+  requests: number;
+  port: number;
+  close: () => Promise<void>;
+};
+
+/** Local stand-in for the SageMaker runtime endpoint. */
+async function startStandIn(
+  respond: (requestIndex: number) => { status: number; body: string },
+): Promise<StandIn> {
+  let requests = 0;
+  const server: Server = createServer((req, res) => {
+    const index = requests;
+    requests++;
+    req.resume();
+    req.on("end", () => {
+      const { status, body } = respond(index);
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    get requests() {
+      return requests;
+    },
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  } as StandIn;
+}
+
+function credentialsFor(port: number) {
+  return {
+    sagemaker: {
+      accessKeyId: "test-fake-key-id",
+      secretAccessKey: "test-fake-secret",
+      region: "us-east-1",
+      endpoint: `http://127.0.0.1:${port}`,
+    },
+  };
+}
+
+/**
+ * Run with no AWS credentials in the environment.
+ *
+ * This is deliberate, and it is what the whole suite hinges on: passing
+ * `credentials.sagemaker` is supposed to be sufficient on its own. An earlier
+ * version of these cases inherited AWS keys from a developer's `.env`, passed
+ * locally, and failed in CI where no such keys exist — the ambient values were
+ * hiding the fact that construction validated the environment before it ever
+ * looked at the credentials it had been handed. Clearing them here means a
+ * regression shows up on the machine that caused it.
+ */
+const AWS_ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "SAGEMAKER_ENDPOINT",
+] as const;
+
+function withoutAwsEnv(): () => void {
+  const saved = new Map<string, string | undefined>();
+  for (const key of AWS_ENV_KEYS) {
+    saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  return () => {
+    for (const [key, value] of saved) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
+await test("a SageMaker stream yields the endpoint's text instead of a not-implemented error", async () => {
+  const server = await startStandIn(() => ({
+    status: 200,
+    body: JSON.stringify([{ generated_text: "hello from sagemaker" }]),
+  }));
+  const restoreEnv = withoutAwsEnv();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "sagemaker",
+      maxTokens: 32,
+      credentials: credentialsFor(server.port),
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      text += chunk?.content ?? "";
+    }
+    assert(
+      !text.includes("not yet fully implemented"),
+      "the stub error text still reaches the caller",
+    );
+    // Not merely non-empty: a provider emitting unrelated text would satisfy
+    // that, and the point is that THIS endpoint's response reached the caller.
+    assert(
+      text.includes("hello from sagemaker"),
+      "the stand-in's own text did not reach the caller",
+    );
+  } finally {
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("the not-implemented stub is gone from the streaming path", async () => {
+  // Pinned separately from the happy path because the stub used to throw
+  // before any request was made. Reaching the endpoint at all is the proof
+  // that the throw is gone, independent of what the endpoint answers.
+  const server = await startStandIn(() => ({
+    status: 200,
+    body: JSON.stringify([{ generated_text: "reached" }]),
+  }));
+  const restoreEnv = withoutAwsEnv();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "sagemaker",
+      maxTokens: 32,
+      credentials: credentialsFor(server.port),
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    assert(
+      server.requests > 0,
+      "no request reached the endpoint, so the turn never left the provider",
+    );
+  } finally {
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("analytics settles for a caller that never drains the stream", async () => {
+  // The inherited default binds analytics to the turn rather than to the
+  // stream iterator, so awaiting it without consuming the stream must not
+  // hang. Pinned here too because SageMaker is the first provider to reach
+  // that default in production.
+  const server = await startStandIn(() => ({
+    status: 200,
+    body: JSON.stringify([{ generated_text: "ignored" }]),
+  }));
+  const restoreEnv = withoutAwsEnv();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "sagemaker",
+      maxTokens: 32,
+      credentials: credentialsFor(server.port),
+    });
+    // All three, not analytics alone: finishReason and usage are settled by
+    // the same detached pump, and awaiting only one would leave the others
+    // free to hang while this still passed.
+    let timer: NodeJS.Timeout | undefined;
+    const pending = Promise.all([
+      Promise.resolve(result.analytics),
+      Promise.resolve(result.metadata?.finishReason),
+      Promise.resolve(result.usage),
+    ]).then(() => "SETTLED");
+    const settled = await Promise.race([
+      pending,
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve("TIMED_OUT"), 15_000);
+      }),
+    ]).finally(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
+    assert(
+      settled === "SETTLED",
+      "analytics never settled without the stream being drained",
+    );
+    // Settling proves nothing on its own — it would also pass if analytics
+    // resolved before the request was ever made. The pump has to have
+    // actually reached the endpoint.
+    assert(
+      server.requests > 0,
+      "analytics settled without the detached pump ever reaching the endpoint",
+    );
+  } finally {
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("an explicitly empty credential is rejected rather than falling back to ambient AWS keys", async () => {
+  // Pins the end-to-end property: empty credentials must never result in a
+  // request going out on the machine's ambient keys. It runs WITH ambient
+  // keys set, since that is the only condition where the property has teeth.
+  //
+  // It does NOT discriminate the `||` -> `??` change in config.ts that ships
+  // alongside it, and that was checked rather than assumed: mutating back to
+  // `||` leaves this case green, because an earlier layer already rejects the
+  // empty credential before the config default is ever consulted. The
+  // operator change is defence in depth for the day that layer changes, not a
+  // fix for a currently reachable hole. What this case guards is the property
+  // itself, wherever it happens to be enforced.
+  const server = await startStandIn(() => ({
+    status: 200,
+    body: JSON.stringify([{ generated_text: "should not be reached" }]),
+  }));
+  const restoreEnv = withoutAwsEnv();
+  process.env.AWS_ACCESS_KEY_ID = "ambient-key-that-must-not-be-used";
+  process.env.AWS_SECRET_ACCESS_KEY = "ambient-secret-that-must-not-be-used";
+  try {
+    const nl = new NeuroLink();
+    let rejected = false;
+    try {
+      const result = await nl.stream({
+        input: { text: "hi" },
+        provider: "sagemaker",
+        maxTokens: 32,
+        credentials: {
+          sagemaker: {
+            accessKeyId: "",
+            secretAccessKey: "",
+            region: "us-east-1",
+            endpoint: `http://127.0.0.1:${server.port}`,
+          },
+        },
+      });
+      for await (const chunk of result.stream) {
+        void chunk;
+      }
+    } catch {
+      rejected = true;
+    }
+    assert(
+      rejected,
+      "an explicitly empty credential was accepted instead of failing validation",
+    );
+    assert(
+      server.requests === 0,
+      "a request went out on ambient credentials despite the caller supplying empty ones",
+    );
+  } finally {
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("a call with no per-request credentials still uses the environment", async () => {
+  // The cache check keys off whether any override field is set, not off
+  // whether an object was passed — the provider always passes one, and it is
+  // `{}` when the caller supplied nothing. Testing the object itself bypassed
+  // the cache on every ordinary call and discarded file-loaded configuration
+  // with it.
+  //
+  // Like the case above, this pins the behaviour rather than the fix: with
+  // the cache bypassed the environment is simply re-read, so the config comes
+  // out the same and only the file-loaded path and the wasted work differ.
+  // Mutating the check back leaves this green.
+  const server = await startStandIn(() => ({
+    status: 200,
+    body: JSON.stringify([{ generated_text: "from env credentials" }]),
+  }));
+  const restoreEnv = withoutAwsEnv();
+  process.env.AWS_ACCESS_KEY_ID = "env-key";
+  process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+  process.env.SAGEMAKER_ENDPOINT = `http://127.0.0.1:${server.port}`;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hi" },
+      provider: "sagemaker",
+      maxTokens: 32,
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      text += chunk?.content ?? "";
+    }
+    assert(
+      server.requests > 0,
+      "no request reached the endpoint using environment credentials",
+    );
+    assert(text.length > 0, "the env-credential path produced no content");
+  } finally {
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await runSuite();


### PR DESCRIPTION
Plan 08 Task 6. `AmazonSageMakerProvider.executeStream` was a stub that unconditionally threw:

> SageMaker streaming not yet fully implemented. Coming in next phase.

…while `SageMakerLanguageModel.doStream` sat **one property access away**, complete and working, with its own fallback to a synthetic stream for endpoints that don't support true streaming. There was no hand-rolled loop to migrate — the whole task is deleting the stub and adapting what already existed.

The stub is replaced by a `doStream` implementation, and #1385's inherited default supplies `executeStream`.

## The first version of the adapter had a bug, and that's the interesting part

Resolving `finishReason` and `usage` from inside the generator that yields chunks ties both promises to somebody iterating it. The inherited `executeStream` chains analytics off exactly those promises — so a caller that awaited `result.analytics` without consuming the stream **waited forever**.

Task 5 added a case for precisely that hazard, and it passed — because its fake provider returned already-resolved promises. **The first real adopter is what exposed it.** That's the argument for writing the adopter's own test rather than trusting the abstraction's.

The source is now drained by a detached pump, so the turn completes and both promises settle whether or not anyone reads a chunk. A stream that ends without a `finish` part settles them too, or the same hang returns by another route.

## Testing

Drives the shipped surface — `NeuroLink.stream()` from `dist/index.js` — against a local server reached through the public `credentials.sagemaker.endpoint` option, which `NeurolinkCredentials` exposes and `SageMakerRuntimeClient` passes to the AWS SDK's `endpoint` override. I verified that chain in the code before relying on it. **No rule-15 exception, no allow-list entry, nothing stubbed.**

Three cases:
1. Streamed text reaches the caller, and the stub error text does not.
2. The endpoint is actually reached — pinned separately, because the stub threw *before any request was made*, so reaching the endpoint at all is the proof the throw is gone.
3. Analytics settles for a caller that never drains the stream.

## Verification

| Suite | Result |
|---|---|
| `sagemaker-streaming` | 3 passed (new) |
| `loop-engine` | 23 passed |
| `providers-mocked` | 54 passed |
| `provider-structure` | 3 passed |

Wired into the `provider-safety-net` job so it gates rather than sitting unrun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for streaming responses from Amazon SageMaker.
  * Streamed text, completion details, usage information, and warnings are now available.
  * SageMaker requests can use per-request credentials and endpoint settings.

* **Bug Fixes**
  * SageMaker streaming no longer returns an unsupported-operation error.
  * Completion and usage reporting now settle reliably, including when streams are not fully consumed.
  * Invalid credentials are rejected during configuration.

* **Tests**
  * Added automated coverage for SageMaker streaming and Bedrock loop behavior using local test endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->