### PR TITLE
fix(core): carry reasoning deltas on the agentic loop's stream channel

### DIFF
--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -1,6 +1,7 @@
 import { createStreamChannel } from "./streamChannel.js";
 import type {
   AgenticLoopAdapter,
+  AgenticLoopChunk,
   AgenticLoopOptions,
   AgenticLoopResult,
   AgenticLoopStepResult,
@@ -63,10 +64,10 @@ export function runAgenticLoop<TConversation>(
   initialConversation: TConversation,
   options: AgenticLoopOptions,
 ): {
-  stream: AsyncIterable<{ content: string }>;
+  stream: AsyncIterable<AgenticLoopChunk>;
   resultPromise: Promise<AgenticLoopResult<TConversation>>;
 } {
-  const channel = createStreamChannel<{ content: string }>();
+  const channel = createStreamChannel<AgenticLoopChunk>();
   const internalAbort = new AbortController();
   const onCallerAbort = () => internalAbort.abort();
   options.abortSignal?.addEventListener("abort", onCallerAbort);
@@ -120,7 +121,7 @@ export function runAgenticLoop<TConversation>(
         // sees, via the unwrap in the catch below.
         let hasEmitted = false;
         const watchedChannel = {
-          push: (chunk: { content: string }) => {
+          push: (chunk: AgenticLoopChunk) => {
             hasEmitted = true;
             channel.push(chunk);
           },

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -1,3 +1,18 @@
+/**
+ * One chunk on the engine's stream.
+ *
+ * `reasoning` is carried alongside `content` rather than instead of it: the
+ * providers that emit extended thinking (direct Anthropic, Google AI Studio,
+ * Vertex) push a chunk with empty `content` and the thinking delta in
+ * `reasoning`, so a channel typed `{ content: string }` alone would drop
+ * every thinking delta the moment those providers move onto the engine —
+ * silently, since the text path would keep working.
+ */
+export type AgenticLoopChunk = {
+  content: string;
+  reasoning?: string;
+};
+
 export type AgenticLoopToolCall = {
   id: string;
   name: string;
@@ -112,7 +127,7 @@ export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
   ): AgenticLoopStepRequest;
   executeStep(
     request: AgenticLoopStepRequest,
-    channel: { push(chunk: { content: string }): void },
+    channel: { push(chunk: AgenticLoopChunk): void },
     signal: AbortSignal,
   ): Promise<AgenticLoopStepResult<TRaw>>;
   buildToolResultMessages(

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -953,4 +953,50 @@ await test("an adapter that omits a terminal call from toolCalls ends the turn v
   );
 });
 
+// ---------------------------------------------------------------------------
+// Reasoning chunks survive the engine's channel
+// ---------------------------------------------------------------------------
+
+await test("a reasoning delta pushed by an adapter reaches the consumer", async () => {
+  // Extended-thinking providers (direct Anthropic, AI Studio, Vertex) emit a
+  // chunk whose `content` is empty and whose thinking delta rides in
+  // `reasoning`. A channel typed `{ content: string }` drops that field
+  // silently — the text path keeps working, so the loss would only show up as
+  // missing thinking output for every one of those providers at once, which
+  // is exactly what Tasks 8-11 would have shipped.
+  const adapter: AgenticLoopAdapter<string[]> = {
+    providerLabel: "fake-reasoning",
+    maxSteps: 2,
+    buildStepRequest: (conversation) => ({ raw: conversation }),
+    executeStep: async (_request, channel) => {
+      channel.push({ content: "", reasoning: "thinking out loud" });
+      channel.push({ content: "the answer" });
+      return {
+        text: "the answer",
+        reasoning: "thinking out loud",
+        toolCalls: [],
+        usage: { inputTokens: 1, outputTokens: 1 },
+        rawStopReason: "end_turn",
+        raw: undefined,
+      };
+    },
+    buildToolResultMessages: (conversation) => conversation,
+    mapFinishReason: () => "stop",
+  };
+  const { stream, resultPromise } = runAgenticLoop(adapter, [], { tools: {} });
+  const chunks: Array<{ content: string; reasoning?: string }> = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  await resultPromise;
+  assert(
+    chunks.some((c) => c.reasoning === "thinking out loud"),
+    "the reasoning delta was dropped on its way through the engine channel",
+  );
+  assert(
+    chunks.some((c) => c.content === "the answer"),
+    "the text chunk did not survive alongside the reasoning chunk",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
The engine's channel was typed `{ content: string }`.

Every provider that supports extended thinking — **direct Anthropic, Google AI Studio, Vertex** — emits its thinking deltas as a chunk whose `content` is empty and whose text rides in `reasoning`:

```ts
pushChunk({ content: "", reasoning: delta.thinking });
```

Moving those providers onto the engine as written would have dropped every one of those deltas.

**It would have done so silently, which is the part that matters.** The text path keeps working, so nothing fails and no test goes red. The only symptom is that thinking output stops appearing — for all four remaining migrations at once, and only for users who asked for it via `thinkingLevel`.

## How it was found

Reading the Anthropic loop ahead of writing its adapter, not by a test. The plan's preflight identified **three** architectural blockers for Tasks 8–11; this is a fourth, unlisted one. The adapter contract simply cannot express what those providers already emit.

## The change

The channel now carries `AgenticLoopChunk` — `content` plus an optional `reasoning`. Additive and backward compatible: Bedrock, the only migrated provider today, pushes content-only chunks and is unaffected, which its characterization suite confirms.

## Verification

Mutation-verified: narrowing the channel back to content-only fails the new case, and only that case.

| Suite | Result |
|---|---|
| `loop-engine` | 28 passed (1 new) |
| `bedrock-loop-characterization` | 12 passed |
| `providers-mocked` | 54 passed |

Blocks Tasks 8–11 until merged — those migrations should not start against a contract that cannot carry reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses can now include optional reasoning details alongside generated content.
  * Extended-thinking output is preserved as it moves through the agentic loop.

* **Tests**
  * Added coverage confirming that reasoning and response text are both delivered to stream consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->