### PR TITLE
chore(ci): typecheck the shared test helpers

### DIFF
--- a/tsconfig.ci-scripts.json
+++ b/tsconfig.ci-scripts.json
@@ -14,6 +14,15 @@
   // tools/ tree has ~109 pre-existing errors and is a separate cleanup — the
   // point here is to cover the surface that CI trusts, not to boil the ocean.
   //
+  // test/helpers/** is included for the same reason. It is shared test
+  // infrastructure that every suite imports, and test/ is excluded from the
+  // root tsconfig as well, so nothing typechecks it. Both of the test bugs
+  // found while auditing this repo lived in exactly these files: harness.ts
+  // (a SIGKILL escalation gated on proc.killed, which reports signal delivery
+  // rather than exit) and distFreshness.ts (imported relatively by a script run
+  // from a mkdtemp directory, so a test silently never ran for two weeks).
+  // It costs nothing today: all 18 files typecheck clean.
+  //
   // Add a file here whenever a workflow starts depending on a new one.
   "extends": "./tsconfig.json",
   "compilerOptions": { "noEmit": true },
@@ -26,7 +35,8 @@
     "tools/testing/proxyLifecycleBenchmark.ts",
     "tools/testing/proxyRollingHandoffBenchmark.ts",
     "tools/testing/proxyTransportBenchmark.ts",
-    "tools/testing/proxyUsageStatsBenchmark.ts"
+    "tools/testing/proxyUsageStatsBenchmark.ts",
+    "test/helpers/**/*.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
`test/` is in the root `tsconfig`'s exclude list, so nothing typechecks `test/helpers` — the modules every suite imports. A defect there is invisible until a suite misbehaves at runtime, and it affects all of them at once.

**Both test defects found while auditing this repo lived in exactly these files:**

| file | defect |
|---|---|
| `harness.ts` | escalated to SIGKILL behind `if (!proc.killed)` — but `proc.killed` records that a *signal was delivered*, not that the child exited, so a child ignoring SIGTERM was never force-killed (#1450) |
| `distFreshness.ts` | imported relatively by a script written into a `mkdtemp` dir and run with plain `node`, resolving to a path that cannot exist — one test silently did not run for **two weeks** (#1471) |

Neither is a type error, so this wouldn't have caught either directly. The point is narrower and still worth having: these files are load-bearing for every suite and currently have **no check of any kind** standing behind them.

## Free today

All 18 helper files typecheck clean, so this lands green. It reuses `tsconfig.ci-scripts.json` from #1469 — same rationale, same gate, no new machinery.

## Verified against the right failure

| | |
|---|---|
| introduce a type error in `distFreshness.ts` | `check:ci-scripts` **exit 2**, names file and line |
| revert | **exit 0** |