### PR TITLE
chore(supply-chain): add a pnpm release-age cooldown and pin CI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       # Acquire::*::Timeout) plus a step timeout-minutes.
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: 🔄 SvelteKit Sync
         run: |
@@ -94,7 +94,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: 🔄 SvelteKit Sync
         run: |

--- a/docs-site/pnpm-workspace.yaml
+++ b/docs-site/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Standalone project — this file exists only to stop pnpm's upward workspace-root
+# search at this directory (mirrors landing/pnpm-workspace.yaml). Without it, pnpm walks
+# up to the repo-root pnpm-workspace.yaml and docs-site drops out of its own
+# `pnpm ls -r` / recursive command scope, since it is not listed in that file's
+# `packages:` patterns. docs-site keeps its own lockfile and package.json; it is not
+# part of the root workspace.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# Supply-chain cooldown: delay adoption of freshly published npm releases across every
+# dependency (including the single-maintainer untrusted-input parsers: adm-zip,
+# fast-xml-parser, pdf-parse, pdf-to-img, mammoth, js-yaml, chardet, jsonrepair, sharp)
+# by 3 days, giving the ecosystem time to catch a compromised release before it can be
+# resolved here. No `packages:` field is set, so this does not turn the repo into a
+# pnpm workspace — landing/ and docs-site/ remain independent projects (see
+# docs-site/pnpm-workspace.yaml, added alongside this file, for why that needed a shield).
+minimumReleaseAge: 4320


### PR DESCRIPTION
Nine untrusted-input parsers reachable from public generate()/stream()
calls (adm-zip, fast-xml-parser, pdf-parse, pdf-to-img, mammoth,
js-yaml, chardet, jsonrepair, sharp) each have exactly one npm
maintainer, so a single compromised account could publish a version
that installs on the very next `pnpm install`. pnpm 10's
minimumReleaseAge delays adoption of any freshly published release
(these nine included) by 3 days, giving the ecosystem time to catch a
compromise first.

pnpm 10.15.1 stores this key in pnpm-workspace.yaml, not .npmrc
(confirmed via `pnpm config set --location=project` and reverted).
That file did not exist at the repo root, and adding one is not free:
it makes pnpm treat the directory as a workspace boundary. Verified
docs-site/ has no shielding file of its own (unlike landing/, which
already carries one), so once a root pnpm-workspace.yaml exists,
`pnpm ls -r` run from inside docs-site stops reporting docs-site and
reports the outer repo instead. A matching docs-site/pnpm-workspace.yaml,
mirroring landing's existing pattern, restores that isolation --
verified before and after. Neither directory is added to `packages:`,
so the repo does not become a pnpm workspace and pnpm install
--lockfile-only leaves all three lockfiles (root, landing, docs-site)
byte-for-byte unchanged.

Separately, two of the four required CI status checks -- `test` and
`provider-safety-net` -- ran plain `pnpm install` while `build-check`'s
sibling jobs already pin `--frozen-lockfile`. An unpinned install lets
a required check silently accept a drifted lockfile, undermining any
cooldown placed on it. Both now pass --frozen-lockfile, matching
extended-suites and proxy-performance.

package.json's onlyBuiltDependencies still lists a stale `sqlite3`
entry with no corresponding pnpm-lock.yaml match; left untouched here
since a sibling branch already removes it.