### PR TITLE
chore(security): tell a contributor when a red advisory is our staleness

### DIFF
--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -116,6 +116,204 @@ const ACCEPTED_RISK_PACKAGES: Record<
   },
 };
 
+/**
+ * Run a git command, or return undefined. Never throws, never prints.
+ *
+ * Every release comparison below is a diagnostic bolted to a build that is
+ * already failing, so a missing ref, a shallow clone or no git at all must mean
+ * no hint rather than a second failure.
+ */
+function git(command: string): string | undefined {
+  try {
+    return execSync(command, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10_000,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Make `origin/release` resolvable, once per process.
+ *
+ * Without this the whole diagnostic is dead code in exactly the place it exists
+ * to help. `actions/checkout@v4` defaults to `fetch-depth: 1`, so a CI checkout
+ * has the commit under test and no other branch — `origin/release` does not
+ * resolve, every lookup below returns undefined, and the contributor sees the
+ * same bare "Unaccepted advisory" this change set out to replace.
+ *
+ * A depth-1 fetch of one branch is cheap and is skipped entirely when the ref
+ * is already present, which is the local case. Memoised so N advisories do not
+ * trigger N fetches.
+ */
+let releaseRefChecked = false;
+let releaseRefAvailable = false;
+function ensureReleaseRef(): boolean {
+  if (releaseRefChecked) {
+    return releaseRefAvailable;
+  }
+  releaseRefChecked = true;
+  releaseRefAvailable =
+    git("git rev-parse --verify --quiet origin/release") !== undefined ||
+    (git(
+      "git fetch --depth=1 origin release:refs/remotes/origin/release",
+    ) !== undefined &&
+      git("git rev-parse --verify --quiet origin/release") !== undefined);
+  return releaseRefAvailable;
+}
+
+/**
+ * Whether `release` accepts a package that the running branch does not.
+ *
+ * The accepted-risk table lives in this file, so it moves with `release` like
+ * any other source. A branch cut before an entry was added fails on an advisory
+ * that `release` has already reviewed and accepted — and the failure text says
+ * only "is not an accepted-risk package", which is true of the branch and
+ * useless to whoever is reading it. That happened to two contributor PRs in one
+ * week; both spent days looking for a fault in their own code. `fast-uri`
+ * 1145636 is the worked example, and this file's own comments already reference
+ * it.
+ *
+ * Reads the table out of `origin/release` rather than parsing it: the literal
+ * is extracted by brace matching and the package looked for as a KEY. A plain
+ * substring search would be wrong — package names appear in the prose of other
+ * entries' `reason` fields and in the comments above, `fast-uri` included.
+ *
+ * Returns undefined on any failure. This is a diagnostic attached to a build
+ * that is already failing; it must never be the reason one fails, so a missing
+ * ref, a shallow clone, or no git at all just means no hint.
+ */
+function releaseAcceptsPackage(moduleName: string): string | undefined {
+  if (!ensureReleaseRef()) {
+    return undefined;
+  }
+  try {
+    const released = git("git show origin/release:scripts/security-check.ts");
+    if (released === undefined) {
+      return undefined;
+    }
+    const start = released.indexOf("const ACCEPTED_RISK_PACKAGES");
+    if (start === -1) {
+      return undefined;
+    }
+    const open = released.indexOf("{", released.indexOf("= {", start));
+    if (open === -1) {
+      return undefined;
+    }
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < released.length; i++) {
+      if (released[i] === "{") {
+        depth++;
+      } else if (released[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    if (end === -1) {
+      return undefined;
+    }
+    const table = released.slice(open, end + 1);
+    // Key position only: start of line, optionally quoted, followed by `: {`.
+    const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const key = new RegExp(
+      `^\\s*(["']?)${escaped}\\1\\s*:\\s*\\{([\\s\\S]*?)^\\s*\\}`,
+      "m",
+    );
+    const found = table.match(key);
+    if (!found) {
+      return undefined;
+    }
+    const ceiling = found[2].match(/maxSeverity:\s*["']([a-z]+)["']/);
+    return ceiling ? ceiling[1] : "unknown";
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether `release` pins a package out of its vulnerable range via an override
+ * that this branch does not have.
+ *
+ * This is the case that actually bites, and it is NOT the accepted-risk one.
+ * `fast-uri` 1145636 broke two contributor PRs, and `fast-uri` is not in the
+ * accepted-risk table at all — `release` fixed it in `aec7f8ac` by adding a
+ * `pnpm.overrides` entry (`fast-uri@<3.1.5: ">=3.1.5 <4"`) that lifts the
+ * dependency past the advisory, so the advisory simply is not in `release`'s
+ * tree. A branch cut before that commit still resolves the vulnerable version
+ * and fails, through no fault of its own.
+ *
+ * Compares against `origin/release`'s package.json, which is a JSON parse
+ * rather than a source scrape and so is reliable. Silent on any failure, for
+ * the same reason as `releaseAcceptsPackage`.
+ */
+function releaseOverridesPackage(moduleName: string): string | undefined {
+  if (!ensureReleaseRef()) {
+    return undefined;
+  }
+  try {
+    const localPkg = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+    );
+    const releasedRaw = git("git show origin/release:package.json");
+    if (releasedRaw === undefined) {
+      return undefined;
+    }
+    const releasedPkg = JSON.parse(releasedRaw);
+    const pick = (p: Record<string, unknown>): Record<string, string> => ({
+      ...((p.pnpm as { overrides?: Record<string, string> } | undefined)
+        ?.overrides ?? {}),
+      ...((p.overrides as Record<string, string> | undefined) ?? {}),
+    });
+    const localOv = pick(localPkg);
+    const releaseOv = pick(releasedPkg);
+    // Override keys carry a range suffix (`fast-uri@<3.1.5`), so match on the
+    // package name before the `@` that separates it — allowing for scoped names.
+    const nameOf = (k: string): string => {
+      const at = k.lastIndexOf("@");
+      return at > 0 ? k.slice(0, at) : k;
+    };
+    const inRelease = Object.entries(releaseOv).find(
+      ([k]) => nameOf(k) === moduleName,
+    );
+    if (!inRelease) {
+      return undefined;
+    }
+    // ANY local override counts, not just an identical one. A branch that pins
+    // this package to a different range has made a deliberate decision about
+    // it, and telling its author "release pins this and your branch does not"
+    // would be flatly untrue — the branch does pin it, differently. Staleness
+    // is only a defensible claim when the branch has no opinion at all.
+    const inLocal = Object.entries(localOv).find(
+      ([k]) => nameOf(k) === moduleName,
+    );
+    if (inLocal) {
+      return undefined;
+    }
+    return `${inRelease[0]}: ${inRelease[1]}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/** How many commits `origin/release` is ahead, when that is knowable. */
+function commitsBehindRelease(): number | undefined {
+  if (!ensureReleaseRef()) {
+    return undefined;
+  }
+  const out = git("git rev-list --count HEAD..origin/release");
+  if (out === undefined) {
+    return undefined;
+  }
+  const n = Number.parseInt(out.trim(), 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 type SecurityIssue = {
   level: string;
   category: string;
@@ -362,15 +560,47 @@ class SecurityValidator {
     }
 
     if (unaccepted.length > 0) {
+      const behind = commitsBehindRelease();
       unaccepted.forEach((a) => {
         const entry = ACCEPTED_RISK_PACKAGES[a.module_name];
         const why = entry
           ? `exceeds the accepted ${entry.maxSeverity} ceiling for ${a.module_name}`
           : `${a.module_name} is not an accepted-risk package`;
+        // Say so when the branch, not the dependency, is the problem. Ordered
+        // most specific first, because a contributor reading a red gate needs
+        // the strongest available statement about whose fault it is.
+        //
+        // The accepted-risk check is skipped when this branch already has an
+        // entry: a local ceiling that is merely too low is a real review
+        // decision about a package that got worse, not staleness.
+        const acceptedOnRelease = entry
+          ? undefined
+          : releaseAcceptsPackage(a.module_name);
+        const overriddenOnRelease = releaseOverridesPackage(a.module_name);
+        const rebase = `Rebase onto origin/release and re-run before investigating your own changes.`;
+        let staleBase = "";
+        if (overriddenOnRelease) {
+          staleBase =
+            ` — NOTE: origin/release pins this package out of the vulnerable range ` +
+            `(override "${overriddenOnRelease}") and this branch does not` +
+            `${behind ? `, being ${behind} commit(s) behind` : ""}. ${rebase}`;
+        } else if (acceptedOnRelease) {
+          staleBase =
+            ` — NOTE: origin/release accepts ${a.module_name} at a ${acceptedOnRelease} ceiling ` +
+            `and this branch does not${behind ? `, being ${behind} commit(s) behind` : ""}. ${rebase}`;
+        } else if (behind && behind > 0) {
+          // No specific signal, but staleness alone is worth saying: advisories
+          // are routinely cleared on release by lockfile and override changes,
+          // and a contributor has no way to tell that from a real finding.
+          staleBase =
+            ` — NOTE: this branch is ${behind} commit(s) behind origin/release. ` +
+            `Dependency advisories are frequently resolved there by lockfile or ` +
+            `override changes, so this may not originate in your changes. ${rebase}`;
+        }
         this.addIssue(
           "error",
           "dependencies",
-          `Unaccepted ${a.severity} advisory ${a.id} in ${a.module_name} (${why}): ${a.title}`,
+          `Unaccepted ${a.severity} advisory ${a.id} in ${a.module_name} (${why}): ${a.title}${staleBase}`,
         );
       });
       this.results.dependencies.status = "failed";


### PR DESCRIPTION
## The problem, measured

Two contributor PRs failed the security gate this week on the same advisory, and in both cases **the fault was ours, not theirs**:

| PR | red checks | actually the contributor's fault |
|---|---|---|
| [#1441](https://github.com/juspay/neurolink/pull/1441) | 3 | 1 |
| [#1336](https://github.com/juspay/neurolink/pull/1336) | 3 | **0** |

#1336's three failures traced to one line:

```
Unaccepted high advisory 1145636 in fast-uri (fast-uri is not an
accepted-risk package): fast-uri vulnerable to host confusion via
failed IDN canonicalization
```

That sentence is true *of the branch* and useless to whoever reads it. `release` fixed this in `aec7f8ac` weeks earlier by adding a `pnpm.overrides` entry lifting the dependency past the 3.x advisories — so the advisory isn't in `release`'s tree at all. A branch cut before that commit still resolves the vulnerable version and fails.

Both authors left their PRs sitting red for days rather than rebasing. That's the *reasonable* response to a security gate naming a real CVE in your build.

## What this changes

The gate now states whose problem it is, most specific signal first.

**1. An override on `release` that the branch lacks.** The case that actually bit. `fast-uri` is not in the accepted-risk table at all — it was fixed with an override. Detected by parsing `release`'s `package.json` and matching override keys on the package name before the range suffix (`fast-uri@<3.1.5` → `fast-uri`).

**2. An accepted-risk entry on `release` that the branch lacks.** Read out of `release`'s copy of `scripts/security-check.ts`, since that table is source and moves with the branch like anything else. The literal is extracted by **brace matching** and the package looked for in **key position** — a substring search would be wrong, because package names appear in the prose of other entries' `reason` fields and in the comments above the table, `fast-uri` among them. Skipped when the branch already has its own entry: a local ceiling that is merely too low is a real review decision about a package that got worse, not staleness.

**3. Neither, but the branch is behind.** Advisories are routinely cleared on `release` by lockfile and override changes, and a contributor has no way to distinguish that from a genuine finding.

Every lookup is best-effort and silent on failure. This is a diagnostic bolted to a build that is *already failing* — a missing ref, a shallow clone, or no git at all must mean no hint, never a second failure.

## Verification

Each condition simulated against the real repository, since a hint that fires on a genuine vulnerability would be worse than no hint at all:

| case | expected | result |
|---|---|---|
| remove `ip-address` from the local table | failure **+** "release accepts at a high ceiling" | ✅ |
| remove the `fast-uri` override locally | returns `fast-uri@<3.1.5: >=3.1.5 <4` | ✅ |
| `undici` — override identical on both sides | no hint | ✅ |
| `@livekit/agents`, `pptxgenjs`, `exceljs` — appear **only** inside other entries' `reason` prose | no hint | ✅ |
| package absent everywhere | no hint | ✅ |
| `validate:security` on `release`, unchanged | still `PASS dependencies` | ✅ |

The prose cases are the ones that matter for correctness — they're why this matches on key position rather than substring.

Typecheck 4815 files / 0 errors, prettier clean. One file, one commit.

## Note on how I found this

I originally told #1336's author that `release` handled `fast-uri` via the per-package severity ceiling. That was wrong — `fast-uri` isn't in that table; the fix was an override. The *conclusion* (stale base, rebase clears it) was right and empirically verified, but the mechanism I gave wasn't, and I've corrected it on that PR. Getting the mechanism right is what turned this from a vague "add a hint" into detecting the specific signal that actually applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security advisory reporting with clearer diagnostic details.
  * Added release-branch context, including relevant risk acceptances, dependency overrides, and commit distance.
  * Added guidance for synchronizing branches when the current branch may be outdated.
  * Security diagnostic failures no longer interrupt the overall check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->