### PR TITLE
fix(docs): restore the docs MCP server and cover it so it stops regressing

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "// CI tier — fast, no live AI calls, safe for every commit (test:unit; also see the separate provider-safety-net CI job, which runs build + test:providers-mocked + test:provider-structure + test:error-classifier-contract on every PR)": "",
     "test:tool-routing": "npx tsx test/continuous-test-suite-tool-routing.ts",
     "test:tool-routing-semantic": "npx tsx test/continuous-test-suite-tool-routing-semantic.ts",
-    "test:unit": "pnpm run test:bugfixes && pnpm run test:mcp:infra && pnpm run test:mcp:spans && pnpm run test:tool-routing && pnpm run test:tool-routing-cli && pnpm run test:tool-dedup && pnpm run test:model-pool && pnpm run test:tool-routing-semantic && pnpm run test:mcp-result-cache && pnpm run test:model-not-found-retryable && pnpm run test:archive:security && pnpm run test:office:security && pnpm run test:vector-chroma && pnpm run test:vector-pgvector && pnpm run test:vector-pinecone && pnpm run test:provider-wiring",
+    "test:unit": "pnpm run test:bugfixes && pnpm run test:mcp:infra && pnpm run test:mcp:spans && pnpm run test:tool-routing && pnpm run test:tool-routing-cli && pnpm run test:tool-dedup && pnpm run test:model-pool && pnpm run test:tool-routing-semantic && pnpm run test:mcp-result-cache && pnpm run test:model-not-found-retryable && pnpm run test:archive:security && pnpm run test:office:security && pnpm run test:vector-chroma && pnpm run test:vector-pgvector && pnpm run test:vector-pinecone && pnpm run test:provider-wiring && pnpm run test:docs-mcp",
     "// CI tier — live providers, runs only when API keys are present (test:credentials and test:dynamic make real provider calls when keys are set, so they live here, not in test:unit; test:matrix, a different suite covering the full provider capability matrix, runs nightly via .github/workflows/live-matrix.yml — test:providers itself is still only wired into test:live, not any GitHub Actions workflow)": "",
     "test:live": "pnpm run test:providers && pnpm run test:mcp:http && pnpm run test:mcp:sdk && pnpm run test:mcp:cli && pnpm run test:observability && pnpm run test:context && pnpm run test:memory && pnpm run test:tool-reliability && pnpm run test:evaluation && pnpm run test:autoresearch && pnpm run test:credentials && pnpm run test:dynamic",
     "// CI tier — product output (image/video/TTS/PPT) — costs $$ per run (not wired into any GitHub Actions workflow as of this comment; run manually or add to live-matrix.yml if nightly coverage is needed)": "",
@@ -210,7 +210,8 @@
     "test:bedrock-loop-characterization": "tsx test/continuous-test-suite-bedrock-loop-characterization.ts",
     "test:sagemaker-streaming": "tsx test/continuous-test-suite-sagemaker-streaming.ts",
     "test:anthropic-loop-characterization": "tsx test/continuous-test-suite-anthropic-loop-characterization.ts",
-    "test:aistudio-loop-characterization": "tsx test/continuous-test-suite-aistudio-loop-characterization.ts"
+    "test:aistudio-loop-characterization": "tsx test/continuous-test-suite-aistudio-loop-characterization.ts",
+    "test:docs-mcp": "npx tsx test/continuous-test-suite-docs-mcp.ts"
   },
   "files": [
     "dist",
@@ -377,6 +378,7 @@
     "js-yaml": "^4.3.1",
     "json-schema-to-zod": "^2.7.0",
     "jsonrepair": "^3.14.0",
+    "minisearch": "^7.2.0",
     "nanoid": "^5.1.16",
     "ora": "^9.3.0",
     "p-limit": "^7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       nanoid:
         specifier: ^5.1.16
         version: 5.1.16

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -36,6 +36,7 @@ import { EvaluateCommandFactory } from "./commands/evaluate.js";
 import { TaskCommandFactory } from "./commands/task.js";
 import { AutoresearchCommandFactory } from "./commands/autoresearch.js";
 import { voiceServerCommand } from "./commands/voiceServer.js";
+import { DocsCommandFactory } from "./commands/docs.js";
 
 // Enhanced CLI with Professional UX
 export function initializeCliParser() {
@@ -181,6 +182,8 @@ export function initializeCliParser() {
 
       // Generate Command (Primary) - Using CLICommandFactory
       .command(CLICommandFactory.createGenerateCommand())
+      // Docs MCP Server Command
+      .command(DocsCommandFactory.createDocsCommand())
 
       // Stream Text Command - Using CLICommandFactory
       .command(CLICommandFactory.createStreamCommand())

--- a/test/continuous-test-suite-docs-mcp.ts
+++ b/test/continuous-test-suite-docs-mcp.ts
@@ -1,0 +1,105 @@
+/**
+ * Docs MCP server — regression suite.
+ *
+ * The `neurolink docs` MCP server has now been broken THREE separate times by
+ * commits that had nothing to do with documentation, each time silently:
+ *
+ *   1. 66c45592 (observability work)  — dropped the DocsCommandFactory
+ *                                       registration from src/cli/parser.ts.
+ *   2. bd51c31c (dependency cleanup)  — removed `minisearch`, judging it unused
+ *                                       because it is only imported by the
+ *                                       shipped docs-site/mcp-server/search.js,
+ *                                       which no tsconfig or lint scope covers.
+ *   3. 150ac851 + 3a8086b8            — repeated both of the above, undoing the
+ *      (dependency cleanup again)       fix that 27773c6a had just landed.
+ *
+ * Every one of those shipped to npm. The feature has no other coverage: the
+ * mcp-server directory is excluded from every project tsconfig, ESLint does not
+ * lint it, and no other suite drives the command. This file is that coverage.
+ *
+ * Deliberately requires NO provider credentials. The docs server indexes a
+ * static JSON file and speaks MCP over stdio — it never calls a model. Gating
+ * this behind credentials is what made the archive/office security suites
+ * useless in CI, and the same trap must not be repeated here.
+ */
+import "dotenv/config";
+import { defineSuite, assert, runCLI } from "./helpers/harness.js";
+
+const { test, runSuite, section } = defineSuite("Docs MCP server", {
+  perTestTimeoutMs: 120_000,
+});
+
+section("Command registration");
+
+await test("the docs command is registered on the CLI", async () => {
+  const res = await runCLI(["--help"], { timeoutMs: 60_000 });
+  const combined = `${res.stdout}${res.stderr}`;
+  const registered = /\bdocs\b/.test(combined);
+  if (!registered) {
+    // Log the payload for a human, but keep it OUT of the assertion message:
+    // defineSuite downgrades a throw to SKIP when the message matches
+    // isExpectedProviderError(), which would turn this failure green.
+    console.log("[debug] neurolink --help output:\n" + combined);
+  }
+  assert(
+    registered,
+    "docs command missing from CLI help — DocsCommandFactory is likely unregistered in src/cli/parser.ts",
+  );
+});
+
+await test("the docs command resolves rather than suggesting another", async () => {
+  const res = await runCLI(["docs", "--help"], { timeoutMs: 60_000 });
+  const combined = `${res.stdout}${res.stderr}`;
+  const unknown = /did you mean/i.test(combined);
+  if (unknown) {
+    console.log("[debug] neurolink docs --help output:\n" + combined);
+  }
+  assert(
+    !unknown,
+    "neurolink docs resolved to an unknown-command suggestion instead of the docs command",
+  );
+});
+
+section("Runtime dependency and index");
+
+await test("the server starts and indexes a non-zero number of documents", async () => {
+  // The server prints its startup banner before it blocks reading MCP frames
+  // from stdin, and never exits on its own. `stopWhen` terminates it as soon
+  // as the outcome is known — either the banner or a module-resolution
+  // failure — so the suite does not sit out the timeout on every run. The
+  // timeout remains only as the upper bound for a server that prints neither.
+  const res = await runCLI(["docs"], {
+    timeoutMs: 30_000,
+    stopWhen: /\d+\s+docs indexed|ERR_MODULE_NOT_FOUND|Cannot find package/,
+  });
+  const combined = `${res.stdout}${res.stderr}`;
+
+  // A missing runtime dependency surfaces here as a module-resolution failure.
+  const moduleMissing = /ERR_MODULE_NOT_FOUND|Cannot find package/.test(
+    combined,
+  );
+  if (moduleMissing) {
+    console.log("[debug] docs server startup output:\n" + combined);
+  }
+  assert(
+    !moduleMissing,
+    "docs server failed to resolve a runtime dependency — minisearch is likely missing from package.json dependencies",
+  );
+
+  const banner = combined.match(/(\d+)\s+docs indexed/);
+  if (!banner) {
+    console.log("[debug] docs server startup output:\n" + combined);
+  }
+  assert(
+    banner !== null,
+    "docs server did not report an indexed-document count on startup",
+  );
+
+  const count = Number(banner?.[1] ?? 0);
+  assert(
+    count > 0,
+    "docs server reported zero indexed documents — the search index shape likely no longer matches the loader",
+  );
+});
+
+await runSuite();

--- a/test/helpers/harness.ts
+++ b/test/helpers/harness.ts
@@ -203,9 +203,10 @@ export type ProcessResult = {
 export function runCommand(
   command: string,
   args: string[] = [],
-  options: SpawnOptions & { timeoutMs?: number } = {},
+  options: SpawnOptions & { timeoutMs?: number; stopWhen?: RegExp } = {},
 ): Promise<ProcessResult> {
   const timeoutMs = options.timeoutMs ?? 30_000;
+  const stopWhen = options.stopWhen;
   return new Promise((resolve, reject) => {
     let isResolved = false;
     let proc: ReturnType<typeof spawn>;
@@ -221,11 +222,28 @@ export function runCommand(
 
     let stdout = "";
     let stderr = "";
+    let hasExited = false;
+
+    // A server-style command never exits on its own, so waiting for `close`
+    // means waiting out the whole timeout. `stopWhen` lets a caller name the
+    // output that means "done", and we terminate as soon as it appears.
+    const checkStopWhen = (): void => {
+      if (!stopWhen || isResolved) {
+        return;
+      }
+      if (stopWhen.test(stdout + stderr)) {
+        terminate();
+        settle({ stdout, stderr, exitCode: 0 });
+      }
+    };
+
     proc.stdout?.on("data", (d: Buffer) => {
       stdout += d.toString();
+      checkStopWhen();
     });
     proc.stderr?.on("data", (d: Buffer) => {
       stderr += d.toString();
+      checkStopWhen();
     });
 
     const settle = (result: ProcessResult): void => {
@@ -236,17 +254,25 @@ export function runCommand(
       }
     };
 
-    const timeoutId = setTimeout(() => {
+    // `proc.killed` only records that a signal was delivered — it says nothing
+    // about whether the child actually exited, so it cannot gate the SIGKILL
+    // escalation. Track the real exit instead: a child that ignores SIGTERM
+    // leaves `hasExited` false and gets SIGKILL a second later.
+    const terminate = (): void => {
       try {
         proc.kill("SIGTERM");
         setTimeout(() => {
-          if (!proc.killed) {
+          if (!hasExited) {
             proc.kill("SIGKILL");
           }
-        }, 1_000);
+        }, 1_000).unref();
       } catch {
         /* swallow */
       }
+    };
+
+    const timeoutId = setTimeout(() => {
+      terminate();
       settle({
         stdout,
         stderr: stderr + `\n[harness] command timed out after ${timeoutMs}ms`,
@@ -254,7 +280,11 @@ export function runCommand(
       });
     }, timeoutMs);
 
+    proc.on("exit", () => {
+      hasExited = true;
+    });
     proc.on("close", (code) => {
+      hasExited = true;
       settle({ stdout, stderr, exitCode: code ?? -1 });
     });
     proc.on("error", (err) => {
@@ -270,11 +300,16 @@ export function runCommand(
 /** Run the built CLI: `node dist/cli/index.js <args>` with merged env. */
 export function runCLI(
   args: string[],
-  options: { env?: Record<string, string>; timeoutMs?: number } = {},
+  options: {
+    env?: Record<string, string>;
+    timeoutMs?: number;
+    stopWhen?: RegExp;
+  } = {},
 ): Promise<ProcessResult> {
   return runCommand("node", ["dist/cli/index.js", ...args], {
     env: { ...process.env, ...(options.env ?? {}) } as NodeJS.ProcessEnv,
     timeoutMs: options.timeoutMs,
+    stopWhen: options.stopWhen,
   });
 }
 


### PR DESCRIPTION
The `neurolink docs` MCP server has now been broken three separate times by
commits that had nothing to do with documentation, and all three shipped:

  66c45592 (observability)      dropped the DocsCommandFactory registration
  bd51c31c (dependency cleanup) removed minisearch as "unused"
  150ac851 + 3a8086b8           did both again, undoing 27773c6a

The failure mode is structural, not careless. docs-site/mcp-server/ is excluded
from every project tsconfig and from ESLint's scope, so the only import of
minisearch — search.js line 1, a file that ships via package.json "files" — is
invisible to every static check the repo runs. Nothing exercises the command
either. A reviewer looking for consumers of minisearch finds none.

Restore both halves, and add the coverage that was missing all along:
test/continuous-test-suite-docs-mcp.ts drives the built CLI and asserts the
command is registered, resolves, and that the server starts and reports a
non-zero indexed-document count. Wired into test:unit.

The suite deliberately requires no provider credentials. The docs server reads
a static index and speaks MCP over stdio; it never calls a model. Gating it
would reproduce what already makes the archive and office security suites inert
in CI, where no provider secrets exist.

Verified by re-introducing the exact regression: the suite reports two ✗
failures and exits non-zero rather than downgrading to a skip, and passes again
once restored.

---
**Note on `scripts/security-check.ts`:** this branch adds fast-uri advisory `1145636` to the accepted list. That same one-line addition is also in #1449 — whichever merges first, the other resolves trivially. It is required here because `validate:security` runs in the pre-commit hook and currently rejects every commit on a clean checkout.

**Follow-up worth its own change:** keying acceptance on numeric advisory id means upstream publishing a new id for a bypass variant of an already-assessed issue hard-blocks the whole repo. Module-scoped acceptance would keep the property that matters (a genuinely new package still fails loudly) without the false blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Docs MCP Server command to the CLI.
  * Added document search support for the Docs MCP Server.

* **Bug Fixes**
  * Improved command startup handling to detect successful readiness and shut down cleanly.

* **Tests**
  * Added credential-free regression coverage for CLI registration, help output, dependency availability, indexing startup, and indexed document results.
  * Expanded test execution to include Docs MCP validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->