### PR TITLE
ci(workflow): add a smoke test that installs without optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,58 @@ jobs:
 
   #         echo "✅ Action smoke test passed!"
 
+  # Installs with optionalDependencies omitted, then runs the built CLI.
+  # optionalDependencies (express, the AWS SDK bedrock/sagemaker clients,
+  # fastify, koa, etc.) are exactly the packages npm/pnpm silently skip on a
+  # failed native build or a --no-optional install, so "it built" here proves
+  # nothing about whether the CLI still runs without them.
+  #
+  # continue-on-error: true — deliberately non-blocking on day one. Today
+  # `voiceServerApp.js` statically imports `express` (an optionalDependency)
+  # at module load, so `node dist/cli/index.js --help` crashes with
+  # ERR_MODULE_NOT_FOUND as soon as that module is reachable from the CLI
+  # entrypoint. The fix lives on fix/cli-express-optional-crash, not yet
+  # merged to release. Promote this job to a required check (add it to the
+  # required-status-checks list and drop continue-on-error) once that branch
+  # lands. Note @aws-sdk/client-bedrock-runtime is also statically imported
+  # from an optionalDependency (amazonBedrock/client.ts,
+  # amazonBedrock/loopAdapter.ts), so this job may keep surfacing a second,
+  # separate failure even after the express fix — that is expected and is a
+  # second bug for a follow-up branch, not a reason to loosen this check.
+  optional-deps-omitted-smoke-test:
+    name: CLI Smoke Test (optional deps omitted)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies (optionalDependencies omitted)
+        run: pnpm install --no-optional
+
+      - name: Build CLI
+        run: pnpm run build:cli
+
+      - name: CLI smoke test — --help
+        run: node dist/cli/index.js --help
+
+      - name: CLI smoke test — --version
+        run: node dist/cli/index.js --version
+
+      - name: CLI smoke test — generate --help
+        run: node dist/cli/index.js generate --help
+
   build-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
No job installed with optionalDependencies omitted and then ran the CLI, so
nothing caught packages that are declared optional but are actually load-bearing
at runtime. That gap let the CLI ship broken: dist/lib/server/voice/voiceServerApp.js
statically imports express (an optionalDependency) at module load, so any
consumer whose install skips optional deps - a slow/failed native build, an
explicit --no-optional, a minimal Docker install - gets ERR_MODULE_NOT_FOUND
from `neurolink --help` before the CLI does anything else.

Reproduced locally in this worktree by hiding node_modules/express (simulating
the omitted install without tearing down the real node_modules), building the
CLI, and running the entrypoint:

  $ mv node_modules/express node_modules/.hidden-express
  $ pnpm run build:cli        # succeeds - express is a runtime, not build-time, dep
  $ node dist/cli/index.js --help
  node:internal/modules/package_json_reader:301
    throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'express' imported from
    .../dist/lib/server/voice/voiceServerApp.js
  (exit 1)

Restoring express made --help, --version and generate --help all exit 0 again,
confirming the new job's steps are the right shape to catch this class of bug
in CI.

The new job runs `pnpm install --no-optional` (this repo's pnpm 10.15.1
supports the flag directly, verified with `pnpm install --help`), builds the
CLI, then runs --help / --version / generate --help against the built output.

It is added with continue-on-error: true and is NOT wired into any required
check. On release today it WILL fail: the express crash reproduced above is
still present on this branch, and its fix lives on the separate
fix/cli-express-optional-crash branch, not yet merged. Landing this job as
blocking today would fail every PR. Once that branch merges, drop
continue-on-error and add this job to release's required status checks.

Separately, even after the express fix lands, this job may keep failing for a
second reason: @aws-sdk/client-bedrock-runtime is also statically imported
from an optionalDependency, in both
src/lib/providers/amazonBedrock/client.ts and the newer
src/lib/providers/amazonBedrock/loopAdapter.ts. That is the job doing its
job - it is a second real instance of the same bug class this check exists to
catch, left for a follow-up fix rather than addressed here.