### PR TITLE
test(core): prove the engine breaker matches AI Studio's dispatch count

### DIFF
--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -1077,4 +1077,49 @@ await test("an unresolvable tool name is recorded with an id and an error", asyn
   );
 });
 
+await test("the engine's breaker dispatches an always-failing tool exactly twice at maxRetries 2", async () => {
+  // Task 9 prerequisite, proven rather than assumed. AI Studio's own
+  // dispatcher stops after DEFAULT_TOOL_MAX_RETRIES (2) failures, which the
+  // characterization suite measured end-to-end as attempts=2 across 4 model
+  // calls. Migrating that loop onto this engine is only safe if the engine
+  // reproduces the same count from the same threshold.
+  let attempts = 0;
+  const adapter: AgenticLoopAdapter<string[]> = {
+    ...makeHydrationAdapter({
+      toolCallsByStep: [
+        [{ id: "c1", name: "flaky", args: {} }],
+        [{ id: "c2", name: "flaky", args: {} }],
+        [{ id: "c3", name: "flaky", args: {} }],
+        [{ id: "c4", name: "flaky", args: {} }],
+        [],
+      ],
+    }),
+    toolFailureBreaker: { maxRetries: 2 },
+  };
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    tools: {
+      flaky: {
+        execute: async () => {
+          attempts++;
+          throw new Error("synthetic tool failure");
+        },
+      },
+    },
+  });
+  const result = await resultPromise;
+  assertEqual(
+    attempts,
+    2,
+    "the breaker must stop dispatching after maxRetries failures",
+  );
+  // Every call is still ANSWERED — the model is told the tool is permanently
+  // failed rather than the turn stalling. Four calls, two dispatches.
+  const answered = result.toolExecutions.filter((e) => e.name === "flaky");
+  assertEqual(
+    answered.length,
+    4,
+    "every call must be answered even once the breaker has tripped",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## Why

Task 9 Step 3 prerequisite, **proven rather than assumed**.

AI Studio's own dispatcher stops after `DEFAULT_TOOL_MAX_RETRIES` (2) failures. #1403 measured that end-to-end: exactly 2 dispatches across 4 model calls. Migrating that loop onto `runAgenticLoop` is only safe if the engine produces the same count from the same threshold - and nothing established that it did.

## Result

It does. With `toolFailureBreaker.maxRetries = 2` the engine dispatches an always-throwing tool **exactly twice**, and still **answers all four calls** - the model is told the tool is permanently failed rather than the turn stalling.

Mutation-verified: widening the engine's threshold by one makes this case *and* the existing breaker case both fail.

```
unmutated:  Passed: 32
maxRetries + 1:  Failed: 2
  x runAgenticLoop: tool failure breaker trips after maxRetries...
  x the engine's breaker dispatches an always-failing tool exactly twice at maxRetries 2
```

## It also settles the divergence that prompted the check

`executeNativeToolCalls` clears a tool's accrued strikes whenever it resolves that tool live (`failedTools.delete`), and the engine has no equivalent. That looked like a migration hazard.

It is not. **Neither implementation strikes on `TOOL_NOT_FOUND`** - only a thrown `execute` accrues a strike, which requires the tool to have been present and executable. So a tool cannot accrue strikes while it is deferred, and there is nothing for the reset to clear. The `delete` is vestigial, and the engine needs no reset to match AI Studio's behaviour.

This removes the one open question blocking the AI Studio loop migration.

## Scope

Test-only. No source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for repeated tool failures, ensuring failures are reported and processing continues until the configured step limit.
  - Verified that final accumulated text is delivered when the step limit is reached.
  - Added regression coverage confirming retry limits and execution records after the failure breaker activates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->