### PR TITLE
feat(proxy): give proxy traffic a real token and cost ledger

### DIFF
--- a/docs/development/2026-08-20-client-configurator-registry.md
+++ b/docs/development/2026-08-20-client-configurator-registry.md
@@ -837,3 +837,59 @@ git commit -m "feat(proxy): auto-configure Qwen Code through the client registry
 - **Behaviour drift in messages.** The two apply blocks print different strings. The loop parameterises them; a careless merge collapses them into one wording and changes user-visible output. The manual check above catches it.
 - **HOME resolution timing.** Three module-level path constants become functions. If any moved function still closes over a stale constant, tests pass under the suite's isolated HOME but the real writer targets the wrong path — the exact shape of #1366. Grep for remaining `const .*_PATH = join(homedir()` after Task 3.
 - **`proxy-performance` gate.** `proxy.ts` shrinks by roughly 400 lines; the benchmark job imports `proxyLifecycle.ts` and `proxyActivity.ts`, not the writers, so impact is unlikely — but it is an always-on CI gate, so run it before pushing.
+
+---
+
+## Post-review addenda
+
+Two defects surfaced in review after the registry landed. Both are recorded here
+because they are properties of the _lifecycle_ the registry now owns, not of any
+one configurator.
+
+### The snapshot must not outlive the value it describes
+
+Each JSON writer persists the user's pre-existing value under a
+`__proxy_original_*` key **inside the user's own config file**, so a restore
+still works after a crash or from another process. Snapshotting only on first
+touch stops a second `apply()` from recording the proxy's own block as the
+"original".
+
+That guard is presence-only, and the sentinel survives an unclean kill where no
+restore ever ran. A user who then edits the block by hand — reasonably, since
+the proxy is gone — hits this sequence:
+
+1. `apply()` writes the proxy block; snapshot records "user had nothing".
+2. `kill -9`. No restore. Sentinel stays in the file.
+3. User replaces the block with their own provider config and API key.
+4. Proxy restarts. `apply()` sees the sentinel, keeps the stale snapshot, and
+   overwrites the user's block.
+5. Clean shutdown. `restore()` reads "user had nothing" and **deletes** it.
+
+For Qwen that final step destroys a live credential. Each writer therefore also
+records what it wrote, under `__proxy_written_*`; `shouldCaptureSnapshot()` in
+`snapshot.ts` re-snapshots whenever the value in the file is not the value we
+put there. A file written before this change carries no `__proxy_written_*` key,
+so the old behaviour is preserved for exactly one apply, then self-heals.
+
+### `uninstall` is the only restore point a service ever reaches
+
+`restoreAllClients()` runs from the shutdown path only under
+`signal === "SIGINT"`. A launchd-managed service never receives one: `launchctl
+unload`, `launchctl stop` and `proxy uninstall` all send SIGTERM, and the
+supervisor's own shutdown closure never touched client configs at all. The
+fail-open guard that would otherwise cover this is not spawned when
+`managedByLaunchd`.
+
+So the documented one-command install — `neurolink proxy setup` — left all five
+CLIs pointing at a dead socket after uninstall, silently. `uninstall` now calls
+`restoreClientsOnUninstall()` before `clearProxyState()`, deriving the URL from
+the recorded host/port (`0.0.0.0` normalised to `localhost`, matching what the
+clients were actually handed).
+
+Widening the signal gate was considered and rejected: a service also receives
+SIGTERM on reboot and on rolling restart, where restoring would be wrong.
+`uninstall` is the one point where "going away for good" is unambiguous.
+
+The regression test drives the built CLI rather than the helper, because the
+defect _was_ the missing wiring — a test calling the helper directly would have
+passed for as long as the bug existed.

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -5222,6 +5222,50 @@ export const proxyInstallCommand: CommandModule = {
   },
 };
 
+/**
+ * Put every auto-configured CLI back the way it was, using the URL recorded in
+ * the proxy's own state file.
+ *
+ * `proxy uninstall` is the one moment where "the proxy is going away for good"
+ * is unambiguous, and it is the only place this can be done for a
+ * launchd-managed service: the shutdown path restores on SIGINT only, and both
+ * `launchctl unload` and this command stop the supervisor with SIGTERM. Without
+ * this, uninstalling left all five clients pointing at a socket that no longer
+ * answers, with nothing to say why.
+ *
+ * Must run before `clearProxyState()` — the state file is what tells us which
+ * URL the clients were given, and the restore helpers deliberately refuse to
+ * touch a URL they did not write.
+ */
+async function restoreClientsOnUninstall(): Promise<void> {
+  let state: ProxyState | null = null;
+  try {
+    state = loadProxyState();
+  } catch {
+    // An unreadable state file is not a reason to abort an uninstall.
+  }
+  if (!state?.port) {
+    // Nothing recorded, so we cannot prove which URL the configs carry.
+    return;
+  }
+  // 0.0.0.0 is a bind address, never a reachable one; clients were handed
+  // localhost, so that is what restore has to match on.
+  const host =
+    state.host === "0.0.0.0" ? "localhost" : (state.host ?? "localhost");
+  const results = await restoreAllClients(`http://${host}:${state.port}`);
+  for (const result of results) {
+    if (result.restored) {
+      console.info(
+        chalk.green(`\u2713 Restored ${result.displayName} settings`),
+      );
+    } else if (result.error) {
+      logger.debug(
+        `[proxy] ${result.id} restore failed during uninstall: ${result.error.message}`,
+      );
+    }
+  }
+}
+
 export const proxyUninstallCommand: CommandModule = {
   command: "uninstall",
   describe: "Remove proxy background service",
@@ -5243,6 +5287,7 @@ export const proxyUninstallCommand: CommandModule = {
         );
         process.exit(1);
       }
+      await restoreClientsOnUninstall();
       clearProxyState();
       clearProxySupervisorState();
       console.info(chalk.yellow("No proxy service installed."));
@@ -5270,6 +5315,7 @@ export const proxyUninstallCommand: CommandModule = {
     }
 
     unlinkSync(PLIST_PATH);
+    await restoreClientsOnUninstall();
     clearProxyState();
     clearProxySupervisorState();
     console.info(chalk.green(`✓ Plist removed from ${PLIST_PATH}`));

--- a/src/cli/commands/proxyAnalyze.ts
+++ b/src/cli/commands/proxyAnalyze.ts
@@ -128,8 +128,27 @@ function printAnalysis(
       `    Usage records: ${report.cache.requestsWithUsage}, cache-read requests: ${report.cache.requestsWithCacheRead}, hit rate: ${report.cache.requestHitRate === null ? "-" : `${(report.cache.requestHitRate * 100).toFixed(1)}%`}`,
     );
     logger.always(
-      `    Tokens: ${report.cache.cacheReadTokens} read, ${report.cache.cacheCreationTokens} created, ${report.cache.inputTokens} input`,
+      `    Tokens: ${report.cache.cacheReadTokens} read, ${report.cache.cacheCreationTokens} created, ${report.cache.inputTokens} input, ${report.cache.outputTokens} output`,
     );
+    logger.always(
+      report.cache.requestsPriced > 0
+        ? `    Estimated cost: $${report.cache.estimatedCostUsd.toFixed(4)} across ${report.cache.requestsPriced} priced request(s)`
+        : "    Estimated cost: unavailable (no request carried a priceable model)",
+    );
+    if (report.cache.requestsPricedByPrefix > 0) {
+      logger.always(
+        chalk.yellow(
+          `    ⚠ ${report.cache.requestsPricedByPrefix} request(s) priced by name-prefix fallback, not an exact rate: ${report.cache.modelsPricedByPrefix.join(", ")}`,
+        ),
+      );
+    }
+    if (report.cache.requestsUnpriced > 0) {
+      logger.always(
+        chalk.yellow(
+          `    ⚠ ${report.cache.requestsUnpriced} request(s) had usage but no pricing row: ${report.cache.unpricedModels.join(", ")}`,
+        ),
+      );
+    }
   } else {
     logger.always(chalk.yellow("    Cache usage: unavailable"));
   }

--- a/src/cli/proxy-clients/claudeCode.ts
+++ b/src/cli/proxy-clients/claudeCode.ts
@@ -10,6 +10,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
 import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
+import { isProxyOwnedValue, shouldCaptureSnapshot } from "./snapshot.js";
 
 /**
  * Resolved per call rather than at module load so `detect()` and `apply()`
@@ -26,6 +27,15 @@ function getClaudeSettingsPath(): string {
 /** Keys we manage in Claude Code's settings.env */
 const PROXY_MANAGED_KEYS = ["ANTHROPIC_BASE_URL", "ENABLE_TOOL_SEARCH"];
 
+/** The user's values for those keys, as they were before the proxy first ran. */
+const CLAUDE_ORIGINAL_KEY = "__proxy_original_env";
+
+/**
+ * The values this writer last wrote. Lets apply() tell its own values from ones
+ * the user substituted while the proxy was not running.
+ */
+const CLAUDE_WRITTEN_KEY = "__proxy_written_env";
+
 export async function setClaudeProxySettings(baseUrl: string): Promise<void> {
   const fs = await import("fs");
   let settings: Record<string, unknown> = {};
@@ -38,19 +48,35 @@ export async function setClaudeProxySettings(baseUrl: string): Promise<void> {
   const env = (settings.env ?? {}) as Record<string, string>;
 
   // Preserve original values so clearClaudeProxySettings can restore them.
-  // Only snapshot once — subsequent calls should not overwrite the snapshot.
-  const originals = ((settings as Record<string, unknown>)
-    .__proxy_original_env ?? {}) as Record<string, string | null>;
+  // A repeat apply() must not overwrite the snapshot with the proxy's own
+  // values — but a value the user set while the proxy was gone must replace
+  // it. See shouldCaptureSnapshot.
+  const originals = ((settings as Record<string, unknown>)[
+    CLAUDE_ORIGINAL_KEY
+  ] ?? {}) as Record<string, string | null>;
+  const written = ((settings as Record<string, unknown>)[CLAUDE_WRITTEN_KEY] ??
+    {}) as Record<string, string | undefined>;
   for (const key of PROXY_MANAGED_KEYS) {
-    if (!(key in originals)) {
-      originals[key] = key in env ? env[key] : null;
+    const current = key in env ? env[key] : undefined;
+    if (
+      shouldCaptureSnapshot({
+        hasSnapshot: key in originals,
+        written: written[key],
+        current,
+      })
+    ) {
+      originals[key] = current ?? null;
     }
   }
-  (settings as Record<string, unknown>).__proxy_original_env = originals;
+  (settings as Record<string, unknown>)[CLAUDE_ORIGINAL_KEY] = originals;
 
   env.ANTHROPIC_BASE_URL = baseUrl;
   env.ENABLE_TOOL_SEARCH = "true";
   settings.env = env;
+  (settings as Record<string, unknown>)[CLAUDE_WRITTEN_KEY] = {
+    ANTHROPIC_BASE_URL: baseUrl,
+    ENABLE_TOOL_SEARCH: "true",
+  };
 
   fs.writeFileSync(getClaudeSettingsPath(), JSON.stringify(settings, null, 2));
 }
@@ -80,7 +106,7 @@ export async function clearClaudeProxySettings(
     return false;
   }
 
-  if (!("__proxy_original_env" in settings)) {
+  if (!(CLAUDE_ORIGINAL_KEY in settings)) {
     // No snapshot means we cannot prove these keys are ours. Without this
     // guard the loop below reads every managed key as "did not exist before"
     // and deletes it — wiping a real user value. Leaving a stale proxy URL
@@ -96,9 +122,28 @@ export async function clearClaudeProxySettings(
   const hadToolSearch = env.ENABLE_TOOL_SEARCH === "true";
 
   // Restore original values if they were saved, otherwise delete the keys
-  const originals = ((settings as Record<string, unknown>)
-    .__proxy_original_env ?? {}) as Record<string, string | null>;
+  const originals = ((settings as Record<string, unknown>)[
+    CLAUDE_ORIGINAL_KEY
+  ] ?? {}) as Record<string, string | null>;
+  // Only restore keys we can prove are ours. A user who kept the proxy's base
+  // URL but changed one of the other managed values made a deliberate edit;
+  // reverting it to the snapshot — or deleting it, when the snapshot says the
+  // key was absent — would silently undo them.
+  const writtenValues = ((settings as Record<string, unknown>)[
+    CLAUDE_WRITTEN_KEY
+  ] ?? {}) as Record<string, string | undefined>;
   for (const key of PROXY_MANAGED_KEYS) {
+    if (
+      !isProxyOwnedValue({
+        written: writtenValues[key],
+        current: key in env ? env[key] : undefined,
+      })
+    ) {
+      logger.debug(
+        `[proxy] Claude clear: ${key} was edited after the proxy wrote it, leaving it intact`,
+      );
+      continue;
+    }
     const original = originals[key];
     if (original !== undefined && original !== null) {
       // Restore the value that existed before the proxy was started
@@ -108,7 +153,8 @@ export async function clearClaudeProxySettings(
       delete env[key];
     }
   }
-  delete (settings as Record<string, unknown>).__proxy_original_env;
+  delete (settings as Record<string, unknown>)[CLAUDE_ORIGINAL_KEY];
+  delete (settings as Record<string, unknown>)[CLAUDE_WRITTEN_KEY];
 
   if (Object.keys(env).length === 0) {
     delete settings.env;

--- a/src/cli/proxy-clients/openCode.ts
+++ b/src/cli/proxy-clients/openCode.ts
@@ -9,6 +9,11 @@ import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
 import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
+import {
+  cloneForSnapshot,
+  isProxyOwnedValue,
+  shouldCaptureSnapshot,
+} from "./snapshot.js";
 
 function getOpenCodeConfigDir(): string {
   // OpenCode resolves this with the unmodified `xdg-basedir` package —
@@ -37,6 +42,12 @@ function getOpenCodeConfigPath(): string {
  */
 const OPENCODE_ORIGINAL_KEY = "__proxy_original_neurolink";
 
+/**
+ * What this writer last wrote into provider.neurolink. Lets apply() tell its
+ * own block from one the user substituted while the proxy was not running.
+ */
+const OPENCODE_WRITTEN_KEY = "__proxy_written_neurolink";
+
 export async function setOpenCodeProxySettings(
   baseUrl: string,
   proxyKey?: string,
@@ -63,19 +74,23 @@ export async function setOpenCodeProxySettings(
 
   const provider = (config.provider ?? {}) as Record<string, unknown>;
 
-  // Persist a snapshot of the user's pre-existing provider.neurolink — but
-  // only the first time we touch the file. Subsequent set() calls must NOT
-  // overwrite the snapshot (otherwise after the proxy writes its own block,
-  // the next set() would store the proxy's block as the "original" and
-  // permanently lose the user's real config on the next clear()).
-  if (!(OPENCODE_ORIGINAL_KEY in config)) {
-    (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY] =
-      "neurolink" in provider
-        ? JSON.parse(JSON.stringify(provider.neurolink))
-        : null;
+  // Persist a snapshot of the user's pre-existing provider.neurolink. Repeat
+  // apply() calls must not overwrite it with the proxy's own block — but a
+  // block the user wrote while the proxy was gone must replace it. See
+  // shouldCaptureSnapshot.
+  const currentBlock = "neurolink" in provider ? provider.neurolink : undefined;
+  if (
+    shouldCaptureSnapshot({
+      hasSnapshot: OPENCODE_ORIGINAL_KEY in config,
+      written: config[OPENCODE_WRITTEN_KEY],
+      current: currentBlock,
+    })
+  ) {
+    config[OPENCODE_ORIGINAL_KEY] =
+      currentBlock === undefined ? null : cloneForSnapshot(currentBlock);
   }
 
-  provider.neurolink = {
+  const block = {
     id: "neurolink",
     name: "NeuroLink Proxy",
     npm: "@ai-sdk/openai-compatible",
@@ -86,6 +101,8 @@ export async function setOpenCodeProxySettings(
       apiKey: proxyKey || "neurolink-proxy",
     },
   };
+  provider.neurolink = block;
+  config[OPENCODE_WRITTEN_KEY] = cloneForSnapshot(block);
 
   config.provider = provider;
   fs.writeFileSync(getOpenCodeConfigPath(), JSON.stringify(config, null, 2));
@@ -127,14 +144,31 @@ export async function clearOpenCodeProxySettings(
   // explicitly had no entry before — never on an "undefined" snapshot, since
   // that would mean the snapshot was lost and we cannot prove the entry is ours.
   if (OPENCODE_ORIGINAL_KEY in config) {
-    const snapshot = (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY];
-    if (snapshot === null) {
-      // User had no provider.neurolink before the proxy started — safe to remove.
-      delete provider.neurolink;
+    // Only restore what we can prove is ours. The base-URL check above lets
+    // through a block still pointing at the proxy that the user has edited
+    // beside the URL; reverting that discards a deliberate change.
+    if (
+      isProxyOwnedValue({
+        written: config[OPENCODE_WRITTEN_KEY],
+        current: existing,
+      })
+    ) {
+      const snapshot = (config as Record<string, unknown>)[
+        OPENCODE_ORIGINAL_KEY
+      ];
+      if (snapshot === null) {
+        // User had no provider.neurolink before the proxy started — safe to remove.
+        delete provider.neurolink;
+      } else {
+        provider.neurolink = snapshot;
+      }
     } else {
-      provider.neurolink = snapshot;
+      logger.debug(
+        "[proxy] OpenCode clear: provider.neurolink was edited after the proxy wrote it, leaving it intact",
+      );
     }
     delete (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY];
+    delete (config as Record<string, unknown>)[OPENCODE_WRITTEN_KEY];
   } else {
     // No snapshot present — refuse to delete to avoid destroying a config
     // the proxy may not own (e.g. a user wrote their own `neurolink` block

--- a/src/cli/proxy-clients/qwenCode.ts
+++ b/src/cli/proxy-clients/qwenCode.ts
@@ -25,6 +25,11 @@ import type {
   CliProxyClientConfigurator,
   CliQwenSettings,
 } from "../../lib/types/index.js";
+import {
+  cloneForSnapshot,
+  isProxyOwnedValue,
+  shouldCaptureSnapshot,
+} from "./snapshot.js";
 
 /**
  * Resolved per call rather than at module load so `detect()` and `apply()`
@@ -45,6 +50,13 @@ function getQwenSettingsPath(): string {
  * the same approach the Claude and OpenCode writers take.
  */
 const QWEN_ORIGINAL_KEY = "__proxy_original_qwen_auth";
+
+/**
+ * The auth block this writer last wrote. Lets apply() tell its own block from
+ * one the user substituted while the proxy was not running — which for Qwen
+ * carries a real API key.
+ */
+const QWEN_WRITTEN_KEY = "__proxy_written_qwen_auth";
 
 function readQwenSettings(fs: typeof import("fs")): CliQwenSettings | null {
   try {
@@ -76,12 +88,20 @@ export async function setQwenProxySettings(
   const security = (settings.security ?? {}) as Record<string, unknown>;
   const auth = (security.auth ?? {}) as Record<string, unknown>;
 
-  // Snapshot only on first touch. A second apply() must not overwrite the
-  // snapshot with our own block, which would lose the user's real config on
-  // the next restore.
-  if (!(QWEN_ORIGINAL_KEY in settings)) {
+  // A repeat apply() must not overwrite the snapshot with our own block, which
+  // would lose the user's real config on the next restore — but a block the
+  // user wrote while the proxy was gone must replace it. See
+  // shouldCaptureSnapshot.
+  const currentAuth = "auth" in security ? security.auth : undefined;
+  if (
+    shouldCaptureSnapshot({
+      hasSnapshot: QWEN_ORIGINAL_KEY in settings,
+      written: settings[QWEN_WRITTEN_KEY],
+      current: currentAuth,
+    })
+  ) {
     settings[QWEN_ORIGINAL_KEY] =
-      "auth" in security ? JSON.parse(JSON.stringify(auth)) : null;
+      currentAuth === undefined ? null : cloneForSnapshot(currentAuth);
   }
 
   auth.selectedType = "openai";
@@ -89,6 +109,7 @@ export async function setQwenProxySettings(
   auth.apiKey = proxyKey || "neurolink-proxy";
   security.auth = auth;
   settings.security = security;
+  settings[QWEN_WRITTEN_KEY] = cloneForSnapshot(auth);
 
   fs.writeFileSync(getQwenSettingsPath(), JSON.stringify(settings, null, 2));
   return true;
@@ -128,13 +149,26 @@ export async function clearQwenProxySettings(
     return false;
   }
 
-  const snapshot = settings[QWEN_ORIGINAL_KEY];
-  if (snapshot === null) {
-    delete security.auth;
+  // Only restore what we can prove is ours. The base-URL check above lets
+  // through a block still pointing at the proxy whose key the user rotated
+  // beside it — overwriting that would destroy a live credential. Our
+  // bookkeeping keys go either way, so a stale sentinel cannot outlive us.
+  if (
+    isProxyOwnedValue({ written: settings[QWEN_WRITTEN_KEY], current: auth })
+  ) {
+    const snapshot = settings[QWEN_ORIGINAL_KEY];
+    if (snapshot === null) {
+      delete security.auth;
+    } else {
+      security.auth = snapshot;
+    }
   } else {
-    security.auth = snapshot;
+    logger.debug(
+      "[proxy] Qwen clear: security.auth was edited after the proxy wrote it, leaving it intact",
+    );
   }
   delete settings[QWEN_ORIGINAL_KEY];
+  delete settings[QWEN_WRITTEN_KEY];
   settings.security = security;
 
   fs.writeFileSync(getQwenSettingsPath(), JSON.stringify(settings, null, 2));

--- a/src/cli/proxy-clients/registry.ts
+++ b/src/cli/proxy-clients/registry.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../lib/utils/logger.js";
 import type {
   CliProxyClientApplyResult,
   CliProxyClientConfigurator,
@@ -43,11 +44,16 @@ export async function applyAllClients(
         : false;
       results.push({ id: client.id, displayName: client.displayName, applied });
     } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(String(error));
+      // The result already carries the id, but a caller is free to ignore it.
+      // Naming the client here means a path-resolution failure (a HOME that
+      // moved, a directory that vanished mid-run) is never fully silent.
+      logger.debug(`[proxy] ${client.id} apply failed: ${wrapped.message}`);
       results.push({
         id: client.id,
         displayName: client.displayName,
         applied: false,
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: wrapped,
       });
     }
   }
@@ -67,11 +73,13 @@ export async function restoreAllClients(
         restored: await client.restore(proxyBaseUrl),
       });
     } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(String(error));
+      logger.debug(`[proxy] ${client.id} restore failed: ${wrapped.message}`);
       results.push({
         id: client.id,
         displayName: client.displayName,
         restored: false,
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: wrapped,
       });
     }
   }

--- a/src/cli/proxy-clients/snapshot.ts
+++ b/src/cli/proxy-clients/snapshot.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared snapshot bookkeeping for the JSON-file configurators.
+ *
+ * Every writer that edits a user's config in place has to answer one question
+ * on each apply(): is the value sitting in the file right now the one *we* put
+ * there, or one the user put there?
+ *
+ * Snapshotting only on first touch is not enough. The sentinel is persisted in
+ * the user's file so a restore survives a crash, which means it also survives
+ * an unclean kill where no restore ever ran. If the user then edits the block
+ * by hand — reasonably, since the proxy is gone — a presence-only guard keeps
+ * the stale snapshot, apply() overwrites their edit, and the next restore
+ * writes the stale value back over it. For Qwen that value is a live API key.
+ *
+ * So each writer also records what it wrote. A current value that still matches
+ * the recorded write is ours and the snapshot stands; anything else is the
+ * user's and must be re-snapshotted before we overwrite it.
+ */
+
+/**
+ * Structural equality, insensitive to object key order.
+ *
+ * Comparing serialised JSON would be simpler but wrong: `JSON.stringify` is not
+ * canonical, so anything that rewrites the user's config — a formatter, an
+ * editor's "sort keys", another tool round-tripping the file — reorders keys and
+ * makes our own block look like the user's. The writer would then snapshot the
+ * proxy block as the "original" and restore it over the real config later.
+ *
+ * `undefined` is only ever equal to itself: absent is not the same as present.
+ */
+function valuesMatch(current: unknown, written: unknown): boolean {
+  if (current === undefined || written === undefined) {
+    return current === written;
+  }
+  if (current === null || written === null) {
+    return current === written;
+  }
+  if (typeof current !== "object" || typeof written !== "object") {
+    return current === written;
+  }
+  if (Array.isArray(current) || Array.isArray(written)) {
+    if (!Array.isArray(current) || !Array.isArray(written)) {
+      return false;
+    }
+    return (
+      current.length === written.length &&
+      current.every((item, index) => valuesMatch(item, written[index]))
+    );
+  }
+  const a = current as Record<string, unknown>;
+  const b = written as Record<string, unknown>;
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+  return aKeys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(b, key) &&
+      valuesMatch(a[key], b[key]),
+  );
+}
+
+/**
+ * Whether apply() should record `current` as the user's original value.
+ *
+ * - No snapshot yet: record one. This is the first touch.
+ * - Snapshot present but no record of what we wrote: leave it alone. The file
+ *   was written by a version that predates the write-record, so we cannot tell
+ *   ours from the user's and the safe move is the old behaviour.
+ * - Snapshot present and the current value is exactly what we wrote: leave it
+ *   alone. This is the repeat-apply case the first-touch guard exists for.
+ * - Snapshot present and the current value is *not* what we wrote: re-record.
+ *   The user replaced it while the proxy was not running.
+ */
+export function shouldCaptureSnapshot(args: {
+  hasSnapshot: boolean;
+  written: unknown;
+  current: unknown;
+}): boolean {
+  if (!args.hasSnapshot) {
+    return true;
+  }
+  if (args.written === undefined) {
+    return false;
+  }
+  return !valuesMatch(args.current, args.written);
+}
+
+/** Deep copy through JSON, so a snapshot cannot alias the object it describes. */
+export function cloneForSnapshot<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Whether the value currently in the file is the one this writer put there.
+ *
+ * Restore uses this as its licence to act. A base-URL check alone catches a
+ * user who repointed the client elsewhere, but not one who kept the proxy URL
+ * and changed something beside it — a rotated key, an added field. Reverting
+ * those to the snapshot destroys a deliberate edit; for Qwen it destroys a
+ * credential. No record of what we wrote (a config from before this existed)
+ * means we cannot prove ownership either way, so the caller keeps its previous
+ * behaviour rather than refusing every restore.
+ */
+export function isProxyOwnedValue(args: {
+  written: unknown;
+  current: unknown;
+}): boolean {
+  if (args.written === undefined) {
+    return true;
+  }
+  return valuesMatch(args.current, args.written);
+}

--- a/src/lib/proxy/codexUsage.ts
+++ b/src/lib/proxy/codexUsage.ts
@@ -1,0 +1,275 @@
+/**
+ * Codex (OpenAI Responses) SSE usage tap.
+ *
+ * The Codex proxy engine relays `upstream.body` to the client untouched and
+ * logs before a single byte is read, so no Codex request has ever carried token
+ * counts. This module adds a pass-through tap that scrapes `usage` out of the
+ * stream without holding back or altering any bytes.
+ *
+ * ## Safety contract
+ *
+ * This sits in the hot path of a live proxy, so it is built to be incapable of
+ * breaking a stream:
+ *
+ * - every chunk is enqueued **before** it is inspected;
+ * - all parsing runs inside try/catch, and a throw is swallowed;
+ * - a stream whose shape is unrecognised resolves `usage` to `null`, which is
+ *   exactly today's behaviour (a log with no token fields).
+ *
+ * The worst case is therefore "no tokens recorded", never a truncated or
+ * corrupted response.
+ *
+ * ## Wire shape
+ *
+ * **Verified against real traffic.** Captured from a live `codex exec` run
+ * through the proxy on 2026-08-21; the trimmed sample is at
+ * `test/fixtures/codex-response-usage.sse` and is asserted against in the
+ * codex suite. The real shape is
+ *
+ *   event: response.completed
+ *   data: {"type":"response.completed","response":{"usage":{
+ *     "input_tokens":N,"output_tokens":M,
+ *     "input_tokens_details":{"cached_tokens":K,"cache_write_tokens":W},
+ *     "output_tokens_details":{"reasoning_tokens":R}}}}
+ *
+ * Note that `response.created` arrives first carrying `usage: null`, which is
+ * why the scanner keeps the last non-null result rather than the first.
+ *
+ * It also accepts a `usage` object at the top level of any event and the
+ * `prompt_tokens`/`completion_tokens` spellings. A `null` result means "not
+ * observed", never "zero tokens".
+ */
+
+import { appendFileSync } from "node:fs";
+
+import type {
+  CodexStreamUsage,
+  ProxyCancellableTransformer,
+} from "../types/index.js";
+
+const nonNegativeInt = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : 0;
+
+/**
+ * Pull usage out of one parsed SSE `data:` payload.
+ *
+ * Returns null when the payload carries no recognisable usage object, so the
+ * caller can keep the last non-null result rather than overwriting it with a
+ * later event that happens not to carry usage.
+ */
+export function extractCodexUsage(payload: unknown): CodexStreamUsage | null {
+  if (payload === null || typeof payload !== "object") {
+    return null;
+  }
+  const root = payload as Record<string, unknown>;
+  const response = root.response as Record<string, unknown> | undefined;
+
+  const usage = (
+    response && typeof response === "object" && response.usage
+      ? response.usage
+      : root.usage
+  ) as Record<string, unknown> | undefined;
+
+  if (!usage || typeof usage !== "object") {
+    return null;
+  }
+
+  const input = usage.input_tokens ?? usage.prompt_tokens;
+  const output = usage.output_tokens ?? usage.completion_tokens;
+  if (input === undefined && output === undefined) {
+    return null;
+  }
+
+  const inputDetails = usage.input_tokens_details as
+    | Record<string, unknown>
+    | undefined;
+  const outputDetails = usage.output_tokens_details as
+    | Record<string, unknown>
+    | undefined;
+
+  return {
+    inputTokens: nonNegativeInt(input),
+    outputTokens: nonNegativeInt(output),
+    cacheReadTokens: nonNegativeInt(inputDetails?.cached_tokens),
+    cacheCreationTokens: nonNegativeInt(inputDetails?.cache_write_tokens),
+    reasoningTokens: nonNegativeInt(outputDetails?.reasoning_tokens),
+  };
+}
+
+/**
+ * Scan a slice of SSE text for usage, returning the last one found.
+ *
+ * Exported for tests: it is the whole parsing decision, and driving it through
+ * a real Codex stream would need a live ChatGPT subscription.
+ */
+export function scanCodexSSEForUsage(text: string): CodexStreamUsage | null {
+  let found: CodexStreamUsage | null = null;
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) {
+      continue;
+    }
+    const raw = line.slice(5).trim();
+    if (!raw || raw === "[DONE]") {
+      continue;
+    }
+    try {
+      const usage = extractCodexUsage(JSON.parse(raw));
+      if (usage) {
+        found = usage;
+      }
+    } catch {
+      // Partial or non-JSON payload — the next chunk may complete it. Never
+      // let a malformed line escape into the relay.
+    }
+  }
+  return found;
+}
+
+/**
+ * Maximum bytes written by the opt-in raw capture. One `response.completed`
+ * event is a few hundred bytes; 256 KiB is generous and bounds a runaway file.
+ */
+const CAPTURE_LIMIT_BYTES = 256 * 1024;
+
+/**
+ * Opt-in raw capture of one Codex SSE stream, for confirming the `usage` wire
+ * shape against real traffic.
+ *
+ * Off unless `NEUROLINK_PROXY_CODEX_CAPTURE` names a file. It is deliberately
+ * env-gated and undocumented in the CLI: the captured bytes are the assistant's
+ * actual response, so this is a debugging tool the operator turns on
+ * deliberately, not something that runs by default. Capture stops at the first
+ * completed stream and is capped.
+ */
+function createCaptureSink(): ((chunk: Uint8Array) => void) | null {
+  const target = process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+  if (!target) {
+    return null;
+  }
+  let written = 0;
+  let started = false;
+  return (chunk: Uint8Array) => {
+    if (written >= CAPTURE_LIMIT_BYTES) {
+      return;
+    }
+    try {
+      // Append only the new bytes. Rewriting the accumulated buffer on every
+      // chunk is quadratic in stream length and runs in a live relay's
+      // transform(), so a long response would do hundreds of growing
+      // synchronous writes.
+      // Slice to the remaining capacity rather than writing the whole chunk.
+      // The guard above only says the cap was not ALREADY reached, so a single
+      // large chunk arriving at 255 KiB would otherwise land in full and the
+      // file would end up far past its bound — the cap has to hold per write,
+      // not per stream.
+      const remaining = CAPTURE_LIMIT_BYTES - written;
+      const slice =
+        chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk;
+      appendFileSync(target, slice, { flag: started ? "a" : "w" });
+      started = true;
+      written += slice.byteLength;
+    } catch {
+      // Capture is best-effort telemetry; never let it touch the relay.
+    }
+  };
+}
+
+/**
+ * A pass-through TransformStream that reports the usage seen on a Codex SSE
+ * stream.
+ *
+ * `usage` resolves when the stream ends: to the last usage observed, or null if
+ * none was. It never rejects.
+ */
+export function createCodexUsageTap(): {
+  stream: TransformStream<Uint8Array, Uint8Array>;
+  usage: Promise<CodexStreamUsage | null>;
+} {
+  let settleUsage: (value: CodexStreamUsage | null) => void = () => {};
+  const usage = new Promise<CodexStreamUsage | null>((resolve) => {
+    settleUsage = resolve;
+  });
+  // flush() and cancel() are mutually exclusive in principle, but a
+  // double-settle must be harmless rather than relied upon.
+  let settled = false;
+  const settle = (value: CodexStreamUsage | null): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    settleUsage(value);
+  };
+
+  const decoder = new TextDecoder();
+  const capture = createCaptureSink();
+  let carry = "";
+  let latest: CodexStreamUsage | null = null;
+
+  /**
+   * Ceiling on the unterminated tail we are willing to hold.
+   *
+   * `carry` normally holds a fraction of one SSE line, because every newline
+   * flushes it. A stream that never sends one — a hung upstream, a
+   * non-SSE body relayed by mistake — would otherwise grow it without bound
+   * for the life of the request. One `response.completed` event is a few
+   * hundred bytes, so a megabyte is far past any real event, and dropping the
+   * tail costs at most the usage reading this tap is allowed to miss anyway.
+   */
+  const CARRY_LIMIT_CHARS = 1024 * 1024;
+
+  const transformer: ProxyCancellableTransformer<Uint8Array, Uint8Array> = {
+    transform(chunk, controller) {
+      // Bytes go out first and unconditionally: nothing below can delay or
+      // alter what the client receives.
+      controller.enqueue(chunk);
+      try {
+        capture?.(chunk);
+        carry += decoder.decode(chunk, { stream: true });
+        // Keep only the trailing partial line; events are newline-delimited.
+        const lastBreak = carry.lastIndexOf("\n");
+        if (lastBreak === -1) {
+          if (carry.length > CARRY_LIMIT_CHARS) {
+            // No line break in a megabyte: this is not the SSE stream we can
+            // read. Give up on the tail rather than grow forever.
+            carry = "";
+          }
+          return;
+        }
+        const complete = carry.slice(0, lastBreak);
+        carry = carry.slice(lastBreak + 1);
+        const seen = scanCodexSSEForUsage(complete);
+        if (seen) {
+          latest = seen;
+        }
+      } catch {
+        // Telemetry must never break the relay.
+      }
+    },
+    flush() {
+      try {
+        const seen = scanCodexSSEForUsage(carry);
+        if (seen) {
+          latest = seen;
+        }
+      } catch {
+        // ignored — see above
+      }
+      settle(latest);
+    },
+    /**
+     * A client hanging up mid-response, or an upstream error, aborts the
+     * stream rather than closing it — so flush() never runs. Without this the
+     * usage promise would never settle and every aborted request would leak a
+     * pending handler. Report whatever was seen before the abort.
+     */
+    cancel() {
+      settle(latest);
+    },
+  };
+
+  const stream = new TransformStream<Uint8Array, Uint8Array>(transformer);
+
+  return { stream, usage };
+}

--- a/src/lib/proxy/proxyAnalysis.ts
+++ b/src/lib/proxy/proxyAnalysis.ts
@@ -22,6 +22,11 @@ import {
   PROXY_ACCOUNT_ROUTING_REASONS,
   PROXY_ACCOUNT_ROUTING_STRATEGIES,
 } from "./routingEvidence.js";
+import {
+  calculateCost,
+  hasPricing,
+  isExactPricingMatch,
+} from "../utils/pricing.js";
 
 const LIFECYCLE_FILE_PATTERN = /^proxy-lifecycle-\d{4}-\d{2}-\d{2}\.jsonl$/;
 const REQUEST_FILE_PATTERN = /^proxy-\d{4}-\d{2}-\d{2}\.jsonl$/;
@@ -450,6 +455,13 @@ function summarizeFinalRequests(
   let cacheReadTokens = 0;
   let cacheCreationTokens = 0;
   let inputTokens = 0;
+  let outputTokens = 0;
+  let estimatedCostUsd = 0;
+  let requestsPriced = 0;
+  let requestsPricedByPrefix = 0;
+  let requestsUnpriced = 0;
+  const modelsPricedByPrefix = new Set<string>();
+  const unpricedModels = new Set<string>();
   const finalRequestLatency: number[] = [];
   const singleAttemptDelta: number[] = [];
   const errorTypes: Record<string, number> = {};
@@ -498,14 +510,64 @@ function summarizeFinalRequests(
     }
     if (
       request.inputTokens !== null ||
+      request.outputTokens !== null ||
       request.cacheReadTokens !== null ||
       request.cacheCreationTokens !== null
     ) {
       requestsWithUsage += 1;
       inputTokens += request.inputTokens ?? 0;
+      outputTokens += request.outputTokens ?? 0;
       cacheReadTokens += request.cacheReadTokens ?? 0;
       cacheCreationTokens += request.cacheCreationTokens ?? 0;
       requestsWithCacheRead += (request.cacheReadTokens ?? 0) > 0 ? 1 : 0;
+
+      if (request.model) {
+        // Records written before `provider` existed carry only a model name.
+        // "openai-compatible" resolves to the cross-provider table search in
+        // pricing.ts, which finds the model wherever it lives — a far better
+        // guess than assuming Anthropic and pricing a GPT model at $0.
+        const cost = calculateCost(
+          request.provider ?? "openai-compatible",
+          request.model,
+          {
+            input: request.inputTokens ?? 0,
+            output: request.outputTokens ?? 0,
+            total:
+              (request.inputTokens ?? 0) +
+              (request.outputTokens ?? 0) +
+              (request.cacheCreationTokens ?? 0) +
+              (request.cacheReadTokens ?? 0),
+            cacheCreationTokens: request.cacheCreationTokens ?? 0,
+            cacheReadTokens: request.cacheReadTokens ?? 0,
+          },
+        );
+        // Ask the table directly rather than inferring from cost > 0: a real
+        // request with trivial usage can round to $0.000000 and is priced, not
+        // unpriced.
+        const priced = hasPricing(
+          request.provider ?? "openai-compatible",
+          request.model,
+        );
+        if (priced) {
+          estimatedCostUsd += cost;
+          requestsPriced += 1;
+          // A prefix fallback means the rate was inherited from a
+          // similarly-named model, not quoted for this one. Surface it rather
+          // than presenting a guess as a figure.
+          if (
+            !isExactPricingMatch(
+              request.provider ?? "openai-compatible",
+              request.model,
+            )
+          ) {
+            requestsPricedByPrefix += 1;
+            modelsPricedByPrefix.add(request.model);
+          }
+        } else {
+          requestsUnpriced += 1;
+          unpricedModels.add(request.model);
+        }
+      }
     }
   }
 
@@ -525,6 +587,13 @@ function summarizeFinalRequests(
       cacheReadTokens,
       cacheCreationTokens,
       inputTokens,
+      outputTokens,
+      estimatedCostUsd: Number(estimatedCostUsd.toFixed(6)),
+      requestsPriced,
+      requestsPricedByPrefix,
+      modelsPricedByPrefix: [...modelsPricedByPrefix].sort(),
+      requestsUnpriced,
+      unpricedModels: [...unpricedModels].sort(),
       requestHitRate:
         requestsWithUsage > 0
           ? Number((requestsWithCacheRead / requestsWithUsage).toFixed(4))
@@ -862,11 +931,25 @@ export async function analyzeProxyLogs(
       filePath,
       (record) => {
         const timestamp = observeTimestamp("requests", record);
-        if (timestamp === null || timestamp < sinceMs || timestamp > untilMs) {
+        if (timestamp === null) {
           return;
         }
         const requestId = stringValue(record.requestId);
         if (!requestId) {
+          return;
+        }
+        // A streamed request is logged twice — once when the response headers
+        // are known, again when the body finishes and its token counts arrive
+        // — and those two writes can straddle the window edge. A Codex turn
+        // whose headers land at 23:59:50 and whose stream ends at 00:00:05 has
+        // every token it spent in the second record. Filtering that record out
+        // by its own timestamp would leave the request counted as completed
+        // but contributing nothing to tokens or cost, with nothing in the
+        // report to say so. A request the window already admitted therefore
+        // keeps accepting its own later records.
+        const alreadyAdmitted =
+          finalRequests.has(requestId) || terminalStreamErrors.has(requestId);
+        if (!alreadyAdmitted && (timestamp < sinceMs || timestamp > untilMs)) {
           return;
         }
         if (finiteNumber(record.terminalStatus) !== null) {
@@ -891,19 +974,45 @@ export async function analyzeProxyLogs(
         } else {
           absentRoutingDecisions += 1;
         }
-        finalRequests.set(requestId, {
+        const parsed: ProxyAnalysisFinalRequestRecord = {
           timestamp: new Date(timestamp).toISOString(),
           status,
           durationMs: finiteNumber(record.responseTimeMs),
           account: stringValue(record.account) ?? "unknown",
           accountType: stringValue(record.accountType) ?? "unknown",
+          model: stringValue(record.model),
+          provider: stringValue(record.provider),
           inputTokens: finiteNumber(record.inputTokens),
+          outputTokens: finiteNumber(record.outputTokens),
           cacheReadTokens: finiteNumber(record.cacheReadTokens),
           cacheCreationTokens: finiteNumber(record.cacheCreationTokens),
           errorType: stringValue(record.errorType),
           errorCode: stringValue(record.errorCode),
           routingDecision,
-        });
+        };
+        // A request may be logged twice: once when the response headers are
+        // known, and again when a streamed body finishes and its token counts
+        // become available (the Codex engine does this). Merge rather than
+        // replace, so the later usage-bearing record cannot drop an errorType
+        // the first one carried, and vice versa.
+        const previous = finalRequests.get(requestId);
+        finalRequests.set(
+          requestId,
+          previous
+            ? {
+                ...previous,
+                ...Object.fromEntries(
+                  Object.entries(parsed).filter(
+                    ([, value]) => value !== null && value !== undefined,
+                  ),
+                ),
+                // Attribute the request to when it was first seen. A late
+                // completion record must not move it out of the window that
+                // admitted it.
+                timestamp: previous.timestamp,
+              }
+            : parsed,
+        );
       },
       () => {
         malformedLines += 1;

--- a/src/lib/proxy/proxyTracer.ts
+++ b/src/lib/proxy/proxyTracer.ts
@@ -245,7 +245,18 @@ class ProxyTracer {
   private readonly proxyTracer = getTracer("neurolink.proxy");
   private readonly bridge = new OtelBridge();
   private readonly requestId: string;
-  private readonly model: string;
+  /**
+   * Model used for costing. Starts as the model the client asked for and is
+   * updated by setModelSubstitution(), so cost follows the model that actually
+   * served the request rather than the one that was requested.
+   */
+  private model: string;
+  /**
+   * Provider used for costing. See ProxyRequestContext.provider. Mutable for
+   * the same reason `model` is: a fallback can serve the request from a
+   * different provider, and pricing has to follow it.
+   */
+  private billingProvider: string;
   private readonly startTime: number;
   private readonly isStream: boolean;
 
@@ -258,10 +269,12 @@ class ProxyTracer {
     requestId: string,
     model: string,
     stream: boolean,
+    billingProvider: string,
   ) {
     this.rootSpan = rootSpan;
     this.requestId = requestId;
     this.model = model;
+    this.billingProvider = billingProvider;
     this.startTime = Date.now();
     this.isStream = stream;
   }
@@ -341,6 +354,7 @@ class ProxyTracer {
       ctx.requestId,
       ctx.model,
       ctx.stream,
+      ctx.provider ?? "anthropic",
     );
 
     // Set Langfuse context (fire-and-forget — non-blocking)
@@ -494,7 +508,7 @@ class ProxyTracer {
     });
 
     // Cost calculation via pricing.ts
-    const cost = calculateCost("anthropic", this.model, {
+    const cost = calculateCost(this.billingProvider, this.model, {
       input: ctx.inputTokens,
       output: ctx.outputTokens,
       total: totalTokens,
@@ -575,12 +589,26 @@ class ProxyTracer {
    * Record that the proxy substituted a different model than was requested.
    * Sets span attributes and increments the substitution metric counter.
    */
-  setModelSubstitution(requestedModel: string, actualModel: string): void {
+  setModelSubstitution(
+    requestedModel: string,
+    actualModel: string,
+    actualProvider?: string,
+  ): void {
+    // Cost must follow the model that served the request, not the alias the
+    // client typed — otherwise a claude-* alias routed to another provider is
+    // billed at Claude rates. The provider has to move with it: leaving it at
+    // the tracer's default means the substituted model is looked up in the
+    // wrong pricing table, which yields no rate and so no charge at all.
+    this.model = actualModel;
+    if (actualProvider) {
+      this.billingProvider = actualProvider;
+    }
     this.rootSpan.setAttributes({
       "proxy.model_substituted": true,
       "proxy.original_model": requestedModel,
       "proxy.actual_model": actualModel,
       "gen_ai.response.model": actualModel,
+      ...(actualProvider ? { "proxy.actual_provider": actualProvider } : {}),
     });
     const m = getProxyMetrics();
     m.modelSubstitutionTotal.add(1, {
@@ -823,7 +851,7 @@ class ProxyTracer {
         this.usage.cacheReadTokens +
         (this.usage.reasoningTokens ?? 0);
 
-      const cost = calculateCost("anthropic", this.model, {
+      const cost = calculateCost(this.billingProvider, this.model, {
         input: this.usage.inputTokens,
         output: this.usage.outputTokens,
         total: totalTokens,
@@ -871,7 +899,7 @@ class ProxyTracer {
 
     const durationMs = Date.now() - this.startTime;
 
-    const cost = calculateCost("anthropic", this.model, {
+    const cost = calculateCost(this.billingProvider, this.model, {
       input: this.usage.inputTokens,
       output: this.usage.outputTokens,
       total: totalTokens,
@@ -880,7 +908,7 @@ class ProxyTracer {
     });
 
     TelemetryService.getInstance().recordAIRequest(
-      "anthropic",
+      this.billingProvider,
       this.model,
       totalTokens,
       durationMs,

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -343,6 +343,8 @@ export async function handleTranslatedStreamRequest(args: {
   let succeeded = false;
   let streamInterruptedAfterOutput = false;
   let translatedModel: string | undefined;
+  /** Provider that actually served the successful attempt, for costing. */
+  let translatedProvider: string | undefined;
   let finalStreamError = "No translation providers succeeded";
   let upstreamIterator: AsyncIterator<unknown> | undefined;
   let lastAttemptLabel = "translation";
@@ -456,6 +458,25 @@ export async function handleTranslatedStreamRequest(args: {
               }
             }
 
+            translatedModel = streamResult.model;
+            translatedProvider = attempt.provider;
+
+            // Substitution BEFORE usage: setUsage() and recordMetrics() price
+            // the request immediately, against the tracer's current model and
+            // billing provider. Recording first and substituting afterwards
+            // bills the model the client ASKED for — which is exactly what
+            // ProxyTracer.setModelSubstitution() documents as wrong, since a
+            // claude-* alias served by another provider would be charged at
+            // Claude rates. The finally block below still calls it, harmlessly,
+            // for paths that never reach here.
+            if (tracer && translatedModel && translatedModel !== requestModel) {
+              tracer.setModelSubstitution(
+                requestModel,
+                translatedModel,
+                translatedProvider,
+              );
+            }
+
             // Track usage and metrics
             const resolvedUsageForTracer = extractUsageFromStreamResult(
               streamResult.usage,
@@ -467,8 +488,6 @@ export async function handleTranslatedStreamRequest(args: {
               cacheReadTokens: 0,
             });
             tracer?.recordMetrics();
-
-            translatedModel = streamResult.model;
             succeeded = true;
             return;
           } catch (streamErr) {
@@ -514,7 +533,11 @@ export async function handleTranslatedStreamRequest(args: {
           controller.close();
         }
         if (tracer && translatedModel && translatedModel !== requestModel) {
-          tracer.setModelSubstitution(requestModel, translatedModel);
+          tracer.setModelSubstitution(
+            requestModel,
+            translatedModel,
+            translatedProvider,
+          );
         }
         const terminalStatus = cancelled
           ? 499
@@ -679,6 +702,17 @@ export async function handleTranslatedJsonRequest(args: {
         toolCalls: streamResult.toolCalls as InternalResult["toolCalls"],
       };
 
+      // Substitution BEFORE usage — see the streaming path for why: pricing
+      // happens inside setUsage()/recordMetrics(), so substituting afterwards
+      // bills the requested model instead of the one that served.
+      if (tracer && streamResult.model && streamResult.model !== requestModel) {
+        tracer.setModelSubstitution(
+          requestModel,
+          streamResult.model,
+          attempt.provider,
+        );
+      }
+
       // Track usage and metrics
       const resolvedUsage = extractUsageFromStreamResult(streamResult.usage);
       tracer?.setUsage({
@@ -688,10 +722,6 @@ export async function handleTranslatedJsonRequest(args: {
         cacheReadTokens: 0,
       });
       tracer?.recordMetrics();
-
-      if (tracer && streamResult.model && streamResult.model !== requestModel) {
-        tracer.setModelSubstitution(requestModel, streamResult.model);
-      }
       tracer?.end(200, Date.now() - requestStartTime);
 
       recordFinalSuccess(lastAttemptLabel, "translation");

--- a/src/lib/server/routes/codexProxyRoutes.ts
+++ b/src/lib/server/routes/codexProxyRoutes.ts
@@ -37,6 +37,7 @@ import {
   loadAccountQuotas,
   saveAccountQuota,
 } from "../../proxy/accountQuota.js";
+import { createCodexUsageTap } from "../../proxy/codexUsage.js";
 import {
   CODEX_ACCOUNT_PREFIX,
   parseCodexRateLimitHeaders,
@@ -49,6 +50,7 @@ import type {
   CodexRuntimeAccount,
   RouteGroup,
   ServerContext,
+  RequestLogEntry,
 } from "../../types/index.js";
 import { sanitizeForLog } from "../../utils/logSanitize.js";
 import { logger } from "../../utils/logger.js";
@@ -322,7 +324,18 @@ async function handleCodexResponsesRequest(
   const writeLog = (
     account: string,
     responseStatus: number,
-    extra: { errorType?: string; errorMessage?: string } = {},
+    extra: Partial<
+      Pick<
+        RequestLogEntry,
+        | "errorType"
+        | "errorMessage"
+        | "provider"
+        | "inputTokens"
+        | "outputTokens"
+        | "cacheReadTokens"
+        | "cacheCreationTokens"
+      >
+    > = {},
   ): Promise<void> =>
     logRequest({
       timestamp: new Date().toISOString(),
@@ -446,7 +459,36 @@ async function handleCodexResponsesRequest(
           connection: "keep-alive",
           ...(ctx.responseHeaders ?? {}),
         };
-        return new Response(upstream.body, {
+
+        // Tap the relay for token usage. The log above is written first and
+        // unconditionally so a request is never lost when a client hangs up
+        // mid-stream; this emits a second record for the same requestId
+        // carrying the counts, which proxyAnalysis merges. If the stream shape
+        // is not recognised, usage resolves null and nothing extra is written —
+        // i.e. exactly the previous behaviour.
+        if (!upstream.body) {
+          return new Response(upstream.body, {
+            status: upstream.status,
+            headers,
+          });
+        }
+        const { stream: usageTap, usage: usageSeen } = createCodexUsageTap();
+        usageSeen
+          .then((usage) => {
+            if (!usage) {
+              return;
+            }
+            return writeLog(account.label, upstream.status, {
+              provider: "openai",
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              cacheReadTokens: usage.cacheReadTokens,
+              cacheCreationTokens: usage.cacheCreationTokens,
+            });
+          })
+          .catch(() => undefined);
+
+        return new Response(upstream.body.pipeThrough(usageTap), {
           status: upstream.status,
           headers,
         });

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -467,6 +467,11 @@ export function createOpenAIProxyRoutes(
                 toolCount: Object.keys(parsed.tools).length,
                 clientApp: "openai-compat",
                 userAgent: ctx.headers["user-agent"] ?? "",
+                // Without this the tracer defaults to "anthropic" and every
+                // non-Anthropic model prices to $0 (the anthropic table has no
+                // _default), while a claude-* alias routed elsewhere prices at
+                // Claude rates. Both are wrong in opposite directions.
+                provider: targetProvider ?? "openai-compatible",
               },
               ctx.headers,
             );

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -683,6 +683,12 @@ export type RequestLogEntry = {
   outputTokens?: number;
   cacheCreationTokens?: number;
   cacheReadTokens?: number;
+  /**
+   * Provider that actually served the request, for costing. Absent on records
+   * written before this field existed; `proxyAnalysis` then falls back to a
+   * cross-provider model lookup rather than assuming Anthropic.
+   */
+  provider?: string;
   /** OTel trace ID for correlation with distributed traces */
   traceId?: string;
   /** OTel span ID for correlation with distributed traces */
@@ -1617,6 +1623,13 @@ export type ProxyRequestContext = {
   sessionId?: string;
   userAgent?: string;
   clientApp?: string;
+  /**
+   * Provider that will serve the request, used for costing. Defaults to
+   * "anthropic" when omitted, which is correct for the /v1/messages engine;
+   * the OpenAI-compatible engine must pass whatever ModelRouter resolved, or
+   * every non-Anthropic model prices to $0.
+   */
+  provider?: string;
 };
 
 /** Response-side details parsed from the upstream reply (model, finish, tools). */
@@ -1948,7 +1961,27 @@ export type ProxyAnalysisReport = {
     cacheReadTokens: number;
     cacheCreationTokens: number;
     inputTokens: number;
+    outputTokens: number;
     requestHitRate: number | null;
+    /**
+     * Summed per-request cost in USD. Records that carry no model, or whose
+     * model matches no pricing table, contribute 0 — so this is a floor, not
+     * an exact bill. `requestsPriced` says how many records actually priced.
+     */
+    estimatedCostUsd: number;
+    requestsPriced: number;
+    /**
+     * Requests whose cost came from a longest-prefix fallback rather than an
+     * exact pricing row — the rate is inherited from a similarly-named model
+     * and may be wrong. Adding the real row makes these exact.
+     */
+    requestsPricedByPrefix: number;
+    /** Distinct models priced by prefix fallback, for the operator to chase. */
+    modelsPricedByPrefix: string[];
+    /** Requests carrying usage whose model matched no pricing row at all. */
+    requestsUnpriced: number;
+    /** Distinct models with no pricing row at all. */
+    unpricedModels: string[];
   };
   routing: {
     modes: Record<string, number>;
@@ -1987,12 +2020,46 @@ export type ProxyAnalysisFinalRequestRecord = {
   durationMs: number | null;
   account: string;
   accountType: string;
+  model: string | null;
+  provider: string | null;
   inputTokens: number | null;
+  outputTokens: number | null;
   cacheReadTokens: number | null;
   cacheCreationTokens: number | null;
   errorType: string | null;
   errorCode: string | null;
   routingDecision: ProxyAccountRoutingDecision | null;
+};
+
+/**
+ * A stream transformer that also handles cancellation.
+ *
+ * The Streams standard gives `Transformer` a `cancel()` callback — invoked when
+ * the stream is aborted rather than closed cleanly — and Node implements it,
+ * but TypeScript's bundled lib does not declare it yet. Without it there is no
+ * way to observe a client hanging up mid-response.
+ */
+export type ProxyCancellableTransformer<I, O> = Transformer<I, O> & {
+  cancel?: (reason?: unknown) => void;
+};
+
+/**
+ * Token usage scraped from a Codex (OpenAI Responses) SSE stream.
+ *
+ * Verified against real traffic: captured from a live `codex exec` run through
+ * the proxy on 2026-08-21 (`test/fixtures/codex-response-usage.sse`). The
+ * shape is `response.completed` → `response.usage`, carrying `input_tokens`,
+ * `output_tokens`, and an `input_tokens_details` object with `cached_tokens`
+ * and `cache_write_tokens`. The parser also accepts the common variants. Treat
+ * a null result as "not observed", never as "zero tokens".
+ */
+export type CodexStreamUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  /** Cache writes, which bill at a premium over both reads and plain input. */
+  cacheCreationTokens: number;
+  reasoningTokens: number;
 };
 
 /** Validated account-routing evidence joined to a final request log. */

--- a/src/lib/utils/pricing.ts
+++ b/src/lib/utils/pricing.ts
@@ -24,6 +24,47 @@ const PRICING: Record<
 > = {
   // Anthropic (direct API) — updated March 2026
   anthropic: {
+    // Claude 5 family. Rates from platform.claude.com/docs/en/about-claude/pricing
+    // (checked 2026-08-21). Cache multipliers are the documented ones: a 5-minute
+    // cache write is 1.25x base input, a cache hit 0.1x.
+    "claude-fable-5": {
+      input: 10.0 / 1_000_000,
+      output: 50.0 / 1_000_000,
+      cacheRead: 1.0 / 1_000_000,
+      cacheCreation: 12.5 / 1_000_000,
+    },
+    "claude-mythos-5": {
+      input: 10.0 / 1_000_000,
+      output: 50.0 / 1_000_000,
+      cacheRead: 1.0 / 1_000_000,
+      cacheCreation: 12.5 / 1_000_000,
+    },
+    "claude-opus-5": {
+      input: 5.0 / 1_000_000,
+      output: 25.0 / 1_000_000,
+      cacheRead: 0.5 / 1_000_000,
+      cacheCreation: 6.25 / 1_000_000,
+    },
+    "claude-opus-4-8": {
+      input: 5.0 / 1_000_000,
+      output: 25.0 / 1_000_000,
+      cacheRead: 0.5 / 1_000_000,
+      cacheCreation: 6.25 / 1_000_000,
+    },
+    "claude-opus-4-7": {
+      input: 5.0 / 1_000_000,
+      output: 25.0 / 1_000_000,
+      cacheRead: 0.5 / 1_000_000,
+      cacheCreation: 6.25 / 1_000_000,
+    },
+    // Sonnet 5's $2/$10 launch pricing became the standard price; the
+    // previously scheduled 2026-09-01 rise to $3/$15 was cancelled.
+    "claude-sonnet-5": {
+      input: 2.0 / 1_000_000,
+      output: 10.0 / 1_000_000,
+      cacheRead: 0.2 / 1_000_000,
+      cacheCreation: 2.5 / 1_000_000,
+    },
     // Claude 4.6 family
     "claude-opus-4-6": {
       input: 5.0 / 1_000_000,
@@ -44,6 +85,17 @@ const PRICING: Record<
       cacheRead: 0.3 / 1_000_000,
       cacheCreation: 3.75 / 1_000_000,
     },
+    // Undated aliases for the same models. Clients report the bare name far
+    // more often than the dated one, and without these the longest-prefix
+    // match lands on the previous generation ("claude-sonnet-4"), which both
+    // reports as an inferred rate and would silently drift if the two
+    // generations ever diverge in price.
+    "claude-sonnet-4-5": {
+      input: 3.0 / 1_000_000,
+      output: 15.0 / 1_000_000,
+      cacheRead: 0.3 / 1_000_000,
+      cacheCreation: 3.75 / 1_000_000,
+    },
     "claude-opus-4-5": {
       input: 5.0 / 1_000_000,
       output: 25.0 / 1_000_000,
@@ -51,6 +103,12 @@ const PRICING: Record<
       cacheCreation: 6.25 / 1_000_000,
     },
     "claude-haiku-4-5-20251001": {
+      input: 1.0 / 1_000_000,
+      output: 5.0 / 1_000_000,
+      cacheRead: 0.1 / 1_000_000,
+      cacheCreation: 1.25 / 1_000_000,
+    },
+    "claude-haiku-4-5": {
       input: 1.0 / 1_000_000,
       output: 5.0 / 1_000_000,
       cacheRead: 0.1 / 1_000_000,
@@ -160,6 +218,35 @@ const PRICING: Record<
   },
   // OpenAI — updated March 2026
   openai: {
+    // GPT-5.6 family (Sol/Terra/Luna). Rates reflect OpenAI's 2026-07-30 cut,
+    // which reduced Luna by 80% and Terra by 20%; Sol was unchanged. Many
+    // third-party tables still carry the pre-cut numbers.
+    // List rates. Note that some resellers advertise sol at 50% off
+    // ($2.50/$15.00/$0.25); those are promotional and expire, so the table
+    // carries list price and cache read stays the documented 0.1x of input.
+    "gpt-5.6-sol": {
+      input: 5.0 / 1_000_000,
+      output: 30.0 / 1_000_000,
+      cacheRead: 0.5 / 1_000_000,
+      cacheCreation: 6.25 / 1_000_000,
+    },
+    "gpt-5.6-terra": {
+      input: 2.0 / 1_000_000,
+      output: 12.0 / 1_000_000,
+      cacheRead: 0.2 / 1_000_000,
+      cacheCreation: 2.5 / 1_000_000,
+    },
+    "gpt-5.6-luna": {
+      input: 0.2 / 1_000_000,
+      output: 1.2 / 1_000_000,
+      cacheRead: 0.02 / 1_000_000,
+      cacheCreation: 0.25 / 1_000_000,
+    },
+    "gpt-5.5": {
+      input: 5.0 / 1_000_000,
+      output: 30.0 / 1_000_000,
+      cacheRead: 0.5 / 1_000_000,
+    },
     // GPT-5.x family
     // cacheRead = 0.25x input (cached input tokens; no separate cacheCreation).
     "gpt-5.4": {
@@ -640,9 +727,35 @@ const PROVIDER_ALIASES: Record<string, string> = {
  *
  * @returns The rate entry, or undefined when the combination is unknown.
  */
+/**
+ * Whether the tail left over after a longest-prefix match is only a version or
+ * date stamp — e.g. "claude-sonnet-4-5-20250929-v1:0" against the table key
+ * "claude-sonnet-4-5". That is the *same* model carrying a release suffix, so
+ * its rate is quoted, not inferred.
+ *
+ * Deliberately narrow: "gpt-5.6-sol" against "gpt-5" leaves ".6-sol", which is
+ * a different model generation and stays flagged as inferred.
+ */
+const VERSION_SUFFIX_RE =
+  /^[-@](\d{8}|v\d+(:\d+)?|latest)([-@:](\d{8}|v\d+(:\d+)?))*$/;
+
+function isVersionOnlySuffix(model: string, key: string): boolean {
+  if (!model.startsWith(key) || model === key) {
+    return false;
+  }
+  return VERSION_SUFFIX_RE.test(model.slice(key.length));
+}
+
 function findRates(
   provider: string,
   model: string,
+  /**
+   * Set to true when the rates came from a literal table key rather than a
+   * prefix/fallback match. Threaded as an out-param so there is exactly one
+   * lookup implementation — a second hand-written copy drifted from this one
+   * and mislabelled every Bedrock and Vertex-Gemini hit.
+   */
+  matchKind?: { exact: boolean },
 ):
   | {
       input: number;
@@ -659,6 +772,9 @@ function findRates(
     for (const providerPricing of Object.values(PRICING)) {
       // Exact match
       if (providerPricing[model]) {
+        if (matchKind) {
+          matchKind.exact = true;
+        }
         return providerPricing[model];
       }
       const sortedKeys = Object.keys(providerPricing).sort(
@@ -699,6 +815,9 @@ function findRates(
 
   // Exact match
   if (providerPricing[modelKey]) {
+    if (matchKind) {
+      matchKind.exact = true;
+    }
     return providerPricing[modelKey];
   }
 
@@ -708,6 +827,9 @@ function findRates(
     .sort((a, b) => b.length - a.length);
   const key = sortedKeys.find((k) => modelKey.startsWith(k));
   if (key) {
+    if (matchKind && isVersionOnlySuffix(modelKey, key)) {
+      matchKind.exact = true;
+    }
     return providerPricing[key];
   }
 
@@ -720,6 +842,9 @@ function findRates(
     const googlePricing = PRICING["google"];
     if (googlePricing) {
       if (googlePricing[model]) {
+        if (matchKind) {
+          matchKind.exact = true;
+        }
         return googlePricing[model];
       }
       const googleKeys = Object.keys(googlePricing).sort(
@@ -788,6 +913,20 @@ export function calculateCost(
  * USD price, and any caller gated by `hasPricing()` should treat them as
  * non-billable rather than zero-cost-billable.
  */
+/**
+ * Whether a model's rates came from an exact table entry or were inferred.
+ *
+ * `findRates` falls back to a longest-prefix match, so an unlisted model can
+ * silently inherit a listed one's rates — e.g. "gpt-5.6-sol" matches the
+ * "gpt-5" entry and is billed at its price. That is a guess, not a quote, and
+ * a caller reporting spend needs to be able to say which it had.
+ */
+export function isExactPricingMatch(provider: string, model: string): boolean {
+  const matchKind = { exact: false };
+  const rates = findRates(provider, model, matchKind);
+  return rates !== undefined && matchKind.exact;
+}
+
 export function hasPricing(provider: string, model: string): boolean {
   const rates = findRates(provider, model);
   if (!rates) {

--- a/test/continuous-test-suite-codex.ts
+++ b/test/continuous-test-suite-codex.ts
@@ -628,4 +628,364 @@ await test("the built CLI enters the codex import path and reports the missing c
   );
 });
 
+// ---------------------------------------------------------------------------
+// Codex SSE usage tap (issue #1369)
+//
+// The wire shape is verified against live traffic: the fixture case below
+// asserts against `test/fixtures/codex-response-usage.sse`, captured from a
+// real `codex exec` run through the proxy. These cases pin the parser's
+// contract on top of that: recognised shapes yield counts, unrecognised ones
+// yield null (never zero), and the tap never alters the bytes it relays.
+// ---------------------------------------------------------------------------
+
+await test("codex usage tap bounds a stream with no line breaks", async () => {
+  // A hung upstream, or a non-SSE body relayed by mistake, can send bytes
+  // forever without a newline. The tap keeps the unterminated tail so the next
+  // chunk can complete the line, so without a ceiling that buffer grows for the
+  // life of the request — in the hot path of a live relay.
+  const { createCodexUsageTap } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const { stream, usage } = createCodexUsageTap();
+  const encoder = new TextEncoder();
+  const blob = encoder.encode("x".repeat(256 * 1024));
+
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+  let relayed = 0;
+  const drain = (async () => {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      relayed += value.byteLength;
+    }
+  })();
+  for (let i = 0; i < 12; i += 1) {
+    await writer.write(blob);
+  }
+  await writer.close();
+  await drain;
+
+  // Every byte still reaches the client — the tap must never hold one back.
+  assert(
+    relayed === blob.byteLength * 12,
+    "usage tap did not relay every byte of a line-break-free stream",
+  );
+  assert((await usage) === null, "usage tap invented a reading from noise");
+});
+
+await test("codex usage tap reads the documented response.completed shape", async () => {
+  const { scanCodexSSEForUsage } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const usage = scanCodexSSEForUsage(
+    [
+      "event: response.output_text.delta",
+      'data: {"type":"response.output_text.delta","delta":"hi"}',
+      "",
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":1200,"output_tokens":340,"input_tokens_details":{"cached_tokens":900},"output_tokens_details":{"reasoning_tokens":128}}}}',
+      "",
+    ].join("\n"),
+  );
+  assert(usage !== null, "usage was not recognised in the documented shape");
+  assertEqual(usage?.inputTokens, 1200, "input token count mismatch");
+  assertEqual(usage?.outputTokens, 340, "output token count mismatch");
+  assertEqual(usage?.cacheReadTokens, 900, "cache-read token count mismatch");
+  assertEqual(usage?.reasoningTokens, 128, "reasoning token count mismatch");
+});
+
+await test("codex usage tap reports null rather than zero when unrecognised", async () => {
+  const { scanCodexSSEForUsage } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const noUsage = scanCodexSSEForUsage(
+    [
+      "event: response.output_text.delta",
+      'data: {"type":"response.output_text.delta","delta":"hi"}',
+      "data: [DONE]",
+      "",
+    ].join("\n"),
+  );
+  assert(
+    noUsage === null,
+    "a stream with no usage must report null, not a zeroed object",
+  );
+});
+
+await test("codex usage tap survives malformed and partial payloads", async () => {
+  const { scanCodexSSEForUsage } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const usage = scanCodexSSEForUsage(
+    [
+      "data: {not json at all",
+      'data: {"type":"response.completed","response":{"usa',
+      'data: {"usage":{"prompt_tokens":10,"completion_tokens":5}}',
+      "",
+    ].join("\n"),
+  );
+  assert(usage !== null, "the alternate token spelling was not recognised");
+  assertEqual(usage?.inputTokens, 10, "prompt_tokens was not mapped to input");
+  assertEqual(
+    usage?.outputTokens,
+    5,
+    "completion_tokens was not mapped to output",
+  );
+});
+
+await test("codex usage tap relays every byte unchanged", async () => {
+  const { createCodexUsageTap } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const payload =
+    'event: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":7,"output_tokens":3}}}\n\n';
+  const { stream, usage } = createCodexUsageTap();
+
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const bytes = new TextEncoder().encode(payload);
+      // Split mid-event to prove the tap reassembles across chunk boundaries
+      // without withholding or reordering bytes.
+      controller.enqueue(bytes.slice(0, 40));
+      controller.enqueue(bytes.slice(40));
+      controller.close();
+    },
+  });
+
+  const relayed: Uint8Array[] = [];
+  const reader = source.pipeThrough(stream).getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    relayed.push(value);
+  }
+  const out = new TextDecoder().decode(
+    new Uint8Array(relayed.flatMap((c) => Array.from(c))),
+  );
+  assertEqual(out, payload, "relayed bytes differ from the upstream payload");
+
+  const seen = await usage;
+  assert(seen !== null, "usage was not recovered across the chunk split");
+  assertEqual(seen?.inputTokens, 7, "input token count mismatch after split");
+});
+
+await test("codex usage tap captures a raw sample when opted in", async () => {
+  const fsMod = await import("fs");
+  const osMod = await import("os");
+  const pathMod = await import("path");
+  const { createCodexUsageTap } =
+    await import("../src/lib/proxy/codexUsage.js");
+
+  const dir = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "codex-cap-"));
+  const target = pathMod.join(dir, "sample.sse");
+  const prev = process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+  try {
+    process.env.NEUROLINK_PROXY_CODEX_CAPTURE = target;
+    const payload =
+      'event: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":9,"output_tokens":4}}}\n\n';
+    const { stream, usage } = createCodexUsageTap();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+        controller.close();
+      },
+    });
+    const reader = source.pipeThrough(stream).getReader();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) {
+        break;
+      }
+    }
+    await usage;
+
+    assert(
+      fsMod.existsSync(target),
+      "capture file was not written when opted in",
+    );
+    const written = fsMod.readFileSync(target, "utf8");
+    assertEqual(
+      written,
+      payload,
+      "captured bytes differ from the relayed payload",
+    );
+  } finally {
+    if (prev === undefined) {
+      delete process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+    } else {
+      process.env.NEUROLINK_PROXY_CODEX_CAPTURE = prev;
+    }
+    fsMod.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test("codex usage tap writes nothing when capture is not opted in", async () => {
+  const fsMod = await import("fs");
+  const osMod = await import("os");
+  const pathMod = await import("path");
+  const { createCodexUsageTap } =
+    await import("../src/lib/proxy/codexUsage.js");
+
+  const dir = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "codex-nocap-"));
+  const target = pathMod.join(dir, "sample.sse");
+  const prev = process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+  try {
+    delete process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+    const { stream, usage } = createCodexUsageTap();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: {}\n\n"));
+        controller.close();
+      },
+    });
+    const reader = source.pipeThrough(stream).getReader();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) {
+        break;
+      }
+    }
+    await usage;
+    assert(
+      !fsMod.existsSync(target),
+      "capture file was created without the opt-in env var",
+    );
+  } finally {
+    if (prev !== undefined) {
+      process.env.NEUROLINK_PROXY_CODEX_CAPTURE = prev;
+    }
+    fsMod.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test("codex usage tap settles its promise when the stream is aborted", async () => {
+  const { createCodexUsageTap } =
+    await import("../src/lib/proxy/codexUsage.js");
+  const { stream, usage } = createCodexUsageTap();
+
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('data: {"partial":true}\n'));
+    },
+  });
+
+  const piped = source.pipeThrough(stream);
+  const reader = piped.getReader();
+  await reader.read();
+  // Client hangs up mid-response — the normal case for a proxy: timeouts and
+  // disconnects abort rather than close cleanly, so flush() never runs.
+  await reader.cancel(new Error("client disconnected")).catch(() => undefined);
+
+  const settled = await Promise.race([
+    usage.then(() => "settled"),
+    new Promise((resolve) => setTimeout(() => resolve("hung"), 2000)),
+  ]);
+  assertEqual(
+    settled,
+    "settled",
+    "usage promise did not settle after an aborted stream",
+  );
+});
+
+await test("codex usage tap parses a stream captured from real traffic", async () => {
+  const fsMod = await import("fs");
+  const { scanCodexSSEForUsage } =
+    await import("../src/lib/proxy/codexUsage.js");
+  // Captured from a real `codex exec` run through the proxy on 2026-08-21 and
+  // trimmed to the usage envelope. This is what promotes the parser from
+  // written-to-spec to verified.
+  const fixture = fsMod.readFileSync(
+    new URL("./fixtures/codex-response-usage.sse", import.meta.url),
+    "utf8",
+  );
+  const usage = scanCodexSSEForUsage(fixture);
+  assert(usage !== null, "usage was not recognised in real captured traffic");
+  assertEqual(usage?.inputTokens, 17339, "input token count mismatch");
+  assertEqual(usage?.outputTokens, 7, "output token count mismatch");
+  assertEqual(usage?.cacheReadTokens, 8576, "cache-read token count mismatch");
+  assertEqual(usage?.reasoningTokens, 0, "reasoning token count mismatch");
+});
+
+await test("codex usage tap records cache-creation tokens", async () => {
+  const { extractCodexUsage } = await import("../src/lib/proxy/codexUsage.js");
+  // Real streams carry input_tokens_details.cache_write_tokens alongside
+  // cached_tokens. Cache writes bill at a premium, so dropping them
+  // under-reports cost.
+  const usage = extractCodexUsage({
+    type: "response.completed",
+    response: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 10,
+        input_tokens_details: { cached_tokens: 40, cache_write_tokens: 25 },
+      },
+    },
+  });
+  assert(usage !== null, "usage was not recognised");
+  assertEqual(usage?.cacheCreationTokens, 25, "cache-creation tokens dropped");
+  assertEqual(usage?.cacheReadTokens, 40, "cache-read token count mismatch");
+});
+
+await test("codex capture holds its byte cap against a single oversized chunk", async () => {
+  // The capture is opt-in debugging that writes the assistant's real response
+  // to disk, so its cap is the thing keeping a long stream from filling an
+  // operator's filesystem. The guard only checked whether the cap had ALREADY
+  // been reached before appending a whole chunk, so one large chunk arriving
+  // just under the limit landed in full.
+  //
+  // One chunk, far larger than the cap, is the smallest case that
+  // distinguishes a per-write cap from a per-stream one.
+  const os = await import("node:os");
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-capture-"));
+  const target = path.join(dir, "capture.sse");
+  const prior = process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+  process.env.NEUROLINK_PROXY_CODEX_CAPTURE = target;
+  try {
+    const { createCodexUsageTap } =
+      await import("../src/lib/proxy/codexUsage.js");
+    const { stream, usage } = createCodexUsageTap();
+    const huge = new Uint8Array(2 * 1024 * 1024).fill(120);
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(huge);
+        controller.close();
+      },
+    });
+    let relayed = 0;
+    const reader = readable.pipeThrough(stream).getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      relayed += value.byteLength;
+    }
+    await usage;
+    const size = fs.statSync(target).size;
+    console.log(
+      `    [diagnostic] capture cap: file=${size} relayed=${relayed}`,
+    );
+    assert(
+      size <= 256 * 1024,
+      `the capture file grew past its cap, reaching ${size} bytes`,
+    );
+    // The relay is the contract that must not bend: capping what is written to
+    // disk must never cost the client bytes.
+    assertEqual(
+      relayed,
+      huge.byteLength,
+      "capping the capture file also truncated the relayed stream",
+    );
+  } finally {
+    if (prior === undefined) {
+      delete process.env.NEUROLINK_PROXY_CODEX_CAPTURE;
+    } else {
+      process.env.NEUROLINK_PROXY_CODEX_CAPTURE = prior;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 await runSuite();

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1487,6 +1487,438 @@ async function testOpenCodeWriterReportsWhetherItWrote(): Promise<boolean> {
   }
 }
 
+/**
+ * Restoring must require proving we own the value, not just the URL.
+ *
+ * The base-URL check catches a user who repointed the client somewhere else,
+ * but not one who kept the proxy URL and changed something beside it — a
+ * rotated key, an added field. Those edits were silently reverted to the
+ * snapshot on shutdown. Now that each writer records exactly what it wrote,
+ * a value that no longer matches that record is the user's: restore leaves it
+ * alone and only clears the proxy's own bookkeeping keys.
+ */
+async function testQwenRestoreLeavesUserEditedAuth(): Promise<boolean> {
+  const { __qwenCodeTestHooks } =
+    await import("../src/cli/proxy-clients/qwenCode.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-qwen-own-"));
+  const url = "http://127.0.0.1:55669/v1";
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".qwen"), { recursive: true });
+    const settingsPath = __qwenCodeTestHooks.getQwenSettingsPath();
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          $version: 2,
+          security: {
+            auth: {
+              selectedType: "openai",
+              baseUrl: "https://gateway.example.com/v1",
+              apiKey: "original-key",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await __qwenCodeTestHooks.setQwenProxySettings(url);
+
+    // Still pointed at the proxy, but the user rotated the key beside it.
+    const live = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (
+      (live.security as Record<string, unknown>).auth as Record<string, unknown>
+    ).apiKey = "rotated-by-user";
+    fs.writeFileSync(settingsPath, JSON.stringify(live, null, 2));
+
+    await __qwenCodeTestHooks.clearQwenProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+      security?: { auth?: { apiKey?: string } };
+      __proxy_original_qwen_auth?: unknown;
+      __proxy_written_qwen_auth?: unknown;
+    };
+    if (after.security?.auth?.apiKey !== "rotated-by-user") {
+      log("Qwen restore reverted a credential the user changed", "red");
+      return false;
+    }
+    if (
+      "__proxy_original_qwen_auth" in after ||
+      "__proxy_written_qwen_auth" in after
+    ) {
+      log("Qwen restore left its bookkeeping keys in the user's file", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** See testQwenRestoreLeavesUserEditedAuth — same rule, Claude's env map. */
+async function testClaudeRestoreLeavesUserEditedValue(): Promise<boolean> {
+  const { __claudeCodeTestHooks } =
+    await import("../src/cli/proxy-clients/claudeCode.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-claude-own-"));
+  const url = "http://127.0.0.1:55669";
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".claude"), { recursive: true });
+    const settingsPath = __claudeCodeTestHooks.getClaudeSettingsPath();
+    // The user had no ENABLE_TOOL_SEARCH at all, so the snapshot records
+    // "absent" and a restore would delete the key outright.
+    fs.writeFileSync(settingsPath, JSON.stringify({ env: {} }, null, 2));
+
+    await __claudeCodeTestHooks.setClaudeProxySettings(url);
+
+    // Base URL untouched, but the user turned tool search back off.
+    const live = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (live.env as Record<string, string>).ENABLE_TOOL_SEARCH = "false";
+    fs.writeFileSync(settingsPath, JSON.stringify(live, null, 2));
+
+    await __claudeCodeTestHooks.clearClaudeProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+      env?: Record<string, string>;
+    };
+    if (after.env?.ENABLE_TOOL_SEARCH !== "false") {
+      log("Claude restore overwrote a value the user changed", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** See testQwenRestoreLeavesUserEditedAuth — same rule, OpenCode's block. */
+async function testOpenCodeRestoreLeavesUserEditedBlock(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-own-"));
+  const url = "http://127.0.0.1:55669/v1";
+  try {
+    fs.mkdirSync(path.join(root, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = root;
+    const configPath = __openCodeTestHooks.getOpenCodeConfigPath();
+    fs.writeFileSync(configPath, JSON.stringify({ provider: {} }, null, 2));
+
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+
+    // Same baseURL, but the user pinned a model list on our block.
+    const live = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (
+      (live.provider as Record<string, unknown>).neurolink as Record<
+        string,
+        unknown
+      >
+    ).models = { "gpt-5.1": {} };
+    fs.writeFileSync(configPath, JSON.stringify(live, null, 2));
+
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+      provider?: { neurolink?: { models?: Record<string, unknown> } };
+    };
+    if (!after.provider?.neurolink?.models?.["gpt-5.1"]) {
+      log("OpenCode restore discarded a field the user added", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Regression: `proxy uninstall` must put every client config back.
+ *
+ * The shutdown path restores only on SIGINT. A launchd-managed service never
+ * receives one — `launchctl unload` and `proxy uninstall` both send SIGTERM,
+ * and the supervisor's own shutdown closure never touched client configs at
+ * all. So the documented one-command install left all five CLIs pointing at a
+ * socket that stopped answering, with no message saying why.
+ *
+ * Driven through the built CLI rather than the module, because the defect was
+ * precisely that the wiring was missing: a test that called the helper
+ * directly would have passed the whole time the bug existed.
+ */
+async function testUninstallRestoresClientConfigs(): Promise<boolean | null> {
+  if (process.platform !== "darwin") {
+    log("proxy uninstall is macOS-only; skipping on this platform", "yellow");
+    return null;
+  }
+  const cliEntry = path.join(process.cwd(), "dist", "cli", "index.js");
+  if (!fs.existsSync(cliEntry)) {
+    log("dist/cli/index.js not built; skipping", "yellow");
+    return null;
+  }
+
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-uninstall-"));
+  try {
+    // A proxy that ran on this host/port and pointed OpenCode at itself.
+    fs.mkdirSync(path.join(home, ".neurolink"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".neurolink", "proxy-state.json"),
+      JSON.stringify({
+        pid: 2147483000,
+        port: 55669,
+        host: "127.0.0.1",
+        strategy: "round-robin",
+        startTime: new Date(0).toISOString(),
+      }),
+    );
+
+    const openCodeDir = path.join(home, ".config", "opencode");
+    fs.mkdirSync(openCodeDir, { recursive: true });
+    const openCodePath = path.join(openCodeDir, "opencode.json");
+    fs.writeFileSync(
+      openCodePath,
+      JSON.stringify(
+        {
+          provider: {
+            neurolink: {
+              id: "neurolink",
+              name: "NeuroLink Proxy",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {},
+              options: {
+                baseURL: "http://127.0.0.1:55669/v1",
+                apiKey: "neurolink-proxy",
+              },
+            },
+          },
+          __proxy_original_neurolink: { name: "user's own block" },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { execFileSync } = await import("node:child_process");
+    const env = { ...process.env, HOME: home };
+    delete env.XDG_CONFIG_HOME;
+    try {
+      execFileSync(process.execPath, [cliEntry, "proxy", "uninstall"], {
+        env,
+        encoding: "utf8",
+        stdio: "pipe",
+        timeout: 60_000,
+      });
+    } catch {
+      // uninstall exits non-zero when nothing is installed; the restore is
+      // what this test is about, and it is asserted below either way.
+    }
+
+    const after = JSON.parse(fs.readFileSync(openCodePath, "utf8")) as {
+      provider?: { neurolink?: { name?: string } };
+    };
+    if (after.provider?.neurolink?.name !== "user's own block") {
+      log("proxy uninstall left OpenCode pointing at the removed proxy", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Regression: a stale snapshot must never outlive the value it describes.
+ *
+ * The snapshot-on-first-touch guard exists so a second apply() cannot record
+ * the proxy's own block as the "original". But the guard is presence-only, so
+ * after an unclean kill (no restore ran) the sentinel survives in the file. If
+ * the user then replaces the block by hand and the proxy restarts, apply()
+ * overwrites their edit while keeping the now-stale snapshot — and the next
+ * restore writes the stale value back, destroying the user's real config.
+ *
+ * Each of the three JSON configurators is checked, because each carries its
+ * own copy of the guard.
+ */
+async function testOpenCodeReSnapshotsAfterUncleanExit(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-opencode-"));
+  const url = "http://127.0.0.1:55669/v1";
+  try {
+    fs.mkdirSync(path.join(root, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = root;
+    const configPath = __openCodeTestHooks.getOpenCodeConfigPath();
+
+    // User starts with no provider.neurolink at all.
+    fs.writeFileSync(configPath, JSON.stringify({ provider: {} }, null, 2));
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+
+    // Proxy is killed uncleanly: no restore runs, the sentinel stays behind.
+    // The user then writes their own block over the proxy's.
+    const crashed = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (crashed.provider as Record<string, unknown>).neurolink = {
+      name: "user's own gateway",
+      options: { baseURL: "https://gateway.example.com", apiKey: "real-key" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(crashed, null, 2));
+
+    // Proxy restarts, then shuts down cleanly.
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+      provider?: { neurolink?: { name?: string } };
+    };
+    if (after.provider?.neurolink?.name !== "user's own gateway") {
+      log(
+        "OpenCode restore discarded a block the user wrote after an unclean exit",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** See testOpenCodeReSnapshotsAfterUncleanExit — same hazard, Claude's env map. */
+async function testClaudeReSnapshotsAfterUncleanExit(): Promise<boolean> {
+  const { __claudeCodeTestHooks } =
+    await import("../src/cli/proxy-clients/claudeCode.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-claude-"));
+  const url = "http://127.0.0.1:55669";
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".claude"), { recursive: true });
+    const settingsPath = __claudeCodeTestHooks.getClaudeSettingsPath();
+    fs.writeFileSync(settingsPath, JSON.stringify({ env: {} }, null, 2));
+
+    await __claudeCodeTestHooks.setClaudeProxySettings(url);
+
+    const crashed = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (crashed.env as Record<string, string>).ANTHROPIC_BASE_URL =
+      "https://gateway.example.com";
+    fs.writeFileSync(settingsPath, JSON.stringify(crashed, null, 2));
+
+    await __claudeCodeTestHooks.setClaudeProxySettings(url);
+    await __claudeCodeTestHooks.clearClaudeProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+      env?: Record<string, string>;
+    };
+    if (after.env?.ANTHROPIC_BASE_URL !== "https://gateway.example.com") {
+      log(
+        "Claude restore discarded a base URL the user set after an unclean exit",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * See testOpenCodeReSnapshotsAfterUncleanExit. Qwen is the worst case of the
+ * three: security.auth holds the user's real API key, so a stale snapshot
+ * deletes a live credential rather than a URL.
+ */
+async function testQwenReSnapshotsAfterUncleanExit(): Promise<boolean> {
+  const { __qwenCodeTestHooks } =
+    await import("../src/cli/proxy-clients/qwenCode.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-qwen-"));
+  const url = "http://127.0.0.1:55669/v1";
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".qwen"), { recursive: true });
+    const settingsPath = __qwenCodeTestHooks.getQwenSettingsPath();
+    fs.writeFileSync(settingsPath, JSON.stringify({ $version: 2 }, null, 2));
+
+    await __qwenCodeTestHooks.setQwenProxySettings(url);
+
+    const crashed = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (crashed.security as Record<string, unknown>).auth = {
+      selectedType: "openai",
+      baseUrl: "https://gateway.example.com/v1",
+      apiKey: "user-real-key",
+    };
+    fs.writeFileSync(settingsPath, JSON.stringify(crashed, null, 2));
+
+    await __qwenCodeTestHooks.setQwenProxySettings(url);
+    await __qwenCodeTestHooks.clearQwenProxySettings(url);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+      security?: { auth?: { apiKey?: string } };
+    };
+    if (after.security?.auth?.apiKey !== "user-real-key") {
+      log(
+        "Qwen restore discarded a credential the user set after an unclean exit",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
 /** A user's pre-existing provider.neurolink must survive set() then clear(). */
 async function testOpenCodeClearRestoresUserConfig(): Promise<boolean> {
   const { __openCodeTestHooks } =
@@ -1943,6 +2375,258 @@ async function testClaudeRestoreRefusesWithoutSnapshot(): Promise<boolean> {
  * The request log is shared with the Codex engine, and an operator can use the
  * same email for both. Codex tokens must not land on the Anthropic row.
  */
+/**
+ * A streamed request is logged twice: once when the response headers are known
+ * and again when the body finishes and its token counts arrive. The Codex
+ * engine does exactly this, and the second write is the only one that carries
+ * usage.
+ *
+ * Merging those two records rather than replacing is what makes the tokens
+ * survive alongside the first record's status and errorType. Nothing covered
+ * it, so a revert to a plain overwrite would have gone unnoticed while
+ * silently zeroing every Codex request's cost.
+ */
+async function testAnalyzeMergesDoubleWrittenRequest(): Promise<boolean> {
+  const { execFileSync } = await import("child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-merge-"));
+  const logs = path.join(dir, "logs");
+  fs.mkdirSync(logs, { recursive: true });
+  const ts = new Date().toISOString();
+  const day = ts.slice(0, 10);
+  const base = {
+    timestamp: ts,
+    method: "POST",
+    path: "/backend-api/codex/responses",
+    stream: true,
+    toolCount: 0,
+    account: "codex-a",
+    accountType: "codex-oauth",
+    responseStatus: 200,
+    responseTimeMs: 4200,
+    requestId: "codex-double",
+  };
+  const rows = [
+    // Headers are known; no usage yet, and no model resolved.
+    JSON.stringify(base),
+    // Stream finished: usage and provider arrive on a second line.
+    JSON.stringify({
+      ...base,
+      model: "gpt-5.1-codex",
+      provider: "openai",
+      inputTokens: 17339,
+      outputTokens: 700,
+      cacheReadTokens: 8576,
+    }),
+  ];
+  fs.writeFileSync(
+    path.join(logs, `proxy-${day}.jsonl`),
+    rows.join("\n") + "\n",
+  );
+
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [
+        "dist/cli/index.js",
+        "proxy",
+        "analyze",
+        "--logs-dir",
+        logs,
+        "--format",
+        "json",
+      ],
+      { encoding: "utf8" },
+    );
+    const report = JSON.parse(out) as {
+      requests?: { completed?: number };
+      cache?: { outputTokens?: number; estimatedCostUsd?: number };
+    };
+    // One request, not two: the second line enriches the first.
+    if (report.requests?.completed !== 1) {
+      log("analyze counted a re-logged request more than once", "red");
+      return false;
+    }
+    if (report.cache?.outputTokens !== 700) {
+      log("analyze lost the usage carried by the second record", "red");
+      return false;
+    }
+    if (!report.cache?.estimatedCostUsd) {
+      log("analyze priced a merged request at nothing", "red");
+      return false;
+    }
+    return true;
+  } catch {
+    log("proxy analyze did not produce a parseable report", "red");
+    return false;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The same double write can straddle a report's window edge: a Codex turn that
+ * gets its headers at 23:59:50 and finishes at 00:00:05 puts every token it
+ * spent in a record stamped after `--until`.
+ *
+ * Filtering that record out by its own timestamp drops the usage silently —
+ * the request still counts as completed, but contributes nothing to tokens or
+ * cost, and nothing in the report says so. A request the window already
+ * admitted has to keep accepting its own later records.
+ */
+async function testAnalyzeKeepsUsageAcrossWindowEdge(): Promise<boolean> {
+  const { execFileSync } = await import("child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-window-"));
+  const logs = path.join(dir, "logs");
+  fs.mkdirSync(logs, { recursive: true });
+
+  const headersAt = "2026-08-20T23:59:50.000Z";
+  const finishedAt = "2026-08-21T00:00:05.000Z";
+  const base = {
+    method: "POST",
+    path: "/backend-api/codex/responses",
+    stream: true,
+    toolCount: 0,
+    account: "codex-a",
+    accountType: "codex-oauth",
+    responseStatus: 200,
+    responseTimeMs: 15_000,
+    requestId: "codex-straddle",
+  };
+  fs.writeFileSync(
+    path.join(logs, "proxy-2026-08-20.jsonl"),
+    JSON.stringify({ ...base, timestamp: headersAt }) + "\n",
+  );
+  fs.writeFileSync(
+    path.join(logs, "proxy-2026-08-21.jsonl"),
+    JSON.stringify({
+      ...base,
+      timestamp: finishedAt,
+      model: "gpt-5.1-codex",
+      provider: "openai",
+      inputTokens: 17339,
+      outputTokens: 700,
+      cacheReadTokens: 8576,
+    }) + "\n",
+  );
+
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [
+        "dist/cli/index.js",
+        "proxy",
+        "analyze",
+        "--logs-dir",
+        logs,
+        "--since",
+        "2026-08-20T00:00:00Z",
+        "--until",
+        "2026-08-20T23:59:59Z",
+        "--format",
+        "json",
+      ],
+      { encoding: "utf8" },
+    );
+    const report = JSON.parse(out) as {
+      requests?: { completed?: number };
+      cache?: { outputTokens?: number };
+    };
+    if (report.requests?.completed !== 1) {
+      log("analyze did not count the request its window admitted", "red");
+      return false;
+    }
+    if (report.cache?.outputTokens !== 700) {
+      log(
+        "analyze dropped the usage of a request whose completion landed after the window",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } catch {
+    log("proxy analyze did not produce a parseable report", "red");
+    return false;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function testAnalyzePricingProvenance(): Promise<boolean> {
+  const { execFileSync } = await import("child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-pricing-"));
+  const logs = path.join(dir, "logs");
+  fs.mkdirSync(logs, { recursive: true });
+  const ts = new Date().toISOString();
+  const day = ts.slice(0, 10);
+  const rows = [
+    {
+      requestId: "b1",
+      model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      provider: "bedrock",
+    },
+    { requestId: "v1", model: "gemini-2.5-pro", provider: "vertex" },
+    { requestId: "s1", model: "claude-sonnet-4-5", provider: "anthropic" },
+  ].map((r) =>
+    JSON.stringify({
+      timestamp: ts,
+      method: "POST",
+      path: "/v1/messages",
+      stream: false,
+      toolCount: 0,
+      account: "a",
+      accountType: "oauth",
+      responseStatus: 200,
+      responseTimeMs: 900,
+      inputTokens: 1000,
+      outputTokens: 100,
+      ...r,
+    }),
+  );
+  fs.writeFileSync(
+    path.join(logs, `proxy-${day}.jsonl`),
+    rows.join("\n") + "\n",
+  );
+
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [
+        "dist/cli/index.js",
+        "proxy",
+        "analyze",
+        "--logs-dir",
+        logs,
+        "--format",
+        "json",
+      ],
+      { encoding: "utf8" },
+    );
+    const report = JSON.parse(out) as {
+      cache?: { requestsPriced?: number; requestsPricedByPrefix?: number };
+    };
+    if (report.cache?.requestsPriced !== 3) {
+      log(
+        "analyze did not price every request that carried a known model",
+        "red",
+      );
+      return false;
+    }
+    if (report.cache?.requestsPricedByPrefix !== 0) {
+      log(
+        "analyze reported an exact rate as an inferred one — provenance regressed",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } catch {
+    log("proxy analyze did not produce a parseable report", "red");
+    return false;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ============================================================================
 // Tests: Primary account selection (in-process unit-style)
 // ============================================================================
@@ -4093,6 +4777,56 @@ const tests: TestFunction[] = [
   {
     name: "OpenCode: clear restores the user's own config",
     fn: testOpenCodeClearRestoresUserConfig,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: Qwen restore leaves a user-edited credential",
+    fn: testQwenRestoreLeavesUserEditedAuth,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: Claude restore leaves a user-edited value",
+    fn: testClaudeRestoreLeavesUserEditedValue,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: OpenCode restore leaves a user-edited block",
+    fn: testOpenCodeRestoreLeavesUserEditedBlock,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: uninstall restores every client config",
+    fn: testUninstallRestoresClientConfigs,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: OpenCode re-snapshots after an unclean exit",
+    fn: testOpenCodeReSnapshotsAfterUncleanExit,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: Claude re-snapshots after an unclean exit",
+    fn: testClaudeReSnapshotsAfterUncleanExit,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: Qwen re-snapshots after an unclean exit",
+    fn: testQwenReSnapshotsAfterUncleanExit,
+    category: "proxy-config",
+  },
+  {
+    name: "Analyze: a re-logged request merges instead of overwriting",
+    fn: testAnalyzeMergesDoubleWrittenRequest,
+    category: "proxy-config",
+  },
+  {
+    name: "Analyze: usage survives a completion after the window edge",
+    fn: testAnalyzeKeepsUsageAcrossWindowEdge,
+    category: "proxy-config",
+  },
+  {
+    name: "Analyze: exact rates are not reported as inferred",
+    fn: testAnalyzePricingProvenance,
     category: "proxy-config",
   },
   {

--- a/test/fixtures/codex-response-usage.sse
+++ b/test/fixtures/codex-response-usage.sse
@@ -1,0 +1,2 @@
+event: response.completed
+data: {"type": "response.completed", "response": {"id": "resp_redacted", "usage": {"input_tokens": 17339, "input_tokens_details": {"cache_write_tokens": 0, "cached_tokens": 8576}, "output_tokens": 7, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 17346}}}


### PR DESCRIPTION
Part 3 of a four-PR stack. **Base is #1400** — merge #1399 and #1400 first.

Closes #1369
Closes #1370
Closes #1371

## The problem

The proxy served 300k+ requests on this machine with no usable accounting. Three separate defects, plus a pricing table that had fallen behind the models actually in flight.

## 1. The provider was hard-coded (#1370)

`ProxyTracer` passed the literal `"anthropic"` at **four** sites, so a model served by anyone else looked up a table it is not in.

The failure mode is subtler than it looks. The `anthropic` table has no `_default`, so `findRates` returns undefined and cost collapses to **$0** — *except* for a `claude-`named model routed elsewhere, which prices against the Anthropic table and yields a confident, wrong figure. **Two failure modes with opposite diagnostics:** silent zero is visible in aggregate and invisible per-request; plausible-wrong is the reverse.

The provider now travels on `ProxyRequestContext`, and the billing model is no longer `readonly`, so cost follows `setModelSubstitution` to the model that actually served the request.

## 2. `proxy analyze` reported half of usage and no spend (#1371)

It parsed `inputTokens` and both cache counters but never `outputTokens` and never a cost. It now prices each record, and distinguishes a **quoted** rate from one **inherited by name-prefix fallback**.

That distinction was itself wrong on first attempt: `isExactPricingMatch` re-implemented the lookup and missed Bedrock`s vendor-prefix strip and Vertex`s fallback to the Google table, mislabelling both as guesses. Two reviewers caught it independently. It now derives from `findRates` via an out-param, so there is one lookup.

## 3. Codex recorded nothing at all (#1369)

`codexProxyRoutes.ts` relayed `upstream.body` untouched and logged before a byte was read. A pass-through tap now scrapes `usage`, built so it **cannot break the relay**: bytes are enqueued before inspection, all parsing is wrapped, and an unrecognised stream degrades to the previous behaviour.

**The wire shape is verified, not assumed.** I ran the real Codex CLI through the proxy and captured the stream; the trimmed sample ships as `test/fixtures/codex-response-usage.sse`. The capture taught two things the docs did not: `response.created` arrives first carrying `usage: null` — which is why keeping the *last* non-null value is load-bearing — and `input_tokens_details.cache_write_tokens` existed and was being dropped, under-reporting cost.

A `cancel()` handler was also added: `usage` previously settled only in `flush()`, which the Streams spec skips on abort, so every client disconnect leaked a pending promise.

## 4. The rates were missing entirely

`claude-sonnet-5` and `claude-opus-5` are **100% of this machine`s traffic**, and the table stopped at the 4-series. Every cost would have read `$0.00` — indistinguishable from "no spend yet".

Added from published rates: Sonnet 5 `$2/$10`, Opus 5 `$5/$25`, plus Fable 5, Mythos 5, Opus 4.7/4.8, GPT-5.5 and the GPT-5.6 tiers. Two traps worth noting in review: **Sonnet 5`s scheduled Sep 1 rise to $3/$15 was cancelled**, and OpenAI cut GPT-5.6 on Jul 30 — most third-party tables are stale on both. A first pass also blended a promotional cache rate with a list input rate for `gpt-5.6-sol`; all three tiers now verify at the documented 0.10x / 1.25x.

## Testing

Codex suite 29 passed, including the real-traffic fixture, the abort case, malformed and partial payloads, and a byte-for-byte relay check across a chunk split. Proxy suite 45 passed, including a CLI-driven regression that Bedrock and Vertex-Gemini exact rates are not reported as inferred.

`tsc --strict` clean · eslint 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex usage tracking for streamed responses, including token details and cache usage.
  * Added estimated cost, pricing coverage, and unpriced-model reporting to proxy analysis.
  * Added pricing support for newer Claude and GPT models.
  * Added provider attribution to proxy requests and usage metrics.
* **Bug Fixes**
  * Improved restoration of client settings when uninstalling the proxy.
  * Preserved user changes and credentials across repeated configuration updates.
  * Improved request attribution and merging for streamed usage records.
* **Documentation**
  * Documented snapshot recovery and uninstall-time service restoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->