### PR TITLE
chore(examples): refresh stale dependency versions

### DIFF
--- a/examples/projects/chat-app/package.json
+++ b/examples/projects/chat-app/package.json
@@ -21,14 +21,14 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@juspay/neurolink": "^8.32.0",
+    "@juspay/neurolink": "^11.15.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.20.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.2"
   },

--- a/examples/projects/enterprise-app/package.json
+++ b/examples/projects/enterprise-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
-    "@juspay/neurolink": "^8.32.0",
+    "@juspay/neurolink": "^11.15.6",
     "express": "^4.18.2",
     "ioredis": "^5.3.2",
     "dotenv": "^16.3.1",
@@ -18,9 +18,9 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.20.0",
     "typescript": "^5.3.2",
     "ts-node": "^10.9.2",
-    "vitest": "^1.0.0"
+    "vitest": "^3.2.6"
   }
 }

--- a/examples/projects/mcp-tools-demo/package.json
+++ b/examples/projects/mcp-tools-demo/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.1",
-    "@juspay/neurolink": "^8.32.0",
+    "@juspay/neurolink": "^11.15.6",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.20.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.2"
   },

--- a/examples/starters/chat/package.json
+++ b/examples/starters/chat/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@juspay/neurolink": "^9.88.12"
+    "@juspay/neurolink": "^11.15.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/starters/mcp-client/package.json
+++ b/examples/starters/mcp-client/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@juspay/neurolink": "^9.88.12"
+    "@juspay/neurolink": "^11.15.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/starters/proxy-failover/package.json
+++ b/examples/starters/proxy-failover/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@juspay/neurolink": "^9.88.12"
+    "@juspay/neurolink": "^11.15.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",


### PR DESCRIPTION
Every example manifest pointed at a `@juspay/neurolink` **two majors behind** — three at `^8.32.0`, three at `^9.88.12`, against `11.15.6` published. Anyone following a starter installed a different major and got whatever API surface it had.

| file | was | now |
|---|---|---|
| `examples/projects/chat-app` | `^8.32.0` | `^11.15.6` |
| `examples/projects/enterprise-app` | `^8.32.0` | `^11.15.6` |
| `examples/projects/mcp-tools-demo` | `^8.32.0` | `^11.15.6` |
| `examples/starters/chat` | `^9.88.12` | `^11.15.6` |
| `examples/starters/mcp-client` | `^9.88.12` | `^11.15.6` |
| `examples/starters/proxy-failover` | `^9.88.12` | `^11.15.6` |

## Clears the only critical Dependabot alert

`vitest ^1.0.0` in `examples/projects/enterprise-app` — arbitrary file read/execute when the Vitest UI server is listening, patched in 3.2.6.

Practical exposure is nil: `examples/` is not in `package.json` `"files"` so it never ships, and no workflow installs or builds it. But it was the single entry making the repo banner read **"1 critical"**, which costs attention on every triage.

For context, the other 60 open alerts break down as: `docs-site/pnpm-lock.yaml` 34 (CI-only doc site), root `pnpm-lock.yaml` 23 (16 are the accepted-risk production set the security check already tracks), `landing/` 3.

## Also

Three examples pinned `@types/node ^20.10.0`, now below the `>=22` engine floor — raised to `^22.20.0`.

## Verification

Not assumed — `examples/starters/chat` was installed against `@juspay/neurolink@11.15.6` and compiled with `tsc --noEmit`, exit 0. The `import { NeuroLink }` / `new NeuroLink()` surface these examples use holds across the bump.