### PR TITLE
fix(build): collapse the dist/lib duplicate out of the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "vite build && pnpm run prepack",
     "build:browser": "node scripts/build-browser.mjs",
     "build:browser:dev": "node scripts/build-browser.mjs --dev",
-    "build:cli": "echo 'Building CLI...' && svelte-kit sync && tsc --project tsconfig.cli.json",
+    "build:cli": "echo 'Building CLI...' && svelte-kit sync && tsc --project tsconfig.cli.json && node scripts/collapse-cli-lib-duplicate.mjs",
     "build:cli:bundle": "node scripts/bundle-cli.mjs",
     "build:cli:bundle:minify": "node scripts/bundle-cli.mjs --minify",
     "build:action": "ncc build src/action/index.ts -o action-dist --source-map",

--- a/scripts/collapse-cli-lib-duplicate.mjs
+++ b/scripts/collapse-cli-lib-duplicate.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Collapse the dist/lib/** duplicate produced by `tsc --project tsconfig.cli.json`.
+ *
+ * Why this exists: tsconfig.cli.json sets rootDir:"./src" and includes BOTH
+ * src/cli/**​/*.ts and src/lib/**​/*.ts — the latter is required so the CLI's
+ * ~258 relative "../lib/..." imports type-check. As a side effect, tsc
+ * re-emits the entire src/lib tree a second time at dist/lib/**, on top of
+ * the already-flattened dist/** tree svelte-package produced moments earlier
+ * from the same sources. The two trees are the same compiled output (modulo
+ * sourcemap comments) — roughly 13MB / ~2,700 files of pure duplication that
+ * ships inside the published tarball for no reason.
+ *
+ * What this script does, in order:
+ *   1. Walks dist/cli/**​/*.{js,d.ts} and rewrites every relative import/
+ *      require/dynamic-import specifier of the shape "(../)+lib/..." so it
+ *      points at the already-flattened dist/** tree instead of dist/lib/**
+ *      (i.e. it deletes the "lib/" path segment — dist/cli and dist/lib are
+ *      siblings under dist/, and after flattening, lib's former contents are
+ *      dist's direct children, so removing "lib/" is the exact, sufficient
+ *      rewrite regardless of nesting depth).
+ *   2. Verifies every rewritten specifier resolves to a real file on disk.
+ *      If even one does not, the script exits non-zero WITHOUT touching
+ *      dist/lib — a hard build failure is much better than a silently
+ *      broken CLI import.
+ *   3. Only once every rewrite has been verified does it remove dist/lib.
+ *
+ * Nothing under dist/lib itself is rewritten — it is deleted outright once
+ * dist/cli no longer references it. Nothing in dist/lib is a runtime target
+ * for anything outside dist/cli (dist/index.js and friends already come
+ * from the flattened dist/** tree).
+ */
+
+import { readdirSync, statSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CLI_DIR = join(REPO_ROOT, "dist", "cli");
+const LIB_DUP_DIR = join(REPO_ROOT, "dist", "lib");
+
+/** Recursively collect files under `dir` whose name ends with one of `exts`. */
+function collectFiles(dir, exts) {
+  const out = [];
+  const walk = (current) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+        out.push(full);
+      }
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+// Matches a "(../)+lib/" relative-import prefix inside a quoted or
+// backtick-delimited module specifier, e.g. "../lib/foo.js",
+// '../../lib/bar/baz.js', or `../../lib/server/index.js?t=${timestamp}`.
+// Deliberately anchored on the leading "../" chain so it never matches
+// unrelated text like "src/lib/..." inside a comment.
+const SPEC_PATTERNS = [
+  { quote: '"', re: /"((?:\.\.\/)+lib\/[^"]*)"/g },
+  { quote: "'", re: /'((?:\.\.\/)+lib\/[^']*)'/g },
+  { quote: "`", re: /`((?:\.\.\/)+lib\/[^`]*)`/g },
+];
+
+function rewriteLibSpecifiers(source) {
+  let rewritten = source;
+  const specifiers = [];
+  for (const { quote, re } of SPEC_PATTERNS) {
+    rewritten = rewritten.replace(re, (whole, inner) => {
+      const newInner = inner.replace(/^((?:\.\.\/)+)lib\//, "$1");
+      specifiers.push({ original: inner, rewritten: newInner });
+      return `${quote}${newInner}${quote}`;
+    });
+  }
+  return { rewritten, specifiers };
+}
+
+function verifySpecifierResolves(fileDir, specifier) {
+  // Strip a trailing query string (e.g. the "?t=${timestamp}" cache-busting
+  // suffix used by `serve --watch`'s hot-reload re-import) before resolving
+  // — it is not part of the filesystem path.
+  const withoutQuery = specifier.split("?")[0];
+  if (withoutQuery.includes("${")) {
+    // Statically-unresolvable segment (a template-literal interpolation
+    // inside the path itself, not just the query string). None exist in
+    // this codebase today, but if one appears, don't silently pass it.
+    return { ok: false, reason: "unresolvable template interpolation in path" };
+  }
+  const target = resolve(fileDir, withoutQuery);
+  return { ok: existsSync(target), target };
+}
+
+function main() {
+  if (!existsSync(CLI_DIR)) {
+    console.error(
+      `[collapse-cli-lib-duplicate] dist/cli does not exist (${CLI_DIR}). ` +
+        "Run tsc --project tsconfig.cli.json first.",
+    );
+    process.exit(1);
+  }
+  if (!existsSync(LIB_DUP_DIR)) {
+    // Nothing to collapse — treat as a no-op success rather than an error,
+    // so re-running this script (or running it when tsc's output shape ever
+    // changes) doesn't break the build.
+    console.log(
+      "[collapse-cli-lib-duplicate] dist/lib does not exist — nothing to collapse.",
+    );
+    return;
+  }
+
+  const files = collectFiles(CLI_DIR, [".js", ".d.ts"]);
+  const pendingWrites = [];
+  const verificationFailures = [];
+  let totalSpecifiers = 0;
+
+  for (const file of files) {
+    const original = readFileSync(file, "utf-8");
+    const { rewritten, specifiers } = rewriteLibSpecifiers(original);
+    if (specifiers.length === 0) {
+      continue;
+    }
+    totalSpecifiers += specifiers.length;
+    const fileDir = dirname(file);
+    for (const { original: origSpec, rewritten: newSpec } of specifiers) {
+      const result = verifySpecifierResolves(fileDir, newSpec);
+      if (!result.ok) {
+        verificationFailures.push({
+          file: relative(REPO_ROOT, file),
+          originalSpecifier: origSpec,
+          rewrittenSpecifier: newSpec,
+          reason: result.reason ?? `resolved path does not exist: ${result.target}`,
+        });
+      }
+    }
+    pendingWrites.push({ file, rewritten });
+  }
+
+  if (verificationFailures.length > 0) {
+    console.error(
+      `[collapse-cli-lib-duplicate] ${verificationFailures.length} rewritten ` +
+        "import specifier(s) do not resolve to a real file. Aborting WITHOUT " +
+        "touching dist/lib or writing any rewritten file — the build is broken " +
+        "and must fail loudly instead of shipping a CLI with dangling imports.",
+    );
+    for (const failure of verificationFailures) {
+      console.error(
+        `  ${failure.file}: "${failure.originalSpecifier}" -> "${failure.rewrittenSpecifier}" ` +
+          `(${failure.reason})`,
+      );
+    }
+    process.exit(1);
+  }
+
+  // Only now — after every rewritten specifier in every file has been
+  // verified to resolve — actually write the files and delete dist/lib.
+  for (const { file, rewritten } of pendingWrites) {
+    writeFileSync(file, rewritten, "utf-8");
+  }
+
+  const dupSizeBytes = (() => {
+    let total = 0;
+    const walk = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else {
+          total += statSync(full).size;
+        }
+      }
+    };
+    walk(LIB_DUP_DIR);
+    return total;
+  })();
+
+  rmSync(LIB_DUP_DIR, { recursive: true, force: true });
+
+  console.log(
+    `[collapse-cli-lib-duplicate] rewrote ${totalSpecifiers} import specifier(s) ` +
+      `across ${pendingWrites.length} file(s) in dist/cli, verified every one, ` +
+      `and removed dist/lib (${(dupSizeBytes / (1024 * 1024)).toFixed(1)} MB).`,
+  );
+}
+
+main();

--- a/test/continuous-test-suite-auth.ts
+++ b/test/continuous-test-suite-auth.ts
@@ -77,14 +77,14 @@ import { NeuroLink } from "../dist/index.js";
 
 import { Hono } from "hono";
 
-import { CustomAuthProvider } from "../dist/lib/auth/index.js";
+import { CustomAuthProvider } from "../dist/auth/index.js";
 
-import { ServerAuthorizationError } from "../dist/lib/server/index.js";
+import { ServerAuthorizationError } from "../dist/server/index.js";
 
 import {
   createBearerAuthMiddleware,
   createRoleAuthMiddleware,
-} from "../dist/lib/server/middleware/auth.js";
+} from "../dist/server/middleware/auth.js";
 
 import { assertDistFresh } from "./helpers/distFreshness.js";
 

--- a/test/continuous-test-suite-context.ts
+++ b/test/continuous-test-suite-context.ts
@@ -2059,7 +2059,7 @@ async function testFileDetectorLoadFromURLRetry(): Promise<boolean | null> {
     // compile-time-only modifier — at runtime it's a plain static method on
     // FileDetector, which is what this test exercises directly rather than
     // routing through the full detectAndProcess() pipeline.
-    const { FileDetector } = await import("../dist/lib/utils/fileDetector.js");
+    const { FileDetector } = await import("../dist/utils/fileDetector.js");
     const detector = FileDetector as unknown as {
       loadFromURL: (
         url: string,
@@ -2386,7 +2386,7 @@ async function callSdk(
 async function test_2_0_static_artifact_contains_fix(): Promise<void> {
   const testName = "2.0 — STATIC: shipped artifact contains the fix code";
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/neurolink.js";
+  const path = "dist/neurolink.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -2849,7 +2849,7 @@ async function test_6_static_artifact_shape(): Promise<void> {
   // StreamHandler). Verify the literal carries finishReason / usage /
   // providerError so downstream telemetry has structured failure context.
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/utils/noOutputSentinel.js";
+  const path = "dist/utils/noOutputSentinel.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -2940,7 +2940,7 @@ async function test_6_1_all_providers_wired(): Promise<void> {
   const fs = await import("node:fs/promises");
   for (const p of [...providers.map((n) => `providers/${n}`), ...otherSites]) {
     const testName = `6.1 — ${p} wired to NoOutput sentinel helper`;
-    const path = `dist/lib/${p}.js`;
+    const path = `dist/${p}.js`;
     let src: string;
     try {
       src = await fs.readFile(path, "utf-8");
@@ -2975,7 +2975,7 @@ async function test_6_1_all_providers_wired(): Promise<void> {
 async function test_6_2_helper_produces_full_sentinel(): Promise<void> {
   const testName =
     "6.2 — RUNTIME: buildNoOutputSentinel produces all 6 enriched keys";
-  const mod = await import("../dist/lib/utils/noOutputSentinel.js");
+  const mod = await import("../dist/utils/noOutputSentinel.js");
   if (typeof mod.buildNoOutputSentinel !== "function") {
     return recordIssue06(
       testName,
@@ -3034,7 +3034,7 @@ async function test_6_2_helper_produces_full_sentinel(): Promise<void> {
 async function test_6_3_helper_reads_partial_values(): Promise<void> {
   const testName =
     "6.3 — RUNTIME: buildNoOutputSentinel reads partial values from result-like";
-  const mod = await import("../dist/lib/utils/noOutputSentinel.js");
+  const mod = await import("../dist/utils/noOutputSentinel.js");
 
   // Case A: resolved result fields surface to the sentinel.
   const errA = new Error("Stream produced no output");
@@ -3096,7 +3096,7 @@ async function test_6_3_helper_reads_partial_values(): Promise<void> {
 async function test_6_4_helper_extracts_cause(): Promise<void> {
   const testName =
     "6.4 — RUNTIME: buildNoOutputSentinel surfaces error.cause into modelResponseRaw";
-  const mod = await import("../dist/lib/utils/noOutputSentinel.js");
+  const mod = await import("../dist/utils/noOutputSentinel.js");
 
   // Case A: error has a `cause` (AI SDK wraps the underlying provider error).
   const errA = new Error("AI_NoOutputGeneratedError") as Error & {
@@ -3300,7 +3300,7 @@ async function test_6_6_streamhandler_no_duplicate_sentinel(): Promise<void> {
   // Read the shipped artifact and verify the catch block returns after
   // yielding the sentinel (so the post-stream detection block doesn't run).
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/core/modules/StreamHandler.js";
+  const path = "dist/core/modules/StreamHandler.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -3354,7 +3354,7 @@ async function test_6_7_pipeline_b_preserves_status_message(): Promise<void> {
   const testName =
     "6.7 — REGRESSION: Pipeline B applyNonErrorLangfuseLevel preserves enriched langfuse.status_message";
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/services/server/ai/observability/instrumentation.js";
+  const path = "dist/services/server/ai/observability/instrumentation.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -3483,7 +3483,7 @@ async function test_6_9_all_wired_sites_stamp_otel_span(): Promise<void> {
   ];
   for (const t of targets) {
     const testName = `6.9 — ${t} stamps OTel span via stampNoOutputSpan`;
-    const path = `dist/lib/${t}.js`;
+    const path = `dist/${t}.js`;
     let src: string;
     try {
       src = await fs.readFile(path, "utf-8");
@@ -3515,7 +3515,7 @@ async function test_6_9_all_wired_sites_stamp_otel_span(): Promise<void> {
 async function test_6_10_status_message_handles_v6_usage(): Promise<void> {
   const testName =
     "6.10 — REGRESSION: buildNoOutputStatusMessage reads AI SDK v6 usage fields";
-  const mod = await import("../dist/lib/utils/noOutputSentinel.js");
+  const mod = await import("../dist/utils/noOutputSentinel.js");
   // v6 shape
   const v6 = mod.buildNoOutputStatusMessage("stop", {
     inputTokens: 42,
@@ -3551,7 +3551,7 @@ async function test_6_11_wrapper_excludes_sentinel_from_fallback_gate(): Promise
   const testName =
     "6.11 — REGRESSION: NeuroLink stream wrapper excludes NoOutputSentinel from fallback content gate";
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/neurolink.js";
+  const path = "dist/neurolink.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -3592,7 +3592,7 @@ async function test_6_12_media_chunks_count_as_real_output(): Promise<void> {
   const testName =
     "6.12 — REGRESSION: wrapper counts audio/image chunks as real output (no spurious fallback)";
   const fs = await import("node:fs/promises");
-  const path = "dist/lib/neurolink.js";
+  const path = "dist/neurolink.js";
   let src: string;
   try {
     src = await fs.readFile(path, "utf-8");
@@ -3637,7 +3637,7 @@ async function test_6_12_media_chunks_count_as_real_output(): Promise<void> {
 async function test_6_13_helper_accepts_underlying_error(): Promise<void> {
   const testName =
     "6.13 — REGRESSION: buildNoOutputSentinel accepts underlyingError and prefers it for providerError/modelResponseRaw";
-  const mod = await import("../dist/lib/utils/noOutputSentinel.js");
+  const mod = await import("../dist/utils/noOutputSentinel.js");
   const aiSdkError = new Error(
     "No output generated. Check the stream for errors.",
   );
@@ -3701,11 +3701,11 @@ async function test_6_14_providers_capture_and_pass_error(): Promise<void> {
   // during the native migration. Assert the capture on the base for those, and
   // on their own file for self-streaming providers (openRouter, anthropic).
   const baseSrc = await fs
-    .readFile("dist/lib/providers/openaiChatCompletionsBase.js", "utf-8")
+    .readFile("dist/providers/openaiChatCompletionsBase.js", "utf-8")
     .catch(() => "");
   for (const t of targets) {
     const testName = `6.14 — ${t} captures onError and passes underlyingError to NoOutput helpers`;
-    const path = `dist/lib/${t}.js`;
+    const path = `dist/${t}.js`;
     let src: string;
     try {
       src = await fs.readFile(path, "utf-8");

--- a/test/continuous-test-suite-credentials.ts
+++ b/test/continuous-test-suite-credentials.ts
@@ -35,8 +35,8 @@ import type {
   GenerateOptions,
   StreamOptions,
 } from "../dist/index.js";
-import { ProviderFactory } from "../dist/lib/factories/providerFactory.js";
-import { ProviderRegistry } from "../dist/lib/factories/providerRegistry.js";
+import { ProviderFactory } from "../dist/factories/providerFactory.js";
+import { ProviderRegistry } from "../dist/factories/providerRegistry.js";
 
 import { assertDistFresh } from "./helpers/distFreshness.js";
 

--- a/test/continuous-test-suite-memory.ts
+++ b/test/continuous-test-suite-memory.ts
@@ -3561,7 +3561,7 @@ async function testPromptBuilderFiltersPollutedTurns(): Promise<
     await memorySdk.setSessionMessages(sessionId, polluted, userId);
 
     const utilModule =
-      (await import("../dist/lib/utils/conversationMemory.js")) as {
+      (await import("../dist/utils/conversationMemory.js")) as {
         getConversationMessages: (
           memory: unknown,
           options: unknown,
@@ -3783,7 +3783,7 @@ async function testFilterPreservesToolBearingTurns(): Promise<boolean | null> {
     await memorySdk.setSessionMessages(sessionId, polluted, userId);
 
     const utilModule =
-      (await import("../dist/lib/utils/conversationMemory.js")) as {
+      (await import("../dist/utils/conversationMemory.js")) as {
         getConversationMessages: (
           memory: unknown,
           options: unknown,

--- a/test/continuous-test-suite-model-manifests.ts
+++ b/test/continuous-test-suite-model-manifests.ts
@@ -10,7 +10,7 @@ import "dotenv/config";
  * and the output-ceiling invariant (maxOutputTokens must never exceed the
  * relevant contextWindow) across every registered provider manifest.
  *
- * ## Why this reaches into `dist/lib/` directly (CLAUDE.md rule 15)
+ * ## Why this reaches into `dist/` directly (CLAUDE.md rule 15)
  *
  * manifestRegistry.ts has no consumer yet, by design: this PR (model-metadata
  * consolidation, Task 5) is purely additive and deliberately does not migrate
@@ -29,12 +29,12 @@ import "dotenv/config";
  * a public surface, not a unit test.
  *
  * This is not the rule 15 `allow`-list exception (deterministic control a
- * live call can't give) — it is the same "drive a specific compiled dist/lib
+ * live call can't give) — it is the same "drive a specific compiled dist
  * module that isn't re-exported from dist/index.js" pattern already used by
  * continuous-test-suite.ts (AccountPool, ModelRouter, the cloaking plugins),
  * -credentials.ts (ProviderFactory/ProviderRegistry), -provider-structure.ts
  * (providerRegistry.js) and others, none of which are on the `allow` list.
- * Every import below resolves under `../dist/lib/...` — the compiled
+ * Every import below resolves under `../dist/...` — the compiled
  * artifact, not raw TypeScript source — so it stays a single module graph
  * per rule 15's "one module graph per suite" mandate, it just isn't the
  * top-level public one.
@@ -56,7 +56,7 @@ const {
   resolveManifestEntryExact,
   getManifestForProvider,
   getAllManifestProviders,
-} = await import("../dist/lib/models/manifestRegistry.js");
+} = await import("../dist/models/manifestRegistry.js");
 
 await test("Alias resolves to its canonical entry, not the default", async () => {
   // ollama's "llama3.2:latest" entry declares "llama3.2" as a bare-name

--- a/test/continuous-test-suite-provider-structure.ts
+++ b/test/continuous-test-suite-provider-structure.ts
@@ -217,10 +217,10 @@ await test("Provider Registration Completeness", async () => {
   );
 
   const { ProviderRegistry } =
-    await import("../dist/lib/factories/providerRegistry.js");
+    await import("../dist/factories/providerRegistry.js");
   const { ProviderFactory } =
-    await import("../dist/lib/factories/providerFactory.js");
-  const { AIProviderName } = await import("../dist/lib/constants/enums.js");
+    await import("../dist/factories/providerFactory.js");
+  const { AIProviderName } = await import("../dist/constants/enums.js");
 
   ProviderRegistry.clearRegistrations();
   await ProviderRegistry.registerAllProviders();
@@ -318,9 +318,8 @@ const KNOWN_UNREFERENCED_TOKEN_KEYS: Record<string, readonly string[]> = {
 
 await test("Model id tables agree with the model enums", async () => {
   const { BedrockModels, VertexModels, AnthropicModels } =
-    await import("../dist/lib/constants/enums.js");
-  const { PROVIDER_TOKEN_LIMITS } =
-    await import("../dist/lib/constants/tokens.js");
+    await import("../dist/constants/enums.js");
+  const { PROVIDER_TOKEN_LIMITS } = await import("../dist/constants/tokens.js");
 
   const surfaces = [
     { table: "BEDROCK", models: BedrockModels },

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -1881,9 +1881,9 @@ async function runVertexSection(): Promise<void> {
 
   try {
     const { GoogleVertexProvider } =
-      await import("../dist/lib/providers/googleVertex/client.js");
+      await import("../dist/providers/googleVertex/client.js");
     const { AuthenticationError, RateLimitError } =
-      await import("../dist/lib/types/index.js");
+      await import("../dist/types/index.js");
 
     const provider = new GoogleVertexProvider(
       "gemini-2.5-flash",
@@ -1949,9 +1949,9 @@ async function runBedrockSection(): Promise<void> {
 
   try {
     const { AmazonBedrockProvider } =
-      await import("../dist/lib/providers/amazonBedrock/client.js");
+      await import("../dist/providers/amazonBedrock/client.js");
     const { AuthenticationError, RateLimitError } =
-      await import("../dist/lib/types/index.js");
+      await import("../dist/types/index.js");
 
     const provider = new AmazonBedrockProvider(
       "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/test/continuous-test-suite-providers.ts
+++ b/test/continuous-test-suite-providers.ts
@@ -3038,9 +3038,9 @@ async function testIssue03TypeSurfaceMissesOptions(): Promise<boolean | null> {
   const fs = await import("node:fs/promises");
   const candidatePaths = [
     "dist/index.d.ts",
-    "dist/lib/types/config.d.ts",
-    "dist/lib/types/generate.d.ts",
-    "dist/lib/types/stream.d.ts",
+    "dist/types/config.d.ts",
+    "dist/types/generate.d.ts",
+    "dist/types/stream.d.ts",
   ];
   let combined = "";
   for (const p of candidatePaths) {

--- a/test/continuous-test-suite-skills.ts
+++ b/test/continuous-test-suite-skills.ts
@@ -31,9 +31,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { NeuroLink, RedisSkillStore, S3SkillStore } from "../dist/index.js";
-import { ConversationMemoryManager } from "../dist/lib/core/conversationMemoryManager.js";
-import { buildContextFromPointer } from "../dist/lib/utils/conversationMemory.js";
-import { truncateWithSlidingWindow } from "../dist/lib/context/stages/slidingWindowTruncator.js";
+import { ConversationMemoryManager } from "../dist/core/conversationMemoryManager.js";
+import { buildContextFromPointer } from "../dist/utils/conversationMemory.js";
+import { truncateWithSlidingWindow } from "../dist/context/stages/slidingWindowTruncator.js";
 
 import { assertDistFresh } from "./helpers/distFreshness.js";
 

--- a/test/continuous-test-suite-tool-dedup.ts
+++ b/test/continuous-test-suite-tool-dedup.ts
@@ -578,7 +578,7 @@ async function buildToolSeam(
   neurolinkInstance: InstanceType<typeof NeuroLink>,
 ): Promise<(opts: Record<string, unknown>) => Promise<Record<string, Tool>>> {
   const { BaseProvider } =
-    (await import("../dist/lib/core/baseProvider.js")) as unknown as {
+    (await import("../dist/core/baseProvider.js")) as unknown as {
       BaseProvider: new (
         modelName: string,
         providerName: string,

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -3150,7 +3150,7 @@ async function testSDKMimetypeHintExtensionlessBuffer(): Promise<
   // tiers in one test invocation.
   try {
     const { FileDetector } = await import(
-      `${process.cwd()}/dist/lib/utils/fileDetector.js`
+      `${process.cwd()}/dist/utils/fileDetector.js`
     );
     const tinyJson = Buffer.from('{"ok":true}', "utf-8");
     const det = await FileDetector.detectAndProcess(tinyJson, {
@@ -4152,7 +4152,7 @@ async function testModelAliasWarn(): Promise<boolean | null> {
 async function testAccountPoolRuntime(): Promise<boolean | null> {
   logSection("Testing AccountPool Runtime");
   try {
-    const { AccountPool } = await import("../dist/lib/auth/accountPool.js");
+    const { AccountPool } = await import("../dist/auth/accountPool.js");
 
     const pool = new AccountPool({ strategy: "round-robin" });
     pool.addAccount({
@@ -4231,7 +4231,7 @@ async function testAccountPoolRuntime(): Promise<boolean | null> {
 async function testModelRouterRuntime(): Promise<boolean | null> {
   logSection("Testing ModelRouter Runtime");
   try {
-    const { ModelRouter } = await import("../dist/lib/proxy/modelRouter.js");
+    const { ModelRouter } = await import("../dist/proxy/modelRouter.js");
     const router = new ModelRouter({
       strategy: "round-robin",
       modelMappings: [
@@ -4294,7 +4294,7 @@ async function testClaudeFormatRuntime(): Promise<boolean | null> {
   logSection("Testing ClaudeFormat Runtime");
   try {
     const { parseClaudeRequest, serializeClaudeResponse, buildClaudeError } =
-      await import("../dist/lib/proxy/claudeFormat.js");
+      await import("../dist/proxy/claudeFormat.js");
 
     // Parse request
     const parsed = parseClaudeRequest({
@@ -4366,7 +4366,7 @@ async function testSSESerializerRuntime(): Promise<boolean | null> {
   logSection("Testing SSE Serializer Runtime");
   try {
     const { ClaudeStreamSerializer } =
-      await import("../dist/lib/proxy/claudeFormat.js");
+      await import("../dist/proxy/claudeFormat.js");
     const sse = new ClaudeStreamSerializer("claude-sonnet-4", 100);
 
     const events: string[] = [];
@@ -4450,15 +4450,15 @@ async function testCloakingRuntime(): Promise<boolean | null> {
   logSection("Testing Cloaking Pipeline Runtime");
   try {
     const { CloakingPipeline } =
-      await import("../dist/lib/proxy/cloaking/index.js");
+      await import("../dist/proxy/cloaking/index.js");
     const { parseClaudeCodeUserId } =
-      await import("../dist/lib/auth/anthropicOAuth.js");
+      await import("../dist/auth/anthropicOAuth.js");
     const { createHeaderScrubber } =
-      await import("../dist/lib/proxy/cloaking/plugins/headerScrubber.js");
+      await import("../dist/proxy/cloaking/plugins/headerScrubber.js");
     const { createSessionIdentity } =
-      await import("../dist/lib/proxy/cloaking/plugins/sessionIdentity.js");
+      await import("../dist/proxy/cloaking/plugins/sessionIdentity.js");
     const { createWordObfuscator } =
-      await import("../dist/lib/proxy/cloaking/plugins/wordObfuscator.js");
+      await import("../dist/proxy/cloaking/plugins/wordObfuscator.js");
 
     const pipeline = new CloakingPipeline();
     pipeline.use(createHeaderScrubber());
@@ -4574,7 +4574,7 @@ async function testProxyConfigRuntime(): Promise<boolean | null> {
   logSection("Testing ProxyConfig Runtime");
   try {
     const { parseProxyConfigString } =
-      await import("../dist/lib/proxy/proxyConfig.js");
+      await import("../dist/proxy/proxyConfig.js");
 
     const config = await parseProxyConfigString(
       JSON.stringify({


### PR DESCRIPTION
tsconfig.cli.json sets rootDir:"./src" and includes both src/cli/**
and src/lib/** (needed so the CLI's ~258 relative "../lib/..." imports
type-check), so `tsc --project tsconfig.cli.json` re-emits the entire
src/lib tree a second time at dist/lib/**, on top of the already-
flattened dist/** tree svelte-package produced moments earlier from
the same sources. That duplicate measured ~19.6MB / ~2,682 files and
accounted for roughly 40% of the unpacked package (34.7MB -> 21.0MB,
3719 -> 1931 files, confirmed via `npm pack --dry-run --json`).

Add scripts/collapse-cli-lib-duplicate.mjs, wired into build:cli right
after tsc: it rewrites every "(../)+lib/..." import/require/dynamic-
import specifier under dist/cli/**/*.{js,d.ts} to drop the "lib/"
segment (pointing at the already-flattened dist/** tree instead),
verifies every rewritten specifier resolves to a real file, and only
then removes dist/lib. Any unresolved rewrite hard-fails the build
without touching dist/lib, rather than silently deleting anything.

~10 test suites imported dist/lib/... directly (providers-mocked,
provider-structure, model-manifests, credentials, auth, skills,
memory, tool-dedup, providers, continuous-test-suite, context) —
rewritten in this same commit to the flattened dist/... path so
provider-safety-net (test:providers-mocked, test:provider-structure)
and the pre-push gate (+ test:model-manifests) keep passing.

Verified: full `pnpm run build`, dist/lib no longer exists, `node
dist/cli/index.js --version|--help` and several subcommands (generate,
serve routing, config, proxy, voice, workflow, auth) exit clean, and
all four gating suites pass (providers-mocked 54/54, provider-structure
3/3, model-manifests 7/7, error-classifier-contract 44/44).