### PR TITLE
fix(proxy): stop 500ing when the Gemini CLI continues from a model turn

### DIFF
--- a/src/lib/proxy/geminiFormat.ts
+++ b/src/lib/proxy/geminiFormat.ts
@@ -29,6 +29,15 @@ import type {
 /** Google's role for assistant turns. */
 const MODEL_ROLE = "model";
 
+/**
+ * Sent as `input.text` when a request's final turn is a model turn.
+ *
+ * Google lets a client continue generation from the assistant's own last turn;
+ * the chat-completions wire format the engine targets has no way to say that,
+ * and an empty prompt is rejected before any provider is reached.
+ */
+const CONTINUATION_PROMPT = "Continue.";
+
 function partsToText(parts: ProxyGeminiPart[] | undefined): string {
   if (!Array.isArray(parts)) {
     return "";
@@ -115,11 +124,24 @@ export function parseGeminiRequest(
   // it, which is the same lost-turn bug one case further along.
   //
   // A terminal placeholder restores the invariant: the slice removes this
-  // instead of the model turn. It is never sent anywhere — `prompt` is
-  // independently "" in exactly this case, so the placeholder only exists to be
-  // consumed by the slice.
+  // instead of the model turn.
+  //
+  // The prompt needs its own answer, and leaving it "" was a 500. A
+  // model-final request carries no user turn to send as `input.text`, and
+  // NeuroLink's stream() rejects an empty one outright — "Stream options must
+  // include either input.text, input.audio, or stt.audio" — so every continue
+  // from a model turn failed at the door rather than reaching a provider. The
+  // placeholder above fixed the history slice but never exercised this path,
+  // because nothing had sent the request.
+  //
+  // Google's semantics for a model-final `contents` are "keep going", and the
+  // chat-completions shape the engine translates into has no assistant-prefill
+  // to express that. An explicit continuation instruction is the closest
+  // faithful equivalent: the full conversation still arrives as history, and
+  // the model is told to continue it rather than being handed an empty turn.
   if (turns.length > 0 && turns[turns.length - 1].role !== "user") {
-    conversationMessages.push({ role: "user", content: "" });
+    conversationMessages.push({ role: "user", content: CONTINUATION_PROMPT });
+    prompt = CONTINUATION_PROMPT;
   }
 
   const numeric = (v: unknown): number | undefined =>

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -2328,6 +2328,151 @@ async function testGeminiMultiTurnHistoryReachesProvider(): Promise<
 }
 
 /**
+ * Continuing from a model turn must reach a provider, not 500 at the door.
+ *
+ * Google lets a client send `contents` whose final entry is a model turn — the
+ * Gemini CLI does exactly that when continuing — and there is no user turn to
+ * become `input.text`. That left `prompt` empty, and NeuroLink's stream()
+ * rejects an empty input before any provider is contacted, so every continue
+ * failed with a 500 and the message "Stream options must include either
+ * input.text, input.audio, or stt.audio".
+ *
+ * This was missed twice over. The review that found the history-slice half of
+ * it proposed a terminal placeholder, which was applied and is correct as far
+ * as it goes — but a placeholder consumed by the slice does nothing about the
+ * prompt, and no case ever sent a model-final request to find out. The
+ * multi-turn case next door covers [user, model, user] only, which always has
+ * a user turn to promote.
+ *
+ * The status assertion is the load-bearing one here: the turns could all
+ * arrive correctly and the request still fail.
+ */
+async function testGeminiModelFinalTurnReachesProvider(): Promise<
+  boolean | null
+> {
+  const MARKERS = { user: "MF_USER_ONE", model: "MF_MODEL_FINAL_CANARY" };
+
+  let capturedBody: string | undefined;
+  const upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => {
+      raw += c.toString();
+    });
+    req.on("end", () => {
+      capturedBody = raw;
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      const chunk = (o: unknown) => res.write(`data: ${JSON.stringify(o)}\n\n`);
+      chunk({
+        id: "chatcmpl-capture",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "capture-model",
+        choices: [{ index: 0, delta: { role: "assistant", content: "OK" } }],
+      });
+      chunk({
+        id: "chatcmpl-capture",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "capture-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 8, completion_tokens: 1, total_tokens: 9 },
+      });
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+
+  const capturePort = await freePort();
+  let proxy: Awaited<ReturnType<typeof spawnIsolatedProxy>> = null;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      upstream.once("error", reject);
+      upstream.listen(capturePort, "127.0.0.1", () => resolve());
+    });
+
+    proxy = await spawnIsolatedProxy({
+      configYaml: `routing:
+  modelMappings:
+    - from: "gemini-2.5-flash"
+      to: "capture-model"
+      provider: "openai-compatible"
+`,
+      env: {
+        OPENAI_COMPATIBLE_BASE_URL: `http://127.0.0.1:${capturePort}/v1`,
+        OPENAI_COMPATIBLE_API_KEY: "capture-key",
+      },
+    });
+    if (!proxy) {
+      log(
+        "capture proxy never became healthy; the model-final path could not be observed",
+        "yellow",
+      );
+      return null;
+    }
+
+    const resp = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1beta/models/gemini-2.5-flash:generateContent`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "user-agent": "neurolink-model-final-probe/1.0",
+        },
+        body: JSON.stringify({
+          // No trailing user turn — this is the continue-from-model shape.
+          contents: [
+            { role: "user", parts: [{ text: MARKERS.user }] },
+            { role: "model", parts: [{ text: MARKERS.model }] },
+          ],
+          generationConfig: { maxOutputTokens: 32 },
+        }),
+      },
+    );
+
+    if (resp.status !== 200) {
+      log(
+        `continuing from a model turn answered ${resp.status} instead of 200 — ` +
+          "the door is failing the CLI's continue flow",
+        "red",
+      );
+      return false;
+    }
+
+    if (!capturedBody) {
+      log(
+        "the capture upstream was never called on a model-final request",
+        "red",
+      );
+      return false;
+    }
+
+    if (
+      !capturedBody.includes(MARKERS.user) ||
+      !capturedBody.includes(MARKERS.model)
+    ) {
+      log(
+        "a model-final request reached the provider without its full history",
+        "red",
+      );
+      return false;
+    }
+
+    log(
+      "continuing from a model turn reaches the provider, with both turns intact",
+      "green",
+    );
+    return true;
+  } finally {
+    proxy?.stop();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  }
+}
+
+/**
  * Every inbound door must be covered by the tracking middleware.
  *
  * Hono matches a wildcard one path segment at a time, so `app.use("/v1/*")`
@@ -6577,6 +6722,11 @@ const tests: TestFunction[] = [
     category: "proxy-api",
   },
   {
+    name: "Gemini Door: continuing from a model turn reaches the provider",
+    fn: testGeminiModelFinalTurnReachesProvider,
+    category: "proxy-api",
+  },
+  {
     name: "Attribution: the request log records the calling CLI",
     fn: testPerClientAttribution,
     category: "proxy-config",
@@ -6729,6 +6879,52 @@ const tests: TestFunction[] = [
 // Test Runner
 // ============================================================================
 
+/**
+ * Bound every case in this suite.
+ *
+ * This suite drives its own runner — it destructures `recordTest`/`runSuite`
+ * from `defineSuite` and calls `test.fn()` directly — so it never passes
+ * through the harness's own `Promise.race` per-case timeout
+ * (test/helpers/harness.ts:411). Any case that hangs hangs the whole run, with
+ * nothing to distinguish it from slow work: a spawned proxy that never becomes
+ * healthy, an upstream that accepts a connection and never answers, a fetch
+ * with no signal.
+ *
+ * Reported as a failure rather than a skip, deliberately. The harness's own
+ * timeout raises a `SKIP:`-prefixed message, which is right for a live-provider
+ * suite where a hung upstream is not the code's fault — but every case here
+ * talks to a proxy this repo builds and spawns, so a hang is a defect and must
+ * not go green.
+ */
+const CASE_TIMEOUT_MS = 180_000;
+
+async function withCaseTimeout(
+  name: string,
+  fn: () => Promise<boolean | null>,
+): Promise<boolean | null> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `case exceeded ${CASE_TIMEOUT_MS}ms and was aborted — treat as a hang, not slowness`,
+              ),
+            ),
+          CASE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 async function runAllTests(): Promise<void> {
   if (!fs.existsSync("dist") || !fs.existsSync("dist/cli/index.js")) {
     log("Build artifacts not found. Run: pnpm run build:cli", "red");
@@ -6753,7 +6949,7 @@ async function runAllTests(): Promise<void> {
         continue;
       }
       try {
-        const result = await test.fn();
+        const result = await withCaseTimeout(test.name, test.fn);
         recordTest(
           test.name,
           result === true,


### PR DESCRIPTION
## What this is

Two defects found while working the review threads on already-merged PRs — neither was found *by* a thread. Both were sitting behind findings that looked closed.

## The Gemini door 500s on every continue

Google lets a client send `contents` whose final entry is a **model** turn, and the Gemini CLI does exactly that when continuing. There's no trailing user turn to become `input.text`, so `prompt` was left `""` — and NeuroLink's `stream()` rejects an empty input before contacting any provider:

```
[proxy:gemini] request failed: Stream options must include either
               input.text, input.audio, or stt.audio
```

**This was missed twice over.** The review on #1468 found the neighbouring half — that the engine's `slice(0, -1)` ate the final model turn — and #1480 answered it with a terminal placeholder consumed by the slice. That fix is correct as far as it goes and is kept here. But a placeholder eaten by the slice does nothing about the prompt, and **no case ever sent a model-final request**, so the 500 sat behind a finding that read as resolved. The multi-turn case #1480 added covers `[user, model, user]` only — which always has a user turn to promote.

Google's semantics for a model-final `contents` are "keep going". The chat-completions shape the engine translates into has no assistant-prefill to express that, so an explicit continuation instruction is the closest faithful equivalent: the whole conversation still arrives as history, and the model is told to continue rather than handed an empty turn.

## The suite could not have caught a hang

`continuous-test-suite-proxy.ts` drives its own runner — it destructures `recordTest`/`runSuite` from `defineSuite` and calls `test.fn()` directly — so it never passes through the harness's own `Promise.race` per-case timeout at `test/helpers/harness.ts:411`. Any case that hung hung the whole run, indistinguishable from slow work.

Two threads on #1455 raised this against the atomic-write race case. It was never about that one case: **all 74 were unbounded.**

Every case is now bounded at 180s, and a breach reports as a **FAILURE**, not the harness's `SKIP:`-prefixed default. That difference is deliberate — a skip is right for a live-provider suite where a hung upstream isn't the code's fault, but every case here talks to a proxy this repo builds and spawns, so a hang is a defect and must not go green.

## Proof

Both confirmed by reverting the fix:

```
prompt left ""        ✗ continuing from a model turn answered 500 instead of 200
                        — the door is failing the CLI's continue flow

CASE_TIMEOUT_MS = 1     Passed 49, Failed 25, exit 1
                        reported as FAILURES, not skips — the part that matters,
                        since the harness downgrades abort-shaped messages

fixed                   74 passed, 6 skipped, 0 failed, exit 0
```

The timeout's own message was checked against the skip-masking rule specifically: it contains the word "aborted", which is exactly the shape `isExpectedProviderError()` can swallow. It reports as a failure — verified, not assumed.

## Gates

```
tsc --noEmit          0 errors
pnpm run lint         0 errors (56 pre-existing warnings)
proxy suite           74 passed, 6 skipped, 0 failed
```

## Review threads

This lands alongside a pass over all 30 unresolved threads on #1455, #1468 and #1480 — each verified against the current tree, answered on the thread, and resolved where settled. The two genuinely-open ones were the timeout pair, fixed here.

## Second witness

Worth recording, because it's the strongest evidence this is a real user-facing path rather than a shape only a test would send.

A peer session working the model-turn fix independently tried to add an end-to-end case for the model-terminal shape and **could not make it exercise the path — the capture upstream was never called.** Unable to tell whether that was a further defect or a limitation of the capture harness, they pulled the test rather than ship one that skips, and logged it as an open question instead of guessing.

That symptom *was* this bug, one layer down: `contents` ending on a model turn leaves `prompt` empty, `stream()` rejects it before contacting any provider, so of course no upstream was ever reached. Two independent attempts to test this shape both hit the wall; neither run got a request through.

Their call to report the ambiguity rather than guess at it is why it was still legible when I hit the same wall from the other side.
