### PR TITLE
feat(proxy): add the Gemini CLI door

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1516,6 +1516,8 @@ export async function createProxyStartApp(params: {
     await import("../../lib/server/routes/openaiProxyRoutes.js");
   const { createCodexProxyRoutes } =
     await import("../../lib/server/routes/codexProxyRoutes.js");
+  const { createGeminiProxyRoutes } =
+    await import("../../lib/server/routes/geminiProxyRoutes.js");
   const { logBodyCapture, logRequest } =
     await import("../../lib/proxy/requestLogger.js");
   const { recordFinalError } = await import("../../lib/proxy/usageStats.js");
@@ -1674,10 +1676,17 @@ export async function createProxyStartApp(params: {
     runtimeConfigProvider,
   );
   const codexRouteGroup = createCodexProxyRoutes("");
+  const geminiRouteGroup = createGeminiProxyRoutes(
+    params.modelRouter,
+    "",
+    params.port,
+    runtimeConfigProvider,
+  );
   const allProxyRoutes = [
     ...routeGroup.routes,
     ...openaiRouteGroup.routes,
     ...codexRouteGroup.routes,
+    ...geminiRouteGroup.routes,
   ];
 
   for (const route of allProxyRoutes) {

--- a/src/lib/proxy/geminiFormat.ts
+++ b/src/lib/proxy/geminiFormat.ts
@@ -1,0 +1,283 @@
+/**
+ * Google `generateContent` wire format.
+ *
+ * The Gemini CLI honours `GOOGLE_GEMINI_BASE_URL`, so it can be pointed at this
+ * proxy with no vendor cooperation — verified live: with the variable set the
+ * CLI reached the proxy and failed with `ModelNotFoundError: 404`, which is the
+ * right answer from a proxy that had no route to answer it. This module is the
+ * missing half.
+ *
+ * Three differences from the Claude and OpenAI shapes drive everything here:
+ *
+ * - Roles are `user` / `model`, not `user` / `assistant`.
+ * - The system prompt is a sibling `systemInstruction`, not a turn.
+ * - Generation settings nest under `generationConfig`.
+ *
+ * Token counts also have their own names — `promptTokenCount`,
+ * `candidatesTokenCount`, `totalTokenCount` — and the CLI reads them to render
+ * its own usage line, so getting them wrong is visible to the user rather than
+ * merely wrong in a log.
+ */
+
+import type {
+  ParsedGeminiRequest,
+  ProxyGeminiContent,
+  ProxyGeminiPart,
+  StreamSerializerAdapter,
+} from "../types/index.js";
+
+/** Google's role for assistant turns. */
+const MODEL_ROLE = "model";
+
+function partsToText(parts: ProxyGeminiPart[] | undefined): string {
+  if (!Array.isArray(parts)) {
+    return "";
+  }
+  return parts
+    .map((p) => (typeof p?.text === "string" ? p.text : ""))
+    .filter(Boolean)
+    .join("");
+}
+
+function partsToImages(parts: ProxyGeminiPart[] | undefined): string[] {
+  if (!Array.isArray(parts)) {
+    return [];
+  }
+  return parts
+    .map((p) => p?.inlineData?.data)
+    .filter((d): d is string => typeof d === "string" && d.length > 0);
+}
+
+/**
+ * Parse a `generateContent` body into the shape the translation engine takes.
+ *
+ * The final user turn becomes `prompt`; everything before it becomes
+ * `conversationMessages`, with Google's `model` role mapped to `assistant` so
+ * downstream providers see a role they understand.
+ */
+export function parseGeminiRequest(
+  model: string,
+  body: Record<string, unknown>,
+  stream: boolean,
+): ParsedGeminiRequest {
+  const contents = Array.isArray(body.contents)
+    ? (body.contents as ProxyGeminiContent[])
+    : [];
+  const generationConfig = (body.generationConfig ?? {}) as Record<
+    string,
+    unknown
+  >;
+
+  const systemInstruction = body.systemInstruction as
+    | ProxyGeminiContent
+    | undefined;
+  const systemPrompt = systemInstruction
+    ? partsToText(systemInstruction.parts)
+    : undefined;
+
+  const turns = contents.map((c) => ({
+    role: c?.role === MODEL_ROLE ? "assistant" : "user",
+    content: partsToText(c?.parts),
+    images: partsToImages(c?.parts),
+  }));
+
+  // The last user turn is the prompt; anything before it is history. A request
+  // whose final turn is a model turn (the CLI does this when continuing) leaves
+  // an empty prompt rather than replaying the assistant's own words as input.
+  let prompt = "";
+  let images: string[] = [];
+  const conversationMessages: Array<{ role: string; content: string }> = [];
+  for (let i = 0; i < turns.length; i += 1) {
+    const isLast = i === turns.length - 1;
+    if (isLast && turns[i].role === "user") {
+      prompt = turns[i].content;
+      images = turns[i].images;
+    } else {
+      conversationMessages.push({
+        role: turns[i].role,
+        content: turns[i].content,
+      });
+    }
+  }
+
+  const numeric = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
+
+  const stops = generationConfig.stopSequences;
+
+  return {
+    model,
+    maxTokens: numeric(generationConfig.maxOutputTokens),
+    temperature: numeric(generationConfig.temperature),
+    topP: numeric(generationConfig.topP),
+    systemPrompt: systemPrompt || undefined,
+    stream,
+    prompt,
+    images,
+    conversationMessages,
+    tools: {},
+    stopSequences: Array.isArray(stops)
+      ? stops.filter((x): x is string => typeof x === "string")
+      : undefined,
+  };
+}
+
+/** Google's finishReason vocabulary. */
+function toGeminiFinishReason(reason: string): string {
+  switch (reason) {
+    case "length":
+    case "max_tokens":
+      return "MAX_TOKENS";
+    case "content_filter":
+      return "SAFETY";
+    default:
+      return "STOP";
+  }
+}
+
+function usageMetadata(usage: {
+  input: number;
+  output: number;
+  total: number;
+}): Record<string, number> {
+  return {
+    promptTokenCount: usage.input,
+    candidatesTokenCount: usage.output,
+    totalTokenCount: usage.total || usage.input + usage.output,
+  };
+}
+
+/** Build a complete `generateContent` response body. */
+export function buildGeminiResponse(
+  text: string,
+  finishReason: string,
+  usage: { input: number; output: number; total: number },
+  modelVersion: string,
+): Record<string, unknown> {
+  return {
+    candidates: [
+      {
+        content: { role: MODEL_ROLE, parts: [{ text }] },
+        finishReason: toGeminiFinishReason(finishReason),
+        index: 0,
+      },
+    ],
+    usageMetadata: usageMetadata(usage),
+    modelVersion,
+  };
+}
+
+/** Google's error envelope, which the CLI parses to classify failures. */
+export function buildGeminiErrorResponse(
+  status: number,
+  message: string,
+  statusText = "INVALID_ARGUMENT",
+): Response {
+  return new Response(
+    JSON.stringify({ error: { code: status, message, status: statusText } }),
+    { status, headers: { "content-type": "application/json" } },
+  );
+}
+
+/**
+ * SSE serializer for `streamGenerateContent?alt=sse`.
+ *
+ * Google streams whole `GenerateContentResponse` objects, one per `data:`
+ * frame, rather than the deltas Claude and OpenAI send. Each frame therefore
+ * carries a complete `candidates[0].content.parts[0].text` holding only that
+ * chunk's text — the CLI concatenates them — and the final frame is the one
+ * that carries `finishReason` and `usageMetadata`.
+ */
+export class GeminiStreamSerializer {
+  private readonly model: string;
+
+  constructor(model: string) {
+    this.model = model;
+  }
+
+  private frame(payload: Record<string, unknown>): string {
+    return `data: ${JSON.stringify(payload)}\n\n`;
+  }
+
+  /** Google sends no preamble frame; the first delta is the first frame. */
+  start(): string[] {
+    return [];
+  }
+
+  pushDelta(text: string): string[] {
+    if (!text) {
+      return [];
+    }
+    return [
+      this.frame({
+        candidates: [
+          { content: { role: MODEL_ROLE, parts: [{ text }] }, index: 0 },
+        ],
+        modelVersion: this.model,
+      }),
+    ];
+  }
+
+  /**
+   * Tool calls are surfaced as text.
+   *
+   * The translation engine can emit a tool call, but the Gemini CLI drives its
+   * own tools locally and does not expect `functionCall` parts from a plain
+   * `generateContent`. Emitting one would make the CLI wait for a tool result
+   * that is never coming; rendering it as text keeps the turn terminating.
+   */
+  pushToolUse(_id: string, name: string, input: unknown): string[] {
+    return this.pushDelta(`\n[tool: ${name} ${JSON.stringify(input)}]\n`);
+  }
+
+  finish(
+    finishReason: string,
+    usage: { input: number; output: number; total: number },
+  ): string[] {
+    return [
+      this.frame({
+        candidates: [
+          {
+            content: { role: MODEL_ROLE, parts: [{ text: "" }] },
+            finishReason: toGeminiFinishReason(finishReason),
+            index: 0,
+          },
+        ],
+        usageMetadata: usageMetadata(usage),
+        modelVersion: this.model,
+      }),
+    ];
+  }
+
+  /**
+   * Errors ride the stream as a Google error object.
+   *
+   * Once headers are sent the status code is spent, so the CLI can only learn
+   * about a mid-stream failure from the body.
+   */
+  emitError(message: string): string[] {
+    return [
+      this.frame({
+        error: { code: 500, message, status: "INTERNAL" },
+      }),
+    ];
+  }
+}
+
+/** Adapter so the translation engine can drive this like the other two. */
+export function createGeminiSerializerAdapter(
+  model: string,
+): StreamSerializerAdapter {
+  const s = new GeminiStreamSerializer(model);
+  return {
+    start: () => s.start(),
+    pushDelta: (text: string) => s.pushDelta(text),
+    pushToolUse: (id: string, name: string, input: unknown) =>
+      s.pushToolUse(id, name, input),
+    finish: (
+      finishReason: string,
+      usage: { input: number; output: number; total: number },
+    ) => s.finish(finishReason, usage),
+    emitError: (message: string) => s.emitError(message),
+  };
+}

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -18,6 +18,10 @@ import {
   serializeClaudeResponse,
 } from "./claudeFormat.js";
 import {
+  buildGeminiResponse,
+  createGeminiSerializerAdapter,
+} from "./geminiFormat.js";
+import {
   generateOpenAIToolCallId,
   OpenAIStreamSerializer,
   serializeOpenAIResponse,
@@ -33,6 +37,7 @@ import {
 import type {
   InternalResult,
   ParsedClaudeRequest,
+  ParsedGeminiRequest,
   ParsedOpenAIRequest,
   ProxyFormat,
   ProxyTranslationAttempt,
@@ -147,6 +152,19 @@ export function detectProxyFormat(
   if (path.includes("/messages")) {
     return "claude";
   }
+  // Gemini CLI wire format: POST /v1beta/models/<model>:generateContent
+  // (non-streaming) or :streamGenerateContent (streaming, selected via
+  // ?alt=sse on ctx.query — not part of ctx.path, so it plays no role here).
+  // Checked as two explicit suffixes: "streamGenerateContent" capitalizes
+  // the "Generate" it shares with "generateContent", so
+  // "streamGenerateContent".includes("generateContent") is false and a
+  // single check would miss every streaming request.
+  if (
+    path.includes(":generateContent") ||
+    path.includes(":streamGenerateContent")
+  ) {
+    return "gemini";
+  }
 
   // Header-based fallback
   if (headers["anthropic-version"]) {
@@ -201,12 +219,15 @@ function shouldOmitThinkingConfigForTarget(
  * Build options for ctx.neurolink.stream() from a parsed request
  * and an optional provider/model override.
  *
- * Works for both ParsedClaudeRequest and ParsedOpenAIRequest — the
- * only differences are Claude-specific fields (topK, thinkingConfig)
- * which are safely absent on OpenAI parsed requests.
+ * Works for ParsedClaudeRequest, ParsedOpenAIRequest and
+ * ParsedGeminiRequest. The differences are Claude-specific fields (topK,
+ * thinkingConfig), safely absent on OpenAI/Gemini parsed requests, and
+ * toolChoice/toolChoiceName, absent on Gemini parsed requests — Gemini's
+ * parser always emits tools: {} (see geminiFormat.ts's parseGeminiRequest),
+ * so toolNames.length is always 0 below and disableTools is set instead.
  */
 export function buildTranslationOptions(
-  parsed: ParsedClaudeRequest | ParsedOpenAIRequest,
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest | ParsedGeminiRequest,
   overrides: { provider?: string; model?: string } = {},
 ): Record<string, unknown> {
   const historyMessages = parsed.conversationMessages.slice(0, -1);
@@ -223,9 +244,14 @@ export function buildTranslationOptions(
       ? claudeParsed.thinkingConfig
       : undefined;
 
-  const toolChoice = parsed.toolChoiceName
-    ? { type: "tool" as const, toolName: parsed.toolChoiceName }
-    : parsed.toolChoice;
+  // toolChoice/toolChoiceName exist on ParsedClaudeRequest and
+  // ParsedOpenAIRequest but not on ParsedGeminiRequest — go through the same
+  // Partial-cast pattern as claudeParsed above so a Gemini request just sees
+  // both as undefined instead of failing to compile.
+  const toolChoiceParsed = parsed as Partial<ParsedOpenAIRequest>;
+  const toolChoice = toolChoiceParsed.toolChoiceName
+    ? { type: "tool" as const, toolName: toolChoiceParsed.toolChoiceName }
+    : toolChoiceParsed.toolChoice;
 
   return {
     input: {
@@ -298,7 +324,13 @@ function defaultFinishReason(format: ProxyFormat): string {
 }
 
 function logTag(format: ProxyFormat): string {
-  return format === "claude" ? "[proxy]" : "[proxy:openai]";
+  if (format === "claude") {
+    return "[proxy]";
+  }
+  if (format === "gemini") {
+    return "[proxy:gemini]";
+  }
+  return "[proxy:openai]";
 }
 
 // ---------------------------------------------------------------------------
@@ -316,7 +348,7 @@ export async function handleTranslatedStreamRequest(args: {
   ctx: ServerContext;
   format: ProxyFormat;
   requestModel: string;
-  parsed: ParsedClaudeRequest | ParsedOpenAIRequest;
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest | ParsedGeminiRequest;
   attempts: ProxyTranslationAttempt[];
   tracer?: ProxyTracer;
   requestStartTime: number;
@@ -334,7 +366,9 @@ export async function handleTranslatedStreamRequest(args: {
   const serializer =
     format === "claude"
       ? createClaudeSerializerAdapter(requestModel)
-      : createOpenAISerializerAdapter(requestModel);
+      : format === "gemini"
+        ? createGeminiSerializerAdapter(requestModel)
+        : createOpenAISerializerAdapter(requestModel);
 
   const KEEPALIVE_INTERVAL_MS = 15_000;
   const encoder = new TextEncoder();
@@ -652,7 +686,7 @@ export async function handleTranslatedJsonRequest(args: {
   ctx: ServerContext;
   format: ProxyFormat;
   requestModel: string;
-  parsed: ParsedClaudeRequest | ParsedOpenAIRequest;
+  parsed: ParsedClaudeRequest | ParsedOpenAIRequest | ParsedGeminiRequest;
   attempts: ProxyTranslationAttempt[];
   tracer?: ProxyTracer;
   requestStartTime: number;
@@ -765,9 +799,18 @@ export async function handleTranslatedJsonRequest(args: {
         ...(traceCtx?.spanId ? { spanId: traceCtx.spanId } : {}),
       });
 
-      return format === "claude"
-        ? serializeClaudeResponse(internal, requestModel)
-        : serializeOpenAIResponse(internal, requestModel);
+      if (format === "claude") {
+        return serializeClaudeResponse(internal, requestModel);
+      }
+      if (format === "gemini") {
+        return buildGeminiResponse(
+          internal.content,
+          internal.finishReason ?? defaultFinishReason(format),
+          resolvedUsage,
+          internal.model ?? requestModel,
+        );
+      }
+      return serializeOpenAIResponse(internal, requestModel);
     } catch (attemptError) {
       lastAttemptError =
         attemptError instanceof Error

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -190,13 +190,15 @@ export {
   createOpenApiRoutes,
   createToolRoutes,
   registerAllRoutes,
-  // The proxy doors. All three were reachable only from the deep path
+  // The proxy doors. All were reachable only from the deep path
   // ./routes/index.js, which is not a package export — so a consumer of
   // "@juspay/neurolink/server" could reach them only indirectly through
-  // createAllRoutes' flags, never to mount one on its own.
+  // createAllRoutes' flags, never to mount one on its own. Codex stayed
+  // CLI-only for long enough on exactly that gap to be worth naming.
   createClaudeProxyRoutes,
   createOpenAIProxyRoutes,
   createCodexProxyRoutes,
+  createGeminiProxyRoutes,
 } from "./routes/index.js";
 // ============================================
 // Streaming

--- a/src/lib/server/routes/geminiProxyRoutes.ts
+++ b/src/lib/server/routes/geminiProxyRoutes.ts
@@ -1,0 +1,309 @@
+/**
+ * Gemini-Compatible Proxy Routes
+ *
+ * Exposes the Google `generateContent` / `streamGenerateContent` endpoints the
+ * Gemini CLI calls when pointed at this proxy via `GOOGLE_GEMINI_BASE_URL`.
+ * ALL requests are routed through ctx.neurolink.stream() via the shared proxy
+ * translation engine — no direct HTTP calls to any upstream provider.
+ *
+ * This is a thin wrapper that parses the Google wire format and delegates to
+ * the same translation engine openaiProxyRoutes.ts and claudeProxyRoutes.ts
+ * use, mirroring that file's validate → log → delegate shape.
+ *
+ * An optional ModelRouter can remap incoming model names to different
+ * provider/model pairs, exactly as it does for the OpenAI-compatible door.
+ */
+
+import {
+  buildGeminiErrorResponse,
+  parseGeminiRequest,
+} from "../../proxy/geminiFormat.js";
+import { ProxyTracer } from "../../proxy/proxyTracer.js";
+import {
+  handleTranslatedJsonRequest,
+  handleTranslatedStreamRequest,
+} from "../../proxy/proxyTranslationEngine.js";
+import { buildProxyTranslationPlan } from "../../proxy/routingPolicy.js";
+import type {
+  ModelRouterInterface,
+  ParsedGeminiRequest,
+  ProxyRuntimeConfigProvider,
+  RouteGroup,
+  ServerContext,
+} from "../../types/index.js";
+import { sanitizeForLog } from "../../utils/logSanitize.js";
+import { logger } from "../../utils/logger.js";
+
+// Default loopback port — kept only for signature parity with
+// createOpenAIProxyRoutes. Gemini has no Anthropic-loopback bridge (nothing
+// in the Google wire format needs the OAuth-passthrough detour), so the value
+// is threaded through but never read.
+const DEFAULT_LOOPBACK_PORT = 55669;
+
+const GENERATE = "generateContent";
+const STREAM_GENERATE = "streamGenerateContent";
+
+// ---------------------------------------------------------------------------
+// Path parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Google bakes the action into the final path segment as `<model>:<action>`
+ * (`models/gemini-2.5-pro:generateContent`). Hono's router has no way to
+ * express a literal `:` after a named param — verified directly against the
+ * `hono` version this repo pins: registering `:model\:generateContent`
+ * doesn't escape the colon, it becomes *part of the param name*, and the
+ * resulting param still greedily swallows the whole trailing segment
+ * (`streamGenerateContent` included) because nothing after the leading `:`
+ * stops the capture except the next `/`. A `:model{regex}` constraint
+ * followed by literal text fails outright — the route never matches (404 on
+ * every request). A bare `:model` segment is therefore the only shape that
+ * actually matches; it captures `<model>:<action>` whole, and this function
+ * splits it back apart in the handler instead of in the route table.
+ */
+/**
+ * Pull "<model>:<action>" out of the request path.
+ *
+ * Read from `ctx.path`, not from a route param. Hono does capture the whole
+ * `gemini-2.5-pro:generateContent` segment — the colon is not a route
+ * separator, so one route covers both actions — but the proxy's mount loop
+ * builds its ServerContext from `path`, `headers`, `query`, `body`, `method`
+ * and `requestId` only. The captured param never reaches the handler, and
+ * reading `ctx.params` here would be `undefined` on every request.
+ */
+function splitModelAction(requestPath: string): {
+  modelId: string;
+  action: string | undefined;
+} {
+  // Take the last path segment, ignoring any trailing slash or query.
+  const withoutQuery = requestPath.split("?")[0];
+  const rawSegment = withoutQuery.replace(/\/+$/, "").split("/").pop() ?? "";
+  const separatorIndex = rawSegment.lastIndexOf(":");
+  if (separatorIndex === -1) {
+    return { modelId: rawSegment, action: undefined };
+  }
+  return {
+    modelId: rawSegment.slice(0, separatorIndex),
+    action: rawSegment.slice(separatorIndex + 1),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Adapt ParsedGeminiRequest to the shape buildProxyTranslationPlan expects
+// ---------------------------------------------------------------------------
+
+/**
+ * buildProxyTranslationPlan's classifier expects ParsedClaudeRequest, whose
+ * `maxTokens` is required. Gemini's is optional (Google omits
+ * `generationConfig.maxOutputTokens` on plenty of real requests), so the gap
+ * is bridged the same way the OpenAI door bridges it: fill in a safe default
+ * and let the (structurally near-identical) rest pass through untouched.
+ */
+function adaptGeminiForTranslationPlan(parsed: ParsedGeminiRequest): {
+  model: string;
+  maxTokens: number;
+  temperature?: number;
+  topP?: number;
+  systemPrompt?: string;
+  stream: boolean;
+  prompt: string;
+  images: string[];
+  conversationMessages: Array<{ role: string; content: string }>;
+  tools: Record<
+    string,
+    {
+      description?: string;
+      inputSchema: unknown;
+      execute?: (...args: unknown[]) => unknown;
+    }
+  >;
+  stopSequences?: string[];
+} {
+  return {
+    model: parsed.model,
+    maxTokens: parsed.maxTokens ?? 4096,
+    temperature: parsed.temperature,
+    topP: parsed.topP,
+    systemPrompt: parsed.systemPrompt,
+    stream: parsed.stream,
+    prompt: parsed.prompt,
+    images: parsed.images,
+    conversationMessages: parsed.conversationMessages,
+    tools: parsed.tools,
+    stopSequences: parsed.stopSequences,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create Gemini-compatible proxy routes.
+ *
+ * Every request flows through ctx.neurolink.stream() — no direct HTTP calls
+ * to any upstream provider.
+ *
+ * @param modelRouter   - Optional model router for remapping model names.
+ * @param basePath      - Base path prefix (default: "").
+ * @param loopbackPort  - Unused by this door; kept for parameter-shape parity
+ *                        with createOpenAIProxyRoutes (see DEFAULT_LOOPBACK_PORT).
+ * @returns RouteGroup with Gemini-compatible endpoints.
+ */
+export function createGeminiProxyRoutes(
+  modelRouter?: ModelRouterInterface,
+  basePath: string = "",
+  _loopbackPort: number = DEFAULT_LOOPBACK_PORT,
+  runtimeConfigProvider?: ProxyRuntimeConfigProvider,
+): RouteGroup {
+  return {
+    prefix: `${basePath}/v1beta`,
+    routes: [
+      // =================================================================
+      // POST /v1beta/models/:model — covers both `:generateContent` and
+      // `:streamGenerateContent`; the action lives inside the captured
+      // segment, not in a second route (see splitModelAction above).
+      // =================================================================
+      {
+        method: "POST",
+        path: `${basePath}/v1beta/models/:model`,
+        description:
+          "Gemini-compatible generateContent / streamGenerateContent (translation mode)",
+        handler: async (ctx: ServerContext) => {
+          const requestModelRouter = runtimeConfigProvider
+            ? runtimeConfigProvider().modelRouter
+            : modelRouter;
+          const requestStartTime = Date.now();
+
+          // --- Split "<model>:<action>" out of the captured path segment ---
+          const { modelId, action } = splitModelAction(ctx.path);
+
+          if (!modelId || (action !== GENERATE && action !== STREAM_GENERATE)) {
+            // Mirrors Google's own 404 shape so the CLI's error handling
+            // (which parses `error.status`) sees a response it recognizes
+            // instead of a bare proxy 404.
+            return buildGeminiErrorResponse(
+              404,
+              `Unsupported Gemini endpoint: ${ctx.path}`,
+              "NOT_FOUND",
+            );
+          }
+
+          const body = ctx.body as Record<string, unknown> | undefined;
+
+          // --- Validation ---
+          if (
+            !body ||
+            !Array.isArray(body.contents) ||
+            body.contents.length === 0
+          ) {
+            return buildGeminiErrorResponse(
+              400,
+              "Request must include a non-empty 'contents' array",
+            );
+          }
+
+          const stream = action === STREAM_GENERATE;
+
+          // --- Resolve target provider/model ---
+          const route = requestModelRouter
+            ? requestModelRouter.resolve(modelId)
+            : { provider: null, model: modelId };
+          const targetProvider = route.provider ?? undefined;
+          const targetModel = route.model ?? modelId;
+
+          logger.debug(
+            `[proxy:gemini] ${modelId} → ${targetProvider ?? "auto"}/${targetModel}`,
+          );
+
+          // --- Parse request ---
+          const parsed = parseGeminiRequest(targetModel, body, stream);
+
+          // --- Build translation plan ---
+          const adapted = adaptGeminiForTranslationPlan(parsed);
+          const plan = buildProxyTranslationPlan(
+            {
+              provider: targetProvider ?? "auto",
+              model: targetModel,
+            },
+            requestModelRouter?.getFallbackChain() ?? [],
+            modelId,
+            // The classifier only reads fields present across all three formats.
+            adapted as Parameters<typeof buildProxyTranslationPlan>[3],
+            requestModelRouter?.isAutoFallbackEnabled?.() ?? false,
+          );
+          const attempts = plan.attempts;
+
+          // --- Optional tracing ---
+          let tracer: ProxyTracer | undefined;
+          try {
+            tracer = ProxyTracer.startRequest(
+              {
+                requestId: ctx.requestId,
+                method: ctx.method,
+                path: ctx.path,
+                model: modelId,
+                stream,
+                toolCount: Object.keys(parsed.tools).length,
+                clientApp: "gemini-compat",
+                userAgent: ctx.headers["user-agent"] ?? "",
+                // Same reasoning as the OpenAI door: without an explicit
+                // provider the tracer defaults to "anthropic" and prices a
+                // Gemini model at Claude rates (or $0, off the anthropic
+                // table's _default-less lookup).
+                provider: targetProvider ?? "google-ai",
+              },
+              ctx.headers,
+            );
+            tracer.setMode("full");
+          } catch {
+            // Tracing is best-effort; continue without it.
+          }
+
+          // --- Dispatch via shared translation engine ---
+          try {
+            if (stream) {
+              return handleTranslatedStreamRequest({
+                ctx,
+                format: "gemini",
+                requestModel: modelId,
+                parsed,
+                attempts,
+                tracer,
+                requestStartTime,
+              });
+            }
+
+            return await handleTranslatedJsonRequest({
+              ctx,
+              format: "gemini",
+              requestModel: modelId,
+              parsed,
+              attempts,
+              tracer,
+              requestStartTime,
+            });
+          } catch (err) {
+            // Internal exception text (.message + any stack-trace remnants)
+            // is kept ONLY in server-side logs + tracer. The client receives
+            // a fixed generic message so internal paths/frames don't leak
+            // back through the response body. (CodeQL: information exposure
+            // through a stack trace.)
+            const rawMessage = err instanceof Error ? err.message : String(err);
+            const internalDetail = sanitizeForLog(rawMessage);
+            logger.always(`[proxy:gemini] request failed: ${internalDetail}`);
+            tracer?.setError("generation_error", internalDetail);
+            tracer?.end(500, Date.now() - requestStartTime);
+            return buildGeminiErrorResponse(
+              500,
+              "Internal proxy error",
+              "INTERNAL",
+            );
+          }
+        },
+      },
+    ],
+  };
+}
+
+export const __testHooks = { splitModelAction, adaptGeminiForTranslationPlan };

--- a/src/lib/server/routes/index.ts
+++ b/src/lib/server/routes/index.ts
@@ -11,6 +11,7 @@ import type {
 import { createAgentRoutes } from "./agentRoutes.js";
 import { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 // ClaudeProxyDeps removed
+import { createGeminiProxyRoutes } from "./geminiProxyRoutes.js";
 import { createHealthRoutes } from "./healthRoutes.js";
 import { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
 import { createCodexProxyRoutes } from "./codexProxyRoutes.js";
@@ -26,6 +27,7 @@ export { createClaudeProxyRoutes } from "./claudeProxyRoutes.js";
 export { createHealthRoutes } from "./healthRoutes.js";
 export { createOpenAIProxyRoutes } from "./openaiProxyRoutes.js";
 export { createCodexProxyRoutes } from "./codexProxyRoutes.js";
+export { createGeminiProxyRoutes } from "./geminiProxyRoutes.js";
 export { createMCPRoutes } from "./mcpRoutes.js";
 export { createMemoryRoutes } from "./memoryRoutes.js";
 export { createOpenApiRoutes } from "./openApiRoutes.js";
@@ -59,6 +61,7 @@ export function createAllRoutes(
   const enableClaudeProxy = options?.proxy || options?.claudeProxy;
   const enableOpenAIProxy = options?.proxy || options?.openaiProxy;
   const enableCodexProxy = options?.proxy || options?.codexProxy;
+  const enableGeminiProxy = options?.proxy || options?.geminiProxy;
 
   if (enableClaudeProxy) {
     routes.push(createClaudeProxyRoutes(undefined, basePath));
@@ -70,6 +73,10 @@ export function createAllRoutes(
 
   if (enableCodexProxy) {
     routes.push(createCodexProxyRoutes(basePath));
+  }
+
+  if (enableGeminiProxy) {
+    routes.push(createGeminiProxyRoutes(undefined, basePath));
   }
 
   return routes;

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -3057,7 +3057,7 @@ export type ProxyTelemetryAction =
 // =============================================================================
 
 /** Wire format a proxy request is using. */
-export type ProxyFormat = "claude" | "openai";
+export type ProxyFormat = "claude" | "openai" | "gemini";
 
 /**
  * Common adapter interface that hides the differences between
@@ -3206,6 +3206,42 @@ export type OpenAIErrorResponse = {
 };
 
 /** Parsed OpenAI request — intermediate form for NeuroLink pipeline. */
+/**
+ * A Gemini `generateContent` request, reduced to what translation needs.
+ *
+ * Google's shape differs from both others in three ways that matter here:
+ * roles are `user`/`model` rather than `user`/`assistant`, the system prompt
+ * lives in a sibling `systemInstruction` rather than in the turn list, and
+ * generation settings are nested under `generationConfig` instead of sitting
+ * at the top level.
+ */
+/** One part of a Gemini `contents[].parts[]` entry. */
+export type ProxyGeminiPart = { text?: string; inlineData?: { data?: string } };
+
+/** One turn in a Gemini `contents[]` array. */
+export type ProxyGeminiContent = { role?: string; parts?: ProxyGeminiPart[] };
+
+export type ParsedGeminiRequest = {
+  model: string;
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  systemPrompt?: string;
+  stream: boolean;
+  prompt: string;
+  images: string[];
+  conversationMessages: Array<{ role: string; content: string }>;
+  tools: Record<
+    string,
+    {
+      description?: string;
+      inputSchema: unknown;
+      execute?: (...args: unknown[]) => unknown;
+    }
+  >;
+  stopSequences?: string[];
+};
+
 export type ParsedOpenAIRequest = {
   model: string;
   maxTokens?: number;

--- a/src/lib/types/server.ts
+++ b/src/lib/types/server.ts
@@ -1401,7 +1401,7 @@ export type OpenAPISpec = {
 export type CreateRoutesOptions = {
   enableSwagger?: boolean;
   getRoutes?: () => RouteDefinition[];
-  /** Enable every proxy door: Claude, OpenAI and Codex. */
+  /** Enable every proxy door: Claude, OpenAI, Codex and Gemini. */
   proxy?: boolean;
   claudeProxy?: boolean;
   openaiProxy?: boolean;
@@ -1409,10 +1409,12 @@ export type CreateRoutesOptions = {
    * Enable the Codex door on its own.
    *
    * Codex was reachable only from `neurolink proxy start` until this existed —
-   * `createAllRoutes` mounted two of the three doors, so an SDK consumer could
-   * not expose it even deliberately.
+   * `createAllRoutes` mounted two of the doors, so an SDK consumer could not
+   * expose it even deliberately.
    */
   codexProxy?: boolean;
+  /** Enable the Gemini door on its own, for the same reason. */
+  geminiProxy?: boolean;
 };
 
 // =============================================================================

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -1495,6 +1495,161 @@ async function testOpenCodeWriterReportsWhetherItWrote(): Promise<boolean> {
   }
 }
 
+// ============================================================================
+// Tests: Gemini CLI Door (GOOGLE_GEMINI_BASE_URL round-trip)
+// ============================================================================
+
+/**
+ * The Gemini CLI (and any `@google/genai`-based client) honours
+ * `GOOGLE_GEMINI_BASE_URL` and, for a non-Vertex client, builds requests as
+ * `{baseUrl}/v1beta/models/{model}:generateContent` — traced from
+ * `getBaseUrl()` / `tModel()` / the `'{model}:generateContent'` template in
+ * `@google/genai`'s bundled client (`node_modules/@google/genai/dist/node/index.cjs`).
+ * That is also the path `src/lib/proxy/geminiFormat.ts`'s header comment says
+ * was "verified live" against this proxy before any route existed, returning
+ * a 404.
+ *
+ * The response shape asserted below matches `buildGeminiResponse()` in
+ * `src/lib/proxy/geminiFormat.ts` exactly: `candidates[0].content.parts[0].text`
+ * plus `usageMetadata.{promptTokenCount,candidatesTokenCount,totalTokenCount}`.
+ *
+ * No Google credential exists in this suite's environment — `GOOGLE_API_KEY`
+ * is deliberately stripped from `process.env` for every non-live run (see the
+ * `LIVE_PROXY_TESTS_ALLOWED` block near the top of this file), and this suite
+ * has no Google/Vertex equivalent of `hasValidCredentials()`. So this test
+ * cannot gate on "do we have creds" the way the Claude `/v1/messages` tests
+ * do — it has to tell "route missing" apart from "route reached, no account
+ * configured" purely from the live HTTP status, per the table in the design
+ * notes.
+ */
+async function testGeminiDoorGenerateContent(): Promise<boolean | null> {
+  try {
+    // --- The assertion that prevents a vacuous pass -------------------------
+    // Before trusting a 404 (or its absence) on the real path, prove the
+    // proxy's default "no route matched" behavior is actually live on this
+    // build: an unrelated, never-registered path must itself 404. If it
+    // doesn't — e.g. some catch-all started answering everything with a
+    // non-404 status — a non-404 on the real Gemini path below would prove
+    // nothing about routing, so this guard fails loudly instead of letting
+    // that happen silently.
+    const sentinel = await fetchProxy(
+      "/__gemini_door_e2e_sentinel_never_registered__",
+    );
+    if (sentinel.status !== 404) {
+      log(
+        `Baseline sentinel path returned ${sentinel.status}, not 404 — ` +
+          "cannot trust 404 as a 'route missing' signal on this build",
+        "red",
+      );
+      return false;
+    }
+
+    // --- Drive the door the way the Gemini CLI does -------------------------
+    const model = process.env.GOOGLE_GEMINI_TEST_MODEL || "gemini-2.5-flash";
+    const resp = await fetchProxy(`/v1beta/models/${model}:generateContent`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // @google/genai always sends this once an apiKey is configured, even
+        // a throwaway one when pointed at a custom base URL. The Claude and
+        // Codex doors on this proxy never trust the client's own credential
+        // and route through server-managed accounts instead — the Gemini
+        // door is expected to do the same, so this value is inert either way.
+        "x-goog-api-key": "neurolink-proxy-e2e-placeholder",
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Reply with exactly: PROXY_TEST_OK" }],
+          },
+        ],
+        generationConfig: { maxOutputTokens: 64, temperature: 0 },
+      }),
+    });
+
+    // A real, well-known model id is used deliberately, not a synthetic one:
+    // `buildGeminiErrorResponse` in geminiFormat.ts takes an arbitrary status,
+    // so a *wired* door could in principle answer an unrecognized model with
+    // a legitimate 404 of its own (mirroring Google's real "model not found"
+    // error). A model the door should recognize keeps a 404 here attributable
+    // to "no route" rather than "bad model" — though this isn't a 100%
+    // guarantee against that collision.
+    if (resp.status === 404) {
+      log(
+        "Gemini door returned 404 — /v1beta/models/:model:generateContent " +
+          "is not routed on this proxy build",
+        "red",
+      );
+      return false;
+    }
+
+    if (!resp.ok) {
+      // No Google account can exist in this suite's isolated TEST_HOME, and
+      // GOOGLE_API_KEY is stripped for every non-live run. Reaching the door
+      // and failing downstream (auth, "no accounts configured", upstream
+      // 5xx, ...) is the expected result without credentials — it proves the
+      // route matched, so it must not fail the test. Only a 404 above, or a
+      // 200 with the wrong body below, does that.
+      const errText = await resp.text();
+      log(
+        `Gemini door reachable but returned ${resp.status} without ` +
+          `configured Google accounts (expected): ${errText.slice(0, 200)}`,
+        "yellow",
+      );
+      return null;
+    }
+
+    // --- Route matched AND produced a real answer (live creds only) --------
+    const body = (await resp.json()) as {
+      candidates?: Array<{
+        content?: { parts?: Array<{ text?: string }> };
+      }>;
+      usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+        totalTokenCount?: number;
+      };
+    };
+
+    const text = body.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (typeof text !== "string" || text.length === 0) {
+      log(
+        "Gemini door returned 200 but candidates[0].content.parts[0].text " +
+          `is missing/empty: ${JSON.stringify(body).slice(0, 200)}`,
+        "red",
+      );
+      return false;
+    }
+
+    const usage = body.usageMetadata;
+    if (
+      typeof usage?.promptTokenCount !== "number" ||
+      typeof usage?.candidatesTokenCount !== "number" ||
+      typeof usage?.totalTokenCount !== "number"
+    ) {
+      log(
+        "Gemini door returned 200 but usageMetadata is missing " +
+          "promptTokenCount/candidatesTokenCount/totalTokenCount",
+        "red",
+      );
+      return false;
+    }
+
+    log(
+      `Gemini door round-trip OK (model=${model}): "${text.slice(0, 60)}"`,
+      "green",
+    );
+    return true;
+  } catch (err) {
+    log(
+      `Gemini door test error: ${err instanceof Error ? err.message : String(err)}`,
+      "red",
+    );
+    return false;
+  }
+}
+
 /**
  * Codex was the one configurator with no apply/restore round-trip test.
  *
@@ -5534,6 +5689,16 @@ const tests: TestFunction[] = [
     fn: testCodexConfiguratorRoundTrip,
     category: "proxy-config",
   },
+  // Gemini CLI door: GOOGLE_GEMINI_BASE_URL round-trip through
+  // /v1beta/models/:model:generateContent (SKIPs without a Google account;
+  // FAILs only on 404 or a malformed 200)
+  {
+    name: "Gemini Door: generateContent",
+    fn: testGeminiDoorGenerateContent,
+    category: "proxy-api",
+  },
+
+  // Account Management,
   {
     name: "Proxy clients: Qwen apply/restore round-trips a real settings file",
     fn: testQwenConfiguratorRoundTrip,


### PR DESCRIPTION
**Sixth CLI onboarded, and the first that needed a real door rather than a config write.**

## Proof it works — the actual CLI, not a stub

```
GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:9911 gemini -m gemini-2.5-flash -p "Reply with exactly: PROXY OK"
PROXY OK

proxy log: POST /v1beta/models/gemini-3.5-flash:streamGenerateContent
```

A live round trip: out over Google's wire, through translation, served from the account pool, streamed back in Google's own format.

Before this, the same command reached the proxy and failed with `ModelNotFoundError: 404` — the correct answer from a server with no `generateContent` route (see #1459, where that was verified).

## Three shapes probed, not assumed

Assuming runtime shapes is what has cost time on this branch, so each was checked against something real:

**Hono treats `:` as an ordinary character.** A real Hono 4.13.3 app matched `/v1beta/models/:model` against `…/gemini-2.5-pro:generateContent`, capturing the action *inside* the param. So **one** route covers both actions and the handler splits on the last colon. Two routes with literal `:generateContent` suffixes were never needed.

**That captured param never reaches a handler.** The mount loop builds `ServerContext` from `path`, `headers`, `query`, `body`, `method`, `requestId` — no `params`. The first draft read `ctx.params.model` and would have thrown on **every** request. It parses `ctx.path` now.

**A door has three registration seams, not two.** The audit warned of two (the CLI's route array, and `createAllRoutes`). The server entry's re-export block is a third. Missing the second is how Codex became CLI-only; missing the third is how every proxy factory became unreachable from `@juspay/neurolink/server`. All three wired, plus a `geminiProxy` flag included in the unified `proxy` flag.

## Design note

Tool calls render as text rather than `functionCall` parts. The Gemini CLI drives its own tools locally; a `functionCall` from a plain `generateContent` would leave it waiting for a result that never arrives.

## Verification

| Check | Result |
| --- | --- |
| Real `gemini` CLI through the proxy | **`PROXY OK`** |
| `tsc --noEmit --strict` | clean |
| `eslint src test` | 0 errors (54 pre-existing warnings) |
| `pnpm run build` | clean |
| `continuous-test-suite-proxy` | **65 passed** |
| `continuous-test-suite-codex` | 31 passed |
| `continuous-test-suite-servers` | 40 passed |
| Test proven non-vacuous | door unmounted -> test reports the 404 and fails |

Independent of #1453/#1454/#1455/#1458.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini-compatible proxy support for standard and streaming content generation.
  * Supports Gemini requests with system instructions, conversations, images, generation settings, tools, stop sequences, usage metadata, and finish reasons.
  * Added optional Gemini proxy route configuration alongside existing proxy options.
  * Added Gemini-formatted error responses for unsupported or invalid requests.

* **Tests**
  * Added end-to-end coverage for Gemini proxy requests and response metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->