### PR TITLE
refactor(googleVertex): extract the Gemini step collector

### DIFF
--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -159,6 +159,9 @@ import type {
   Schema,
   LanguageModel,
   ImageWithAltText,
+  CollectedChunkResult,
+  NativeFunctionCall,
+  VertexUsageCounter,
 } from "../../types/index.js";
 
 // Import proper types for multimodal message handling
@@ -794,6 +797,152 @@ function reclaimVertexAnthropicContext(
   messages.length = 0;
   messages.push(...rebuilt);
   return true;
+}
+
+/**
+ * Fold one Vertex Gemini step's stream into the shape the loop engine reports.
+ *
+ * Lifted from the inline drain in executeNativeGemini3Stream so the loop can
+ * later be handed to createGeminiLoopAdapter as `collectStep`. Vertex does not
+ * share googleNativeGemini3's collector: it reads parts straight off each
+ * candidate — avoiding the SDK warning that `chunk.text` raises when
+ * thoughtSignature or functionCall parts are present — and that behaviour is
+ * characterized.
+ *
+ * `onUsageDelta` fires PER CHUNK and is not an optimisation to fold away. The
+ * drain updates the turn totals incrementally so they are correct at every
+ * point mid-stream: a step killed by an abort, the turn deadline or the stall
+ * watchdog still bills the tokens it already reported. Returning a step total
+ * for the caller to add would be arithmetically identical and operationally
+ * wrong, because a killed step never returns.
+ */
+async function collectVertexStreamChunks(
+  stream: AsyncIterable<{
+    functionCalls?: NativeFunctionCall[];
+    [key: string]: unknown;
+  }>,
+  channel: { push(chunk: { content: string }): void },
+  hooks: {
+    onProgress?: () => void;
+    onUsage?: (inputTokens: number, outputTokens: number) => void;
+    onUsageDelta?: (counter: VertexUsageCounter, delta: number) => void;
+  } = {},
+): Promise<CollectedChunkResult> {
+  const rawResponseParts: unknown[] = [];
+  const stepFunctionCalls: NativeFunctionCall[] = [];
+  let lastFinishReason: string | undefined;
+  let stepInputTokens = 0;
+  let stepOutputTokens = 0;
+  let stepCacheReadTokens = 0;
+  let stepReasoningTokens = 0;
+
+  for await (const chunk of stream) {
+    hooks.onProgress?.();
+    // Extract raw parts from candidates FIRST
+    // This avoids using chunk.text which triggers SDK warning when
+    // non-text parts (thoughtSignature, functionCall) are present
+    const chunkRecord = chunk as Record<string, unknown>;
+    const candidates = chunkRecord.candidates as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const firstCandidate = candidates?.[0];
+    // Capture the SDK finish reason (Bug 2: previously dropped). Last
+    // non-empty value across chunks wins.
+    const chunkFinishReason = firstCandidate?.finishReason;
+    if (typeof chunkFinishReason === "string" && chunkFinishReason) {
+      lastFinishReason = chunkFinishReason;
+    }
+    const chunkContent = firstCandidate?.content as
+      | Record<string, unknown>
+      | undefined;
+    if (chunkContent && Array.isArray(chunkContent.parts)) {
+      for (const part of chunkContent.parts as Array<Record<string, unknown>>) {
+        rawResponseParts.push(part);
+        if (typeof part.text === "string" && part.text.length > 0) {
+          channel.push({ content: part.text });
+        }
+      }
+    }
+    if (chunk.functionCalls) {
+      stepFunctionCalls.push(...chunk.functionCalls);
+    }
+
+    // Extract usage metadata from chunk
+    // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
+    const usageMetadata = chunkRecord.usageMetadata as
+      | {
+          promptTokenCount?: number;
+          candidatesTokenCount?: number;
+          cachedContentTokenCount?: number;
+          thoughtsTokenCount?: number;
+          totalTokenCount?: number;
+        }
+      | undefined;
+    if (usageMetadata) {
+      // Take the latest promptTokenCount (usually only in final chunk)
+      if (
+        usageMetadata.promptTokenCount !== undefined &&
+        usageMetadata.promptTokenCount > 0
+      ) {
+        hooks.onUsageDelta?.(
+          "input",
+          usageMetadata.promptTokenCount - stepInputTokens,
+        );
+        stepInputTokens = usageMetadata.promptTokenCount;
+        // Feed the context guard the REAL prompt size of this call.
+        hooks.onUsage?.(
+          usageMetadata.promptTokenCount,
+          usageMetadata.candidatesTokenCount ?? 0,
+        );
+        // cachedContentTokenCount is OVERLAPPING (a subset already inside
+        // promptTokenCount). Clamp to the prompt count so an uncached
+        // step reports 0 instead of a stale cached value.
+        const chunkCacheReadTokens = Math.min(
+          usageMetadata.cachedContentTokenCount ?? 0,
+          usageMetadata.promptTokenCount,
+        );
+        hooks.onUsageDelta?.(
+          "cacheRead",
+          chunkCacheReadTokens - stepCacheReadTokens,
+        );
+        stepCacheReadTokens = chunkCacheReadTokens;
+      }
+      // Take the latest candidatesTokenCount (accumulates through chunks)
+      if (
+        usageMetadata.candidatesTokenCount !== undefined &&
+        usageMetadata.candidatesTokenCount > 0
+      ) {
+        hooks.onUsageDelta?.(
+          "output",
+          usageMetadata.candidatesTokenCount - stepOutputTokens,
+        );
+        stepOutputTokens = usageMetadata.candidatesTokenCount;
+      }
+      // thoughtsTokenCount (thinking tokens, billed at the output
+      // rate) is NOT part of candidatesTokenCount — Gemini reports
+      // totalTokenCount = prompt + candidates + thoughts.
+      if (
+        usageMetadata.thoughtsTokenCount !== undefined &&
+        usageMetadata.thoughtsTokenCount > 0
+      ) {
+        hooks.onUsageDelta?.(
+          "reasoning",
+          usageMetadata.thoughtsTokenCount - stepReasoningTokens,
+        );
+        stepReasoningTokens = usageMetadata.thoughtsTokenCount;
+      }
+    }
+  }
+
+  return {
+    rawResponseParts,
+    stepFunctionCalls,
+    ...(lastFinishReason ? { finishReason: lastFinishReason } : {}),
+    inputTokens: stepInputTokens,
+    outputTokens: stepOutputTokens,
+    ...(stepCacheReadTokens ? { cacheReadTokens: stepCacheReadTokens } : {}),
+    ...(stepReasoningTokens ? { reasoningTokens: stepReasoningTokens } : {}),
+  };
 }
 
 export class GoogleVertexProvider extends BaseProvider {
@@ -2013,102 +2162,41 @@ export class GoogleVertexProvider extends BaseProvider {
           // are therefore correct at every point mid-drain — a step killed
           // mid-stream (abort / turn deadline / stall watchdog) still counts
           // the billed tokens it already reported.
-          let stepInputTokens = 0;
-          let stepOutputTokens = 0;
-          let stepCacheReadTokens = 0;
-          let stepReasoningTokens = 0;
 
-          for await (const chunk of stream) {
-            turnClock.noteProgress();
-            // Extract raw parts from candidates FIRST
-            // This avoids using chunk.text which triggers SDK warning when
-            // non-text parts (thoughtSignature, functionCall) are present
-            const chunkRecord = chunk as Record<string, unknown>;
-            const candidates = chunkRecord.candidates as
-              | Array<Record<string, unknown>>
-              | undefined;
-            const firstCandidate = candidates?.[0];
-            // Capture the SDK finish reason (Bug 2: previously dropped). Last
-            // non-empty value across chunks wins.
-            const chunkFinishReason = firstCandidate?.finishReason;
-            if (typeof chunkFinishReason === "string" && chunkFinishReason) {
-              lastFinishReason = chunkFinishReason;
-              stepFinishReason = chunkFinishReason;
-            }
-            const chunkContent = firstCandidate?.content as
-              | Record<string, unknown>
-              | undefined;
-            if (chunkContent && Array.isArray(chunkContent.parts)) {
-              for (const part of chunkContent.parts as Array<
-                Record<string, unknown>
-              >) {
-                rawResponseParts.push(part);
-                if (typeof part.text === "string" && part.text.length > 0) {
-                  incrementalTextChunks.push(part.text);
+          // The drain now lives in collectVertexStreamChunks. The hooks below
+          // are the two couplings it had to this loop, plus the per-chunk
+          // usage deltas — those must stay per-chunk so a step killed
+          // mid-stream still bills what it reported.
+          const collected = await collectVertexStreamChunks(
+            stream,
+            {
+              push: (chunk) => {
+                if (chunk.content) {
+                  incrementalTextChunks.push(chunk.content);
                 }
-              }
-            }
-            if (chunk.functionCalls) {
-              stepFunctionCalls.push(...chunk.functionCalls);
-            }
-
-            // Extract usage metadata from chunk
-            // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
-            const usageMetadata = chunkRecord.usageMetadata as
-              | {
-                  promptTokenCount?: number;
-                  candidatesTokenCount?: number;
-                  cachedContentTokenCount?: number;
-                  thoughtsTokenCount?: number;
-                  totalTokenCount?: number;
+              },
+            },
+            {
+              onProgress: () => turnClock.noteProgress(),
+              onUsage: (input, output) => contextGuard.noteUsage(input, output),
+              onUsageDelta: (counter, delta) => {
+                if (counter === "input") {
+                  totalInputTokens += delta;
+                } else if (counter === "output") {
+                  totalOutputTokens += delta;
+                } else if (counter === "cacheRead") {
+                  totalCacheReadTokens += delta;
+                } else {
+                  totalReasoningTokens += delta;
                 }
-              | undefined;
-            if (usageMetadata) {
-              // Take the latest promptTokenCount (usually only in final chunk)
-              if (
-                usageMetadata.promptTokenCount !== undefined &&
-                usageMetadata.promptTokenCount > 0
-              ) {
-                totalInputTokens +=
-                  usageMetadata.promptTokenCount - stepInputTokens;
-                stepInputTokens = usageMetadata.promptTokenCount;
-                // Feed the context guard the REAL prompt size of this call.
-                contextGuard.noteUsage(
-                  usageMetadata.promptTokenCount,
-                  usageMetadata.candidatesTokenCount ?? 0,
-                );
-                // cachedContentTokenCount is OVERLAPPING (a subset already inside
-                // promptTokenCount). Clamp to the prompt count so an uncached
-                // step reports 0 instead of a stale cached value.
-                const chunkCacheReadTokens = Math.min(
-                  usageMetadata.cachedContentTokenCount ?? 0,
-                  usageMetadata.promptTokenCount,
-                );
-                totalCacheReadTokens +=
-                  chunkCacheReadTokens - stepCacheReadTokens;
-                stepCacheReadTokens = chunkCacheReadTokens;
-              }
-              // Take the latest candidatesTokenCount (accumulates through chunks)
-              if (
-                usageMetadata.candidatesTokenCount !== undefined &&
-                usageMetadata.candidatesTokenCount > 0
-              ) {
-                totalOutputTokens +=
-                  usageMetadata.candidatesTokenCount - stepOutputTokens;
-                stepOutputTokens = usageMetadata.candidatesTokenCount;
-              }
-              // thoughtsTokenCount (thinking tokens, billed at the output
-              // rate) is NOT part of candidatesTokenCount — Gemini reports
-              // totalTokenCount = prompt + candidates + thoughts.
-              if (
-                usageMetadata.thoughtsTokenCount !== undefined &&
-                usageMetadata.thoughtsTokenCount > 0
-              ) {
-                totalReasoningTokens +=
-                  usageMetadata.thoughtsTokenCount - stepReasoningTokens;
-                stepReasoningTokens = usageMetadata.thoughtsTokenCount;
-              }
-            }
+              },
+            },
+          );
+          rawResponseParts.push(...collected.rawResponseParts);
+          stepFunctionCalls.push(...collected.stepFunctionCalls);
+          if (collected.finishReason) {
+            stepFinishReason = collected.finishReason;
+            lastFinishReason = collected.finishReason;
           }
 
           // Extract text from raw parts after stream completes
@@ -3294,96 +3382,36 @@ export class GoogleVertexProvider extends BaseProvider {
           // are therefore correct at every point mid-drain — a step killed
           // mid-stream (abort / turn deadline / stall watchdog) still counts
           // the billed tokens it already reported.
-          let stepInputTokens = 0;
-          let stepOutputTokens = 0;
-          let stepCacheReadTokens = 0;
-          let stepReasoningTokens = 0;
-
-          // Collect all chunks from stream
-          for await (const chunk of stream) {
-            turnClock.noteProgress();
-            // Extract raw parts from candidates FIRST
-            // This avoids using chunk.text which triggers SDK warning when
-            // non-text parts (thoughtSignature, functionCall) are present
-            const chunkRecord = chunk as Record<string, unknown>;
-            const candidates = chunkRecord.candidates as
-              | Array<Record<string, unknown>>
-              | undefined;
-            const firstCandidate = candidates?.[0];
-            // Capture the SDK finish reason (Bug 2: previously dropped). Last
-            // non-empty value across chunks wins.
-            const chunkFinishReason = firstCandidate?.finishReason;
-            if (typeof chunkFinishReason === "string" && chunkFinishReason) {
-              lastFinishReason = chunkFinishReason;
-              stepFinishReason = chunkFinishReason;
-            }
-            const chunkContent = firstCandidate?.content as
-              | Record<string, unknown>
-              | undefined;
-            if (chunkContent && Array.isArray(chunkContent.parts)) {
-              rawResponseParts.push(...chunkContent.parts);
-            }
-            if (chunk.functionCalls) {
-              stepFunctionCalls.push(...chunk.functionCalls);
-            }
-
-            // Extract usage metadata from chunk
-            // promptTokenCount is typically in the final chunk, candidatesTokenCount accumulates
-            const usageMetadata = chunkRecord.usageMetadata as
-              | {
-                  promptTokenCount?: number;
-                  candidatesTokenCount?: number;
-                  cachedContentTokenCount?: number;
-                  thoughtsTokenCount?: number;
-                  totalTokenCount?: number;
+          // Same collector as the streaming twin. generate() returns one
+          // result rather than streaming, so the channel is a no-op — the
+          // stream loop uses it to fill incrementalTextChunks for replay, and
+          // there is nothing to replay here. Everything else is identical,
+          // including the per-chunk usage deltas that keep the turn totals
+          // correct for a step killed mid-stream.
+          const collected = await collectVertexStreamChunks(
+            stream,
+            { push: () => {} },
+            {
+              onProgress: () => turnClock.noteProgress(),
+              onUsage: (input, output) => contextGuard.noteUsage(input, output),
+              onUsageDelta: (counter, delta) => {
+                if (counter === "input") {
+                  totalInputTokens += delta;
+                } else if (counter === "output") {
+                  totalOutputTokens += delta;
+                } else if (counter === "cacheRead") {
+                  totalCacheReadTokens += delta;
+                } else {
+                  totalReasoningTokens += delta;
                 }
-              | undefined;
-            if (usageMetadata) {
-              // Take the latest promptTokenCount (usually only in final chunk)
-              if (
-                usageMetadata.promptTokenCount !== undefined &&
-                usageMetadata.promptTokenCount > 0
-              ) {
-                totalInputTokens +=
-                  usageMetadata.promptTokenCount - stepInputTokens;
-                stepInputTokens = usageMetadata.promptTokenCount;
-                // Feed the context guard the REAL prompt size of this call.
-                contextGuard.noteUsage(
-                  usageMetadata.promptTokenCount,
-                  usageMetadata.candidatesTokenCount ?? 0,
-                );
-                // cachedContentTokenCount is OVERLAPPING (a subset already inside
-                // promptTokenCount). Clamp to the prompt count so an uncached
-                // step reports 0 instead of a stale cached value.
-                const chunkCacheReadTokens = Math.min(
-                  usageMetadata.cachedContentTokenCount ?? 0,
-                  usageMetadata.promptTokenCount,
-                );
-                totalCacheReadTokens +=
-                  chunkCacheReadTokens - stepCacheReadTokens;
-                stepCacheReadTokens = chunkCacheReadTokens;
-              }
-              // Take the latest candidatesTokenCount (accumulates through chunks)
-              if (
-                usageMetadata.candidatesTokenCount !== undefined &&
-                usageMetadata.candidatesTokenCount > 0
-              ) {
-                totalOutputTokens +=
-                  usageMetadata.candidatesTokenCount - stepOutputTokens;
-                stepOutputTokens = usageMetadata.candidatesTokenCount;
-              }
-              // thoughtsTokenCount (thinking tokens, billed at the output
-              // rate) is NOT part of candidatesTokenCount — Gemini reports
-              // totalTokenCount = prompt + candidates + thoughts.
-              if (
-                usageMetadata.thoughtsTokenCount !== undefined &&
-                usageMetadata.thoughtsTokenCount > 0
-              ) {
-                totalReasoningTokens +=
-                  usageMetadata.thoughtsTokenCount - stepReasoningTokens;
-                stepReasoningTokens = usageMetadata.thoughtsTokenCount;
-              }
-            }
+              },
+            },
+          );
+          rawResponseParts.push(...collected.rawResponseParts);
+          stepFunctionCalls.push(...collected.stepFunctionCalls);
+          if (collected.finishReason) {
+            stepFinishReason = collected.finishReason;
+            lastFinishReason = collected.finishReason;
           }
 
           // Extract text from raw parts after stream completes

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -2015,6 +2015,15 @@ export type NativeFunctionResponse = {
 };
 
 /** Result from collectStreamChunks. */
+/**
+ * Which turn-level counter a per-chunk Vertex usage delta belongs to.
+ *
+ * Vertex updates its turn totals incrementally so they stay correct mid-stream
+ * — a step killed by an abort, the turn deadline or the stall watchdog still
+ * bills the tokens it already reported.
+ */
+export type VertexUsageCounter = "input" | "output" | "cacheRead" | "reasoning";
+
 export type CollectedChunkResult = {
   rawResponseParts: unknown[];
   stepFunctionCalls: NativeFunctionCall[];

--- a/test/continuous-test-suite-vertex-loop-characterization.ts
+++ b/test/continuous-test-suite-vertex-loop-characterization.ts
@@ -914,4 +914,55 @@ await test("text is replayed after the turn completes, not streamed live", async
   );
 });
 
+section("generate path");
+
+await test("the generate path declares and executes a caller's tools", async () => {
+  // executeNativeGemini3Generate is a SECOND hand-rolled loop with its own
+  // stream drain, and nothing in this suite reached it — every other case
+  // drives nl.stream(). Task 10 migrates both loops, so the generate one needs
+  // its own baseline or a change there would be invisible here.
+  const server = await startStandIn((i) =>
+    i === 0
+      ? sse([{ functionCall: { name: "lookup", args: {} } }], "STOP")
+      : sse([{ text: "generated answer" }], "STOP"),
+  );
+  const restore = withVertexEnv();
+  const counter = { calls: 0 };
+  try {
+    const result = await nl().generate({
+      input: { text: "look something up" },
+      provider: "vertex",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      disableInternalFallback: true,
+      tools: customTool(counter),
+      credentials: credentialsFor(server.port),
+    });
+    console.log(
+      `    [diagnostic] vertex generate: calls=${server.calls.length} tools=${counter.calls} content=${JSON.stringify(String(result?.content ?? "").slice(0, 40))}`,
+    );
+    assert(
+      declaredToolNames(server.calls[0]).includes("lookup"),
+      "the generate path did not declare the caller's tool",
+    );
+    assert(counter.calls === 1, "the caller's tool did not execute once");
+    assert(
+      functionResponsePayloads(server.calls[1]).some(
+        (entry) => entry.name === "lookup",
+      ),
+      "the tool result was not carried back to the model",
+    );
+    assert(
+      typeof result?.content === "string" &&
+        result.content.includes("generated answer"),
+      "the final turn's text was not returned",
+    );
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
 await runSuite();


### PR DESCRIPTION
## What

Task 10 groundwork. Lifts the inline stream drain out of **both** Gemini loops — `executeNativeGemini3Stream` and `executeNativeGemini3Generate` — into `collectVertexStreamChunks`, returning the `CollectedChunkResult` shape that `collectStep` (#1436) expects. Each loop can then be handed to `createGeminiLoopAdapter` without changing how it reads a stream.

**Behaviour-preserving.** All ten Vertex characterization cases pass with byte-identical diagnostics:

```
step-cap      calls=4 tools=3 chars=25
failing-tool  attempts=2 calls=5
context-cap   calls=2 chars=219
generate      calls=2 tools=1 content="generated answer"
```

## The two drains were 83% similar

That is the range where assuming interchangeability is a mistake, so I diffed them line by line first. The only real difference: the stream loop iterates parts to emit text per-part, while generate does `rawResponseParts.push(...parts)` and emits none — it returns one result rather than streaming. Every other difference was a `,` vs `;`.

So generate passes a no-op channel and shares the collector.

## The couplings become hooks, not folded away

- **`onProgress`** — the turn clock's per-chunk ping, which stops the stall watchdog firing during a healthy stream.
- **`onUsage`** — the context guard's per-step prompt size.
- **`onUsageDelta`** — the turn totals, updated **per chunk**.

The last is deliberate. The deltas telescope to the step total, so returning one total for the caller to add is arithmetically identical — and operationally wrong. The loops update totals incrementally so they stay correct mid-stream, and `client.ts` states that a step killed by an abort, the turn deadline or the stall watchdog *"still counts the billed tokens it already reported"*. Verified rather than taken on faith: `totalInputTokens` is read at the result-building site and every abort path reaches it. A collector reporting only on return would lose those tokens — a billing defect.

## Coverage added first

Every existing case drove `nl.stream()`, so the generate loop was **entirely uncovered** — changing it would have been invisible. A generate-path case was added and proven to reach that loop by breaking only its drain: exactly that case fails, nothing else.

`VertexUsageCounter` lives in `src/lib/types/` per CLAUDE.md rule 2. Typecheck clean across 4830 files, eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vertex AI streaming so text, tool calls, completion reasons, and token usage are captured consistently.
  * Preserved progress updates and usage reporting during streamed responses.
  * Improved handling of multi-step tool interactions and final response generation.

* **Tests**
  * Added coverage for tool declarations, execution, function responses, final content delivery, and cleanup.
  * Added validation for Vertex AI streaming responses delivered through server-sent events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->