### PR TITLE
fix(core): drop the loop adapter's dead turn-timeout fields

### DIFF
--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -105,9 +105,21 @@ export type AgenticLoopToolFailureBreaker = {
 export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
   readonly providerLabel: string;
   readonly maxSteps: number;
-  /** Pre-existing per-family flat timeout, used as createTurnClock's deadline default. */
-  readonly defaultTurnTimeoutMs?: number;
-  readonly stallTimeoutMs?: number;
+  //
+  // NOTE — turn deadlines and stall detection are deliberately NOT adapter
+  // fields.
+  //
+  // `defaultTurnTimeoutMs` and `stallTimeoutMs` used to be declared here and
+  // were read by nothing: `runAgenticLoop` has no turn clock, and no adapter
+  // ever set them. Leaving them in place was worse than omitting them,
+  // because the natural move when migrating a provider that HAS a turn clock
+  // (Vertex) is to set them and assume the engine honours it — which would
+  // silently drop the deadline and the stall detection from that turn.
+  //
+  // Both belong to the caller, which already owns the clock and can compose
+  // its abort into the `abortSignal` it passes, and can reset a stall timer
+  // as it drains the engine's stream. That keeps one implementation of the
+  // behaviour rather than a second, weaker one inside the engine.
   /** Set only for adapter instances whose client has the TOOL_NOT_FOUND strike breaker today: both Gemini adapters (AI Studio, Vertex+Gemini) AND the Vertex+Claude call to createAnthropicLoopAdapter — NOT the native-Anthropic call to that same factory, and not Bedrock. See Verified Fact 4. */
   readonly toolFailureBreaker?: AgenticLoopToolFailureBreaker;
   /**


### PR DESCRIPTION
## What

`AgenticLoopAdapter` declared `defaultTurnTimeoutMs` and `stallTimeoutMs`. **Nothing read them.** `runAgenticLoop` has no turn clock at all - zero references to any of it - and no adapter ever set one. They were inert.

## Why it matters

Found while planning the Vertex migration (Plan 08 Task 10), which is precisely where they would have done damage.

Vertex is the one provider with a real turn clock - a per-turn deadline plus stall detection. The natural move when writing its adapter is to set these two fields and assume the engine honours them. It does not. The turn would have lost both silently: no type error, no test failure, just a turn that never times out and never detects a stall.

That is the same shape as every other defect this plan has surfaced - behaviour that disappears without anything going red.

## Removed, not implemented

The caller already owns the clock. It can compose the clock's abort into the `abortSignal` it passes to `runAgenticLoop`, and reset a stall timer as it drains the engine's stream. Keeping the behaviour there means one implementation rather than a second, weaker one inside the engine.

A comment in their place records the decision, so the fields are not reintroduced by the next person who goes looking for them.

## Safety

- Typecheck clean across 4858 files - which **is** the proof nothing referenced them.
- `AgenticLoopAdapter` does not appear in `dist/index.d.ts`, so it is internal and no external adapter author can be affected.

## Tests

loop-engine suite 32/32, `test:providers-mocked` 54/54.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the agent loop adapter contract by removing unused timeout configuration options.
  * Clarified that callers manage turn deadlines and stalled-stream detection through existing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->