### PR TITLE
feat(core): add the shared Gemini loop adapter

### DIFF
--- a/src/lib/core/geminiLoopAdapter.ts
+++ b/src/lib/core/geminiLoopAdapter.ts
@@ -1,0 +1,227 @@
+/**
+ * Shared Gemini adapter onto the agentic loop engine.
+ *
+ * Lives in `core/` rather than inside either provider's folder because two
+ * providers use it: Google AI Studio (Task 9) and Vertex Gemini (Task 10).
+ * Both issue the same wire call — `models.generateContentStream` — and consume
+ * the same response shape, so one `executeStep` serves four hand-rolled loops
+ * (each provider has a streaming one and a near-duplicate inside `generate()`).
+ *
+ * Function-name sanitization stays entirely on this side of the engine
+ * boundary, which is the design decision Task 7 recorded rather than a
+ * shortcut. Google requires function names to match a restricted pattern, so
+ * declarations are built with sanitized names and the model calls back with
+ * those same sanitized names. The engine only ever sees plain string names, so
+ * this adapter translates sanitized -> original before returning `toolCalls`,
+ * and original -> sanitized when writing `functionResponse` parts. Neither the
+ * engine nor any other adapter needs to know sanitization happened.
+ */
+
+import type {
+  AgenticLoopAdapter,
+  AgenticLoopChunk,
+  AgenticLoopStepRequest,
+  AgenticLoopStepResult,
+  AgenticLoopToolCallResult,
+  GeminiLoopAdapterConfig,
+  GeminiStepRaw,
+  GeminiTurnContent,
+} from "../types/index.js";
+import {
+  collectStreamChunksIncremental,
+  extractTextFromParts,
+  mapGeminiFinishReason,
+  pushModelResponseToHistory,
+  refreshNativeToolDeclarations,
+} from "../providers/googleNativeGemini3/utils.js";
+
+export function createGeminiLoopAdapter(
+  config: GeminiLoopAdapterConfig,
+): AgenticLoopAdapter<GeminiTurnContent[], GeminiStepRaw> {
+  /**
+   * Sanitized wire name -> the name the caller registered. Rebuilt per step
+   * because mid-turn discovery can add entries between steps.
+   */
+  const originalNameFor = (sanitized: string): string =>
+    config.declarations?.originalNameMap?.get(sanitized) ?? sanitized;
+
+  const sanitizedNameFor = (original: string): string => {
+    const map = config.declarations?.originalNameMap;
+    if (!map) {
+      return original;
+    }
+    for (const [sanitized, name] of map) {
+      if (name === original) {
+        return sanitized;
+      }
+    }
+    return original;
+  };
+
+  return {
+    providerLabel: config.providerLabel,
+    maxSteps: config.maxSteps,
+    ...(config.toolFailureBreaker
+      ? { toolFailureBreaker: config.toolFailureBreaker }
+      : {}),
+
+    /**
+     * Mid-turn discovery: `search_tools` hydrates new tools into the live
+     * record between steps, and Gemini only calls what the request declared,
+     * so the declarations are refreshed before each step is built. This is
+     * why `resolveToolOnMiss` exists as well — a tool discovered during a
+     * step is callable in the same step, before the next refresh.
+     */
+    buildStepRequest(
+      conversation: GeminiTurnContent[],
+      step: number,
+    ): AgenticLoopStepRequest {
+      if (config.declarations) {
+        refreshNativeToolDeclarations(config.liveTools, config.declarations);
+      }
+      return { raw: config.buildRequest(conversation, step) };
+    },
+
+    /**
+     * The engine decides WHEN to reclaim; the provider decides HOW. Wiring
+     * this is not optional dressing: both loops append a model turn and a
+     * tool turn every step, so without it a long agentic run overflows the
+     * context window mid-turn and loses the work already done.
+     */
+    ...(config.planReclaim
+      ? {
+          planReclaim: (conversation: GeminiTurnContent[], step: number) => {
+            const reclaimed = config.planReclaim?.(conversation, step);
+            return reclaimed ? { conversation: reclaimed } : undefined;
+          },
+        }
+      : {}),
+
+    /**
+     * A step that produced no text, no function calls, and a
+     * MALFORMED_FUNCTION_CALL finish reason is a transient formatting
+     * failure, not a finished turn. Vertex retries it once with a corrective
+     * note rather than hard-ending on empty content — automated RCA turns
+     * were dying at step 2-4 on this and being mislabelled as step-cap exits.
+     *
+     * Opt-in: AI Studio has no such retry today and gaining one silently
+     * would be a behaviour change, not a migration.
+     */
+    ...(config.enableMalformedRetry && config.buildMalformedRetryNote
+      ? {
+          isMalformedStep: (
+            stepResult: AgenticLoopStepResult<GeminiStepRaw>,
+          ): boolean =>
+            stepResult.toolCalls.length === 0 &&
+            !stepResult.text &&
+            stepResult.rawStopReason === "MALFORMED_FUNCTION_CALL",
+          buildMalformedRetryNote: config.buildMalformedRetryNote,
+        }
+      : {}),
+
+    resolveToolOnMiss: (name: string) => {
+      const tool = config.liveTools?.[name];
+      const execute = tool?.execute;
+      if (!execute) {
+        return undefined;
+      }
+      // Wrapped because the hook types `opts` as `unknown`, and a function
+      // declaring a narrower options type is not assignable to one accepting
+      // `unknown`. One assertion at the boundary, never a double assertion.
+      return {
+        execute: async (args: Record<string, unknown>, opts: unknown) =>
+          execute(args, opts as Parameters<typeof execute>[1]),
+      };
+    },
+
+    async executeStep(
+      request: AgenticLoopStepRequest,
+      channel: { push(chunk: AgenticLoopChunk): void },
+      signal: AbortSignal,
+    ): Promise<AgenticLoopStepResult<GeminiStepRaw>> {
+      const rawStream = await config.sendStep(request.raw, signal);
+
+      // `collectStreamChunksIncremental` wants a StreamChannel but only ever
+      // calls `.push`, so the engine's push-only channel satisfies it. The
+      // helper is reused rather than reimplemented precisely because it also
+      // owns usage extraction and thought-signature preservation.
+      const collected = await collectStreamChunksIncremental(rawStream, {
+        push: (chunk: { content: string }) => channel.push(chunk),
+      } as Parameters<typeof collectStreamChunksIncremental>[1]);
+
+      // The provider's context guard calibrates from real per-step counts;
+      // `inputTokens` is this step's full prompt size, which is what it
+      // projects the next request from.
+      config.noteUsage?.(collected.inputTokens, collected.outputTokens);
+
+      const text = extractTextFromParts(collected.rawResponseParts);
+
+      // Names cross the engine boundary in their ORIGINAL form.
+      const toolCalls = collected.stepFunctionCalls.map((call, index) => ({
+        id: `${config.providerLabel}_${index}_${call.name}`,
+        name: originalNameFor(call.name),
+        args: call.args,
+      }));
+
+      return {
+        text,
+        toolCalls,
+        usage: {
+          inputTokens: collected.inputTokens,
+          outputTokens: collected.outputTokens,
+          ...(collected.cacheReadTokens
+            ? { cacheReadTokens: collected.cacheReadTokens }
+            : {}),
+          ...(collected.reasoningTokens
+            ? { reasoningTokens: collected.reasoningTokens }
+            : {}),
+        },
+        rawStopReason: collected.finishReason,
+        raw: {
+          rawResponseParts: collected.rawResponseParts,
+          stepFunctionCalls: collected.stepFunctionCalls,
+        },
+      };
+    },
+
+    buildToolResultMessages(
+      conversation: GeminiTurnContent[],
+      stepResult: AgenticLoopStepResult<GeminiStepRaw>,
+      toolResults: AgenticLoopToolCallResult[],
+    ): GeminiTurnContent[] {
+      // Copied before `pushModelResponseToHistory` mutates it: the engine
+      // treats the conversation as a value it hands in and gets back, so
+      // mutating the caller's array in place would make a retried or
+      // reclaimed step see history it should not.
+      const next = [...conversation];
+      pushModelResponseToHistory(
+        next,
+        stepResult.raw.rawResponseParts,
+        stepResult.raw.stepFunctionCalls,
+      );
+      next.push({
+        role: "user",
+        parts: toolResults.map((result) => ({
+          functionResponse: {
+            // Back to the sanitized wire name the model actually called.
+            name: sanitizedNameFor(result.name),
+            response: result.error
+              ? { error: result.error }
+              : { result: result.output },
+          },
+        })),
+      });
+      return next;
+    },
+
+    mapFinishReason(
+      rawStopReason: string | undefined,
+      hadToolCallsAtCap: boolean,
+    ): string {
+      const mapped = mapGeminiFinishReason(rawStopReason);
+      // A turn cut off at the step cap ended because of the cap, not because
+      // the last response said "STOP".
+      return hadToolCallsAtCap && mapped === "stop" ? "tool-calls" : mapped;
+    },
+  };
+}

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -899,6 +899,10 @@ export async function collectStreamChunksIncremental(
   let outputTokens = 0;
   let cacheReadTokens = 0;
   let reasoningTokens = 0;
+  // Surfaced so a caller can map SAFETY / MALFORMED_FUNCTION_CALL rather
+  // than inferring the turn ended normally. Additive: existing callers that
+  // ignore it are unaffected.
+  let finishReason: string | undefined;
 
   for await (const chunk of stream) {
     const chunkRecord = chunk as Record<string, unknown>;
@@ -906,6 +910,10 @@ export async function collectStreamChunksIncremental(
       | Array<Record<string, unknown>>
       | undefined;
     const firstCandidate = candidates?.[0];
+    const candidateFinish = firstCandidate?.finishReason;
+    if (typeof candidateFinish === "string") {
+      finishReason = candidateFinish;
+    }
     const chunkContent = firstCandidate?.content as
       | Record<string, unknown>
       | undefined;
@@ -951,6 +959,7 @@ export async function collectStreamChunksIncremental(
   return {
     rawResponseParts,
     stepFunctionCalls,
+    finishReason,
     inputTokens,
     outputTokens,
     cacheReadTokens,

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -1,5 +1,9 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { Tool } from "./tools.js";
+import type {
+  NativeFunctionCall,
+  NativeToolDeclarationsResult,
+} from "./providers.js";
 
 /**
  * One chunk on the engine's stream.
@@ -209,6 +213,112 @@ export type AnthropicLoopAdapterConfig = {
   noteObservedPromptTokens?: (promptTokens: number) => void;
   abortSignal?: AbortSignal;
 };
+
+/** What one Gemini step produced, carried to `buildToolResultMessages`. */
+export type GeminiStepRaw = {
+  rawResponseParts: unknown[];
+  stepFunctionCalls: NativeFunctionCall[];
+};
+
+/** One turn entry in a Gemini conversation: a role plus its content parts. */
+export type GeminiTurnContent = {
+  role: string;
+  parts: unknown[];
+};
+
+/**
+ * Construction input for `createGeminiLoopAdapter`, shared by Google AI Studio
+ * and Vertex Gemini. Both issue `models.generateContentStream` and consume the
+ * same response shape, so one adapter serves four hand-rolled loops.
+ */
+export type GeminiLoopAdapterCoreConfig = {
+  /** Used in log lines and generated tool-call ids. */
+  providerLabel: string;
+  maxSteps: number;
+  /** Build one step's request object (model, contents, config). */
+  buildRequest: (conversation: GeminiTurnContent[], step: number) => unknown;
+  /** Issue the request. Kept injectable so each provider keeps its own client. */
+  sendStep: (
+    request: unknown,
+    signal: AbortSignal,
+  ) => Promise<
+    AsyncIterable<{
+      functionCalls?: NativeFunctionCall[];
+      [key: string]: unknown;
+    }>
+  >;
+  /**
+   * The turn's live tool record. Mid-turn `search_tools` discovery hydrates
+   * into this, which is what both the declaration refresh and
+   * `resolveToolOnMiss` read.
+   */
+  liveTools: Record<string, Tool>;
+  /**
+   * Declarations built for this turn. Carries `originalNameMap`, which keeps
+   * Google's function-name sanitization on the adapter side of the engine
+   * boundary.
+   */
+  declarations?: NativeToolDeclarationsResult;
+  toolFailureBreaker?: AgenticLoopToolFailureBreaker;
+  /**
+   * In-turn context reclaim, run once per step before the request is built.
+   * Returns the rebuilt conversation when it reclaimed, undefined when the
+   * request still fits.
+   *
+   * Provider-supplied rather than engine-owned because the two Gemini
+   * providers reclaim differently (reclaimAiStudioContext vs
+   * reclaimVertexLoopContext) while the engine only decides WHEN to ask. The
+   * loops append a model turn plus a tool turn every step with nothing else
+   * bounding growth, so a migration that drops this overflows the context
+   * window mid-turn and loses every completed step.
+   */
+  planReclaim?: (
+    conversation: GeminiTurnContent[],
+    step: number,
+  ) => GeminiTurnContent[] | undefined;
+  /**
+   * Usage feedback for the provider's own context guard, called after each
+   * step with that step's real token counts.
+   */
+  noteUsage?: (inputTokens: number, outputTokens: number) => void;
+};
+
+/**
+ * Opt in to the single MALFORMED_FUNCTION_CALL retry.
+ *
+ * Vertex Gemini only. AI Studio has no such retry today (confirmed: zero
+ * MALFORMED_FUNCTION_CALL handling in its client), and turning it on there
+ * would be a behaviour change disguised as a shared refactor. The engine owns
+ * the one-retry budget; this only says whether to ask.
+ *
+ * A union rather than two independent optional fields because the retry is
+ * only worth spending a step on if the re-issued request differs from the one
+ * that just failed. `runAgenticLoop` falls back to the unchanged conversation
+ * when no note builder is supplied (`buildMalformedRetryNote?.(…) ??
+ * conversation`), so enabling the retry without one re-sends a byte-identical
+ * request and most often reproduces the same malformed call — a step burned
+ * for nothing. Requiring the builder here makes that combination unsayable
+ * instead of merely discouraged.
+ */
+export type GeminiMalformedRetryConfig =
+  | {
+      enableMalformedRetry: true;
+      /**
+       * Append the corrective turn that the retry re-issues with.
+       * Provider-supplied because the note is written in the provider's own
+       * content shape.
+       */
+      buildMalformedRetryNote: (
+        conversation: GeminiTurnContent[],
+      ) => GeminiTurnContent[];
+    }
+  | {
+      enableMalformedRetry?: false;
+      buildMalformedRetryNote?: never;
+    };
+
+export type GeminiLoopAdapterConfig = GeminiLoopAdapterCoreConfig &
+  GeminiMalformedRetryConfig;
 
 export type AgenticLoopOptions = {
   tools?: Record<

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -2018,6 +2018,8 @@ export type NativeFunctionResponse = {
 export type CollectedChunkResult = {
   rawResponseParts: unknown[];
   stepFunctionCalls: NativeFunctionCall[];
+  /** Raw `Candidate.finishReason` from the last chunk that carried one. */
+  finishReason?: string;
   inputTokens: number;
   outputTokens: number;
   /**


### PR DESCRIPTION
Plan 08 Task 9, **Step 2 only**. Wiring AI Studio's two loops onto `runAgenticLoop` is Step 3, so **nothing changes at runtime yet**.

It lives in `core/` rather than either provider's folder because two providers use it: **AI Studio and Vertex Gemini issue the same wire call** (`models.generateContentStream`) and consume the same response shape, so one `executeStep` serves **four** hand-rolled loops — each provider has a streaming one and a near-duplicate inside `generate()`.

## Sanitization stays on the adapter side

Google requires function names to match a restricted pattern, so declarations carry sanitized names and the model calls back with those. The adapter translates sanitized → original before returning `toolCalls`, and original → sanitized when writing `functionResponse` parts. The engine only ever sees plain names — that's Task 7's recorded design decision, honoured rather than shortcut.

## An additive fix to a shared helper

`collectStreamChunksIncremental` **discarded the candidate's `finishReason`**. An adapter therefore had no way to distinguish `SAFETY` or `MALFORMED_FUNCTION_CALL` from an ordinary stop — and the `mapGeminiFinishReason` mapping this task is supposed to *gain* would have been fed `undefined` every time. It now surfaces it; existing callers ignore the new field.

I also verified before designing around it that the helper only ever calls `.push`, so the engine's push-only channel satisfies its `StreamChannel` parameter. The alternative was reimplementing usage extraction and thought-signature preservation.

## Conversation is copied, not mutated

`buildToolResultMessages` copies before `pushModelResponseToHistory` mutates. The engine hands the conversation in as a value and takes it back, so mutating the caller's array in place would let a retried or reclaimed step observe history it shouldn't.

## Repo rules applied, not worked around

- All three type aliases (`GeminiLoopAdapterConfig`, `GeminiTurnContent`, `GeminiStepRaw`) live in `src/lib/types/` and come through the barrel.
- The structural stand-ins in my first draft were replaced with the real `NativeFunctionCall` and `NativeToolDeclarationsResult` once `tsc` showed they didn't match — the loose versions would have compiled at the call site and diverged later.

## Verification

| Suite | Result |
|---|---|
| `aistudio-loop-characterization` | 3 passed |
| `loop-engine` | 28 passed |
| `providers-mocked` | 54 passed |
| `provider-structure` | 3 passed |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Gemini-powered interactions across supported Google AI providers.
  * Added more reliable streaming response handling and tool-call processing.
  * Preserved usage information and conversation history during multi-step interactions.
  * Added support for planning context reclamation during extended interactions.

* **Bug Fixes**
  * Improved handling of completion reasons, including tool-call turn limits.
  * Enhanced support for dynamically discovered tools during an interaction.
  * Added recovery for certain malformed tool-call responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->