### PR TITLE
fix(proxy): make OpenCode auto-configuration work on macOS

### DIFF
--- a/docs/features/opencode-proxy-support.md
+++ b/docs/features/opencode-proxy-support.md
@@ -60,13 +60,23 @@ Claude Code then sends all requests to the proxy's `/v1/messages` endpoint (Anth
 
 ### Config File Locations
 
-OpenCode uses XDG base directories (via `xdg-basedir` npm package):
+OpenCode uses XDG base directories via the `xdg-basedir` npm package, which
+resolves `XDG_CONFIG_HOME || ~/.config` on **every** platform — there is no
+macOS special case. (OpenCode's binary does contain a
+`/Library/Application Support/opencode` literal, but that is
+`systemManagedConfigDir()`, an MDM policy directory at the filesystem root
+with no `$HOME` prefix — not the per-user config path.)
 
-| Platform    | Global Config Path                                     |
-| ----------- | ------------------------------------------------------ |
-| **macOS**   | `~/Library/Application Support/opencode/opencode.json` |
-| **Linux**   | `~/.config/opencode/opencode.json`                     |
-| **Windows** | `%LOCALAPPDATA%/opencode/opencode.json`                |
+| Platform    | Global Config Path                              |
+| ----------- | ----------------------------------------------- |
+| **macOS**   | `~/.config/opencode/opencode.json`              |
+| **Linux**   | `~/.config/opencode/opencode.json`              |
+| **Windows** | `~/.config/opencode/opencode.json` (unverified) |
+
+The macOS row was verified empirically against OpenCode 1.3.13 (embedded
+`xdg-basedir` source in the shipped binary, plus `opencode models` confirming
+which file is actually loaded). The Windows row follows from the same
+branch-free resolution code but has **not** been checked on a Windows machine.
 
 Project-level config: `.opencode/opencode.json` in any parent directory.
 
@@ -319,8 +329,8 @@ const OPENCODE_CONFIG_DIR = join(
 const OPENCODE_CONFIG_PATH = join(OPENCODE_CONFIG_DIR, "opencode.json");
 ```
 
-On macOS: `~/Library/Application Support/opencode/opencode.json`
-On Linux: `~/.config/opencode/opencode.json`
+On macOS and Linux alike: `~/.config/opencode/opencode.json`
+(`XDG_CONFIG_HOME` wins when set)
 
 ### Detection
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -268,7 +268,9 @@ export default [
             "test/continuous-test-suite-rag.ts",
             // Parser edge cases, outgoing wire format, proxy cooldown/quota.
             "test/continuous-test-suite-bugfixes.ts",
-            // 429-cooldown planning and quota ordering across accounts.
+            // 429-cooldown planning and quota ordering across accounts, plus
+            // OpenCode client-config writing against a throwaway XDG dir —
+            // including the not-installed branch, which no live run reaches.
             "test/continuous-test-suite-proxy.ts",
             // Background task system with no public surface at all.
             "test/continuous-test-suite-autoresearch.ts",

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -709,17 +709,21 @@ async function clearClaudeProxySettings(
 // =============================================================================
 
 function getOpenCodeConfigDir(): string {
-  if (process.platform === "darwin") {
-    return join(homedir(), "Library", "Application Support", "opencode");
-  }
-  // Linux/other: XDG_CONFIG_HOME or ~/.config
+  // OpenCode resolves this with the unmodified `xdg-basedir` package —
+  // `XDG_CONFIG_HOME || ~/.config` — on every platform, macOS included. There
+  // is deliberately no darwin branch here: `~/Library/Application Support/
+  // opencode` is not a path OpenCode reads. (The similar-looking literal in
+  // OpenCode's binary is `systemManagedConfigDir()`, an MDM policy directory
+  // at the filesystem root with no $HOME prefix.)
   return join(
     process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
     "opencode",
   );
 }
 
-const OPENCODE_CONFIG_PATH = join(getOpenCodeConfigDir(), "opencode.json");
+function getOpenCodeConfigPath(): string {
+  return join(getOpenCodeConfigDir(), "opencode.json");
+}
 
 /**
  * Key under which we persist the snapshot of the user's pre-existing
@@ -734,20 +738,22 @@ const OPENCODE_ORIGINAL_KEY = "__proxy_original_neurolink";
 async function setOpenCodeProxySettings(
   baseUrl: string,
   proxyKey?: string,
-): Promise<void> {
+): Promise<boolean> {
   const fs = await import("fs");
 
   const configDir = getOpenCodeConfigDir();
   try {
     fs.accessSync(configDir);
   } catch {
-    // OpenCode not installed — config directory does not exist, skip silently
-    return;
+    // OpenCode not installed — config directory does not exist. Report the
+    // skip so the caller does not print a success message for work that did
+    // not happen.
+    return false;
   }
 
   let config: Record<string, unknown>;
   try {
-    config = JSON.parse(fs.readFileSync(OPENCODE_CONFIG_PATH, "utf8"));
+    config = JSON.parse(fs.readFileSync(getOpenCodeConfigPath(), "utf8"));
   } catch {
     // file missing/invalid — create fresh config object
     config = { provider: {} };
@@ -780,7 +786,8 @@ async function setOpenCodeProxySettings(
   };
 
   config.provider = provider;
-  fs.writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2));
+  fs.writeFileSync(getOpenCodeConfigPath(), JSON.stringify(config, null, 2));
+  return true;
 }
 
 async function clearOpenCodeProxySettings(
@@ -789,7 +796,7 @@ async function clearOpenCodeProxySettings(
   const fs = await import("fs");
   let config: Record<string, unknown>;
   try {
-    config = JSON.parse(fs.readFileSync(OPENCODE_CONFIG_PATH, "utf8"));
+    config = JSON.parse(fs.readFileSync(getOpenCodeConfigPath(), "utf8"));
   } catch {
     return false;
   }
@@ -838,9 +845,23 @@ async function clearOpenCodeProxySettings(
   }
 
   config.provider = provider;
-  fs.writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2));
+  fs.writeFileSync(getOpenCodeConfigPath(), JSON.stringify(config, null, 2));
   return hadNeurolink;
 }
+
+/**
+ * Test-only export (CLAUDE.md rule 15 determinism exception). The OpenCode
+ * client writers resolve paths from the environment and are only reachable
+ * from `proxy start` / `proxy setup`, neither of which can be driven against a
+ * throwaway HOME without starting a real server. Consumed by
+ * test/continuous-test-suite-proxy.ts.
+ */
+export const __openCodeTestHooks = {
+  getOpenCodeConfigDir,
+  getOpenCodeConfigPath,
+  setOpenCodeProxySettings,
+  clearOpenCodeProxySettings,
+};
 
 // =============================================================================
 // CODEX (ChatGPT) AUTO-CONFIGURATION
@@ -3488,9 +3509,12 @@ async function startProxyRuntime(params: {
     }
 
     try {
-      await setOpenCodeProxySettings(`${url}/v1`);
-      logger.always(chalk.green("  ✓ Auto-configured OpenCode settings"));
-      logger.always(chalk.dim("    Restart OpenCode to connect through proxy"));
+      if (await setOpenCodeProxySettings(`${url}/v1`)) {
+        logger.always(chalk.green("  ✓ Auto-configured OpenCode settings"));
+        logger.always(
+          chalk.dim("    Restart OpenCode to connect through proxy"),
+        );
+      }
     } catch (error) {
       logger.debug(
         "[proxy] Failed to auto-configure OpenCode: " +
@@ -5400,8 +5424,9 @@ export const proxySetupCommand: CommandModule = {
         console.info(chalk.yellow(`  Set manually: ANTHROPIC_BASE_URL=${url}`));
       }
       try {
-        await setOpenCodeProxySettings(`${url}/v1`);
-        console.info(chalk.green("  ✓ OpenCode configured"));
+        if (await setOpenCodeProxySettings(`${url}/v1`)) {
+          console.info(chalk.green("  ✓ OpenCode configured"));
+        }
       } catch (e) {
         console.info(
           chalk.yellow(

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -14,6 +14,14 @@
  * cannot be arranged on demand. `__testHooks` is a test-only export in `src/`
  * and should shrink as this logic gains a real surface.
  *
+ * Three further cases import `__openCodeTestHooks` from the proxy CLI command
+ * to cover OpenCode client auto-configuration. Those writers resolve paths
+ * from the environment and are reachable only from `proxy start` and
+ * `proxy setup` — neither of which can be pointed at a throwaway HOME without
+ * starting a real server and a launchd unit. Determinism here buys the one
+ * thing an end-to-end run cannot: asserting what the writer does when the
+ * target CLI is *absent*, which is the case that silently regressed.
+ *
  * Tests the proxy server end-to-end:
  * - Starts the proxy
  * - Sends real requests through it
@@ -1364,6 +1372,149 @@ async function testProxyShutdown(): Promise<boolean | null> {
 
   log("Proxy shutdown verified", "green");
   return true;
+}
+
+// ============================================================================
+// Tests: OpenCode client auto-configuration (in-process, throwaway HOME)
+// ============================================================================
+
+/**
+ * OpenCode resolves its global config with the unmodified `xdg-basedir`
+ * package — `XDG_CONFIG_HOME || ~/.config`, with no platform branch. The proxy
+ * used to special-case darwin to `~/Library/Application Support/opencode`,
+ * which OpenCode never reads, so auto-configuration silently no-opped on every
+ * Mac.
+ */
+async function testOpenCodeConfigDirIsXdgOnAllPlatforms(): Promise<boolean> {
+  const { __openCodeTestHooks } = await import("../src/cli/commands/proxy.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  try {
+    process.env.XDG_CONFIG_HOME = "/tmp/neurolink-xdg-probe";
+    const dir = __openCodeTestHooks.getOpenCodeConfigDir();
+    if (dir !== path.join("/tmp/neurolink-xdg-probe", "opencode")) {
+      log(
+        `OpenCode config dir ignored XDG_CONFIG_HOME on ${process.platform}`,
+        "red",
+      );
+      return false;
+    }
+
+    delete process.env.XDG_CONFIG_HOME;
+    const fallback = __openCodeTestHooks.getOpenCodeConfigDir();
+    if (fallback !== path.join(os.homedir(), ".config", "opencode")) {
+      log(
+        `OpenCode config dir did not fall back to ~/.config on ${process.platform}`,
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+  }
+}
+
+/**
+ * The writer must report whether it actually wrote. It used to return void, so
+ * the caller printed "Auto-configured OpenCode settings" even when OpenCode was
+ * absent and nothing had been written.
+ */
+async function testOpenCodeWriterReportsWhetherItWrote(): Promise<boolean> {
+  const { __openCodeTestHooks } = await import("../src/cli/commands/proxy.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-opencode-"));
+  try {
+    // OpenCode absent: the config dir does not exist.
+    process.env.XDG_CONFIG_HOME = path.join(root, "absent");
+    const missing = await __openCodeTestHooks.setOpenCodeProxySettings(
+      "http://127.0.0.1:55669/v1",
+    );
+    if (missing !== false) {
+      log(
+        `OpenCode writer claimed success with no config dir (got ${String(missing)})`,
+        "red",
+      );
+      return false;
+    }
+
+    // OpenCode present: the config dir exists.
+    const present = path.join(root, "present");
+    fs.mkdirSync(path.join(present, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = present;
+    const wrote = await __openCodeTestHooks.setOpenCodeProxySettings(
+      "http://127.0.0.1:55669/v1",
+    );
+    if (wrote !== true) {
+      log(
+        `OpenCode writer did not report a successful write (got ${String(wrote)})`,
+        "red",
+      );
+      return false;
+    }
+
+    const written = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as { provider?: { neurolink?: { options?: { baseURL?: string } } } };
+    if (
+      written.provider?.neurolink?.options?.baseURL !==
+      "http://127.0.0.1:55669/v1"
+    ) {
+      log("OpenCode writer did not record the proxy base URL", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** A user's pre-existing provider.neurolink must survive set() then clear(). */
+async function testOpenCodeClearRestoresUserConfig(): Promise<boolean> {
+  const { __openCodeTestHooks } = await import("../src/cli/commands/proxy.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-opencode-"));
+  try {
+    fs.mkdirSync(path.join(root, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = root;
+    const configPath = __openCodeTestHooks.getOpenCodeConfigPath();
+    const original = { provider: { neurolink: { name: "user's own block" } } };
+    fs.writeFileSync(configPath, JSON.stringify(original, null, 2));
+
+    await __openCodeTestHooks.setOpenCodeProxySettings(
+      "http://127.0.0.1:55669/v1",
+    );
+    await __openCodeTestHooks.clearOpenCodeProxySettings(
+      "http://127.0.0.1:55669/v1",
+    );
+
+    const after = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+      provider?: { neurolink?: { name?: string } };
+    };
+    if (after.provider?.neurolink?.name !== "user's own block") {
+      log(
+        "OpenCode clear did not restore the user's pre-existing block",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 // ============================================================================
@@ -3502,6 +3653,21 @@ const tests: TestFunction[] = [
     name: "Quota: merge preserves provider configuration",
     fn: testQuotaMergePreservesProviderConfig,
     category: "proxy-primary",
+  },
+  {
+    name: "OpenCode: config dir is XDG on all platforms",
+    fn: testOpenCodeConfigDirIsXdgOnAllPlatforms,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: writer reports whether it wrote",
+    fn: testOpenCodeWriterReportsWhetherItWrote,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: clear restores the user's own config",
+    fn: testOpenCodeClearRestoresUserConfig,
+    category: "proxy-config",
   },
   {
     name: "Entitlement: detector tiers",


### PR DESCRIPTION
Closes #1366
Closes #1367

## What was wrong

`neurolink proxy start` reported `✓ Auto-configured OpenCode settings` on every Mac and wrote nothing.

`getOpenCodeConfigDir()` special-cased darwin to `~/Library/Application Support/opencode`. OpenCode resolves its config with the **unmodified `xdg-basedir` package** — `XDG_CONFIG_HOME || ~/.config` — on every platform, with no darwin branch. So `fs.accessSync` threw `ENOENT`, the writer took its silent skip path, and the config was never written.

Verified against the installed OpenCode 1.3.13 binary: `~/.config/opencode/opencode.json` exists and is loaded (`opencode models` confirms it); `~/Library/Application Support/opencode` does not exist.

**Where the wrong path came from:** OpenCode`s binary does contain the literal `/Library/Application Support/opencode` — as `systemManagedConfigDir()`, an MDM policy directory at the **filesystem root**, with no `$HOME` prefix. It looks like that string was found and read as the per-user path. The fix carries a comment naming it, so the branch is not re-added.

## The path fix alone was not enough

`setOpenCodeProxySettings` returned `Promise<void>` and both call sites printed the `✓` unconditionally. `setCodexProxySettings` returns a boolean and gates its `✓` on it. So even after fixing the path, a user without OpenCode still got a success message for work that did not happen. It now returns `boolean` and both callers gate on it.

## Why it was never caught

The design doc`s own end-to-end playbook runs the dev proxy with `--dev`, whose option description is "no client auto-configuration", and hand-copies a fixture into place. **The writer is never executed by the documented verification.** There was also no automated coverage — `grep` for `setOpenCodeProxySettings` across `test/` returned nothing.

## Also corrected

`docs/features/opencode-proxy-support.md` asserted the same wrong macOS path while showing resolution code with no darwin branch — it contradicted itself, and is titled "Implemented & Verified". The Windows row is corrected by the same logic but **marked unverified**, since only darwin was confirmed empirically.

## Testing

Three regression tests, added to `test/continuous-test-suite-proxy.ts`:

- config dir resolves via XDG on all platforms, and falls back to `~/.config`
- the writer reports whether it wrote — including the **not-installed** branch, which is the case that silently regressed and which no live run reaches
- `clear` restores a user`s pre-existing `provider.neurolink` block

TDD: all four assertions were watched failing first, quoting the actual wrong values (`got /Users/…/Library/Application Support/opencode`, `got undefined`), then fixed, then green. Re-verified against the **built** `dist/cli/commands/proxy.js`, not source.

`tsc --noEmit --strict` clean · eslint 0 errors · proxy suite 36 passed.

---

**This is the first of a four-PR stack.** #2 moves these writers behind a registry, so this one lands first and stays reviewable on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenCode proxy setup now automatically uses the standard XDG configuration location across platforms, including macOS.
  - Setup reports whether configuration was successfully applied, enabling clearer startup feedback.
  - Existing OpenCode configuration is preserved and restored appropriately during setup workflows.

- **Documentation**
  - Updated OpenCode configuration path guidance, including clarification that the Windows location remains unverified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->