### PR TITLE
fix(core): thread the caller's span through the agentic loop

### DIFF
--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -141,7 +141,10 @@ export function runAgenticLoop<TConversation>(
                 throw hasEmitted ? new PostEmissionStepError(err) : err;
               }
             },
-            undefined, // no OTel span threaded through the engine today; adapters instrument their own steps if they need span-level detail
+            // The caller's span, when it passes one. withProviderRetry writes
+            // gen_ai.provider.total_attempts here, so a loop that threaded a
+            // span before it moved onto this engine keeps emitting it.
+            options.span,
             `${adapter.providerLabel}.step`,
           );
         } catch (err) {

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -2194,12 +2194,20 @@ export class AnthropicProvider extends BaseProvider {
         };
       }
 
+      // The active span goes with it. Before this loop moved onto the shared
+      // engine it called
+      //   withProviderRetry(fn, trace.getActiveSpan() ?? undefined, label)
+      // and that span is where gen_ai.provider.total_attempts is recorded.
+      // The engine passed `undefined` in its place, so the attribute silently
+      // stopped being emitted for every native Anthropic turn.
+      const activeSpan = trace.getActiveSpan();
       const { stream, resultPromise } = runAgenticLoop(
         adapter,
         payload.messages.slice(),
         {
           tools: engineTools,
           ...(abortSignal ? { abortSignal } : {}),
+          ...(activeSpan ? { span: activeSpan } : {}),
         },
       );
 

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -1,4 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
+import type { Span } from "@opentelemetry/api";
 import type { Tool } from "./tools.js";
 import type {
   CollectedChunkResult,
@@ -373,6 +374,19 @@ export type AgenticLoopOptions = {
     }
   >;
   abortSignal?: AbortSignal;
+  /**
+   * Span the per-step provider retry annotates, via
+   * `withProviderRetry(..., span, ...)` — it records
+   * `gen_ai.provider.total_attempts` on every completed step, retried or not.
+   *
+   * Caller-supplied rather than read from the ambient context inside the
+   * engine. Reading it here would hand the attribute to every provider on the
+   * engine, including ones whose hand-rolled loops never emitted it, and a
+   * refactor that silently ADDS observable behaviour is the same defect as one
+   * that silently drops it. Today only the direct Anthropic loops set this,
+   * because only they threaded a span before moving onto the engine.
+   */
+  span?: Span;
 };
 
 export type AgenticLoopResult<TConversation> = {

--- a/test/continuous-test-suite-anthropic-loop-characterization.ts
+++ b/test/continuous-test-suite-anthropic-loop-characterization.ts
@@ -41,6 +41,12 @@ import "dotenv/config";
 
 import { createServer, type Server } from "node:http";
 import { z } from "zod";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { assert, defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
 
@@ -49,6 +55,14 @@ assertDistFresh();
 const { test, section, runSuite } = defineSuite(
   "Anthropic loop characterization",
 );
+
+// Registered BEFORE NeuroLink is imported, so its tracers bind to this
+// provider. Only the span-attribute case below reads the exporter; for every
+// other case it is an inert extra span processor.
+const spanExporter = new InMemorySpanExporter();
+new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+}).register();
 
 const { NeuroLink } = await import("../dist/index.js");
 
@@ -511,6 +525,69 @@ await test("a truncated final_result payload survives verbatim instead of collap
     restore();
     await server.close();
   }
+});
+
+section("retry telemetry");
+
+await test("a native loop turn records the provider attempt count on the active span", async () => {
+  // Before this loop moved onto the shared engine it called
+  //   withProviderRetry(fn, trace.getActiveSpan() ?? undefined, label)
+  // and withProviderRetry writes gen_ai.provider.total_attempts on that span
+  // after every completed attempt, retried or not. The engine passed
+  // `undefined` in its place, so the attribute stopped being emitted for
+  // every native Anthropic turn — invisibly, because nothing asserted on it.
+  //
+  // One tool step so the turn actually runs on the agentic loop rather than a
+  // single-shot call.
+  const server = await startStandIn((i) =>
+    i === 0 ? toolTurn("lookup", { q: "x" }) : textTurn("done"),
+  );
+  const restore = withAnthropicEnv(server.port);
+  const counter = { calls: 0 };
+  spanExporter.reset();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "look something up" },
+      provider: "anthropic",
+      disableInternalFallback: true,
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      tools: customTool(counter),
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+  } finally {
+    restore();
+    await server.close();
+  }
+  const ATTR = "gen_ai.provider.total_attempts";
+  const carrying = spanExporter
+    .getFinishedSpans()
+    .filter((span: ReadableSpan) => span.attributes[ATTR] !== undefined);
+  console.log(
+    `    [diagnostic] anthropic retry telemetry: toolCalls=${counter.calls} spansWithAttr=${carrying.length} values=${carrying
+      .map((span: ReadableSpan) => String(span.attributes[ATTR]))
+      .join(",")}`,
+  );
+  assert(
+    counter.calls === 1,
+    "the turn did not run a tool step, so it never reached the agentic loop",
+  );
+  assert(
+    carrying.length > 0,
+    "no span carries the provider attempt count, so the loop is not passing one",
+  );
+  // Every step of a clean turn succeeds first try, so each recorded count is 1.
+  // Asserting the VALUE and not merely the key's presence is what keeps this
+  // from passing on an attribute written by some unrelated code path.
+  assert(
+    carrying.every((span: ReadableSpan) => span.attributes[ATTR] === 1),
+    "a step reported an attempt count other than the single attempt it made",
+  );
 });
 
 await runSuite();


### PR DESCRIPTION
## The regression

Before the native Anthropic stream turn moved onto the shared loop engine, it called:

```ts
withProviderRetry(fn, trace.getActiveSpan() ?? undefined, `${this.providerName} stream`)
```

`withProviderRetry` writes `gen_ai.provider.total_attempts` on that span after every completed attempt — retried or not. `runAgenticLoop` passed `undefined` in its place, so the attribute silently stopped being emitted for every native Anthropic turn.

The engine carried a comment justifying it:

> no OTel span threaded through the engine today; adapters instrument their own steps if they need span-level detail

I wrote that comment. It is a rationalization written after the fact, not a decision checked against what the old code did. No adapter instruments anything — the attribute just stopped appearing.

## The fix

`AgenticLoopOptions` gains `span?: Span`; the engine passes it to `withProviderRetry`; the Anthropic caller passes `trace.getActiveSpan()` exactly as it used to.

**Caller-supplied, not read from ambient context inside the engine.** Calling `trace.getActiveSpan()` in the engine would be one line shorter and would hand the attribute to *every* provider on the engine — including Google AI Studio, whose hand-rolled loops never emitted it (confirmed: `getActiveSpan` is absent from its pre-migration symbol set). A refactor that silently **adds** observable behaviour is the same defect as one that silently drops it, so this is opt-in and only the Anthropic loops set it.

Only two call sites thread a span into `withProviderRetry` at all — `openaiChatCompletionsBase.ts:1339`, which never moved onto the engine, and this one. No other provider is affected.

## Proven both ways, on a real build

```
without the fix   [diagnostic] anthropic retry telemetry: toolCalls=1 spansWithAttr=0 values=
                  ✗ a native loop turn records the provider attempt count on the active span
                  Passed: 5, Failed: 1

with the fix      [diagnostic] anthropic retry telemetry: toolCalls=1 spansWithAttr=1 values=1
                  Passed: 6
```

The new case asserts the attribute's **value** is `1`, not merely that the key exists, so it cannot pass on an attribute written by some unrelated code path. It also asserts the tool actually ran, so a turn that never reached the agentic loop fails rather than vacuously passing.

The case lives in the existing Anthropic characterization suite, which already has the HTTP stand-in and SSE framing. An `InMemorySpanExporter` is registered above the `dist/` import so NeuroLink's tracers bind to it; for the other five cases it is an inert extra span processor, and all five still pass.

## How it was found

Not by noticing the missing attribute — nothing asserts on it, which is exactly why it went unnoticed. It came out of a **set-difference audit** of the migration commit: every identifier the old implementation referenced, minus every identifier the new one references. Eleven symbols vanished; eight were noise or legitimately relocated (`stringifyFinalResultInput` → `loopAdapter.ts:337`, `resolveDeferredTool` → `loopAdapter.ts:88`, `withProviderRetry` → the engine), and `getActiveSpan` was the one that had simply been dropped.

The same audit run against the Google AI Studio migration surfaced a separate, larger regression, fixed in #1444.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of retry-attempt tracking during provider interactions.
  - Anthropic streaming requests now correctly record retry information in telemetry.

- **Observability**
  - Added per-step provider attempt details to OpenTelemetry traces.
  - Enhanced tracing coverage for tool-enabled Anthropic conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->