### PR TITLE
test(googleAiStudio): make the breaker case assert the actual failure response

### DIFF
--- a/test/continuous-test-suite-aistudio-loop-characterization.ts
+++ b/test/continuous-test-suite-aistudio-loop-characterization.ts
@@ -133,6 +133,19 @@ function functionResponses(call: StandInCall | undefined): string[] {
     .filter((n): n is string => typeof n === "string");
 }
 
+/** functionResponse parts with their payloads, for a given request. */
+function functionResponsePayloads(
+  call: StandInCall | undefined,
+): Array<{ name?: string; response?: unknown }> {
+  const contents = (call?.body?.contents ?? []) as Array<{
+    parts?: Array<{ functionResponse?: { name?: string; response?: unknown } }>;
+  }>;
+  return contents
+    .flatMap((c) => c.parts ?? [])
+    .map((p) => p.functionResponse)
+    .filter((r): r is { name?: string; response?: unknown } => r !== undefined);
+}
+
 async function startStandIn(
   reply: (callIndex: number) => string,
 ): Promise<StandIn> {
@@ -397,10 +410,29 @@ await test("a tool that always throws is reported to the model and does not run 
     server.calls.length === 4,
     `a maxSteps=4 turn made ${server.calls.length} calls, not the 4 this loop performs`,
   );
-  const responses = JSON.stringify(server.calls.slice(1).map((c) => c.body));
+  // Structural, not a substring scan of the whole request body.
+  //
+  // The first version of this assertion searched the serialized body for the
+  // tool's name, which can never fail: the name is in the function
+  // DECLARATIONS on every single request, whether or not any result came
+  // back. Mutation-testing proved it — replacing every functionResponse with
+  // a stub broke two other cases in this file and left this one green.
+  //
+  // What actually matters is that each failed dispatch is answered: a
+  // functionResponse under the tool's own name, carrying a failure rather
+  // than a result.
+  const failureResponses = functionResponsePayloads(server.calls[3]).filter(
+    (entry) => entry.name === "flaky",
+  );
   assert(
-    responses.includes("flaky"),
-    "the failed dispatch was never reported back to the model",
+    failureResponses.length > 0,
+    "the failed dispatch was never answered back to the model",
+  );
+  assert(
+    failureResponses.every((entry) =>
+      JSON.stringify(entry.response ?? {}).includes("error"),
+    ),
+    "the dispatch was answered, but not as a failure",
   );
 });
 


### PR DESCRIPTION
## What

CodeRabbit's finding on #1403 - verified before acting on it, and correct.

The breaker case asserted:

```ts
const responses = JSON.stringify(server.calls.slice(1).map((c) => c.body));
assert(responses.includes("flaky"), "the failed dispatch was never reported back to the model");
```

That can **never fail**. The tool's name appears in the function *declarations* on every single request, whether or not any result came back.

## Proven by mutation, not by reading

Replacing every `functionResponse` the native dispatcher builds with a stub broke two other cases in this file and left this one green:

```
mutated, old assertion:  Passed 3   Failed 2    <- this case still green
mutated, new assertion:  Passed 2   Failed 3    <- this case now fails
unmutated:               Passed 5   RESULT: PASS
```

## The fix

Structural instead of a substring scan: a `functionResponse` under the tool's own name must come back on the final request, and its payload must carry a failure rather than a result.

## Note on process

This is the **second** non-discriminating assertion in this file. The first - the step-cap case - I caught myself by mutation-testing before committing. This one shipped because I did not do the same here. Both are now covered by the standing rule to mutate every new characterization assertion before it lands, which is exactly the check that would have caught this one for free.

## Scope

Test-only. No source changes.