### PR TITLE
feat(localUsage): read OpenCode token spend from its SQLite store

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1308,6 +1308,8 @@ console.log(result.content);
 - [LocalUsageAggregateReport](type-aliases/LocalUsageAggregateReport.md)
 - [LocalUsageClaudeRawUsage](type-aliases/LocalUsageClaudeRawUsage.md)
 - [LocalUsageCodexSessionRollup](type-aliases/LocalUsageCodexSessionRollup.md)
+- [LocalUsageSqliteDatabase](type-aliases/LocalUsageSqliteDatabase.md)
+- [LocalUsageSqliteDatabaseCtor](type-aliases/LocalUsageSqliteDatabaseCtor.md)
 - [AgenticLoopChunk](type-aliases/AgenticLoopChunk.md)
 - [AgenticLoopToolCall](type-aliases/AgenticLoopToolCall.md)
 - [AgenticLoopUsage](type-aliases/AgenticLoopUsage.md)

--- a/docs/api/type-aliases/LocalUsageSqliteDatabase.md
+++ b/docs/api/type-aliases/LocalUsageSqliteDatabase.md
@@ -1,0 +1,56 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / LocalUsageSqliteDatabase
+
+# Type Alias: LocalUsageSqliteDatabase
+
+> **LocalUsageSqliteDatabase** = `object`
+
+Defined in: [types/localUsage.ts:194](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L194)
+
+The slice of `node:sqlite`'s `DatabaseSync` the OpenCode reader uses.
+
+Deliberately minimal. `node:sqlite` is still flagged experimental and may
+change shape between Node releases, so the reader validates this much at
+runtime rather than trusting a type assertion — naming only what is actually
+called keeps that check small and honest.
+
+## Properties
+
+### prepare
+
+> **prepare**: (`sql`) => `object`
+
+Defined in: [types/localUsage.ts:195](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L195)
+
+#### Parameters
+
+##### sql
+
+`string`
+
+#### Returns
+
+`object`
+
+##### all
+
+> **all**: () => `unknown`[]
+
+###### Returns
+
+`unknown`[]
+
+---
+
+### close
+
+> **close**: () => `void`
+
+Defined in: [types/localUsage.ts:196](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L196)
+
+#### Returns
+
+`void`

--- a/docs/api/type-aliases/LocalUsageSqliteDatabaseCtor.md
+++ b/docs/api/type-aliases/LocalUsageSqliteDatabaseCtor.md
@@ -1,0 +1,29 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / LocalUsageSqliteDatabaseCtor
+
+# Type Alias: LocalUsageSqliteDatabaseCtor
+
+> **LocalUsageSqliteDatabaseCtor** = (`path`, `options?`) => [`LocalUsageSqliteDatabase`](LocalUsageSqliteDatabase.md)
+
+Defined in: [types/localUsage.ts:200](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L200)
+
+Constructor shape for the same.
+
+## Parameters
+
+### path
+
+`string`
+
+### options?
+
+#### readOnly?
+
+`boolean`
+
+## Returns
+
+[`LocalUsageSqliteDatabase`](LocalUsageSqliteDatabase.md)

--- a/src/lib/localUsage/localUsageReaderRegistry.ts
+++ b/src/lib/localUsage/localUsageReaderRegistry.ts
@@ -74,3 +74,18 @@ registerLocalUsageReader({
     return createCodexReader();
   },
 });
+
+registerLocalUsageReader({
+  descriptor: {
+    id: "opencode",
+    displayName: "OpenCode",
+    verified: true,
+    dedupStrategy: "rowid-high-water-mark",
+    costConfidence: "unavailable",
+    requiresSqlite: true,
+  },
+  factory: async () => {
+    const { createOpenCodeReader } = await import("./openCodeReader.js");
+    return createOpenCodeReader();
+  },
+});

--- a/src/lib/localUsage/openCodeReader.ts
+++ b/src/lib/localUsage/openCodeReader.ts
@@ -1,0 +1,235 @@
+/**
+ * Reads token usage out of OpenCode's local SQLite store.
+ *
+ * Store: `~/.local/share/opencode/opencode.db` (NOT `~/.config/opencode`,
+ * which holds only configuration). Usage lives on the `message` table, whose
+ * `data` column is a JSON blob carrying `role`, `modelID`, `providerID`,
+ * `cost` and a `tokens` object.
+ *
+ * Two things the real data settled, both of which would corrupt totals
+ * silently if assumed instead of checked.
+ *
+ * **Cache is DISJOINT from input here.** Measured across all 4,674
+ * usage-bearing messages on a reference machine, `total` equals
+ * `input + output + cache.read + cache.write` — never `input + output` alone
+ * unless cache happened to be zero. This is the opposite of Codex, where
+ * `cached_input_tokens` is a SUBSET of `input_tokens` and has to be subtracted
+ * back out. Three readers now, three conventions; none of them is safe to
+ * infer from the others.
+ *
+ * **OpenCode's own `cost` field is not usable.** It was 0 in all 4,674
+ * messages, while the provider mix spanned `github-copilot` (a subscription),
+ * `openai` (metered) and `neurolink` (this proxy). A single cost figure for
+ * that mixture would be wrong whichever way it was computed, so tokens are
+ * reported and cost is declared `unavailable` rather than invented or
+ * quietly zeroed.
+ *
+ * Worth knowing for anyone summing sources: traffic OpenCode sent through the
+ * NeuroLink proxy appears under `providerID: "neurolink"` here AND in the
+ * proxy's own ledger. The two are independent measurements of the same
+ * requests, not additive. On the reference machine that was 41 messages and
+ * ~772k tokens against 458M total, so it is small — but it is not zero, and a
+ * dashboard adding local usage to proxy usage double-counts exactly that
+ * slice.
+ */
+
+import { stat } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import type {
+  LocalUsageReader,
+  LocalUsageSqliteDatabase,
+  LocalUsageSqliteDatabaseCtor,
+  LocalUsageScanError,
+  LocalUsageScanOptions,
+  LocalUsageScanResult,
+  LocalUsageTotals,
+} from "../types/index.js";
+
+const CLI_ID = "opencode" as const;
+const DEFAULT_SINCE_DAYS = 30;
+
+function databasePath(): string {
+  return join(homedir(), ".local", "share", "opencode", "opencode.db");
+}
+
+function emptyTotals(): LocalUsageTotals {
+  return {
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    costConfidence: "unavailable",
+    unpricedRequests: 0,
+    unpricedModels: [],
+  };
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export async function createOpenCodeReader(): Promise<LocalUsageReader> {
+  return {
+    descriptor: {
+      id: CLI_ID,
+      displayName: "OpenCode",
+      verified: true,
+      dedupStrategy: "rowid-high-water-mark",
+      costConfidence: "unavailable",
+      requiresSqlite: true,
+    },
+
+    detect: async () => {
+      try {
+        const info = await stat(databasePath());
+        return info.isFile();
+      } catch {
+        return false;
+      }
+    },
+
+    scan: async (
+      options?: LocalUsageScanOptions,
+    ): Promise<LocalUsageScanResult> => {
+      const totals = emptyTotals();
+      const errors: LocalUsageScanError[] = [];
+      const models = new Set<string>();
+      const dbPath = databasePath();
+
+      // `node:sqlite` is built in from Node 22 but still flagged experimental,
+      // so it can be absent or change shape. Imported lazily and behind a
+      // try/catch: a runtime without it must degrade to a reported failure for
+      // this one reader, not take down a scan of all the others.
+      let DatabaseSync: LocalUsageSqliteDatabaseCtor | undefined;
+      try {
+        const sqlite: unknown = await import("node:sqlite");
+        // Validated, not asserted. The module is experimental and may change
+        // shape between Node releases; a cast would let a changed export sail
+        // through and fail later as an unrelated TypeError deep in the scan.
+        if (
+          typeof sqlite === "object" &&
+          sqlite !== null &&
+          "DatabaseSync" in sqlite &&
+          typeof (sqlite as { DatabaseSync: unknown }).DatabaseSync ===
+            "function"
+        ) {
+          DatabaseSync = (
+            sqlite as { DatabaseSync: LocalUsageSqliteDatabaseCtor }
+          ).DatabaseSync;
+        }
+      } catch (error) {
+        errors.push({
+          cliId: CLI_ID,
+          filePath: dbPath,
+          message: `node:sqlite unavailable on this runtime: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+        return { cliId: CLI_ID, totals, filesScanned: 0, errors };
+      }
+      if (!DatabaseSync) {
+        errors.push({
+          cliId: CLI_ID,
+          filePath: dbPath,
+          message:
+            "node:sqlite did not expose a callable DatabaseSync — the experimental API has likely changed shape",
+        });
+        return { cliId: CLI_ID, totals, filesScanned: 0, errors };
+      }
+
+      const sinceDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      const cutoffMs =
+        Number.isFinite(sinceDays) && sinceDays > 0
+          ? Date.now() - sinceDays * 86_400_000
+          : 0;
+
+      let db: LocalUsageSqliteDatabase | undefined;
+      try {
+        // Read-only: this is the user's live store and OpenCode may be running.
+        db = new DatabaseSync(dbPath, { readOnly: true });
+        // Filtered in SQL rather than in JS. `time_created` is epoch ms, and
+        // the table holds thousands of rows whose `data` blobs are large — the
+        // point of the time window is not reading them at all.
+        const rows = db
+          .prepare(`SELECT data FROM message WHERE time_created >= ${cutoffMs}`)
+          .all() as Array<{ data?: string }>;
+
+        for (const row of rows) {
+          if (typeof row.data !== "string") {
+            continue;
+          }
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(row.data);
+          } catch {
+            continue;
+          }
+          const message = parsed as {
+            role?: string;
+            modelID?: string;
+            tokens?: {
+              input?: number;
+              output?: number;
+              reasoning?: number;
+              cache?: { read?: number; write?: number };
+            };
+          };
+          const tokens = message.tokens;
+          if (!tokens || message.role !== "assistant") {
+            continue;
+          }
+          const input = num(tokens.input);
+          const output = num(tokens.output);
+          const cacheRead = num(tokens.cache?.read);
+          const cacheWrite = num(tokens.cache?.write);
+          if (
+            input === 0 &&
+            output === 0 &&
+            cacheRead === 0 &&
+            cacheWrite === 0
+          ) {
+            continue;
+          }
+
+          totals.requests += 1;
+          // Added as-is: cache is disjoint from input in this store. See the
+          // note on this module — Codex is the other way round.
+          totals.inputTokens += input;
+          totals.outputTokens += output;
+          totals.cacheReadTokens += cacheRead;
+          totals.cacheCreationTokens += cacheWrite;
+          if (message.modelID) {
+            models.add(message.modelID);
+          }
+        }
+      } catch (error) {
+        errors.push({
+          cliId: CLI_ID,
+          filePath: dbPath,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        try {
+          db?.close();
+        } catch {
+          // Closing a database that failed to open is not a second failure.
+        }
+      }
+
+      // Unpriced by construction rather than by a failed lookup — see the note
+      // on this module about the mixed subscription/metered provider set.
+      totals.unpricedRequests = totals.requests;
+      totals.unpricedModels = [...models].sort();
+
+      return {
+        cliId: CLI_ID,
+        totals,
+        filesScanned: totals.requests > 0 || errors.length === 0 ? 1 : 0,
+        errors,
+      };
+    },
+  };
+}

--- a/src/lib/types/localUsage.ts
+++ b/src/lib/types/localUsage.ts
@@ -182,3 +182,22 @@ export type LocalUsageCodexSessionRollup = {
   /** token_count events where the cumulative total actually advanced. */
   billableEvents: number;
 };
+
+/**
+ * The slice of `node:sqlite`'s `DatabaseSync` the OpenCode reader uses.
+ *
+ * Deliberately minimal. `node:sqlite` is still flagged experimental and may
+ * change shape between Node releases, so the reader validates this much at
+ * runtime rather than trusting a type assertion — naming only what is actually
+ * called keeps that check small and honest.
+ */
+export type LocalUsageSqliteDatabase = {
+  prepare: (sql: string) => { all: () => unknown[] };
+  close: () => void;
+};
+
+/** Constructor shape for the same. */
+export type LocalUsageSqliteDatabaseCtor = new (
+  path: string,
+  options?: { readOnly?: boolean },
+) => LocalUsageSqliteDatabase;

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -194,6 +194,61 @@ function codexTurnContext(model: string): string {
   });
 }
 
+/**
+ * Build a temp HOME containing an OpenCode SQLite store.
+ *
+ * Written with the same `node:sqlite` the reader uses, so the fixture cannot
+ * drift from the shape the reader expects by using a different writer.
+ */
+async function writeOpenCodeFixtureHome(
+  messages: Array<Record<string, unknown>>,
+): Promise<string> {
+  const { DatabaseSync } = await import("node:sqlite");
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nl-ocusage-"));
+  const dir = path.join(home, ".local", "share", "opencode");
+  fs.mkdirSync(dir, { recursive: true });
+  const db = new DatabaseSync(path.join(dir, "opencode.db"));
+  db.exec(
+    "CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)",
+  );
+  const insert = db.prepare(
+    "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+  );
+  messages.forEach((m, index) => {
+    insert.run(
+      `msg_${index}`,
+      "ses_fixture",
+      Date.now(),
+      Date.now(),
+      JSON.stringify(m),
+    );
+  });
+  db.close();
+  return home;
+}
+
+function openCodeMessage(tokens: {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}): Record<string, unknown> {
+  return {
+    role: "assistant",
+    modelID: "claude-opus-4.6",
+    providerID: "github-copilot",
+    cost: 0,
+    tokens: {
+      input: tokens.input,
+      output: tokens.output,
+      reasoning: 0,
+      total:
+        tokens.input + tokens.output + tokens.cacheRead + tokens.cacheWrite,
+      cache: { read: tokens.cacheRead, write: tokens.cacheWrite },
+    },
+  };
+}
+
 async function runAllTests(): Promise<void> {
   await test("the SDK exports the local-usage surface", async () => {
     assert(
@@ -650,6 +705,117 @@ async function runAllTests(): Promise<void> {
     );
     log(
       `real Codex scan: ${month.totals.requests} turns over ${month.filesScanned} rollouts in 30d`,
+      "green",
+    );
+  });
+
+  await test("OpenCode: cache tokens are disjoint from input, not subtracted", async () => {
+    // The convention differs per CLI and cannot be inferred from a sibling
+    // reader. Verified across all 4,674 usage-bearing messages on a real
+    // store: `total` equals input + output + cache.read + cache.write, so
+    // cache is DISJOINT from input here. Codex is the opposite — its
+    // `cached_input_tokens` is a SUBSET of `input_tokens` and the reader
+    // subtracts it back out.
+    //
+    // This fixture is built so applying Codex's rule here is visible:
+    // subtracting cache from input would report 700 input instead of 1000.
+    const home = await writeOpenCodeFixtureHome([
+      openCodeMessage({
+        input: 1000,
+        output: 200,
+        cacheRead: 300,
+        cacheWrite: 50,
+      }),
+    ]);
+
+    const report = await withHome(home, () =>
+      readAllLocalUsage({ sinceDays: Infinity }),
+    );
+    const totals = report.totals["opencode"];
+    assert(totals !== undefined, "the opencode reader produced no totals");
+    assert(
+      totals!.inputTokens === 1000,
+      `cache was subtracted from input as if this were Codex — expected 1000, got ${totals!.inputTokens}`,
+    );
+    assert(
+      totals!.cacheReadTokens === 300 && totals!.cacheCreationTokens === 50,
+      `cache read/write were not carried through — expected 300/50, got ${totals!.cacheReadTokens}/${totals!.cacheCreationTokens}`,
+    );
+    assert(
+      totals!.outputTokens === 200,
+      `output tokens were altered — expected 200, got ${totals!.outputTokens}`,
+    );
+    log(
+      "OpenCode cache tokens are added alongside input, not subtracted from it",
+      "green",
+    );
+  });
+
+  await test("OpenCode: assistant rows with no tokens are not counted as turns", async () => {
+    // 56 of 4,674 rows on a real store are assistant messages whose token
+    // fields are all zero. Counting them inflates the turn count while
+    // adding nothing, which makes an average-tokens-per-turn figure wrong
+    // without making any total wrong — the kind of error that survives a
+    // glance at the headline number.
+    const home = await writeOpenCodeFixtureHome([
+      openCodeMessage({ input: 10, output: 5, cacheRead: 0, cacheWrite: 0 }),
+      openCodeMessage({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }),
+      { role: "user", modelID: "claude-opus-4.6", tokens: { input: 999 } },
+    ]);
+
+    const report = await withHome(home, () =>
+      readAllLocalUsage({ sinceDays: Infinity }),
+    );
+    const totals = report.totals["opencode"];
+    assert(totals !== undefined, "the opencode reader produced no totals");
+    assert(
+      totals!.requests === 1,
+      `empty or non-assistant rows were counted as turns — expected 1, got ${totals!.requests}`,
+    );
+    assert(
+      totals!.inputTokens === 10,
+      `a non-assistant row's tokens were counted — expected 10, got ${totals!.inputTokens}`,
+    );
+    log("empty and non-assistant OpenCode rows are skipped", "green");
+  });
+
+  await test("OpenCode: this machine's real store scans coherently", async () => {
+    const realDb = path.join(
+      os.homedir(),
+      ".local",
+      "share",
+      "opencode",
+      "opencode.db",
+    );
+    if (!fs.existsSync(realDb)) {
+      throw new Error("SKIP: no OpenCode store on this machine");
+    }
+    const reader = await createLocalUsageReader("opencode");
+    assert(await reader.detect(), "detect() denied a store that exists");
+
+    const all = await reader.scan({ sinceDays: Infinity });
+    if (all.totals.requests === 0) {
+      throw new Error("SKIP: OpenCode store has no usage-bearing messages");
+    }
+
+    assert(
+      all.errors.length === 0,
+      "reading the real OpenCode store reported an error",
+    );
+    assert(
+      all.totals.costConfidence === "unavailable" && all.totals.costUsd === 0,
+      "OpenCode invented a cost despite reporting none of its own",
+    );
+    assert(
+      all.totals.unpricedRequests === all.totals.requests,
+      "not every OpenCode turn was reported as unpriced",
+    );
+    assert(
+      all.totals.unpricedModels.length > 0,
+      "no models were named behind the unpriced turns",
+    );
+    log(
+      `real OpenCode scan: ${all.totals.requests} turns, models ${all.totals.unpricedModels.slice(0, 3).join(", ")}`,
       "green",
     );
   });


### PR DESCRIPTION
## What this is

Third reader in the observability lane, and the first needing SQLite. Store is `~/.local/share/opencode/opencode.db` — **not** `~/.config/opencode`, which holds only configuration — with usage on the `message` table's JSON `data` column.

## Two things the real data settled

**Cache is DISJOINT from input here.** Across all 4,674 usage-bearing messages, `total` equals `input + output + cache.read + cache.write`. The 353 rows where `input + output` alone reproduced it were simply the ones with no cache.

Codex is the **opposite** — its `cached_input_tokens` is a *subset* of `input_tokens` and that reader subtracts it back out. Three readers now, three conventions, and none is safe to guess from the others. Getting this wrong doesn't error; it just quietly reports the wrong number.

**OpenCode's own `cost` field is not usable.** It was `0` in all 4,674 messages, while the provider mix spanned `github-copilot` (subscription), `openai` (metered) and `neurolink` (this proxy). One cost figure for that mixture is wrong whichever way it's computed — so tokens are reported and cost is declared `"unavailable"`, with every turn under `unpricedRequests` and its model named.

**56 of the 4,674 rows are assistant messages with all-zero tokens.** Skipped: counting them inflates the turn count without changing any total, which makes tokens-per-turn wrong while every headline figure still looks right.

## `node:sqlite` is experimental — handled, not assumed

Built in from Node 22 but still flagged experimental, so it can be absent or change shape. Imported lazily inside the reader, opened **read-only** (OpenCode may be running against the same file), and its export is **validated at runtime rather than cast** — a double assertion would let a changed export sail through and fail later as an unrelated `TypeError` deep in the scan. A runtime without it degrades to a reported failure for this one reader instead of taking down a scan of all the others.

## A double-counting hazard worth knowing

Traffic OpenCode sent through the NeuroLink proxy appears under `providerID: "neurolink"` here **and** in the proxy's own ledger. Those are independent measurements of the same requests, not additive. On this machine that's 41 messages / ~772k tokens against 458M total — small, but not zero, and a dashboard adding the two double-counts exactly that slice. It's recorded on the module rather than left for someone to rediscover from a total that's slightly too large.

## Proof

**Cross-validated, not merely tested.** The reader's full-history total reproduces an independent SQL sum of the same store exactly:

```
311,467,935 (github-copilot) + 146,422,531 (openai) + 771,884 (neurolink)
= 458,662,350   ← reader reports the same
4,674 token-bearing rows − 56 all-zero = 4,618 turns   ← reader reports 4,618
```

Three cases added. The first is built so applying Codex's rule here is *visible* — 1000 input against 300 cache-read — and was confirmed by implementing that rule:

```
Codex's rule applied   ✗ cache was subtracted from input as if this were
                         Codex — expected 1000, got 700
correct                ✓ 15 passed
```

## Gates

```
tsc --noEmit       0 errors
pnpm run lint      0 errors (56 pre-existing warnings)
test:local-usage   15 passed, 0 failed
```
