### PR TITLE
fix(build): make the browser bundle's __esm resilience patch actually match and fail loudly

### DIFF
--- a/scripts/build-browser.mjs
+++ b/scripts/build-browser.mjs
@@ -334,35 +334,73 @@ const catchAllPlugin = {
 
 // Build
 const dev = process.argv.includes('--dev');
+const outFile = dev ? 'dist/browser/neurolink.js' : 'dist/browser/neurolink.min.js';
 
+// Bundle WITHOUT minification first. esbuild's minifier renames every local
+// identifier that isn't part of the module's public surface — including its
+// own `__esm` / `__getOwnPropNames` helper names — so a regex written against
+// those literal names can never match minified output. Patching has to run on
+// the unminified bundle; minification (when not --dev) happens afterwards as
+// a separate transform over the already-patched source, so the injected
+// try/catch survives renamed but functionally intact.
 const result = await esbuild.build({
   entryPoints: ['./src/browser/entry.ts'],
   bundle: true,
   platform: 'neutral',
   format: 'esm',
-  outfile: dev ? 'dist/browser/neurolink.js' : 'dist/browser/neurolink.min.js',
   target: 'es2022',
   logLimit: 0,
-  minify: !dev,
+  minify: false,
   treeShaking: true,
   plugins: [catchAllPlugin],
   loader: { '.ts': 'ts' },
   nodePaths: ['./node_modules'],
+  write: false,
 });
 
-const outFile = dev ? 'dist/browser/neurolink.js' : 'dist/browser/neurolink.min.js';
+const unminifiedSrc = result.outputFiles[0].text;
 
-// Post-process: patch __esm to be resilient to init failures
-const originalSrc = readFileSync(outFile, 'utf8');
-// Match esbuild's __esm pattern and wrap the init call in try/catch
-const patchedSrc = originalSrc.replace(
-  /var __esm\s*=\s*\(fn,\s*res\)\s*=>\s*function __init\(\)\s*\{\s*return fn\s*&&\s*\(res\s*=\s*\(0,\s*fn\[__getOwnPropNames\(fn\)\[0\]\]\)\(fn\s*=\s*0\)\),\s*res;\s*\}/,
-  `var __esm = (fn, res) => function __init() { try { return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res; } catch(e) { console.warn("[NeuroLink:browser] module init skipped:", String(e)); fn = 0; return res; } }`
-);
-if (patchedSrc === originalSrc) {
-  console.warn('[NeuroLink:browser] Warning: __esm pattern not found, patch not applied');
+// Post-process: patch __esm to be resilient to module init failures.
+// Current esbuild emits (fn, res, err) and RETHROWS on failure (both on the
+// first call and, via `if (err) throw err[0]`, on every call after) — the
+// opposite of the swallow-and-continue behaviour this bundle depends on to
+// survive its ~40 stubbed Node builtins and ~35 stubbed npm packages.
+const esmPattern =
+  /var __esm = \(fn, res, err\) => function __init\(\) \{\s*if \(err\) throw err\[0\];\s*try \{\s*return fn && \(res = \(0, fn\[__getOwnPropNames\(fn\)\[0\]\]\)\(fn = 0\)\), res;\s*\} catch \(e\) \{\s*throw err = \[e\], e;\s*\}\s*\};/;
+
+if (!esmPattern.test(unminifiedSrc)) {
+  console.error(
+    '[NeuroLink:browser] FATAL: __esm pattern not found — esbuild\'s emitted lazy-init ' +
+      'wrapper shape has changed again. The resilience patch (try/catch around module init ' +
+      'so stubbed builtins/packages cannot crash the whole bundle) was NOT applied. Update ' +
+      'the `esmPattern` regex in scripts/build-browser.mjs to match the new shape before ' +
+      'shipping this bundle.',
+  );
+  process.exit(1);
 }
-writeFileSync(outFile, patchedSrc);
+
+const patchedSrc = unminifiedSrc.replace(
+  esmPattern,
+  `var __esm = (fn, res, err) => function __init() {
+  try {
+    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  } catch (e) {
+    console.warn("[NeuroLink:browser] module init skipped:", String(e));
+    fn = 0;
+    return res;
+  }
+};`,
+);
+
+// Minify the already-patched source as a separate pass so the try/catch we
+// just injected survives (with its identifiers renamed, same as everything
+// else) instead of never being written to a file that gets minified out from
+// under it.
+const finalSrc = dev
+  ? patchedSrc
+  : (await esbuild.transform(patchedSrc, { minify: true, target: 'es2022', loader: 'js' })).code;
+
+writeFileSync(outFile, finalSrc);
 
 const raw = readFileSync(outFile);
 const gz = gzipSync(raw);


### PR DESCRIPTION
The regex patching esbuild's lazy-init __esm wrapper into a try/catch safety
net had gone silently inert: every build printed "pattern not found, patch
not applied" and shipped an unprotected bundle. Two things had drifted out
from under the regex.

First, esbuild's own __esm signature changed from (fn, res) to (fn, res,
err), and its internal try/catch now rethrows the cached error on every
call via `if (err) throw err[0]` instead of the shape the old regex
expected — the opposite of the swallow-and-continue behaviour this bundle
needs to survive its ~40 stubbed Node builtins and ~35 stubbed npm
packages.

Second, and more fundamentally, the patch ran against the already-minified
output. esbuild's minifier renames every local identifier that isn't part
of the bundle's public surface, including its own __esm/__getOwnPropNames
helper names, so no literal-name regex could ever match minified code. The
patch now bundles unminified first (write: false), matches and rewrites
the current __esm shape, and only then runs a separate esbuild.transform
minify pass over the already-patched source — so the injected try/catch
survives minification with its identifiers renamed but its logic intact.

Finally, replace the silent console.warn fallback with process.exit(1): a
safety net that can silently detach itself is worse than no safety net,
since nothing downstream signals the bundle shipped unprotected.

Verified pattern found and try/catch present in both dist/browser/neurolink.js
(dev) and dist/browser/neurolink.min.js (prod) — grep count of 1 in each,
matching the single __esm definition site.