### PR TITLE
chore(security): warn when an accepted-risk entry has no live advisory

### DIFF
--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -329,6 +329,38 @@ class SecurityValidator {
       });
     }
 
+    // An accepted-risk entry whose package no longer has any live advisory is
+    // dead weight: it makes the accepted list look larger than the real
+    // exposure, and it hides the fact that something was fixed upstream. Report
+    // it as a warning rather than an error — a stale acceptance is tidy-up, not
+    // a vulnerability, and failing the build for it would break unrelated work
+    // the moment a dependency gets patched.
+    //
+    // This is the safeguard the previous advisory-id list never had. That list
+    // could only grow: ids were added by hand whenever the build broke, and
+    // nothing ever told anyone when one stopped mattering.
+    //
+    // Computed BEFORE the unaccepted-advisory return below. A run that fails on
+    // a real advisory is exactly a run someone is about to read carefully, so
+    // it is the worst moment to withhold the rest of what the scan noticed.
+    //
+    // The threshold is named explicitly: `actionable` drops low-severity
+    // advisories, so a package whose only open advisory is low would otherwise
+    // be described as having none at all.
+    const packagesWithLiveAdvisories = new Set(
+      actionable.map((a) => a.module_name),
+    );
+    const staleAcceptances = Object.keys(ACCEPTED_RISK_PACKAGES).filter(
+      (pkg) => !packagesWithLiveAdvisories.has(pkg),
+    );
+    if (staleAcceptances.length > 0) {
+      this.addIssue(
+        "warning",
+        "dependencies",
+        `Accepted-risk entries with no live moderate-or-higher advisory (safe to remove from ACCEPTED_RISK_PACKAGES): ${staleAcceptances.join(", ")}`,
+      );
+    }
+
     if (unaccepted.length > 0) {
       unaccepted.forEach((a) => {
         const entry = ACCEPTED_RISK_PACKAGES[a.module_name];


### PR DESCRIPTION
`ACCEPTED_RISK_PACKAGES` could only ever grow. Entries go in by hand whenever the build breaks, and nothing tells anyone when one stops mattering — so the list drifts from real exposure, reads as scarier than the truth, and hides the fact that an upstream fix landed.

Not hypothetical for this file. Its predecessor keyed acceptance to individual advisory ids, and one of those ids was added **inside an unrelated proxy-feature commit** (`819bbaf7`) purely to unblock a build. All four `fast-uri` ids it accumulated are now moot — removing the hippocampus shadow tree took `fast-uri` out of the dependency tree entirely.

Now any accepted package with no live moderate-or-worse advisory is reported by name, so it can be deleted.

## Warning, not error — deliberately

A stale acceptance is tidy-up, not a vulnerability. Failing the build for one would break unrelated work the moment a dependency gets patched upstream, which is the exact dynamic that made the old id list a tax.

The fail-closed paths added alongside it stay **errors**, because those mean *"the scan produced no answer"* — a different thing from *"the answer is smaller than the list"*.

## Verified both directions

| | |
|---|---|
| list in sync (9 accepted, 9 with live advisories) | silent |
| inject an entry for a package with no advisory | names it, still exits 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency security reporting by distinguishing accepted risks from active advisories.
  * Dependency checks now pass when all actionable advisories have been accepted, while still displaying warnings for accepted-risk packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->