### PR TITLE
feat(core): carry tool-call id and error on loop tool executions

### DIFF
--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -193,9 +193,11 @@ export function runAgenticLoop<TConversation>(
               permanentlyFailed: true,
             });
             allToolExecutions.push({
+              id: call.id,
               name: call.name,
               input: call.args,
               output,
+              error: output.error,
             });
             continue;
           }
@@ -224,9 +226,11 @@ export function runAgenticLoop<TConversation>(
               permanentlyFailed: !!breaker,
             });
             allToolExecutions.push({
+              id: call.id,
               name: call.name,
               input: call.args,
               output,
+              error: output.error,
             });
             continue;
           }
@@ -237,6 +241,7 @@ export function runAgenticLoop<TConversation>(
             });
             toolResults.push({ ...call, output });
             allToolExecutions.push({
+              id: call.id,
               name: call.name,
               input: call.args,
               output,
@@ -255,9 +260,11 @@ export function runAgenticLoop<TConversation>(
             const output = { error: message, status: "failed" };
             toolResults.push({ ...call, output, error: message });
             allToolExecutions.push({
+              id: call.id,
               name: call.name,
               input: call.args,
               output,
+              error: message,
             });
           }
         }

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -226,10 +226,24 @@ export type AgenticLoopOptions = {
 export type AgenticLoopResult<TConversation> = {
   text: string;
   toolCalls: AgenticLoopToolCall[];
+  /**
+   * Every tool dispatch the loop performed, in order, including the ones that
+   * failed.
+   *
+   * `id` and `error` are carried because providers persist tool activity as
+   * paired call/result records keyed by the provider's own tool-call id, and
+   * a result that failed is stored differently from one that succeeded. A
+   * shape with only name/input/output cannot reconstruct either, so a
+   * provider migrating its hand-rolled loop onto this engine would have to
+   * silently drop both from its history — which is a behaviour change, not a
+   * refactor.
+   */
   toolExecutions: Array<{
+    id: string;
     name: string;
     input: Record<string, unknown>;
     output: unknown;
+    error?: string;
   }>;
   usage: AgenticLoopUsage;
   finishReason: string;

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -999,4 +999,82 @@ await test("a reasoning delta pushed by an adapter reaches the consumer", async 
   );
 });
 
+await test("a successful execution records the call id and no error", async () => {
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [
+      [{ id: "call_abc", name: "ok_tool", args: { q: 1 } }],
+      [],
+    ],
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    tools: {
+      ok_tool: {
+        execute: async () => ({ ok: true }),
+      },
+    },
+  });
+  const result = await resultPromise;
+  const record = result.toolExecutions.find((e) => e.name === "ok_tool");
+  assertEqual(
+    record?.id,
+    "call_abc",
+    "a successful execution must carry the provider's tool-call id",
+  );
+  assertEqual(
+    record?.error,
+    undefined,
+    "a successful execution must not be recorded with an error",
+  );
+});
+
+await test("a throwing tool records the call id and its error message", async () => {
+  // Providers store a failed tool result differently from a successful one,
+  // so the engine has to say which it was. Without `error` a migrated loop
+  // would persist every failure as if it had succeeded.
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [[{ id: "call_bad", name: "bad_tool", args: {} }], []],
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    tools: {
+      bad_tool: {
+        execute: async () => {
+          throw new Error("upstream unavailable");
+        },
+      },
+    },
+  });
+  const result = await resultPromise;
+  const record = result.toolExecutions.find((e) => e.name === "bad_tool");
+  assertEqual(
+    record?.id,
+    "call_bad",
+    "a failed execution must still carry the tool-call id",
+  );
+  assert(
+    typeof record?.error === "string" && record.error.length > 0,
+    "a failed execution must be recorded with an error message",
+  );
+});
+
+await test("an unresolvable tool name is recorded with an id and an error", async () => {
+  const adapter = makeHydrationAdapter({
+    toolCallsByStep: [
+      [{ id: "call_missing", name: "nowhere_tool", args: {} }],
+      [],
+    ],
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], { tools: {} });
+  const result = await resultPromise;
+  const record = result.toolExecutions.find((e) => e.name === "nowhere_tool");
+  assertEqual(
+    record?.id,
+    "call_missing",
+    "an unresolved call must still carry the tool-call id",
+  );
+  assert(
+    typeof record?.error === "string" && record.error.length > 0,
+    "an unresolved call must be recorded with an error message",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## What

`AgenticLoopResult.toolExecutions` now carries the provider's tool-call `id` on every record, and an `error` string on the three failure paths (breaker trip, unresolvable name, thrown `execute`).

## Why

This is a prerequisite for Plan 08 Task 8 Step 3 (migrating Anthropic's hand-rolled loop onto `runAgenticLoop`), and it was found by attempting that migration rather than assumed up front.

Anthropic's existing loop persists tool activity as paired records:

```ts
toolCallsForStorage.push({ type: "tool-call", toolCallId: acc.id, toolName: acc.name, args });
toolResultsForStorage.push({ type: "tool-result", toolCallId: acc.id, toolName: acc.name, error: message });
```

Both are keyed by the provider's tool-call id, and a failed result is stored differently from a successful one. The engine's `toolExecutions` carried only `name`/`input`/`output`, so a migrated loop could reconstruct neither — it would have had to drop the id and record every failure as if it had succeeded. That is a behaviour change wearing a refactor's clothes, so the engine grows the two fields instead.

## Scope

Additive only. `id` is always set; `error` is optional and absent on success. No existing consumer reads a field that changed meaning.

## Tests

Three cases added to the loop-engine suite covering success, a throwing tool, and an unresolvable name.

Each was **mutation-verified**: setting `id: ""` on the success path and dropping `error` from the throw path makes exactly those two cases report `✗` and the suite exit non-zero — they are not passing by construction.

```
Passed: 31   RESULT: PASS
# with both mutations applied:
Passed: 29   Failed: 2
```