### PR TITLE
chore(deps): fail the install when a dependency outgrows our Node floor

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,14 @@
+# Fail the install when a dependency's `engines` is not satisfied, instead of
+# printing a warning nobody reads.
+#
+# package.json already declares `node: >=22.0.0`, and every CI job runs
+# node-version: "22" — so this changes nothing about which Node is used. What
+# it changes is what happens when a dependency quietly raises its floor past
+# ours: today that install succeeds and the failure surfaces later as a
+# runtime error on whichever machine happened to have the older Node.
+#
+# This was tried once before and reverted: it broke CI with
+# ERR_PNPM_UNSUPPORTED_ENGINE because semantic-release wanted a newer Node
+# than the test job's Node 20. That job is on 22 now, and semantic-release
+# asks for ^22.14.0 || >=24.10.0, which "22" satisfies.
+engine-strict=true


### PR DESCRIPTION
## What

Adds `.npmrc` with `engine-strict=true`, so an install **fails** when a dependency's `engines` is not satisfied instead of printing a warning nobody reads.

`package.json` already declares `node >=22.0.0` and every job in `ci.yml` runs `node-version: "22"` — so this changes nothing about which Node is used. What it changes is what happens when a dependency quietly raises its floor past ours: today that install succeeds, and the failure surfaces later as a runtime error on whichever machine happened to have the older Node.

## This was tried once and reverted

It broke CI with `ERR_PNPM_UNSUPPORTED_ENGINE`, because `semantic-release` wanted a newer Node than the test job's Node 20 — and I had judged it safe by **reading** rather than running. That mistake is where the standing order about config lines came from: *a config line that changes install behaviour must be run, not read.*

The blocker is gone. Every job is on `"22"` now, and `semantic-release` asks for `^22.14.0 || >=24.10.0`, which `"22"` resolves past.

## Verified by running

```
pnpm install --frozen-lockfile           exit 0
pnpm install --frozen-lockfile --force   exit 0, 28.5s from cold
prettier --check .                       clean — it does not match .npmrc
```

CI across the full matrix is the real proof, so I'll check the next run's conclusion rather than assume it. If any dependency turns out to demand more than `"22"` provides, this fails loudly at install — which is the point, and the right place to find out.