### PR TITLE
fix(proxy): repair four defects in the Gemini CLI door

### DIFF
--- a/docs/api/type-aliases/ParsedGeminiRequest.md
+++ b/docs/api/type-aliases/ParsedGeminiRequest.md
@@ -10,6 +10,14 @@
 
 Defined in: [types/proxy.ts:3236](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3236)
 
+A Gemini `generateContent` request, reduced to what translation needs.
+
+Google's shape differs from both others in three ways that matter here:
+roles are `user`/`model` rather than `user`/`assistant`, the system prompt
+lives in a sibling `systemInstruction` rather than in the turn list, and
+generation settings are nested under `generationConfig` instead of sitting
+at the top level.
+
 ## Properties
 
 ### model

--- a/docs/api/type-aliases/ProxyGeminiContent.md
+++ b/docs/api/type-aliases/ProxyGeminiContent.md
@@ -8,7 +8,7 @@
 
 > **ProxyGeminiContent** = `object`
 
-Defined in: [types/proxy.ts:3234](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3234)
+Defined in: [types/proxy.ts:3225](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3225)
 
 One turn in a Gemini `contents[]` array.
 
@@ -18,7 +18,7 @@ One turn in a Gemini `contents[]` array.
 
 > `optional` **role?**: `string`
 
-Defined in: [types/proxy.ts:3234](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3234)
+Defined in: [types/proxy.ts:3225](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3225)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/proxy.ts:3234](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **parts?**: [`ProxyGeminiPart`](ProxyGeminiPart.md)[]
 
-Defined in: [types/proxy.ts:3234](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3234)
+Defined in: [types/proxy.ts:3225](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3225)

--- a/docs/api/type-aliases/ProxyGeminiPart.md
+++ b/docs/api/type-aliases/ProxyGeminiPart.md
@@ -8,7 +8,7 @@
 
 > **ProxyGeminiPart** = `object`
 
-Defined in: [types/proxy.ts:3231](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3231)
+Defined in: [types/proxy.ts:3222](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3222)
 
 One part of a Gemini `contents[].parts[]` entry.
 
@@ -18,7 +18,7 @@ One part of a Gemini `contents[].parts[]` entry.
 
 > `optional` **text?**: `string`
 
-Defined in: [types/proxy.ts:3231](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3231)
+Defined in: [types/proxy.ts:3222](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3222)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/proxy.ts:3231](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **inlineData?**: `object`
 
-Defined in: [types/proxy.ts:3231](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3231)
+Defined in: [types/proxy.ts:3222](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxy.ts#L3222)
 
 #### data?
 

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1188,6 +1188,15 @@ function printProxyBanner(url: string, strategy: string): void {
   logger.always(
     `  ${chalk.blue("POST")} /v1/chat/completions — OpenAI-compatible proxy`,
   );
+  // The banner listed two of the four inbound doors, so the Codex and Gemini
+  // CLIs looked unsupported to anyone reading start-up output rather than the
+  // docs. Every door the proxy actually answers on belongs here.
+  logger.always(
+    `  ${chalk.blue("POST")} /backend-api/codex/… — Codex proxy (Responses format)`,
+  );
+  logger.always(
+    `  ${chalk.blue("POST")} /v1beta/models/…     — Gemini proxy (generateContent)`,
+  );
   logger.always(`  ${chalk.green("GET")}  /health              — Health check`);
   logger.always(
     `  ${chalk.green("GET")}  /status              — Detailed status`,
@@ -1491,9 +1500,17 @@ function registerProxyRequestTracking(
       throw error;
     }
   };
-  // Cover both the Anthropic (/v1/*) and Codex (/backend-api/*) inbound paths so
-  // drain/reject, lifecycle logging, and concurrency accounting apply to both.
+  // Cover every inbound door so drain/reject, lifecycle logging, and
+  // concurrency accounting apply to all of them.
+  //
+  // `/v1beta/*` is listed separately on purpose: Hono matches wildcards a path
+  // segment at a time, so `/v1/*` does NOT cover `/v1beta/models/...` — the
+  // segment is `v1beta`, not `v1`. When the Gemini door landed it inherited
+  // neither tracker, which meant its requests were absent from the request
+  // log, from per-CLI attribution, and from the in-flight count the graceful
+  // drain waits on. An update could therefore cut a live Gemini stream.
   app.use("/v1/*", trackingHandler);
+  app.use("/v1beta/*", trackingHandler);
   app.use("/backend-api/*", trackingHandler);
 }
 

--- a/src/cli/proxy-clients/snapshot.ts
+++ b/src/cli/proxy-clients/snapshot.ts
@@ -193,6 +193,12 @@ export async function writeFileAtomic(
     }
   }
   try {
+    // The temp file is a sibling of the destination, so a missing parent fails
+    // the write rather than the rename — the config is untouched, but the
+    // caller sees an ENOENT naming a path it never asked to write. Creating
+    // the directory first makes a first-run write behave like the plain
+    // writeFileSync it replaced.
+    fs.mkdirSync(dirname(filePath), { recursive: true });
     fs.writeFileSync(tempPath, contents, { mode: effectiveMode });
     stage = "chmod";
     fs.chmodSync(tempPath, effectiveMode);

--- a/src/lib/proxy/geminiFormat.ts
+++ b/src/lib/proxy/geminiFormat.ts
@@ -51,9 +51,17 @@ function partsToImages(parts: ProxyGeminiPart[] | undefined): string[] {
 /**
  * Parse a `generateContent` body into the shape the translation engine takes.
  *
- * The final user turn becomes `prompt`; everything before it becomes
- * `conversationMessages`, with Google's `model` role mapped to `assistant` so
- * downstream providers see a role they understand.
+ * The final user turn becomes `prompt`, with Google's `model` role mapped to
+ * `assistant` so downstream providers see a role they understand.
+ *
+ * `conversationMessages` carries EVERY turn, the final one included. That
+ * looks redundant next to `prompt`, and it is the contract the shared engine
+ * expects: `buildTranslationOptions` does `conversationMessages.slice(0, -1)`
+ * to derive history, because the final turn is already being sent as `prompt`.
+ * `claudeFormat` and `openaiFormat` both push unconditionally for that reason.
+ * Excluding the last turn here — the intuitive reading of "history" — made the
+ * engine's slice eat one real turn instead, so every multi-turn Gemini request
+ * silently lost its most recent message.
  */
 export function parseGeminiRequest(
   model: string,
@@ -81,9 +89,9 @@ export function parseGeminiRequest(
     images: partsToImages(c?.parts),
   }));
 
-  // The last user turn is the prompt; anything before it is history. A request
-  // whose final turn is a model turn (the CLI does this when continuing) leaves
-  // an empty prompt rather than replaying the assistant's own words as input.
+  // The last user turn is the prompt. A request whose final turn is a model
+  // turn (the CLI does this when continuing) leaves an empty prompt rather
+  // than replaying the assistant's own words as input.
   let prompt = "";
   let images: string[] = [];
   const conversationMessages: Array<{ role: string; content: string }> = [];
@@ -92,12 +100,26 @@ export function parseGeminiRequest(
     if (isLast && turns[i].role === "user") {
       prompt = turns[i].content;
       images = turns[i].images;
-    } else {
-      conversationMessages.push({
-        role: turns[i].role,
-        content: turns[i].content,
-      });
     }
+    // Unconditional — see the slice-contract note on this function.
+    conversationMessages.push({
+      role: turns[i].role,
+      content: turns[i].content,
+    });
+  }
+
+  // The engine's `slice(0, -1)` drops the LAST entry on the assumption that it
+  // is the turn already being sent as `prompt`. That holds only when the
+  // request ends with a user turn. The Gemini CLI also continues from a model
+  // turn, and there the last entry is a real assistant reply — so the slice ate
+  // it, which is the same lost-turn bug one case further along.
+  //
+  // A terminal placeholder restores the invariant: the slice removes this
+  // instead of the model turn. It is never sent anywhere — `prompt` is
+  // independently "" in exactly this case, so the placeholder only exists to be
+  // consumed by the slice.
+  if (turns.length > 0 && turns[turns.length - 1].role !== "user") {
+    conversationMessages.push({ role: "user", content: "" });
   }
 
   const numeric = (v: unknown): number | undefined =>
@@ -148,16 +170,41 @@ function usageMetadata(usage: {
 }
 
 /** Build a complete `generateContent` response body. */
+/**
+ * Render a tool call as text.
+ *
+ * The proxy does not forward tool calls in Google's `functionCall` part shape:
+ * the CLI drives tools locally, so a `functionCall` it never asked for would be
+ * an unresolvable pending call. Text is what it can act on. Both the streaming
+ * serializer and the non-streaming builder go through here so the two paths
+ * cannot drift.
+ */
+export function renderGeminiToolUse(name: string, input: unknown): string {
+  return `\n[tool: ${name} ${JSON.stringify(input)}]\n`;
+}
+
 export function buildGeminiResponse(
   text: string,
   finishReason: string,
   usage: { input: number; output: number; total: number },
   modelVersion: string,
+  toolCalls?: ReadonlyArray<{
+    toolName: string;
+    args: Record<string, unknown>;
+  }>,
 ): Record<string, unknown> {
+  // A translated result can legitimately carry tool calls and no text — the
+  // engine's hasTranslatedOutput() accepts that. Rendering only `text` there
+  // handed the client parts[0].text === "" with finishReason STOP, which reads
+  // as "the model answered nothing" rather than "the model wants a tool".
+  const rendered = (toolCalls ?? [])
+    .map((call) => renderGeminiToolUse(call.toolName, call.args))
+    .join("");
+  const body = `${text}${rendered}`;
   return {
     candidates: [
       {
-        content: { role: MODEL_ROLE, parts: [{ text }] },
+        content: { role: MODEL_ROLE, parts: [{ text: body }] },
         finishReason: toGeminiFinishReason(finishReason),
         index: 0,
       },
@@ -227,7 +274,7 @@ export class GeminiStreamSerializer {
    * that is never coming; rendering it as text keeps the turn terminating.
    */
   pushToolUse(_id: string, name: string, input: unknown): string[] {
-    return this.pushDelta(`\n[tool: ${name} ${JSON.stringify(input)}]\n`);
+    return this.pushDelta(renderGeminiToolUse(name, input));
   }
 
   finish(

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -808,6 +808,7 @@ export async function handleTranslatedJsonRequest(args: {
           internal.finishReason ?? defaultFinishReason(format),
           resolvedUsage,
           internal.model ?? requestModel,
+          internal.toolCalls,
         );
       }
       return serializeOpenAIResponse(internal, requestModel);

--- a/src/lib/server/routes/geminiProxyRoutes.ts
+++ b/src/lib/server/routes/geminiProxyRoutes.ts
@@ -263,7 +263,12 @@ export function createGeminiProxyRoutes(
           // --- Dispatch via shared translation engine ---
           try {
             if (stream) {
-              return handleTranslatedStreamRequest({
+              // Awaited, not returned bare: `handleTranslatedStreamRequest` is
+              // async, so a rejection raised before the Response exists would
+              // escape this try/catch and land in `app.onError`, which answers
+              // in Anthropic's error shape. A Gemini client parsing that finds
+              // no `error.message` and reports an empty failure.
+              return await handleTranslatedStreamRequest({
                 ctx,
                 format: "gemini",
                 requestModel: modelId,

--- a/src/lib/types/proxy.ts
+++ b/src/lib/types/proxy.ts
@@ -3218,6 +3218,12 @@ export type OpenAIErrorResponse = {
 };
 
 /** Parsed OpenAI request — intermediate form for NeuroLink pipeline. */
+/** One part of a Gemini `contents[].parts[]` entry. */
+export type ProxyGeminiPart = { text?: string; inlineData?: { data?: string } };
+
+/** One turn in a Gemini `contents[]` array. */
+export type ProxyGeminiContent = { role?: string; parts?: ProxyGeminiPart[] };
+
 /**
  * A Gemini `generateContent` request, reduced to what translation needs.
  *
@@ -3227,12 +3233,6 @@ export type OpenAIErrorResponse = {
  * generation settings are nested under `generationConfig` instead of sitting
  * at the top level.
  */
-/** One part of a Gemini `contents[].parts[]` entry. */
-export type ProxyGeminiPart = { text?: string; inlineData?: { data?: string } };
-
-/** One turn in a Gemini `contents[]` array. */
-export type ProxyGeminiContent = { role?: string; parts?: ProxyGeminiPart[] };
-
 export type ParsedGeminiRequest = {
   model: string;
   maxTokens?: number;

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -51,6 +51,7 @@
  */
 
 import { spawn, ChildProcess } from "child_process";
+import * as http from "http";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -1650,13 +1651,29 @@ async function testGeminiDoorGenerateContent(): Promise<boolean | null> {
       return false;
     }
 
+    if (resp.status === 400) {
+      // 400 is the door's OWN request-shape rejection: buildGeminiErrorResponse
+      // answers 400 when `contents` is missing or empty. This test builds the
+      // body itself and always sends one user turn, so a 400 means the request
+      // contract moved underneath it — never a missing credential. Skipping
+      // here would report SKIP on exactly the regression this test exists to
+      // catch.
+      const badReqText = await resp.text();
+      log(
+        "Gemini door answered 400 to a well-formed generateContent body — " +
+          `the request-shape contract has changed: ${badReqText.slice(0, 200)}`,
+        "red",
+      );
+      return false;
+    }
+
     if (!resp.ok) {
       // No Google account can exist in this suite's isolated TEST_HOME, and
       // GOOGLE_API_KEY is stripped for every non-live run. Reaching the door
       // and failing downstream (auth, "no accounts configured", upstream
       // 5xx, ...) is the expected result without credentials — it proves the
-      // route matched, so it must not fail the test. Only a 404 above, or a
-      // 200 with the wrong body below, does that.
+      // route matched, so it must not fail the test. Only a 404 above, a 400
+      // above, or a 200 with the wrong body below, does that.
       const errText = await resp.text();
       log(
         `Gemini door reachable but returned ${resp.status} without ` +
@@ -2051,6 +2068,389 @@ async function testClientConfigWritesPreservePermissions(): Promise<boolean> {
 }
 
 /**
+ * Ask the OS for a free TCP port.
+ *
+ * The two cases below spawn their own proxies, and fixed ports made them
+ * collide with anything already listening — including another agent running
+ * this same suite in this worktree, which turned an unrelated concurrent run
+ * into a hard FAIL on EADDRINUSE. Binding port 0 and reading back what the
+ * kernel assigned leaves only the narrow window between close and re-bind,
+ * which is a better race than a guaranteed collision.
+ */
+async function freePort(): Promise<number> {
+  const net = await import("net");
+  return new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() =>
+        port ? resolve(port) : reject(new Error("no free port")),
+      );
+    });
+  });
+}
+
+/**
+ * Spawn a proxy with its own HOME, its own port, and its own config.
+ *
+ * The suite's shared proxy is fine for a case that only needs a door to
+ * answer, but a case that reads what the proxy *wrote* must own the directory
+ * it reads: the shared log dir accumulates every other case's traffic, and
+ * whether a given record is present depends on suite ordering and on which
+ * earlier cases happened to have credentials. An isolated HOME makes the
+ * observation deterministic instead.
+ */
+async function spawnIsolatedProxy(options: {
+  configYaml?: string;
+  env?: Record<string, string>;
+}): Promise<{ port: number; home: string; stop: () => void } | null> {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nl-isolated-proxy-"));
+  fs.mkdirSync(path.join(home, ".neurolink"), { recursive: true });
+  if (options.configYaml) {
+    fs.writeFileSync(
+      path.join(home, ".neurolink", "proxy-config.yaml"),
+      options.configYaml,
+    );
+  }
+
+  const port = await freePort();
+  const child = spawn(
+    process.execPath,
+    [
+      path.resolve("dist/cli/index.js"),
+      "proxy",
+      "start",
+      "--port",
+      String(port),
+      "--quiet",
+    ],
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        NEUROLINK_SKIP_MCP: "true",
+        NEUROLINK_PROXY_IGNORE_LAUNCHD: "1",
+        ...(options.env ?? {}),
+      },
+    },
+  );
+
+  const stop = () => {
+    child.kill();
+    // The proxy is still flushing its journal when the kill lands, so a plain
+    // rmSync loses a race with it and throws ENOTEMPTY — `force` suppresses
+    // "missing", not "still being written to". That turned a PASSING assertion
+    // into a red test, intermittently, which is worse than either outcome:
+    // the failure names a temp directory and says nothing about the behaviour
+    // under test.
+    //
+    // Retry briefly, then give up silently. Cleanup of a temp directory must
+    // never decide whether a test passed.
+    try {
+      fs.rmSync(home, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      });
+    } catch {
+      // The OS reaps its own temp directory; a leftover here is not a result.
+    }
+  };
+
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    try {
+      const probe = await fetch(`http://127.0.0.1:${port}/health`);
+      if (probe.ok) {
+        return { port, home, stop };
+      }
+    } catch {
+      // not listening yet
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  stop();
+  return null;
+}
+
+/**
+ * A multi-turn Gemini request must reach the provider with its history intact.
+ *
+ * The shared engine derives history with `conversationMessages.slice(0, -1)`,
+ * because the final turn is already sent separately as `prompt` — so
+ * claudeFormat and openaiFormat push EVERY turn, the last one included.
+ * geminiFormat pushed only the non-final turns, the intuitive reading of
+ * "history", which left the slice eating a real turn: a three-turn request
+ * arrived at the provider with the assistant's reply deleted.
+ *
+ * Nothing internal is asserted on. A proxy is spawned against a capture server
+ * standing in for the provider's HTTP endpoint, a three-turn generateContent
+ * goes through the real door, and the assertion is on what the provider
+ * actually received. The middle turn is the canary — the exact turn the bug
+ * ate. Both ends of the conversation are the control.
+ */
+async function testGeminiMultiTurnHistoryReachesProvider(): Promise<
+  boolean | null
+> {
+  const MARKERS = {
+    first: "TURN_ONE_USER",
+    canary: "TURN_TWO_MODEL_CANARY",
+    last: "TURN_THREE_USER",
+  };
+
+  let capturedBody: string | undefined;
+  const upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => {
+      raw += c.toString();
+    });
+    req.on("end", () => {
+      capturedBody = raw;
+      // The engine drives providers through stream(), so a plain JSON body
+      // yields "no content or tool calls" and a 500 at the door. SSE keeps the
+      // door's own answer honest while the capture above does the real work.
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      const chunk = (o: unknown) => res.write(`data: ${JSON.stringify(o)}\n\n`);
+      chunk({
+        id: "chatcmpl-capture",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "capture-model",
+        choices: [{ index: 0, delta: { role: "assistant", content: "OK" } }],
+      });
+      chunk({
+        id: "chatcmpl-capture",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "capture-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+      });
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+
+  const capturePort = await freePort();
+  let proxy: Awaited<ReturnType<typeof spawnIsolatedProxy>> = null;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      upstream.once("error", reject);
+      upstream.listen(capturePort, "127.0.0.1", () => resolve());
+    });
+
+    proxy = await spawnIsolatedProxy({
+      configYaml: `routing:
+  modelMappings:
+    - from: "gemini-2.5-flash"
+      to: "capture-model"
+      provider: "openai-compatible"
+`,
+      env: {
+        OPENAI_COMPATIBLE_BASE_URL: `http://127.0.0.1:${capturePort}/v1`,
+        OPENAI_COMPATIBLE_API_KEY: "capture-key",
+      },
+    });
+    if (!proxy) {
+      log(
+        "capture proxy never became healthy; history could not be observed",
+        "yellow",
+      );
+      return null;
+    }
+
+    await fetch(
+      `http://127.0.0.1:${proxy.port}/v1beta/models/gemini-2.5-flash:generateContent`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "user-agent": "neurolink-history-probe/1.0",
+        },
+        body: JSON.stringify({
+          contents: [
+            { role: "user", parts: [{ text: MARKERS.first }] },
+            { role: "model", parts: [{ text: MARKERS.canary }] },
+            { role: "user", parts: [{ text: MARKERS.last }] },
+          ],
+          generationConfig: { maxOutputTokens: 32 },
+        }),
+      },
+    );
+
+    if (!capturedBody) {
+      log(
+        "the capture upstream was never called; history could not be observed",
+        "yellow",
+      );
+      return null;
+    }
+
+    if (
+      !capturedBody.includes(MARKERS.first) ||
+      !capturedBody.includes(MARKERS.last)
+    ) {
+      log(
+        "the provider received neither end of the conversation; " +
+          "translation did not survive, so history is not observable here",
+        "yellow",
+      );
+      return null;
+    }
+
+    if (!capturedBody.includes(MARKERS.canary)) {
+      log(
+        "the provider received the first and last turns but not the middle " +
+          "one — conversation history is being truncated in translation",
+        "red",
+      );
+      return false;
+    }
+
+    log(
+      "a three-turn Gemini request reaches the provider with every turn intact",
+      "green",
+    );
+    return true;
+  } finally {
+    proxy?.stop();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  }
+}
+
+/**
+ * Every inbound door must be covered by the tracking middleware.
+ *
+ * Hono matches a wildcard one path segment at a time, so `app.use("/v1/*")`
+ * does NOT cover `/v1beta/models/...` — the segment is `v1beta`, not `v1`.
+ * The Gemini door landed matching neither `/v1/*` nor `/backend-api/*`, so its
+ * requests were invisible to the request log, to per-CLI attribution, and to
+ * the in-flight counter the graceful drain waits on — an auto-update could
+ * therefore cut a live Gemini stream mid-answer.
+ *
+ * Observed the way an operator would: drive the real doors over HTTP, then
+ * read the lifecycle journal the proxy itself wrote. No credentials are needed
+ * — `request_accepted` is emitted BEFORE `next()`, so the record exists
+ * whether or not an account is configured downstream. The proxy is isolated so
+ * the journal contains this case's traffic and nothing else.
+ */
+async function testEveryDoorIsTracked(): Promise<boolean | null> {
+  const proxy = await spawnIsolatedProxy({});
+  if (!proxy) {
+    log(
+      "isolated proxy never became healthy; door tracking could not be observed",
+      "yellow",
+    );
+    return null;
+  }
+
+  try {
+    // One request per door, so a regression naming only one of them stays
+    // attributable to that door rather than to "tracking is off everywhere".
+    const doors = [
+      {
+        path: "/v1/messages",
+        body: {
+          model: "claude-sonnet-4-5",
+          max_tokens: 1,
+          messages: [{ role: "user", content: "hi" }],
+        },
+      },
+      {
+        path: "/v1beta/models/gemini-2.5-flash:generateContent",
+        body: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          generationConfig: { maxOutputTokens: 1 },
+        },
+      },
+    ];
+
+    for (const door of doors) {
+      await fetch(`http://127.0.0.1:${proxy.port}${door.path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "user-agent": "neurolink-door-tracking-probe/1.0",
+        },
+        body: JSON.stringify(door.body),
+      });
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    const lifecyclePath = path.join(
+      proxy.home,
+      ".neurolink",
+      "logs",
+      `proxy-lifecycle-${today}.jsonl`,
+    );
+
+    // Written by a queued async writer. Poll for the records rather than
+    // sleeping a guessed interval, so a loaded machine reports the real answer
+    // instead of "unobservable".
+    const trackedPaths = new Set<string>();
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(lifecyclePath)) {
+        for (const line of fs
+          .readFileSync(lifecyclePath, "utf8")
+          .split("\n")
+          .filter((l) => l.trim())) {
+          try {
+            const rec = JSON.parse(line) as { event?: string; path?: string };
+            if (rec.event === "request_accepted" && rec.path) {
+              trackedPaths.add(rec.path);
+            }
+          } catch {
+            // partial trailing line
+          }
+        }
+      }
+      if (trackedPaths.size >= doors.length) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 300));
+    }
+
+    // The Anthropic door is the control: if IT is missing, tracking is off for
+    // reasons unrelated to the fix and this run proves nothing either way.
+    if (![...trackedPaths].some((p) => p.startsWith("/v1/messages"))) {
+      log(
+        "the control door produced no lifecycle record; " +
+          "tracking is not observable on this build",
+        "yellow",
+      );
+      return null;
+    }
+
+    if (![...trackedPaths].some((p) => p.startsWith("/v1beta/models/"))) {
+      log(
+        "the Gemini door produced no lifecycle record while the control door " +
+          "did — /v1beta/* is not covered by the tracking middleware",
+        "red",
+      );
+      return false;
+    }
+
+    log(
+      "every inbound door reaches the tracking middleware (anthropic + gemini)",
+      "green",
+    );
+    return true;
+  } finally {
+    proxy.stop();
+  }
+}
+
+/**
  * Usage must be attributable to the CLI that spent it, not only the account.
  *
  * The proxy already derived a client label from User-Agent, then dropped it
@@ -2093,9 +2493,14 @@ async function testPerClientAttribution(): Promise<boolean | null> {
     );
     return null;
   }
+  // sizeBefore is a BYTE offset from statSync. Slicing a decoded string by it
+  // counts UTF-16 code units instead, so one multi-byte character anywhere in
+  // the earlier log shifts the cut and the first "appended" line arrives
+  // truncated mid-JSON. Slice the buffer, then decode.
   const appended = fs
-    .readFileSync(logPath, "utf8")
-    .slice(sizeBefore)
+    .readFileSync(logPath)
+    .subarray(sizeBefore)
+    .toString("utf8")
     .split("\n")
     .filter((l) => l.trim());
   if (appended.length === 0) {
@@ -6160,6 +6565,16 @@ const tests: TestFunction[] = [
     name: "Ledger: usage splits by calling CLI and reconciles",
     fn: testLedgerSplitsUsageByClient,
     category: "proxy-config",
+  },
+  {
+    name: "Tracking: every inbound door reaches the tracking middleware",
+    fn: testEveryDoorIsTracked,
+    category: "proxy-api",
+  },
+  {
+    name: "Gemini Door: multi-turn history reaches the provider intact",
+    fn: testGeminiMultiTurnHistoryReachesProvider,
+    category: "proxy-api",
   },
   {
     name: "Attribution: the request log records the calling CLI",


### PR DESCRIPTION
## What this is

Review follow-ups for the six PRs merged yesterday (#1453, #1454, #1455, #1458, #1459, #1468). CodeRabbit and Tara posted findings that landed **after** those merges, so per the stack convention they are addressed here rather than reopened.

I verified every finding against current `release` before acting. **Five were already fixed** in the merged code and needed nothing:

| Finding | Origin | Status |
|---|---|---|
| Unbounded `fetch` in Codex model discovery | CodeRabbit #1453 | already fixed — `AbortSignal.timeout(CODEX_UPSTREAM_TIMEOUT_MS)` |
| Relay 401/403 without refresh+rotate | CodeRabbit #1453 | already fixed — `authRetried` forced-refresh loop |
| Discovery test tolerated 400 | CodeRabbit #1453 | already fixed — fails by name at `:636` |
| Temp file born world-readable | CodeRabbit #1455 | already fixed — `writeFileSync(…, { mode })` |
| Windows `renameSync` atomicity undocumented | Tara #1455 | already fixed — JSDoc covers `MOVEFILE_REPLACE_EXISTING` |

Eight were real and are fixed here.

## The two that mattered

**The Gemini door was invisible to request tracking.** Hono matches wildcards one path segment at a time, so `app.use("/v1/*")` does **not** cover `/v1beta/models/…` — the segment is `v1beta`, not `v1`. The door inherited no tracker, so its traffic was absent from the request log, from the per-CLI attribution added in #1458, and from the in-flight count the graceful drain waits on. An auto-update could have cut a live Gemini stream mid-answer.

Proven against a real Hono 4.13.3 app before fixing:

```
app.use("/v1/*", tracker); app.use("/backend-api/*", tracker);
POST /v1beta/models/gemini-2.5-pro:generateContent  ->  tracker hits: []
POST /v1/messages                                   ->  tracker hits: ["/v1/messages"]
```

**Multi-turn Gemini conversations silently dropped their most recent turn.** The shared engine derives history with `conversationMessages.slice(0, -1)`, because the final turn is already sent separately as `prompt` — so `claudeFormat` and `openaiFormat` both push *every* turn. `geminiFormat` pushed only the non-final ones, the intuitive reading of "history", leaving the slice to eat a real turn:

```
turns [u1, m1, u2]
  gemini  [u1, m1]      -> slice -> [u1]        m1 LOST
  claude  [u1, m1, u2]  -> slice -> [u1, m1]
```

## The other six

- **Non-streaming path dropped tool calls.** `hasTranslatedOutput` accepts tool calls with no text, and the stream serializer renders them as text — but the JSON branch passed only `internal.content`, handing the client `parts[0].text === ""` with `finishReason: STOP`. Both paths now share one `renderGeminiToolUse`.
- **Streaming call returned, not awaited** — a rejection before the `Response` existed escaped the handler's catch into `app.onError`, which answers in *Anthropic's* error shape. A Gemini client finds no `error.message` there.
- **`writeFileAtomic` assumed its parent directory existed.** The temp file is a sibling of the destination, so a missing parent failed the *write*, surfacing an ENOENT naming a path the caller never asked to write.
- **Attribution test sliced a decoded string by a byte offset.** One multi-byte character earlier in the log shifts the cut and the first "appended" line arrives truncated mid-JSON.
- **Start-up banner listed two of the four doors.** Codex and Gemini looked unsupported to anyone reading start-up output rather than the docs.
- **Gemini door test skipped on 400.** `buildGeminiErrorResponse` answers 400 when `contents` is missing, and the test builds its own body with one user turn — so a 400 can only mean the request contract moved. It was being swallowed by the "no credentials, any non-ok is fine" branch: the same false-green shape as the Codex discovery test. Now fails by name.

## Proof

Both majors are proven against the running system, not a stand-in. Each was confirmed non-vacuous by reverting its own fix and rebuilding.

**Tracking.** A case drives *both* doors over HTTP against the spawned proxy and reads the lifecycle journal the proxy itself wrote. No credentials needed — `request_accepted` is emitted before `next()`. The Anthropic door is the control, so "tracking is off entirely" reports as unobservable rather than as a Gemini regression.

```
regressed (unmount /v1beta/*)
  ✗ Tracking: every inbound door reaches the tracking middleware
    the Gemini door produced no lifecycle record while the control door did
  Passed: 71  Failed: 1   RESULT: FAIL   exit 1

fixed
  ✓ every inbound door reaches the tracking middleware (anthropic + gemini)
  Passed: 73  Failed: 0   RESULT: PASS   exit 0
```

**History.** A second proxy is spawned against a capture server standing in for the provider's HTTP endpoint, and a three-turn `generateContent` goes through the real door. The assertion is on what the provider *actually received*. Both ends of the conversation are the control; the middle turn is the canary, because it is the exact turn the bug ate.

```
regressed (restore the conditional push)
  PRESENT  TURN_ONE_USER
  MISSING  TURN_TWO_MODEL_CANARY      <- the assistant's reply, deleted
  PRESENT  TURN_THREE_USER

fixed
  PRESENT  TURN_ONE_USER
  PRESENT  TURN_TWO_MODEL_CANARY
  PRESENT  TURN_THREE_USER
```

Both fail with `✗`, not `⊘` — no skip-masking.

## Gates

```
tsc --noEmit                      0 errors
pnpm run lint                     0 errors (56 pre-existing warnings)
pnpm run pre-push                 exit 0
proxy suite                       73 passed, 6 skipped, 0 failed
codex suite                       31 passed, 0 failed
servers suite                     41 passed, 0 failed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini endpoints to the proxy startup information.
  * Preserved complete multi-turn Gemini conversation history.
  * Added support for displaying Gemini tool calls in streaming and non-streaming responses.
* **Bug Fixes**
  * Improved request lifecycle tracking and shutdown handling for Gemini routes.
  * Fixed first-run configuration writes when the destination directory is missing.
  * Improved handling of asynchronous streaming errors with consistent Gemini error responses.
* **Documentation**
  * Expanded and corrected documentation for Gemini request and content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->