### PR TITLE
fix(anthropic): keep truncated final_result payloads verbatim in the loop adapter

### DIFF
--- a/src/lib/providers/anthropic/loopAdapter.ts
+++ b/src/lib/providers/anthropic/loopAdapter.ts
@@ -34,6 +34,7 @@ import type {
 } from "../../types/index.js";
 import { resolveDeferredTool } from "../../tools/toolDiscovery.js";
 import { stringifyAnthropicToolOutput } from "./toolOutput.js";
+import { stringifyFinalResultInput } from "./structuredOutput.js";
 
 /** Map Anthropic's stop_reason onto the unified finish reason. */
 function mapAnthropicFinishReason(
@@ -320,10 +321,21 @@ export function createAnthropicLoopAdapter(
       // never dispatched, never counted against the breaker, and never shows
       // up as a tool execution.
       const terminal = config.finalResultToolName
-        ? allCalls.find((call) => call.name === config.finalResultToolName)
+        ? [...toolByIndex.values()].find(
+            (pending) => pending.name === config.finalResultToolName,
+          )
         : undefined;
       const toolCalls = terminal ? [] : allCalls;
-      const finalText = terminal ? JSON.stringify(terminal.args) : text;
+      // The RAW accumulated input_json, never the parsed-then-restringified
+      // args. `parseArgs` yields {} for a payload the token cap cut off
+      // mid-string, so re-stringifying would turn a truncated answer into
+      // "{}" and lose it outright. `stringifyFinalResultInput` canonicalizes
+      // when the JSON parses and returns it verbatim when it does not, which
+      // is what lets the caller's coercion layer repair a partial payload
+      // into a partial object instead of nothing.
+      const finalText = terminal
+        ? stringifyFinalResultInput(terminal.inputJson)
+        : text;
 
       return {
         text: finalText,

--- a/test/continuous-test-suite-anthropic-loop-characterization.ts
+++ b/test/continuous-test-suite-anthropic-loop-characterization.ts
@@ -40,6 +40,7 @@ import "dotenv/config";
  */
 
 import { createServer, type Server } from "node:http";
+import { z } from "zod";
 import { assert, defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
 
@@ -436,6 +437,76 @@ await test("a model that never stops calling tools is bounded by maxSteps", asyn
       `    [diagnostic] step-cap turn: calls=${server.calls.length} threw=${failed}`,
     );
     assert(!failed, "reaching the step cap should not fail the turn");
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+section("structured output");
+
+await test("a truncated final_result payload survives verbatim instead of collapsing to an empty object", async () => {
+  // Load-bearing, and the reason it is pinned here: the loop extracts the
+  // terminal structured-output call with `stringifyFinalResultInput`, which
+  // returns the RAW accumulated input_json when it does not parse. A payload
+  // cut off by the token cap therefore reaches the caller's coercion layer
+  // intact and can be repaired into a partial object.
+  //
+  // The obvious-looking alternative — parse the arguments, then re-stringify
+  // them — turns exactly this case into "{}" and loses the whole answer,
+  // because a truncated JSON string parses to nothing. Anything that migrates
+  // this loop must keep the verbatim path.
+  const truncated = '{"title":"a very long answer that was cut off mid-str';
+  const server = await startStandIn(() => [
+    sse("message_start", {
+      message: { id: "msg_1", usage: { input_tokens: 5, output_tokens: 0 } },
+    }),
+    sse("content_block_start", {
+      index: 0,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_f",
+        name: "final_result",
+        input: {},
+      },
+    }),
+    sse("content_block_delta", {
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: truncated },
+    }),
+    sse("content_block_stop", { index: 0 }),
+    sse("message_delta", {
+      delta: { stop_reason: "max_tokens" },
+      usage: { output_tokens: 64 },
+    }),
+    sse("message_stop", {}),
+  ]);
+  const restore = withAnthropicEnv(server.port);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "answer in json" },
+      provider: "anthropic",
+      disableInternalFallback: true,
+      model: MODEL,
+      maxTokens: 32,
+      schema: z.object({ title: z.string() }),
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      text += chunk?.content ?? "";
+    }
+    console.log(
+      `    [diagnostic] structured stream produced: ${text.slice(0, 120)}`,
+    );
+    assert(
+      text.includes("a very long answer that was cut off"),
+      "the truncated structured payload did not survive to the consumer",
+    );
+    assert(
+      text.trim() !== "{}",
+      "the truncated structured payload collapsed to an empty object",
+    );
   } finally {
     restore();
     await server.close();


### PR DESCRIPTION
## The defect

`createAnthropicLoopAdapter` extracted the terminal structured-output call as:

```ts
const finalText = terminal ? JSON.stringify(terminal.args) : text;
```

`terminal.args` comes from `parseArgs`, which returns `{}` for JSON the token cap cut off mid-string. So a truncated structured response would have reached the caller as **`"{}"`** — the entire answer lost.

The hand-rolled loop being replaced does not do this. It calls `stringifyFinalResultInput(inputJson)`, which canonicalizes when the JSON parses and returns the **raw accumulated text verbatim** when it does not, so the caller's coercion layer can repair a partial payload into a partial object. That is what CLAUDE.md rule 3 requires: a truncated response must still yield a partial object, never nothing.

## How it was found

By reading the old loop line-by-line while starting Task 8 Step 3, rather than by a test — the adapter is not wired into the client yet, so this is a **latent** defect being fixed before it can ship, not a live one.

## The guard

The characterization suite gains the case that catches it: a stream whose `final_result` `input_json` is cut off mid-string must reach the consumer with its partial content intact.

It passes today against the hand-rolled loop, and it is what will fail when Step 3 swaps the loop out if the verbatim path is not preserved:

```
[diagnostic] structured stream produced: {"title":"a very long answer that was cut off mid-str
✓ a truncated final_result payload survives verbatim instead of collapsing to an empty object
Passed: 5   RESULT: PASS
```

The two assertions are written without provider wording, so a genuine failure reports `✗` rather than being downgraded to a skip by `isExpectedProviderError()`.