### PR TITLE
fix(cli): load voice-server modules lazily so --help survives a no-optional install

### DIFF
--- a/src/cli/commands/voiceServer.ts
+++ b/src/cli/commands/voiceServer.ts
@@ -1,7 +1,5 @@
 import type { CommandModule } from "yargs";
 import type { VoiceServerArgs } from "../../lib/types/index.js";
-import { startVoiceServer } from "../../lib/server/voice/voiceServerApp.js";
-import { configureVoiceServerEnvironment } from "../../lib/server/voice/voiceWebSocketHandler.js";
 
 /**
  * @deprecated Use `neurolink serve voice` instead. This top-level alias is
@@ -25,6 +23,14 @@ export const voiceServerCommand: CommandModule<object, VoiceServerArgs> = {
     console.warn(
       "[deprecation] 'neurolink voice-server' is deprecated. Use 'neurolink serve voice' instead. This alias will be removed in a future release.",
     );
+    // Loaded lazily: voiceServerApp statically imports `express`, an
+    // optionalDependency. A top-level import here puts it on the CLI's
+    // always-loaded path, so `neurolink --help` crashes when optional
+    // dependencies are absent. Mirrors `serve voice` in serve.ts.
+    const { configureVoiceServerEnvironment } =
+      await import("../../lib/server/voice/voiceWebSocketHandler.js");
+    const { startVoiceServer } =
+      await import("../../lib/server/voice/voiceServerApp.js");
     configureVoiceServerEnvironment();
     await startVoiceServer(argv.port);
   },


### PR DESCRIPTION
`voice-server` statically imported voiceServerApp, which in turn statically
imports `express` — an optionalDependency. parser.ts registers that command
unconditionally and is reached from the CLI bin entry, so express sat on the
always-loaded path: every invocation, including `neurolink --help` and
`--version`, died with ERR_MODULE_NOT_FOUND whenever optional dependencies
were absent (`--omit=optional`, or a platform that skips them).

Move both imports inside the handler, mirroring the lazy import that
`serve voice` already uses in serve.ts. express is now resolved only when the
command actually runs.

Verified with node_modules/express moved aside: --help, --version and
`generate --help` all exit 0 where they previously crashed; with express
restored, `voice-server --help` still resolves.