### PR TITLE
test(anthropic): pin which span carries the retry attempt count

### DIFF
--- a/test/continuous-test-suite-anthropic-loop-characterization.ts
+++ b/test/continuous-test-suite-anthropic-loop-characterization.ts
@@ -569,7 +569,7 @@ await test("a native loop turn records the provider attempt count on the active 
     .getFinishedSpans()
     .filter((span: ReadableSpan) => span.attributes[ATTR] !== undefined);
   console.log(
-    `    [diagnostic] anthropic retry telemetry: toolCalls=${counter.calls} spansWithAttr=${carrying.length} values=${carrying
+    `    [diagnostic] anthropic retry telemetry: toolCalls=${counter.calls} spansWithAttr=${carrying.length} names=${carrying.map((s2: ReadableSpan) => s2.name).join("|")} values=${carrying
       .map((span: ReadableSpan) => String(span.attributes[ATTR]))
       .join(",")}`,
   );
@@ -581,9 +581,24 @@ await test("a native loop turn records the provider attempt count on the active 
     carrying.length > 0,
     "no span carries the provider attempt count, so the loop is not passing one",
   );
+  // Named, not merely present. The attribute lands on the turn's own
+  // `neurolink.stream` span — the one the SDK opens around the request, which
+  // is what `trace.getActiveSpan()` resolves to when the client hands its span
+  // to the loop. Pinning the name is what stops this passing on an attribute
+  // some unrelated provider path wrote on a different span.
+  //
+  // It cannot be pinned by wrapping this call in the test's own
+  // `startActiveSpan` and asserting on that wrapper: the SDK opens
+  // `neurolink.stream` beneath it, so the attribute lands on the child and the
+  // wrapper stays bare. Verified by printing the carrying span's name rather
+  // than assumed.
+  assert(
+    carrying.every((span: ReadableSpan) => span.name === "neurolink.stream"),
+    "the attempt count was recorded on some span other than the turn's own",
+  );
   // Every step of a clean turn succeeds first try, so each recorded count is 1.
-  // Asserting the VALUE and not merely the key's presence is what keeps this
-  // from passing on an attribute written by some unrelated code path.
+  // Asserting the VALUE and not merely the key's presence keeps a broken
+  // attempt counter from passing.
   assert(
     carrying.every((span: ReadableSpan) => span.attributes[ATTR] === 1),
     "a step reported an attempt count other than the single attempt it made",


### PR DESCRIPTION
Follow-up to #1445, acting on a review note left on it.

## The valid half of the note

The assertion accepted **any** finished span carrying `gen_ai.provider.total_attempts`, so an attribute written by an unrelated provider path would have satisfied it. That is a fair criticism and this tightens it.

## The suggested fix does not work, and why is worth recording

The note proposed wrapping `nl.stream()` in the test's own `startActiveSpan` and asserting on that span. That would fail.

The attribute lands on **`neurolink.stream`** — the span the SDK opens around the request, and what `trace.getActiveSpan()` resolves to when the Anthropic client hands its span to the loop. A test-created wrapper sits *above* that span, so the attribute goes to the child and the wrapper stays bare.

Established by printing the carrying span's name rather than assumed in either direction:

```
[diagnostic] anthropic retry telemetry: toolCalls=1 spansWithAttr=1 names=neurolink.stream values=1
```

## What this does instead

Pins the span by name, which buys the same tightness without the incorrect mechanism. Mutating the expected name to anything else fails exactly this case and no other:

```
name → "some.other.span"   →  Passed: 5, Failed: 1
```

The three assertions now cover identity, value, and that the tool actually ran — so the case cannot pass on a span that isn't the turn's own, on a wrong attempt count, or on a turn that never reached the agentic loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced retry telemetry validation to report the spans associated with provider attempt counts.
  * Added checks confirming these telemetry spans use the expected naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->