### PR TITLE
fix(providers): stop pretending the Google SDK honours a proxy

### DIFF
--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -82,7 +82,7 @@ import {
 } from "../googleNativeGemini3/index.js";
 import { createStreamChannel } from "../../core/streamChannel.js";
 import { toNativeToolDeclarations } from "../../core/nativeToolFormat.js";
-import { createProxyFetch } from "../../proxy/proxyFetch.js";
+import { warnGoogleSdkIgnoresProxy } from "../../proxy/proxyFetch.js";
 import type { LanguageModel, Schema } from "../../types/index.js";
 
 // Google AI Live API types now imported from ../types/providerSpecific.js
@@ -107,16 +107,20 @@ async function createGoogleGenAIClient(
     });
   }
   const Ctor = ctor as GoogleGenAIClass;
-  // Include httpOptions with proxy fetch for corporate network support.
+  // httpOptions carries the endpoint override and nothing else. It used to
+  // also pass a proxy fetch, which the SDK silently ignored — see
+  // warnGoogleSdkIgnoresProxy for why that is not fixable here.
+  //
   // baseUrl is only included when resolved — verified against
   // @google/genai's ApiClient (dist/node/index.cjs) that it falls back to
   // its own default whenever httpOptions.baseUrl is undefined, so omitting
   // the key and passing `baseUrl: undefined` behave identically; the key is
   // still omitted outright for a cleaner outbound config object.
+  warnGoogleSdkIgnoresProxy("GoogleAIStudio");
+
   return new Ctor({
     apiKey,
     httpOptions: {
-      fetch: createProxyFetch(),
       ...(baseURL ? { baseUrl: baseURL } : {}),
     },
   });

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -29,7 +29,7 @@ import {
   stringifyContentSafe,
 } from "../../utils/logSanitize.js";
 import type { NeuroLink } from "../../neurolink.js";
-import { createProxyFetch } from "../../proxy/proxyFetch.js";
+import { warnGoogleSdkIgnoresProxy } from "../../proxy/proxyFetch.js";
 import type {
   UnknownRecord,
   ZodUnknownSchema,
@@ -1147,6 +1147,8 @@ export class GoogleVertexProvider extends BaseProvider {
   private async createVertexGenAIClient(
     regionOverride?: string,
   ): Promise<GenAIClient> {
+    warnGoogleSdkIgnoresProxy("GoogleVertex");
+
     const expressApiKey = this.resolveExpressApiKey();
     // Resolved only on the ADC path: getVertexProjectId() throws when no
     // project is configured, which an Express request legitimately has none of.
@@ -1170,8 +1172,10 @@ export class GoogleVertexProvider extends BaseProvider {
 
     const baseUrl = this.resolveBaseURL();
     const httpOptions = {
-      // Proxy fetch for corporate network support.
-      fetch: createProxyFetch(),
+      // The endpoint override and nothing else. This object used to also pass
+      // a proxy fetch, which the SDK silently ignored — see
+      // warnGoogleSdkIgnoresProxy for why that is not fixable here.
+      //
       // Only set when resolved: the SDK falls back to its own default
       // whenever httpOptions.baseUrl is undefined, so omitting the key and
       // passing undefined behave identically.

--- a/src/lib/proxy/proxyFetch.ts
+++ b/src/lib/proxy/proxyFetch.ts
@@ -853,3 +853,36 @@ export function getProxyStatus() {
     ],
   };
 }
+
+/**
+ * One-time warning that the @google/genai SDK cannot honour a configured
+ * proxy.
+ *
+ * Both Google providers passed `httpOptions: { fetch: createProxyFetch() }`,
+ * which does nothing. `HttpOptions` in @google/genai 1.46.0 declares only
+ * baseUrl, baseUrlResourceScope, apiVersion, headers, timeout, extraBody and
+ * retryOptions — there is no `fetch` on it. That property belongs to a
+ * different interface (`ClientOptions`), which `GoogleGenAIOptions` does not
+ * accept, and the SDK's request path calls global `fetch`. The option was
+ * silently dropped and requests went direct.
+ *
+ * It type-checked only because those constructors are reached through a
+ * loosely-typed local alias, which turns off excess-property checking.
+ *
+ * This SDK version offers no supported injection point, so rather than keep a
+ * line that reads like working proxy support, the situation is reported once
+ * per process — and only to someone who actually configured a proxy. Silent
+ * bypass is the worst outcome available: a corporate user believes their
+ * traffic is proxied when it is not.
+ */
+let proxyUnsupportedWarned = false;
+
+export function warnGoogleSdkIgnoresProxy(providerLabel: string): void {
+  if (proxyUnsupportedWarned || !getProxyStatus().enabled) {
+    return;
+  }
+  proxyUnsupportedWarned = true;
+  logger.warn(
+    `[${providerLabel}] A proxy is configured, but the @google/genai SDK provides no way to route its requests through it (HttpOptions has no 'fetch', and GoogleGenAIOptions accepts none). Requests from this provider go direct.`,
+  );
+}

--- a/test/continuous-test-suite-vertex-loop-characterization.ts
+++ b/test/continuous-test-suite-vertex-loop-characterization.ts
@@ -195,6 +195,10 @@ function credentialsFor(port: number) {
   };
 }
 
+function nl() {
+  return new NeuroLink();
+}
+
 function customTool(counter: { calls: number }) {
   return {
     lookup: {
@@ -209,6 +213,62 @@ function customTool(counter: { calls: number }) {
         return { found: true };
       },
     },
+  };
+}
+
+/**
+ * A stand-in that answers the request headers and then never sends a body,
+ * reproducing a provider that accepts a stream and wedges.
+ */
+async function startSilentStandIn(): Promise<StandIn> {
+  const calls: StandInCall[] = [];
+  const server: Server = createServer((req, res) => {
+    calls.push({ body: {}, path: String(req.url ?? "").split("?")[0] });
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    // Deliberately no write and no end: the turn clock is what must react.
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    calls,
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/**
+ * A stand-in that keeps the stream alive with periodic events.
+ *
+ * Progress resets the stall clock, so a turn against this server can only be
+ * ended by the wall-clock deadline — which is what separates the two limits.
+ */
+async function startDribblingStandIn(): Promise<StandIn> {
+  const calls: StandInCall[] = [];
+  const timers: NodeJS.Timeout[] = [];
+  const server: Server = createServer((req, res) => {
+    calls.push({ body: {}, path: String(req.url ?? "").split("?")[0] });
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    const t = setInterval(() => {
+      res.write(sse([{ text: "." }]));
+    }, 300);
+    timers.push(t);
+    res.on("close", () => clearInterval(t));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    calls,
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        timers.forEach(clearInterval);
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
   };
 }
 
@@ -473,6 +533,173 @@ await test("a tool that always throws is dispatched a bounded number of times", 
   assert(
     attempts === 2,
     `the failing tool was dispatched ${attempts} times, not the 2 this loop performs`,
+  );
+});
+
+section("turn clock");
+
+await test("a stream that stops making progress ends the turn as stalled", async () => {
+  // The turn clock is the part of this loop a migration is most likely to
+  // drop, because nothing about it shows up in a normal turn: it only acts
+  // when a stream goes quiet. `stallTimeoutMs` is a public option threaded
+  // straight into createTurnClock, so the behaviour IS reachable
+  // deterministically — a stand-in that opens a response and then says
+  // nothing reproduces a wedged provider exactly.
+  //
+  // Pinned before the Vertex loops move onto runAgenticLoop, because the
+  // engine has no turn clock of its own: the fields that once advertised one
+  // on the adapter were removed for being inert, so the clock has to stay on
+  // this side, composed into the abort signal.
+  const server = await startSilentStandIn();
+  const restore = withVertexEnv();
+  let stopReason: string | undefined;
+  let outcome: string;
+  let thrown: unknown;
+  try {
+    // The ENTIRE turn is bounded, not just the drain. Removing the stall
+    // clock does not make this case fail — it makes it HANG, and it hangs
+    // inside stream() before any drain begins, so a race around the drain
+    // alone would never fire. A hung suite is a worse CI signal than a red
+    // one, and this bound is what turns the regression into a clean failure.
+    const turn = (async () => {
+      const result = await nl().stream({
+        input: { text: "hi" },
+        provider: "vertex",
+        model: MODEL,
+        maxTokens: 32,
+        disableInternalFallback: true,
+        stallTimeoutMs: 1500,
+        credentials: credentialsFor(server.port),
+      });
+      for await (const chunk of result.stream) {
+        void chunk;
+      }
+      // metadata.stopReason, not the top-level field: for these
+      // background-loop streams the top-level one is a late-resolving getter
+      // and reading it early yields undefined however the turn ended. That is
+      // documented on StreamResult and is not a defect — the first version of
+      // this case read the wrong field and reported a working turn clock as
+      // broken.
+      stopReason = (result as { metadata?: { stopReason?: string } }).metadata
+        ?.stopReason;
+      return "ended";
+    })();
+    outcome = await Promise.race([
+      // The rejection is RETAINED, not converted into a pass. Mapping every
+      // error to a passing outcome would let any unrelated failure — a
+      // connection refused, a misconfigured credential — satisfy a test whose
+      // whole subject is the turn clock. Both of these turns end cleanly
+      // today, so a throw is a real signal and is reported as one.
+      turn.catch((error: unknown) => {
+        thrown = error;
+        return "threw";
+      }),
+      new Promise<string>((resolve) => {
+        const t = setTimeout(() => resolve("never-ended"), 20_000);
+        t.unref?.();
+      }),
+    ]);
+  } finally {
+    restore();
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] stall turn: outcome=${outcome} stopReason=${String(stopReason)}`,
+  );
+  assert(
+    outcome !== "never-ended",
+    "a wedged turn was never ended by the turn clock within the bound",
+  );
+  if (outcome === "threw") {
+    // Printed, never interpolated into an assertion: the harness downgrades a
+    // failure whose text matches isExpectedProviderError() to a SKIP, so
+    // provider wording must not reach an assert.
+    console.log(
+      `    [diagnostic] stall turn threw: ${String((thrown as Error)?.message).slice(0, 160)}`,
+    );
+  }
+  assert(
+    outcome === "ended",
+    "the wedged turn failed instead of being ended by the turn clock",
+  );
+  assert(
+    stopReason === "stalled",
+    "a wedged turn ended without being reported as a stall",
+  );
+});
+
+await test("a turn that outlives turnTimeoutMs ends on the wall-clock deadline", async () => {
+  // The stall clock and the wall-clock deadline are separate limits with
+  // separate stop reasons, and a turn can hit either. This one is reachable
+  // with a stand-in that DOES make progress — it keeps dribbling events, so
+  // the stall clock is continually reset and only turnTimeoutMs can end the
+  // turn. Without that distinction a single fixture would prove one limit
+  // works and say nothing about the other.
+  const server = await startDribblingStandIn();
+  const restore = withVertexEnv();
+  let stopReason: string | undefined;
+  let outcome: string;
+  let thrown: unknown;
+  try {
+    const turn = (async () => {
+      const result = await nl().stream({
+        input: { text: "hi" },
+        provider: "vertex",
+        model: MODEL,
+        maxTokens: 32,
+        maxSteps: 20,
+        disableInternalFallback: true,
+        turnTimeoutMs: 2500,
+        // Deliberately far above the deadline so a stall cannot be what ends
+        // this turn.
+        stallTimeoutMs: 60_000,
+        credentials: credentialsFor(server.port),
+      });
+      for await (const chunk of result.stream) {
+        void chunk;
+      }
+      stopReason = (result as { metadata?: { stopReason?: string } }).metadata
+        ?.stopReason;
+      return "ended";
+    })();
+    outcome = await Promise.race([
+      // The rejection is RETAINED, not converted into a pass. Mapping every
+      // error to a passing outcome would let any unrelated failure — a
+      // connection refused, a misconfigured credential — satisfy a test whose
+      // whole subject is the turn clock. Both of these turns end cleanly
+      // today, so a throw is a real signal and is reported as one.
+      turn.catch((error: unknown) => {
+        thrown = error;
+        return "threw";
+      }),
+      new Promise<string>((resolve) => {
+        const t = setTimeout(() => resolve("never-ended"), 25_000);
+        t.unref?.();
+      }),
+    ]);
+  } finally {
+    restore();
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] time-limit turn: outcome=${outcome} stopReason=${String(stopReason)}`,
+  );
+  assert(
+    outcome !== "never-ended",
+    "a turn past its wall-clock deadline was never ended within the bound",
+  );
+  if (outcome === "threw") {
+    console.log(
+      `    [diagnostic] time-limit turn threw: ${String((thrown as Error)?.message).slice(0, 160)}`,
+    );
+  }
+  assert(
+    outcome === "ended",
+    "the turn failed instead of being ended by its wall-clock deadline",
+  );
+  assert(
+    stopReason === "time-limit",
+    "a turn past its wall-clock deadline was not reported against that deadline",
   );
 });
 


### PR DESCRIPTION
## The bug

Both Google providers passed `httpOptions: { fetch: createProxyFetch() }`. **The SDK ignores it.**

`@google/genai` 1.46.0's `HttpOptions` declares only `baseUrl`, `baseUrlResourceScope`, `apiVersion`, `headers`, `timeout`, `extraBody`, `retryOptions`. There is no `fetch` on it — that property belongs to a *different* interface, `ClientOptions`, which `GoogleGenAIOptions` does not accept — and the SDK's request path calls global `fetch`.

So every Vertex and AI Studio request has been going **direct**, while the code read as though corporate proxy support was wired up.

It type-checked only because both constructors are reached through a loosely-typed local alias, which disables excess-property checking.

## Why there is no fix, only honesty

This SDK version offers no supported injection point. `GoogleGenAIOptions` accepts `vertexai`, `project`, `location`, `apiKey`, `apiVersion`, `googleAuthOptions` and `httpOptions` — none of them take a fetch.

What *can* be fixed is the silence. The dead option is removed, and a process that actually has a proxy configured is told once, per provider family, that these requests will not use it.

Silent bypass is the worst outcome available here: a corporate user believes their traffic is proxied when it is not. The warning is gated on `getProxyStatus().enabled`, so nobody without a proxy ever sees it.

I deliberately did **not** reach for `setGlobalDispatcher` — patching global fetch from a provider constructor is a process-wide side effect that nobody asked for.

## Verified, not assumed

- `HttpOptions` field list read directly from the installed `genai.d.ts`.
- The helper fires exactly once, and only with a proxy configured.
- Warn output confirmed visible under `NEUROLINK_DEBUG=true`. Worth noting for reviewers: `shouldLog()` suppresses everything except errors unless debug mode is on, so a `logger.warn` that "does not print" in a plain run is this codebase's deliberate convention, not a broken warning.

Found by CodeRabbit on #1408; the interface fields were checked directly rather than taking the finding on trust.

## Tests

Vertex characterization 5/5, AI Studio characterization 6/6, `test:providers-mocked` 54/54, typecheck and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when Google AI integrations are configured with a proxy that the SDK cannot use.
  * Prevented repeated warnings by displaying the notice only once.
  * Preserved API key and base URL configuration for Google AI integrations.
  * Improved handling of stalled or continuously running Vertex AI streams so they end with an appropriate timeout reason instead of hanging indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->