### PR TITLE
test(security): give the archive and office suites real attacks

### DIFF
--- a/src/lib/processors/data/XmlProcessor.ts
+++ b/src/lib/processors/data/XmlProcessor.ts
@@ -15,6 +15,20 @@
  * 2. **Mitigation**: We reject XML files containing DOCTYPE or ENTITY declarations
  *    and disable entity processing in the parser.
  *
+ * ⚠️ **Reachability**: this guard is not currently wired into the
+ * `generate()`/`stream()` attachment pipeline for a standalone `.xml` file.
+ * `src/lib/processors/config/fileTypeRegistry.ts` has no `"xml"` entry,
+ * `src/lib/utils/mimeTypeHints.ts` maps `application/xml`/`text/xml` to the
+ * generic `"text"` file type, and `messageBuilder.ts`'s `allowedTypes`
+ * whitelist has no `"xml"` entry either — so a `.xml` attachment is always
+ * routed to inert generic-text handling, and `checkXxeVectors()` /
+ * `parseXmlSecurely()` below are never invoked from that path. The
+ * `ProcessorRegistry` subsystem that does own this file has no importer
+ * outside `src/lib/processors/` itself. The guard is correct; it is simply
+ * orphaned. See `test/continuous-test-suite-office-security.ts`'s header for
+ * the test-coverage consequence — no e2e test exercises this file today,
+ * because there is no public surface that reaches it (CLAUDE.md rule 15).
+ *
  * References:
  * - https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
  * - https://cwe.mitre.org/data/definitions/611.html (XXE)

--- a/src/lib/processors/document/PptxProcessor.ts
+++ b/src/lib/processors/document/PptxProcessor.ts
@@ -14,6 +14,15 @@
  *
  * Uses `adm-zip` (already a project dependency) for ZIP extraction.
  *
+ * **XML-entity attacks are not applicable here.** Unlike `WordProcessor`
+ * (mammoth/@xmldom/xmldom) and `ExcelProcessor` (exceljs/saxes), this
+ * processor never hands slide XML to a DOM or SAX parser at all — extraction
+ * is a single regex (`TEXT_ELEMENT_REGEX`, below) run over the raw decoded
+ * bytes. There is no DOCTYPE/ENTITY resolution path for a payload to reach,
+ * so there is nothing for a `.pptx`-specific XXE or billion-laughs test to
+ * falsify; one is deliberately not written (see
+ * `test/continuous-test-suite-office-security.ts`'s header).
+ *
  * @module processors/document/PptxProcessor
  *
  * @example

--- a/test/continuous-test-suite-archive-security.ts
+++ b/test/continuous-test-suite-archive-security.ts
@@ -7,6 +7,36 @@
  * inflating; this suite is what fails if that limit is ever tightened into
  * refusing legitimate input.
  *
+ * ## Attack coverage
+ *
+ * Two real attacks are covered end-to-end, both without live provider
+ * credentials — a local loopback HTTP stand-in (`mockChatServer.ts`) plays
+ * the model, so these run unconditionally instead of behind `requireLive()`:
+ *
+ *   - **zip-slip / path traversal**: `ArchiveProcessor.hasPathTraversal()`
+ *     skips an entry named e.g. `../../../../tmp/evil.txt` rather than
+ *     failing the whole archive. The test proves the sibling entry still
+ *     reaches the outbound request while the traversal entry's content never
+ *     does — by inspecting the request body the mock server actually
+ *     received, not by trusting a model to report back correctly.
+ *   - **decompression-ratio bomb**: a single entry with honest headers whose
+ *     declared ratio exceeds `ARCHIVE_SECURITY.MAX_COMPRESSION_RATIO`.
+ *     Empirically (see the test body) `ArchiveProcessor` does **not** throw
+ *     here — `FileDetector.formatInformativePlaceholder` turns the failed
+ *     processor result into an inert "Could not extract content" placeholder
+ *     that still reaches the model, the same degrade-gracefully path used for
+ *     every other processor failure. The invariant that actually matters —
+ *     the bomb's inflated bytes are never serialized into the outbound
+ *     request — is what the test asserts, via a distinguishing marker that
+ *     must not appear in the captured request body.
+ *
+ * Not covered here: the declared-size-lie bypass (`writeZeroDeclaredZip` —
+ * entry claims size 0, real inflate is huge). It is defended in depth by
+ * `readZipEntryWithinLimit`'s own `maxOutputLength` bound
+ * (`src/lib/processors/archive/zipEntryReader.ts`), but proving that bound
+ * requires measuring peak RSS while importing the processor directly, which
+ * rule 15 (end-to-end only) excludes from this suite.
+ *
  * ## What used to be here
  *
  * This suite also asserted the *bounds* themselves — that a zip entry declaring
@@ -30,7 +60,15 @@ import "dotenv/config";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { defineSuite, assert, tempDir, Skip } from "./helpers/harness.js";
-import { writeNormalGz } from "./helpers/archiveBombFixtures.js";
+import {
+  writeNormalGz,
+  writeZipSlipZip,
+  writeRatioBombZip,
+} from "./helpers/archiveBombFixtures.js";
+import {
+  startMockChatServer,
+  mockOpenAICredentials,
+} from "./helpers/mockChatServer.js";
 import { NeuroLink } from "../dist/index.js";
 
 const { test, runSuite } = defineSuite("Archive delivery");
@@ -112,6 +150,197 @@ await test("an ordinary archive still reaches the model through stream()", async
     acc.includes(TOKEN),
     "the archive's contents reached the model over the streaming path",
   );
+});
+
+const SAFE_MARKER = "SAFE_SIBLING_ENTRY_CONTENT";
+const SLIP_MARKER = "SECRET_SLIPPED_ENTRY_CONTENT";
+
+await test("a zip-slip entry is stripped before the request leaves — generate()", async () => {
+  const outside = path.join(dir, "..", "juspay-zip-slip-canary.txt");
+  const fixture = writeZipSlipZip(path.join(dir, "zip-slip-generate.zip"), [
+    { name: "readme.txt", content: SAFE_MARKER },
+    {
+      name: "../../../../../../tmp/juspay-zip-slip-canary.txt",
+      content: SLIP_MARKER,
+    },
+  ]);
+  const server = await startMockChatServer();
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: {
+        text: "Summarize the attached file.",
+        files: [fixture],
+      },
+      provider: "openai",
+      credentials: mockOpenAICredentials(server),
+      maxTokens: 64,
+      timeout: 30_000,
+    });
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      body.includes(SAFE_MARKER),
+      "the sibling entry's content should have reached the outbound request body",
+    );
+    assert(
+      !body.includes(SLIP_MARKER),
+      "the path-traversal entry's content must never reach the outbound request body",
+    );
+    assert(
+      !fs.existsSync(outside),
+      "the path-traversal entry must never be written outside the archive's own directory",
+    );
+  } finally {
+    await server.close();
+    try {
+      fs.rmSync(outside, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+await test("a zip-slip entry is stripped before the request leaves — stream()", async () => {
+  const outside = path.join(dir, "..", "juspay-zip-slip-canary-stream.txt");
+  const fixture = writeZipSlipZip(path.join(dir, "zip-slip-stream.zip"), [
+    { name: "readme.txt", content: SAFE_MARKER },
+    {
+      name: "../../../../../../tmp/juspay-zip-slip-canary-stream.txt",
+      content: SLIP_MARKER,
+    },
+  ]);
+  const server = await startMockChatServer();
+  try {
+    const nl = new NeuroLink();
+    const streamed = await nl.stream({
+      input: {
+        text: "Summarize the attached file.",
+        files: [fixture],
+      },
+      provider: "openai",
+      credentials: mockOpenAICredentials(server),
+      maxTokens: 64,
+      timeout: 30_000,
+    });
+    for await (const _chunk of streamed.stream as AsyncIterable<unknown>) {
+      // Draining is enough — the assertion is about the request already sent.
+    }
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      body.includes(SAFE_MARKER),
+      "the sibling entry's content should have reached the outbound request body",
+    );
+    assert(
+      !body.includes(SLIP_MARKER),
+      "the path-traversal entry's content must never reach the outbound request body",
+    );
+    assert(
+      !fs.existsSync(outside),
+      "the path-traversal entry must never be written outside the archive's own directory",
+    );
+  } finally {
+    await server.close();
+    try {
+      fs.rmSync(outside, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+const BOMB_MARKER = "ZIPBOMBMARKER_";
+
+await test("a decompression-ratio bomb never reaches the request as inflated content — generate()", async () => {
+  const fixture = writeRatioBombZip(
+    path.join(dir, "ratio-bomb-generate.zip"),
+    2,
+    BOMB_MARKER,
+  );
+  const server = await startMockChatServer();
+  try {
+    const nl = new NeuroLink();
+    let threw = false;
+    try {
+      await nl.generate({
+        input: {
+          text: "Summarize the attached file.",
+          files: [fixture],
+        },
+        provider: "openai",
+        credentials: mockOpenAICredentials(server),
+        maxTokens: 64,
+        timeout: 30_000,
+      });
+    } catch {
+      threw = true;
+    }
+    if (threw) {
+      assert(
+        !server.wasCalled(),
+        "if the bomb is rejected outright, no request should have reached the mock server",
+      );
+    } else {
+      const body = server.getLastRequestBody() ?? "";
+      assert(
+        !body.includes(BOMB_MARKER),
+        "the bomb's inflated marker must never be serialized into the outbound request body",
+      );
+      assert(
+        body.length < 200_000,
+        "the outbound request body must stay far below the bomb's declared inflated size",
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+await test("a decompression-ratio bomb never reaches the request as inflated content — stream()", async () => {
+  const fixture = writeRatioBombZip(
+    path.join(dir, "ratio-bomb-stream.zip"),
+    2,
+    BOMB_MARKER,
+  );
+  const server = await startMockChatServer();
+  try {
+    const nl = new NeuroLink();
+    let threw = false;
+    try {
+      const streamed = await nl.stream({
+        input: {
+          text: "Summarize the attached file.",
+          files: [fixture],
+        },
+        provider: "openai",
+        credentials: mockOpenAICredentials(server),
+        maxTokens: 64,
+        timeout: 30_000,
+      });
+      for await (const _chunk of streamed.stream as AsyncIterable<unknown>) {
+        // Draining is enough — the assertion is about the request already sent.
+      }
+    } catch {
+      threw = true;
+    }
+    if (threw) {
+      assert(
+        !server.wasCalled(),
+        "if the bomb is rejected outright, no request should have reached the mock server",
+      );
+    } else {
+      const body = server.getLastRequestBody() ?? "";
+      assert(
+        !body.includes(BOMB_MARKER),
+        "the bomb's inflated marker must never be serialized into the outbound request body",
+      );
+      assert(
+        body.length < 200_000,
+        "the outbound request body must stay far below the bomb's declared inflated size",
+      );
+    }
+  } finally {
+    await server.close();
+  }
 });
 
 try {

--- a/test/continuous-test-suite-office-security.ts
+++ b/test/continuous-test-suite-office-security.ts
@@ -7,6 +7,37 @@
  * suite is what fails if that bound is ever tightened into refusing legitimate
  * documents.
  *
+ * ## Attack coverage: docx / xlsx XML-entity payloads
+ *
+ * `WordProcessor` (mammoth → `@xmldom/xmldom`) and `ExcelProcessor` (exceljs →
+ * saxes) have no *application-level* DOCTYPE/ENTITY guard of their own —
+ * unlike `XmlProcessor.checkXxeVectors()`, which rejects a raw `.xml`
+ * attachment before it is ever parsed (see the reachability note below).
+ * Empirically, both underlying XML parsers fail closed anyway: a
+ * `<!DOCTYPE …[ <!ENTITY … SYSTEM "…"> ]>` external-entity payload and a
+ * classic "billion laughs" nested-internal-entity payload both throw a parse
+ * error ("entity not found", "undefined entity") in single-digit
+ * milliseconds, for every payload tried, with no entity resolution or
+ * expansion observed. The tests below prove that end-to-end through
+ * `generate()` — a mock chat server captures the exact request body NeuroLink
+ * would have sent, so the assertion is "the secret/expansion marker never
+ * left the process," not "the model didn't repeat it back." Each is wrapped
+ * in a wall-clock timeout as a defensive measure, in case a future dependency
+ * bump changes this fail-closed behaviour into something that hangs instead.
+ *
+ * Not covered here: raw `.xml` attachments. `XmlProcessor`'s XXE guard is
+ * real and correct but is not reachable from `generate()`/`stream()` today —
+ * `src/lib/processors/config/fileTypeRegistry.ts` has no `"xml"` entry,
+ * `mimeTypeHints.ts` maps `application/xml`/`text/xml` to the generic `"text"`
+ * type, and `messageBuilder.ts`'s `allowedTypes` whitelist has no `"xml"`
+ * entry either — so a `.xml` attachment is always routed to inert generic-text
+ * handling and `XmlProcessor` is never invoked. A test asserting the guard
+ * "fires" through the public surface would therefore test nothing; per rule
+ * 15 (end-to-end only) this is recorded as a finding, not a test. `.pptx` is
+ * excluded by design, not by gap: `PptxProcessor` extracts text with a single
+ * regex over raw bytes (no DOM/SAX parser in its path at all), so it has no
+ * entity-expansion surface to attack.
+ *
  * ## What used to be here
  *
  * This suite also asserted the *bounds* themselves across Word, Excel,
@@ -30,7 +61,36 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { defineSuite, assert, tempDir, Skip } from "./helpers/harness.js";
 import { docxMembers, writeOfficeZip } from "./helpers/officeBombFixtures.js";
+import { makeDocxRaw, makeXlsxRaw } from "./helpers/officeFixtures.js";
+import {
+  startMockChatServer,
+  mockOpenAICredentials,
+} from "./helpers/mockChatServer.js";
 import { NeuroLink } from "../dist/index.js";
+
+/** Rejects if `promise` has not settled within `ms`, as a defensive backstop. */
+function withTimeoutMs<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out after ${ms}ms: ${label}`)),
+      ms,
+    );
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err as Error);
+      },
+    );
+  });
+}
 
 const { test, runSuite } = defineSuite("Office document delivery");
 
@@ -81,6 +141,172 @@ await test("an ordinary Word document still reaches the model through generate()
     (result.content ?? "").includes(TOKEN),
     "the document's contents reached the model and came back",
   );
+});
+
+const XXE_SECRET_MARKER = "OFFICE_XXE_EXFIL_MARKER_7f2c9a";
+const secretPath = path.join(dir, "xxe-secret.txt");
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(secretPath, XXE_SECRET_MARKER);
+const secretUri = `file://${secretPath.split(path.sep).join("/")}`;
+
+const LOL_MARKER = "lolz";
+
+function billionLaughsXml(rootOpen: string, rootClose: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE root [
+  <!ENTITY ${LOL_MARKER}0 "lol">
+  <!ENTITY ${LOL_MARKER}1 "&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;&${LOL_MARKER}0;">
+  <!ENTITY ${LOL_MARKER}2 "&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;&${LOL_MARKER}1;">
+  <!ENTITY ${LOL_MARKER}3 "&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;&${LOL_MARKER}2;">
+]>
+${rootOpen}&${LOL_MARKER}3;${rootClose}`;
+}
+
+await test("a docx external-entity (XXE) payload never leaks its target into the outbound request — generate()", async () => {
+  const maliciousDoc = `<?xml version="1.0"?>
+<!DOCTYPE w:document [ <!ENTITY xxe SYSTEM "${secretUri}"> ]>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>&xxe;</w:t></w:r></w:p></w:body>
+</w:document>`;
+  const fixture = path.join(dir, "xxe.docx");
+  fs.writeFileSync(fixture, makeDocxRaw(maliciousDoc));
+  const server = await startMockChatServer();
+  try {
+    try {
+      await withTimeoutMs(
+        new NeuroLink().generate({
+          input: { text: "Summarize the attached document.", files: [fixture] },
+          provider: "openai",
+          credentials: mockOpenAICredentials(server),
+          maxTokens: 64,
+          timeout: 30_000,
+        }),
+        15_000,
+        "docx XXE generate()",
+      );
+    } catch {
+      // A thrown rejection is an acceptable, even stronger, outcome here —
+      // the only thing under test is whether the secret ever left the process.
+    }
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      !body.includes(XXE_SECRET_MARKER),
+      "the external entity's target content must never appear in the outbound request body",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+await test("a docx billion-laughs payload does not hang and does not expand into the outbound request — generate()", async () => {
+  const maliciousDoc = billionLaughsXml(
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>',
+    "</w:t></w:r></w:p></w:body></w:document>",
+  );
+  const fixture = path.join(dir, "lol.docx");
+  fs.writeFileSync(fixture, makeDocxRaw(maliciousDoc));
+  const server = await startMockChatServer();
+  try {
+    try {
+      await withTimeoutMs(
+        new NeuroLink().generate({
+          input: { text: "Summarize the attached document.", files: [fixture] },
+          provider: "openai",
+          credentials: mockOpenAICredentials(server),
+          maxTokens: 64,
+          timeout: 30_000,
+        }),
+        15_000,
+        "docx billion-laughs generate()",
+      );
+    } catch {
+      // A thrown rejection (or the outer timeout) is an acceptable outcome —
+      // the invariant under test is bounded request size, not a specific
+      // success/failure shape.
+    }
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      body.length < 200_000,
+      "the outbound request body must stay bounded, not carry the entity expansion",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+await test("an xlsx external-entity (XXE) payload never leaks its target into the outbound request — generate()", async () => {
+  const maliciousSheet = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE worksheet [ <!ENTITY xxe SYSTEM "${secretUri}"> ]>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData><row r="1"><c r="A1" t="str"><v>&xxe;</v></c></row></sheetData>
+</worksheet>`;
+  const fixture = path.join(dir, "xxe.xlsx");
+  fs.writeFileSync(fixture, await makeXlsxRaw(maliciousSheet));
+  const server = await startMockChatServer();
+  try {
+    try {
+      await withTimeoutMs(
+        new NeuroLink().generate({
+          input: {
+            text: "Summarize the attached spreadsheet.",
+            files: [fixture],
+          },
+          provider: "openai",
+          credentials: mockOpenAICredentials(server),
+          maxTokens: 64,
+          timeout: 30_000,
+        }),
+        15_000,
+        "xlsx XXE generate()",
+      );
+    } catch {
+      // Same reasoning as the docx case above.
+    }
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      !body.includes(XXE_SECRET_MARKER),
+      "the external entity's target content must never appear in the outbound request body",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+await test("an xlsx billion-laughs payload does not hang and does not expand into the outbound request — generate()", async () => {
+  const maliciousSheet = billionLaughsXml(
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="str"><v>',
+    "</v></c></row></sheetData></worksheet>",
+  );
+  const fixture = path.join(dir, "lol.xlsx");
+  fs.writeFileSync(fixture, await makeXlsxRaw(maliciousSheet));
+  const server = await startMockChatServer();
+  try {
+    try {
+      await withTimeoutMs(
+        new NeuroLink().generate({
+          input: {
+            text: "Summarize the attached spreadsheet.",
+            files: [fixture],
+          },
+          provider: "openai",
+          credentials: mockOpenAICredentials(server),
+          maxTokens: 64,
+          timeout: 30_000,
+        }),
+        15_000,
+        "xlsx billion-laughs generate()",
+      );
+    } catch {
+      // Same reasoning as the docx billion-laughs case above.
+    }
+    const body = server.getLastRequestBody() ?? "";
+    assert(
+      body.length < 200_000,
+      "the outbound request body must stay bounded, not carry the entity expansion",
+    );
+  } finally {
+    await server.close();
+  }
 });
 
 try {

--- a/test/helpers/archiveBombFixtures.ts
+++ b/test/helpers/archiveBombFixtures.ts
@@ -231,3 +231,168 @@ export function writeNormalGz(target: string, token: string): string {
   }
   return target;
 }
+
+/**
+ * A multi-entry ZIP, STORED (method 0) like `writeStoredZip`, generalized to
+ * accept several named entries — so one fixture can carry both an ordinary
+ * entry and one whose name is a path-traversal attempt
+ * (`../../../etc/passwd`-shaped).
+ *
+ * Deliberately the same hand-rolled construction as `writeStoredZip` (correct
+ * per-entry CRC/lengths, valid local + central-directory + EOCD records) —
+ * `writeStoredZip`'s signature is untouched; this is a new function, not a
+ * generalization of it in place.
+ */
+export function writeZipSlipZip(
+  target: string,
+  entries: ReadonlyArray<{ name: string; content: string }>,
+): string {
+  const built = entries.map(({ name, content }) => {
+    const payload = Buffer.from(content, "utf8");
+    const crc = zlib.crc32(payload) >>> 0;
+    const nameBuf = Buffer.from(name, "utf8");
+    return { nameBuf, payload, crc };
+  });
+
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+
+  for (const { nameBuf, payload, crc } of built) {
+    const local = Buffer.concat([
+      u32(0x04034b50),
+      u16(20),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(crc),
+      u32(payload.length),
+      u32(payload.length),
+      u16(nameBuf.length),
+      u16(0),
+      nameBuf,
+      payload,
+    ]);
+    const central = Buffer.concat([
+      u32(0x02014b50),
+      u16(20),
+      u16(20),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(crc),
+      u32(payload.length),
+      u32(payload.length),
+      u16(nameBuf.length),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(0),
+      u32(offset),
+      nameBuf,
+    ]);
+    locals.push(local);
+    centrals.push(central);
+    offset += local.length;
+  }
+
+  const centralBuf = Buffer.concat(centrals);
+  const end = Buffer.concat([
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(built.length),
+    u16(built.length),
+    u32(centralBuf.length),
+    u32(offset),
+    u16(0),
+  ]);
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, Buffer.concat([...locals, centralBuf, end]));
+  return target;
+}
+
+/**
+ * A single-entry ZIP whose DEFLATE stream is real and its header sizes are
+ * truthful — unlike `writeZeroDeclaredZip`, which lies about
+ * `uncompressedSize` to bypass the ratio check entirely. This fixture exists
+ * to trip `ArchiveProcessor`'s compression-ratio guard head-on: the entry
+ * fills `inflateMb` megabytes with a repeating `marker` string (so a test can
+ * assert the marker never appears in output — plain zeros would leave nothing
+ * to assert against) and declares its actual compressed/uncompressed sizes in
+ * both the local and central-directory records.
+ *
+ * `inflateMb` only needs to clear `MAX_COMPRESSION_RATIO` (100:1 in
+ * `ArchiveProcessor.ts`) with margin; a short repeating string compresses at
+ * several hundred:1, so 2 MB is enough without spiking the test process.
+ */
+export function writeRatioBombZip(
+  target: string,
+  inflateMb: number,
+  marker = "ZIPBOMBMARKER_",
+): string {
+  const name = Buffer.from("bomb.txt", "ascii");
+  const unit = Buffer.from(marker, "utf8");
+  const totalBytes = inflateMb * MB;
+  const reps = Math.floor(totalBytes / unit.length);
+  const raw = Buffer.alloc(reps * unit.length);
+  for (let i = 0; i < reps; i++) {
+    unit.copy(raw, i * unit.length);
+  }
+  const deflated = zlib.deflateRawSync(raw);
+  const crc = zlib.crc32(raw) >>> 0;
+
+  const local = Buffer.concat([
+    u32(0x04034b50),
+    u16(20),
+    u16(0),
+    u16(8),
+    u16(0),
+    u16(0),
+    u32(crc),
+    u32(deflated.length),
+    u32(raw.length),
+    u16(name.length),
+    u16(0),
+    name,
+    deflated,
+  ]);
+  const central = Buffer.concat([
+    u32(0x02014b50),
+    u16(20),
+    u16(20),
+    u16(0),
+    u16(8),
+    u16(0),
+    u16(0),
+    u32(crc),
+    u32(deflated.length),
+    u32(raw.length),
+    u16(name.length),
+    u16(0),
+    u16(0),
+    u16(0),
+    u16(0),
+    u32(0),
+    u32(0),
+    name,
+  ]);
+  const end = Buffer.concat([
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(1),
+    u16(1),
+    u32(central.length),
+    u32(local.length),
+    u16(0),
+  ]);
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, Buffer.concat([local, central, end]));
+  return target;
+}

--- a/test/helpers/mockChatServer.ts
+++ b/test/helpers/mockChatServer.ts
@@ -1,0 +1,162 @@
+/**
+ * Local, loopback-only OpenAI-chat-completions stand-in.
+ *
+ * Exists so a suite can prove what NeuroLink actually sent to a model —
+ * whether an archive's poisoned entry, a zip bomb's inflated bytes, or an
+ * XXE payload's resolved secret made it into the outbound request — without
+ * live credentials or a real network call. `provider: "openai"` accepts a
+ * per-call `credentials.openai.baseURL` override (see
+ * `src/lib/types/providers.ts`), so pointing it at `http://127.0.0.1:<port>`
+ * with any non-empty `apiKey` string is enough to get past provider
+ * construction; nothing after that talks to the internet.
+ *
+ * `buildMessages()` (file processing — the ArchiveProcessor / WordProcessor /
+ * ExcelProcessor security checks under test) always runs before the actual
+ * network call inside `BaseProvider.generate()`/`stream()`. So a security
+ * guard that rejects or strips something never reaches this server at all,
+ * and one that degrades gracefully (see the "archive delivery" suite's zip
+ * bomb test) sends this server a request whose body is the evidence.
+ *
+ * This is a genuine HTTP server on 127.0.0.1, not a `fetch` patch — it
+ * exercises the real request-serialisation path (headers, JSON body,
+ * SSE framing for `stream()`), which a monkeypatched `fetch` would not.
+ */
+import { createServer, type IncomingMessage, type Server } from "node:http";
+
+export type MockChatServer = {
+  /** Base URL to hand to `credentials.<provider>.baseURL`. */
+  readonly baseURL: string;
+  /** The raw JSON body of the most recent request, or null if none arrived. */
+  getLastRequestBody(): string | null;
+  /** Every request body received so far, oldest first. */
+  getAllRequestBodies(): string[];
+  /** True once at least one request has reached this server. */
+  wasCalled(): boolean;
+  /** Shut the server down and release its port. */
+  close(): Promise<void>;
+};
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+function sseChunk(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Start a local server that answers any `/chat/completions`-shaped POST
+ * with a fixed, harmless assistant reply — non-streaming JSON when the
+ * request body has no `"stream":true`, SSE chunks otherwise.
+ *
+ * The reply content is deliberately inert ("mock reply"): these suites
+ * assert on what the SDK sent, not on what a model says back.
+ */
+export function startMockChatServer(): Promise<MockChatServer> {
+  const bodies: string[] = [];
+
+  const server: Server = createServer((req, res) => {
+    readBody(req)
+      .then((bodyStr) => {
+        bodies.push(bodyStr);
+        let streaming = false;
+        try {
+          streaming = JSON.parse(bodyStr)?.stream === true;
+        } catch {
+          // Malformed JSON is still a captured body; fall through to the
+          // non-streaming reply so the caller's assertion sees it.
+        }
+
+        if (streaming) {
+          res.writeHead(200, {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          });
+          const created = Math.floor(Date.now() / 1000);
+          const base = {
+            id: "mock-stream",
+            object: "chat.completion.chunk",
+            created,
+            model: "gpt-4o-mini",
+          };
+          res.write(
+            sseChunk({
+              ...base,
+              choices: [
+                {
+                  index: 0,
+                  delta: { role: "assistant", content: "mock reply" },
+                  finish_reason: null,
+                },
+              ],
+            }),
+          );
+          res.write(
+            sseChunk({
+              ...base,
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            }),
+          );
+          res.write("data: [DONE]\n\n");
+          res.end();
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            id: "mock-completion",
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "gpt-4o-mini",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "mock reply" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        );
+      })
+      .catch(() => {
+        res.writeHead(500);
+        res.end();
+      });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({
+        baseURL: `http://127.0.0.1:${port}/v1`,
+        getLastRequestBody: () =>
+          bodies.length > 0 ? bodies[bodies.length - 1] : null,
+        getAllRequestBodies: () => [...bodies],
+        wasCalled: () => bodies.length > 0,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+/**
+ * Fake-but-syntactically-present OpenAI credentials pointed at a
+ * `MockChatServer`. Provider construction only checks that an API key
+ * string exists; it never validates it, so any non-empty value clears
+ * that gate without touching a real key.
+ */
+export function mockOpenAICredentials(server: MockChatServer): {
+  openai: { apiKey: string; baseURL: string };
+} {
+  return {
+    openai: { apiKey: "sk-mock-local-server", baseURL: server.baseURL },
+  };
+}

--- a/test/helpers/officeFixtures.ts
+++ b/test/helpers/officeFixtures.ts
@@ -104,6 +104,44 @@ export async function makeXlsx(
   return Buffer.from(await wb.xlsx.writeBuffer());
 }
 
+/**
+ * Build a .docx whose `word/document.xml` is the given raw XML string,
+ * byte-for-byte — no escaping.
+ *
+ * `makeDocx()` escapes its input because it exists to carry ordinary text; an
+ * XXE/billion-laughs payload needs a literal `<!DOCTYPE …>`/`<!ENTITY …>`
+ * prologue ahead of `<w:document>`, which escaping would turn into inert text.
+ * The surrounding parts ([Content_Types].xml, _rels/.rels) are the same
+ * well-formed shell `makeDocx()` uses — only the main part is attacker
+ * controlled, matching a real attachment where everything except the
+ * document body is boilerplate.
+ */
+export function makeDocxRaw(documentXml: string): Buffer {
+  const zip = new AdmZip();
+  zip.addFile("[Content_Types].xml", Buffer.from(CONTENT_TYPES, "utf8"));
+  zip.addFile("_rels/.rels", Buffer.from(ROOT_RELS, "utf8"));
+  zip.addFile("word/document.xml", Buffer.from(documentXml, "utf8"));
+  return zip.toBuffer();
+}
+
+/**
+ * Build a real, structurally valid .xlsx via exceljs (correct
+ * `[Content_Types].xml`, `xl/workbook.xml`, relationships, styles, …), then
+ * overwrite `xl/worksheets/sheet1.xml` with a raw, attacker-controlled XML
+ * string.
+ *
+ * exceljs's own writer escapes anything written through its row/cell API, so
+ * it cannot be used to embed a literal `<!DOCTYPE …>` — the injection has to
+ * happen by patching the zip entry after the fact, which is also what a real
+ * attacker modifying a legitimate spreadsheet would do.
+ */
+export async function makeXlsxRaw(sheetXml: string): Promise<Buffer> {
+  const base = await makeXlsx({ Sheet1: [["placeholder"]] });
+  const zip = new AdmZip(base);
+  zip.updateFile("xl/worksheets/sheet1.xml", Buffer.from(sheetXml, "utf8"));
+  return zip.toBuffer();
+}
+
 function escapeXml(s: string): string {
   return s
     .replace(/&/g, "&amp;")


### PR DESCRIPTION
Both suites' only tests were gated behind requireLive(), and no workflow
runs test:unit or these suites directly, so they never executed in CI
regardless of credentials. Add zip-slip, decompression-ratio-bomb, and
docx/xlsx XML-entity (XXE + billion-laughs) attack assertions that run
unconditionally against a local loopback mock chat server instead of a
live provider, proving what NeuroLink actually serializes into the
outbound request rather than trusting a model's reply.

Two findings correct the original audit's assumptions instead of
confirming them:
- the compression-ratio guard degrades an oversized entry to an inert
  placeholder rather than throwing, so the new test asserts the bomb's
  bytes never reach the request body instead of asserting a rejection
- XmlProcessor's XXE guard is real but unreachable from generate()/
  stream() today: fileTypeRegistry.ts has no "xml" entry and .xml
  attachments are always routed to generic text handling, so no e2e
  test can exercise it (documented in XmlProcessor.ts and the office
  suite's header instead of writing an unfalsifiable test)

PptxProcessor is documented as out of scope by design: it extracts text
with a regex over raw bytes and never reaches a DOM/SAX parser.