### PR TITLE
chore(ci): typecheck the scripts and tools that CI depends on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,19 @@ jobs:
           echo "🔍 Verifying no banned packages leaked into production dependencies..."
           pnpm run check:deps
 
+      # tools/ and scripts/ are excluded from the root tsconfig, so the files a
+      # workflow actually depends on were never typechecked. That is how the
+      # provider onboarding gate shipped reading a field that does not exist.
+      - name: 🔎 Typecheck CI-critical scripts and tools
+        run: pnpm run check:ci-scripts
+
+      # test/ is excluded from tsconfig too, so `check` never looks at the
+      # suites. A full typecheck there is 296 errors and a separate cleanup;
+      # a parse check is free and catches the breakage that actually happens
+      # when editing them — a stray backtick inside a generated-script template.
+      - name: 🔎 Parse-check the test suites
+        run: pnpm run check:test-parse
+
       - name: Build package
         run: pnpm run build
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "prepack": "svelte-kit sync && svelte-package && pnpm run build:react-hooks && pnpm run build:cli && pnpm run build:browser && publint",
     "build:react-hooks": "npx tsc --jsx react-jsx --module nodenext --moduleResolution nodenext --target esnext --esModuleInterop --skipLibCheck --outDir dist --declaration false src/lib/client/reactHooks.tsx",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc --noEmit --strict",
+    "check:ci-scripts": "svelte-kit sync && tsc -p tsconfig.ci-scripts.json",
+    "check:test-parse": "node scripts/parse-check-tests.mjs",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "typecheck": "tsc --noEmit",
     "modelServer": "tsx scripts/modelServer.ts",

--- a/scripts/parse-check-tests.mjs
+++ b/scripts/parse-check-tests.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Parse every file under test/ with esbuild.
+ *
+ * test/ is in tsconfig's exclude list, so `pnpm run check` does not look at it
+ * at all — a green "0 errors" says nothing about the suites. A full typecheck
+ * is not the answer either: test/ currently has 296 type errors across 50 of
+ * its files, which is a separate cleanup.
+ *
+ * A parse check is the part that is both free and load-bearing. It catches the
+ * failure that actually happens when editing these files: a syntax error, most
+ * often from a stray backtick inside one of the generated-script template
+ * literals, which turns the whole suite into a TransformError at startup and
+ * tells you nothing until you run it.
+ *
+ * Takes ~20s and passes cleanly on all 106 files today.
+ */
+import { build } from "esbuild";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules") {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = walk("test");
+const failures = [];
+
+await Promise.all(
+  files.map(async (file) => {
+    try {
+      await build({
+        entryPoints: [file],
+        write: false,
+        logLevel: "silent",
+        bundle: false,
+      });
+    } catch (err) {
+      failures.push({ file, message: String(err?.message ?? err) });
+    }
+  }),
+);
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} of ${files.length} test files failed to parse:\n`);
+  for (const f of failures) {
+    console.error(`  ${f.file}\n    ${f.message.split("\n").slice(0, 3).join("\n    ")}\n`);
+  }
+  process.exit(1);
+}
+
+console.log(`Parsed ${files.length} test files, no syntax errors.`);

--- a/tools/testing/proxyTransportBenchmark.ts
+++ b/tools/testing/proxyTransportBenchmark.ts
@@ -100,7 +100,11 @@ const proxy = createServer(
       const response = await fetch(upstreamUrl, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body,
+        // Node accepts a Buffer at runtime, but BodyInit in this project's lib
+        // set admits neither Buffer nor any ArrayBufferView. The payload is
+        // JSON (see the content-type just above), so decode it as UTF-8 text —
+        // which is a BodyInit and round-trips JSON exactly.
+        body: body.toString("utf8"),
       });
       outgoing.writeHead(
         response.status,

--- a/tsconfig.ci-scripts.json
+++ b/tsconfig.ci-scripts.json
@@ -1,0 +1,32 @@
+{
+  // Typecheck the scripts and tools that CI actually depends on.
+  //
+  // The root tsconfig excludes `tools` and `scripts` wholesale, and ESLint
+  // ignores `scripts/**`. That blind spot is not theoretical: the provider
+  // onboarding gate shipped with a cast asserting a field
+  // (`OpenAICompatCatalogEntry.provider`) that does not exist, so its catalog
+  // lookup silently produced {undefined} and half the gate never ran. Nothing
+  // could have caught it, because the file that gates a required CI check was
+  // itself unchecked.
+  //
+  // Scope is deliberately narrow: only the files reachable from a workflow, via
+  // a package.json script, where a defect can gate or break a release. The wider
+  // tools/ tree has ~109 pre-existing errors and is a separate cleanup — the
+  // point here is to cover the surface that CI trusts, not to boil the ocean.
+  //
+  // Add a file here whenever a workflow starts depending on a new one.
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": [
+    "scripts/build-validations.ts",
+    "scripts/check-banned-deps.ts",
+    "scripts/env-validation.ts",
+    "scripts/security-check.ts",
+    "tools/verify-provider-onboarding.ts",
+    "tools/testing/proxyLifecycleBenchmark.ts",
+    "tools/testing/proxyRollingHandoffBenchmark.ts",
+    "tools/testing/proxyTransportBenchmark.ts",
+    "tools/testing/proxyUsageStatsBenchmark.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
The root `tsconfig` excludes `tools` and `scripts` wholesale, and ESLint ignores `scripts/**`. Nothing checks either directory — and both contain code that gates releases.

Not theoretical: the provider onboarding gate backing the required `provider-safety-net` check shipped asserting `OpenAICompatCatalogEntry.provider`, **a field that does not exist**. Every row resolved to `undefined`, so its catalog lookup produced `{undefined}` and half the gate silently never ran (fixed in #1463). No check in the repo could have caught it, because the file gating a required check was itself unchecked.

## Scope

`tsconfig.ci-scripts.json` covers only files reachable from a workflow via a `package.json` script — the surface where a defect can gate or break a release:

```
scripts/build-validations.ts          scripts/check-banned-deps.ts
scripts/env-validation.ts             scripts/security-check.ts
tools/verify-provider-onboarding.ts   tools/testing/proxy*Benchmark.ts  (4)
```

Wired as `pnpm run check:ci-scripts`, added to the `test` job beside the existing banned-dependency check.

Deliberately narrow — the wider `tools/` tree has **~109 pre-existing errors** and is a separate cleanup. The point is covering what CI trusts, not boiling the ocean. Add to the include list whenever a workflow starts depending on a new file.

## Cost: one real error

`tools/testing/proxyTransportBenchmark.ts` forwarded a `Buffer` as `fetch`'s `body`. Node accepts that at runtime, but `BodyInit` in this project's lib set admits neither `Buffer` nor any `ArrayBufferView`. The payload is JSON, so it's decoded as UTF-8 text — a valid `BodyInit` that round-trips JSON exactly.

The benchmark still runs and still passes its budget: `addedP95Ms 0.293` against a 5ms budget.

## Verified against the bug it exists for

| | |
|---|---|
| re-introduce the original onboarding-gate cast | `check:ci-scripts` **exit 2**, names file and line |
| restore | **exit 0** |