### PR TITLE
fix(googleAiStudio): restore the per-turn tool dedup

### DIFF
--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -71,6 +71,7 @@ import { estimateTokens } from "../../utils/tokenEstimation.js";
 import { transformToolExecutions } from "../../utils/transformationUtils.js";
 import { resolveToolExecutionRecords } from "../../core/toolExecutionRecorder.js";
 import {
+  buildDedupedEngineTools,
   buildGeminiResponseSchema,
   buildNativeConfig,
   computeMaxSteps,
@@ -1161,27 +1162,13 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 },
               };
 
-              const engineTools: Record<
-                string,
-                {
-                  execute: (
-                    args: Record<string, unknown>,
-                    opts: unknown,
-                  ) => Promise<unknown>;
-                }
-              > = {};
-              for (const [name, tool] of Object.entries(options.tools ?? {})) {
-                const execute = tool?.execute;
-                if (!execute) {
-                  continue;
-                }
-                engineTools[name] = {
-                  execute: async (
-                    args: Record<string, unknown>,
-                    opts: unknown,
-                  ) => execute(args, opts as Parameters<typeof execute>[1]),
-                };
-              }
+              // Through the turn's DedupExecuteMap, NOT the raw executors:
+              // `.get()` returns the dedup wrapper that answers an identical
+              // repeated {name, args} from the per-turn cache (BZ-3327).
+              const engineTools = buildDedupedEngineTools(
+                declarationsResult,
+                options.tools,
+              );
 
               const { stream: engineStream, resultPromise } = runAgenticLoop(
                 adapter,
@@ -1624,25 +1611,11 @@ export class GoogleAIStudioProvider extends BaseProvider {
             },
           };
 
-          const engineTools: Record<
-            string,
-            {
-              execute: (
-                args: Record<string, unknown>,
-                opts: unknown,
-              ) => Promise<unknown>;
-            }
-          > = {};
-          for (const [name, tool] of Object.entries(options.tools ?? {})) {
-            const execute = tool?.execute;
-            if (!execute) {
-              continue;
-            }
-            engineTools[name] = {
-              execute: async (args: Record<string, unknown>, opts: unknown) =>
-                execute(args, opts as Parameters<typeof execute>[1]),
-            };
-          }
+          // Same dedup routing as the streaming twin above.
+          const engineTools = buildDedupedEngineTools(
+            declarationsResult,
+            options.tools,
+          );
 
           const { stream: engineStream, resultPromise } = runAgenticLoop(
             adapter,

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -22,6 +22,7 @@ import type {
   GenerateStopReason,
   ZodUnknownSchema,
   ThinkingConfig,
+  AgenticLoopOptions,
   ChatMessage,
   CollectedChunkResult,
   MinimalChatMessage,
@@ -614,6 +615,57 @@ export function buildNativeToolDeclarations(
  * TOOL_NOT_FOUND. Mutates the snapshot in place — the request config holds
  * `toolsConfig` by reference — and returns true when anything was added.
  */
+/**
+ * Build the tool record handed to `runAgenticLoop`, routed through the turn's
+ * DedupExecuteMap.
+ *
+ * The engine looks tools up by the name the adapter reports, which is the
+ * ORIGINAL caller-facing name; `executeMap` is keyed by the SANITIZED wire
+ * name Google actually declares. `originalNameMap` is the bridge, and it
+ * carries an entry for every converted tool (identity mappings included), so
+ * iterating it yields exactly the declared, executable set.
+ *
+ * Going through `executeMap.get()` rather than the raw `tool.execute` is the
+ * entire point: `.get()` returns the dedup wrapper, so an identical
+ * {name, args} repeated within one turn is answered from the per-turn cache
+ * instead of running the tool again (BZ-3327). Passing the raw executor looks
+ * identical in every test that calls a tool once, and silently reintroduces
+ * duplicate side effects the moment the model repeats itself.
+ */
+export function buildDedupedEngineTools(
+  declarations: NativeToolDeclarationsResult | undefined,
+  tools: Record<string, Tool> | undefined,
+): NonNullable<AgenticLoopOptions["tools"]> {
+  const engineTools: NonNullable<AgenticLoopOptions["tools"]> = {};
+  if (declarations) {
+    for (const [safeName, originalName] of declarations.originalNameMap) {
+      const execute = declarations.executeMap.get(safeName);
+      if (!execute) {
+        continue;
+      }
+      engineTools[originalName] = {
+        execute: async (args: Record<string, unknown>, opts: unknown) =>
+          execute(args, opts as Parameters<typeof execute>[1]),
+      };
+    }
+    return engineTools;
+  }
+  // No declarations were built (no tools, or a path that skips the snapshot).
+  // Fall back to the caller's own executors so this helper can never REMOVE a
+  // tool that would otherwise have been callable.
+  for (const [name, tool] of Object.entries(tools ?? {})) {
+    const execute = tool?.execute;
+    if (!execute) {
+      continue;
+    }
+    engineTools[name] = {
+      execute: async (args: Record<string, unknown>, opts: unknown) =>
+        execute(args, opts as Parameters<typeof execute>[1]),
+    };
+  }
+  return engineTools;
+}
+
 export function refreshNativeToolDeclarations(
   liveTools: Record<string, Tool> | undefined,
   current: NativeToolDeclarationsResult,

--- a/test/continuous-test-suite-aistudio-loop-characterization.ts
+++ b/test/continuous-test-suite-aistudio-loop-characterization.ts
@@ -547,4 +547,124 @@ await test("the generate path hitting the step cap still returns the last step's
   }
 });
 
+section("repeated identical tool calls");
+
+// BZ-3327: Gemini re-emits a tool call with identical arguments across
+// agentic steps even though the prior result is already in the conversation
+// history. Re-executing means duplicate side effects and duplicate reports
+// for the user, so the per-turn executeMap (DedupExecuteMap) caches by
+// {name + stable-stringified args} and serves the repeat from the cache.
+//
+// Both AI Studio loops are covered because both had the dedup and both were
+// migrated onto the shared engine.
+
+await test("the streaming loop runs an identical repeated call only once", async () => {
+  const server = await startStandIn(() => toolTurn("repeatable", { q: "x" }));
+  const restore = withAiStudioEnv();
+  let dispatched = 0;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "call the same tool repeatedly" },
+      provider: "google-ai",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 5,
+      disableTools: false,
+      disableInternalFallback: true,
+      tools: {
+        repeatable: {
+          description: "records how often it really ran",
+          inputSchema: {
+            type: "object",
+            properties: { q: { type: "string" } },
+            additionalProperties: true,
+          },
+          execute: async () => {
+            dispatched++;
+            return { ran: dispatched };
+          },
+        },
+      },
+      credentials: credentialsFor(server.port),
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+  } catch {
+    // The dispatch count is what is pinned, not the turn's outcome.
+  } finally {
+    restore();
+    await server.close();
+  }
+  const responses = functionResponsePayloads(
+    server.calls[server.calls.length - 1],
+  );
+  console.log(
+    `    [diagnostic] aistudio dedup stream: dispatched=${dispatched} responses=${responses.length}`,
+  );
+  assert(
+    dispatched === 1,
+    `the repeated identical call executed ${dispatched} times instead of being served from the per-turn cache`,
+  );
+  // Both halves matter: the dispatch count alone would also be 1 if the loop
+  // had simply stopped after the first step.
+  assert(
+    responses.length === 4,
+    `the model was answered ${responses.length} times, so the turn did not keep running on cached results`,
+  );
+});
+
+await test("the generate loop runs an identical repeated call only once", async () => {
+  const server = await startStandIn(() => toolTurn("repeatable", { q: "x" }));
+  const restore = withAiStudioEnv();
+  let dispatched = 0;
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "call the same tool repeatedly" },
+      provider: "google-ai",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 5,
+      disableTools: false,
+      disableInternalFallback: true,
+      tools: {
+        repeatable: {
+          description: "records how often it really ran",
+          inputSchema: {
+            type: "object",
+            properties: { q: { type: "string" } },
+            additionalProperties: true,
+          },
+          execute: async () => {
+            dispatched++;
+            return { ran: dispatched };
+          },
+        },
+      },
+      credentials: credentialsFor(server.port),
+    });
+  } catch {
+    // The dispatch count is what is pinned, not the turn's outcome.
+  } finally {
+    restore();
+    await server.close();
+  }
+  const responses = functionResponsePayloads(
+    server.calls[server.calls.length - 1],
+  );
+  console.log(
+    `    [diagnostic] aistudio dedup generate: dispatched=${dispatched} responses=${responses.length}`,
+  );
+  assert(
+    dispatched === 1,
+    `the repeated identical call executed ${dispatched} times instead of being served from the per-turn cache`,
+  );
+  assert(
+    responses.length === 4,
+    `the model was answered ${responses.length} times, so the turn did not keep running on cached results`,
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## The regression

My own Task 9 migration dropped `DedupExecuteMap` from Google AI Studio, on **both** the stream and generate paths. Symbol counts across the two commits that did it:

```
509d090b (stream)    DedupExecuteMap 3 → 2    executeMap 6 → 3
ee9cc2a7 (generate)  DedupExecuteMap 2 → 0    executeMap 3 → 0
HEAD                 DedupExecuteMap 0        executeMap 0
```

The migrated code built its `engineTools` record by wrapping the **raw** executors out of `options.tools` instead of going through the dedup map. So BZ-3327 was live again for AI Studio: when Gemini re-emits a tool call with identical arguments across steps — the exact behaviour that class exists to absorb — the tool **re-executed**. Duplicate side effects, duplicate user-visible reports, wasted tokens.

## Proven before fixed

Two failing cases first, one per path. Both reported `dispatched=5` where `1` is correct:

```
[diagnostic] aistudio dedup stream:   dispatched=5 responses=4   ← before
[diagnostic] aistudio dedup generate: dispatched=5 responses=4   ← before
[diagnostic] aistudio dedup stream:   dispatched=1 responses=4   ← after
[diagnostic] aistudio dedup generate: dispatched=1 responses=4   ← after
```

Both halves of each assertion matter: the dispatch count alone would also read `1` if the loop had simply stopped after the first step, so the response count pins that the turn kept running on cached results.

## The fix is a re-wiring, not a reintroduction

`buildNativeToolDeclarations` already builds and returns a `DedupExecuteMap` — the migration just stopped consulting it. New shared helper `buildDedupedEngineTools()` routes `engineTools` back through `executeMap.get()`, which is the call that returns the dedup wrapper.

One wiring detail carries the whole thing: `executeMap` is keyed by the **sanitized** wire name, while the engine looks tools up by the **original** name the adapter reports. `originalNameMap` is the bridge, and it holds an entry for every converted tool (identity mappings included), so iterating it yields exactly the declared, executable set.

The helper cannot remove a callable tool. A tool that threw during conversion is absent from `originalNameMap`, but it also has no declaration, so the model cannot call it — and both call sites still pass `liveTools: options.tools ?? {}`, so `resolveToolOnMiss` covers it regardless.

## How it was missed, and what changed as a result

I audited this migration when I made it by grepping four hand-picked symbols (`extractToolFailureText`, `failedTools.delete`, `toolExecTimeoutMs`, `raceWithAbort`), got `0/0/0` on all four, and recorded "the migration dropped nothing". I never grepped the symbol that mattered. A four-symbol grep only ever proves something about those four symbols.

The replacement is a **set difference**: every identifier the old implementation referenced, minus every identifier the new one references. Run against these commits it prints `GONE: DedupExecuteMap` immediately. It also surfaced a second, unrelated loss on the Anthropic path, which is being fixed separately rather than smuggled in here.

## Scope

Deliberately excluded: I also wired the adapter's `resolveToolOnMiss` through the same map and then reverted it. No test in this suite can reach that path — AI Studio builds `liveTools` and its declarations from the same `options.tools`, so a declared tool never misses — and shipping an unverified change inside a regression fix makes the review harder, not easier. It belongs with the Vertex migration, where `search_tools` discovery makes it genuinely reachable and testable.

## Verification

- AI Studio characterization: **8/8** (was 6/8 with the two new cases failing)
- Vertex characterization: **10/10**, unaffected
- `test:providers-mocked` and `test:provider-structure`: pass — the pair CI actually gates
- typecheck 0 errors / 4830 files; eslint clean on every touched file (only pre-existing `max-lines-per-function` warnings)
