### PR TITLE
feat(proxy): attribute usage to the CLI that spent it

### DIFF
--- a/docs/features/proxy-accounts-endpoint.md
+++ b/docs/features/proxy-accounts-endpoint.md
@@ -181,3 +181,47 @@ uniqueness, so a fixed correlation header or an idempotency wrapper produces
 genuinely distinct requests that agree on id, account and model. Those each
 carry their own usage, and are counted separately rather than collapsed into
 one.
+
+## Per-CLI attribution
+
+Each row's `usage` carries a `byClient` map splitting the same totals by the CLI
+that spent them:
+
+```json
+"usage": {
+  "requests": 412, "costUsd": 18.44,
+  "byClient": {
+    "claude-code": { "requests": 380, "costUsd": 17.90, "inputTokens": 1200000, "outputTokens": 90000, "cacheReadTokens": 400000, "cacheCreationTokens": 12000 },
+    "opencode":    { "requests": 32,  "costUsd": 0.54,  "inputTokens": 40000,   "outputTokens": 3000,  "cacheReadTokens": 0,      "cacheCreationTokens": 0 }
+  }
+}
+```
+
+One pooled account is routinely shared by several CLIs, so an account-level
+total cannot answer _what_ is costing money — only _which credential_ paid. The
+split reconciles with the account total: summing `byClient` requests and cost
+gives back `requests` and `costUsd`, and a test asserts it, so a dashboard
+showing both cannot contradict itself.
+
+### Client names
+
+The name is derived from `User-Agent`, and the raw header is stored alongside
+it. Only prefixes observed in real traffic are classified — a guessed mapping
+that never matches looks identical to one that works, and files a client under
+the wrong name when the guess collides.
+
+| Key            | Meaning                                                              |
+| -------------- | -------------------------------------------------------------------- |
+| `claude-code`  | `claude-cli/*`                                                       |
+| `sdk`          | `ai/*`, the AI SDK's own agent                                       |
+| `unknown`      | A `User-Agent` was sent but is not classified yet                    |
+| `unattributed` | No `User-Agent` recorded — traffic logged before attribution existed |
+
+`unknown` and `unattributed` are deliberately distinct: the first is a client
+we saw and could not name, the second is history we cannot reconstruct. Folding
+them together would make old traffic look like an unidentified tool.
+
+For an `unknown` client the raw `User-Agent` is preserved on the log record, so
+it stays attributable by its own header rather than collapsing into one bucket
+with every other unrecognised caller. Adding a name is then a one-line entry in
+`src/lib/proxy/clientAttribution.ts` once the header has actually been observed.

--- a/src/lib/proxy/accountLedger.ts
+++ b/src/lib/proxy/accountLedger.ts
@@ -166,6 +166,7 @@ async function advanceCursor(
       outputTokens: finiteNumber(record.outputTokens),
       cacheReadTokens: finiteNumber(record.cacheReadTokens),
       cacheCreationTokens: finiteNumber(record.cacheCreationTokens),
+      clientApp: resolveClientApp(record),
     };
     // A later record for the same request enriches the earlier one — it must
     // replace it, never add to it. But token fields take the MAX rather than
@@ -255,6 +256,28 @@ function resolveSlotKey(
   return slot;
 }
 
+/**
+ * Which CLI a log row came from.
+ *
+ * Prefers the derived name the proxy recorded. Falls back to the raw
+ * User-Agent's leading token so an unclassified client is still attributable
+ * instead of collapsing into one bucket with everything else. Rows written
+ * before attribution existed carry neither and are reported as "unattributed"
+ * — distinct from "unknown", which means a client we saw but could not name.
+ */
+function resolveClientApp(record: Record<string, unknown>): string {
+  if (typeof record.clientApp === "string" && record.clientApp) {
+    return record.clientApp;
+  }
+  if (typeof record.userAgent === "string" && record.userAgent) {
+    const token = record.userAgent.trim().split(/[\s/]/)[0];
+    if (token) {
+      return token;
+    }
+  }
+  return "unattributed";
+}
+
 /** UTC date stamp of the log file the totals cover. */
 export function currentUsageDate(now = new Date()): string {
   return now.toISOString().slice(0, 10);
@@ -270,6 +293,7 @@ function emptyTotals(): CliAccountUsageTotals {
     costUsd: 0,
     unpricedRequests: 0,
     unpricedModels: [],
+    byClient: {},
   };
 }
 
@@ -317,16 +341,32 @@ export async function readAccountUsage(
     row.cacheReadTokens += entry.cacheReadTokens;
     row.cacheCreationTokens += entry.cacheCreationTokens;
 
+    const client = (row.byClient[entry.clientApp] ??= {
+      requests: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+    });
+    client.requests += 1;
+    client.inputTokens += entry.inputTokens;
+    client.outputTokens += entry.outputTokens;
+    client.cacheReadTokens += entry.cacheReadTokens;
+    client.cacheCreationTokens += entry.cacheCreationTokens;
+
     const provider = resolveProvider(entry);
     if (entry.model && entry.model !== "-") {
       if (hasPricing(provider, entry.model)) {
-        row.costUsd += calculateCost(provider, entry.model, {
+        const cost = calculateCost(provider, entry.model, {
           input: entry.inputTokens,
           output: entry.outputTokens,
           total: entry.inputTokens + entry.outputTokens,
           cacheReadTokens: entry.cacheReadTokens,
           cacheCreationTokens: entry.cacheCreationTokens,
         });
+        row.costUsd += cost;
+        client.costUsd += cost;
       } else {
         row.unpricedRequests += 1;
         const seen = unpriced.get(entry.account) ?? new Set<string>();
@@ -339,6 +379,9 @@ export async function readAccountUsage(
 
   for (const [account, row] of totals) {
     row.costUsd = Number(row.costUsd.toFixed(6));
+    for (const slice of Object.values(row.byClient)) {
+      slice.costUsd = Number(slice.costUsd.toFixed(6));
+    }
     row.unpricedModels = [...(unpriced.get(account) ?? [])].sort();
   }
   return totals;

--- a/src/lib/proxy/clientAttribution.ts
+++ b/src/lib/proxy/clientAttribution.ts
@@ -1,0 +1,73 @@
+/**
+ * Which CLI is calling, from its User-Agent.
+ *
+ * The proxy already computed a client label for trace spans, but it only
+ * distinguished `claude-cli/` from `ai/` and dropped the result into an OTel
+ * attribute. Nothing persisted it, so usage could be attributed to an account
+ * but never to the tool that spent it — the question a pooled-subscription
+ * operator actually asks.
+ *
+ * Two rules keep this honest as the roster grows:
+ *
+ * - **Only prefixes observed in real traffic appear here.** A guessed mapping
+ *   that never matches is indistinguishable from one that works, and silently
+ *   files a client under the wrong name if the guess collides.
+ * - **The raw header is persisted alongside the derived name.** An unrecognised
+ *   client is then still attributable by its own User-Agent rather than
+ *   collapsing into one bucket with every other unknown.
+ */
+
+/** Longest prefix wins, so a more specific match cannot be shadowed. */
+const CLIENT_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  // Verified against this machine's proxy logs.
+  ["claude-cli/", "claude-code"],
+  // Verified: the AI SDK's own UA, used by NeuroLink's SDK callers.
+  ["ai/", "sdk"],
+];
+
+/** Cap stored User-Agents. They are attacker-influenced and unbounded. */
+const MAX_USER_AGENT_CHARS = 200;
+
+/**
+ * Derive a stable client name, or "unknown" when the header is absent or
+ * unrecognised. Never throws: attribution must not be able to fail a request.
+ */
+export function detectProxyClient(userAgent: string | undefined): string {
+  if (!userAgent) {
+    return "unknown";
+  }
+  const ua = userAgent.trim();
+  let best: string | undefined;
+  let bestLength = 0;
+  for (const [prefix, name] of CLIENT_PREFIXES) {
+    if (ua.startsWith(prefix) && prefix.length > bestLength) {
+      best = name;
+      bestLength = prefix.length;
+    }
+  }
+  return best ?? "unknown";
+}
+
+/** Read the User-Agent case-insensitively and bound it for storage. */
+export function readUserAgent(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === "user-agent" && typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? trimmed.slice(0, MAX_USER_AGENT_CHARS) : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** The pair every proxy engine attaches to its request log entry. */
+export function buildClientAttribution(
+  headers: Record<string, string> | undefined,
+): { clientApp: string; userAgent?: string } {
+  const userAgent = readUserAgent(headers);
+  return { clientApp: detectProxyClient(userAgent), userAgent };
+}

--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -81,6 +81,7 @@ import {
   logRequest,
   logRequestAttempt,
 } from "../../proxy/requestLogger.js";
+import { buildClientAttribution } from "../../proxy/clientAttribution.js";
 import { createSSEInterceptor } from "../../proxy/sseInterceptor.js";
 import {
   createStreamTerminalOutcomeTracker,
@@ -6971,6 +6972,7 @@ function createClaudeRequestRuntimeContext(args: {
       toolCount: Array.isArray(body.tools) ? body.tools.length : 0,
       account: finalAccountLabel ?? "",
       accountType: finalAccountType ?? "",
+      ...buildClientAttribution(ctx.headers),
       responseStatus: status,
       responseTimeMs: Date.now() - requestStartTime,
       ...(errorType ? { errorType } : {}),

--- a/src/lib/server/routes/codexProxyRoutes.ts
+++ b/src/lib/server/routes/codexProxyRoutes.ts
@@ -43,6 +43,7 @@ import {
   CODEX_ACCOUNT_PREFIX,
   parseCodexRateLimitHeaders,
 } from "../../proxy/codexAccountUsage.js";
+import { buildClientAttribution } from "../../proxy/clientAttribution.js";
 import { logRequest } from "../../proxy/requestLogger.js";
 import { parseRetryAfterMs } from "../../proxy/routingPolicy.js";
 import type {
@@ -350,6 +351,7 @@ async function handleCodexResponsesRequest(
         : 0,
       account,
       accountType: "codex-oauth",
+      ...buildClientAttribution(ctx.headers),
       responseStatus,
       responseTimeMs: Date.now() - requestStartTime,
       ...extra,

--- a/src/lib/server/routes/openaiProxyRoutes.ts
+++ b/src/lib/server/routes/openaiProxyRoutes.ts
@@ -25,6 +25,7 @@ import {
   handleTranslatedJsonRequest,
   handleTranslatedStreamRequest,
 } from "../../proxy/proxyTranslationEngine.js";
+import { buildClientAttribution } from "../../proxy/clientAttribution.js";
 import { logRequest } from "../../proxy/requestLogger.js";
 import { buildProxyTranslationPlan } from "../../proxy/routingPolicy.js";
 import type {
@@ -180,6 +181,7 @@ async function handleOpenAIToAnthropicBridge(args: {
       toolCount,
       account: "",
       accountType: "openai-bridge",
+      ...buildClientAttribution(ctx.headers),
       responseStatus,
       responseTimeMs: Date.now() - requestStartTime,
       ...extra,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -689,6 +689,18 @@ export type RequestLogEntry = {
    * cross-provider model lookup rather than assuming Anthropic.
    */
   provider?: string;
+  /**
+   * Which CLI made the request, derived from User-Agent, and the raw header it
+   * was derived from.
+   *
+   * Both are stored. The derived name is what a dashboard groups on, but the
+   * classifier only knows the clients it has seen — keeping the raw header
+   * means a client it does not recognise is still attributable rather than
+   * collapsing into "unknown" with everything else.
+   */
+  clientApp?: string;
+  /** Raw User-Agent, truncated. See clientApp. */
+  userAgent?: string;
   /** OTel trace ID for correlation with distributed traces */
   traceId?: string;
   /** OTel span ID for correlation with distributed traces */

--- a/src/lib/types/proxyClient.ts
+++ b/src/lib/types/proxyClient.ts
@@ -77,6 +77,23 @@ export type CliAccountUsageTotals = {
   unpricedRequests: number;
   /** Distinct models with no pricing row, so an operator can chase them. */
   unpricedModels: string[];
+  /**
+   * Same totals split by calling CLI, keyed by the derived client name.
+   *
+   * Empty for traffic logged before attribution existed — those rows carry no
+   * User-Agent, and guessing one retroactively would invent history.
+   */
+  byClient: Record<string, CliClientUsageTotals>;
+};
+
+/** Per-CLI slice of an account's usage. See CliAccountUsageTotals.byClient. */
+export type CliClientUsageTotals = {
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
 };
 
 /** One row of GET /accounts. */
@@ -125,6 +142,8 @@ export type CliAccountsResponse = {
 /** One request as recorded in the proxy request log, reduced to what costing needs. */
 export type ProxyLedgerEntry = {
   account: string;
+  /** Derived calling CLI; see CliAccountUsageTotals.byClient. */
+  clientApp: string;
   accountType: string;
   model: string;
   provider?: string;

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1679,6 +1679,98 @@ async function testCodexConfiguratorRoundTrip(): Promise<boolean> {
 }
 
 /**
+ * Usage must be attributable to the CLI that spent it, not only the account.
+ *
+ * The proxy already derived a client label from User-Agent, then dropped it
+ * into an OTel span attribute and nothing else. The request log never carried
+ * it, so the ledger could group by account and by nothing else — a pooled
+ * operator could see that an account burned $40 today but not whether it was
+ * Claude Code or a runaway script.
+ *
+ * Driven the way the CLIs drive it: real requests to a spawned proxy carrying
+ * real User-Agent headers, then the attribution read back out of the log the
+ * proxy itself wrote. Nothing here is stubbed.
+ */
+async function testPerClientAttribution(): Promise<boolean | null> {
+  const logsDir = path.join(os.homedir(), ".neurolink", "logs");
+  const today = new Date().toISOString().slice(0, 10);
+  const logPath = path.join(logsDir, `proxy-${today}.jsonl`);
+  const sizeBefore = fs.existsSync(logPath) ? fs.statSync(logPath).size : 0;
+
+  // Two distinct callers: one the classifier knows, one it does not.
+  const agents = [
+    { ua: "claude-cli/2.1.223 (external, cli)", expect: "claude-code" },
+    { ua: "some-unreleased-cli/9.9.9", expect: "unknown" },
+  ];
+  for (const a of agents) {
+    await fetchProxy("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "user-agent": a.ua },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+  }
+
+  if (!fs.existsSync(logPath)) {
+    log(
+      "proxy wrote no request log; attribution could not be observed",
+      "yellow",
+    );
+    return null;
+  }
+  const appended = fs
+    .readFileSync(logPath, "utf8")
+    .slice(sizeBefore)
+    .split("\n")
+    .filter((l) => l.trim());
+  if (appended.length === 0) {
+    log(
+      "proxy appended no log lines; attribution could not be observed",
+      "yellow",
+    );
+    return null;
+  }
+
+  const seen = new Map<string, string | undefined>();
+  for (const line of appended) {
+    try {
+      const rec = JSON.parse(line) as {
+        clientApp?: string;
+        userAgent?: string;
+      };
+      if (rec.clientApp) {
+        seen.set(rec.clientApp, rec.userAgent);
+      }
+    } catch {
+      // partial trailing line
+    }
+  }
+
+  for (const a of agents) {
+    if (!seen.has(a.expect)) {
+      log(
+        `request log carried no attribution for the ${a.expect} caller`,
+        "red",
+      );
+      return false;
+    }
+  }
+  // The raw header must survive for the client the classifier cannot name,
+  // otherwise every unrecognised CLI collapses into one indistinguishable
+  // bucket and the feature is useless exactly where it is most needed.
+  const rawForUnknown = seen.get("unknown");
+  if (!rawForUnknown || !rawForUnknown.startsWith("some-unreleased-cli/")) {
+    log("an unrecognised client lost its raw User-Agent", "red");
+    return false;
+  }
+  log(`attributed ${seen.size} distinct clients from live traffic`, "green");
+  return true;
+}
+
+/**
  * Restoring must require proving we own the value, not just the URL.
  *
  * The base-URL check catches a user who repointed the client somewhere else,
@@ -3269,6 +3361,73 @@ async function testAccountsQuotaWindowsAreNormalised(): Promise<boolean> {
     return false;
   }
   return true;
+}
+
+/**
+ * The ledger must split an account's usage by the CLI that spent it.
+ *
+ * One account is routinely shared by several CLIs, so an account-level total
+ * cannot answer "what is costing me this". Rows written before attribution
+ * existed carry no client at all and must land in their own bucket rather than
+ * being folded into a named one, which would overstate that client's spend.
+ */
+async function testLedgerSplitsUsageByClient(): Promise<boolean> {
+  const { readAccountUsage, resetAccountLedgerCache } =
+    await import("../src/lib/proxy/accountLedger.js");
+  const rows = [
+    ledgerRow({ requestId: "c1", account: "a@t", clientApp: "claude-code" }),
+    ledgerRow({ requestId: "c2", account: "a@t", clientApp: "claude-code" }),
+    ledgerRow({ requestId: "o1", account: "a@t", clientApp: "opencode" }),
+    // Pre-attribution row: no clientApp, no userAgent.
+    ledgerRow({ requestId: "x1", account: "a@t" }),
+  ];
+  return await withLedgerHome(rows, LEDGER_DATE, async () => {
+    resetAccountLedgerCache();
+    const row = (await readAccountUsage(LEDGER_DATE)).get("a@t");
+    if (!row) {
+      log("ledger reported nothing for an account with traffic", "red");
+      return false;
+    }
+    if (row.requests !== 4) {
+      log("ledger lost a request while splitting by client", "red");
+      return false;
+    }
+    const claude = row.byClient["claude-code"];
+    const opencode = row.byClient["opencode"];
+    const legacy = row.byClient["unattributed"];
+    if (!claude || claude.requests !== 2) {
+      log("ledger did not group both requests under their client", "red");
+      return false;
+    }
+    if (!opencode || opencode.requests !== 1) {
+      log("ledger dropped a second client's usage", "red");
+      return false;
+    }
+    if (!legacy || legacy.requests !== 1) {
+      log("a row predating attribution was not kept in its own bucket", "red");
+      return false;
+    }
+    // The split must reconcile with the total, or a dashboard showing both
+    // side by side contradicts itself.
+    const summed = Object.values(row.byClient).reduce(
+      (n, c) => n + c.requests,
+      0,
+    );
+    if (summed !== row.requests) {
+      log("per-client requests do not reconcile with the account total", "red");
+      return false;
+    }
+    const summedCost = Number(
+      Object.values(row.byClient)
+        .reduce((n, c) => n + c.costUsd, 0)
+        .toFixed(6),
+    );
+    if (summedCost !== row.costUsd) {
+      log("per-client cost does not reconcile with the account total", "red");
+      return false;
+    }
+    return true;
+  });
 }
 
 /** The route must join quota, stats and usage, and label the cost basis. */
@@ -5603,6 +5762,16 @@ const tests: TestFunction[] = [
   {
     name: "Proxy clients: Codex apply/restore round-trips a real config",
     fn: testCodexConfiguratorRoundTrip,
+    category: "proxy-config",
+  },
+  {
+    name: "Ledger: usage splits by calling CLI and reconciles",
+    fn: testLedgerSplitsUsageByClient,
+    category: "proxy-config",
+  },
+  {
+    name: "Attribution: the request log records the calling CLI",
+    fn: testPerClientAttribution,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
`GET /accounts` could say an account burned $40 today. It could not say whether that was Claude Code, OpenCode, or a runaway script — every figure was per-account only, and one pooled account is routinely shared by several CLIs.

**The signal already existed and was discarded.** `detectClientApp()` derived a label from `User-Agent`, wrote it into an OTel span attribute, and stopped. `RequestLogEntry` never carried it, so the ledger had nothing to group by.

## What lands

Requests record the calling client *and* the raw User-Agent. The ledger splits each account's totals into `byClient`:

```json
"usage": {
  "requests": 412, "costUsd": 18.44,
  "byClient": {
    "claude-code": { "requests": 380, "costUsd": 17.90 },
    "opencode":    { "requests": 32,  "costUsd": 0.54 }
  }
}
```

The split **reconciles with the total** — summing `byClient` requests and cost returns `requests` and `costUsd`, asserted in a test — so a dashboard showing both side by side cannot contradict itself.

## Two decisions worth challenging

**The raw header is stored, not just the derived name.** The classifier knows only prefixes observed in real traffic: `claude-cli/` and `ai/`, both verified against this machine's proxy logs. I deliberately did **not** guess prefixes for OpenCode, Qwen or Copilot — a guessed mapping is indistinguishable from a working one until it collides and files a client under the wrong name. Keeping the raw header means an unclassified client stays attributable by its own User-Agent instead of collapsing into one bucket, and naming it later is one line in `clientAttribution.ts` once the header has actually been seen.

**`unknown` and `unattributed` are separate buckets.** The first is a client we saw and could not name; the second is a row logged before attribution existed, carrying no header at all. Folding them together would make months of history look like an unidentified tool.

## Verification

Driven through the surface a CLI uses — real POSTs to a **spawned proxy** carrying real User-Agent headers, with attribution read back out of the request log the proxy itself wrote:

```
attributed 2 distinct clients from live traffic
```

That case includes a caller the classifier cannot name, asserting its raw header survives verbatim — the scenario where this feature is most needed and easiest to get wrong.

| Check | Result |
| --- | --- |
| `tsc --noEmit --strict` | clean |
| `eslint src test` | 0 errors (54 pre-existing warnings) |
| `pnpm run build` | clean |
| `continuous-test-suite-proxy` | **66 passed** |
| `continuous-test-suite-codex` | 31 passed |

Independent of #1453, #1454, #1455 — no overlapping files with the first two; touches `accountLedger.ts` which #1455 does not.