### PR TITLE
fix(core): hydrate deferred tools again on the shared Gemini adapter

### DIFF
--- a/src/lib/core/geminiLoopAdapter.ts
+++ b/src/lib/core/geminiLoopAdapter.ts
@@ -27,8 +27,11 @@ import type {
   GeminiStepRaw,
   GeminiTurnContent,
 } from "../types/index.js";
+import type { Tool } from "../types/index.js";
+import { resolveLiveTool } from "../tools/toolDiscovery.js";
 import {
   collectStreamChunksIncremental,
+  guardToolExecutor,
   extractTextFromParts,
   mapGeminiFinishReason,
   pushModelResponseToHistory,
@@ -121,18 +124,35 @@ export function createGeminiLoopAdapter(
       : {}),
 
     resolveToolOnMiss: (name: string) => {
-      const tool = config.liveTools?.[name];
+      // resolveLiveTool, NOT a plain record lookup. A deferred-catalog tool is
+      // not a key on the record at all — it lives behind a symbol-keyed
+      // resolver — so `liveTools[name]` returns undefined for exactly the
+      // tools this hook exists to hydrate, and the model gets TOOL_NOT_FOUND
+      // for a tool it was told about.
+      const tool = resolveLiveTool(config.liveTools, name);
       const execute = tool?.execute;
       if (!execute) {
         return undefined;
       }
-      // Wrapped because the hook types `opts` as `unknown`, and a function
-      // declaring a narrower options type is not assignable to one accepting
-      // `unknown`. One assertion at the boundary, never a double assertion.
-      return {
-        execute: async (args: Record<string, unknown>, opts: unknown) =>
-          execute(args, opts as Parameters<typeof execute>[1]),
-      };
+      // Registered into the turn's DedupExecuteMap and taken back through
+      // `.get()`, so a hydrated tool gets the same per-turn result cache as a
+      // declared one. A tool the model just discovered is the one most likely
+      // to be re-requested with identical arguments.
+      const executeMap = config.declarations?.executeMap;
+      let resolved: NonNullable<Tool["execute"]> = execute;
+      if (executeMap) {
+        executeMap.set(name, execute);
+        resolved = executeMap.get(name) ?? execute;
+      }
+      const guarded = config.toolGuards
+        ? guardToolExecutor(name, resolved, config.toolGuards)
+        : // Wrapped because the hook types `opts` as `unknown`, and a function
+          // declaring a narrower options type is not assignable to one
+          // accepting `unknown`. One assertion at the boundary, never a double
+          // assertion.
+          async (args: Record<string, unknown>, opts: unknown) =>
+            resolved(args, opts as Parameters<typeof resolved>[1]);
+      return { execute: guarded };
     },
 
     async executeStep(

--- a/src/lib/core/loopEngine.ts
+++ b/src/lib/core/loopEngine.ts
@@ -117,9 +117,19 @@ async function dispatchStepTools(params: {
     // a deferred-catalog placeholder is exactly that shape, and it is
     // precisely what hydration exists to resolve.
     const declaredTool = tools?.[call.name];
-    const tool = declaredTool?.execute
-      ? declaredTool
-      : (adapter.resolveToolOnMiss?.(call.name) ?? declaredTool);
+    let tool = declaredTool;
+    if (!declaredTool?.execute) {
+      const hydrated = adapter.resolveToolOnMiss?.(call.name);
+      if (hydrated) {
+        tool = hydrated;
+        // It resolves NOW, so any strikes standing against this name were
+        // recorded while it genuinely did not resolve — snapshot artifacts of
+        // a deferred catalog, not failures of a tool that exists. Leaving them
+        // in place would disable the tool at the exact moment it became
+        // usable.
+        failedTools.delete(call.name);
+      }
+    }
     if (!tool?.execute) {
       const output = breaker
         ? {

--- a/src/lib/providers/googleNativeGemini3/utils.ts
+++ b/src/lib/providers/googleNativeGemini3/utils.ts
@@ -621,6 +621,50 @@ export function buildNativeToolDeclarations(
  * `toolsConfig` by reference — and returns true when anything was added.
  */
 /**
+ * Everything a native Gemini loop wraps around a tool call that the shared
+ * engine does not do itself.
+ *
+ * Order matters. `raceWithAbort` sits INSIDE `withTimeout` so a turn-level
+ * abort is observed the moment it fires rather than after the tool settles,
+ * and the timeout still bounds a tool that neither settles nor honours its
+ * signal. The progress pings bracket the await because the stall watchdog is
+ * a whole-turn interval comparing wall-clock against the last progress mark —
+ * without them a legitimately slow tool reads as a stalled turn and is killed.
+ *
+ * Exported because a tool hydrated MID-TURN has to be wrapped the same way as
+ * one declared up front; keeping this inline made the discovered tool the one
+ * executor in the system that ran raw.
+ */
+export function guardToolExecutor(
+  name: string,
+  execute: NonNullable<Tool["execute"]>,
+  guards: GeminiToolExecutionGuards,
+): (args: Record<string, unknown>, opts: unknown) => Promise<unknown> {
+  return async (args: Record<string, unknown>, opts: unknown) => {
+    const call = () =>
+      Promise.resolve(execute(args, opts as Parameters<typeof execute>[1]));
+    guards.onProgress?.();
+    try {
+      const raced = guards.abortSignal
+        ? raceWithAbort(call(), guards.abortSignal)
+        : call();
+      return await (guards.toolTimeoutMs === undefined
+        ? raced
+        : withTimeout(
+            raced,
+            guards.toolTimeoutMs,
+            `Tool "${name}" execution timed out after ${guards.toolTimeoutMs}ms`,
+          ));
+    } finally {
+      // In `finally`, not after a successful await: a tool that times out or
+      // throws has still consumed real time, and skipping the mark there would
+      // leave the watchdog measuring from before the call.
+      guards.onProgress?.();
+    }
+  };
+}
+
+/**
  * Build the tool record handed to `runAgenticLoop`, routed through the turn's
  * DedupExecuteMap.
  *
@@ -659,33 +703,11 @@ export function buildDedupedEngineTools(
   const guard = (
     name: string,
     execute: NonNullable<Tool["execute"]>,
-  ): ((args: Record<string, unknown>, opts: unknown) => Promise<unknown>) => {
-    return async (args: Record<string, unknown>, opts: unknown) => {
-      const call = () =>
-        Promise.resolve(execute(args, opts as Parameters<typeof execute>[1]));
-      if (!guards) {
-        return call();
-      }
-      guards.onProgress?.();
-      try {
-        const raced = guards.abortSignal
-          ? raceWithAbort(call(), guards.abortSignal)
-          : call();
-        return await (guards.toolTimeoutMs === undefined
-          ? raced
-          : withTimeout(
-              raced,
-              guards.toolTimeoutMs,
-              `Tool "${name}" execution timed out after ${guards.toolTimeoutMs}ms`,
-            ));
-      } finally {
-        // In `finally`, not after a successful await: a tool that times out or
-        // throws has still consumed real time, and skipping the mark there
-        // would leave the watchdog measuring from before the call.
-        guards.onProgress?.();
-      }
-    };
-  };
+  ): ((args: Record<string, unknown>, opts: unknown) => Promise<unknown>) =>
+    guards
+      ? guardToolExecutor(name, execute, guards)
+      : async (args: Record<string, unknown>, opts: unknown) =>
+          execute(args, opts as Parameters<typeof execute>[1]);
 
   if (declarations) {
     for (const [safeName, originalName] of declarations.originalNameMap) {

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -2154,6 +2154,13 @@ export class GoogleVertexProvider extends BaseProvider {
             extractToolFailureText(output) ?? undefined,
         },
         liveTools: options.tools ?? {},
+        // A tool hydrated mid-turn gets the SAME bound, abort race and stall
+        // ping as one declared up front — see guardToolExecutor.
+        toolGuards: {
+          toolTimeoutMs: toolExecTimeoutMs,
+          abortSignal: effectiveSignal,
+          onProgress: () => turnClock.noteProgress(),
+        },
         ...(declarations ? { declarations } : {}),
         ...(useFinalResultTool
           ? {
@@ -3171,6 +3178,13 @@ export class GoogleVertexProvider extends BaseProvider {
             extractToolFailureText(output) ?? undefined,
         },
         liveTools: options.tools ?? {},
+        // A tool hydrated mid-turn gets the SAME bound, abort race and stall
+        // ping as one declared up front — see guardToolExecutor.
+        toolGuards: {
+          toolTimeoutMs: toolExecTimeoutMs,
+          abortSignal: effectiveSignal,
+          onProgress: () => turnClock.noteProgress(),
+        },
         ...(declarations ? { declarations } : {}),
         ...(useFinalResultTool
           ? {

--- a/src/lib/types/loopEngine.ts
+++ b/src/lib/types/loopEngine.ts
@@ -400,6 +400,16 @@ export type GeminiLoopAdapterCoreConfig = {
    */
   noteUsage?: (inputTokens: number, outputTokens: number) => void;
   /**
+   * The same guards `buildDedupedEngineTools` wraps declared tools in, applied
+   * to one hydrated mid-turn.
+   *
+   * Without this a tool discovered during a turn is the ONE executor that runs
+   * raw: no per-turn dedup, no execution timeout, no stall-clock ping. That is
+   * the opposite of what discovery is for — the tool the model just found is
+   * the one most likely to be called repeatedly with the same arguments.
+   */
+  toolGuards?: GeminiToolExecutionGuards;
+  /**
    * Name of the terminal structured-output tool when one is in play. A call
    * to it ends the turn: its arguments ARE the answer, so it is reported as
    * text and omitted from `toolCalls`, which routes it through the engine's


### PR DESCRIPTION
## The regression

Task 10 (#1460) moved both Vertex Gemini loops onto the engine, and tool resolution went with them. The adapter's `resolveToolOnMiss` does `config.liveTools?.[name]` — a **plain record lookup**. A deferred-catalog tool is not a key on that record at all: it lives behind a symbol-keyed resolver reached through `resolveLiveTool`.

So the migrated loops returned `TOOL_NOT_FOUND` for exactly the tools discovery exists to serve. Vertex's own `resolveGeminiToolOnMiss` did it correctly, and is now dead code.

## My own audit script names it in seconds

```
$ node scripts/migration-symbol-diff.mjs 1ad20bfd src/lib/providers/googleVertex/client.ts
449 -> 450 called symbols; 11 vanished
   GONE: resolveGeminiToolOnMiss
   GONE: refreshGeminiToolDeclarations
```

I wrote that tool (#1448, #1452) for this exact failure mode, wrote the standing order to use it, and then did not run it on my own largest migration. It runs before the PR opens from here on.

## Four changes, all restoring prior behaviour

1. **`resolveLiveTool`** instead of a plain lookup, so a deferred tool hydrates.
2. **The hydrated executor joins the turn's `DedupExecuteMap`** — registered, then taken back through `.get()`. A tool the model has just discovered is the one *most* likely to be re-requested with identical arguments (BZ-3327).
3. **`guardToolExecutor` lifted out and exported**, so a hydrated tool gets the same execution timeout, abort race and stall-clock ping. It was previously the one executor in the system that ran raw — a discovered tool could hang a turn that a declared tool could only ever cost a step.
4. **The engine clears that name's breaker strikes when a miss resolves.** Strikes recorded while a tool genuinely did not resolve are artifacts of the deferred catalog; leaving them disables the tool at the exact moment it becomes usable.

## No new test, and why

Deferral applies only to external MCP tools that are neither per-call nor explicitly matched (`baseProvider.ts:1015-1035`), so the path needs a live MCP catalog and is not reachable from the stand-in harness. I am not going to claim coverage I do not have.

What this *is*: a restoration of behaviour that existed before the migration, with the symbol diff above as the evidence for what was lost. The four suites that do exercise this file are unaffected — **vertex 14/14, aistudio 10/10, anthropic 6/6, vertex-claude 2/2**, typecheck 0 errors, lint clean.

Making the deferred path reachable from the harness is worth doing on its own; `test/helpers/mcpHelpers.ts` exists and would be the starting point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tools discovered during an active turn.
  * Ensured dynamically available tools respect execution timeouts and cancellation requests.
  * Added progress signaling during tool execution, including when tools fail or time out.
  * Prevented stale tool lookup failures from affecting subsequent attempts.
  * Applied consistent execution safeguards to tools, whether available initially or discovered later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->