### PR TITLE
fix(scripts): parse the symbol diff instead of pattern-matching it

### DIFF
--- a/scripts/migration-symbol-diff.mjs
+++ b/scripts/migration-symbol-diff.mjs
@@ -5,7 +5,7 @@
  * Written for reviewing refactors that MOVE code — a loop extracted into a
  * shared engine, a helper lifted into a module. The risk in that shape of
  * change is not a broken build; it is a behaviour that quietly stops
- * happening, because the call that performed it was dropped rather than
+ * happening, because the call performing it was dropped rather than
  * relocated. Those do not fail a typecheck and they do not fail a test that
  * nobody wrote.
  *
@@ -24,15 +24,100 @@
  *   node scripts/migration-symbol-diff.mjs <commit> <path> [<path>...]
  *
  * Every name it prints still needs a human decision. "Vanished" means the new
- * revision of THIS file no longer references it — which is the correct and
- * expected outcome when the code moved somewhere else. Check each one lands
- * in its new home; treat the ones that do not as suspects.
+ * revision of THIS file no longer calls it — which is the correct and expected
+ * outcome when the code moved somewhere else. Check each one lands in its new
+ * home; treat the ones that do not as suspects.
  */
 
 import { execFileSync } from "node:child_process";
+import ts from "typescript";
 
-/** Identifiers that appear in call position, which is where behaviour lives. */
-const CALL_SITE = /\b([A-Za-z_][A-Za-z0-9_]{3,})\s*\(/g;
+/**
+ * Every identifier this revision CALLS.
+ *
+ * Parsed rather than pattern-matched. A regex over raw source cannot tell a
+ * call from a declaration, a mention in a comment, or a substring of a string
+ * literal, and the first version of this script reported `while`, `throw` and
+ * assorted prose from comments as vanished symbols. Worse than the noise was
+ * the other direction: it required four or more characters to avoid some of
+ * that noise, so a dropped `map()`, `get()` or `log()` — exactly the kind of
+ * one-line side effect this tool exists to catch — was invisible.
+ *
+ * Property calls are recorded under BOTH the full path and the bare property,
+ * so `span.setAttribute()` matches whether the reader thinks of it as
+ * `setAttribute` or as the span call it was.
+ */
+function callsIn(source, fileName) {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    fileName.endsWith(".tsx") || fileName.endsWith(".jsx")
+      ? ts.ScriptKind.TSX
+      : ts.ScriptKind.TS,
+  );
+  const found = new Set();
+  /**
+   * The dotted path, but only while every link is a plain name: `trace`,
+   * `trace.getActiveSpan`, `a.b.c`. Returns undefined the moment the chain
+   * roots in something else — `foo().bar`, `arr[0].bar` — because the printed
+   * form of such a chain is the whole sub-expression, and an earlier cut of
+   * this happily emitted a thirty-line `withTimeout(...).catch` as a symbol
+   * name.
+   */
+  const dottedName = (expression) => {
+    if (ts.isIdentifier(expression)) {
+      return expression.text;
+    }
+    if (ts.isPropertyAccessExpression(expression)) {
+      const prefix = dottedName(expression.expression);
+      return prefix === undefined ? undefined : `${prefix}.${expression.name.text}`;
+    }
+    return undefined;
+  };
+  const record = (expression) => {
+    if (ts.isIdentifier(expression)) {
+      found.add(expression.text);
+      return;
+    }
+    if (ts.isPropertyAccessExpression(expression)) {
+      // Always the bare property, so a call is findable by the name a reader
+      // remembers; the dotted path as well when it is short enough to be one.
+      found.add(expression.name.text);
+      const dotted = dottedName(expression);
+      if (dotted !== undefined) {
+        found.add(dotted);
+      }
+      return;
+    }
+    if (ts.isNewExpression(expression) || ts.isCallExpression(expression)) {
+      record(expression.expression);
+    }
+  };
+  const visit = (node) => {
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+      record(node.expression);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * A `git show` failure that genuinely means "this PATH is not in that tree".
+ *
+ * Deliberately narrow. A bad REVISION is not an absence — it is a typo in the
+ * invocation, and reporting it as "absent on one side" answers a question the
+ * caller never asked while looking like a clean result.
+ */
+function isAbsentPath(err) {
+  const text = `${err?.stderr ?? ""}${err?.message ?? ""}`;
+  return /exists on disk, but not in|does not exist in|path .* does not exist/i.test(
+    text,
+  );
+}
 
 function referencedSymbols(rev, path) {
   let source;
@@ -41,10 +126,17 @@ function referencedSymbols(rev, path) {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
-  } catch {
-    return undefined;
+  } catch (err) {
+    // Only a genuine absence is reported as "not on this side". Anything else
+    // — a bad repository, a permission error, output past maxBuffer — is a
+    // failure of the tool, and swallowing it would print a reassuring
+    // "absent on one side" for a comparison that never happened.
+    if (isAbsentPath(err)) {
+      return undefined;
+    }
+    throw err;
   }
-  return new Set(Array.from(source.matchAll(CALL_SITE), (m) => m[1]));
+  return callsIn(source, path);
 }
 
 function main() {
@@ -57,6 +149,7 @@ function main() {
   }
 
   let anyVanished = false;
+  let anyCompared = false;
   for (const path of paths) {
     const before = referencedSymbols(`${commit}^`, path);
     const after = referencedSymbols(commit, path);
@@ -64,9 +157,10 @@ function main() {
       console.log(`${path} @ ${commit}: absent on one side of the commit`);
       continue;
     }
+    anyCompared = true;
     const vanished = [...before].filter((s) => !after.has(s)).sort();
     console.log(
-      `${path} @ ${commit}: ${before.size} -> ${after.size} referenced symbols; ${vanished.length} vanished`,
+      `${path} @ ${commit}: ${before.size} -> ${after.size} called symbols; ${vanished.length} vanished`,
     );
     for (const symbol of vanished) {
       console.log(`   GONE: ${symbol}`);
@@ -74,11 +168,26 @@ function main() {
     anyVanished ||= vanished.length > 0;
   }
 
-  // Exit 0 either way. A vanished symbol is a prompt to look, not a verdict —
-  // failing here would turn "read this list" into "silence this list".
-  if (!anyVanished) {
+  // Only claim a clean result when something was actually compared. Saying
+  // "nothing vanished" after comparing nothing is the same defect this tool
+  // exists to find, one level up.
+  if (!anyCompared) {
+    console.log("no comparisons ran — every path was absent on one side");
+  } else if (!anyVanished) {
     console.log("nothing vanished");
   }
+
+  // Exit 0 either way. A vanished symbol is a prompt to look, not a verdict —
+  // failing here would turn "read this list" into "silence this list".
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  // git has already written its own diagnosis to stderr; a Node stack on top
+  // of it just buries the useful line.
+  console.error(
+    `migration-symbol-diff: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Acts on the three review findings left on #1448. All three were valid, and a colleague confirmed them.

Worth stating plainly: a tool built to catch **silent behaviour loss** had three ways of **silently reporting success**.

## 1. The regex missed things — worse than the noise it made

It required four or more characters to suppress some of its own false positives, so a dropped `map()`, `get()` or `log()` — exactly the one-line side effect this exists to catch — was invisible. It also could not distinguish a call from a declaration, a comment, or a substring of a string literal, and duly reported `while`, `throw` and assorted prose as vanished symbols.

Now parsed with the `typescript` dependency the repo already has, counting only `CallExpression` and `NewExpression` callees. Property calls are recorded under both the bare name and the dotted path, so `getActiveSpan` now also surfaces as `trace.getActiveSpan`.

## 2. Every `git show` failure was read as absence

A bad repository, a permission error, or output past `maxBuffer` all printed a reassuring *"absent on one side"* for a comparison that never ran. Only a genuine missing **path** counts as absence now; everything else throws.

A bad **revision** throws too. That is a typo in the invocation, not a fact about the tree, and answering it with "absent on one side" responds to a question the caller never asked while looking like a clean result.

## 3. `nothing vanished` was printed when nothing was compared

If every path was absent on one side, no comparison happened, `anyVanished` stayed `false`, and the run ended on a clean bill of health it had not earned — the same defect this tool looks for, one level up. It now distinguishes the two:

```
no comparisons ran — every path was absent on one side
```

## Two defects in my own fix, found by running it

- `getText()` on a property access rooted in a call expression emitted a **thirty-line** `withTimeout(...).catch` as a symbol name. The dotted path is now built by walking identifiers and skipped the moment the chain roots in anything that isn't a plain name.
- The first cut of the absence classifier still swallowed bad revisions.

## Verification

Against the two regressions it was written for:

```
ee9cc2a7 googleAiStudio/client.ts   →  GONE: DedupExecuteMap
ff6fc698 anthropic/client.ts        →  GONE: getActiveSpan
                                       GONE: trace.getActiveSpan
```

Bad revision now exits 1 with git's own diagnosis and no Node stack on top of it.

**No test file.** There is no unit-test runner in this repo, and `test/` is end-to-end only by CLAUDE.md rule 15 — a suite asserting on a dev script's internals would be exactly the kind of test that rule excludes. A script is verified by running it against commits whose answers are already known, which is what the above is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration symbol comparison accuracy by recognizing direct and property-based calls.
  * Added clearer handling for missing migration paths and unexpected tool errors.
  * Reports when no comparisons can be performed and exits cleanly when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->