### PR TITLE
refactor(googleVertex): run both Gemini turns on the shared loop engine

### DIFF
--- a/src/lib/core/geminiLoopAdapter.ts
+++ b/src/lib/core/geminiLoopAdapter.ts
@@ -76,10 +76,13 @@ export function createGeminiLoopAdapter(
       conversation: GeminiTurnContent[],
       step: number,
     ): AgenticLoopStepRequest {
-      if (config.declarations) {
-        refreshNativeToolDeclarations(config.liveTools, config.declarations);
-      }
-      return { raw: config.buildRequest(conversation, step) };
+      const hydratedToolNames = config.declarations
+        ? refreshNativeToolDeclarations(config.liveTools, config.declarations)
+        : [];
+      return {
+        raw: config.buildRequest(conversation, step),
+        ...(hydratedToolNames.length > 0 ? { hydratedToolNames } : {}),
+      };
     },
 
     /**
@@ -90,10 +93,8 @@ export function createGeminiLoopAdapter(
      */
     ...(config.planReclaim
       ? {
-          planReclaim: (conversation: GeminiTurnContent[], step: number) => {
-            const reclaimed = config.planReclaim?.(conversation, step);
-            return reclaimed ? { conversation: reclaimed } : undefined;
-          },
+          planReclaim: (conversation: GeminiTurnContent[], step: number) =>
+            config.planReclaim?.(conversation, step),
         }
       : {}),
 
@@ -163,14 +164,28 @@ export function createGeminiLoopAdapter(
       const text = extractTextFromParts(collected.rawResponseParts);
 
       // Names cross the engine boundary in their ORIGINAL form.
-      const toolCalls = collected.stepFunctionCalls.map((call, index) => ({
+      const allCalls = collected.stepFunctionCalls.map((call, index) => ({
         id: `${config.providerLabel}_${index}_${call.name}`,
         name: originalNameFor(call.name),
         args: call.args,
       }));
 
+      // A call to the terminal structured-output tool is not a tool call at
+      // all — its arguments ARE the answer. Reporting it as text and leaving
+      // it out of `toolCalls` routes it through the engine's ordinary
+      // zero-tool-calls exit, so it is never dispatched, never struck against
+      // the breaker, and never recorded as a tool execution.
+      const terminal = config.finalResultToolName
+        ? allCalls.find((call) => call.name === config.finalResultToolName)
+        : undefined;
+      const toolCalls = terminal ? [] : allCalls;
+      const finalText = terminal ? JSON.stringify(terminal.args) : text;
+      if (terminal) {
+        config.onTerminalResult?.(finalText);
+      }
+
       return {
-        text,
+        text: finalText,
         toolCalls,
         usage: {
           inputTokens: collected.inputTokens,
@@ -194,6 +209,11 @@ export function createGeminiLoopAdapter(
       conversation: GeminiTurnContent[],
       stepResult: AgenticLoopStepResult<GeminiStepRaw>,
       toolResults: AgenticLoopToolCallResult[],
+      // Declared and unused: writing history needs no step number. It is here
+      // for the provider wrappers around this adapter, which record tool
+      // activity keyed by the loop's own step and must not count their own
+      // invocations to get it.
+      _step: number,
     ): GeminiTurnContent[] {
       // Copied before `pushModelResponseToHistory` mutates it: the engine
       // treats the conversation as a value it hands in and gets back, so
@@ -211,8 +231,13 @@ export function createGeminiLoopAdapter(
           functionResponse: {
             // Back to the sanitized wire name the model actually called.
             name: sanitizedNameFor(result.name),
+            // The engine's own payload, verbatim. A blocked or burnt-out
+            // tool is reported as { error, status, do_not_retry }, and those
+            // extra fields are MODEL-VISIBLE instructions — re-wrapping just
+            // the message drops the "do not call this again" hint and the
+            // model keeps spending steps on a tool that will never work.
             response: result.error
-              ? { error: result.error }
+              ? (result.output as Record<string, unknown>)
               : { result: result.output },
           },
         })),

--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -5,6 +5,7 @@ import type {
   AgenticLoopOptions,
   AgenticLoopResult,
   AgenticLoopStepResult,
+  AgenticLoopToolCall,
   AgenticLoopToolCallResult,
   AgenticLoopUsage,
 } from "../types/index.js";
@@ -41,6 +42,164 @@ function sumUsage(a: AgenticLoopUsage, b: AgenticLoopUsage): AgenticLoopUsage {
     reasoningTokens:
       (a.reasoningTokens ?? 0) + (b.reasoningTokens ?? 0) || undefined,
   };
+}
+
+/**
+ * Dispatch one step's tool calls.
+ *
+ * Split out of `runAgenticLoop` because it is the one part of the turn with
+ * its own decision tree — breaker, hydration, execution, failure
+ * classification — and reading the loop should not mean reading all of it.
+ * It owns no state: everything it needs arrives as arguments, and it reports
+ * what happened by returning it, so the turn's accumulators stay in one place.
+ */
+async function dispatchStepTools(params: {
+  calls: AgenticLoopToolCall[];
+  adapter: Pick<
+    AgenticLoopAdapter<unknown>,
+    "toolFailureBreaker" | "resolveToolOnMiss"
+  >;
+  tools: AgenticLoopOptions["tools"];
+  failedTools: Map<string, { count: number; lastError: string }>;
+  abortSignal: AbortSignal;
+}): Promise<{
+  toolResults: AgenticLoopToolCallResult[];
+  executions: AgenticLoopResult<unknown>["toolExecutions"];
+  dispatched: AgenticLoopToolCall[];
+  /** True when an abort cut the batch short, so the caller must NOT append a
+   *  partial tool-result turn. */
+  abortedMidBatch: boolean;
+}> {
+  const { calls, adapter, tools, failedTools, abortSignal } = params;
+  const toolResults: AgenticLoopToolCallResult[] = [];
+  const executions: AgenticLoopResult<unknown>["toolExecutions"] = [];
+  const dispatched: AgenticLoopToolCall[] = [];
+  let abortedMidBatch = false;
+  for (const call of calls) {
+    // Honour an abort BETWEEN tool executions. A step can carry several calls,
+    // and each one costs up to a full tool timeout, so without this a wide
+    // batch keeps running long past the moment the turn was cancelled — the
+    // step-top check only fires once the whole batch has drained. Passing the
+    // signal into execute() is not enough on its own: a tool that ignores it
+    // runs to completion, and every remaining call still gets STARTED.
+    if (abortSignal.aborted) {
+      abortedMidBatch = true;
+      break;
+    }
+    dispatched.push(call);
+    const breaker = adapter.toolFailureBreaker;
+    const failInfo = breaker ? failedTools.get(call.name) : undefined;
+    if (breaker && failInfo && failInfo.count >= breaker.maxRetries) {
+      const output = {
+        error: `TOOL_PERMANENTLY_FAILED: "${call.name}" has failed ${failInfo.count} times. Last error: ${failInfo.lastError}.`,
+        status: "permanently_failed",
+        do_not_retry: true,
+      };
+      toolResults.push({
+        ...call,
+        output,
+        error: output.error,
+        permanentlyFailed: true,
+      });
+      executions.push({
+        id: call.id,
+        name: call.name,
+        input: call.args,
+        output,
+        error: output.error,
+      });
+      continue;
+    }
+    // Second lookup path for adapters that discover tools mid-turn.
+    // The miss is defined as "nothing executable under this name"
+    // rather than "no key under this name", because the guard directly
+    // below already treats a present-but-unexecutable entry as absent —
+    // a deferred-catalog placeholder is exactly that shape, and it is
+    // precisely what hydration exists to resolve.
+    const declaredTool = tools?.[call.name];
+    const tool = declaredTool?.execute
+      ? declaredTool
+      : (adapter.resolveToolOnMiss?.(call.name) ?? declaredTool);
+    if (!tool?.execute) {
+      const output = breaker
+        ? {
+            error: `TOOL_NOT_FOUND: "${call.name}" does not exist.`,
+            status: "permanently_failed",
+            do_not_retry: true,
+          }
+        : { error: `Tool not found: ${call.name}` };
+      toolResults.push({
+        ...call,
+        output,
+        error: output.error,
+        permanentlyFailed: !!breaker,
+      });
+      executions.push({
+        id: call.id,
+        name: call.name,
+        input: call.args,
+        output,
+        error: output.error,
+      });
+      continue;
+    }
+    try {
+      const output = await tool.execute(call.args, {
+        toolCallId: call.id,
+        abortSignal: abortSignal,
+      });
+      // A result can report failure without throwing — an MCP isError
+      // payload, a proxy-blocked call resolving with `{ error }`. When
+      // the breaker is told how to recognise those, they strike it
+      // exactly as a throw does; otherwise the model can grind on a
+      // blocked tool for the whole step budget.
+      const resultFailure = breaker?.classifyResultFailure?.(output);
+      if (breaker) {
+        if (resultFailure) {
+          const current = failedTools.get(call.name) ?? {
+            count: 0,
+            lastError: "",
+          };
+          current.count++;
+          current.lastError = resultFailure;
+          failedTools.set(call.name, current);
+        } else if (breaker.consecutive) {
+          // Genuinely consecutive: a clean result clears the count, so
+          // an argument-dependent soft error cannot accumulate its way
+          // to disabling a tool that works.
+          failedTools.delete(call.name);
+        }
+      }
+      toolResults.push({ ...call, output });
+      executions.push({
+        id: call.id,
+        name: call.name,
+        input: call.args,
+        output,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (breaker) {
+        const current = failedTools.get(call.name) ?? {
+          count: 0,
+          lastError: "",
+        };
+        current.count++;
+        current.lastError = message;
+        failedTools.set(call.name, current);
+      }
+      const output = { error: message, status: "failed" };
+      toolResults.push({ ...call, output, error: message });
+      executions.push({
+        id: call.id,
+        name: call.name,
+        input: call.args,
+        output,
+        error: message,
+      });
+    }
+  }
+  return { toolResults, executions, dispatched, abortedMidBatch };
 }
 
 /**
@@ -100,12 +259,27 @@ export function runAgenticLoop<TConversation>(
 
         if (adapter.planReclaim) {
           const reclaimed = adapter.planReclaim(conversation, step);
-          if (reclaimed) {
+          if (reclaimed?.conversation !== undefined) {
             conversation = reclaimed.conversation;
+          }
+          // A guard that could not reclaim enough room ends the turn HERE,
+          // before the request goes out — stepping into a provider rejection
+          // would lose every completed step of the turn.
+          if (reclaimed?.stop) {
+            break;
           }
         }
 
         const request = adapter.buildStepRequest(conversation, step);
+
+        // A tool that just became callable starts clean. Its TOOL_NOT_FOUND
+        // strikes were recorded against a name that genuinely did not resolve
+        // yet, and the breaker is consulted before the lookup, so without this
+        // a deferred tool the model named twice is refused for the rest of the
+        // turn at the exact moment it becomes usable.
+        for (const name of request.hydratedToolNames ?? []) {
+          failedTools.delete(name);
+        }
 
         // Pre-first-chunk 429/5xx retry: watch whether THIS attempt of
         // THIS step pushes anything to the shared channel before it
@@ -165,7 +339,8 @@ export function runAgenticLoop<TConversation>(
             `[${adapter.providerLabel}] Malformed function call at step ${step + 1}/${adapter.maxSteps}; retrying once.`,
           );
           conversation =
-            adapter.buildMalformedRetryNote?.(conversation) ?? conversation;
+            adapter.buildMalformedRetryNote?.(conversation, step) ??
+            conversation;
           continue;
         }
 
@@ -178,111 +353,17 @@ export function runAgenticLoop<TConversation>(
           hadToolCallsAtCap = true;
         }
 
-        const toolResults: AgenticLoopToolCallResult[] = [];
-        let abortedMidBatch = false;
-        for (const call of stepResult.toolCalls) {
-          // Honour an abort BETWEEN tool executions. A step can carry several
-          // calls, and each one costs up to a full tool timeout, so without
-          // this a wide batch keeps running long past the moment the turn was
-          // cancelled — the step-top check above only fires once the whole
-          // batch has drained. Passing the signal into execute() is not
-          // enough on its own: a tool that ignores it still runs to
-          // completion, and every remaining call still gets STARTED.
-          if (internalAbort.signal.aborted) {
-            abortedMidBatch = true;
-            break;
-          }
-          allToolCalls.push(call);
-          const breaker = adapter.toolFailureBreaker;
-          const failInfo = breaker ? failedTools.get(call.name) : undefined;
-          if (breaker && failInfo && failInfo.count >= breaker.maxRetries) {
-            const output = {
-              error: `TOOL_PERMANENTLY_FAILED: "${call.name}" has failed ${failInfo.count} times. Last error: ${failInfo.lastError}.`,
-              status: "permanently_failed",
-              do_not_retry: true,
-            };
-            toolResults.push({
-              ...call,
-              output,
-              error: output.error,
-              permanentlyFailed: true,
-            });
-            allToolExecutions.push({
-              id: call.id,
-              name: call.name,
-              input: call.args,
-              output,
-              error: output.error,
-            });
-            continue;
-          }
-          // Second lookup path for adapters that discover tools mid-turn.
-          // The miss is defined as "nothing executable under this name"
-          // rather than "no key under this name", because the guard directly
-          // below already treats a present-but-unexecutable entry as absent —
-          // a deferred-catalog placeholder is exactly that shape, and it is
-          // precisely what hydration exists to resolve.
-          const declaredTool = options.tools?.[call.name];
-          const tool = declaredTool?.execute
-            ? declaredTool
-            : (adapter.resolveToolOnMiss?.(call.name) ?? declaredTool);
-          if (!tool?.execute) {
-            const output = breaker
-              ? {
-                  error: `TOOL_NOT_FOUND: "${call.name}" does not exist.`,
-                  status: "permanently_failed",
-                  do_not_retry: true,
-                }
-              : { error: `Tool not found: ${call.name}` };
-            toolResults.push({
-              ...call,
-              output,
-              error: output.error,
-              permanentlyFailed: !!breaker,
-            });
-            allToolExecutions.push({
-              id: call.id,
-              name: call.name,
-              input: call.args,
-              output,
-              error: output.error,
-            });
-            continue;
-          }
-          try {
-            const output = await tool.execute(call.args, {
-              toolCallId: call.id,
-              abortSignal: internalAbort.signal,
-            });
-            toolResults.push({ ...call, output });
-            allToolExecutions.push({
-              id: call.id,
-              name: call.name,
-              input: call.args,
-              output,
-            });
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            if (breaker) {
-              const current = failedTools.get(call.name) ?? {
-                count: 0,
-                lastError: "",
-              };
-              current.count++;
-              current.lastError = message;
-              failedTools.set(call.name, current);
-            }
-            const output = { error: message, status: "failed" };
-            toolResults.push({ ...call, output, error: message });
-            allToolExecutions.push({
-              id: call.id,
-              name: call.name,
-              input: call.args,
-              output,
-              error: message,
-            });
-          }
-        }
+        const dispatch = await dispatchStepTools({
+          calls: stepResult.toolCalls,
+          adapter,
+          tools: options.tools,
+          failedTools,
+          abortSignal: internalAbort.signal,
+        });
+        const toolResults = dispatch.toolResults;
+        allToolCalls.push(...dispatch.dispatched);
+        allToolExecutions.push(...dispatch.executions);
+        const abortedMidBatch = dispatch.abortedMidBatch;
 
         // A batch cut short leaves some calls without results, and the
         // tool-result turn is appended as one message: writing it here would
@@ -298,6 +379,7 @@ export function runAgenticLoop<TConversation>(
           conversation,
           stepResult,
           toolResults,
+          step,
         );
       }
 

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -2106,7 +2106,12 @@ export class AnthropicProvider extends BaseProvider {
       // instead would batch every step's tools into one late write.
       const adapter: typeof baseAdapter = {
         ...baseAdapter,
-        buildToolResultMessages: (conversation, stepResult, toolResults) => {
+        buildToolResultMessages: (
+          conversation,
+          stepResult,
+          toolResults,
+          engineStep,
+        ) => {
           for (const result of toolResults) {
             toolsUsed.push(result.name);
           }
@@ -2157,6 +2162,7 @@ export class AnthropicProvider extends BaseProvider {
             conversation,
             stepResult,
             toolResults,
+            engineStep,
           );
         },
       };

--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -1070,7 +1070,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
                     return undefined;
                   }
                   contextGuard.resetAfterReclaim();
-                  return working;
+                  return { conversation: working };
                 },
               });
 
@@ -1085,8 +1085,17 @@ export class GoogleAIStudioProvider extends BaseProvider {
                   contents,
                   stepResult,
                   toolResults,
+                  engineStep,
                 ) => {
-                  step++;
+                  // The engine's own step, not a count of times this hook ran.
+                  // The two agree only while nothing skips the hook mid-turn:
+                  // a malformed-call retry `continue`s before it and still
+                  // consumes a step, so a self-incrementing counter drifts by
+                  // exactly the number of retries and mislabels every row
+                  // after the first. Values are unchanged for this provider
+                  // today — it enables no such retry — and stay correct if it
+                  // ever does.
+                  step = engineStep + 1;
                   for (const call of stepResult.toolCalls) {
                     span.addEvent("gen_ai.tool_call", {
                       "tool.name": call.name,
@@ -1147,6 +1156,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
                     contents,
                     stepResult,
                     toolResults,
+                    engineStep,
                   );
                   // Project this step's growth: the appended tool results ride
                   // the next prompt, which the provider has not reported on yet.
@@ -1537,14 +1547,21 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 return undefined;
               }
               contextGuard.resetAfterReclaim();
-              return working;
+              return { conversation: working };
             },
           });
 
           const adapter: typeof baseAdapter = {
             ...baseAdapter,
-            buildToolResultMessages: (contents, stepResult, toolResults) => {
-              step++;
+            buildToolResultMessages: (
+              contents,
+              stepResult,
+              toolResults,
+              engineStep,
+            ) => {
+              // Same as the streaming twin: the engine's step, not a count of
+              // hook invocations. See the comment there.
+              step = engineStep + 1;
               for (const call of stepResult.toolCalls) {
                 span.addEvent("gen_ai.tool_call", {
                   "tool.name": call.name,
@@ -1598,6 +1615,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
                 contents,
                 stepResult,
                 toolResults,
+                engineStep,
               );
               try {
                 const appended = next[next.length - 1];

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -55,7 +55,12 @@ import {
 
 import { createNativeThinkingConfig } from "../../utils/thinkingConfig.js";
 import { resolveLiveTool } from "../../tools/toolDiscovery.js";
-import type { ToolExecuteFunction, Tool } from "../../types/index.js";
+import { raceWithAbort, withTimeout } from "../../utils/async/index.js";
+import type {
+  ToolExecuteFunction,
+  Tool,
+  GeminiToolExecutionGuards,
+} from "../../types/index.js";
 import {
   jsonSchema as aiJsonSchema,
   tool as createAISDKTool,
@@ -635,18 +640,60 @@ export function buildNativeToolDeclarations(
 export function buildDedupedEngineTools(
   declarations: NativeToolDeclarationsResult | undefined,
   tools: Record<string, Tool> | undefined,
+  guards?: GeminiToolExecutionGuards,
 ): NonNullable<AgenticLoopOptions["tools"]> {
   const engineTools: NonNullable<AgenticLoopOptions["tools"]> = {};
+
+  /**
+   * Everything a loop needs around a tool call that the engine does not do
+   * itself, in one place so both the declared and the fallback path get it.
+   *
+   * Order matters. `raceWithAbort` sits INSIDE `withTimeout` so a turn-level
+   * abort is observed the moment it fires rather than after the tool settles,
+   * and the timeout still bounds a tool that neither settles nor honours its
+   * signal. The progress pings bracket the await because the stall watchdog
+   * is a whole-turn interval comparing wall-clock against the last progress
+   * mark — without them a legitimately slow tool reads as a stalled turn and
+   * gets killed.
+   */
+  const guard = (
+    name: string,
+    execute: NonNullable<Tool["execute"]>,
+  ): ((args: Record<string, unknown>, opts: unknown) => Promise<unknown>) => {
+    return async (args: Record<string, unknown>, opts: unknown) => {
+      const call = () =>
+        Promise.resolve(execute(args, opts as Parameters<typeof execute>[1]));
+      if (!guards) {
+        return call();
+      }
+      guards.onProgress?.();
+      try {
+        const raced = guards.abortSignal
+          ? raceWithAbort(call(), guards.abortSignal)
+          : call();
+        return await (guards.toolTimeoutMs === undefined
+          ? raced
+          : withTimeout(
+              raced,
+              guards.toolTimeoutMs,
+              `Tool "${name}" execution timed out after ${guards.toolTimeoutMs}ms`,
+            ));
+      } finally {
+        // In `finally`, not after a successful await: a tool that times out or
+        // throws has still consumed real time, and skipping the mark there
+        // would leave the watchdog measuring from before the call.
+        guards.onProgress?.();
+      }
+    };
+  };
+
   if (declarations) {
     for (const [safeName, originalName] of declarations.originalNameMap) {
       const execute = declarations.executeMap.get(safeName);
       if (!execute) {
         continue;
       }
-      engineTools[originalName] = {
-        execute: async (args: Record<string, unknown>, opts: unknown) =>
-          execute(args, opts as Parameters<typeof execute>[1]),
-      };
+      engineTools[originalName] = { execute: guard(originalName, execute) };
     }
     return engineTools;
   }
@@ -658,10 +705,7 @@ export function buildDedupedEngineTools(
     if (!execute) {
       continue;
     }
-    engineTools[name] = {
-      execute: async (args: Record<string, unknown>, opts: unknown) =>
-        execute(args, opts as Parameters<typeof execute>[1]),
-    };
+    engineTools[name] = { execute: guard(name, execute) };
   }
   return engineTools;
 }
@@ -669,16 +713,16 @@ export function buildDedupedEngineTools(
 export function refreshNativeToolDeclarations(
   liveTools: Record<string, Tool> | undefined,
   current: NativeToolDeclarationsResult,
-): boolean {
+): string[] {
   if (!liveTools) {
-    return false;
+    return [];
   }
   const declaredOriginals = new Set(current.originalNameMap.values());
   const missing = Object.entries(liveTools).filter(
     ([name]) => !declaredOriginals.has(name),
   );
   if (missing.length === 0) {
-    return false;
+    return [];
   }
   const built = buildNativeToolDeclarations(
     Object.fromEntries(missing),
@@ -698,7 +742,12 @@ export function refreshNativeToolDeclarations(
       .map(([name]) => name)
       .join(", ")}`,
   );
-  return true;
+  // The ORIGINAL names, which is what a caller's breaker is keyed by. A tool
+  // that accrued TOOL_NOT_FOUND strikes while it was still deferred was never
+  // really failing — those strikes are snapshot artifacts, and leaving them in
+  // place disables the tool for the rest of the turn at the very moment it
+  // becomes callable.
+  return missing.map(([name]) => name);
 }
 
 /**

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -31,6 +31,8 @@ import {
 import type { NeuroLink } from "../../neurolink.js";
 import { warnGoogleSdkIgnoresProxy } from "../../proxy/proxyFetch.js";
 import type {
+  GeminiTurnContent,
+  NativeToolDeclarationsResult,
   UnknownRecord,
   ZodUnknownSchema,
   EnhancedGenerateResult,
@@ -111,6 +113,7 @@ import {
   appendStepText,
   buildAbortedTurnMessage,
   buildContextCapMessage,
+  buildDedupedEngineTools,
   buildToolLoopCapMessage,
   buildTurnStalledMessage,
   buildTurnTimeoutMessage,
@@ -124,6 +127,8 @@ import {
   resolveTurnStopReason,
   DedupExecuteMap,
 } from "../googleNativeGemini3/index.js";
+import { createGeminiLoopAdapter } from "../../core/geminiLoopAdapter.js";
+import { runAgenticLoop } from "../../core/loopEngine.js";
 import { createStreamChannel } from "../../core/streamChannel.js";
 import { toNativeToolDeclarations } from "../../core/nativeToolFormat.js";
 import {
@@ -1798,6 +1803,7 @@ export class GoogleVertexProvider extends BaseProvider {
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
     const executeMap = new DedupExecuteMap();
+    let declarations: NativeToolDeclarationsResult | undefined;
 
     if (
       options.tools &&
@@ -1808,6 +1814,11 @@ export class GoogleVertexProvider extends BaseProvider {
         options.tools,
         "functionDeclarations",
       );
+      // Kept, not discarded: the shared adapter needs originalNameMap to
+      // translate sanitized wire names back, and buildDedupedEngineTools
+      // reads executeMap through it — which is the DedupExecuteMap that makes
+      // an identical repeated call answer from cache instead of re-running.
+      declarations = declared;
       tools = declared.toolsConfig;
       for (const [name, execute] of declared.executeMap) {
         executeMap.set(name, execute);
@@ -2011,14 +2022,9 @@ export class GoogleVertexProvider extends BaseProvider {
       input: Record<string, unknown>;
       output: unknown;
     }> = [];
-    let step = 0;
 
     // Track structured output from final_result tool (when using final_result pattern)
     let finalResultStructuredOutput: Record<string, unknown> | undefined;
-
-    // Track failed tools to prevent infinite retry loops
-    // Key: tool name, Value: { count: retry attempts, lastError: error message }
-    const failedTools = new Map<string, { count: number; lastError: string }>();
 
     // In-loop context guard: stop calling tools when the accumulated
     // conversation approaches the model's context window instead of stepping
@@ -2079,103 +2085,91 @@ export class GoogleVertexProvider extends BaseProvider {
       internalAbort.abort();
     }
     let wasAborted = false;
-    // One retry per turn for MALFORMED_FUNCTION_CALL steps (see the retry
-    // block after the step drain).
-    let malformedRetryCount = 0;
 
     // Step-cap flags declared in the outer scope so the terminal block (also
     // inside the try) and the finishReason mapping (after the finally) can
     // both read them.
     let hitStepLimit = false;
     let synthesizedFinalAnswer = false;
+    // How many steps the ENGINE actually took, reported back from the per-step
+    // hook. The terminal block compares it against maxSteps, and counting hook
+    // invocations instead would drift by the number of malformed retries.
+    let stepsTaken = 0;
 
     try {
       // Agentic loop for tool calling
-      while (step < maxSteps) {
-        if (effectiveSignal.aborted) {
-          wasAborted = true;
-          break;
-        }
-        // Context guard: stop the tool loop before the accumulated
-        // conversation crosses the window threshold — synthesize from what
-        // we have instead of stepping into a provider rejection.
-        if (contextGuard.shouldStop()) {
-          // Parity upgrade: try to RECLAIM budget and keep going before
-          // falling back to the historic stop-only behaviour. Ending the turn
-          // early is safe but throws away work the model was mid-way through;
-          // dropping the oldest complete tool exchanges usually buys enough
-          // room to finish. Only when reclaiming changes nothing do we stop.
-          const reclaimed = reclaimVertexLoopContext(
-            currentContents,
-            modelName,
-            contextGuard.projectedNextPromptTokens,
-          );
-          if (reclaimed) {
-            contextGuard.resetAfterReclaim();
-          } else {
-            hitContextLimit = true;
-            logger.warn(
-              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
-            );
-            break;
-          }
-        }
-        step++;
-        turnClock.noteProgress();
-        // Mid-turn discovery sync: search_tools may have hydrated new tools
-        // into the live record during the previous step — advertise them in
-        // this step's request instead of leaving them invisible until the
-        // next turn (TOOL_NOT_FOUND).
-        this.refreshGeminiToolDeclarations(
-          options.tools,
-          tools?.[0]?.functionDeclarations,
-          executeMap,
-          failedTools,
-        );
-        logger.debug(`[GoogleVertex] Native SDK step ${step}/${maxSteps}`);
-
-        try {
-          const stream = await client.models.generateContentStream({
-            model: modelName,
-            contents: currentContents,
-            config: { ...config, abortSignal: effectiveSignal },
-          });
-
-          const stepFunctionCalls: Array<{
-            name: string;
-            args: Record<string, unknown>;
-          }> = [];
-
-          // Capture raw response parts including thoughtSignature
-          const rawResponseParts: unknown[] = [];
-          // This step's own finish reason (vs the cross-step
-          // lastFinishReason) — drives the single MALFORMED_FUNCTION_CALL
-          // retry below.
-          let stepFinishReason: string | undefined;
-          // Per-step usage trackers for WRITE-THROUGH accumulation: within a
-          // step's chunk stream the counts are latest-wins (promptTokenCount
-          // arrives once in the final chunk; candidates/thoughts counts are
-          // cumulative across chunks), so each chunk folds only the DELTA
-          // over this step's previous value into the turn totals. The totals
-          // are therefore correct at every point mid-drain — a step killed
-          // mid-stream (abort / turn deadline / stall watchdog) still counts
-          // the billed tokens it already reported.
-
-          // The drain now lives in collectVertexStreamChunks. The hooks below
-          // are the two couplings it had to this loop, plus the per-chunk
-          // usage deltas — those must stay per-chunk so a step killed
-          // mid-stream still bills what it reported.
-          const collected = await collectVertexStreamChunks(
-            stream,
-            {
-              push: (chunk) => {
-                if (chunk.content) {
-                  incrementalTextChunks.push(chunk.content);
+      // The turn runs on the shared engine. The step cap, tool dispatch, the
+      // failure breaker, per-step usage accumulation, the single malformed
+      // retry and the pre-first-chunk provider retry all live there now; what
+      // stays here is everything the engine has no opinion about — the turn
+      // clock, the context guard, conversation-memory storage, the wrap-up
+      // nudge, and the terminal block below.
+      const engineAdapter = createGeminiLoopAdapter({
+        providerLabel: "GoogleVertex",
+        maxSteps,
+        // Ported verbatim: the same DEFAULT_TOOL_MAX_RETRIES threshold, plus
+        // the two rules this loop has always had and the engine did not.
+        toolFailureBreaker: {
+          maxRetries: DEFAULT_TOOL_MAX_RETRIES,
+          // Strikes are CONSECUTIVE here: a clean result clears the count, so
+          // an argument-dependent soft error cannot accumulate its way to
+          // disabling a tool that works.
+          consecutive: true,
+          // A result that reports failure without throwing — an MCP isError
+          // payload, a proxy-blocked call resolving with { error } — counts
+          // toward the breaker exactly as a throw does.
+          classifyResultFailure: (output) =>
+            extractToolFailureText(output) ?? undefined,
+        },
+        liveTools: options.tools ?? {},
+        ...(declarations ? { declarations } : {}),
+        ...(useFinalResultTool
+          ? {
+              finalResultToolName: "final_result",
+              onTerminalResult: (text) => {
+                try {
+                  finalResultStructuredOutput = JSON.parse(text) as Record<
+                    string,
+                    unknown
+                  >;
+                } catch {
+                  /* the caller's coercion layer repairs a partial payload */
                 }
               },
+            }
+          : {}),
+        enableMalformedRetry: true,
+        buildMalformedRetryNote: (conversation, retriedStep) => {
+          this.emitTurnEvent({
+            phase: "malformed-retry",
+            step: retriedStep + 1,
+            maxSteps,
+          });
+          return [
+            ...conversation,
+            {
+              role: "user",
+              parts: [
+                {
+                  text:
+                    "Your previous function call was malformed and could not " +
+                    "be parsed. Re-issue it as a single valid function call, " +
+                    "or answer in plain text.",
+                },
+              ],
             },
+          ];
+        },
+        // The turn clock's per-chunk ping and the context guard's per-step
+        // prompt size both ride the drain, which is why this loop keeps its
+        // own collector rather than the adapter's default.
+        collectStep: (stream, channel) =>
+          collectVertexStreamChunks(
+            stream as AsyncIterable<{
+              functionCalls?: NativeFunctionCall[];
+              [key: string]: unknown;
+            }>,
+            channel,
             {
               onProgress: () => turnClock.noteProgress(),
               onUsage: (input, output) => contextGuard.noteUsage(input, output),
@@ -2191,431 +2185,242 @@ export class GoogleVertexProvider extends BaseProvider {
                 }
               },
             },
-          );
-          rawResponseParts.push(...collected.rawResponseParts);
-          stepFunctionCalls.push(...collected.stepFunctionCalls);
-          if (collected.finishReason) {
-            stepFinishReason = collected.finishReason;
-            lastFinishReason = collected.finishReason;
+          ),
+        planReclaim: (conversation) => {
+          if (!contextGuard.shouldStop()) {
+            return undefined;
           }
-
-          // Extract text from raw parts after stream completes
-          // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
-          const stepText = rawResponseParts
-            .filter(
-              (part): part is { text: string } =>
-                typeof (part as Record<string, unknown>).text === "string",
-            )
-            .map((part) => part.text)
-            .join("");
-
-          // MALFORMED_FUNCTION_CALL is usually a transient formatting failure
-          // (the model emitted an unparseable call): retry the step ONCE with
-          // a corrective note instead of hard-ending the turn with empty
-          // content — automated alert-RCA turns were dying at step 2-4 on
-          // this, mislabeled as step-cap exits.
+          // Try to RECLAIM budget and keep going before falling back to the
+          // historic stop-only behaviour. Ending the turn early is safe but
+          // throws away work the model was mid-way through; dropping the
+          // oldest complete tool exchanges usually buys enough room to finish.
+          const working = [...conversation] as Array<{
+            role: string;
+            parts: VertexNativeLoopPart[];
+          }>;
           if (
-            stepFunctionCalls.length === 0 &&
-            !stepText &&
-            stepFinishReason === "MALFORMED_FUNCTION_CALL" &&
-            malformedRetryCount < 1 &&
-            !effectiveSignal.aborted
+            reclaimVertexLoopContext(
+              working,
+              modelName,
+              contextGuard.projectedNextPromptTokens,
+            )
           ) {
-            malformedRetryCount++;
-            logger.warn(
-              `[GoogleVertex] Model returned MALFORMED_FUNCTION_CALL at step ${step}/${maxSteps}; retrying once with a corrective note.`,
-            );
-            this.emitTurnEvent({ phase: "malformed-retry", step, maxSteps });
-            if (rawResponseParts.length > 0) {
-              currentContents.push({
-                role: "model",
-                parts: rawResponseParts as VertexNativePart[],
-              });
-            }
-            currentContents.push({
-              role: "user",
-              parts: [
-                {
-                  text:
-                    "Your previous function call was malformed and could not " +
-                    "be parsed. Re-issue it as a single valid function call, " +
-                    "or answer in plain text.",
-                },
-              ],
-            });
-            continue;
+            contextGuard.resetAfterReclaim();
+            return { conversation: working };
           }
-
-          // If no function calls, we're done
-          if (stepFunctionCalls.length === 0) {
-            finalText = stepText;
-            break;
-          }
-
-          // Check for final_result tool call - this is our structured output pattern
-          if (useFinalResultTool) {
-            const finalResultCall = stepFunctionCalls.find(
-              (call) => call.name === "final_result",
-            );
-            if (finalResultCall) {
-              // Extract the structured output from final_result arguments
-              finalResultStructuredOutput = finalResultCall.args as Record<
-                string,
-                unknown
-              >;
-              logger.debug(
-                "[GoogleVertex] Received final_result tool call with structured output (stream)",
-                {
-                  outputKeys: Object.keys(finalResultStructuredOutput),
-                },
-              );
-              // Return the structured output as JSON text
-              finalText = JSON.stringify(finalResultStructuredOutput);
-              break;
-            }
-          }
-
-          // Execute function calls
-          logger.debug(
-            `[GoogleVertex] Executing ${stepFunctionCalls.length} function calls`,
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} — synthesizing a final answer.`,
           );
+          return { stop: true };
+        },
+        buildRequest: (conversation) => ({
+          model: modelName,
+          contents: conversation,
+          config: { ...config, ...(tools ? { tools } : {}) },
+        }),
+        sendStep: async (request, signal) => {
+          turnClock.noteProgress();
+          const built = request as {
+            model: string;
+            contents: Array<{ role: string; parts: unknown[] }>;
+            config?: Record<string, unknown>;
+          };
+          return client.models.generateContentStream({
+            model: built.model,
+            contents: built.contents,
+            config: { ...(built.config ?? {}), abortSignal: signal },
+          }) as Promise<
+            AsyncIterable<{
+              functionCalls?: NativeFunctionCall[];
+              [key: string]: unknown;
+            }>
+          >;
+        },
+      });
 
-          // Add model response with ALL parts (including thoughtSignature) to history
-          // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
-          currentContents.push({
-            role: "model",
-            parts:
-              rawResponseParts.length > 0
-                ? (rawResponseParts as VertexNativeLoopPart[])
-                : stepFunctionCalls.map((fc) => ({
-                    functionCall: fc,
-                  })),
-          });
-
-          // Execute each function and collect responses (plus an optional
-          // trailing wrap-up nudge text part).
-          const functionResponses: Array<
-            | {
-                functionResponse: {
-                  name: string;
-                  response: Record<string, unknown>;
-                };
-              }
-            | { text: string }
-          > = [];
-          // Per-step bookkeeping for conversation-memory storage.
-          const stepStorageCalls: Array<{
-            toolName: string;
-            args: Record<string, unknown>;
-          }> = [];
-          const stepStorageResults: Array<{
-            toolName: string;
-            output: unknown;
-          }> = [];
-
-          // Note: tool:start / tool:end events are emitted by ToolsManager's
-          // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
-          for (const call of stepFunctionCalls) {
-            // Honor a deadline/stall/caller abort BETWEEN tool executions —
-            // without this check a multi-tool step keeps executing its whole
-            // batch (up to N × toolTimeoutMs past the deadline) before the
-            // while-top check finally breaks.
-            if (effectiveSignal.aborted) {
-              wasAborted = true;
-              break;
-            }
-            allToolCalls.push({ toolName: call.name, args: call.args });
-            stepStorageCalls.push({ toolName: call.name, args: call.args });
-
-            // Check if this tool has already exceeded retry limit
-            const failedInfo = failedTools.get(call.name);
-            if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
-              logger.warn(
-                `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
-              );
-              const errorPayload = {
-                error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
-                status: "permanently_failed",
-                do_not_retry: true,
-              };
-              functionResponses.push({
-                functionResponse: {
-                  name: call.name,
-                  response: errorPayload,
-                },
-              });
-              toolExecutions.push({
-                name: call.name,
-                input: call.args,
-                output: errorPayload,
-              });
-              stepStorageResults.push({
-                toolName: call.name,
-                output: errorPayload,
-              });
-              continue;
-            }
-
-            let execute = executeMap.get(call.name);
-            if (!execute) {
-              // Snapshot miss: the tool may have been hydrated into the live
-              // record by search_tools within this very step batch, or the
-              // model called a deferred catalog tool directly by name.
-              execute = this.resolveGeminiToolOnMiss(
-                call.name,
-                options.tools,
-                tools?.[0]?.functionDeclarations,
-                executeMap,
-                failedTools,
-              );
-            }
-            if (execute) {
-              try {
-                // AI SDK Tool execute requires (args, options) - provide minimal options
-                const toolOptions = {
-                  toolCallId: `${call.name}-${Date.now()}`,
-                  messages: [],
-                  abortSignal: effectiveSignal,
-                };
-                turnClock.noteProgress();
-                // Bound the execute() await — a wedged tool costs one step
-                // (error tool_result), not the whole turn — and race it
-                // against the turn's abort so a deadline/caller abort is
-                // observed IMMEDIATELY instead of after the tool settles.
-                const result = await withTimeout(
-                  raceWithAbort(
-                    Promise.resolve(execute(call.args, toolOptions)),
-                    effectiveSignal,
-                  ),
-                  toolExecTimeoutMs,
-                  `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
-                );
-                turnClock.noteProgress();
-                // Error-shaped success (MCP isError / { error } payloads —
-                // e.g. proxy-blocked tools) counts toward the breaker too:
-                // these fail without throwing, and only counting throws lets
-                // the model grind on a blocked tool for the whole budget.
-                const resultErrorText = extractToolFailureText(result);
-                if (resultErrorText) {
-                  const info = failedTools.get(call.name) || {
-                    count: 0,
-                    lastError: "",
-                  };
-                  info.count++;
-                  info.lastError = resultErrorText;
-                  failedTools.set(call.name, info);
-                } else {
-                  // Genuinely consecutive: a success clears the strike count
-                  // (argument-dependent soft errors — file-not-found on
-                  // different paths — must not disable a working tool).
-                  failedTools.delete(call.name);
-                }
-                toolExecutions.push({
-                  name: call.name,
-                  input: call.args,
-                  output: result,
-                });
-                functionResponses.push({
-                  functionResponse: { name: call.name, response: { result } },
-                });
-                stepStorageResults.push({
-                  toolName: call.name,
-                  output: result,
-                });
-              } catch (error) {
-                // An abort during tool execution ends the turn gracefully — it
-                // must NOT be recorded as a spurious tool failure. Both checks
-                // matter: effectiveSignal.aborted catches an abort WE triggered
-                // (even if the throw isn't abort-shaped); isAbortError(error)
-                // catches an abort-shaped throw (e.g. a tool raising AbortError)
-                // even when the signal itself never fired.
-                if (effectiveSignal.aborted || isAbortError(error)) {
-                  wasAborted = true;
-                  break;
-                }
-                turnClock.noteProgress();
-                if (error instanceof TimeoutError) {
-                  this.emitTurnEvent({
-                    phase: "tool-timeout",
-                    step,
-                    maxSteps,
-                    toolName: call.name,
-                  });
-                }
-                const errorMessage =
-                  error instanceof Error ? error.message : "Unknown error";
-
-                // Track this failure
-                const currentFailInfo = failedTools.get(call.name) || {
-                  count: 0,
-                  lastError: "",
-                };
-                currentFailInfo.count++;
-                currentFailInfo.lastError = errorMessage;
-                failedTools.set(call.name, currentFailInfo);
-
-                logger.warn(
-                  `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
-                );
-
-                // Determine if this is a permanent failure
-                const isPermanentFailure =
-                  currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
-
-                const errorPayload = {
-                  error: isPermanentFailure
-                    ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
-                    : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
-                  status: isPermanentFailure ? "permanently_failed" : "failed",
-                  do_not_retry: isPermanentFailure,
-                  retry_count: currentFailInfo.count,
-                  max_retries: DEFAULT_TOOL_MAX_RETRIES,
-                };
-                functionResponses.push({
-                  functionResponse: {
-                    name: call.name,
-                    response: errorPayload,
-                  },
-                });
-                toolExecutions.push({
-                  name: call.name,
-                  input: call.args,
-                  output: errorPayload,
-                });
-                stepStorageResults.push({
-                  toolName: call.name,
-                  output: errorPayload,
-                });
-              }
-            } else {
-              // Tool not found is a permanent error. Count it toward the
-              // breaker too (parity with the Anthropic loops) — a model that
-              // ignores the do_not_retry hint and keeps calling a
-              // hallucinated/stale tool name must not burn the whole step
-              // budget on TOOL_NOT_FOUND round-trips.
-              const errorPayload = {
-                error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
-                status: "permanently_failed",
-                do_not_retry: true,
-              };
-              const notFoundInfo = failedTools.get(call.name) || {
-                count: 0,
-                lastError: "",
-              };
-              notFoundInfo.count++;
-              notFoundInfo.lastError = errorPayload.error;
-              failedTools.set(call.name, notFoundInfo);
-              functionResponses.push({
-                functionResponse: {
-                  name: call.name,
-                  response: errorPayload,
-                },
-              });
-              toolExecutions.push({
-                name: call.name,
-                input: call.args,
-                output: errorPayload,
-              });
-              stepStorageResults.push({
-                toolName: call.name,
-                output: errorPayload,
+      // Wrapped rather than configured: these fire once PER STEP, and
+      // buildToolResultMessages is the only hook that runs per step with
+      // exactly that step's results. Reading them off the turn's final result
+      // would batch every step into one late write and lose the per-step
+      // thought signature.
+      const adapter: typeof engineAdapter = {
+        ...engineAdapter,
+        // Counted HERE, not in buildToolResultMessages: this runs once per
+        // step exactly as the old `step++` at the top of the loop did,
+        // malformed retries included. Counting in the tool-result hook would
+        // skip the final text-only step and quietly report one step fewer in
+        // `stepsUsed`, which is a public field on the result.
+        buildStepRequest: (conversation, step) => {
+          stepsTaken = step + 1;
+          return engineAdapter.buildStepRequest(conversation, step);
+        },
+        buildToolResultMessages: (
+          conversation,
+          stepResult,
+          toolResults,
+          engineStep,
+        ) => {
+          const next = engineAdapter.buildToolResultMessages(
+            conversation,
+            stepResult,
+            toolResults,
+            engineStep,
+          );
+          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft step
+          // nudge): with the turn deadline approaching, tell the model to
+          // consolidate. Rides as a trailing text part on the tool-response
+          // user turn.
+          if (turnClock.shouldNudgeWrapup()) {
+            const last = next[next.length - 1];
+            if (last && Array.isArray(last.parts)) {
+              last.parts.push({
+                text: buildWrapupNudgeText(useFinalResultTool),
               });
             }
           }
-
-          // An abort inside the tool-exec loop only breaks that inner for-loop.
-          // Break the while too so no further model call is issued and control
-          // reaches the terminal step-cap handling below.
-          if (wasAborted) {
-            break;
-          }
-
           // Persist this step's tool calls/results into conversation memory.
           // Without this, tool_call / tool_result rows never reach Redis and
-          // the chat-history UI loses every tool invocation.
-          //
-          // `thoughtSignature` rides as a sibling on the first call of the
-          // step — Gemini 3 needs it to match thinking patterns when the
-          // conversation is replayed on the next turn.
-          if (stepStorageCalls.length > 0 || stepStorageResults.length > 0) {
-            const stepThoughtSig = extractThoughtSignature(rawResponseParts);
-            withTimeout(
-              this.handleToolExecutionStorage(
-                stepStorageCalls.map((c, i) => ({
-                  ...c,
-                  ...(i === 0 && stepThoughtSig
-                    ? { thoughtSignature: stepThoughtSig }
-                    : {}),
-                  stepIndex: step,
-                })),
-                stepStorageResults.map((r) => ({ ...r, stepIndex: step })),
-                options,
-                new Date(),
-              ),
-              TOOL_STORAGE_TIMEOUT_MS,
-              "tool storage write timed out",
-            ).catch((error: unknown) => {
-              logger.warn(
-                "[GoogleVertex] Failed to store native Gemini stream tool executions",
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              );
-            });
-          }
-
-          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft
-          // step nudge): with the turn deadline approaching, tell the model
-          // to consolidate. Rides as a trailing text part on the
-          // tool-response user turn.
-          if (turnClock.shouldNudgeWrapup()) {
-            functionResponses.push({
-              text: buildWrapupNudgeText(useFinalResultTool),
-            });
-          }
-
-          // The @google/genai SDK only accepts "user" and "model" as valid
-          // roles in contents — function/tool responses must use role: "user"
-          // (matching the SDK's automaticFunctionCalling implementation and
-          // the Google AI Studio path). Sending role: "function" was causing
-          // native Vertex Gemini tool loops to be silently rejected by the
-          // request validator.
-          currentContents.push({
-            role: "user",
-            parts: functionResponses,
+          // the chat-history UI loses every tool invocation. `thoughtSignature`
+          // rides as a sibling on the first call of the step — Gemini 3 needs
+          // it to match thinking patterns when the conversation is replayed.
+          const stepThoughtSig = extractThoughtSignature(
+            stepResult.raw.rawResponseParts,
+          );
+          withTimeout(
+            this.handleToolExecutionStorage(
+              toolResults.map((result, index) => ({
+                toolName: result.name,
+                args: result.args,
+                ...(index === 0 && stepThoughtSig
+                  ? { thoughtSignature: stepThoughtSig }
+                  : {}),
+                stepIndex: engineStep + 1,
+              })),
+              toolResults.map((result) => ({
+                toolName: result.name,
+                output: result.output,
+                stepIndex: engineStep + 1,
+              })),
+              options,
+              new Date(),
+            ),
+            TOOL_STORAGE_TIMEOUT_MS,
+            "tool storage write timed out",
+          ).catch((error: unknown) => {
+            logger.warn(
+              "[GoogleVertex] Failed to store native Gemini stream tool executions",
+              {
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
           });
           // Project this step's growth for the context guard: the appended
           // tool results ride the next prompt (Gemini reports usage per call,
           // but only for content it has already seen).
           try {
+            const appended = next[next.length - 1];
             contextGuard.noteAppendedChars(
-              JSON.stringify(functionResponses).length,
+              JSON.stringify(appended?.parts ?? []).length,
             );
           } catch {
             /* estimation is best-effort — never break the loop */
           }
-        } catch (error) {
-          // A mid-drain abort surfaces as an AbortError from the `for await`.
-          // Break gracefully into the terminal block instead of re-throwing
-          // (a re-throw would route the caller's abort into a second unbounded
-          // fallback stream()). Dual check as with the inner catch:
-          // effectiveSignal.aborted (a signal we tripped) OR isAbortError(error)
-          // (an abort-shaped throw) — either means "stop", not a real failure.
-          if (effectiveSignal.aborted || isAbortError(error)) {
-            wasAborted = true;
-            break;
+          return next;
+        },
+      };
+
+      const { stream: engineStream, resultPromise } = runAgenticLoop(
+        adapter,
+        // A concrete parts array widens to the engine's `unknown[]` on its
+        // own; only the direction back needs an assertion.
+        currentContents as GeminiTurnContent[],
+        {
+          tools: buildDedupedEngineTools(declarations, options.tools, {
+            toolTimeoutMs: toolExecTimeoutMs,
+            abortSignal: effectiveSignal,
+            onProgress: () => turnClock.noteProgress(),
+          }),
+          abortSignal: effectiveSignal,
+        },
+      );
+
+      // Collected, NOT forwarded to the consumer here. This loop replays the
+      // gathered text after the turn rather than streaming it live, and a
+      // characterization case pins exactly that — pushing to the consumer
+      // channel from inside the pump would make the turn stream live and break
+      // it.
+      const pump = (async () => {
+        for await (const chunk of engineStream) {
+          if (chunk.content) {
+            incrementalTextChunks.push(chunk.content);
           }
-          logger.error("[GoogleVertex] Native SDK error", error);
-          throw this.handleProviderError(error);
         }
+      })();
+
+      let engineResult;
+      let turnFailure: unknown;
+      try {
+        engineResult = await resultPromise;
+      } catch (error) {
+        turnFailure = error;
+      }
+      // Drained unconditionally and tolerantly. When the turn ends by abort the
+      // channel rejects too, and re-awaiting a settled rejection here would
+      // rethrow the very error the branch below has already decided to absorb —
+      // which is what turned both turn-clock cases into failures instead of
+      // clean deadline exits.
+      await pump.catch(() => {});
+      if (turnFailure !== undefined) {
+        // A mid-drain abort surfaces as an AbortError. End gracefully into the
+        // terminal block instead of re-throwing — a re-throw would route the
+        // caller's abort into a second unbounded fallback stream().
+        if (effectiveSignal.aborted || isAbortError(turnFailure)) {
+          wasAborted = true;
+        } else {
+          logger.error("[GoogleVertex] Native SDK error", turnFailure);
+          throw this.handleProviderError(turnFailure);
+        }
+      }
+
+      if (engineResult) {
+        finalText = engineResult.text;
+        lastFinishReason = engineResult.rawStopReason ?? lastFinishReason;
+        for (const call of engineResult.toolCalls) {
+          allToolCalls.push({ toolName: call.name, args: call.args });
+        }
+        for (const execution of engineResult.toolExecutions) {
+          toolExecutions.push({
+            name: execution.name,
+            input: execution.input,
+            output: execution.output,
+          });
+        }
+        // Replace in place: `currentContents` is a const the terminal block
+        // and the synth call both read.
+        currentContents.length = 0;
+        currentContents.push(
+          ...(engineResult.conversation as Array<{
+            role: string;
+            parts: VertexNativeLoopPart[];
+          }>),
+        );
+      }
+      if (effectiveSignal.aborted) {
+        wasAborted = true;
       }
 
       // Handle maxSteps termination / abort — the loop exited because the step
       // cap was reached (or the turn was aborted) while the model was still
       // calling tools. Surface a real answer instead of the canned placeholder
       // (Bug 1) and a meaningful finishReason (Bug 2).
-      if (!finalText && (step >= maxSteps || wasAborted || hitContextLimit)) {
-        hitStepLimit = step >= maxSteps && !wasAborted;
+      if (
+        !finalText &&
+        (stepsTaken >= maxSteps || wasAborted || hitContextLimit)
+      ) {
+        hitStepLimit = stepsTaken >= maxSteps && !wasAborted;
         const toolCallCount = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
         ).length;
@@ -2716,7 +2521,7 @@ export class GoogleVertexProvider extends BaseProvider {
     if (stopReason !== "completed") {
       this.emitTurnEvent({
         phase: stopReason,
-        step,
+        step: stepsTaken,
         maxSteps,
         toolCallCount: allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
@@ -2813,7 +2618,7 @@ export class GoogleVertexProvider extends BaseProvider {
         totalToolExecutions: externalToolCalls.length,
         stopReason,
         rawFinishReason: lastFinishReason,
-        stepsUsed: step,
+        stepsUsed: stepsTaken,
       },
     };
 
@@ -3034,12 +2839,16 @@ export class GoogleVertexProvider extends BaseProvider {
       | Array<{ functionDeclarations: VertexGenaiFunctionDeclaration[] }>
       | undefined;
     const executeMap = new DedupExecuteMap();
+    let declarations: NativeToolDeclarationsResult | undefined;
 
     if (Object.keys(combinedTools).length > 0) {
       const declared = toNativeToolDeclarations(
         combinedTools,
         "functionDeclarations",
       );
+      // Kept for the shared adapter: originalNameMap for name translation,
+      // executeMap for the per-turn dedup wrapper.
+      declarations = declared;
       tools = declared.toolsConfig;
       for (const [name, execute] of declared.executeMap) {
         executeMap.set(name, execute);
@@ -3239,14 +3048,9 @@ export class GoogleVertexProvider extends BaseProvider {
       input: Record<string, unknown>;
       output: unknown;
     }> = [];
-    let step = 0;
 
     // Track structured output from final_result tool (when using final_result pattern)
     let finalResultStructuredOutput: Record<string, unknown> | undefined;
-
-    // Track failed tools to prevent infinite retry loops
-    // Key: tool name, Value: { count: retry attempts, lastError: error message }
-    const failedTools = new Map<string, { count: number; lastError: string }>();
 
     // In-loop context guard: stop calling tools when the accumulated
     // conversation approaches the model's context window instead of stepping
@@ -3299,98 +3103,90 @@ export class GoogleVertexProvider extends BaseProvider {
       internalAbort.abort();
     }
     let wasAborted = false;
-    // One retry per turn for MALFORMED_FUNCTION_CALL steps (see the retry
-    // block after the step drain).
-    let malformedRetryCount = 0;
 
     // Step-cap flags declared in the outer scope so the terminal block (also
     // inside the try) and the finishReason mapping (after the finally) can
     // both read them.
     let hitStepLimit = false;
     let synthesizedFinalAnswer = false;
+    // Steps the ENGINE took, reported back from the per-step hook; counting
+    // hook invocations would drift by the number of malformed retries.
+    let stepsTaken = 0;
 
     try {
       // Agentic loop for tool calling
-      while (step < maxSteps) {
-        if (effectiveSignal.aborted) {
-          wasAborted = true;
-          break;
-        }
-        // Context guard: stop the tool loop before the accumulated
-        // conversation crosses the window threshold — synthesize from what
-        // we have instead of stepping into a provider rejection.
-        if (contextGuard.shouldStop()) {
-          // Parity upgrade: try to RECLAIM budget and keep going before
-          // falling back to the historic stop-only behaviour. Ending the turn
-          // early is safe but throws away work the model was mid-way through;
-          // dropping the oldest complete tool exchanges usually buys enough
-          // room to finish. Only when reclaiming changes nothing do we stop.
-          const reclaimed = reclaimVertexLoopContext(
-            currentContents,
-            modelName,
-            contextGuard.projectedNextPromptTokens,
-          );
-          if (reclaimed) {
-            contextGuard.resetAfterReclaim();
-          } else {
-            hitContextLimit = true;
-            logger.warn(
-              `[GoogleVertex] Gemini turn stopped by the context guard: ` +
-                `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
-                `>= threshold ${contextGuard.thresholdTokens} (step ${step}) — synthesizing a final answer.`,
-            );
-            break;
-          }
-        }
-        step++;
-        turnClock.noteProgress();
-        // Mid-turn discovery sync — see the stream twin.
-        this.refreshGeminiToolDeclarations(
-          combinedTools,
-          tools?.[0]?.functionDeclarations,
-          executeMap,
-          failedTools,
-        );
-        logger.debug(
-          `[GoogleVertex] Native SDK generate step ${step}/${maxSteps}`,
-        );
-
-        try {
-          // Use generateContentStream and collect all chunks (same as GoogleAIStudio)
-          const stream = await client.models.generateContentStream({
-            model: modelName,
-            contents: currentContents,
-            config: { ...config, abortSignal: effectiveSignal },
+      // The turn runs on the shared engine. The step cap, tool dispatch, the
+      // failure breaker, per-step usage accumulation, the single malformed
+      // retry and the pre-first-chunk provider retry all live there now; what
+      // stays here is everything the engine has no opinion about — the turn
+      // clock, the context guard, conversation-memory storage, the wrap-up
+      // nudge, and the terminal block below.
+      const engineAdapter = createGeminiLoopAdapter({
+        providerLabel: "GoogleVertex",
+        maxSteps,
+        // Ported verbatim: the same DEFAULT_TOOL_MAX_RETRIES threshold, plus
+        // the two rules this loop has always had and the engine did not.
+        toolFailureBreaker: {
+          maxRetries: DEFAULT_TOOL_MAX_RETRIES,
+          // Strikes are CONSECUTIVE here: a clean result clears the count, so
+          // an argument-dependent soft error cannot accumulate its way to
+          // disabling a tool that works.
+          consecutive: true,
+          // A result that reports failure without throwing — an MCP isError
+          // payload, a proxy-blocked call resolving with { error } — counts
+          // toward the breaker exactly as a throw does.
+          classifyResultFailure: (output) =>
+            extractToolFailureText(output) ?? undefined,
+        },
+        liveTools: options.tools ?? {},
+        ...(declarations ? { declarations } : {}),
+        ...(useFinalResultTool
+          ? {
+              finalResultToolName: "final_result",
+              onTerminalResult: (text) => {
+                try {
+                  finalResultStructuredOutput = JSON.parse(text) as Record<
+                    string,
+                    unknown
+                  >;
+                } catch {
+                  /* the caller's coercion layer repairs a partial payload */
+                }
+              },
+            }
+          : {}),
+        enableMalformedRetry: true,
+        buildMalformedRetryNote: (conversation, retriedStep) => {
+          this.emitTurnEvent({
+            phase: "malformed-retry",
+            step: retriedStep + 1,
+            maxSteps,
           });
-
-          const stepFunctionCalls: Array<{
-            name: string;
-            args: Record<string, unknown>;
-          }> = [];
-
-          // Capture raw response parts including thoughtSignature
-          const rawResponseParts: unknown[] = [];
-          // This step's own finish reason (vs the cross-step
-          // lastFinishReason) — drives the single MALFORMED_FUNCTION_CALL
-          // retry below.
-          let stepFinishReason: string | undefined;
-          // Per-step usage trackers for WRITE-THROUGH accumulation: within a
-          // step's chunk stream the counts are latest-wins (promptTokenCount
-          // arrives once in the final chunk; candidates/thoughts counts are
-          // cumulative across chunks), so each chunk folds only the DELTA
-          // over this step's previous value into the turn totals. The totals
-          // are therefore correct at every point mid-drain — a step killed
-          // mid-stream (abort / turn deadline / stall watchdog) still counts
-          // the billed tokens it already reported.
-          // Same collector as the streaming twin. generate() returns one
-          // result rather than streaming, so the channel is a no-op — the
-          // stream loop uses it to fill incrementalTextChunks for replay, and
-          // there is nothing to replay here. Everything else is identical,
-          // including the per-chunk usage deltas that keep the turn totals
-          // correct for a step killed mid-stream.
-          const collected = await collectVertexStreamChunks(
-            stream,
-            { push: () => {} },
+          return [
+            ...conversation,
+            {
+              role: "user",
+              parts: [
+                {
+                  text:
+                    "Your previous function call was malformed and could not " +
+                    "be parsed. Re-issue it as a single valid function call, " +
+                    "or answer in plain text.",
+                },
+              ],
+            },
+          ];
+        },
+        // The turn clock's per-chunk ping and the context guard's per-step
+        // prompt size both ride the drain, which is why this loop keeps its
+        // own collector rather than the adapter's default.
+        collectStep: (stream, channel) =>
+          collectVertexStreamChunks(
+            stream as AsyncIterable<{
+              functionCalls?: NativeFunctionCall[];
+              [key: string]: unknown;
+            }>,
+            channel,
             {
               onProgress: () => turnClock.noteProgress(),
               onUsage: (input, output) => contextGuard.noteUsage(input, output),
@@ -3406,431 +3202,231 @@ export class GoogleVertexProvider extends BaseProvider {
                 }
               },
             },
-          );
-          rawResponseParts.push(...collected.rawResponseParts);
-          stepFunctionCalls.push(...collected.stepFunctionCalls);
-          if (collected.finishReason) {
-            stepFinishReason = collected.finishReason;
-            lastFinishReason = collected.finishReason;
+          ),
+        planReclaim: (conversation) => {
+          if (!contextGuard.shouldStop()) {
+            return undefined;
           }
-
-          // Extract text from raw parts after stream completes
-          // This avoids SDK warning about non-text parts (thoughtSignature, functionCall)
-          const stepText = rawResponseParts
-            .filter(
-              (part): part is { text: string } =>
-                typeof (part as Record<string, unknown>).text === "string",
-            )
-            .map((part) => part.text)
-            .join("");
-
-          // MALFORMED_FUNCTION_CALL is usually a transient formatting failure
-          // (the model emitted an unparseable call): retry the step ONCE with
-          // a corrective note instead of hard-ending the turn with empty
-          // content — automated alert-RCA turns were dying at step 2-4 on
-          // this, mislabeled as step-cap exits.
+          // Try to RECLAIM budget and keep going before falling back to the
+          // historic stop-only behaviour. Ending the turn early is safe but
+          // throws away work the model was mid-way through; dropping the
+          // oldest complete tool exchanges usually buys enough room to finish.
+          const working = [...conversation] as Array<{
+            role: string;
+            parts: VertexNativeLoopPart[];
+          }>;
           if (
-            stepFunctionCalls.length === 0 &&
-            !stepText &&
-            stepFinishReason === "MALFORMED_FUNCTION_CALL" &&
-            malformedRetryCount < 1 &&
-            !effectiveSignal.aborted
+            reclaimVertexLoopContext(
+              working,
+              modelName,
+              contextGuard.projectedNextPromptTokens,
+            )
           ) {
-            malformedRetryCount++;
-            logger.warn(
-              `[GoogleVertex] Model returned MALFORMED_FUNCTION_CALL at step ${step}/${maxSteps}; retrying once with a corrective note.`,
-            );
-            this.emitTurnEvent({ phase: "malformed-retry", step, maxSteps });
-            if (rawResponseParts.length > 0) {
-              currentContents.push({
-                role: "model",
-                parts: rawResponseParts as VertexNativePart[],
-              });
-            }
-            currentContents.push({
-              role: "user",
-              parts: [
-                {
-                  text:
-                    "Your previous function call was malformed and could not " +
-                    "be parsed. Re-issue it as a single valid function call, " +
-                    "or answer in plain text.",
-                },
-              ],
-            });
-            continue;
+            contextGuard.resetAfterReclaim();
+            return { conversation: working };
           }
-
-          // If no function calls, we're done
-          if (stepFunctionCalls.length === 0) {
-            finalText = stepText;
-            break;
-          }
-
-          // Check for final_result tool call - this is our structured output pattern
-          if (useFinalResultTool) {
-            const finalResultCall = stepFunctionCalls.find(
-              (call) => call.name === "final_result",
-            );
-            if (finalResultCall) {
-              // Extract the structured output from final_result arguments
-              finalResultStructuredOutput = finalResultCall.args as Record<
-                string,
-                unknown
-              >;
-              logger.debug(
-                "[GoogleVertex] Received final_result tool call with structured output (generate)",
-                {
-                  outputKeys: Object.keys(finalResultStructuredOutput),
-                },
-              );
-              // Return the structured output as JSON text
-              finalText = JSON.stringify(finalResultStructuredOutput);
-              break;
-            }
-          }
-
-          // Accumulate non-empty step text across steps so the
-          // maxSteps-exhaustion exit can surface the prose the model produced
-          // instead of a canned placeholder (Bug 1). Mirrors the Vertex-Claude
-          // loop's text accumulation.
-          accumulatedText = appendStepText(accumulatedText, stepText);
-
-          // Execute function calls
-          logger.debug(
-            `[GoogleVertex] Generate executing ${stepFunctionCalls.length} function calls`,
+          hitContextLimit = true;
+          logger.warn(
+            `[GoogleVertex] Gemini turn stopped by the context guard: ` +
+              `projected prompt ~${contextGuard.projectedNextPromptTokens} tokens ` +
+              `>= threshold ${contextGuard.thresholdTokens} — synthesizing a final answer.`,
           );
+          return { stop: true };
+        },
+        buildRequest: (conversation) => ({
+          model: modelName,
+          contents: conversation,
+          config: { ...config, ...(tools ? { tools } : {}) },
+        }),
+        sendStep: async (request, signal) => {
+          turnClock.noteProgress();
+          const built = request as {
+            model: string;
+            contents: Array<{ role: string; parts: unknown[] }>;
+            config?: Record<string, unknown>;
+          };
+          return client.models.generateContentStream({
+            model: built.model,
+            contents: built.contents,
+            config: { ...(built.config ?? {}), abortSignal: signal },
+          }) as Promise<
+            AsyncIterable<{
+              functionCalls?: NativeFunctionCall[];
+              [key: string]: unknown;
+            }>
+          >;
+        },
+      });
 
-          // Add model response with ALL parts (including thoughtSignature) to history
-          // This preserves the thought_signature which is required for Gemini 3 multi-turn tool calling
-          currentContents.push({
-            role: "model",
-            parts:
-              rawResponseParts.length > 0
-                ? (rawResponseParts as VertexNativeLoopPart[])
-                : stepFunctionCalls.map((fc) => ({
-                    functionCall: fc,
-                  })),
-          });
-
-          // Execute each function and collect responses (plus an optional
-          // trailing wrap-up nudge text part).
-          const functionResponses: Array<
-            | {
-                functionResponse: {
-                  name: string;
-                  response: Record<string, unknown>;
-                };
-              }
-            | { text: string }
-          > = [];
-          const toolCallsBefore = allToolCalls.length;
-          const toolExecsBefore = toolExecutions.length;
-          // Note: tool:start / tool:end events are emitted by ToolsManager's
-          // wrapped `execute` (see ToolsManager.ts:355) — no inline emit needed.
-
-          for (const call of stepFunctionCalls) {
-            // Honor a deadline/stall/caller abort BETWEEN tool executions —
-            // without this check a multi-tool step keeps executing its whole
-            // batch (up to N × toolTimeoutMs past the deadline) before the
-            // while-top check finally breaks.
-            if (effectiveSignal.aborted) {
-              wasAborted = true;
-              break;
-            }
-            allToolCalls.push({ toolName: call.name, args: call.args });
-
-            // Check if this tool has already exceeded retry limit
-            const failedInfo = failedTools.get(call.name);
-            if (failedInfo && failedInfo.count >= DEFAULT_TOOL_MAX_RETRIES) {
-              logger.warn(
-                `[GoogleVertex] Tool "${call.name}" has exceeded retry limit (${DEFAULT_TOOL_MAX_RETRIES}), skipping execution`,
-              );
-
-              const errorOutput = {
-                error: `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${failedInfo.count} times and will not be retried. Last error: ${failedInfo.lastError}. Please proceed without using this tool or inform the user that this functionality is unavailable.`,
-                status: "permanently_failed",
-                do_not_retry: true,
-              };
-
-              toolExecutions.push({
-                name: call.name,
-                input: call.args,
-                output: errorOutput,
-              });
-
-              functionResponses.push({
-                functionResponse: {
-                  name: call.name,
-                  response: errorOutput,
-                },
-              });
-              continue;
-            }
-
-            let execute = executeMap.get(call.name);
-            if (!execute) {
-              // Snapshot miss — see the stream twin.
-              execute = this.resolveGeminiToolOnMiss(
-                call.name,
-                combinedTools,
-                tools?.[0]?.functionDeclarations,
-                executeMap,
-                failedTools,
-              );
-            }
-            if (execute) {
-              try {
-                // AI SDK Tool execute requires (args, options) - provide minimal options
-                const toolOptions = {
-                  toolCallId: `${call.name}-${Date.now()}`,
-                  messages: [],
-                  abortSignal: effectiveSignal,
-                };
-                turnClock.noteProgress();
-                // Bound the execute() await — a wedged tool costs one step
-                // (error tool_result), not the whole turn.
-                const execResult = await withTimeout(
-                  raceWithAbort(
-                    Promise.resolve(execute(call.args, toolOptions)),
-                    effectiveSignal,
-                  ),
-                  toolExecTimeoutMs,
-                  `Tool "${call.name}" execution timed out after ${toolExecTimeoutMs}ms`,
-                );
-                turnClock.noteProgress();
-                // Error-shaped success (MCP isError / { error } payloads —
-                // e.g. proxy-blocked tools) counts toward the breaker too:
-                // these fail without throwing, and only counting throws lets
-                // the model grind on a blocked tool for the whole budget.
-                const resultErrorText = extractToolFailureText(execResult);
-                if (resultErrorText) {
-                  const info = failedTools.get(call.name) || {
-                    count: 0,
-                    lastError: "",
-                  };
-                  info.count++;
-                  info.lastError = resultErrorText;
-                  failedTools.set(call.name, info);
-                } else {
-                  // Genuinely consecutive: a success clears the strike count
-                  // (argument-dependent soft errors — file-not-found on
-                  // different paths — must not disable a working tool).
-                  failedTools.delete(call.name);
-                }
-
-                // Track execution
-                toolExecutions.push({
-                  name: call.name,
-                  input: call.args,
-                  output: execResult,
-                });
-
-                functionResponses.push({
-                  functionResponse: {
-                    name: call.name,
-                    response: { result: execResult },
-                  },
-                });
-              } catch (error) {
-                // An abort during tool execution ends the turn gracefully — it
-                // must NOT be recorded as a spurious tool failure. Both checks
-                // matter: effectiveSignal.aborted catches an abort WE triggered
-                // (even if the throw isn't abort-shaped); isAbortError(error)
-                // catches an abort-shaped throw (e.g. a tool raising AbortError)
-                // even when the signal itself never fired.
-                if (effectiveSignal.aborted || isAbortError(error)) {
-                  wasAborted = true;
-                  break;
-                }
-                turnClock.noteProgress();
-                if (error instanceof TimeoutError) {
-                  this.emitTurnEvent({
-                    phase: "tool-timeout",
-                    step,
-                    maxSteps,
-                    toolName: call.name,
-                  });
-                }
-                const errorMessage =
-                  error instanceof Error ? error.message : "Unknown error";
-
-                // Track this failure
-                const currentFailInfo = failedTools.get(call.name) || {
-                  count: 0,
-                  lastError: "",
-                };
-                currentFailInfo.count++;
-                currentFailInfo.lastError = errorMessage;
-                failedTools.set(call.name, currentFailInfo);
-
-                logger.warn(
-                  `[GoogleVertex] Tool "${call.name}" failed (attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}): ${errorMessage}`,
-                );
-
-                // Determine if this is a permanent failure
-                const isPermanentFailure =
-                  currentFailInfo.count >= DEFAULT_TOOL_MAX_RETRIES;
-
-                const errorOutput = {
-                  error: isPermanentFailure
-                    ? `TOOL_PERMANENTLY_FAILED: The tool "${call.name}" has failed ${currentFailInfo.count} times with error: ${errorMessage}. This tool will not be retried. Please proceed without using this tool or inform the user that this functionality is unavailable.`
-                    : `TOOL_EXECUTION_ERROR: ${errorMessage}. Retry attempt ${currentFailInfo.count}/${DEFAULT_TOOL_MAX_RETRIES}.`,
-                  status: isPermanentFailure ? "permanently_failed" : "failed",
-                  do_not_retry: isPermanentFailure,
-                  retry_count: currentFailInfo.count,
-                  max_retries: DEFAULT_TOOL_MAX_RETRIES,
-                };
-
-                toolExecutions.push({
-                  name: call.name,
-                  input: call.args,
-                  output: errorOutput,
-                });
-
-                functionResponses.push({
-                  functionResponse: {
-                    name: call.name,
-                    response: errorOutput,
-                  },
-                });
-              }
-            } else {
-              // Tool not found is a permanent error
-              const errorOutput = {
-                error: `TOOL_NOT_FOUND: The tool "${call.name}" does not exist. Do not attempt to call this tool again.`,
-                status: "permanently_failed",
-                do_not_retry: true,
-              };
-
-              toolExecutions.push({
-                name: call.name,
-                input: call.args,
-                output: errorOutput,
-              });
-
-              functionResponses.push({
-                functionResponse: {
-                  name: call.name,
-                  response: errorOutput,
-                },
+      // Wrapped rather than configured: these fire once PER STEP, and
+      // buildToolResultMessages is the only hook that runs per step with
+      // exactly that step's results. Reading them off the turn's final result
+      // would batch every step into one late write and lose the per-step
+      // thought signature.
+      const adapter: typeof engineAdapter = {
+        ...engineAdapter,
+        // Counted HERE, not in buildToolResultMessages: this runs once per
+        // step exactly as the old `step++` at the top of the loop did,
+        // malformed retries included. Counting in the tool-result hook would
+        // skip the final text-only step and quietly report one step fewer in
+        // `stepsUsed`, which is a public field on the result.
+        buildStepRequest: (conversation, step) => {
+          stepsTaken = step + 1;
+          return engineAdapter.buildStepRequest(conversation, step);
+        },
+        buildToolResultMessages: (
+          conversation,
+          stepResult,
+          toolResults,
+          engineStep,
+        ) => {
+          const next = engineAdapter.buildToolResultMessages(
+            conversation,
+            stepResult,
+            toolResults,
+            engineStep,
+          );
+          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft step
+          // nudge): with the turn deadline approaching, tell the model to
+          // consolidate. Rides as a trailing text part on the tool-response
+          // user turn.
+          if (turnClock.shouldNudgeWrapup()) {
+            const last = next[next.length - 1];
+            if (last && Array.isArray(last.parts)) {
+              last.parts.push({
+                text: buildWrapupNudgeText(useFinalResultTool),
               });
             }
           }
-
-          // An abort inside the tool-exec loop only breaks that inner for-loop.
-          // Break the while too so no further model call is issued and control
-          // reaches the terminal step-cap handling below.
-          if (wasAborted) {
-            break;
-          }
-
           // Persist this step's tool calls/results into conversation memory.
           // Without this, tool_call / tool_result rows never reach Redis and
-          // the chat-history UI loses every tool invocation. The first call
-          // of the step carries the step's `thoughtSignature` so Gemini 3 can
-          // match thinking patterns on replay.
-          const stepToolCalls = allToolCalls.slice(toolCallsBefore);
-          const stepToolExecs = toolExecutions.slice(toolExecsBefore);
-          if (stepToolCalls.length > 0 || stepToolExecs.length > 0) {
-            const stepThoughtSig = extractThoughtSignature(rawResponseParts);
-            withTimeout(
-              this.handleToolExecutionStorage(
-                stepToolCalls.map((tc, i) => ({
-                  toolName: tc.toolName,
-                  args: tc.args,
-                  ...(i === 0 && stepThoughtSig
-                    ? { thoughtSignature: stepThoughtSig }
-                    : {}),
-                  stepIndex: step,
-                })),
-                stepToolExecs.map((te) => ({
-                  toolName: te.name,
-                  output: te.output,
-                  stepIndex: step,
-                })),
-                options,
-                new Date(),
-              ),
-              TOOL_STORAGE_TIMEOUT_MS,
-              "tool storage write timed out",
-            ).catch((error: unknown) => {
-              logger.warn(
-                "[GoogleVertex] Failed to store native Gemini generate tool executions",
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              );
-            });
-          }
-
-          // Time-budget wrap-up nudge (twin of the Anthropic loops' soft
-          // step nudge): with the turn deadline approaching, tell the model
-          // to consolidate. Rides as a trailing text part on the
-          // tool-response user turn.
-          if (turnClock.shouldNudgeWrapup()) {
-            functionResponses.push({
-              text: buildWrapupNudgeText(useFinalResultTool),
-            });
-          }
-
-          // The @google/genai SDK only accepts "user" and "model" as valid
-          // roles in contents — function/tool responses must use role: "user"
-          // (matching the SDK's automaticFunctionCalling implementation and
-          // the Google AI Studio path). See note in executeNativeGemini3Stream.
-          currentContents.push({
-            role: "user",
-            parts: functionResponses,
+          // the chat-history UI loses every tool invocation. `thoughtSignature`
+          // rides as a sibling on the first call of the step — Gemini 3 needs
+          // it to match thinking patterns when the conversation is replayed.
+          const stepThoughtSig = extractThoughtSignature(
+            stepResult.raw.rawResponseParts,
+          );
+          withTimeout(
+            this.handleToolExecutionStorage(
+              toolResults.map((result, index) => ({
+                toolName: result.name,
+                args: result.args,
+                ...(index === 0 && stepThoughtSig
+                  ? { thoughtSignature: stepThoughtSig }
+                  : {}),
+                stepIndex: engineStep + 1,
+              })),
+              toolResults.map((result) => ({
+                toolName: result.name,
+                output: result.output,
+                stepIndex: engineStep + 1,
+              })),
+              options,
+              new Date(),
+            ),
+            TOOL_STORAGE_TIMEOUT_MS,
+            "tool storage write timed out",
+          ).catch((error: unknown) => {
+            logger.warn(
+              "[GoogleVertex] Failed to store native Gemini stream tool executions",
+              {
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
           });
           // Project this step's growth for the context guard: the appended
           // tool results ride the next prompt (Gemini reports usage per call,
           // but only for content it has already seen).
           try {
+            const appended = next[next.length - 1];
             contextGuard.noteAppendedChars(
-              JSON.stringify(functionResponses).length,
+              JSON.stringify(appended?.parts ?? []).length,
             );
           } catch {
             /* estimation is best-effort — never break the loop */
           }
-        } catch (error) {
-          // A mid-drain abort surfaces as an AbortError from the `for await`.
-          // Break gracefully into the terminal block instead of re-throwing
-          // (a re-throw would route the caller's abort into a second unbounded
-          // fallback generate()). Dual check as with the inner catch:
-          // effectiveSignal.aborted (a signal we tripped) OR isAbortError(error)
-          // (an abort-shaped throw) — either means "stop", not a real failure.
-          if (effectiveSignal.aborted || isAbortError(error)) {
-            wasAborted = true;
-            break;
-          }
-          logger.error("[GoogleVertex] Native SDK generate error", {
-            error,
-            model: modelName,
-            location: effectiveLocation,
-            status: (error as { status?: number })?.status,
-          });
-          // Best-effort request context for formatProviderError —
-          // this.modelName can be stale when options.model overrides the
-          // instance default.
-          try {
-            if (error && typeof error === "object") {
-              const e = error as Record<string, unknown>;
-              e.requestModel = modelName;
-              e.requestRegion = effectiveLocation;
-            }
-          } catch {
-            /* frozen/sealed error — context stays best-effort */
-          }
+          return next;
+        },
+      };
+
+      const { stream: engineStream, resultPromise } = runAgenticLoop(
+        adapter,
+        // A concrete parts array widens to the engine's `unknown[]` on its
+        // own; only the direction back needs an assertion.
+        currentContents as GeminiTurnContent[],
+        {
+          tools: buildDedupedEngineTools(declarations, options.tools, {
+            toolTimeoutMs: toolExecTimeoutMs,
+            abortSignal: effectiveSignal,
+            onProgress: () => turnClock.noteProgress(),
+          }),
+          abortSignal: effectiveSignal,
+        },
+      );
+
+      // generate() returns one result rather than streaming, so the engine's
+      // chunks are drained and discarded — the answer comes off the turn's
+      // result. The drain still has to happen: leaving the channel unread
+      // would stall the engine once its buffer fills.
+      const pump = (async () => {
+        for await (const chunk of engineStream) {
+          void chunk;
+        }
+      })();
+
+      let engineResult;
+      try {
+        engineResult = await resultPromise;
+      } catch (error) {
+        await pump.catch(() => {});
+        // A mid-drain abort surfaces as an AbortError. End gracefully into the
+        // terminal block instead of re-throwing — a re-throw would route the
+        // caller's abort into a second unbounded fallback stream().
+        if (effectiveSignal.aborted || isAbortError(error)) {
+          wasAborted = true;
+        } else {
+          logger.error("[GoogleVertex] Native SDK error", error);
           throw this.handleProviderError(error);
         }
+      }
+      await pump;
+
+      if (engineResult) {
+        finalText = engineResult.text;
+        lastFinishReason = engineResult.rawStopReason ?? lastFinishReason;
+        for (const call of engineResult.toolCalls) {
+          allToolCalls.push({ toolName: call.name, args: call.args });
+        }
+        for (const execution of engineResult.toolExecutions) {
+          toolExecutions.push({
+            name: execution.name,
+            input: execution.input,
+            output: execution.output,
+          });
+        }
+        // Replace in place: `currentContents` is a const the terminal block
+        // and the synth call both read.
+        currentContents.length = 0;
+        currentContents.push(
+          ...(engineResult.conversation as Array<{
+            role: string;
+            parts: VertexNativeLoopPart[];
+          }>),
+        );
+      }
+      if (effectiveSignal.aborted) {
+        wasAborted = true;
       }
 
       // Handle maxSteps termination / abort — the loop exited because the step
       // cap was reached (or the turn was aborted) while the model was still
       // calling tools. Surface a real answer instead of the canned placeholder
       // (Bug 1) and a meaningful finishReason (Bug 2).
-      if (!finalText && (step >= maxSteps || wasAborted || hitContextLimit)) {
-        hitStepLimit = step >= maxSteps && !wasAborted;
+      if (
+        !finalText &&
+        (stepsTaken >= maxSteps || wasAborted || hitContextLimit)
+      ) {
+        hitStepLimit = stepsTaken >= maxSteps && !wasAborted;
         const toolCallCount = allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
         ).length;
@@ -3928,7 +3524,7 @@ export class GoogleVertexProvider extends BaseProvider {
     if (stopReason !== "completed") {
       this.emitTurnEvent({
         phase: stopReason,
-        step,
+        step: stepsTaken,
         maxSteps,
         toolCallCount: allToolCalls.filter(
           (tc) => tc.toolName !== "final_result",
@@ -3962,7 +3558,7 @@ export class GoogleVertexProvider extends BaseProvider {
       finishReason: resolvedFinishReason,
       stopReason,
       rawFinishReason: lastFinishReason,
-      stepsUsed: step,
+      stepsUsed: stepsTaken,
       usage: {
         input: adjustedInputTokens,
         // Thinking tokens are billed at the output rate but Gemini does NOT
@@ -7164,7 +6760,7 @@ export class GoogleVertexProvider extends BaseProvider {
     if (stopReason !== "completed") {
       this.emitTurnEvent({
         phase: stopReason,
-        step,
+        step: step,
         maxSteps,
         toolCallCount: externalToolCalls.length,
         elapsedMs: turnClock.elapsedMs(),

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -54,14 +54,68 @@ export type AgenticLoopToolCallResult = AgenticLoopToolCall & {
   permanentlyFailed?: boolean;
 };
 
-export type AgenticLoopStepRequest = { raw: unknown };
+export type AgenticLoopStepRequest = {
+  raw: unknown;
+  /**
+   * Tools that became callable while this step's request was being built —
+   * mid-turn discovery hydrating a name the model had already tried.
+   *
+   * The engine clears each one's failure strikes before dispatching, because
+   * TOOL_NOT_FOUND strikes accrued while a tool was deferred are snapshot
+   * artifacts rather than real failures. Clearing them at the miss-resolution
+   * path instead would be too late: the breaker is consulted BEFORE the
+   * lookup, so a tool already at the strike limit is refused without the
+   * resolution path ever running.
+   */
+  hydratedToolNames?: string[];
+};
 
 export type AgenticLoopReclaimResult<TConversation> = {
-  conversation: TConversation;
+  conversation?: TConversation;
+  /**
+   * End the turn now, BEFORE this step's request is issued.
+   *
+   * A context guard does two things, and only one of them is "reclaim". When
+   * dropping old exchanges buys enough room the turn continues; when it does
+   * not, the guard has to stop rather than step into a provider rejection
+   * that would lose every completed step. Nothing else can express that: the
+   * hook returns a conversation, and an adapter cannot break the engine's
+   * loop.
+   *
+   * Aborting the caller's own signal from inside this hook does NOT work as a
+   * substitute — the engine checks for an abort at the TOP of the step, above
+   * this call, so the request would still be issued and the stop would not
+   * take effect until the following step.
+   */
+  stop?: boolean;
 };
 
 export type AgenticLoopToolFailureBreaker = {
   maxRetries: number;
+  /**
+   * Count CONSECUTIVE failures rather than lifetime ones: a clean result
+   * clears the strike count for that tool.
+   *
+   * Off by default because the two behaviours diverge for a tool that fails
+   * intermittently, and the providers already on this engine accumulate. What
+   * it protects is the argument-dependent soft error — a file-not-found on one
+   * path, fine on the next — which under lifetime counting disables a working
+   * tool for the rest of the turn.
+   */
+  consecutive?: boolean;
+  /**
+   * Decide whether a RESOLVED tool result is really a failure.
+   *
+   * Some tools report failure without throwing: MCP `isError` payloads, a
+   * proxy-blocked call returning `{ error }`. Counting only thrown errors lets
+   * the model grind on one of those for the entire step budget. Returning a
+   * non-empty string strikes the breaker exactly as a throw does; returning
+   * undefined leaves the result a success.
+   *
+   * Off by default — a provider whose loop never inspected results this way
+   * must not start doing so as a side effect of migrating.
+   */
+  classifyResultFailure?: (output: unknown) => string | undefined;
 };
 
 /**
@@ -151,10 +205,19 @@ export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
     channel: { push(chunk: AgenticLoopChunk): void },
     signal: AbortSignal,
   ): Promise<AgenticLoopStepResult<TRaw>>;
+  /**
+   * `step` is the engine's own zero-based step index, not a count of times
+   * this hook ran. Adapters persist tool activity keyed by it, and the two
+   * numbers diverge: a malformed-call retry `continue`s before this hook is
+   * reached and still consumes a step, so an adapter counting its own
+   * invocations drifts by exactly the number of retries and mislabels every
+   * row after the first one.
+   */
   buildToolResultMessages(
     conversation: TConversation,
     stepResult: AgenticLoopStepResult<TRaw>,
     toolResults: AgenticLoopToolCallResult[],
+    step: number,
   ): TConversation;
   mapFinishReason(
     rawStopReason: string | undefined,
@@ -168,7 +231,10 @@ export type AgenticLoopAdapter<TConversation = unknown, TRaw = unknown> = {
   ): AgenticLoopReclaimResult<TConversation> | undefined;
   /** Optional: Vertex+Gemini-only single-retry-on-malformed-call. */
   isMalformedStep?(stepResult: AgenticLoopStepResult<TRaw>): boolean;
-  buildMalformedRetryNote?(conversation: TConversation): TConversation;
+  buildMalformedRetryNote?(
+    conversation: TConversation,
+    step: number,
+  ): TConversation;
 };
 
 /**
@@ -240,6 +306,32 @@ export type AnthropicLoopAdapterConfig = {
   abortSignal?: AbortSignal;
 };
 
+/**
+ * The three things a native Gemini loop wraps around every tool call that the
+ * shared engine does not do itself.
+ *
+ * All optional, and the whole object is optional, because the two Gemini
+ * providers differ here: Vertex bounds tool execution and runs a stall
+ * watchdog, AI Studio does neither. Passing nothing leaves an executor exactly
+ * as the caller supplied it, so this cannot quietly give AI Studio behaviour
+ * its hand-rolled loops never had.
+ */
+export type GeminiToolExecutionGuards = {
+  /** Upper bound on a single execute(); omit for no bound. */
+  toolTimeoutMs?: number;
+  /**
+   * Turn-level abort, raced against the call so a deadline or caller cancel is
+   * observed immediately instead of after the tool settles.
+   */
+  abortSignal?: AbortSignal;
+  /**
+   * Stall-watchdog ping, called either side of the await. The watchdog is a
+   * whole-turn interval measuring wall-clock since the last mark, so a
+   * legitimately slow tool reads as a stalled turn without this.
+   */
+  onProgress?: () => void;
+};
+
 /** What one Gemini step produced, carried to `buildToolResultMessages`. */
 export type GeminiStepRaw = {
   rawResponseParts: unknown[];
@@ -301,12 +393,30 @@ export type GeminiLoopAdapterCoreConfig = {
   planReclaim?: (
     conversation: GeminiTurnContent[],
     step: number,
-  ) => GeminiTurnContent[] | undefined;
+  ) => AgenticLoopReclaimResult<GeminiTurnContent[]> | undefined;
   /**
    * Usage feedback for the provider's own context guard, called after each
    * step with that step's real token counts.
    */
   noteUsage?: (inputTokens: number, outputTokens: number) => void;
+  /**
+   * Name of the terminal structured-output tool when one is in play. A call
+   * to it ends the turn: its arguments ARE the answer, so it is reported as
+   * text and omitted from `toolCalls`, which routes it through the engine's
+   * ordinary zero-tool-calls exit — never dispatched, never counted against
+   * the breaker, never recorded as a tool execution.
+   */
+  finalResultToolName?: string;
+  /**
+   * Called with the terminal tool's payload when one was actually detected.
+   *
+   * The caller cannot infer this from the turn's result: a structured turn
+   * ends with the payload in `text` when the model called the terminal tool,
+   * and with ordinary prose in `text` when it answered directly instead, and
+   * those two are indistinguishable downstream while being handled
+   * differently. Comparing strings to tell them apart would be guesswork.
+   */
+  onTerminalResult?: (text: string) => void;
   /**
    * Fold one step's raw stream into the shape the adapter reports.
    *
@@ -353,6 +463,7 @@ export type GeminiMalformedRetryConfig =
        */
       buildMalformedRetryNote: (
         conversation: GeminiTurnContent[],
+        step: number,
       ) => GeminiTurnContent[];
     }
   | {

--- a/test/continuous-test-suite-aistudio-loop-characterization.ts
+++ b/test/continuous-test-suite-aistudio-loop-characterization.ts
@@ -35,6 +35,12 @@ import "dotenv/config";
  */
 
 import { createServer, type Server } from "node:http";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { assert, defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
 
@@ -43,6 +49,14 @@ assertDistFresh();
 const { test, section, runSuite } = defineSuite(
   "AI Studio loop characterization",
 );
+
+// Registered BEFORE NeuroLink is imported so its tracers bind to this
+// provider. Only the step-numbering case reads the exporter; everywhere else
+// it is an inert extra span processor.
+const spanExporter = new InMemorySpanExporter();
+new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+}).register();
 
 const { NeuroLink } = await import("../dist/index.js");
 
@@ -755,6 +769,76 @@ await test("an abort mid-step stops the loop from dispatching the rest of the ba
   assert(
     server.calls.length === 1,
     `the loop issued ${server.calls.length} requests, so it continued past the abort`,
+  );
+});
+
+section("step numbering");
+
+await test("tool activity is numbered by the turn's steps, one per step", async () => {
+  // Each step's tool activity is recorded with a step number — on the
+  // `gen_ai.tool_call` span event as `tool.step`, and on the conversation
+  // memory rows as `stepIndex`. The numbering has to come from the loop's own
+  // step, not from a count of how many times the recording hook ran: a
+  // malformed-call retry re-enters the loop without reaching that hook and
+  // still consumes a step, so a self-incrementing counter drifts by exactly
+  // the number of retries and mislabels every row after the first.
+  //
+  // AI Studio enables no such retry today, so this pins the numbering as it
+  // stands and fails if it is ever renumbered.
+  const server = await startStandIn((i) =>
+    i < 2 ? toolTurn("count", { n: i }) : textTurn("done"),
+  );
+  const restore = withAiStudioEnv();
+  spanExporter.reset();
+  let dispatched = 0;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "use the tool twice" },
+      provider: "google-ai",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 4,
+      disableTools: false,
+      disableInternalFallback: true,
+      credentials: credentialsFor(server.port),
+      tools: {
+        count: {
+          description: "counts",
+          inputSchema: {
+            type: "object",
+            properties: { n: { type: "number" } },
+            additionalProperties: true,
+          },
+          execute: async () => {
+            dispatched++;
+            return { ok: true };
+          },
+        },
+      },
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+  } finally {
+    restore();
+    await server.close();
+  }
+  const steps = spanExporter
+    .getFinishedSpans()
+    .flatMap((span: ReadableSpan) => span.events)
+    .filter((event) => event.name === "gen_ai.tool_call")
+    .map((event) => event.attributes?.["tool.step"]);
+  console.log(
+    `    [diagnostic] aistudio step numbering: dispatched=${dispatched} steps=${steps.join(",")}`,
+  );
+  assert(dispatched === 2, "the tool did not run once per tool-calling step");
+  // One event per tool call, numbered from 1, in order. Asserting the exact
+  // sequence rather than the count is what catches a renumbering that still
+  // produces the right number of events.
+  assert(
+    steps.length === 2 && steps[0] === 1 && steps[1] === 2,
+    "tool activity was not numbered 1,2 across the turn's two tool steps",
   );
 });
 


### PR DESCRIPTION
## What

Both hand-rolled Gemini loops in `googleVertex/client.ts` — `executeNativeGemini3Stream` and `executeNativeGemini3Generate` — move onto `runAgenticLoop`. **1031 lines replaced** by `createGeminiLoopAdapter`.

The engine takes the step cap, tool dispatch, the failure breaker, per-step usage accumulation, the single malformed retry, and the pre-first-chunk provider retry. The provider keeps the turn clock, the context guard, conversation-memory storage, the wrap-up nudge and the terminal block — the engine has no opinion about any of them.

## Proof: 14 characterization cases, unchanged

```
vertex   14/14      aistudio  9/9      anthropic  6/6
providers-mocked 54/54        provider-structure PASS
typecheck 0 errors            eslint 0 errors
```

**Three failed on the first run. None were adjusted.**

- **Both turn-clock cases** — a bug in the new code. The pump was awaited a second time after the catch had already absorbed the abort, so re-awaiting the settled rejection rethrew the error the branch had decided to swallow. A turn that should have ended cleanly on its deadline reported failure instead.
- **The non-throwing-failure case** — a real gap. The breaker tripped correctly, but the model-visible payload had collapsed from `{error, status, do_not_retry}` to `{error}`: the adapter was re-wrapping the message instead of relaying what the engine built. Those fields are **instructions to the model**; without them it keeps spending steps on a tool that will never work.

## Seven engine changes, six opt-in

| change | why |
|---|---|
| `toolFailureBreaker.consecutive` | a clean result clears the strikes, so an argument-dependent soft error can't disable a working tool |
| `toolFailureBreaker.classifyResultFailure` | a resolved `{error}` / MCP `isError` counts as a failure, not just a throw |
| `buildToolResultMessages(..., step)` | a malformed retry burns a step without reaching this hook, so a self-counting adapter drifts |
| `buildMalformedRetryNote(..., step)` | same, for the public `turn:lifecycle` event payload |
| `planReclaim → { stop }` | a guard that can't reclaim must **end** the turn; aborting from inside the hook doesn't work, because the engine checks for aborts *above* it |
| `finalResultToolName` / `onTerminalResult` | a terminal call is reported as text and omitted from `toolCalls` |
| `hydratedToolNames` on the step request | strikes accrued while a tool was deferred are snapshot artifacts — and the breaker is consulted **before** the lookup, so clearing them at the miss path is too late |

## Deliberate behaviour changes, stated rather than buried

1. **AI Studio's tool-error payload** becomes `{error, status, do_not_retry}`. Its pre-migration loop had no such payloads at all, so this makes the wire match what the engine already decided to send.
2. **AI Studio's stored `stepIndex`** now comes from the engine's step rather than a self-incremented counter. Values are identical today and stay correct if that provider ever enables the malformed retry. A new case pins the sequence via the `tool.step` span event.
3. **Vertex gains bounded per-step 429/5xx retry** it never had. This does *not* contradict its `maxRetries: 0`, which objects to the SDK's **unbounded** `Retry-After` honouring — `withProviderRetry` caps at 2 attempts and 60s and hands longer back-offs to the orchestrator.

## Also here

`runAgenticLoop` was 302 lines and tripping `max-lines-per-function`; tool dispatch is now `dispatchStepTools` (197 + 134). It owns no state and reports by returning, so the turn's accumulators stay in one place.

**One off-by-one caught by reading, not testing.** `stepsTaken` was being set in `buildToolResultMessages`, which only runs on steps that called tools, while the old counter sat at the top of the loop and counted every step. `stepsUsed` is a public result field, so it would have been one lower on every normal turn. The count moved to `buildStepRequest`. No case asserts `stepsUsed`, and the step-cap case is the one situation where both counts agree — the suite would not have caught this.

## Note

Touches the same file as #1456 (Vertex+Claude auth) but different regions; I'll rebase if they conflict.