### PR TITLE
fix(googleAiStudio): stop dropping caller tools on the generate path

### DIFF
--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -1419,7 +1419,18 @@ export class GoogleAIStudioProvider extends BaseProvider {
               "[GoogleAIStudio] Gemini does not support tools and JSON schema output simultaneously. Disabling tools for this request (generate()).",
             );
           }
-          if (shouldUseTools && !exclusionInForce) {
+          // Both conjuncts, matching the warning directly above and the
+          // stream path's gate. `isToolsSchemaExclusionInForce` answers "does
+          // the tools/schema exclusion APPLY to this provider and model", and
+          // is true for any Gemini request that has tools at all — it is not
+          // "the exclusion is triggered". Testing `!exclusionInForce` alone
+          // therefore made this branch reachable only when there were NO
+          // tools, so every caller-supplied tool was dropped on the generate
+          // path whether or not structured output was ever requested.
+          if (
+            shouldUseTools &&
+            !(wantsNativeJsonRequested && exclusionInForce)
+          ) {
             const tools = options.tools || {};
 
             if (Object.keys(tools).length > 0) {

--- a/test/continuous-test-suite-aistudio-loop-characterization.ts
+++ b/test/continuous-test-suite-aistudio-loop-characterization.ts
@@ -272,7 +272,7 @@ await test("a caller's own tool is declared, executed, and its result returns to
 
 section("generate loop");
 
-await test("the generate path does not declare a caller's tools (known defect)", async () => {
+await test("the generate path declares and executes a caller's tools", async () => {
   // AI Studio's generate() has a second, near-duplicate hand-rolled loop.
   // Pinning it separately matters because Task 9 migrates BOTH onto one
   // adapter, and a regression in either would otherwise be invisible.
@@ -294,29 +294,26 @@ await test("the generate path does not declare a caller's tools (known defect)",
       tools: customTool(counter),
       credentials: credentialsFor(server.port),
     });
-    // Pins behaviour that is WRONG, so the migration has a baseline.
+    // The inverted form of what the characterization pass pinned, now that
+    // the cause is fixed.
     //
-    // AI Studio's generate() never advertises the caller's tools: the loop
-    // builds its declarations from `options.tools`, but nothing merges the
-    // caller's tools into it on this path the way BaseProvider.stream() does
-    // for the streaming twin. So `nl.generate({ provider: "google-ai",
-    // tools })` cannot use those tools at all — the model is never told they
-    // exist. This is the same defect class already found and fixed on
-    // Bedrock's generate path.
-    //
-    // The two calls below therefore prove the loop ran, not that the tool
-    // worked: the fixture returns a canned functionCall the provider never
-    // declared, so the loop answers it with a not-found functionResponse and
-    // takes a second turn. When Task 9's migration fixes the declaration,
-    // these assertions invert — which is the intended outcome, not a
-    // regression.
+    // The generate path gated its tool-declaration branch on
+    // `!exclusionInForce` alone. `isToolsSchemaExclusionInForce` reports
+    // whether the Gemini tools/schema exclusion APPLIES to this provider and
+    // model, and it is true for any Gemini request that carries tools at all
+    // — so that branch was reachable only when there were no tools to
+    // declare, and every caller-supplied tool was dropped whether or not
+    // structured output was ever requested. The gate now takes both
+    // conjuncts, matching the warning immediately above it and the stream
+    // path's own gate.
     assert(
-      !declaredToolNames(server.calls[0]).includes("lookup"),
-      "the generate path declared the caller's tool — the defect is fixed, invert this assertion",
+      declaredToolNames(server.calls[0]).includes("lookup"),
+      "the generate path did not declare the caller's tool",
     );
+    assert(counter.calls === 1, "the caller's tool did not execute once");
     assert(
-      counter.calls === 0,
-      "the caller's tool executed on the generate path — the defect is fixed, invert this assertion",
+      functionResponses(server.calls[1]).includes("lookup"),
+      "the tool result was not carried back to the model",
     );
     assert(
       server.calls.length === 2,


### PR DESCRIPTION
## The bug

`nl.generate({ provider: "google-ai", tools })` never advertised the caller's tools to the model. They could not be used at all, silently — no error, the model simply was never told they existed.

## Cause

`executeNativeGemini3Generate` gated its tool-declaration branch on one conjunct:

```ts
if (shouldUseTools && !exclusionInForce) {
  const tools = options.tools || {};
```

`isToolsSchemaExclusionInForce(provider, model, shouldUseTools, toolCount)` returns `isGemini && shouldUseTools && toolCount > 0`. It answers **"does the tools/schema exclusion apply to this provider and model"** — not **"is the exclusion triggered"**. It is true for any Gemini request that carries tools.

So `!exclusionInForce` was true only when there were **no tools to declare**. Every caller-supplied tool was dropped, whether or not structured output was ever requested.

The correct predicate was already sitting two lines above, used for the warning:

```ts
if (wantsNativeJsonRequested && exclusionInForce) { logger.warn(...) }
```

and it is what the stream path uses at `client.ts:812`. The generate path computed the right condition for its log line and then branched on the wrong one.

## How it was found

Three earlier attempts at this defect targeted the wrong layer — including one I proved wrong with a probe and reverted rather than shipped. The cause only surfaced after establishing which function actually serves `generate()`: not either `executeStream` loop, but `executeNativeGemini3Generate`.

## Tests

The characterization suite pinned this as a known defect in #1393 with assertions written to be inverted once fixed. This PR inverts them: the tool is now declared on call 1, executed exactly once, and its `functionResponse` is carried back on call 2.

**Mutation-verified.** Restoring the single-conjunct gate makes exactly this case fail:

```
✓ the generate path declares and executes a caller's tools     # with the fix
✗ the generate path declares and executes a caller's tools     # gate reverted
Passed: 2   Failed: 1
```

It reports `✗` and exits non-zero rather than being downgraded to a skip.

## Scope

Fixes D10 for AI Studio. Bedrock was fixed in #1382; Vertex Gemini and Vertex Claude were checked and are clear (they call `getToolsForStream(options)` at `googleVertex/client.ts:7352`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Caller-supplied tools now remain available for standard Google AI Studio requests.
  - Tool usage is correctly disabled when it conflicts with JSON or schema-based output requirements.
  - Tool calls are now executed and returned to the model as expected during generation loops.

- **Tests**
  - Updated coverage to verify the corrected tool-routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->