### PR TITLE
fix(pack): un-ignore the tracked docs search index so it ships in the tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,8 +168,10 @@ quality-metrics.json
 *.key
 *.pem
 test-output/
-# Generated docs search index
+# Generated docs search index — tracked and shipped in the npm tarball (package.json
+# "files"); do not ignore it, ignoring a tracked file only hides it from packers.
 docs-site/static/search-index.json
+!docs-site/static/search-index.json
 .type-consolidation/
 .tmp-tests/
 .proof-of-work/

--- a/.prettierignore
+++ b/.prettierignore
@@ -60,6 +60,10 @@ test-reports/
 docs-site/.docusaurus/
 docs-site/docs/
 
+# Generated, tracked-but-shipped search index — a machine-built minified JSON
+# blob (docusaurus-plugin-docs-search-index), not source; do not reformat it.
+docs-site/static/search-index.json
+
 # Svelte files require prettier-plugin-svelte (handled by landing workspace)
 landing/**/*.svelte
 

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -7,5 +7,7 @@ docs/
 static/llms.txt
 static/llms-full.txt
 
-# Generated search index (built by docusaurus-plugin-docs-search-index)
+# Generated search index (built by docusaurus-plugin-docs-search-index) — tracked
+# and shipped in the npm tarball; do not ignore it, that only hides it from packers.
 static/search-index.json
+!static/search-index.json


### PR DESCRIPTION
docs-site/static/search-index.json is listed in package.json's "files" array,
is 6.8MB, and is git-tracked — but it was silently dropped from every npm
tarball anyway, because it also matched .gitignore:172 and
docs-site/.gitignore:11. npm layers gitignore-based exclusion on top of
"files" for entries that aren't already staged/committed at pack time, so a
tracked-but-gitignored file gets filtered out of the pack even though "files"
explicitly names it.

Ignoring a file git already tracks achieves nothing for git itself (it only
suppresses status/add noise for untracked copies), so the ignore rules were
pure dead weight that happened to have this side effect on packing. Negating
both rules (verified live that negating only one still drops the file) is
preferred over adding a .npmignore, since introducing a .npmignore would
silently disable all .gitignore-based pack filtering for the whole package,
changing what else ships as a side effect.

Un-ignoring the file also exposed it to prettier, which respects .gitignore
by default: the pre-commit hook then tried to reformat a 6.8MB machine-built
minified JSON blob and failed. Added it to .prettierignore alongside the
existing docs-site generated-output entries so it stays un-ignored for git/npm
but is not treated as source to format.

Verified with npm pack --dry-run --json (full prepack build, run once before
and once after): before, the manifest omitted
docs-site/static/search-index.json entirely; after, it's present at 6,789,976
bytes unpacked (total tarball 6,329,014 -> 7,418,688 bytes). Also confirmed
docs-site/mcp-server/*.js and *.d.ts were already present in both runs, so
that part of package.json's "files" array was not affected by this bug.