### PR TITLE
docs(types): scope stallTimeoutMs to the loops that enforce it

### DIFF
--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -409,6 +409,13 @@ export type GenerateOptions = {
    * with `stopReason: "stalled"`. Catches wedged tools and hung model calls
    * that a whole-turn deadline would let run to the bitter end.
    * Unset = disabled.
+   *
+   * Enforced by the native Vertex loops (Gemini + Claude) ONLY. Unlike
+   * `turnTimeoutMs`, the AI-SDK loop path does not implement stall detection,
+   * so setting this on any other provider has no effect — the turn runs until
+   * it finishes, times out some other way, or the caller aborts. The narrower
+   * scope is stated here because the option itself is accepted everywhere:
+   * without this note a caller would reasonably read silence as coverage.
    */
   stallTimeoutMs?: number;
   /**

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -421,7 +421,7 @@ export type StreamOptions = {
   timeout?: number | string;
   /** Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs. */
   turnTimeoutMs?: number;
-  /** Max time with no progress before the turn ends as "stalled" (ms). See GenerateOptions.stallTimeoutMs. */
+  /** Max time with no progress before the turn ends as "stalled" (ms). Native Vertex loops only — see GenerateOptions.stallTimeoutMs. */
   stallTimeoutMs?: number;
   /** Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs. */
   wrapupTimeLeadMs?: number;


### PR DESCRIPTION
## What

`stallTimeoutMs` is accepted on every provider's options and enforced by **one**: the native Vertex loops.

- `googleVertex/client.ts` is the only consumer of `createTurnClock`.
- `GenerationHandler` — the AI-SDK loop path — does not reference `stallTimeoutMs` at all.

Its documentation said nothing about that. A caller setting it on Anthropic, Bedrock, OpenAI or AI Studio would reasonably believe wedged turns were covered. They are not: the turn runs until it finishes, times out some other way, or the caller aborts.

## Why this is a defect and not a nitpick

The neighbouring `turnTimeoutMs` already documents its own scope honestly:

> Enforced by the native Vertex loops (Gemini + Claude) AND the AI-SDK loop path (litellm and other OpenAI-compatible providers).

And that claim checks out — `GenerationHandler` does read `turnTimeoutMs`. So the codebase already knows scope notes matter here; `stallTimeoutMs` simply never got the same treatment.

## Verified by enumeration, not by reading intent

- `createTurnClock` has exactly one caller.
- `stallTimeoutMs` appears in no provider outside `googleVertex`.

## Related

Same family as the proxy-fetch finding earlier today (#1410): an option accepted everywhere and honoured in one place reads as working support right up until someone depends on it. Found while characterizing Vertex's turn clock for Plan 08 Task 10 — the behaviour is real and now covered by tests there, which is what prompted checking who else honours it.

Docs only; no behaviour change. Typecheck clean across 4865 files, eslint clean.