### PR TITLE
fix(security): scope dependency audit to advisory ids, not package names

### DIFF
--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -36,28 +36,88 @@ const CRITICAL_SECURITY_RULES = [
   "private-key",
 ];
 
-// Configuration: Packages to temporarily ignore in vulnerability scanning
-// TODO(#1318): Address these vulnerabilities in a separate security update
-const IGNORED_VULNERABLE_PACKAGES = [
-  "jsondiffpatch", // XSS in ai dependency - tracked separately
-  "ai", // File upload bypass - planned upgrade
-  // undici/lodash/lodash-es removed: now patched via pnpm.overrides.
-  // The @opentelemetry/* advisories below come ONLY from a stale @juspay/neurolink@9.37.0
-  // that pnpm auto-installs to satisfy @juspay/hippocampus's neurolink peer. That old
-  // neurolink directly depends on the vulnerable OTEL; the latest published neurolink
-  // (>=9.70.x) removed those deps. They are a dev-install artifact and do NOT reach
-  // consumers of the published package (peer deps are not bundled).
-  //
-  // UPSTREAM IS FIXED: @juspay/hippocampus@0.1.7 raised its neurolink peer to ">=9.70.0"
-  // (this change bumps the dependency to it). The entries remain only because of a pnpm
-  // resolver bug: pnpm keeps resolving the peer to 9.37.0 even though that violates the
-  // published ">=9.70.0" range — reproduced through --force, --fix-lockfile, dedupe,
-  // pnpm update, and a full lockfile regen. These entries clear automatically once pnpm
-  // resolves the peer correctly. Upstream: https://github.com/juspay/hippocampus (v0.1.7)
-  "@opentelemetry/sdk-node",
-  "@opentelemetry/auto-instrumentations-node",
-  "@opentelemetry/exporter-prometheus",
-];
+// Configuration: known-open production advisories that are explicitly accepted
+// as risk, keyed by pnpm/GitHub advisory id (NOT package name — a package can
+// have several advisories and accepting one must not silently accept the rest).
+// Every entry needs its own honest one-line reason; a bare id is not a review
+// decision, it is a rubber stamp. Re-seed this list from
+// `pnpm audit --prod --json` whenever it goes stale — see checkDependencyVulnerabilities().
+//
+// Snapshot taken 2026-08-21 against `pnpm audit --prod --json`. `--prod`
+// structurally excludes the @juspay/hippocampus dev-only shadow tree (a full
+// audit shows 55 advisories; --prod shows 25 and drops all 3
+// @opentelemetry/* entries that used to be filtered by package name below).
+const ACCEPTED_RISK_ADVISORY_IDS: Record<string, string> = {
+  // uuid — transitive via @anthropic-ai/vertex-sdk, bullmq, exceljs; no
+  // single direct dependency to bump, upstreams need to move first.
+  "1119441":
+    "uuid buffer bounds check — deep transitive via vertex-sdk/bullmq/exceljs, no direct control",
+  // form-data — transitive via optional @livekit/agents (voice feature only).
+  "1120743":
+    "form-data CRLF injection — transitive via optional @livekit/agents, not on the default request path",
+  // @opentelemetry/core — transitive via optional livekit OTEL exporters.
+  "1120821":
+    "@opentelemetry/core baggage allocation — transitive via optional livekit OTEL exporter chain",
+  // adm-zip — transitive via optional livekit onnxruntime-node.
+  "1123686":
+    "adm-zip 4GB allocation — transitive via optional @livekit/agents-plugin-livekit onnxruntime-node",
+  // brace-expansion — three separate DoS advisories, same transitive chain.
+  "1123898":
+    "brace-expansion DoS — transitive via @google-cloud/text-to-speech>google-gax>rimraf>glob>minimatch, no direct control",
+  "1130591":
+    "brace-expansion DoS (unbounded expansion variant) — same google-gax>rimraf>glob>minimatch chain as 1123898",
+  "1130734":
+    "brace-expansion DoS (mitigation-bypass variant) — same google-gax>rimraf>glob>minimatch chain as 1123898",
+  // protobufjs — transitive via @google/genai and optional livekit OTEL.
+  "1123964":
+    "protobufjs infinite loop — transitive via @google/genai and optional @livekit/agents OTEL exporter",
+  // body-parser — transitive via express, low severity.
+  "1123976":
+    "body-parser size-limit bypass (low severity) — transitive via express",
+  // fast-uri — three advisories, all through modelcontextprotocol/sdk's ajv.
+  "1124064":
+    "fast-uri host confusion — transitive via @modelcontextprotocol/sdk's ajv dependency",
+  "1130720":
+    "fast-uri host confusion (backslash variant) — same @modelcontextprotocol/sdk>ajv chain as 1124064",
+  "1145555":
+    "fast-uri host confusion (IDN variant) — same @modelcontextprotocol/sdk>ajv chain as 1124064",
+  // sharp — optional dependency for the image-processing feature only.
+  "1124066":
+    "sharp libvips CVEs — optionalDependency for image handling, not required at runtime for most consumers",
+  // find-my-way — transitive via optional fastify server adapter.
+  "1124273":
+    "find-my-way HTTP/2 DDoS — transitive via optional fastify server adapter",
+  // undici — direct dependency (range ">=7.24.0 <8.0.0"). Patched 7.29.0
+  // already satisfies that range; the lockfile is just pinned to 7.28.0.
+  // This is a real lockfile bump, tracked separately from this audit fix.
+  "1130715":
+    "undici response desync — direct dep, patched 7.29.0 fits our existing >=7.24.0 <8.0.0 range, needs a lockfile bump (tracked separately)",
+  "1130718":
+    "undici cache-directive crash — same undici lockfile-bump fix as 1130715",
+  "1130726":
+    "undici CRLF injection via blob type — same undici lockfile-bump fix as 1130715",
+  "1130729":
+    "undici cache-control whitespace disclosure — same undici lockfile-bump fix as 1130715",
+  "1130731":
+    "undici cookie attribute injection — same undici lockfile-bump fix as 1130715",
+  // ip-address — transitive via express-rate-limit, three related advisories.
+  "1130722":
+    "ip-address octal/decimal SSRF bypass — transitive via express-rate-limit",
+  "1130723":
+    "ip-address CIDR-suffix SSRF bypass — same express-rate-limit chain as 1130722",
+  "1130724":
+    "ip-address IPv4-mapped/NAT64 SSRF bypass — same express-rate-limit chain as 1130722",
+  // image-size — transitive via pptxgenjs; upstream has NOT published a fix
+  // (patched_versions reports none), so there is nothing to bump to yet.
+  "1138808":
+    "image-size ICNS parser DoS — transitive via pptxgenjs, no patched version published upstream yet",
+  "1138809":
+    "image-size JXL/HEIF parser DoS — same pptxgenjs chain as 1138808, no patched version published upstream yet",
+  // nanoid — direct dependency (range "^5.1.5"). Patched 5.1.16 already
+  // satisfies that range; the lockfile is just pinned to 5.1.7.
+  "1138810":
+    "nanoid negative-size infinite loop — direct dep, patched 5.1.16 fits our existing ^5.1.5 range, needs a lockfile bump (tracked separately)",
+};
 
 type SecurityIssue = {
   level: string;
@@ -65,6 +125,17 @@ type SecurityIssue = {
   message: string;
   details: Record<string, unknown> | null;
   timestamp: string;
+};
+
+type PnpmAdvisory = {
+  id: number;
+  severity: string;
+  module_name: string;
+  title: string;
+};
+
+type PnpmAuditJson = {
+  advisories?: Record<string, PnpmAdvisory>;
 };
 
 type GitleaksFinding = {
@@ -135,94 +206,109 @@ class SecurityValidator {
   }
 
   // 1. Dependency Vulnerability Scanning
+  //
+  // Parses `pnpm audit --prod --json` and checks each advisory individually
+  // against ACCEPTED_RISK_ADVISORY_IDS. This deliberately replaced an older
+  // implementation that ran plain-text `pnpm audit` and computed a single
+  // boolean over the *entire* output: if any one of a handful of allowlisted
+  // package *names* appeared anywhere in the text, the whole check passed —
+  // regardless of how many other, unrelated advisories were open. That let a
+  // build with 15 open high-severity production advisories report PASS
+  // because one unrelated, genuinely-ignorable OTEL package happened to also
+  // appear in the table. `--prod` additionally excludes the dev-only
+  // @juspay/hippocampus shadow tree, so this only ever evaluates advisories
+  // that can reach a real consumer of the published package.
   async checkDependencyVulnerabilities(): Promise<void> {
     this.log("Scanning dependencies for vulnerabilities...", "blue");
 
+    let output: string;
     try {
-      // Try pnpm audit first (faster and more accurate)
-      try {
-        execSync("pnpm audit --audit-level=moderate", {
-          encoding: "utf8",
-          stdio: "pipe",
-        });
+      // pnpm audit exits non-zero whenever advisories are found — that is
+      // expected and not itself a tool failure, so capture stdout on both
+      // the success and the error path rather than treating a throw as
+      // "the scan could not run".
+      output = execSync("pnpm audit --prod --json", {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (pnpmError: unknown) {
+      const execErr = pnpmError as { stdout?: string };
+      output = execErr.stdout || "";
+    }
 
-        // If pnpm audit succeeds with no output, no vulnerabilities found
-        this.log("No known vulnerabilities found", "green");
-        this.results.dependencies.status = "passed";
-      } catch (pnpmError: unknown) {
-        // pnpm audit exits with non-zero when vulnerabilities found
-        const execErr = pnpmError as {
-          stdout?: string;
-          message?: string;
-        };
-        const output = execErr.stdout || execErr.message || "";
-
-        // Check if vulnerabilities are from ignored packages
-        const isIgnoredPackage = IGNORED_VULNERABLE_PACKAGES.some(
-          (pkg) =>
-            output.includes(`│ Package             │ ${pkg}`) ||
-            output.includes(`Package: ${pkg}`),
-        );
-
-        if (isIgnoredPackage) {
-          const ignoredList = IGNORED_VULNERABLE_PACKAGES.join(", ");
-          this.log(
-            `Found vulnerabilities in temporarily ignored packages: ${ignoredList}`,
-            "cyan",
-          );
-          this.log(
-            "No critical vulnerabilities (ignored packages excluded)",
-            "green",
-          );
-          this.results.dependencies.status = "passed";
-          return;
-        }
-
-        // Check if it contains moderate/high/critical vulnerabilities
-        if (
-          output.includes("moderate") ||
-          output.includes("high") ||
-          output.includes("critical")
-        ) {
-          // Count moderate+ severity issues
-          const moderateMatches = (output.match(/moderate/gi) || []).length;
-          const highMatches = (output.match(/high/gi) || []).length;
-          const criticalMatches = (output.match(/critical/gi) || []).length;
-
-          if (highMatches > 0 || criticalMatches > 0) {
-            this.addIssue(
-              "error",
-              "dependencies",
-              `Found ${highMatches + criticalMatches} high/critical severity vulnerabilities`,
-            );
-            this.results.dependencies.status = "failed";
-          } else if (moderateMatches > 0) {
-            this.addIssue(
-              "warning",
-              "dependencies",
-              `Found ${moderateMatches} moderate vulnerabilities`,
-            );
-            this.results.dependencies.status = "warning";
-          } else {
-            this.log("No known vulnerabilities found", "green");
-            this.results.dependencies.status = "passed";
-          }
-        } else {
-          // If no specific vulnerabilities mentioned, assume it passed
-          this.log("No known vulnerabilities found", "green");
-          this.results.dependencies.status = "passed";
-        }
-      }
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : String(error);
+    if (!output.trim()) {
       this.addIssue(
         "warning",
         "dependencies",
-        `Could not complete vulnerability scan: ${message}`,
+        "pnpm audit produced no output — could not complete vulnerability scan",
       );
       this.results.dependencies.status = "warning";
+      return;
     }
+
+    let audit: PnpmAuditJson;
+    try {
+      audit = JSON.parse(output) as PnpmAuditJson;
+    } catch (parseError: unknown) {
+      const message =
+        parseError instanceof Error
+          ? parseError.message
+          : String(parseError);
+      this.addIssue(
+        "warning",
+        "dependencies",
+        `Could not parse pnpm audit output as JSON: ${message}`,
+      );
+      this.results.dependencies.status = "warning";
+      return;
+    }
+
+    const advisories = Object.values(audit.advisories ?? {});
+    // Only moderate+ advisories require an explicit accept — this mirrors
+    // the previous --audit-level=moderate threshold. Low/info advisories are
+    // still surfaced for visibility but do not block the build on their own.
+    const actionable = advisories.filter((a) =>
+      ["moderate", "high", "critical"].includes(a.severity),
+    );
+
+    const accepted = actionable.filter(
+      (a) => ACCEPTED_RISK_ADVISORY_IDS[String(a.id)],
+    );
+    const unaccepted = actionable.filter(
+      (a) => !ACCEPTED_RISK_ADVISORY_IDS[String(a.id)],
+    );
+
+    if (accepted.length > 0) {
+      accepted.forEach((a) => {
+        this.log(
+          `Accepted risk — advisory ${a.id} (${a.severity} ${a.module_name}): ${ACCEPTED_RISK_ADVISORY_IDS[String(a.id)]}`,
+          "cyan",
+        );
+      });
+    }
+
+    if (unaccepted.length > 0) {
+      unaccepted.forEach((a) => {
+        this.addIssue(
+          "error",
+          "dependencies",
+          `Unaccepted ${a.severity} advisory ${a.id} in ${a.module_name}: ${a.title}`,
+        );
+      });
+      this.results.dependencies.status = "failed";
+      this.results.dependencies.details = unaccepted;
+      return;
+    }
+
+    if (actionable.length === 0) {
+      this.log("No known vulnerabilities found", "green");
+    } else {
+      this.log(
+        `All ${actionable.length} open production advisories are explicitly accepted risk`,
+        "green",
+      );
+    }
+    this.results.dependencies.status = "passed";
   }
 
   // 2. Professional Secret Detection with Gitleaks Integration


### PR DESCRIPTION
checkDependencyVulnerabilities() ran `pnpm audit --audit-level=moderate` as
plain text and computed a single boolean over the *entire* output: if any one
of ~8 allowlisted package names appeared anywhere in the table, the whole
check reported "passed". Verified live before this change: the script printed
PASS while 15 high-severity production advisories were open, because
@opentelemetry/sdk-node (a genuinely ignorable, dev-chain-only package)
happened to also appear in the table and short-circuited the whole check.
This script gates `validate:all` -> `validate:security`, a required CI job,
so a false pass here was worse than no check at all.

Replaced it with `pnpm audit --prod --json`, parsed and filtered per advisory
id against a new ACCEPTED_RISK_ADVISORY_IDS allowlist (id -> one-line reason),
mirroring the `pnpm why --prod --json` pattern already used in
check-banned-deps.ts. `--prod` structurally excludes the dev-only
@juspay/hippocampus shadow tree that produced the OTEL advisories the old
check leaned on (55 advisories full-audit vs 25 with --prod, with all 3 OTEL
entries dropped by --prod alone). Seeded the allowlist with all 25 of today's
--prod advisories, each with its own honest reason, so new advisories fail
loudly while the existing backlog stays explicitly visible instead of
silently passing.