### PR TITLE
ci(workflow): build both halves before the optional-deps smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,8 +246,23 @@ jobs:
       - name: Install dependencies (full, for the build)
         run: pnpm install --frozen-lockfile
 
-      - name: Build CLI
-        run: pnpm run build:cli
+      # The FULL build, not `build:cli`. `build:cli` alone is a
+      # developer-iteration shortcut that assumes a `vite build` output is
+      # already sitting in dist/: it runs tsc plus
+      # scripts/collapse-cli-lib-duplicate.mjs, and that script rewrites
+      # dist/cli's "../../lib/x.js" specifiers to "../../x.js" and then
+      # verifies each one resolves. On a clean CI checkout the vite half of
+      # dist/ does not exist, so every rewritten specifier dangles and the
+      # script exits 1 by design — "the build is broken and must fail loudly
+      # instead of shipping a CLI with dangling imports".
+      #
+      # That is exactly what happened here: this job failed at Build CLI on
+      # every run since it was added, so the three smoke steps below had
+      # never once executed. `pnpm run build` runs `vite build` and then
+      # prepack, which itself runs build:cli — both halves, in the order the
+      # collapse script requires.
+      - name: Build (full — the CLI's collapse step needs the SDK output)
+        run: pnpm run build
 
       # dist/ survives this: it lives outside node_modules, so the CLI below
       # is the artifact built above, now running against a pruned tree.


### PR DESCRIPTION
## What

The **CLI Smoke Test (optional deps omitted)** job has been red since it was added and has **never once executed a smoke step**. It fails at `Build CLI`, so the three `node dist/cli/index.js` steps it exists for never run.

## Why it fails

`pnpm run build:cli` is a developer-iteration shortcut that assumes a vite build already sits in `dist/`. It runs `tsc` and then `scripts/collapse-cli-lib-duplicate.mjs`, which rewrites `dist/cli`'s `"../../lib/x.js"` specifiers to `"../../x.js"` and verifies each one resolves. On a clean CI checkout the vite half of `dist/` does not exist, so every rewritten specifier dangles and the script exits 1 — **by design**:

> the build is broken and must fail loudly instead of shipping a CLI with dangling imports

`pnpm run build` runs `vite build` and then `prepack`, which itself runs `build:cli`. Both halves, in the order the collapse step requires.

## Verification

Reproduced before fixing — move `dist/` aside, run `build:cli`, identical failure — rather than inferred from the CI log. Then ran the fixed job's exact steps locally, end to end:

```
### 1. install full        OK
### 2. full build          OK   → dist/cli/index.js
### 3. prune (--no-optional) OK
### 4. smoke --help        HELP OK
### 5. smoke --version     11.2.3
### 6. generate --help     GEN OK
```

## This is the second time I "fixed" this job

ea91c53d corrected the install *order* and I recorded it as fixed **without looking at whether the next run went green**. It did not. A job carrying `continue-on-error: true` is exactly the kind that stays red unnoticed — it proves nothing while red, and nothing complains.

So it stays non-blocking in this PR. The job's comment also claims an unmerged express fix blocks it from ever passing; d9f0b495 *is* merged and the local run above confirms `--help` now survives the prune, so that comment is stale too. Both the promotion to a required check and the comment rewrite land in a follow-up **after CI itself shows this job's conclusion change** — which is the whole point of the lesson above.