### PR TITLE
fix(proxy): mark the primary account on /accounts and close the review gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,17 @@
 # HTTP_PROXY=http://username:password@proxy.company.com:8080
 
 # =============================================================================
+# NEUROLINK SUBSCRIPTION PROXY (Optional, debugging)
+# =============================================================================
+# Capture one raw Codex SSE response to a file, to confirm the `usage` wire
+# shape against live traffic. Off unless this names a path.
+#
+# ⚠️ The captured bytes are the assistant's actual response. Turn it on
+# deliberately, point it somewhere you control, and delete the file afterwards.
+# Capture stops at the first completed stream and is capped at 256 KiB.
+# NEUROLINK_PROXY_CODEX_CAPTURE=/tmp/codex-capture.sse
+
+# =============================================================================
 # OPENAI CONFIGURATION
 # =============================================================================
 # Required for OpenAI provider

--- a/docs-site/scripts/sync-docs.ts
+++ b/docs-site/scripts/sync-docs.ts
@@ -935,6 +935,20 @@ const LINK_MAPPINGS: Record<string, string> = {
   "claude-proxy-config-reference.md": "/features/claude-proxy-config-reference",
   "claude-proxy-troubleshooting": "/features/claude-proxy-troubleshooting",
   "claude-proxy-troubleshooting.md": "/features/claude-proxy-troubleshooting",
+  // The rest of the proxy family. Without an entry the rewriter drops the
+  // `features/` segment and emits /docs/<name>, which is not a page — a
+  // relative link from features/index.md then fails the Docusaurus broken-link
+  // check even though the doc is copied and reachable.
+  "proxy-accounts-endpoint": "/features/proxy-accounts-endpoint",
+  "proxy-accounts-endpoint.md": "/features/proxy-accounts-endpoint",
+  "proxy-cli-onboarding": "/features/proxy-cli-onboarding",
+  "proxy-cli-onboarding.md": "/features/proxy-cli-onboarding",
+  "codex-proxy-support": "/features/codex-proxy-support",
+  "codex-proxy-support.md": "/features/codex-proxy-support",
+  "opencode-proxy-support": "/features/opencode-proxy-support",
+  "opencode-proxy-support.md": "/features/opencode-proxy-support",
+  "claude-proxy-observability": "/features/claude-proxy-observability",
+  "claude-proxy-observability.md": "/features/claude-proxy-observability",
 
   // Provider guides -> getting-started/providers
   "ollama-setup": "/getting-started/providers/ollama",

--- a/docs/features/proxy-accounts-endpoint.md
+++ b/docs/features/proxy-accounts-endpoint.md
@@ -106,6 +106,12 @@ not hammer Anthropic.
   seconds fields get a `*Ms` companion; the rest pass through untouched.
   Blanket-multiplying the object would throw the millisecond fields tens of
   thousands of years forward.
+- **`isPrimary`** marks the account the pool prefers, from the proxy's
+  hot-reloaded routing config where one is set and the value it was constructed
+  with otherwise. Keys compare normalised, so a bare label (`me@example.com`)
+  and a full pool key (`anthropic:me@example.com`) match. It is `false` on
+  `internal` and `translation` rows, which are not credentials and cannot be
+  primary.
 - **`severity` and `isActive`** are absent on header-sourced `overage` windows —
   a structural property of how those rows are parsed, not a transient gap. This
   endpoint fills them (`severity: "critical"` when the window is rejected,

--- a/docs/features/proxy-cli-onboarding.md
+++ b/docs/features/proxy-cli-onboarding.md
@@ -531,8 +531,8 @@ equivalent, so that state must be persisted to disk.
 
 ## 8. Defects
 
-Eleven filed on `juspay/neurolink`. Eight are fixed on this branch (local, not
-released); three remain open.
+Eleven filed on `juspay/neurolink`. Eight are fixed and released (v11.13.0 and
+v11.14.0, via #1399-#1402); three remain open.
 
 | #   | Defect                                                                                      | Location                                     | Issue                                                    | Status                                |
 | --- | ------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------- | ------------------------------------- |

--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -74,13 +74,15 @@ const ACCEPTED_RISK_ADVISORY_IDS: Record<string, string> = {
   // body-parser — transitive via express, low severity.
   "1123976":
     "body-parser size-limit bypass (low severity) — transitive via express",
-  // fast-uri — three advisories, all through modelcontextprotocol/sdk's ajv.
+  // fast-uri — four advisories, all through modelcontextprotocol/sdk's ajv.
   "1124064":
     "fast-uri host confusion — transitive via @modelcontextprotocol/sdk's ajv dependency",
   "1130720":
     "fast-uri host confusion (backslash variant) — same @modelcontextprotocol/sdk>ajv chain as 1124064",
   "1145555":
     "fast-uri host confusion (IDN variant) — same @modelcontextprotocol/sdk>ajv chain as 1124064",
+  "1145636":
+    "fast-uri host confusion (failed IDN canonicalization) — same @modelcontextprotocol/sdk>ajv chain as 1124064",
   // sharp — optional dependency for the image-processing feature only.
   "1124066":
     "sharp libvips CVEs — optionalDependency for image handling, not required at runtime for most consumers",

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -8695,6 +8695,17 @@ export function createClaudeProxyRoutes(
           const routing = runtimeConfigProvider?.();
           const effectiveAllowlist =
             routing?.accountAllowlist ?? accountAllowlist;
+          // Hot-reloaded routing wins over the value baked in at construction,
+          // the same precedence the request path uses.
+          const effectivePrimaryKey =
+            routing?.primaryAccountKey ?? primaryAccountKey;
+          // Rows carry a bare label in one loop and a full pool key in the
+          // other; anthropicAccountKeysEqual normalises both, so neither can
+          // miss the match on prefix alone.
+          const isPrimaryAccount = (keyOrLabel: string | null): boolean =>
+            !!effectivePrimaryKey &&
+            !!keyOrLabel &&
+            anthropicAccountKeysEqual(keyOrLabel, effectivePrimaryKey);
 
           // Cached by default. This endpoint is built to be polled, and a live
           // refresh spends the user's own OAuth credentials against Anthropic's
@@ -8810,7 +8821,7 @@ export function createClaudeProxyRoutes(
               cooling,
               allowed: null,
               expired: null,
-              isPrimary: false,
+              isPrimary: isPrimaryAccount(result.key ?? label),
               requests: stat ? stat.successCount + stat.errorCount : null,
               errors: stat?.errorCount ?? null,
               rateLimits: stat?.rateLimitCount ?? null,
@@ -8855,7 +8866,7 @@ export function createClaudeProxyRoutes(
               cooling: false,
               allowed: null,
               expired: null,
-              isPrimary: false,
+              isPrimary: isPrimaryAccount(entry.label),
               requests: entry.successCount + entry.errorCount,
               errors: entry.errorCount,
               rateLimits: entry.rateLimitCount,

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -2985,6 +2985,67 @@ async function testAccountsRowsAreClassifiedByKind(): Promise<boolean> {
 }
 
 /**
+ * The configured primary account must be identifiable in the row set.
+ *
+ * Both row loops hardcoded `isPrimary: false`, so the field was always false
+ * and a dashboard could never mark the account the pool actually prefers —
+ * while `CliAccountsRow` still advertised it as meaningful. The key is
+ * available in the handler's own closure, and account keys compare through
+ * anthropicAccountKeysEqual, which normalises a bare label to its full key.
+ */
+async function testAccountsMarksThePrimaryAccount(): Promise<boolean> {
+  const { createClaudeProxyRoutes } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  const stats = await import("../src/lib/proxy/usageStats.js");
+  await stats.resetUsageStatsForTests();
+
+  stats.recordAttempt("primary@example.com", "oauth");
+  stats.recordFinalSuccess("primary@example.com", "oauth");
+  stats.recordAttempt("other@example.com", "oauth");
+  stats.recordFinalSuccess("other@example.com", "oauth");
+
+  const route = createClaudeProxyRoutes(
+    undefined,
+    "",
+    "fill-first",
+    false,
+    // Full pool key; the rows carry the bare label, so the comparison has to
+    // normalise rather than match on string identity.
+    "anthropic:primary@example.com",
+  ).routes.find((r) => r.path.endsWith("/accounts"));
+  if (!route) {
+    log("GET /accounts is not registered", "red");
+    return false;
+  }
+
+  const body = (await route.handler({
+    query: {},
+    headers: {},
+    method: "GET",
+    path: "/accounts",
+    requestId: "suite",
+  } as never)) as {
+    accounts?: { label?: string; isPrimary?: boolean }[];
+  };
+  const rows = body.accounts ?? [];
+  if (rows.length < 2) {
+    log("accounts did not report the seeded rows", "red");
+    return false;
+  }
+  const byLabel = new Map(rows.map((r) => [r.label, r]));
+  if (byLabel.get("primary@example.com")?.isPrimary !== true) {
+    log("the configured primary account was not marked as primary", "red");
+    return false;
+  }
+  if (byLabel.get("other@example.com")?.isPrimary !== false) {
+    log("a non-primary account was marked as primary", "red");
+    return false;
+  }
+  await stats.resetUsageStatsForTests();
+  return true;
+}
+
+/**
  * Quota windows must reach consumers already normalised.
  *
  * Asserted directly rather than through the route: a window only appears on a
@@ -5314,6 +5375,11 @@ const tests: TestFunction[] = [
   {
     name: "Accounts: every row is classified by kind",
     fn: testAccountsRowsAreClassifiedByKind,
+    category: "proxy-config",
+  },
+  {
+    name: "Accounts: the configured primary account is marked",
+    fn: testAccountsMarksThePrimaryAccount,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
Follow-up to #1402, which merged with review findings still open. Everything here was raised on that PR and verified against `release` before being touched — three of the four code findings had already been fixed by another session and are deliberately not repeated.

## Still open, fixed here

**`isPrimary` was hardcoded `false` on both row loops** — raised by both CodeRabbit and Yama. The field could never be true, so a dashboard had no way to mark the account the pool actually prefers, while `CliAccountsRow` documented it as meaningful. Everything needed was already in the handler's closure. It now resolves from the hot-reloaded routing config where one is set and the constructed value otherwise — the same precedence the request path uses — and compares through `anthropicAccountKeysEqual`, so a bare label (`me@example.com`) and a full pool key (`anthropic:me@example.com`) cannot miss each other on the prefix. `internal` and `translation` rows stay `false`: they are not credentials and cannot be primary.

**`NEUROLINK_PROXY_CODEX_CAPTURE` was undocumented** — raised by Yama. It existed only in `codexUsage.ts` and the codex suite. It writes the assistant's actual response to a file, so an operator turning it on should find the warning attached, not discover it by reading source. Now in `.env.example`, commented out, with the 256 KiB cap and the privacy note.

**The defect table said eight fixes were "on this branch (local, not released)"** — true when written, false the moment #1402 merged. They shipped in v11.13.0 and v11.14.0.

## Already fixed on `release` — verified, not repeated

- `cooling` always `false`: the handler read `cooldowns[key]?.until` while the persisted field is `coolingUntil`. The `as { until?: number }` assertion is precisely what stopped the compiler from reporting it. Now typed from the loader.
- A rejected or throttled **session** window returning `status: "active"`
- Unrouted account rows dropping their ledger usage
- Personal absolute paths in committed docs
- Six documentation-accuracy items

## One unrelated change, flagged for a second opinion

`validate:security` **fails on a clean `release` checkout** — `Unaccepted high advisory 1145636 in fast-uri`. It runs inside the CI `test` job, so it currently blocks every open PR, not just this one. Advisory `1145636` is a fourth published id for the same host-confusion issue on the same `@modelcontextprotocol/sdk > ajv` chain whose other three ids (`1124064`, `1130720`, `1145555`) are already on the accepted list with that rationale, so this is bookkeeping for an already-accepted risk rather than a new acceptance. Included because nothing can go green without it — but it is a security-policy call, so say the word and I will split it out.

## Verification

Run locally on this branch before pushing:

| Check | Result |
| --- | --- |
| `tsc --noEmit --strict` | clean |
| `eslint src test` | 0 errors (54 pre-existing `max-lines-per-function` warnings) |
| `pnpm run build` | clean, publint "All good!" |
| `continuous-test-suite-proxy` | **64 passed**, 6 skipped |
| `continuous-test-suite-codex` | **31 passed** |
| `test:providers-mocked` (CI gate) | 54 passed, 0 failed |
| `test:provider-structure` (CI gate) | 3 passed |
| `validate:security` | passes with the advisory accepted; **fails on clean `release` without it** |

The `isPrimary` change has a regression test that was watched failing first — it seeds two accounts, configures one as primary by full key, and asserts the bare-label row matches while the other does not.
