### PR TITLE
feat(localUsage): read Codex token spend from its rollout transcripts

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1307,6 +1307,7 @@ console.log(result.content);
 - [LocalUsageReaderFailure](type-aliases/LocalUsageReaderFailure.md)
 - [LocalUsageAggregateReport](type-aliases/LocalUsageAggregateReport.md)
 - [LocalUsageClaudeRawUsage](type-aliases/LocalUsageClaudeRawUsage.md)
+- [LocalUsageCodexSessionRollup](type-aliases/LocalUsageCodexSessionRollup.md)
 - [AgenticLoopChunk](type-aliases/AgenticLoopChunk.md)
 - [AgenticLoopToolCall](type-aliases/AgenticLoopToolCall.md)
 - [AgenticLoopUsage](type-aliases/AgenticLoopUsage.md)

--- a/docs/api/type-aliases/LocalUsageCodexSessionRollup.md
+++ b/docs/api/type-aliases/LocalUsageCodexSessionRollup.md
@@ -1,0 +1,58 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / LocalUsageCodexSessionRollup
+
+# Type Alias: LocalUsageCodexSessionRollup
+
+> **LocalUsageCodexSessionRollup** = `object`
+
+Defined in: [types/localUsage.ts:177](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L177)
+
+One Codex rollout reduced to its session-level totals.
+
+The token figures here are the session's CUMULATIVE counter, not a sum of
+per-turn values — see `codexReader.ts` for why summing overstates by ~63%.
+
+## Properties
+
+### model?
+
+> `optional` **model?**: `string`
+
+Defined in: [types/localUsage.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L178)
+
+---
+
+### input
+
+> **input**: `number`
+
+Defined in: [types/localUsage.ts:179](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L179)
+
+---
+
+### output
+
+> **output**: `number`
+
+Defined in: [types/localUsage.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L180)
+
+---
+
+### cached
+
+> **cached**: `number`
+
+Defined in: [types/localUsage.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L181)
+
+---
+
+### billableEvents
+
+> **billableEvents**: `number`
+
+Defined in: [types/localUsage.ts:183](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L183)
+
+token_count events where the cumulative total actually advanced.

--- a/src/lib/localUsage/codexReader.ts
+++ b/src/lib/localUsage/codexReader.ts
@@ -1,0 +1,252 @@
+/**
+ * Reads token usage out of Codex's own rollout transcripts.
+ *
+ * Layout: `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<iso>-<sessionId>.jsonl`.
+ * Each line is one of `session_meta`, `turn_context`, `response_item` or
+ * `event_msg`; usage lives on `event_msg` records whose `payload.type` is
+ * `token_count`.
+ *
+ * The counter semantics are the whole story here, and they are the opposite of
+ * the Claude Code reader's. Every `token_count` event carries BOTH a
+ * cumulative `total_token_usage` for the session and a per-turn
+ * `last_token_usage`. Summing the per-turn values is the obvious move and it is
+ * wrong: measured across all 108 sessions on a real machine, summing yields
+ * 9,191,613,238 tokens against a true 5,653,217,442 — an overstatement of
+ * 62.6%, and 195% on the worst single session. The per-turn value repeats
+ * across events within a turn, so it double-counts.
+ *
+ * The cumulative counter is authoritative and was monotonic in all 108
+ * sessions — it never resets mid-file — so the last one in the file is the
+ * session's true total. `Math.max` is still used rather than "last seen",
+ * because a counter that is only monotonic in every case observed is not the
+ * same as one that is guaranteed to be, and the max costs nothing.
+ *
+ * Cost is deliberately not computed. Codex is a ChatGPT subscription — the
+ * rollouts carry `rate_limits.plan_type` — so a per-token dollar figure would
+ * be an invention, not a measurement. The tokens are real; the cost is
+ * `unavailable`.
+ */
+
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
+import { readdir, stat } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import type {
+  LocalUsageCodexSessionRollup,
+  LocalUsageReader,
+  LocalUsageScanError,
+  LocalUsageScanOptions,
+  LocalUsageScanResult,
+  LocalUsageTotals,
+} from "../types/index.js";
+
+const CLI_ID = "codex" as const;
+const DEFAULT_SINCE_DAYS = 30;
+
+function sessionsRoot(): string {
+  return join(homedir(), ".codex", "sessions");
+}
+
+function emptyTotals(): LocalUsageTotals {
+  return {
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    costConfidence: "unavailable",
+    unpricedRequests: 0,
+    unpricedModels: [],
+  };
+}
+
+async function collectRollouts(dir: string, out: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    // One unreadable date directory must not cost the rest of the scan.
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectRollouts(full, out);
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      out.push(full);
+    }
+  }
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Fold one rollout into a single session-level rollup.
+ *
+ * `billableEvents` counts only the `token_count` events where the cumulative
+ * total actually advanced. Counting every event instead would inherit exactly
+ * the repetition that makes summing the per-turn values wrong.
+ */
+async function readRollout(
+  filePath: string,
+): Promise<LocalUsageCodexSessionRollup | null> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+
+  let model: string | undefined;
+  let bestTotal = -1;
+  let best: { input: number; output: number; cached: number } | undefined;
+  let previousTotal = -1;
+  let billableEvents = 0;
+
+  try {
+    for await (const line of rl) {
+      // Cheap reject before JSON.parse: these files reach hundreds of MB and
+      // most lines are conversation content with no usage on them at all.
+      const isTokenCount = line.includes('"token_count"');
+      const isTurnContext = line.includes('"turn_context"');
+      if (!isTokenCount && !isTurnContext) {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // A rollout being appended to while we read it ends mid-line.
+        continue;
+      }
+      const record = parsed as {
+        type?: string;
+        payload?: {
+          type?: string;
+          model?: string;
+          info?: { total_token_usage?: Record<string, unknown> };
+        };
+      };
+
+      if (record.type === "turn_context" && record.payload?.model) {
+        // Last one wins: a session can switch models partway through, and the
+        // most recent is the better single label for it.
+        model = record.payload.model;
+        continue;
+      }
+
+      if (record.payload?.type !== "token_count") {
+        continue;
+      }
+      const cumulative = record.payload.info?.total_token_usage;
+      if (!cumulative) {
+        continue;
+      }
+      const total = num(cumulative.total_tokens);
+      if (total > previousTotal) {
+        billableEvents += 1;
+      }
+      previousTotal = total;
+      if (total > bestTotal) {
+        bestTotal = total;
+        best = {
+          input: num(cumulative.input_tokens),
+          output: num(cumulative.output_tokens),
+          cached: num(cumulative.cached_input_tokens),
+        };
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  if (!best) {
+    return null;
+  }
+  return { model, billableEvents, ...best };
+}
+
+export async function createCodexReader(): Promise<LocalUsageReader> {
+  return {
+    descriptor: {
+      id: CLI_ID,
+      displayName: "Codex",
+      verified: true,
+      dedupStrategy: "session-dag",
+      costConfidence: "unavailable",
+      requiresSqlite: false,
+    },
+
+    detect: async () => {
+      try {
+        const info = await stat(sessionsRoot());
+        return info.isDirectory();
+      } catch {
+        return false;
+      }
+    },
+
+    scan: async (
+      options?: LocalUsageScanOptions,
+    ): Promise<LocalUsageScanResult> => {
+      const totals = emptyTotals();
+      const errors: LocalUsageScanError[] = [];
+      const models = new Set<string>();
+
+      const files: string[] = [];
+      await collectRollouts(sessionsRoot(), files);
+
+      const sinceDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      const cutoff =
+        Number.isFinite(sinceDays) && sinceDays > 0
+          ? Date.now() - sinceDays * 86_400_000
+          : undefined;
+
+      let filesScanned = 0;
+      for (const file of files) {
+        try {
+          if (cutoff !== undefined) {
+            const info = await stat(file);
+            if (info.mtimeMs < cutoff) {
+              continue;
+            }
+          }
+          const rollup = await readRollout(file);
+          filesScanned += 1;
+          if (!rollup) {
+            continue;
+          }
+          totals.requests += rollup.billableEvents;
+          // `cached_input_tokens` is a SUBSET of `input_tokens` here — verified
+          // on all 108 sessions, where input + output == total exactly and
+          // cached <= input always. The other readers keep the two disjoint, so
+          // the cached portion is subtracted out rather than reported twice; a
+          // caller adding inputTokens + cacheReadTokens would otherwise
+          // over-count Codex and not the rest.
+          totals.inputTokens += Math.max(0, rollup.input - rollup.cached);
+          totals.cacheReadTokens += rollup.cached;
+          totals.outputTokens += rollup.output;
+          if (rollup.model) {
+            models.add(rollup.model);
+          }
+        } catch (error) {
+          errors.push({
+            cliId: CLI_ID,
+            filePath: file,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      // Every turn is unpriced by construction, not by accident: see the note
+      // on this module about Codex being a subscription. Naming the models
+      // keeps that legible instead of looking like a lookup that failed.
+      totals.unpricedRequests = totals.requests;
+      totals.unpricedModels = [...models].sort();
+
+      return { cliId: CLI_ID, totals, filesScanned, errors };
+    },
+  };
+}

--- a/src/lib/localUsage/localUsageReaderRegistry.ts
+++ b/src/lib/localUsage/localUsageReaderRegistry.ts
@@ -59,3 +59,18 @@ registerLocalUsageReader({
     return createClaudeCodeReader();
   },
 });
+
+registerLocalUsageReader({
+  descriptor: {
+    id: "codex",
+    displayName: "Codex",
+    verified: true,
+    dedupStrategy: "session-dag",
+    costConfidence: "unavailable",
+    requiresSqlite: false,
+  },
+  factory: async () => {
+    const { createCodexReader } = await import("./codexReader.js");
+    return createCodexReader();
+  },
+});

--- a/src/lib/types/localUsage.ts
+++ b/src/lib/types/localUsage.ts
@@ -167,3 +167,18 @@ export type LocalUsageClaudeRawUsage = {
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
 };
+
+/**
+ * One Codex rollout reduced to its session-level totals.
+ *
+ * The token figures here are the session's CUMULATIVE counter, not a sum of
+ * per-turn values — see `codexReader.ts` for why summing overstates by ~63%.
+ */
+export type LocalUsageCodexSessionRollup = {
+  model?: string;
+  input: number;
+  output: number;
+  cached: number;
+  /** token_count events where the cumulative total actually advanced. */
+  billableEvents: number;
+};

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -141,6 +141,59 @@ async function withHome<T>(home: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Build a temp HOME containing one Codex rollout.
+ *
+ * Layout matches the real one: `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-*.jsonl`,
+ * nested by date, so the reader's directory walk is exercised rather than
+ * assumed.
+ */
+function writeCodexFixtureHome(lines: string[]): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nl-codexusage-"));
+  const dir = path.join(home, ".codex", "sessions", "2026", "05", "22");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "rollout-2026-05-22T21-39-27-fixture.jsonl"),
+    lines.join("\n") + "\n",
+  );
+  return home;
+}
+
+/** One `token_count` event, carrying both counters the real format carries. */
+function codexTokenCount(
+  cumulative: { input: number; output: number; cached: number },
+  perTurn: { input: number; output: number; cached: number },
+): string {
+  const shape = (t: { input: number; output: number; cached: number }) => ({
+    input_tokens: t.input,
+    cached_input_tokens: t.cached,
+    output_tokens: t.output,
+    reasoning_output_tokens: 0,
+    total_tokens: t.input + t.output,
+  });
+  return JSON.stringify({
+    timestamp: "2026-05-22T16:11:27.095Z",
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: shape(cumulative),
+        last_token_usage: shape(perTurn),
+        model_context_window: 258400,
+      },
+      rate_limits: { limit_id: "codex", plan_type: "prolite" },
+    },
+  });
+}
+
+function codexTurnContext(model: string): string {
+  return JSON.stringify({
+    timestamp: "2026-05-22T16:11:12.517Z",
+    type: "turn_context",
+    payload: { turn_id: "t1", model, cwd: "/tmp/fixture" },
+  });
+}
+
 async function runAllTests(): Promise<void> {
   await test("the SDK exports the local-usage surface", async () => {
     assert(
@@ -469,6 +522,136 @@ async function runAllTests(): Promise<void> {
         // already gone
       }
     }
+  });
+
+  await test("Codex: the cumulative counter is used, not a sum of per-turn values", async () => {
+    // This is the whole design decision, and the naive implementation is the
+    // wrong one. Every token_count event carries a cumulative
+    // total_token_usage AND a per-turn last_token_usage; the per-turn value
+    // repeats across events within a turn, so summing it double-counts.
+    // Measured over 108 real sessions, summing gave 9,191,613,238 tokens
+    // against a true 5,653,217,442 — 62.6% over, and 195% on the worst file.
+    //
+    // The fixture below is built so the two strategies cannot agree:
+    //   sum of per-turn : 100 + 200 + 200 + 300 = 800 output
+    //   cumulative final: 600 output
+    // A reader that sums reports 800. A correct one reports 600.
+    const home = writeCodexFixtureHome([
+      codexTurnContext("gpt-5.5"),
+      codexTokenCount(
+        { input: 1000, output: 100, cached: 400 },
+        { input: 1000, output: 100, cached: 400 },
+      ),
+      codexTokenCount(
+        { input: 3000, output: 300, cached: 1200 },
+        { input: 2000, output: 200, cached: 800 },
+      ),
+      // Repeated event for the same turn — the cumulative total does not
+      // advance, which is exactly what makes summing wrong.
+      codexTokenCount(
+        { input: 3000, output: 300, cached: 1200 },
+        { input: 2000, output: 200, cached: 800 },
+      ),
+      codexTokenCount(
+        { input: 6000, output: 600, cached: 2400 },
+        { input: 3000, output: 300, cached: 1200 },
+      ),
+    ]);
+
+    const report = await withHome(home, () =>
+      readAllLocalUsage({ sinceDays: Infinity }),
+    );
+    const totals = report.totals["codex"];
+    assert(totals !== undefined, "the codex reader produced no totals");
+
+    assert(
+      totals!.outputTokens === 600,
+      `per-turn values were summed instead of using the cumulative counter — expected 600 output, got ${totals!.outputTokens}`,
+    );
+    // input is reported net of the cached subset: 6000 - 2400.
+    assert(
+      totals!.inputTokens === 3600 && totals!.cacheReadTokens === 2400,
+      `cached tokens were not separated from input — expected 3600/2400, got ${totals!.inputTokens}/${totals!.cacheReadTokens}`,
+    );
+    // Three of the four events advanced the counter; the repeat did not.
+    assert(
+      totals!.requests === 3,
+      `a repeated token_count event was counted as a billable turn — expected 3, got ${totals!.requests}`,
+    );
+    log(
+      "Codex usage comes from the cumulative counter, with cached split out of input",
+      "green",
+    );
+  });
+
+  await test("Codex: subscription usage reports no invented cost", async () => {
+    // Codex is a ChatGPT subscription — the rollouts carry rate_limits.plan_type.
+    // A per-token dollar figure would be an invention, so the tokens are real
+    // and the cost is declared unavailable rather than quietly zero.
+    const home = writeCodexFixtureHome([
+      codexTurnContext("gpt-5.5"),
+      codexTokenCount(
+        { input: 500, output: 50, cached: 100 },
+        { input: 500, output: 50, cached: 100 },
+      ),
+    ]);
+
+    const report = await withHome(home, () =>
+      readAllLocalUsage({ sinceDays: Infinity }),
+    );
+    const totals = report.totals["codex"];
+    assert(totals !== undefined, "the codex reader produced no totals");
+    assert(
+      totals!.costConfidence === "unavailable",
+      "a subscription CLI reported a cost confidence other than unavailable",
+    );
+    assert(totals!.costUsd === 0, "a subscription CLI invented a dollar cost");
+    assert(
+      totals!.unpricedRequests === totals!.requests,
+      "a subscription CLI did not report all of its turns as unpriced",
+    );
+    assert(
+      totals!.unpricedModels.includes("gpt-5.5"),
+      "the model behind unpriced subscription turns was not named",
+    );
+    log(
+      "Codex reports real tokens and an explicitly unavailable cost",
+      "green",
+    );
+  });
+
+  await test("Codex: this machine's real rollouts scan coherently", async () => {
+    const realSessions = path.join(os.homedir(), ".codex", "sessions");
+    if (!fs.existsSync(realSessions)) {
+      throw new Error("SKIP: no ~/.codex/sessions on this machine");
+    }
+    const reader = await createLocalUsageReader("codex");
+    assert(await reader.detect(), "detect() denied a store that exists");
+
+    const week = await reader.scan({ sinceDays: 7 });
+    const month = await reader.scan({ sinceDays: 30 });
+
+    if (week.totals.requests === 0 && month.totals.requests === 0) {
+      throw new Error("SKIP: no Codex activity in the last 30 days");
+    }
+
+    assert(
+      month.filesScanned >= week.filesScanned,
+      "a wider time window scanned fewer rollouts than a narrower one",
+    );
+    assert(
+      month.totals.requests >= week.totals.requests,
+      "a wider time window produced fewer turns than a narrower one",
+    );
+    assert(
+      month.totals.costUsd === 0 &&
+        month.totals.costConfidence === "unavailable",
+      "real Codex rollouts produced an invented cost",
+    );
+    log(
+      `real Codex scan: ${month.totals.requests} turns over ${month.filesScanned} rollouts in 30d`,
+      "green",
+    );
   });
 
   await test("repeated scans of the same data agree", async () => {


### PR DESCRIPTION
## What this is

Second reader in the observability lane. Codex is the heaviest CLI on this machine after Claude Code, and the proxy can only account for the fraction that went through its door.

## The counter semantics are the whole story — and the obvious implementation is wrong

Every `token_count` event in a rollout carries **both** a cumulative `total_token_usage` for the session and a per-turn `last_token_usage`. Summing the per-turn values is what a reader modelled on the Claude Code one would naturally do. Measured across all 108 real sessions on this machine:

```
summing per-turn : 9,191,613,238 tokens
high-water mark  : 5,653,217,442 tokens
difference       : +3,538,395,796  (+62.6%)

worst per-file divergence: 195.3%   sum=129,648,113  actual=43,898,543
```

The per-turn value repeats across events within a turn, so summing double-counts. **Only 37 of 108 sessions had the two strategies agree** — which is also why spot-checking one file would have been enough to conclude the wrong thing.

The cumulative counter is authoritative: monotonic in all 108 sessions, never resetting mid-file. `Math.max` is still used rather than "last seen", because a counter that is monotonic in every case *observed* isn't the same as one guaranteed to be, and the max costs nothing.

## Two other things the real data decided

**`cached_input_tokens` is a subset of `input_tokens`, not a sibling.** Verified on all 108 sessions: `input + output == total` exactly, and `cached <= input` always. The Claude Code reader keeps the two disjoint, so the cached portion is subtracted out rather than reported twice — otherwise a caller adding `inputTokens + cacheReadTokens` would over-count Codex and nothing else.

**Cost is deliberately not computed.** Codex is a ChatGPT subscription — the rollouts carry `rate_limits.plan_type` — so a per-token dollar figure would be an invention rather than a measurement. Tokens are real, `costUsd` is 0, `costConfidence` is `"unavailable"`, and every turn appears under `unpricedRequests` with its model named, so the absence reads as deliberate rather than as a lookup that failed.

`requests` counts only events where the cumulative total actually advanced — counting every `token_count` would inherit exactly the repetition that makes summing wrong.

## Proof

**Cross-validated, not merely tested.** The reader's full-history totals reproduce an independent Python measurement of the same 122 rollouts *exactly*:

```
246,609,267 + 5,390,186,496 + 16,421,679 = 5,653,217,442
```

Three cases added, driving `readAllLocalUsage()` and `createLocalUsageReader()` from `dist/index.js`. The first is built so the two strategies **cannot** agree — four events whose per-turn values sum to 800 output against a cumulative 600 — and was confirmed by implementing the naive version:

```
naive summing   ✗ per-turn values were summed instead of using the
                  cumulative counter — expected 600 output, got 800
correct         ✓ 12 passed
```

Live output across both readers, full history:

```
claude-code  req=492978  in=25,550,025   out=400,591,999  cacheRead=83,094,488,541  $56,611.48  modeled
codex        req= 43112  in=246,609,267  out= 16,421,679  cacheRead= 5,390,186,496  $0.00       unavailable
```

## Gates

```
tsc --noEmit       0 errors
pnpm run lint      0 errors (56 pre-existing warnings)
test:local-usage   12 passed, 0 failed
```
