### PR TITLE
fix(errors): read AWS SDK error status from $metadata.httpStatusCode

### DIFF
--- a/src/lib/utils/providerRetry.ts
+++ b/src/lib/utils/providerRetry.ts
@@ -60,12 +60,32 @@ export function duckTypedStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== "object") {
     return undefined;
   }
-  const err = error as { statusCode?: unknown; status?: unknown };
+  const err = error as {
+    statusCode?: unknown;
+    status?: unknown;
+    $metadata?: unknown;
+  };
   if (typeof err.statusCode === "number") {
     return err.statusCode;
   }
   if (typeof err.status === "number") {
     return err.status;
+  }
+  // AWS SDK v3 puts the HTTP status on `$metadata.httpStatusCode` and nowhere
+  // else, so without this branch no AWS error carries a status code as far as
+  // anything here is concerned. That is not only a retry question: this
+  // function also feeds `classifyProviderError` and the retry telemetry, so a
+  // Bedrock or SageMaker 429 was not recognisable as a rate limit, and a 5xx
+  // not recognisable as transient, by any status-based path. Name-based
+  // classification (ThrottlingException, AccessDeniedException) still worked,
+  // which is why this stayed hidden.
+  const metadata = err.$metadata;
+  if (typeof metadata === "object" && metadata !== null) {
+    const httpStatusCode = (metadata as { httpStatusCode?: unknown })
+      .httpStatusCode;
+    if (typeof httpStatusCode === "number") {
+      return httpStatusCode;
+    }
   }
   return undefined;
 }

--- a/test/continuous-test-suite-error-classifier-contract.ts
+++ b/test/continuous-test-suite-error-classifier-contract.ts
@@ -75,6 +75,10 @@ import type {
   OpenAICompatCatalogEntry,
 } from "../src/lib/types/index.js";
 import { TimeoutError } from "../src/lib/utils/timeout.js";
+import {
+  duckTypedStatusCode,
+  isRetryableProviderError,
+} from "../src/lib/utils/providerRetry.js";
 import { AIProviderName } from "../src/lib/constants/enums.js";
 import { ConfiguredOpenAICompatProvider } from "../src/lib/providers/configuredOpenAICompat.js";
 import { OPENAI_COMPAT_CATALOG } from "../src/lib/providers/openaiCompatCatalog.js";
@@ -93,7 +97,7 @@ import { CohereProvider } from "../src/lib/providers/cohere.js";
 import { AnthropicProvider } from "../src/lib/providers/anthropic/client.js";
 import { AmazonBedrockProvider } from "../src/lib/providers/amazonBedrock/client.js";
 import { isToolsSchemaExclusionInForce } from "../src/lib/core/modules/structuredOutputPolicy.js";
-import { defineSuite, assert } from "./helpers/harness.js";
+import { assert, assertEqual, defineSuite } from "./helpers/harness.js";
 
 const { test, runSuite, section } = defineSuite(
   "Error classifier contract (Plan 07, rule 15 determinism exception)",
@@ -742,6 +746,71 @@ void runSuite(async () => {
     assert(
       !isToolsSchemaExclusionInForce("google-ai", "gemini-2.5-pro", true, 0),
       "zero active tools should never trigger the exclusion",
+    );
+  });
+
+  section("AWS SDK v3 error status codes");
+
+  await test("an AWS SDK error's status is read from $metadata.httpStatusCode", async () => {
+    // AWS SDK v3 puts the HTTP status there and nowhere else — no .statusCode,
+    // no .status. Every status-based path in this codebase goes through
+    // duckTypedStatusCode, so without this an AWS 429 is not recognisable as a
+    // rate limit and a 5xx not recognisable as transient.
+    const throttling = Object.assign(new Error("Rate exceeded"), {
+      name: "ThrottlingException",
+      $metadata: { httpStatusCode: 429, requestId: "abc" },
+    });
+    assertEqual(
+      duckTypedStatusCode(throttling),
+      429,
+      "an AWS throttling error's status was not read from $metadata",
+    );
+    assert(
+      isRetryableProviderError(throttling),
+      "an AWS 429 must classify as retryable",
+    );
+  });
+
+  await test("a direct statusCode still wins over $metadata", async () => {
+    // The AWS branch is a last resort; anything carrying its own status keeps
+    // reporting it.
+    const err = Object.assign(new Error("boom"), {
+      statusCode: 503,
+      $metadata: { httpStatusCode: 200 },
+    });
+    assertEqual(
+      duckTypedStatusCode(err),
+      503,
+      "an explicit statusCode must take precedence over $metadata",
+    );
+  });
+
+  await test("an AWS 4xx that is not 429 stays non-retryable", async () => {
+    const validation = Object.assign(new Error("Malformed input"), {
+      name: "ValidationException",
+      $metadata: { httpStatusCode: 400 },
+    });
+    assertEqual(
+      duckTypedStatusCode(validation),
+      400,
+      "an AWS validation error's status was not read",
+    );
+    assert(
+      !isRetryableProviderError(validation),
+      "a 400 must not become retryable just because its status is now visible",
+    );
+  });
+
+  await test("an error with no status anywhere still reports undefined", async () => {
+    assertEqual(
+      duckTypedStatusCode(new Error("plain")),
+      undefined,
+      "a plain error must not acquire a status code",
+    );
+    assertEqual(
+      duckTypedStatusCode({ $metadata: {} }),
+      undefined,
+      "an empty $metadata must not produce a status code",
     );
   });
 });


### PR DESCRIPTION
`duckTypedStatusCode` looked only at `.statusCode` and `.status`. **AWS SDK v3 puts the HTTP status on `$metadata.httpStatusCode` and nowhere else** — so no error from Bedrock, SageMaker or any other AWS provider carried a status code as far as this codebase was concerned.

## Wider than retry

This function feeds four consumers:

| Consumer | What it lost |
|---|---|
| `isRetryableProviderError` | AWS 429/5xx never classified as retryable |
| `getErrorStatusCode` | the 429 check in `neurolink.ts`, and retry telemetry |
| `classifyProviderError` | the `statusCode` field on every AWS error |
| `baseProvider` | status-based handling |

So a Bedrock 429 was not recognisable as a rate limit, and a 5xx not recognisable as transient, by any status-based path.

**It stayed hidden because name-based classification still works.** Bedrock's `formatProviderError` maps `ThrottlingException` and `AccessDeniedException` by exception *name*, which is what the mocked provider suite exercises. The gap only shows on paths that ask for a status code.

## How it surfaced

Found while trying to write a regression test for a *different* fix in the Bedrock loop migration (#1382). The scenario — exhaust the AWS SDK's own retry budget so `executeStep` throws, then expect the engine's retry to take over — never reached the engine's retry at all. This is why: the error arrived unclassifiable, so `withProviderRetry` gave up immediately and the turn degraded to the non-streaming `generate()` fallback.

```
CALL SEQUENCE: converse-stream → converse-stream → converse-stream → converse
TEXT: "FROM-FALLBACK-GENERATE"
```

## Scope control

The AWS branch is a **last resort**, after both existing lookups, so anything carrying its own status keeps reporting it.

Retry semantics are otherwise unchanged: only 429 and 5xx are retryable, bounded by `MAX_PROVIDER_RETRIES = 2`. An AWS 400 stays non-retryable now that its status is visible — **pinned by a case**, because making statuses visible is exactly the change that could otherwise make unretryable failures retryable by accident.

## Verification

Mutation-verified: removing the branch fails the two cases that depend on it, and leaves the precedence and no-status cases green.

| Suite | Result |
|---|---|
| `error-classifier-contract` | 44 passed (4 new) |
| `providers-mocked` | 54 passed |
| `loop-engine` | 23 passed |
| `provider-structure` | 3 passed |