### PR TITLE
fix(proxy): write client configs atomically

### DIFF
--- a/src/cli/proxy-clients/claudeCode.ts
+++ b/src/cli/proxy-clients/claudeCode.ts
@@ -10,7 +10,11 @@ import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
 import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
-import { isProxyOwnedValue, shouldCaptureSnapshot } from "./snapshot.js";
+import {
+  isProxyOwnedValue,
+  shouldCaptureSnapshot,
+  writeFileAtomic,
+} from "./snapshot.js";
 
 /**
  * Resolved per call rather than at module load so `detect()` and `apply()`
@@ -78,7 +82,10 @@ export async function setClaudeProxySettings(baseUrl: string): Promise<void> {
     ENABLE_TOOL_SEARCH: "true",
   };
 
-  fs.writeFileSync(getClaudeSettingsPath(), JSON.stringify(settings, null, 2));
+  await writeFileAtomic(
+    getClaudeSettingsPath(),
+    JSON.stringify(settings, null, 2),
+  );
 }
 
 export async function clearClaudeProxySettings(
@@ -162,7 +169,10 @@ export async function clearClaudeProxySettings(
     settings.env = env;
   }
 
-  fs.writeFileSync(getClaudeSettingsPath(), JSON.stringify(settings, null, 2));
+  await writeFileAtomic(
+    getClaudeSettingsPath(),
+    JSON.stringify(settings, null, 2),
+  );
   return hadBaseUrl || hadToolSearch;
 }
 

--- a/src/cli/proxy-clients/codex.ts
+++ b/src/cli/proxy-clients/codex.ts
@@ -9,6 +9,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
 import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
+import { writeFileAtomic } from "./snapshot.js";
 
 //
 // Points the Codex CLI at the proxy by managing `~/.codex/config.toml`:
@@ -115,10 +116,10 @@ export async function setCodexProxySettings(baseUrl: string): Promise<boolean> {
           ? providerMatch[0]
           : null;
       fs.mkdirSync(join(homedir(), ".neurolink"), { recursive: true });
-      fs.writeFileSync(
+      await writeFileAtomic(
         getCodexSnapshotPath(),
         JSON.stringify({ originalProviderLine }, null, 2),
-        { mode: 0o600 },
+        0o600,
       );
     }
 
@@ -148,7 +149,7 @@ export async function setCodexProxySettings(baseUrl: string): Promise<boolean> {
     }
 
     const trimmed = text.replace(/\s*$/, "\n");
-    fs.writeFileSync(
+    await writeFileAtomic(
       getCodexConfigPath(),
       `${trimmed}\n${buildCodexProviderBlock(baseUrl)}`,
     );
@@ -239,7 +240,7 @@ export async function clearCodexProxySettings(
       }
       return false;
     }
-    fs.writeFileSync(getCodexConfigPath(), text.replace(/\s*$/, "\n"));
+    await writeFileAtomic(getCodexConfigPath(), text.replace(/\s*$/, "\n"));
     try {
       fs.rmSync(getCodexSnapshotPath(), { force: true });
     } catch {

--- a/src/cli/proxy-clients/copilot.ts
+++ b/src/cli/proxy-clients/copilot.ts
@@ -26,6 +26,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
 import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
+import { writeFileAtomic } from "./snapshot.js";
 
 /**
  * Resolved per call rather than at module load so `detect()` and `apply()`
@@ -70,16 +71,15 @@ export async function setCopilotProxySettings(
   try {
     const envPath = getCopilotEnvPath();
     fs.mkdirSync(join(homedir(), ".neurolink"), { recursive: true });
-    fs.writeFileSync(
+    // 0600 is applied to the temp file before the rename, so the script never
+    // exists at the destination with wider permissions — not even briefly.
+    // writeFileSync's own mode option would not do this: it applies only when
+    // open() creates the file, so an overwrite kept whatever mode was there.
+    await writeFileAtomic(
       envPath,
       buildCopilotEnvScript(baseUrl, proxyKey || "neurolink-proxy"),
-      { mode: 0o600 },
+      0o600,
     );
-    // The mode option above only applies when open() creates the file. On an
-    // overwrite it is ignored, so a pre-existing file keeps whatever
-    // permissions it had — which for a file holding a proxy key could be
-    // world-readable. Enforce it on both paths.
-    fs.chmodSync(envPath, 0o600);
     return true;
   } catch (error) {
     logger.debug(

--- a/src/cli/proxy-clients/openCode.ts
+++ b/src/cli/proxy-clients/openCode.ts
@@ -13,6 +13,7 @@ import {
   cloneForSnapshot,
   isProxyOwnedValue,
   shouldCaptureSnapshot,
+  writeFileAtomic,
 } from "./snapshot.js";
 
 function getOpenCodeConfigDir(): string {
@@ -105,7 +106,10 @@ export async function setOpenCodeProxySettings(
   config[OPENCODE_WRITTEN_KEY] = cloneForSnapshot(block);
 
   config.provider = provider;
-  fs.writeFileSync(getOpenCodeConfigPath(), JSON.stringify(config, null, 2));
+  await writeFileAtomic(
+    getOpenCodeConfigPath(),
+    JSON.stringify(config, null, 2),
+  );
   return true;
 }
 
@@ -181,7 +185,10 @@ export async function clearOpenCodeProxySettings(
   }
 
   config.provider = provider;
-  fs.writeFileSync(getOpenCodeConfigPath(), JSON.stringify(config, null, 2));
+  await writeFileAtomic(
+    getOpenCodeConfigPath(),
+    JSON.stringify(config, null, 2),
+  );
   return hadNeurolink;
 }
 

--- a/src/cli/proxy-clients/qwenCode.ts
+++ b/src/cli/proxy-clients/qwenCode.ts
@@ -29,6 +29,7 @@ import {
   cloneForSnapshot,
   isProxyOwnedValue,
   shouldCaptureSnapshot,
+  writeFileAtomic,
 } from "./snapshot.js";
 
 /**
@@ -111,7 +112,10 @@ export async function setQwenProxySettings(
   settings.security = security;
   settings[QWEN_WRITTEN_KEY] = cloneForSnapshot(auth);
 
-  fs.writeFileSync(getQwenSettingsPath(), JSON.stringify(settings, null, 2));
+  await writeFileAtomic(
+    getQwenSettingsPath(),
+    JSON.stringify(settings, null, 2),
+  );
   return true;
 }
 
@@ -171,7 +175,10 @@ export async function clearQwenProxySettings(
   delete settings[QWEN_WRITTEN_KEY];
   settings.security = security;
 
-  fs.writeFileSync(getQwenSettingsPath(), JSON.stringify(settings, null, 2));
+  await writeFileAtomic(
+    getQwenSettingsPath(),
+    JSON.stringify(settings, null, 2),
+  );
   return true;
 }
 

--- a/src/cli/proxy-clients/snapshot.ts
+++ b/src/cli/proxy-clients/snapshot.ts
@@ -111,3 +111,109 @@ export function isProxyOwnedValue(args: {
   }
   return valuesMatch(args.current, args.written);
 }
+
+/** Distinguishes concurrent writers within one process. */
+let atomicWriteCounter = 0;
+
+/**
+ * Replace a file's contents without ever exposing a partial one.
+ *
+ * `writeFileSync` opens with `O_TRUNC`, so from the truncate until the last
+ * byte lands the user's config is short — and a real config spans several
+ * syscalls, not an instant. Anything reading concurrently, the CLI the config
+ * belongs to included, can load a truncated file; a crash in that window leaves
+ * it truncated permanently. Both Qwen and OpenCode keep live API keys there.
+ *
+ * Writing to a sibling temp file and renaming closes it: `rename(2)` within a
+ * directory is atomic, so a reader sees either the whole old file or the whole
+ * new one. The temp file must be a sibling — a rename across filesystems is a
+ * copy, which reintroduces exactly the window this removes.
+ *
+ * PERMISSIONS ARE THE SUBTLE PART, and getting them wrong here leaks API keys.
+ *
+ * Writing through a temp file changes who decides the destination's mode. A
+ * plain `writeFileSync` over an existing file leaves that file's mode alone, so
+ * a config the user had locked to 0600 stayed 0600. A rename replaces the inode,
+ * so the destination inherits the TEMP file's mode instead — and a temp file
+ * created without an explicit mode lands at 0666 minus umask, i.e. 0644 on a
+ * default system. Left unhandled, making the write atomic would have quietly
+ * widened every credential file it touched from 0600 to 0644.
+ *
+ * So when the caller does not specify a mode, the destination's current mode is
+ * carried over, which reproduces `writeFileSync`'s behaviour exactly; a file
+ * that does not exist yet starts at 0600 rather than whatever umask allows.
+ *
+ * The mode is applied at CREATE time, not after. `writeFileSync` followed by
+ * `chmodSync` would put the credential bytes on disk at 0644 first and tighten
+ * them a moment later — a window a local reader can win. The trailing `chmod`
+ * remains only to pin the exact mode, since umask masks the create mode; by
+ * then the file has never been readable more widely than its final mode.
+ *
+ * On Windows the guarantee holds but the failure mode differs, which is worth
+ * stating because the obvious worry there is the wrong one. Node's `renameSync`
+ * is `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`; replacing a file on the
+ * same volume is an atomic directory-entry update, so a concurrent reader still
+ * sees the whole old file or the whole new one and never a torn one. What
+ * Windows adds is that the rename can *fail* — `EPERM`/`EBUSY` when a reader
+ * holds the destination open — where POSIX would succeed. That path is safe:
+ * the catch below removes the temp file and rethrows, leaving the previous
+ * config intact for the caller to report on.
+ *
+ * The sibling rule above is what makes that true. `MOVEFILE_COPY_ALLOWED` is
+ * also set, so a cross-volume rename silently degrades to copy-then-delete and
+ * is NOT atomic. Moving the temp file to `os.tmpdir()` would look like a
+ * tidy-up and would quietly restore the exact window this function exists to
+ * close, on Windows only, where nobody here would see it.
+ */
+export async function writeFileAtomic(
+  filePath: string,
+  contents: string,
+  mode?: number,
+): Promise<void> {
+  const fs = await import("fs");
+  const { dirname, join, basename } = await import("path");
+  atomicWriteCounter += 1;
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.neurolink-${process.pid}-${atomicWriteCounter}.tmp`,
+  );
+  // Which step failed changes what the user should do about it: a failed write
+  // is usually a missing directory or a full disk and the config is untouched,
+  // while a failed rename is a locked destination and the config is intact but
+  // stale. The bare errno is the same shape for both, so the stage is recorded
+  // as it advances and named in the rethrow.
+  let stage: "write" | "chmod" | "rename" = "write";
+  // Resolved before the first byte is written — see the permissions note above.
+  let effectiveMode = mode;
+  if (effectiveMode === undefined) {
+    try {
+      effectiveMode = fs.statSync(filePath).mode & 0o777;
+    } catch {
+      effectiveMode = 0o600;
+    }
+  }
+  try {
+    fs.writeFileSync(tempPath, contents, { mode: effectiveMode });
+    stage = "chmod";
+    fs.chmodSync(tempPath, effectiveMode);
+    stage = "rename";
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    // Never leave scratch in the user's config directory.
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // best effort
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    // The original is attached as `cause`, not discarded: wrapping moves the
+    // errno off the thrown object, and `cause` is where anything that needs
+    // ENOENT/EPERM finds it. No caller reads it today — every call site either
+    // lets this propagate or swallows it — so nothing breaks, but a future one
+    // should not have to re-derive the syscall from a string.
+    throw new Error(
+      `atomic write to ${filePath} failed at the ${stage} step: ${reason}`,
+      { cause: error },
+    );
+  }
+}

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1834,6 +1834,223 @@ async function testCodexConfiguratorRoundTrip(): Promise<boolean> {
 }
 
 /**
+ * A client config must never be observable in a torn state.
+ *
+ * Every writer did readFileSync then writeFileSync. writeFileSync opens with
+ * O_TRUNC, so between the truncate and the last byte the user's config is
+ * short — and for a real config that is several syscalls wide, not an instant.
+ * Anything reading concurrently, including the CLI the config belongs to, can
+ * load a truncated file; a crash in that window leaves it truncated for good.
+ * Both Qwen's and OpenCode's configs hold live API keys.
+ *
+ * Measured against the pre-fix writer on a 1.4 MB config: 121 torn reads out of
+ * 3,717. This drives the real writer while a separate process reads — separate
+ * because writeFileSync blocks the writer's own event loop, so an in-process
+ * reader is never scheduled during the window it is supposed to catch.
+ */
+async function testClientConfigWritesAreAtomic(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const { spawn } = await import("child_process");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-atomic-"));
+  const url = "http://127.0.0.1:55669/v1";
+  const probe = path.resolve("test/fixtures/config-reader-probe.mjs");
+  try {
+    fs.mkdirSync(path.join(root, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = root;
+    const configPath = __openCodeTestHooks.getOpenCodeConfigPath();
+
+    // Large enough that the write spans multiple syscalls. A small file can be
+    // written in one and would hide the window rather than prove it closed.
+    const filler: Record<string, string> = {};
+    for (let i = 0; i < 20000; i += 1) {
+      filler[`key_${i}`] = `value_${i}_${"x".repeat(40)}`;
+    }
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ provider: {}, filler }, null, 2),
+    );
+
+    const durationMs = 4000;
+    const deadline = Date.now() + durationMs;
+    const reader = spawn(
+      process.execPath,
+      [probe, configPath, String(deadline)],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    let out = "";
+    reader.stdout?.on("data", (d: Buffer) => {
+      out += d.toString();
+    });
+
+    let writes = 0;
+    while (Date.now() < deadline) {
+      await __openCodeTestHooks.setOpenCodeProxySettings(url);
+      await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+      writes += 2;
+    }
+    // "close", not "exit", and with an "error" handler: a spawn that fails
+    // outright (ENOENT on the probe path) never emits "exit", so waiting on it
+    // alone hangs this suite forever instead of failing. "close" fires in both
+    // cases, and the guard below turns a probe that never ran into a failure
+    // rather than a hang.
+    await new Promise<void>((resolve) => {
+      reader.on("close", () => resolve());
+      reader.on("error", () => resolve());
+    });
+
+    const parsed = out.trim()
+      ? (JSON.parse(out.trim()) as {
+          total: number;
+          torn: number;
+          unreadable?: number;
+        })
+      : { total: 0, torn: 0, unreadable: 0 };
+    // Reads that never landed prove nothing either way, so they cannot count
+    // toward the sample this test claims to have taken.
+    const observed = parsed.total - (parsed.unreadable ?? 0);
+    if (observed === 0) {
+      log(
+        "atomic-write probe never completed a read; test proved nothing",
+        "red",
+      );
+      return false;
+    }
+    if (parsed.total === 0) {
+      log(
+        "atomic-write probe never read the config; test proved nothing",
+        "red",
+      );
+      return false;
+    }
+    if (writes === 0) {
+      log(
+        "atomic-write probe never wrote the config; test proved nothing",
+        "red",
+      );
+      return false;
+    }
+    if (parsed.torn > 0) {
+      log(
+        `a concurrent reader observed a torn config on ${parsed.torn} of ${parsed.total} reads`,
+        "red",
+      );
+      return false;
+    }
+
+    // A failed rename must not leave scratch files in the user's config dir.
+    const strays = fs
+      .readdirSync(path.dirname(configPath))
+      .filter((f) => f.includes(".tmp") || f.includes("neurolink-"));
+    if (strays.length > 0) {
+      log(`the writer left ${strays.length} scratch file(s) behind`, "red");
+      return false;
+    }
+    log(
+      `${observed} concurrent reads across ${writes} writes, none torn`,
+      "green",
+    );
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Making a write atomic must not widen who can read the file.
+ *
+ * This is the trap the rename introduces and it is easy to miss. Overwriting in
+ * place leaves the destination's mode alone, so a config the user had locked to
+ * 0600 stayed 0600. A rename replaces the inode, so the destination inherits the
+ * TEMP file's mode — and a temp file created without an explicit mode lands at
+ * 0666 minus umask, i.e. 0644 by default. Without the carry-over, switching to
+ * atomic writes would silently relax every credential file it touched from
+ * owner-only to world-readable. Qwen's and OpenCode's configs hold live API
+ * keys, so that is a local disclosure, not a cosmetic change.
+ *
+ * Driven through the real configurators rather than the writer, because the
+ * whole point is the mode a USER's file ends up with after `proxy start`.
+ */
+async function testClientConfigWritesPreservePermissions(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-mode-"));
+  const url = "http://127.0.0.1:55669/v1";
+  const modeOf = (p: string): string =>
+    (fs.statSync(p).mode & 0o777).toString(8);
+
+  try {
+    fs.mkdirSync(path.join(root, "opencode"), { recursive: true });
+    process.env.XDG_CONFIG_HOME = root;
+    const configPath = __openCodeTestHooks.getOpenCodeConfigPath();
+
+    // A user who locked their credential file down. This must survive.
+    fs.writeFileSync(configPath, JSON.stringify({ existing: true }));
+    fs.chmodSync(configPath, 0o600);
+
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    if (modeOf(configPath) !== "600") {
+      log(
+        `apply widened a 0600 config to 0${modeOf(configPath)} — credentials exposed to other local users`,
+        "red",
+      );
+      return false;
+    }
+
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    if (modeOf(configPath) !== "600") {
+      log(`restore widened a 0600 config to 0${modeOf(configPath)}`, "red");
+      return false;
+    }
+
+    // A config the user deliberately left group-readable keeps that too — the
+    // rule is "carry the mode over", not "force 0600 on everyone".
+    fs.chmodSync(configPath, 0o644);
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    if (modeOf(configPath) !== "644") {
+      log(
+        `apply changed a 0644 config to 0${modeOf(configPath)} instead of preserving it`,
+        "red",
+      );
+      return false;
+    }
+
+    // A config that did not exist yet must not be born world-readable.
+    const fresh = path.join(root, "opencode", "fresh.json");
+    const { writeFileAtomic } =
+      await import("../src/cli/proxy-clients/snapshot.js");
+    await writeFileAtomic(fresh, JSON.stringify({ apiKey: "sk-test" }));
+    if (modeOf(fresh) !== "600") {
+      log(
+        `a newly created credential file landed at 0${modeOf(fresh)} rather than 0600`,
+        "red",
+      );
+      return false;
+    }
+
+    log(
+      "config permissions preserved across apply and restore; new files start at 0600",
+      "green",
+    );
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
  * Usage must be attributable to the CLI that spent it, not only the account.
  *
  * The proxy already derived a client label from User-Agent, then dropped it
@@ -5917,6 +6134,16 @@ const tests: TestFunction[] = [
   {
     name: "Proxy clients: Codex apply/restore round-trips a real config",
     fn: testCodexConfiguratorRoundTrip,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: config writes are atomic under a concurrent reader",
+    fn: testClientConfigWritesAreAtomic,
+    category: "proxy-config",
+  },
+  {
+    name: "Proxy clients: atomic writes preserve config permissions",
+    fn: testClientConfigWritesPreservePermissions,
     category: "proxy-config",
   },
   // Gemini CLI door: GOOGLE_GEMINI_BASE_URL round-trip through

--- a/test/fixtures/config-reader-probe.mjs
+++ b/test/fixtures/config-reader-probe.mjs
@@ -1,0 +1,35 @@
+// Reader half of the atomic-write race test. Runs as a separate process so it
+// genuinely races the writer: writeFileSync blocks the writer's event loop, so
+// an in-process reader never gets scheduled during the window it is meant to
+// observe.
+import { readFileSync } from "node:fs";
+
+const [, , target, untilMs] = process.argv;
+const deadline = Number(untilMs);
+let total = 0;
+let torn = 0;
+let unreadable = 0;
+while (Date.now() < deadline) {
+  total += 1;
+  let text;
+  try {
+    text = readFileSync(target, "utf8");
+  } catch {
+    // A failed READ is not a torn read, and conflating the two would make this
+    // probe report tearing for a cause that is not tearing. It happens on
+    // Windows, where a reader can hit EPERM/EBUSY against a file being
+    // replaced: the rename never exposes partial content, it just makes the
+    // open fail. Counted separately so the assertion can tell "the writer is
+    // not atomic" from "this platform blocks readers mid-replace".
+    unreadable += 1;
+    continue;
+  }
+  try {
+    JSON.parse(text);
+  } catch {
+    // Read succeeded but the bytes are not valid JSON — that is tearing, and
+    // it is the only thing that indicts the writer.
+    torn += 1;
+  }
+}
+process.stdout.write(JSON.stringify({ total, torn, unreadable }));


### PR DESCRIPTION
Closes #1384.

## The window, measured

Every writer did `readFileSync` then `writeFileSync`. `writeFileSync` opens with `O_TRUNC`, so from the truncate until the last byte lands the user's config is short — and a real config spans several syscalls, not an instant.

Not inferred from reading the code. A separate reader process racing the real writer on a 1.4 MB OpenCode config:

```
before:  3,717 reads -> 121 torn
after:   1,129 reads across 474 writes -> 0 torn
```

Anything reading in that window loads a truncated file, including the CLI the config belongs to. A crash inside it leaves the file truncated permanently. **Qwen's `settings.json` and OpenCode's `opencode.json` both hold live API keys.**

## The fix

All five writers go through one `writeFileAtomic` helper in `snapshot.ts`: write a sibling temp file, then `rename`. `rename(2)` within a directory is atomic, so a reader sees the whole old file or the whole new one, never a seam.

Two details that matter:

- **The temp file must be a sibling.** A cross-filesystem rename is a copy, which would reintroduce exactly the window this closes.
- **A failed write removes its own scratch**, so nothing accumulates in the user's config directory. The test asserts that too.

## A permissions bug fixed on the way

Copilot's env script holds a proxy key. `0o600` was passed to `writeFileSync`, which applies the mode **only when `open()` creates the file** — on an overwrite the file kept whatever permissions it already had. That was patched earlier with a follow-up `chmod`, which still left the file briefly readable between the write and the chmod. The mode is now applied to the temp file *before* the rename, so the destination never exists with wider permissions, not even for an instant.

## On the test

The reader runs in a **separate process** deliberately: `writeFileSync` blocks the writer's own event loop, so an in-process reader is never scheduled during the window it exists to catch. My first attempt did exactly that, reported `reads=0`, and passed while proving nothing. The test now asserts the reader actually read and the writer actually wrote, so that vacuous pass cannot return.

The config is deliberately large. A small file can be written in a single syscall, which would hide the window rather than demonstrate it is closed.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit --strict` | clean |
| `eslint src test` | 0 errors (54 pre-existing warnings) |
| `pnpm run build` | clean |
| `continuous-test-suite-proxy` | **65 passed** |
| `continuous-test-suite-codex` | 31 passed |
| `continuous-test-suite-servers` | 40 passed |
| Race, pre-fix | 121 / 3,717 torn |
| Race, post-fix | 0 / 1,129 torn |

Independent of #1453 and #1454 — different files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy configuration reliability by preventing partially written settings from being read.
  * Preserved secure file permissions during configuration updates.
  * Reduced the risk of incomplete temporary files after write failures.

* **Tests**
  * Added coverage for concurrent configuration reads and writes.
  * Added validation for proxy routing, model discovery, request attribution, and ledger totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->