### PR TITLE
feat(googleVertex): reach Claude models with an API key and a base URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "test:sagemaker-streaming": "tsx test/continuous-test-suite-sagemaker-streaming.ts",
     "test:anthropic-loop-characterization": "tsx test/continuous-test-suite-anthropic-loop-characterization.ts",
     "test:aistudio-loop-characterization": "tsx test/continuous-test-suite-aistudio-loop-characterization.ts",
-    "test:docs-mcp": "npx tsx test/continuous-test-suite-docs-mcp.ts"
+    "test:docs-mcp": "npx tsx test/continuous-test-suite-docs-mcp.ts",
+    "test:vertex-claude-characterization": "tsx test/continuous-test-suite-vertex-claude-characterization.ts"
   },
   "files": [
     "dist",

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -570,9 +570,21 @@ const hasGoogleCredentials = (): boolean => {
 const createVertexAnthropicSettings = async (
   region?: string,
   timeoutMs?: number,
+  direct?: { apiKey: string; projectId?: string },
+  baseURL?: string,
 ): Promise<AnthropicVertexSettings> => {
   const location = region || getVertexLocation();
-  const project = getVertexProjectId();
+  // Express-style auth carries its own credentials, so the ADC-derived project
+  // is neither available nor needed; asking for it would throw before the
+  // request is ever built. It cannot be EMPTY either — the SDK rejects a
+  // falsy projectId outright ("No projectId was given and it could not be
+  // resolved from credentials") — so a configured project is used when there
+  // is one and a placeholder stands in otherwise. The value only ever appears
+  // in the request path, which an endpoint reached this way is expected to
+  // route on its own.
+  const project = direct
+    ? direct.projectId?.trim() || "express"
+    : getVertexProjectId();
 
   return {
     projectId: project,
@@ -582,6 +594,26 @@ const createVertexAnthropicSettings = async (
     // bound (a 429 with retry-after: 8549 sleeps 2.4h per retry, invisible
     // to fallback orchestration). Retries are the orchestrator's job.
     maxRetries: 0,
+    // Outside the express branch too: an endpoint override is about WHERE the
+    // request goes, not how it is authenticated, so a caller using ADC against
+    // a gateway needs it just as much.
+    ...(baseURL ? { baseURL } : {}),
+    ...(direct
+      ? {
+          // The token goes on the request directly. `accessToken` on the SDK's
+          // own options looks like it should do this and does not — the client
+          // stores it and never reads it for auth, so prepareOptions() still
+          // awaits Application Default Credentials and the call fails with a
+          // credentials error that names nothing useful. `authClient` is the
+          // option the SDK actually consults.
+          authClient: {
+            getRequestHeaders: async () => ({
+              Authorization: `Bearer ${direct.apiKey}`,
+            }),
+            projectId: null,
+          },
+        }
+      : {}),
   };
 };
 
@@ -3762,11 +3794,29 @@ export class GoogleVertexProvider extends BaseProvider {
     timeoutMs?: number,
   ): Promise<AnthropicVertexType> {
     const mod = await getAnthropicVertexModule();
+    const expressApiKey = this.resolveExpressApiKey();
+    const directBaseURL =
+      this.baseURL?.trim() || process.env.GOOGLE_VERTEX_BASE_URL?.trim();
     const settings = await createVertexAnthropicSettings(
       this.location,
       timeoutMs,
+      expressApiKey
+        ? {
+            apiKey: expressApiKey,
+            ...(this.projectId ? { projectId: this.projectId } : {}),
+          }
+        : undefined,
+      directBaseURL,
     );
-    const client = new mod.AnthropicVertex(settings);
+    // One assertion, at the one place the shapes genuinely differ. The SDK
+    // declares `authClient` as its full `AuthClient` (24-plus members) while
+    // `prepareOptions()` only ever calls `getRequestHeaders()` and reads
+    // `projectId`. Naming the narrow surface in our own type and widening it
+    // here is the honest version of that gap; the alternative is standing up a
+    // real AuthClient to satisfy a contract the SDK does not exercise.
+    const client = new mod.AnthropicVertex(
+      settings as ConstructorParameters<typeof mod.AnthropicVertex>[0],
+    );
     // The vertex SDK eagerly starts Google ADC resolution in its constructor
     // (`this._authClientPromise = this._auth.getClient()`) and only awaits it
     // per-request in `prepareOptions()`. A client that is constructed but never

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -1244,6 +1244,19 @@ export type GoogleVertexProviderSettings = {
  * Anthropic Vertex AI settings for Claude models on Vertex
  * Used with @anthropic-ai/vertex-sdk
  */
+/**
+ * The two members `@anthropic-ai/vertex-sdk` actually uses off an auth client.
+ *
+ * Its declared `AuthClient` is far wider, but `prepareOptions()` only ever
+ * awaits `getRequestHeaders()` and reads `projectId` (client.js:109-111).
+ * Naming that narrow surface is what lets a caller supply a token directly
+ * instead of standing up Application Default Credentials.
+ */
+export type VertexAnthropicAuthClient = {
+  getRequestHeaders: () => Promise<Record<string, string>>;
+  projectId?: string | null;
+};
+
 export type AnthropicVertexSettings = {
   /** Google Cloud project ID */
   projectId: string;
@@ -1253,6 +1266,22 @@ export type AnthropicVertexSettings = {
   timeout?: number;
   /** SDK-internal retry budget (transport retries are the orchestrator's job) */
   maxRetries?: number;
+  /**
+   * Endpoint override. The SDK derives
+   * `https://${region}-aiplatform.googleapis.com/v1` by default; a gateway or
+   * a compatible endpoint is reached by setting this instead.
+   */
+  baseURL?: string;
+  /**
+   * Supply the request credentials directly, bypassing Application Default
+   * Credentials.
+   *
+   * Note that `accessToken` on the SDK's own options does NOT do this: the
+   * client stores it and never reads it for auth, so `prepareOptions()` still
+   * awaits ADC and a token-only caller fails with a credentials error that
+   * names nothing useful. `authClient` is the option that actually works.
+   */
+  authClient?: VertexAnthropicAuthClient;
 };
 
 // ============================================================================

--- a/test/continuous-test-suite-vertex-claude-characterization.ts
+++ b/test/continuous-test-suite-vertex-claude-characterization.ts
@@ -1,0 +1,451 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Vertex + Claude native-loop characterization
+ * (Plan 08, Task 11).
+ *
+ * Pins the observable behaviour of the two hand-rolled loops in
+ * googleVertex/client.ts that drive Claude models —
+ * executeNativeAnthropicStream and executeNativeAnthropicGenerate — before
+ * they move onto `runAgenticLoop`.
+ *
+ * Reaching them at all needed a provider change, which is worth stating
+ * plainly. `@anthropic-ai/vertex-sdk` resolves Application Default Credentials
+ * in its constructor and awaits them on every request, so there was no
+ * supported way to point a Claude-on-Vertex turn at a local endpoint. Its
+ * `accessToken` option looks like the answer and is not — the client stores it
+ * and never reads it for auth. The option the SDK actually consults is
+ * `authClient`, so the provider now builds one from an express-style API key,
+ * exactly as the Gemini side already does. That makes these loops reachable
+ * here AND gives callers a gateway/API-key path that did not exist before.
+ *
+ * Everything drives the shipped surface: `new NeuroLink().stream()` and
+ * `.generate()` from `../dist/index.js`, answered by a local server speaking
+ * real Anthropic SSE framing so the SDK's own event parsing runs. No imports
+ * out of `src/`, nothing stubbed. No rule-15 exception.
+ *
+ * Assertion messages carry counts, never payloads: the harness downgrades a
+ * failure whose text matches `isExpectedProviderError()` to a SKIP, so quoting
+ * provider-ish content would turn a real regression green.
+ *
+ * Run: npx tsx test/continuous-test-suite-vertex-claude-characterization.ts
+ */
+
+import { createServer, type Server } from "node:http";
+import { assert, defineSuite } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, section, runSuite } = defineSuite(
+  "Vertex Claude loop characterization",
+);
+
+const { NeuroLink } = await import("../dist/index.js");
+
+const MODEL = "claude-3-5-sonnet-v2@20241022";
+
+const TOUCHED_ENV_VARS = [
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_PROJECT_ID",
+  "VERTEX_PROJECT_ID",
+  "GOOGLE_VERTEX_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
+  "VERTEX_LOCATION",
+  "GOOGLE_VERTEX_LOCATION",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_VERTEX_API_KEY",
+  "GOOGLE_VERTEX_BASE_URL",
+  "GOOGLE_API_KEY",
+] as const;
+
+function withVertexEnv(): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of TOUCHED_ENV_VARS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of TOUCHED_ENV_VARS) {
+      const prior = saved[key];
+      if (prior === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prior;
+      }
+    }
+  };
+}
+
+function sse(event: string, payload: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify({ type: event, ...payload })}\n\n`;
+}
+
+/** A turn that emits text and stops. */
+function textTurn(text: string): string[] {
+  return [
+    // The FULL message shape, not the trimmed one. `MessageStream` builds its
+    // snapshot from this event and then pushes each content block onto
+    // `snapshot.content`; without `content: []` (and the sibling fields it
+    // reads alongside) the accumulator dies on "Cannot read properties of
+    // undefined (reading 'push')" before a single delta is delivered.
+    sse("message_start", {
+      message: {
+        id: "msg_1",
+        type: "message",
+        role: "assistant",
+        model: MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 0 },
+      },
+    }),
+    sse("content_block_start", {
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }),
+    sse("content_block_delta", {
+      index: 0,
+      delta: { type: "text_delta", text },
+    }),
+    sse("content_block_stop", { index: 0 }),
+    sse("message_delta", {
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 4 },
+    }),
+    sse("message_stop", {}),
+  ];
+}
+
+/** A turn that asks for one tool call. */
+function toolTurn(
+  name: string,
+  input: Record<string, unknown>,
+  id = "toolu_1",
+  leadingText?: string,
+): string[] {
+  const frames: string[] = [
+    // The FULL message shape, not the trimmed one. `MessageStream` builds its
+    // snapshot from this event and then pushes each content block onto
+    // `snapshot.content`; without `content: []` (and the sibling fields it
+    // reads alongside) the accumulator dies on "Cannot read properties of
+    // undefined (reading 'push')" before a single delta is delivered.
+    sse("message_start", {
+      message: {
+        id: "msg_1",
+        type: "message",
+        role: "assistant",
+        model: MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 0 },
+      },
+    }),
+  ];
+  let index = 0;
+  if (leadingText !== undefined) {
+    frames.push(
+      sse("content_block_start", {
+        index,
+        content_block: { type: "text", text: "" },
+      }),
+      sse("content_block_delta", {
+        index,
+        delta: { type: "text_delta", text: leadingText },
+      }),
+      sse("content_block_stop", { index }),
+    );
+    index++;
+  }
+  frames.push(
+    sse("content_block_start", {
+      index,
+      content_block: { type: "tool_use", id, name, input: {} },
+    }),
+    sse("content_block_delta", {
+      index,
+      delta: { type: "input_json_delta", partial_json: JSON.stringify(input) },
+    }),
+    sse("content_block_stop", { index }),
+    sse("message_delta", {
+      delta: { stop_reason: "tool_use" },
+      usage: { output_tokens: 6 },
+    }),
+    sse("message_stop", {}),
+  );
+  return frames;
+}
+
+type StandInCall = {
+  body: Record<string, unknown>;
+  /** Recorded so a case can prove which credentials actually went out. */
+  authorization: string | undefined;
+};
+
+type StandIn = {
+  calls: StandInCall[];
+  port: number;
+  close: () => Promise<void>;
+};
+
+/** Tool names declared to the model on a given request. */
+function declaredToolNames(call: StandInCall | undefined): string[] {
+  const tools = (call?.body?.tools ?? []) as Array<{ name?: string }>;
+  return tools
+    .map((t) => t.name)
+    .filter((n): n is string => typeof n === "string");
+}
+
+/** tool_result blocks carried back to the model on a given request. */
+function toolResults(
+  call: StandInCall | undefined,
+): Array<{ is_error?: boolean; content?: unknown }> {
+  const messages = (call?.body?.messages ?? []) as Array<{
+    content?: unknown;
+  }>;
+  const blocks: Array<{ is_error?: boolean; content?: unknown }> = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content as Array<Record<string, unknown>>) {
+      if (block?.type === "tool_result") {
+        blocks.push(block as { is_error?: boolean; content?: unknown });
+      }
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Fold the SSE frames a case declares into the single message body the
+ * non-streaming endpoint returns, so every case states its intent once and
+ * both wire modes are served from it.
+ */
+function messageFromFrames(frames: string[]): Record<string, unknown> {
+  const events = frames.map(
+    (frame) =>
+      JSON.parse(frame.slice(frame.indexOf("data: ") + 6).trim()) as Record<
+        string,
+        unknown
+      >,
+  );
+  const start = events.find((e) => e.type === "message_start") as
+    | { message?: Record<string, unknown> }
+    | undefined;
+  const message: Record<string, unknown> = { ...(start?.message ?? {}) };
+  const content: Array<Record<string, unknown>> = [];
+  for (const event of events) {
+    if (event.type === "content_block_start") {
+      content.push({
+        ...((event.content_block as Record<string, unknown>) ?? {}),
+      });
+    }
+    if (event.type === "content_block_delta") {
+      const delta = (event.delta ?? {}) as Record<string, unknown>;
+      const block = content[content.length - 1];
+      if (!block) {
+        continue;
+      }
+      if (typeof delta.text === "string") {
+        block.text = `${block.text ?? ""}${delta.text}`;
+      }
+      if (typeof delta.partial_json === "string") {
+        block.input = JSON.parse(delta.partial_json) as Record<string, unknown>;
+      }
+    }
+    if (event.type === "message_delta") {
+      Object.assign(message, (event.delta ?? {}) as Record<string, unknown>);
+    }
+  }
+  message.content = content;
+  return message;
+}
+
+async function startStandIn(
+  reply: (callIndex: number) => string[],
+): Promise<StandIn> {
+  const calls: StandInCall[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const parseBody = (): Record<string, unknown> => {
+        try {
+          return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+        } catch {
+          return {};
+        }
+      };
+      const body = parseBody();
+      calls.push({
+        body,
+        authorization: req.headers.authorization,
+      });
+      const frames = reply(calls.length - 1);
+      // The two loops speak DIFFERENT wire modes, and answering both is the
+      // only way to reach them from one stand-in: the streaming loop calls
+      // `client.messages.stream` and gets SSE, while the generate loop calls
+      // `client.messages.create` and expects a single JSON message. A stand-in
+      // that only spoke SSE left the generate path unable to parse anything,
+      // which reads like a broken loop rather than a mismatched fixture.
+      if (body.stream === true) {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        for (const frame of frames) {
+          res.write(frame);
+        }
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(messageFromFrames(frames)));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    calls,
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function credentialsFor(port: number) {
+  return {
+    vertex: {
+      apiKey: "express-key",
+      baseURL: `http://127.0.0.1:${port}`,
+    },
+  };
+}
+
+function customTool(counter: { calls: number }) {
+  return {
+    lookup: {
+      description: "look a value up",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: true,
+      },
+      execute: async () => {
+        counter.calls++;
+        return { found: true };
+      },
+    },
+  };
+}
+
+section("reachability");
+
+await test("a Claude-on-Vertex turn can be answered by a local endpoint", async () => {
+  // The enabler itself. Before the authClient wiring this could not run at
+  // all: the SDK resolved Application Default Credentials in its constructor
+  // and awaited them on every request, so a turn either reached Google or
+  // failed on credentials. Nothing else in this file is reachable if this is
+  // not.
+  //
+  // The turn is wrapped rather than left to throw, and that is deliberate.
+  // The harness downgrades a failure whose text matches
+  // `isExpectedProviderError()` to a SKIP, and "could not be resolved from
+  // credentials" matches — so an unreachable provider reported this case as
+  // PASSED WITH A SKIP while nothing had run. Asserting on the stand-in's own
+  // call count instead cannot be downgraded that way: a count is not provider
+  // wording.
+  const server = await startStandIn(() => textTurn("hello from the stand-in"));
+  const restore = withVertexEnv();
+  let text = "";
+  let failure = "";
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "say hello" },
+      provider: "vertex",
+      model: MODEL,
+      maxTokens: 32,
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: credentialsFor(server.port),
+    });
+    for await (const chunk of result.stream) {
+      const content = (chunk as { content?: string })?.content;
+      if (content) {
+        text += content;
+      }
+    }
+  } catch (error) {
+    // Logged, never asserted on: console output is not subject to the
+    // harness skip matching, so quoting the provider here is safe.
+    failure =
+      error instanceof Error ? error.message.slice(0, 160) : String(error);
+  } finally {
+    restore();
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] vertex-claude reachability: calls=${server.calls.length} chars=${text.length} outcome=${failure || "ok"}`,
+  );
+  assert(
+    server.calls.length === 1,
+    `the provider made ${server.calls.length} requests to the stand-in, not the 1 a text-only turn takes`,
+  );
+  assert(text.length > 0, "the turn delivered no text to the consumer");
+  // The header, not just the fact that a request arrived. Without this the
+  // case passes on a runner that happens to have ambient Application Default
+  // Credentials — the very path the authClient wiring exists to replace — so
+  // a regression in that wiring would look like success.
+  assert(
+    server.calls[0]?.authorization === "Bearer express-key",
+    "the request did not carry the express key as its bearer credential",
+  );
+});
+
+await test("the generate path reaches the same endpoint with the same credential", async () => {
+  // Both loops share this auth wiring, and they do NOT share a wire mode:
+  // executeNativeAnthropicGenerate calls client.messages.create and gets a
+  // single JSON message, where the streaming loop gets SSE. Covering only the
+  // streamed path would leave a regression in the create() path invisible.
+  const server = await startStandIn(() => textTurn("generated answer"));
+  const restore = withVertexEnv();
+  let content = "";
+  let failure = "";
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "say hello" },
+      provider: "vertex",
+      model: MODEL,
+      maxTokens: 32,
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: credentialsFor(server.port),
+    });
+    content = (result as { content?: string })?.content ?? "";
+  } catch (error) {
+    failure =
+      error instanceof Error ? error.message.slice(0, 160) : String(error);
+  } finally {
+    restore();
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] vertex-claude generate reachability: calls=${server.calls.length} chars=${content.length} outcome=${failure || "ok"}`,
+  );
+  assert(
+    server.calls.length === 1,
+    `the generate path made ${server.calls.length} requests to the stand-in, not the 1 a text-only turn takes`,
+  );
+  assert(content.length > 0, "the generate path returned no content");
+  assert(
+    server.calls[0]?.authorization === "Bearer express-key",
+    "the generate request did not carry the express key as its bearer credential",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## What

Claude-on-Vertex could only authenticate through Application Default Credentials. `createVertexAnthropicSettings` returned `{projectId, region, timeout, maxRetries}` and nothing else, and `@anthropic-ai/vertex-sdk` resolves ADC in its constructor and awaits it on every request — so there was no supported way to reach a gateway, a compatible endpoint, or a local server.

The Gemini side of this same provider has had exactly that since Express Mode landed. This closes the gap for Claude.

## `accessToken` is not the option that does this

It reads like it should be, and it silently isn't. The client stores it and never consults it for auth — `prepareOptions()` (`client.js:108-116`) awaits `_authClientPromise` regardless. A token-only caller still fails on credentials, with a message that names ADC and gives no hint the token was ignored.

`authClient` is the option the SDK actually uses, and it only ever calls `getRequestHeaders()` and reads `projectId`:

```js
const authClient = await this._authClientPromise;
const authHeaders = await authClient.getRequestHeaders();
const projectId = authClient.projectId ?? authHeaders['x-goog-user-project'];
```

`VertexAnthropicAuthClient` names that narrow surface, with **one** widening assertion where it meets the SDK's much wider declared `AuthClient`. Standing up a real `AuthClient` to satisfy a contract the SDK does not exercise would be worse, not better.

`projectId` also cannot be omitted or blanked here — the SDK rejects a falsy value outright. A configured project is used when there is one; otherwise a placeholder, which only reaches the request path that such an endpoint routes itself.

## The test is written defensively, for a reason

The first version let the turn throw. **It reported PASS while nothing ran.** The credentials error matches `isExpectedProviderError()`, so the harness downgraded a total failure to `⊘ skipped` and the suite exited 0.

That hazard is documented in CLAUDE.md for *assert-message wording*; this came from the **provider's own error**, which is worse precisely because you don't write it. The case now catches the turn and asserts on the **stand-in's own call count** — a count cannot be skip-matched — and logs the provider error via `console.log`, which is not subject to that matching.

The fixture also sends a full `message_start` rather than the trimmed one used elsewhere: `MessageStream` builds its snapshot from that event and pushes each content block onto `snapshot.content`, so without `content: []` and its siblings it dies on `Cannot read properties of undefined (reading 'push')` before any delta arrives.

## Why this matters beyond the feature

These two loops — `executeNativeAnthropicStream` and `executeNativeAnthropicGenerate` — were **untestable**. This is the prerequisite for characterizing them before they move onto the shared loop engine, which is the next PR.

## Verification

```
new case                    calls=1 chars=23 outcome=ok   →  1 passed
vertex Gemini (14 cases)    unaffected                    →  14 passed
typecheck                   0 errors / 4830 files
eslint + prettier           clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Vertex Claude with direct API credentials.
  - Added optional custom endpoint configuration for Vertex Claude requests.
  - Improved authentication handling when standard cloud credentials are unavailable.

- **Tests**
  - Added continuous coverage validating Claude streaming through Vertex-compatible endpoints, including text responses and tool interactions.
  - Added a dedicated command for running the Vertex Claude characterization tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->