### PR TITLE
fix(server): surface missing optional framework packages instead of failing silently

### DIFF
--- a/scripts/build-browser.mjs
+++ b/scripts/build-browser.mjs
@@ -230,7 +230,7 @@ const PROXY_STUB_JS = `
 const handler={get(t,p){if(p==='__esModule')return true;if(p==='default')return new Proxy({},{get:handler.get});return new Proxy(function(...a){return new Proxy({},{get:handler.get})},{get:handler.get,apply(t,th,a){return new Proxy({},{get:handler.get})},construct(t,a){return new Proxy({},{get:handler.get})}})}};
 const mod=new Proxy({},handler);
 export default mod;
-export const {BedrockClient,ListFoundationModelsCommand,BedrockRuntimeClient,ConverseCommand,ConverseStreamCommand,ImageFormat}=mod;
+export const {BedrockClient,ListFoundationModelsCommand,BedrockRuntimeClient,ConverseCommand,ConverseStreamCommand,ImageFormat,InvokeModelCommand}=mod;
 export const {SageMakerRuntimeClient,InvokeEndpointCommand,InvokeEndpointWithResponseStreamCommand}=mod;
 export const {GoogleAuth,VertexAI,TextToSpeechClient}=mod;
 export const {Webhook}=mod;

--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -129,6 +129,31 @@ async function loadMediaBunny() {
   return _mediabunny;
 }
 
+// Keyframe resize (both extraction paths) previously swallowed a missing
+// `sharp` with a fully silent per-frame catch — every frame failed the same
+// way and nothing ever said why. Route the import through this loader so the
+// cause is logged once (not once per frame) the first time it fails; the
+// per-frame catch sites still skip individually, matching prior behavior.
+let sharpLoadWarned = false;
+async function loadSharp() {
+  try {
+    const mod = await tryImport<{ default: typeof import("sharp") }>(
+      "sharp",
+      "Video keyframe resizing",
+    );
+    return mod.default;
+  } catch (error) {
+    if (!sharpLoadWarned) {
+      sharpLoadWarned = true;
+      logger.warn(
+        "[VideoProcessor] sharp is required to resize extracted keyframes but failed to load; keyframe extraction will return no frames",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    }
+    throw error;
+  }
+}
+
 // =============================================================================
 // FFMPEG PATH INITIALIZATION
 // =============================================================================
@@ -870,7 +895,7 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
         const rawFrame = await fs.readFile(framePath);
 
         // Resize to fit within max dimension while preserving aspect ratio
-        const sharp = (await import("sharp")).default;
+        const sharp = await loadSharp();
         const pipeline = sharp(rawFrame).resize(
           VIDEO_CONFIG.FRAME_MAX_DIMENSION,
           VIDEO_CONFIG.FRAME_MAX_DIMENSION,
@@ -1291,7 +1316,7 @@ export class VideoProcessor extends BaseFileProcessor<ProcessedVideo> {
         try {
           await fs.access(framePath);
           const rawFrame = await fs.readFile(framePath);
-          const sharp = (await import("sharp")).default;
+          const sharp = await loadSharp();
           const resized = await sharp(rawFrame)
             .resize(
               VIDEO_CONFIG.FRAME_MAX_DIMENSION,

--- a/src/lib/providers/amazonBedrock/client.ts
+++ b/src/lib/providers/amazonBedrock/client.ts
@@ -8,6 +8,7 @@ import type {
 import {
   BedrockRuntimeClient,
   ImageFormat,
+  InvokeModelCommand,
 } from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType } from "@smithy/types";
 import path from "path";
@@ -1507,9 +1508,6 @@ export class AmazonBedrockProvider extends BaseProvider {
     });
 
     try {
-      const { InvokeModelCommand } =
-        await import("@aws-sdk/client-bedrock-runtime");
-
       // Titan Embed models expect a specific input format
       const requestBody = JSON.stringify({
         inputText: text,

--- a/src/lib/server/abstract/baseServerAdapter.ts
+++ b/src/lib/server/abstract/baseServerAdapter.ts
@@ -16,9 +16,11 @@ import {
 } from "../../observability/index.js";
 import { withTimeout } from "../../utils/errorHandling.js";
 import { logger } from "../../utils/logger.js";
+import { tryImport } from "../../utils/tryImport.js";
 import {
   DrainTimeoutError,
   InvalidLifecycleStateError,
+  MissingDependencyError,
   ShutdownTimeoutError,
 } from "../errors.js";
 import type {
@@ -188,6 +190,32 @@ export abstract class BaseServerAdapter extends EventEmitter {
   // ============================================
   // Common Methods (Shared Implementation)
   // ============================================
+
+  /**
+   * Import an optional framework dependency (express/fastify/koa and their
+   * plugins), converting a missing package into a {@link MissingDependencyError}
+   * instead of letting the framework's `Cannot find package` propagate raw.
+   *
+   * Delegates to {@link tryImport} for the actual resolution and message
+   * formatting, then re-wraps only the "package genuinely absent" case — the
+   * one `tryImport` signals by attaching the loader's own module-not-found
+   * error as `cause` — into the adapter-specific error type. Any other
+   * failure (installed but broken, non-package specifier) passes through
+   * unchanged, matching `tryImport`'s own contract.
+   */
+  protected async importFrameworkDependency<T>(
+    pkg: string,
+    framework: string,
+  ): Promise<T> {
+    try {
+      return await tryImport<T>(pkg, `${framework} server adapter`);
+    } catch (error) {
+      if (error instanceof Error && isModuleNotFoundCause(error.cause)) {
+        throw new MissingDependencyError(pkg, framework, `pnpm add ${pkg}`);
+      }
+      throw error;
+    }
+  }
 
   /**
    * Initialize the server adapter
@@ -788,4 +816,19 @@ export abstract class BaseServerAdapter extends EventEmitter {
   public getConfig(): RequiredServerAdapterConfig {
     return { ...this.config };
   }
+}
+
+/**
+ * True when `cause` is the module loader's own "package not found" error —
+ * the shape `tryImport` attaches as `cause` exactly when it decides the
+ * package is genuinely missing (see `isMissingModule` in `tryImport.ts`).
+ * Anything else (installed-but-broken, no cause at all) is not our case to
+ * convert into a {@link MissingDependencyError}.
+ */
+function isModuleNotFoundCause(cause: unknown): boolean {
+  if (!(cause instanceof Error)) {
+    return false;
+  }
+  const code = (cause as NodeJS.ErrnoException).code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
 }

--- a/src/lib/server/adapters/expressAdapter.ts
+++ b/src/lib/server/adapters/expressAdapter.ts
@@ -54,7 +54,9 @@ export class ExpressServerAdapter extends BaseServerAdapter {
     }
 
     // Dynamic import to avoid loading if not used (ESM-compatible)
-    const expressModule = await import("express");
+    const expressModule = await this.importFrameworkDependency<{
+      default: typeof import("express");
+    }>("express", "Express");
     const express = expressModule.default;
     this.app = express();
 
@@ -72,7 +74,9 @@ export class ExpressServerAdapter extends BaseServerAdapter {
 
     // CORS
     if (this.config.cors.enabled) {
-      const corsModule = await import("cors");
+      const corsModule = await this.importFrameworkDependency<{
+        default: typeof import("cors");
+      }>("cors", "Express");
       const cors = corsModule.default;
       this.app.use(
         cors({
@@ -87,7 +91,9 @@ export class ExpressServerAdapter extends BaseServerAdapter {
 
     // Rate limiting
     if (this.config.rateLimit.enabled) {
-      const rateLimitModule = await import("express-rate-limit");
+      const rateLimitModule = await this.importFrameworkDependency<
+        typeof import("express-rate-limit")
+      >("express-rate-limit", "Express");
       const rateLimit = rateLimitModule.default;
       const windowMs = this.config.rateLimit.windowMs;
       const limiter = rateLimit({
@@ -159,8 +165,17 @@ export class ExpressServerAdapter extends BaseServerAdapter {
    * Override initialize to ensure async framework setup
    */
   public async initialize(): Promise<void> {
-    // Initialize Express asynchronously first
-    await this.initializeFrameworkAsync();
+    // Initialize Express asynchronously first. This runs before
+    // super.initialize()'s try/catch even starts, so a failure here (e.g. the
+    // "express" package is not installed) must be caught here too — otherwise
+    // it propagates with lifecycleState left at "uninitialized" instead of
+    // "error".
+    try {
+      await this.initializeFrameworkAsync();
+    } catch (error) {
+      this.lifecycleState = "error";
+      throw error;
+    }
 
     // Then call base class initialize
     await super.initialize();

--- a/src/lib/server/adapters/fastifyAdapter.ts
+++ b/src/lib/server/adapters/fastifyAdapter.ts
@@ -60,7 +60,9 @@ export class FastifyServerAdapter extends BaseServerAdapter {
     }
 
     // Dynamic import to avoid loading if not used
-    const fastifyModule = await import("fastify");
+    const fastifyModule = await this.importFrameworkDependency<
+      typeof import("fastify")
+    >("fastify", "Fastify");
     const Fastify = fastifyModule.default;
 
     this.app = Fastify({
@@ -76,7 +78,9 @@ export class FastifyServerAdapter extends BaseServerAdapter {
 
     // Register CORS plugin if enabled
     if (this.config.cors.enabled) {
-      const corsModule = await import("@fastify/cors");
+      const corsModule = await this.importFrameworkDependency<
+        typeof import("@fastify/cors")
+      >("@fastify/cors", "Fastify");
       await this.app.register(corsModule.default, {
         origin: this.config.cors.origins,
         methods: this.config.cors.methods,
@@ -88,7 +92,9 @@ export class FastifyServerAdapter extends BaseServerAdapter {
 
     // Register rate limiting plugin if enabled
     if (this.config.rateLimit.enabled) {
-      const rateLimitModule = await import("@fastify/rate-limit");
+      const rateLimitModule = await this.importFrameworkDependency<
+        typeof import("@fastify/rate-limit")
+      >("@fastify/rate-limit", "Fastify");
       const windowMs = this.config.rateLimit.windowMs;
       await this.app.register(rateLimitModule.default, {
         max: this.config.rateLimit.maxRequests,
@@ -225,8 +231,17 @@ export class FastifyServerAdapter extends BaseServerAdapter {
    * Override initialize to ensure async framework setup
    */
   public async initialize(): Promise<void> {
-    // Initialize Fastify asynchronously first
-    await this.initializeFrameworkAsync();
+    // Initialize Fastify asynchronously first. This runs before
+    // super.initialize()'s try/catch even starts, so a failure here (e.g. the
+    // "fastify" package is not installed) must be caught here too — otherwise
+    // it propagates with lifecycleState left at "uninitialized" instead of
+    // "error".
+    try {
+      await this.initializeFrameworkAsync();
+    } catch (error) {
+      this.lifecycleState = "error";
+      throw error;
+    }
 
     // Then call base class initialize
     await super.initialize();

--- a/src/lib/server/adapters/koaAdapter.ts
+++ b/src/lib/server/adapters/koaAdapter.ts
@@ -56,8 +56,12 @@ export class KoaServerAdapter extends BaseServerAdapter {
     }
 
     // Dynamic imports to avoid loading if not used
-    const KoaModule = await import("koa");
-    const RouterModule = await import("@koa/router");
+    const KoaModule = await this.importFrameworkDependency<{
+      default: typeof import("koa");
+    }>("koa", "Koa");
+    const RouterModule = await this.importFrameworkDependency<
+      typeof import("@koa/router")
+    >("@koa/router", "Koa");
 
     const Koa = KoaModule.default;
     const Router = RouterModule.default;
@@ -111,7 +115,9 @@ export class KoaServerAdapter extends BaseServerAdapter {
 
     // CORS middleware
     if (this.config.cors.enabled) {
-      const corsModule = await import("@koa/cors");
+      const corsModule = await this.importFrameworkDependency<{
+        default: typeof import("@koa/cors");
+      }>("@koa/cors", "Koa");
       const cors = corsModule.default;
       this.app.use(
         cors({
@@ -132,7 +138,9 @@ export class KoaServerAdapter extends BaseServerAdapter {
 
     // Body parsing middleware
     if (this.config.bodyParser.enabled) {
-      const bodyParserModule = await import("koa-bodyparser");
+      const bodyParserModule = await this.importFrameworkDependency<{
+        default: typeof import("koa-bodyparser");
+      }>("koa-bodyparser", "Koa");
       const bodyParser = bodyParserModule.default;
       this.app.use(
         bodyParser({
@@ -257,8 +265,17 @@ export class KoaServerAdapter extends BaseServerAdapter {
    * Override initialize to ensure async framework setup
    */
   public async initialize(): Promise<void> {
-    // Initialize Koa asynchronously first
-    await this.initializeFrameworkAsync();
+    // Initialize Koa asynchronously first. This runs before
+    // super.initialize()'s try/catch even starts, so a failure here (e.g. the
+    // "koa" package is not installed) must be caught here too — otherwise it
+    // propagates with lifecycleState left at "uninitialized" instead of
+    // "error".
+    try {
+      await this.initializeFrameworkAsync();
+    } catch (error) {
+      this.lifecycleState = "error";
+      throw error;
+    }
 
     // Then call base class initialize
     await super.initialize();


### PR DESCRIPTION
Four related gaps in how optional dependencies fail.

The Express, Fastify and Koa adapters each call initializeFrameworkAsync()
— which holds the raw dynamic imports of express/fastify/koa and their
plugins — before super.initialize(). The base class try/catch that sets
lifecycleState and records a failure span only wrapped the synchronous hook,
so a missing framework escaped it entirely: the adapter was left reporting
"uninitialized" rather than "error", with no error event and no failure span.

MissingDependencyError was exported from the public server barrel but thrown
nowhere. Route the ten framework imports through a shared
importFrameworkDependency() helper built on the existing tryImport utility,
so an absent package now produces an actionable message naming the package
and the install command, and any other failure passes through unchanged.

amazonBedrock/client.ts imported @aws-sdk/client-bedrock-runtime statically
and then dynamically imported the same package again for InvokeModelCommand.
That is an inconsistency rather than a crash risk — the module only loads via
providerRegistry's lazy factory — so fold the dynamic import into the static
one. The browser stub list gains InvokeModelCommand to match, since the
bundle stubs that package and must export every symbol the source imports.

VideoProcessor's keyframe extraction swallowed sharp failures with a fully
silent catch, repeated per frame. Log once at warn level naming sharp.

Verified with express removed: initialize() now throws MissingDependencyError
("Missing dependency 'express' for Express adapter. Install with: pnpm add
express") and getLifecycleState() returns "error" where it previously
returned "uninitialized". Full build, providers-mocked, provider-structure
and model-manifests all pass.