### PR TITLE
fix(server): let SDK consumers mount the Codex proxy door

### DIFF
--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -190,6 +190,13 @@ export {
   createOpenApiRoutes,
   createToolRoutes,
   registerAllRoutes,
+  // The proxy doors. All three were reachable only from the deep path
+  // ./routes/index.js, which is not a package export — so a consumer of
+  // "@juspay/neurolink/server" could reach them only indirectly through
+  // createAllRoutes' flags, never to mount one on its own.
+  createClaudeProxyRoutes,
+  createOpenAIProxyRoutes,
+  createCodexProxyRoutes,
 } from "./routes/index.js";
 // ============================================
 // Streaming

--- a/src/lib/server/routes/index.ts
+++ b/src/lib/server/routes/index.ts
@@ -13,6 +13,7 @@ import { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 // ClaudeProxyDeps removed
 import { createHealthRoutes } from "./healthRoutes.js";
 import { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
+import { createCodexProxyRoutes } from "./codexProxyRoutes.js";
 import { createMCPRoutes } from "./mcpRoutes.js";
 import { createMemoryRoutes } from "./memoryRoutes.js";
 import { createOpenApiRoutes } from "./openApiRoutes.js";
@@ -24,6 +25,7 @@ export { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 // ClaudeProxyDeps removed
 export { createHealthRoutes } from "./healthRoutes.js";
 export { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
+export { createCodexProxyRoutes } from "./codexProxyRoutes.js";
 export { createMCPRoutes } from "./mcpRoutes.js";
 export { createMemoryRoutes } from "./memoryRoutes.js";
 export { createOpenApiRoutes } from "./openApiRoutes.js";
@@ -50,10 +52,13 @@ export function createAllRoutes(
     routes.push(createOpenApiRoutes(basePath, options.getRoutes));
   }
 
-  // Unified proxy flag enables both Claude and OpenAI endpoints.
+  // Unified proxy flag enables every door. Codex was omitted here for long
+  // enough that it became reachable only from `neurolink proxy start`; a
+  // consumer opting into proxying means all of it, not a subset.
   // Legacy per-format flags are still supported for backward compatibility.
   const enableClaudeProxy = options?.proxy || options?.claudeProxy;
   const enableOpenAIProxy = options?.proxy || options?.openaiProxy;
+  const enableCodexProxy = options?.proxy || options?.codexProxy;
 
   if (enableClaudeProxy) {
     routes.push(createClaudeProxyRoutes(undefined, basePath));
@@ -61,6 +66,10 @@ export function createAllRoutes(
 
   if (enableOpenAIProxy) {
     routes.push(createOpenAIProxyRoutes(undefined, basePath));
+  }
+
+  if (enableCodexProxy) {
+    routes.push(createCodexProxyRoutes(basePath));
   }
 
   return routes;

--- a/src/lib/types/server.ts
+++ b/src/lib/types/server.ts
@@ -1401,10 +1401,18 @@ export type OpenAPISpec = {
 export type CreateRoutesOptions = {
   enableSwagger?: boolean;
   getRoutes?: () => RouteDefinition[];
-  /** Enable both Claude and OpenAI proxy endpoints. */
+  /** Enable every proxy door: Claude, OpenAI and Codex. */
   proxy?: boolean;
   claudeProxy?: boolean;
   openaiProxy?: boolean;
+  /**
+   * Enable the Codex door on its own.
+   *
+   * Codex was reachable only from `neurolink proxy start` until this existed —
+   * `createAllRoutes` mounted two of the three doors, so an SDK consumer could
+   * not expose it even deliberately.
+   */
+  codexProxy?: boolean;
 };
 
 // =============================================================================

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1496,6 +1496,123 @@ async function testOpenCodeWriterReportsWhetherItWrote(): Promise<boolean> {
 }
 
 /**
+ * Codex was the one configurator with no apply/restore round-trip test.
+ *
+ * It is also the one with the most to get wrong: unlike the other four it edits
+ * TOML by regex rather than round-tripping JSON, it keeps its snapshot in a
+ * sidecar file rather than inside the config, and it rewrites a top-level
+ * selector line that must stay in the preamble — a `model_provider` captured
+ * from inside a `[profiles.*]` table would be written back as the global
+ * selector on restore.
+ *
+ * This drives the real writer against a real config containing exactly that
+ * hazard: a user selector, unrelated keys, and a profile table with its own
+ * model_provider.
+ */
+async function testCodexConfiguratorRoundTrip(): Promise<boolean> {
+  const { __codexClientTestHooks } =
+    await import("../src/cli/proxy-clients/codex.js");
+  const url = "http://127.0.0.1:55669";
+
+  const runCase = async (
+    label: string,
+    preambleSelector: string | null,
+    check: (afterApply: string, afterRestore: string) => string | null,
+  ): Promise<boolean> => {
+    const prevHome = process.env.HOME;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-codex-"));
+    try {
+      process.env.HOME = root;
+      fs.mkdirSync(path.join(root, ".codex"), { recursive: true });
+      const configPath = __codexClientTestHooks.getCodexConfigPath();
+      fs.writeFileSync(
+        configPath,
+        [
+          'model = "gpt-5.1-codex"',
+          ...(preambleSelector ? [preambleSelector] : []),
+          'approval_policy = "on-request"',
+          "",
+          // The hazard: a profile table with its own selector. It must never
+          // be mistaken for the global one.
+          "[profiles.work]",
+          'model_provider = "some-other-provider"',
+          "",
+        ].join("\n"),
+      );
+
+      if (!(await __codexClientTestHooks.setCodexProxySettings(url))) {
+        log(`Codex ${label}: writer reported no write`, "red");
+        return false;
+      }
+      const afterApply = fs.readFileSync(configPath, "utf8");
+      if (!(await __codexClientTestHooks.clearCodexProxySettings(url))) {
+        log(`Codex ${label}: restore reported that it did nothing`, "red");
+        return false;
+      }
+      const afterRestore = fs.readFileSync(configPath, "utf8");
+
+      const failure = check(afterApply, afterRestore);
+      if (failure) {
+        log(`Codex ${label}: ${failure}`, "red");
+        return false;
+      }
+      return true;
+    } finally {
+      if (prevHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = prevHome;
+      }
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  // Case A — the user had a global selector. It must come back verbatim.
+  const withSelector = await runCase(
+    "with a user selector",
+    'model_provider = "openai"',
+    (applied, restored) => {
+      if (!/^model_provider = "neurolink"$/m.test(applied)) {
+        return "apply did not point the selector at the proxy";
+      }
+      if (!applied.includes("[model_providers.neurolink]")) {
+        return "apply did not write its managed provider table";
+      }
+      if (!/^approval_policy = "on-request"$/m.test(applied)) {
+        return "apply disturbed an unrelated top-level key";
+      }
+      if (!/^model_provider = "openai"$/m.test(restored)) {
+        return "restore did not put the user's selector back";
+      }
+      if (restored.includes("neurolink")) {
+        return "restore left its managed block behind";
+      }
+      return null;
+    },
+  );
+  if (!withSelector) {
+    return false;
+  }
+
+  // Case B — no global selector, only a profile's. This is what separates a
+  // preamble-scoped snapshot from a document-wide one: matched document-wide,
+  // the profile's provider is captured and then written back as the GLOBAL
+  // selector, silently repointing every Codex run at another provider.
+  return await runCase("with only a profile selector", null, (_a, restored) => {
+    // Scope to the preamble. A bare /^model_provider/m also matches the line
+    // inside [profiles.work], which is legitimate and must stay.
+    const preamble = restored.split(/^\[/m)[0];
+    if (/^model_provider = /m.test(preamble)) {
+      return "restore invented a global selector the user never had";
+    }
+    if (!restored.includes('model_provider = "some-other-provider"')) {
+      return "restore lost the profile table's own provider";
+    }
+    return null;
+  });
+}
+
+/**
  * Restoring must require proving we own the value, not just the URL.
  *
  * The base-URL check catches a user who repointed the client somewhere else,
@@ -5410,6 +5527,11 @@ const tests: TestFunction[] = [
   {
     name: "Proxy clients: Codex configurator probes before writing",
     fn: testCodexConfiguratorDetectsInstall,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: Codex apply/restore round-trips a real config",
+    fn: testCodexConfiguratorRoundTrip,
     category: "proxy-config",
   },
   {

--- a/test/continuous-test-suite-servers.ts
+++ b/test/continuous-test-suite-servers.ts
@@ -2212,6 +2212,92 @@ async function testRouteRegistration(): Promise<boolean | null> {
 // Base Server Adapter Tests
 // ============================================
 
+/**
+ * An SDK consumer must be able to mount the Codex proxy door.
+ *
+ * `createAllRoutes` is the documented way to assemble the server's routes, and
+ * it handled two of the three proxy doors: `createCodexProxyRoutes` was neither
+ * imported nor re-exported here, and no flag selected it. So Codex proxying was
+ * reachable only by running `neurolink proxy start` — an SDK consumer embedding
+ * the server could not expose it at all, not even deliberately.
+ *
+ * Driven through the published surface exactly as a consumer would: import from
+ * the built package, call createAllRoutes, and look for the door.
+ */
+async function testCodexProxyReachableFromSDK(): Promise<boolean | null> {
+  const mod = await getServerModule();
+  if (!mod) {
+    logTest(
+      "SDK seam - Codex proxy door",
+      "FAIL",
+      `Import failed: ${getServerModuleError()}`,
+    );
+    return false;
+  }
+
+  if (typeof mod.createCodexProxyRoutes !== "function") {
+    logTest(
+      "SDK seam - Codex proxy door",
+      "FAIL",
+      "createCodexProxyRoutes is not exported from the server entry",
+    );
+    return false;
+  }
+
+  // Signature is (basePath, options) — passing options first silently lands
+  // the object in basePath and stringifies it into every route path.
+  const createAllRoutes = mod.createAllRoutes as (
+    basePath?: string,
+    options?: Record<string, unknown>,
+  ) => Array<{ routes?: Array<{ method?: string; path?: string }> }>;
+
+  const hasCodexDoor = (
+    groups: Array<{ routes?: Array<{ method?: string; path?: string }> }>,
+  ): boolean =>
+    groups.some((g) =>
+      (g.routes ?? []).some((r) =>
+        (r.path ?? "").includes("/backend-api/codex/responses"),
+      ),
+    );
+
+  // The dedicated flag must select it.
+  if (!hasCodexDoor(createAllRoutes("/api", { codexProxy: true }))) {
+    logTest(
+      "SDK seam - Codex proxy door",
+      "FAIL",
+      "codexProxy: true did not mount the Codex door",
+    );
+    return false;
+  }
+
+  // And the unified flag must mean every door, not two of three.
+  if (!hasCodexDoor(createAllRoutes("/api", { proxy: true }))) {
+    logTest(
+      "SDK seam - Codex proxy door",
+      "FAIL",
+      "proxy: true mounted the other doors but not Codex",
+    );
+    return false;
+  }
+
+  // Off by default — a consumer who asked for no proxying gets none.
+  if (hasCodexDoor(createAllRoutes("/api", {}))) {
+    logTest(
+      "SDK seam - Codex proxy door",
+      "FAIL",
+      "the Codex door was mounted without any proxy flag",
+    );
+    return false;
+  }
+
+  logTest(
+    "SDK seam - Codex proxy door",
+    "PASS",
+    "codexProxy and proxy both mount it; absent by default",
+  );
+  return true;
+}
+
 async function testBaseServerAdapter(): Promise<boolean | null> {
   logSection("Testing Base Server Adapter");
 
@@ -2560,6 +2646,7 @@ async function runAllTests(): Promise<void> {
     { name: "Common Middleware", fn: testCommonMiddleware },
 
     // Core Infrastructure Tests
+    { name: "SDK seam: Codex proxy door", fn: testCodexProxyReachableFromSDK },
     { name: "Base Server Adapter", fn: testBaseServerAdapter },
     { name: "Type System", fn: testTypeSystem },
     { name: "Index Exports", fn: testIndexExports },


### PR DESCRIPTION
Two gaps that share a root cause: Codex was treated as CLI-only.

## 1. An SDK consumer could not mount the Codex door at all

`createAllRoutes` assembled two of the three proxy doors. `createCodexProxyRoutes` was neither imported nor re-exported from the routes barrel, and no flag selected it — so Codex proxying was reachable only by running `neurolink proxy start`.

Verified through the published surface, not by reading source:

```
before:  createAllRoutes("/api", { proxy: true })      -> no codex door
after:   createAllRoutes("/api", { proxy: true })      -> codex door present
         createAllRoutes("/api", { codexProxy: true }) -> codex door present
         createAllRoutes("/api", {})                   -> absent (unchanged)
```

The unified `proxy` flag now means *every* door rather than two of three. A consumer opting into proxying is opting into proxying, and the silent omission is exactly what let this sit unnoticed. **Flag me if you'd rather `proxy` stayed Claude+OpenAI** and Codex required its own opt-in — it's a judgement call, and reverting it is one line.

**A wider gap found while wiring it:** the server entry re-exported *no* proxy factory. Claude and OpenAI were reachable only via the deep path `./routes/index.js`, which is not a package export — so `@juspay/neurolink/server` consumers could never mount one directly. All three are exported now.

## 2. Codex had no configurator round-trip test — #1368 was closed as covered

Codex is the writer with the most to get wrong: it edits TOML by regex rather than round-tripping JSON, keeps its snapshot in a sidecar file, and rewrites a top-level selector that must stay in the preamble. A `model_provider` read from inside a `[profiles.*]` table would be written back as the **global** selector, silently repointing every Codex run at another provider.

The test drives the real writer against a config carrying that hazard, in two cases:

- **A user selector present** — restore must return it verbatim. This case passes against a correct *and* a broken writer, because document-wide and preamble-scoped matching agree when the preamble already has one. Kept because it covers the common path, but it proves nothing on its own.
- **No global selector, only a profile's** — this is what separates them. Confirmed by regressing the writer to match document-wide, watching this case fail, then restoring it.

Worth recording: my first version of case B asserted `/^model_provider = /m` on the whole file. That matches the line inside `[profiles.work]` too, so it reported a bug that did not exist. The writer was pristine the whole time; the assertion is now scoped to the preamble.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit --strict` | clean |
| `eslint src test` | 0 errors (54 pre-existing warnings) |
| `pnpm run build` | clean |
| `continuous-test-suite-proxy` | **65 passed** |
| `continuous-test-suite-servers` | **41 passed** |
| `continuous-test-suite-codex` | 31 passed |
| Regression proof | writer broken on purpose -> case B fails; restored -> passes |

Stacks cleanly with #1453 (Codex model discovery); the two touch different files.