### PR TITLE
feat(core): add resolveToolOnMiss hydration hook to AgenticLoopAdapter

### DIFF
--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -198,7 +198,16 @@ export function runAgenticLoop<TConversation>(
             });
             continue;
           }
-          const tool = options.tools?.[call.name];
+          // Second lookup path for adapters that discover tools mid-turn.
+          // The miss is defined as "nothing executable under this name"
+          // rather than "no key under this name", because the guard directly
+          // below already treats a present-but-unexecutable entry as absent —
+          // a deferred-catalog placeholder is exactly that shape, and it is
+          // precisely what hydration exists to resolve.
+          const declaredTool = options.tools?.[call.name];
+          const tool = declaredTool?.execute
+            ? declaredTool
+            : (adapter.resolveToolOnMiss?.(call.name) ?? declaredTool);
           if (!tool?.execute) {
             const output = breaker
               ? {

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -40,6 +40,46 @@ export type AgenticLoopToolFailureBreaker = {
   maxRetries: number;
 };
 
+/**
+ * DESIGN DECISION — mid-turn tool-discovery hydration (Plan 08 blocker 2,
+ * Task 7): resolved by the single optional `resolveToolOnMiss` field below,
+ * NOT by a broader `dispatchTools?` full-dispatch override. A full-dispatch
+ * override would let an adapter replace the engine's entire per-call
+ * dispatch — breaker bookkeeping, execution, toolExecutions aggregation — so
+ * every adapter needing hydration would have to reimplement that bookkeeping,
+ * and any later engine-level fix to dispatch would silently not apply to the
+ * adapters using the override. `resolveToolOnMiss` plugs into the existing
+ * dispatch at the one decision point that needs a second lookup, leaving
+ * breaker bookkeeping, retries and aggregation engine-owned for every
+ * provider, hydrated or not.
+ *
+ * DESIGN DECISION — originalNameMap propagation (blocker 3): needs ZERO
+ * engine or type change. Google's function-name sanitization is a translation
+ * concern between the wire (sanitized names out, sanitized names back on
+ * tool_call.name) and the engine's shape, which only ever sees plain string
+ * names. An adapter that needs the map threads it as a constructor-time
+ * closure and translates inside its own `executeStep` /
+ * `buildToolResultMessages`, before those names cross the engine boundary.
+ *
+ * DESIGN DECISION — reserved-step + forced finalization (blocker 1, part 2):
+ * stays OUTSIDE `runAgenticLoop`, in Vertex+Claude's own wrapper around
+ * `resultPromise`. The reserved step needs no engine change at all — an
+ * adapter declaring `maxSteps: requested - 1` means the engine's own loop
+ * never touches the reserved slot. The forced call is a one-shot action taken
+ * on the RESULT of a turn, not a repeatable step within one, so folding it in
+ * would teach the engine a family-specific concept (forced tool_choice, a
+ * distinguished terminal tool name) that every other adapter would then carry
+ * and never set.
+ *
+ * DESIGN DECISION — terminal tool-call marking (blocker 1, part 1): needs
+ * ZERO engine or type change. An adapter treats a detected terminal call as
+ * terminal by omitting it from `toolCalls` and putting its parsed payload in
+ * `text`. The engine already ends a turn the moment a step yields zero tool
+ * calls, so such a step is indistinguishable from an ordinary final text
+ * turn: never looked up in `options.tools`, never reaching TOOL_NOT_FOUND,
+ * never counted against the breaker. Proven by a case in the loop-engine
+ * suite rather than asserted here.
+ */
 export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
   readonly providerLabel: string;
   readonly maxSteps: number;
@@ -48,6 +88,23 @@ export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
   readonly stallTimeoutMs?: number;
   /** Set only for adapter instances whose client has the TOOL_NOT_FOUND strike breaker today: both Gemini adapters (AI Studio, Vertex+Gemini) AND the Vertex+Claude call to createAnthropicLoopAdapter — NOT the native-Anthropic call to that same factory, and not Bedrock. See Verified Fact 4. */
   readonly toolFailureBreaker?: AgenticLoopToolFailureBreaker;
+  /**
+   * Second lookup path, consulted when a tool call names nothing executable
+   * in the caller's `options.tools` — used by adapters supporting mid-turn
+   * discovery to hydrate a tool the model just found via `search_tools`, or a
+   * deferred-catalog tool called by its advertised name, before the engine
+   * falls through to TOOL_NOT_FOUND and the breaker strike. See the design
+   * decision above for why this is a narrow lookup and not a dispatch
+   * override.
+   */
+  readonly resolveToolOnMiss?: (name: string) =>
+    | {
+        execute: (
+          args: Record<string, unknown>,
+          opts: unknown,
+        ) => Promise<unknown>;
+      }
+    | undefined;
 
   buildStepRequest(
     conversation: TConversation,

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -804,4 +804,153 @@ await test("a provider with neither doStream nor an override never yields a sile
   );
 });
 
+// ---------------------------------------------------------------------------
+// resolveToolOnMiss hydration hook (Plan 08, Task 7)
+// ---------------------------------------------------------------------------
+
+function makeHydrationAdapter(config: {
+  toolCallsByStep: Array<
+    Array<{ id: string; name: string; args: Record<string, unknown> }>
+  >;
+  resolveToolOnMiss?: AgenticLoopAdapter<string[]>["resolveToolOnMiss"];
+}): AgenticLoopAdapter<string[]> {
+  let step = 0;
+  return {
+    providerLabel: "fake-hydration",
+    maxSteps: 5,
+    resolveToolOnMiss: config.resolveToolOnMiss,
+    buildStepRequest: (conversation) => ({ raw: conversation }),
+    executeStep: async () => {
+      const calls = config.toolCallsByStep[step] ?? [];
+      step++;
+      return {
+        text: calls.length === 0 ? "final answer" : "",
+        toolCalls: calls,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        rawStopReason: calls.length === 0 ? "end_turn" : "tool_use",
+        raw: undefined,
+      };
+    },
+    buildToolResultMessages: (conversation) => conversation,
+    mapFinishReason: (raw) => (raw === "end_turn" ? "stop" : "tool-calls"),
+  };
+}
+
+await test("a tool call absent from options.tools is hydrated rather than failing as TOOL_NOT_FOUND", async () => {
+  let hydratedArgs: Record<string, unknown> | undefined;
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [
+      [{ id: "call_1", name: "discovered_tool", args: { q: "x" } }],
+      [],
+    ],
+    resolveToolOnMiss: (name) =>
+      name === "discovered_tool"
+        ? {
+            execute: async (args) => {
+              hydratedArgs = args;
+              return { ok: true };
+            },
+          }
+        : undefined,
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], { tools: {} });
+  const result = await resultPromise;
+  assertEqual(hydratedArgs?.q, "x", "hydrated execute got the call's args");
+  const executed = result.toolExecutions.find(
+    (e) => e.name === "discovered_tool",
+  );
+  assert(
+    executed !== undefined &&
+      !("error" in ((executed.output ?? {}) as Record<string, unknown>)),
+    "a hydrated tool call must not be recorded as a failed execution",
+  );
+});
+
+await test("resolveToolOnMiss is not consulted when the name is already executable", async () => {
+  let consulted = false;
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [[{ id: "call_1", name: "known_tool", args: {} }], []],
+    resolveToolOnMiss: () => {
+      consulted = true;
+      return undefined;
+    },
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    tools: { known_tool: { execute: async () => ({ ok: true }) } },
+  });
+  await resultPromise;
+  assert(
+    !consulted,
+    "resolveToolOnMiss must only be consulted on a miss, not for an executable tool",
+  );
+});
+
+await test("a declared-but-unexecutable tool is treated as a miss and hydrated", async () => {
+  // A deferred-catalog placeholder is present under its name but carries no
+  // execute. The engine's own guard already treats that as absent, so
+  // hydration has to reach it too, or the very shape this hook exists for
+  // would fall straight through to TOOL_NOT_FOUND.
+  let hydrated = false;
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [[{ id: "call_1", name: "deferred_tool", args: {} }], []],
+    resolveToolOnMiss: (name) =>
+      name === "deferred_tool"
+        ? {
+            execute: async () => {
+              hydrated = true;
+              return { ok: true };
+            },
+          }
+        : undefined,
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    // Declared, but with nothing to run — the deferred-catalog shape.
+    tools: { deferred_tool: {} },
+  });
+  await resultPromise;
+  assert(hydrated, "a declared-but-unexecutable tool was not hydrated");
+});
+
+// ---------------------------------------------------------------------------
+// Terminal tool-call pattern needs no engine change (Task 7 proof)
+// ---------------------------------------------------------------------------
+
+await test("an adapter that omits a terminal call from toolCalls ends the turn via the existing zero-toolCalls path", async () => {
+  // Proves a design decision rather than new production code: Tasks 8 and 11
+  // mark a detected `final_result` terminal by leaving it out of `toolCalls`
+  // and putting its parsed payload in `text`. If that works against the
+  // engine as it stands, those tasks need no contract change.
+  const adapter: AgenticLoopAdapter<string[]> = {
+    providerLabel: "fake-terminal",
+    maxSteps: 5,
+    buildStepRequest: (conversation) => ({ raw: conversation }),
+    executeStep: async () => ({
+      text: JSON.stringify({ answer: 42 }),
+      toolCalls: [],
+      usage: { inputTokens: 5, outputTokens: 5 },
+      rawStopReason: "tool_use",
+      raw: undefined,
+    }),
+    buildToolResultMessages: (conversation) => conversation,
+    mapFinishReason: () => "stop",
+  };
+  const { resultPromise } = runAgenticLoop(adapter, [], { tools: {} });
+  const result = await resultPromise;
+  assertEqual(
+    result.text,
+    JSON.stringify({ answer: 42 }),
+    "a terminal step's parsed text became the turn's final text",
+  );
+  assertEqual(
+    result.toolCalls.length,
+    0,
+    "a terminal call must not appear in the turn's toolCalls",
+  );
+  assertEqual(
+    result.toolExecutions.length,
+    0,
+    "a terminal call must not be dispatched or recorded as an execution",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
Plan 08 Task 7 — the blocker task for Tasks 8–11.

Of the three architectural blockers the preflight found, **exactly one needs an engine-contract change.** The other two are resolved by *not* changing the contract, and this records both resolutions in writing so the migrations can cite them rather than re-derive them.

## The change

A single optional field, `resolveToolOnMiss`, consulted at the one point the engine decides a tool call is unresolvable. Adapters supporting mid-turn discovery (AI Studio, Vertex+Gemini) use it to hydrate a tool the model just found via `search_tools`, or a deferred-catalog tool called by its advertised name, before the engine falls through to `TOOL_NOT_FOUND` and a breaker strike.

Deliberately a **narrow lookup**, not a `dispatchTools?` full-dispatch override. An override would let an adapter replace the engine's entire per-call dispatch — breaker bookkeeping, execution, `toolExecutions` aggregation — so every hydrating adapter would reimplement that bookkeeping, and a later engine-level fix to dispatch would silently not reach them.

## One deviation from the brief

The brief specifies:

```ts
const tool = options.tools?.[call.name] ?? adapter.resolveToolOnMiss?.(call.name);
```

That only reaches the hook when the key is **absent entirely**. But the guard on the very next line already treats a *present-but-unexecutable* entry as absent — and a deferred-catalog placeholder is exactly that shape: declared under its advertised name with nothing to run. Under the brief's version, the main case this hook exists for falls straight through to `TOOL_NOT_FOUND`.

The miss is defined here as **"nothing executable under this name"**, with a case pinning it.

## The other two blockers

Settled as design decisions on the type, with reasoning:

- **`originalNameMap` propagation** — a translation concern the adapter handles in its own `executeStep` before names ever cross the engine boundary. Zero engine change.
- **Reserved-step forced finalization** — stays in Vertex+Claude's wrapper, because it acts on the *result* of a turn rather than being a step within one. Folding it in would teach the engine a family-specific concept (forced `tool_choice`, a distinguished terminal tool name) that every other adapter would carry and never set. The reserved step itself needs nothing: an adapter declaring `maxSteps: requested - 1` means the engine's loop never touches the reserved slot.

## Terminal tool-call marking is proven, not asserted

A case builds an adapter shaped the way Tasks 8 and 11 will — omitting a detected `final_result` from `toolCalls` and putting its payload in `text` — and shows the engine already ends the turn through its existing zero-`toolCalls` path: never looking the call up, never reaching `TOOL_NOT_FOUND`, never counting it against the breaker. It passes with no production change beyond the one-line dispatch edit.

## Verification

Mutation-verified: removing the hook fails **both** hydration cases and leaves the terminal-call proof **green** — which is exactly the expected split, since that proof is about the engine as it already stood.

| Suite | Result |
|---|---|
| `loop-engine` | 27 passed (4 new) |
| `providers-mocked` | 54 passed |
| `provider-structure` | 3 passed |