### PR TITLE
fix(test): make the proxy-fallback and subprocess cases actually boundable

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -3823,6 +3823,20 @@ async function executeClaudeFallbackTranslation(args: {
   ) => void;
   options: Parameters<ServerContext["neurolink"]["stream"]>[0];
   providerLabel: string;
+  /**
+   * Idle timeout for the fallback stream, in ms. Defaults to
+   * FALLBACK_STREAM_IDLE_TIMEOUT_MS.
+   *
+   * Injectable purely so a test can drive the timeout path in milliseconds
+   * instead of two minutes. The alternative the coverage used before was
+   * patching `globalThis.setTimeout` to fire every timer at 0ms for the
+   * duration of an await — which rewrites the delay of ANY timer created in
+   * that window, not just this one's, inside a 280-case suite sharing a single
+   * process. That is not a hypothetical: an attempt to measure the patched
+   * case with its own `setTimeout`-based watchdog had the watchdog rewritten
+   * out from under it and reported an instant false hang.
+   */
+  idleTimeoutMs?: number;
 }): Promise<unknown> {
   const {
     ctx,
@@ -3833,6 +3847,7 @@ async function executeClaudeFallbackTranslation(args: {
     logFinalRequest,
     options,
     providerLabel,
+    idleTimeoutMs = FALLBACK_STREAM_IDLE_TIMEOUT_MS,
   } = args;
   const fallbackAbortController = new AbortController();
   let streamResult: StreamResult;
@@ -3842,8 +3857,8 @@ async function executeClaudeFallbackTranslation(args: {
         ...options,
         abortSignal: fallbackAbortController.signal,
       }),
-      FALLBACK_STREAM_IDLE_TIMEOUT_MS,
-      `Fallback ${providerLabel} initialization timed out after ${FALLBACK_STREAM_IDLE_TIMEOUT_MS}ms`,
+      idleTimeoutMs,
+      `Fallback ${providerLabel} initialization timed out after ${idleTimeoutMs}ms`,
     );
   } catch (error) {
     fallbackAbortController.abort(error);
@@ -3858,8 +3873,8 @@ async function executeClaudeFallbackTranslation(args: {
       while (true) {
         const { value: chunk, done } = await withTimeout(
           iterator.next(),
-          FALLBACK_STREAM_IDLE_TIMEOUT_MS,
-          `Fallback ${providerLabel} stream timed out after ${FALLBACK_STREAM_IDLE_TIMEOUT_MS}ms of inactivity`,
+          idleTimeoutMs,
+          `Fallback ${providerLabel} stream timed out after ${idleTimeoutMs}ms of inactivity`,
         );
         if (done) {
           return collectedText;

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -3680,6 +3680,7 @@ exit 127
         execFileSync("sh", ["-n", scriptPath], {
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 5_000,
+          killSignal: "SIGKILL" as const,
         });
         return true; // No syntax errors
       } catch (err) {
@@ -3739,6 +3740,7 @@ exit 127
         execFileSync("sh", ["-n", scriptPath], {
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 5_000,
+          killSignal: "SIGKILL" as const,
         });
         return true;
       } catch {
@@ -9954,17 +9956,25 @@ exit 127
     name: "proxy fallback: an idle stream is aborted without ambiguous replay",
     category: "proxy",
     fn: async () => {
-      const originalSetTimeout = globalThis.setTimeout;
       let cancelled = false;
       const cancel = async (): Promise<void> => {
         cancelled = true;
       };
       const abortSignals: AbortSignal[] = [];
       let streamCalls = 0;
-      globalThis.setTimeout = ((callback, _delay, ...args) =>
-        originalSetTimeout(callback, 0, ...args)) as typeof setTimeout;
       try {
         await claudeProxyTestHooks.executeClaudeFallbackWithRetry({
+          // Injected rather than reached by patching `globalThis.setTimeout`
+          // to fire every timer at 0ms, which is how this case used to force
+          // the timeout path. That patch stayed installed across an await
+          // inside a 280-case suite sharing one process, so it rewrote the
+          // delay of every timer created in that window — including ones
+          // belonging to other cases' pending work. The hazard is not
+          // theoretical: an attempt to measure this very case with its own
+          // setTimeout-based watchdog had the watchdog rewritten by the patch
+          // and reported an instant false hang, twice, before the instrument
+          // was blamed instead of the code.
+          idleTimeoutMs: 1,
           ctx: {
             neurolink: {
               stream: async (options: { abortSignal?: AbortSignal }) => {
@@ -10006,8 +10016,6 @@ exit 127
           abortSignals.length === 1 &&
           abortSignals[0]?.aborted === true
         );
-      } finally {
-        globalThis.setTimeout = originalSetTimeout;
       }
     },
   },
@@ -10148,6 +10156,19 @@ exit 127
           env,
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 10_000,
+          // SIGKILL, not the default SIGTERM. spawnSync's `timeout` sends
+          // killSignal and then keeps waiting: a child that ignores SIGTERM is
+          // never killed and spawnSync never returns. Verified directly — a
+          // child with `process.on("SIGTERM",()=>{})` and a live interval hangs
+          // spawnSync past any bound, while killSignal SIGKILL returns at the
+          // timeout with ETIMEDOUT.
+          //
+          // This matters more than an ordinary hygiene fix because spawnSync
+          // blocks the event loop, so the suite's own Promise.race per-case
+          // bound cannot fire while it is stuck. A hung child here is the one
+          // failure mode that defeats the timeout added to protect against
+          // hung cases.
+          killSignal: "SIGKILL" as const,
         },
       );
       const combined = `${r.stdout}${r.stderr}`;
@@ -10181,6 +10202,7 @@ exit 127
           env,
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 10_000,
+          killSignal: "SIGKILL" as const,
         });
       const viaFlag = run(["setup", "--provider", "openai", "--check"]);
       const viaSubcommand = run(["setup", "openai", "--check"]);
@@ -10217,6 +10239,7 @@ exit 127
           env,
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 10_000,
+          killSignal: "SIGKILL" as const,
         },
       );
       const combined = `${r.stdout}${r.stderr}`;
@@ -10257,6 +10280,7 @@ exit 127
           env: { ...process.env, NO_COLOR: "1" },
           stdio: ["ignore", "pipe", "pipe"],
           timeout: 10_000,
+          killSignal: "SIGKILL" as const,
         },
       );
       const combined = `${r.stdout}${r.stderr}`;
@@ -10301,6 +10325,7 @@ exit 127
             env,
             stdio: ["ignore", "pipe", "pipe"],
             timeout: 20_000,
+            killSignal: "SIGKILL" as const,
           },
         );
         const elapsed = Date.now() - start;


### PR DESCRIPTION
## Why

Two cases in `continuous-test-suite-bugfixes` fail on CI runners at a 240s bound while passing everywhere locally, blocking #1487. Different bugs, same consequence: **a case that cannot be bounded.**

## 1. The proxy-fallback case patched a global to force its timeout

It set `globalThis.setTimeout` to fire every timer at 0ms, restoring it in a `finally`. Two problems:

- The patch is live across an `await` inside a **280-case suite sharing one process**, so for that window it rewrites the delay of *every* timer created anywhere — including ones belonging to other cases' pending work.
- If the awaited call never settles, the `finally` never runs and the patch **leaks into the rest of the suite**.

Not theoretical. A peer session trying to measure this case wrote a `setTimeout`-based watchdog around it — and the watchdog was rewritten to 0ms *by the patch it was measuring*, reporting an instant false hang. Twice, at two different bounds, before the instrument was suspected instead of the code.

`executeClaudeFallbackWithRetry` now takes an optional `idleTimeoutMs` (defaulting to `FALLBACK_STREAM_IDLE_TIMEOUT_MS`); the case passes `1`. No global is touched, so the class is gone rather than the instance.

## 2. `spawnSync`'s timeout is not a guarantee — and it defeats #1487 by construction

The second case drives the CLI through `spawnSync` with `timeout: 10_000`. That timeout sends `killSignal` — **SIGTERM by default** — and then keeps waiting. A child that ignores SIGTERM is never killed and `spawnSync` never returns.

Verified directly:

```
child ignores SIGTERM, killSignal default   → spawnSync NEVER returns
                                               (outer 30s kill, exit 124)
same child, killSignal: "SIGKILL"           → returns at 2003ms,
                                               signal SIGKILL, error ETIMEDOUT
```

**This is the one failure mode that defeats #1487's whole approach.** `spawnSync` blocks the event loop, so a `Promise.race` per-case bound *physically cannot fire* while it's stuck — the bound reports only after `spawnSync` returns, and if it never returns, never. All seven timed subprocess calls in this suite now pass `killSignal: "SIGKILL"`.

Worth noting the suite **already asserts production code does this**: the `audioPlayer` case checks `source.includes("killSignal")` so a hung decoder can't block the CLI. The rule existed; the tests weren't following it.

## Proof

The fallback case still catches a real defect — confirmed by removing the abort from the idle-timeout path:

```
abort removed   ✗ proxy fallback: an idle stream is aborted without ambiguous replay
                  Passed 279  Failed 1
restored        ✓ 280 passed, 0 failed  (3 consecutive runs, 58s each)
```

## What this does *not* claim

**The CI hang itself is still unexplained.** Two theories were refuted before this PR: the unpatched path would have waited the real 120s and passed slowly rather than exceeding 240s; and `isRetryableNetworkError` matches on `code`, which a `TimeoutError` doesn't carry, so there's no 2×120s retry path either.

What this removes is the reason those two cases couldn't be bounded or measured honestly when it happens again. If the fallback case hangs after this, the suite bound will actually report it, and any watchdog pointed at it will actually work.

Root cause of the CI failure found and reported by a peer session; the `spawnSync` mechanism is mine.
