### PR TITLE
fix(build): restore the sharp loader's typing so release typechecks

### DIFF
--- a/src/lib/processors/media/VideoProcessor.ts
+++ b/src/lib/processors/media/VideoProcessor.ts
@@ -137,7 +137,16 @@ async function loadMediaBunny() {
 let sharpLoadWarned = false;
 async function loadSharp() {
   try {
-    const mod = await tryImport<{ default: typeof import("sharp") }>(
+    // `typeof import("sharp")` is the MODULE namespace, and sharp 0.35 puts
+    // the callable factory on its `default` export. Typing the import as
+    // `{ default: typeof import("sharp") }` wrapped that namespace a second
+    // time, so `mod.default` came back as a namespace rather than a factory
+    // and every call site failed with "no call signatures".
+    //
+    // imageFormatSupport.ts already reads `sharpModule.default(...)` for the
+    // same reason; this loader is now the one place that normalizes it, so
+    // callers keep calling the returned value directly.
+    const mod = await tryImport<typeof import("sharp")>(
       "sharp",
       "Video keyframe resizing",
     );


### PR DESCRIPTION
## Release is currently red

`pnpm run check` fails on `release` right now with two errors:

```
src/lib/processors/media/VideoProcessor.ts:899  This expression is not callable.
src/lib/processors/media/VideoProcessor.ts:1320 This expression is not callable.
  Type 'typeof import(".../sharp@0.35.3/.../dist/index")' has no call signatures.
```

It went red during today's batch of dependency merges, and **nothing caught it** — the typecheck that gates CI runs per-PR against the base each PR was opened from, not against the base after its siblings land. Each PR was green on its own base and the combination is not.

## Cause

`loadSharp()` typed the dynamic import as:

```ts
tryImport<{ default: typeof import("sharp") }>("sharp", ...)
```

`typeof import("sharp")` is *already* the module namespace, and sharp 0.35 puts the callable factory on that namespace's `default`. Wrapping it in another `{ default: ... }` made `mod.default` resolve to the namespace rather than the factory, so both call sites were calling something with no call signatures.

## Fix

Type the import as the namespace and return its `default`. The repo already had the correct shape one file away — `imageFormatSupport.ts` reads `sharpModule.default(...)` with a runtime guard — so this makes `loadSharp()` the single place that normalizes the module shape and callers keep calling the value it returns.

## Verified

**Mutation-verified**: restoring the old generic reproduces both errors exactly. Typecheck clean across 4858 files, eslint clean, `pnpm run build` passes.

## Worth noting for the queue

This is the kind of gap a merge queue exists to close. Three dependency PRs (#1424, #1426, #1427) are still open against an older base and each needs re-verification against current `release` before merging, not just green checks from when they were opened.