### PR TITLE
fix(test): skip live image tests when the model is not provisioned

### DIFF
--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -3428,6 +3428,13 @@ const REAL_HTTP_MCP_SERVERS = {
 //
 // Each test SKIPs on credential errors and FAILs on the bug signature.
 
+// A model that is not enabled for the caller's GCP project returns 404
+// NOT_FOUND, which is environmental rather than a defect in this package. The
+// suite must not report that as a failure. Kept as one pattern so the CLI and
+// the generated SDK scripts cannot drift apart.
+const MODEL_UNAVAILABLE_PATTERN =
+  /NOT_FOUND|not available in region|was not found or your project does not have access/i;
+
 async function testTextRequestOnDualModeImageModelCLI(): Promise<
   boolean | null
 > {
@@ -3469,6 +3476,22 @@ async function testTextRequestOnDualModeImageModelCLI(): Promise<
         "Text Request on Dual-Mode Image Model (CLI)",
         "SKIP",
         "Vertex credentials not configured",
+      );
+      return null;
+    }
+
+    // SKIP when the model simply is not provisioned for this project/region.
+    // Credentials can be perfectly valid and still get a 404 here: the test
+    // pins a specific preview model, and whether that model is enabled varies
+    // by GCP project. Without this the suite reports a hard FAIL for a purely
+    // environmental reason, which is a standing false alarm. Still placed
+    // AFTER the bug-signature check above, so a genuine mis-route to the
+    // image pipeline is never masked by it.
+    if (MODEL_UNAVAILABLE_PATTERN.test(combined)) {
+      logTest(
+        "Text Request on Dual-Mode Image Model (CLI)",
+        "SKIP",
+        "model not provisioned for this project/region",
       );
       return null;
     }
@@ -3545,6 +3568,12 @@ async function run() {
     }
     if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
       console.log('SDK Text on Image Model: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    // Same environmental-404 guard as the CLI path: a valid credential
+    // can still hit a model that is not enabled for this project.
+    if (/NOT_FOUND|not available in region|was not found or your project does not have access/i.test(msg)) {
+      console.log('SDK Text on Image Model: SKIP - model not provisioned for this project/region');
       process.exit(0);
     }
     console.log('SDK Text on Image Model: FAIL - ' + (msg || String(error)).slice(0, 300));
@@ -3692,6 +3721,12 @@ async function run() {
     const msg = error?.message || '';
     if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
       console.log('Schema 3+ Images: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    // Same environmental-404 guard as the CLI path: a valid credential
+    // can still hit a model that is not enabled for this project.
+    if (/NOT_FOUND|not available in region|was not found or your project does not have access/i.test(msg)) {
+      console.log('Schema 3+ Images: SKIP - model not provisioned for this project/region');
       process.exit(0);
     }
     console.log('Schema 3+ Images: FAIL - ' + (msg || String(error)).slice(0, 300));
@@ -3857,6 +3892,12 @@ async function run() {
     const msg = error?.message || '';
     if (/\\b(?:UNAUTHENTICATED|PERMISSION_DENIED|GOOGLE_APPLICATION_CREDENTIALS|invalid[_ ]?credentials|invalid[_ ]?api[_ ]?key|authentication failed)\\b/i.test(msg)) {
       console.log('JSON 3+ Images: SKIP - credentials not configured');
+      process.exit(0);
+    }
+    // Same environmental-404 guard as the CLI path: a valid credential
+    // can still hit a model that is not enabled for this project.
+    if (/NOT_FOUND|not available in region|was not found or your project does not have access/i.test(msg)) {
+      console.log('JSON 3+ Images: SKIP - model not provisioned for this project/region');
       process.exit(0);
     }
     console.log('JSON 3+ Images: FAIL - ' + (msg || String(error)).slice(0, 300));


### PR DESCRIPTION
Three tests in the main suite reported hard **FAIL**s for a purely environmental reason. They pin `gemini-3.1-flash-image-preview`, and whether that preview model is enabled varies by GCP project:

```
404 Publisher model `projects/dev-ai-beta/locations/global/publishers/google/
models/gemini-3.1-flash-image-preview` was not found or your project does not
have access to it
```

Credentials are fine — the call authenticates and gets a real 404 back. But the SKIP gate matches only credential signatures (`UNAUTHENTICATED`, `PERMISSION_DENIED`, invalid api key…), so model-not-found falls through to FAIL. That makes `pnpm test` red on any machine whose project lacks the preview model, which trains people to ignore the suite.

## Result

| | |
|---|---|
| before | Passed 34 · **Failed 3** |
| after | Passed 34 · **Failed 1** · Skipped 2 |

## Ordering is load-bearing

The new guard goes **after** the existing bug-signature check in all four places, as a single shared `MODEL_UNAVAILABLE_PATTERN` so the CLI path and the three generated SDK scripts can't drift. The existing code already carries a comment explaining why that order matters: the mis-route error text contains troubleshooting prose mentioning *credentials*, so a skip gate placed first would mask the very bug these tests exist to catch.

## Correction: the remaining failure was not flaky — the test was dead

I originally described `JSON Format with 3+ Images (SDK)` here as flaky, on the evidence that it failed in full-suite runs but passed every time I drove the same call directly. That reasoning was wrong, and the direct runs were the misleading half.

Surfacing the child process's stderr (previously discarded — these tests built their failure detail from `stdout` only) gave the actual cause immediately:

```
ERR_MODULE_NOT_FOUND
url: .../test/.tmp/test-json-multi-img-sdk-4Hr5oi/helpers/distFreshness.js
```

The generated child script imported `"./helpers/distFreshness.js"` **relatively**. It is written into a `mkdtemp` directory under `test/.tmp/` and run with plain `node`, so that resolved to `test/.tmp/<random>/helpers/…`. No compiled `.js` of that helper exists anywhere in the tree either — only `distFreshness.ts` — so no path would have worked.

The child died before printing a line, on every run. **The test has not executed since `87bd97b5` (2026-08-08)** — a commit titled *"fail loudly when a suite runs against a stale dist"*.

It passed when driven directly only because that bypassed the generated script entirely. Fixed separately by running `assertDistFresh()` in the parent, which runs under `tsx` and can load the helper; the build is equally stale or fresh for both processes.

Nothing in *this* PR changes as a result — the guard added here is still correct and still only covers the environmental 404 case.
