### PR TITLE
fix(tools): read the real catalog field in the provider onboarding gate

### DIFF
--- a/tools/verify-provider-onboarding.ts
+++ b/tools/verify-provider-onboarding.ts
@@ -102,10 +102,17 @@ async function loadDescriptors(): Promise<ReadonlySet<string>> {
 }
 
 async function loadCatalog(): Promise<ReadonlySet<string>> {
-  const mod = (await import("../src/lib/providers/openaiCompatCatalog.js")) as {
-    OPENAI_COMPAT_CATALOG: ReadonlyArray<{ provider: string }>;
-  };
-  return new Set(mod.OPENAI_COMPAT_CATALOG.map((c) => c.provider));
+  // The field is `providerName`, not `provider`. Reading `.provider` yielded
+  // undefined for every row, so this Set was {undefined} and the catalog half
+  // of the catalog-or-class check below never matched anything — the gate has
+  // been resting entirely on nativeClasses since it was written.
+  //
+  // Import the real type instead of re-declaring a structural shape. The old
+  // local `{ provider: string }` cast is exactly what hid the mistake: it
+  // asserted a field that does not exist, and tools/ is excluded from
+  // tsconfig, so nothing ever typechecked the assertion.
+  const mod = await import("../src/lib/providers/openaiCompatCatalog.js");
+  return new Set(mod.OPENAI_COMPAT_CATALOG.map((c) => String(c.providerName)));
 }
 
 function loadNativeProviderNames(


### PR DESCRIPTION
`loadCatalog()` maps `c.provider`. `OpenAICompatCatalogEntry` has no such field — it is **`providerName`**. Every row yielded `undefined`, so the Set was `{undefined}` and the catalog half of the catalog-or-class check never matched anything. The gate has been resting entirely on `nativeClasses` since it was written.

```
catalog rows          : 7
gate sees (c.provider): [null]
should see            : ["groq","xai","together-ai","fireworks","perplexity","mistral","cloudflare"]
```

## Impact is latent, not active

Every current provider is in `LEGACY_PROVIDERS`, so the gate reports *"No new (post-legacy) providers to check"* and nothing is mis-evaluated **today**. It fires on the first Tier-2 provider anyone adds.

Demonstrated by removing `groq` from `LEGACY_PROVIDERS` so the gate treats it as new:

| | output |
|---|---|
| **with this fix** | `✗ groq` — missing/invalid manifest |
| **without** | `✗ groq` — missing/invalid manifest **+ "no OpenAICompatCatalogEntry and no registered provider class"** |

That second line is a **false accusation** — groq has had a catalog entry all along. A contributor following it would go hunting for something that already exists.

## Why it survived

The local `{ provider: string }` cast asserted a field that does not exist, and `tools/` is in `tsconfig`'s `exclude` list, so nothing ever typechecked the assertion. This imports the real module type instead of re-declaring a structural shape, so the compiler keeps the two in step from now on.

## Related, deliberately not in this PR

`tools/` and `scripts/` are both excluded from `tsconfig`, and `scripts/**` is in ESLint's ignore list. Bringing `tools/` into typecheck surfaces **29 errors across its four top-level files** — more than belongs here. But this bug is exactly what that exclusion costs, on a script that gates the required `provider-safety-net` check.

Found by an adversarial review pass over the 20 dependency-audit commits that merged unreviewed while CodeRabbit was rate-limited.