### PR TITLE
feat(core): let a Gemini adapter supply its own step collector

### DIFF
--- a/src/lib/core/geminiLoopAdapter.ts
+++ b/src/lib/core/geminiLoopAdapter.ts
@@ -141,13 +141,19 @@ export function createGeminiLoopAdapter(
     ): Promise<AgenticLoopStepResult<GeminiStepRaw>> {
       const rawStream = await config.sendStep(request.raw, signal);
 
-      // `collectStreamChunksIncremental` wants a StreamChannel but only ever
-      // calls `.push`, so the engine's push-only channel satisfies it. The
-      // helper is reused rather than reimplemented precisely because it also
-      // owns usage extraction and thought-signature preservation.
-      const collected = await collectStreamChunksIncremental(rawStream, {
-        push: (chunk: { content: string }) => channel.push(chunk),
-      } as Parameters<typeof collectStreamChunksIncremental>[1]);
+      // The shared helper by default: it owns usage extraction and
+      // thought-signature preservation, and it wants a StreamChannel but only
+      // ever calls `.push`, so the engine's push-only channel satisfies it.
+      //
+      // A provider whose drain genuinely differs supplies `collectStep`
+      // instead. Vertex does: it folds cumulative usage counts as deltas in
+      // its own loop, and that behaviour is characterized, so it keeps its
+      // collector rather than being quietly switched to this one.
+      const collected = config.collectStep
+        ? await config.collectStep(rawStream, channel)
+        : await collectStreamChunksIncremental(rawStream, {
+            push: (chunk: { content: string }) => channel.push(chunk),
+          } as Parameters<typeof collectStreamChunksIncremental>[1]);
 
       // The provider's context guard calibrates from real per-step counts;
       // `inputTokens` is this step's full prompt size, which is what it

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -1,6 +1,7 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { Tool } from "./tools.js";
 import type {
+  CollectedChunkResult,
   NativeFunctionCall,
   NativeToolDeclarationsResult,
 } from "./providers.js";
@@ -305,6 +306,23 @@ export type GeminiLoopAdapterCoreConfig = {
    * step with that step's real token counts.
    */
   noteUsage?: (inputTokens: number, outputTokens: number) => void;
+  /**
+   * Fold one step's raw stream into the shape the adapter reports.
+   *
+   * Defaults to `collectStreamChunksIncremental`, which is what AI Studio and
+   * any provider sharing the googleNativeGemini3 helpers want. Vertex does
+   * NOT share them: its loop drains the stream itself, folding cumulative
+   * usage counts as deltas and capturing thought signatures in its own way,
+   * and that behaviour is characterized rather than incidental.
+   *
+   * So the collector is a hook rather than a hard-coded call. A provider
+   * whose drain differs supplies its own and keeps its measured behaviour;
+   * one that matches the shared helper passes nothing.
+   */
+  collectStep?: (
+    stream: unknown,
+    channel: { push(chunk: AgenticLoopChunk): void },
+  ) => Promise<CollectedChunkResult>;
 };
 
 /**

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -1122,4 +1122,64 @@ await test("the engine's breaker dispatches an always-failing tool exactly twice
   );
 });
 
+await test("the Gemini adapter uses a supplied collectStep instead of the shared collector", async () => {
+  // Task 10 prerequisite. Vertex drains its stream itself — folding cumulative
+  // usage counts as deltas and capturing thought signatures its own way — and
+  // that behaviour is characterized, so migrating it must not silently swap in
+  // the shared collector. This proves the hook is honoured rather than
+  // decorative.
+  const { createGeminiLoopAdapter } =
+    await import("../src/lib/core/geminiLoopAdapter.js");
+  // Two steps, not one. A single-step turn would pass even if the adapter
+  // consulted the hook once and then fell back to the shared collector, so
+  // the first step asks for a tool and the second ends the turn.
+  let called = 0;
+  const adapter = createGeminiLoopAdapter({
+    providerLabel: "probe",
+    maxSteps: 3,
+    liveTools: {},
+    buildRequest: () => ({}),
+    sendStep: async () => ({}) as never,
+    collectStep: async () => {
+      called++;
+      if (called === 1) {
+        return {
+          rawResponseParts: [{ text: "step one" }],
+          stepFunctionCalls: [{ name: "probe_tool", args: {} }],
+          inputTokens: 4,
+          outputTokens: 1,
+          finishReason: "STOP",
+        };
+      }
+      return {
+        rawResponseParts: [{ text: "from the custom collector" }],
+        stepFunctionCalls: [],
+        inputTokens: 7,
+        outputTokens: 3,
+        finishReason: "STOP",
+      };
+    },
+  });
+  const { resultPromise } = runAgenticLoop(adapter, [], {
+    tools: {
+      probe_tool: { execute: async () => ({ ok: true }) },
+    },
+  });
+  const result = await resultPromise;
+  assertEqual(called, 2, "the supplied collector was not used on every step");
+  // The SUM of both steps (4 + 7). The engine accumulates usage across a
+  // turn, so this asserts every step's counts came from the supplied
+  // collector — a single-step expectation would have passed while the second
+  // step silently used the shared one.
+  assertEqual(
+    result.usage.inputTokens,
+    11,
+    "usage did not come from the supplied collector on every step",
+  );
+  assert(
+    result.text.includes("from the custom collector"),
+    "text did not come from the supplied collector",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## Why

Task 10 prerequisite, found by *starting* that migration rather than assumed in advance.

`createGeminiLoopAdapter` hard-coded `collectStreamChunksIncremental`. AI Studio shares that helper, so the fit was exact. **Vertex does not**: its loop drains the stream inline over ~90 lines, folding cumulative usage counts as deltas and capturing thought signatures its own way.

Migrating Vertex onto the adapter as it stood would have silently swapped its collector for a different one — a behaviour change wearing a refactor's clothes, and precisely what this plan's characterization suites exist to prevent.

## What

The collector becomes an optional hook. Providers matching the shared helper pass nothing and are unaffected; a provider whose drain genuinely differs supplies `collectStep` and keeps its measured behaviour.

## Verified both directions

**The default path is untouched** — AI Studio's characterization suite is byte-identical:

```
attempts=2 calls=4
calls=2 chars=57
generate content="partial progress"
Passed: 6
```

**The hook is honoured, not decorative** — a new loop-engine case asserts the supplied collector is used for text and usage, and mutation-testing it (forcing the default branch) fails exactly that case:

```
unmutated:      Passed: 33
hook disabled:  Passed: 32   Failed: 1
```

Typecheck clean across 4829 files, eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling by supporting provider-specific collection for each step.
  * Preserved shared incremental collection as the default behavior.
  * Ensured multi-step tool interactions correctly retain cumulative token usage and final response text.

* **Tests**
  * Added regression coverage for custom stream collection across multiple execution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->