### PR TITLE
fix(core): honour an abort between tool executions

### DIFF
--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -179,7 +179,19 @@ export function runAgenticLoop<TConversation>(
         }
 
         const toolResults: AgenticLoopToolCallResult[] = [];
+        let abortedMidBatch = false;
         for (const call of stepResult.toolCalls) {
+          // Honour an abort BETWEEN tool executions. A step can carry several
+          // calls, and each one costs up to a full tool timeout, so without
+          // this a wide batch keeps running long past the moment the turn was
+          // cancelled — the step-top check above only fires once the whole
+          // batch has drained. Passing the signal into execute() is not
+          // enough on its own: a tool that ignores it still runs to
+          // completion, and every remaining call still gets STARTED.
+          if (internalAbort.signal.aborted) {
+            abortedMidBatch = true;
+            break;
+          }
           allToolCalls.push(call);
           const breaker = adapter.toolFailureBreaker;
           const failInfo = breaker ? failedTools.get(call.name) : undefined;
@@ -270,6 +282,16 @@ export function runAgenticLoop<TConversation>(
               error: message,
             });
           }
+        }
+
+        // A batch cut short leaves some calls without results, and the
+        // tool-result turn is appended as one message: writing it here would
+        // put an unanswered tool call into history. Anthropic rejects exactly
+        // that on the next request, and Gemini carries a dangling call
+        // forward. Break instead, leaving history ending on the model turn —
+        // which is a valid place to stop.
+        if (abortedMidBatch) {
+          break;
         }
 
         conversation = adapter.buildToolResultMessages(

--- a/test/continuous-test-suite-aistudio-loop-characterization.ts
+++ b/test/continuous-test-suite-aistudio-loop-characterization.ts
@@ -667,4 +667,95 @@ await test("the generate loop runs an identical repeated call only once", async 
   );
 });
 
+section("abort between tool executions");
+
+await test("an abort mid-step stops the loop from dispatching the rest of the batch", async () => {
+  // A step can carry several tool calls. When the turn is aborted — caller
+  // cancel, turn deadline, stall watchdog — the remaining calls in that batch
+  // must not be started: each one costs up to a full tool timeout, so a wide
+  // batch keeps running long past the moment the turn was cancelled.
+  //
+  // The abort is raised from inside the FIRST tool, which is the realistic
+  // shape (a deadline trips while a tool is running) and makes the test
+  // deterministic without any timing assumptions.
+  const server = await startStandIn(() =>
+    sse(
+      [
+        { functionCall: { name: "first", args: {} } },
+        { functionCall: { name: "second", args: {} } },
+      ],
+      "STOP",
+    ),
+  );
+  const restore = withAiStudioEnv();
+  const controller = new AbortController();
+  let firstCalls = 0;
+  let secondCalls = 0;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "call both tools" },
+      provider: "google-ai",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      disableInternalFallback: true,
+      abortSignal: controller.signal,
+      credentials: credentialsFor(server.port),
+      tools: {
+        first: {
+          description: "aborts the turn",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: true,
+          },
+          execute: async () => {
+            firstCalls++;
+            controller.abort();
+            return { ok: true };
+          },
+        },
+        second: {
+          description: "must not run once the turn is aborted",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: true,
+          },
+          execute: async () => {
+            secondCalls++;
+            return { ok: true };
+          },
+        },
+      },
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+  } catch {
+    // An aborted turn may surface as a throw; the dispatch counts are pinned.
+  } finally {
+    restore();
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] aistudio abort-mid-batch: first=${firstCalls} second=${secondCalls} calls=${server.calls.length}`,
+  );
+  assert(firstCalls === 1, "the first tool did not run exactly once");
+  assert(
+    secondCalls === 0,
+    "the rest of the batch was dispatched after the turn was aborted",
+  );
+  // And the turn stopped rather than issuing another request: a partial
+  // tool-result turn must never be written back, since an unanswered tool
+  // call in history is rejected outright by Anthropic and carried forward by
+  // Gemini.
+  assert(
+    server.calls.length === 1,
+    `the loop issued ${server.calls.length} requests, so it continued past the abort`,
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## What

`runAgenticLoop` never checked for an abort **between** tool executions. A single step can carry several tool calls, and the engine dispatched every one of them regardless of whether the turn had already been cancelled.

The step-top check only fires once the whole batch has drained, so a wide batch keeps running long past the moment the turn was cancelled — up to a full tool timeout per remaining call.

Passing `abortSignal` into `execute()` is not a substitute. A tool that ignores its signal runs to completion, and — more to the point — every remaining call still gets **started**.

Vertex's hand-rolled loop has had this check all along, with the reason spelled out in its own comment:

> without this check a multi-tool step keeps executing its whole batch (up to N × toolTimeoutMs past the deadline) before the while-top check finally breaks

The two providers already on the engine, Google AI Studio and direct Anthropic, lost it when they migrated. This restores it engine-side, so Vertex keeps the behaviour when it migrates too.

## Characterized first, and watched fail

A stand-in turn emitting **two** tool calls in one step; the first tool raises the caller's abort. That is the realistic shape — a deadline trips while a tool is running — and it needs no timing assumptions.

```
before   [diagnostic] aistudio abort-mid-batch: first=1 second=1 calls=1
after    [diagnostic] aistudio abort-mid-batch: first=1 second=0 calls=1
```

## A partial tool-result turn must never be written back

The fix is two changes, not one. Breaking out of the dispatch loop is the obvious half; the second is that the engine must **not** then call `buildToolResultMessages`.

A batch cut short leaves some calls without results, and the tool-result turn is appended as a single message. Writing it would put an unanswered tool call into the returned conversation — which Anthropic rejects outright on the next request, and Gemini silently carries forward. So the loop breaks before appending, leaving history ending on the model turn, which is a valid place to stop.

The case pins this too: `calls=1` asserts the loop issued no further request after the abort, so a fix that stopped dispatching but kept the turn going would still fail.

## Where the check sits matters

It goes **before** `allToolCalls.push(call)`, not after. A call that was never dispatched should not be reported as a tool call the turn made — and this is exactly where Vertex puts its own check (`client.ts:2323`, with the push at `2327`), so the engine and the reference implementation agree on what an aborted batch reports.

## A false start worth recording

The first run of this case reported `first=0 second=0 calls=0` — neither tool ran. That looks like the abort working perfectly. It wasn't: I had omitted `credentials: credentialsFor(server.port)`, so the turn never reached the stand-in at all and died on `Invalid Google AI API key`.

The expected numbers were not adjusted to match. The diagnostic was widened to print the request count and the caught error, which said so plainly. A case that never reaches the stand-in fails for a right-looking reason, so the request count is now part of the permanent diagnostic.

## Verification

- AI Studio characterization: **7/7** (was 6/7 with the new case failing)
- Anthropic characterization, Vertex characterization: unaffected
- `test:providers-mocked` and `test:provider-structure`: pass
- typecheck 0 errors; eslint clean on both touched files

No opt-in flag: unlike the other engine gaps in this area, honouring an abort promptly is correct for every adapter, so there is nothing for a provider to opt into.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation during multi-step tool operations.
  * Remaining tool actions no longer start after an abort.
  * Prevented incomplete tool results from being added to conversation history.
  * Stopped additional model requests after cancellation.
  * Improved retry tracking for operations that use provider retries.

* **Tests**
  * Added coverage for cancellation during tool execution and repeated tool calls in streaming and generated responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->