### PR TITLE
fix(localUsage): treat a non-positive scan window as empty, not unbounded

### DIFF
--- a/docs/api/type-aliases/LocalUsageAggregateReport.md
+++ b/docs/api/type-aliases/LocalUsageAggregateReport.md
@@ -38,7 +38,7 @@ Only CLIs whose store was detected AND scanned appear here.
 
 Defined in: [types/localUsage.ts:154](https://github.com/juspay/neurolink/blob/release/src/lib/types/localUsage.ts#L154)
 
-CLIs that were registered but produced nothing, and why.
+CLIs whose reader could not be created, detected, or scanned, and why.
 
 ---
 

--- a/docs/api/type-aliases/LocalUsageSqliteDatabase.md
+++ b/docs/api/type-aliases/LocalUsageSqliteDatabase.md
@@ -37,7 +37,13 @@ Defined in: [types/localUsage.ts:195](https://github.com/juspay/neurolink/blob/r
 
 ##### all
 
-> **all**: () => `unknown`[]
+> **all**: (...`params`) => `unknown`[]
+
+###### Parameters
+
+###### params
+
+...`unknown`[]
 
 ###### Returns
 

--- a/src/lib/localUsage/claudeCodeReader.ts
+++ b/src/lib/localUsage/claudeCodeReader.ts
@@ -219,11 +219,23 @@ export async function createClaudeCodeReader(): Promise<LocalUsageReader> {
       const files: string[] = [];
       await collectTranscripts(projectsRoot(), files);
 
-      const sinceDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      // Only Infinity means "no time filter". A non-positive sinceDays used to
+      // leave the cutoff undefined and read EVERYTHING — measured at 17,534
+      // files and 35.9s for `sinceDays: 0`, which is the widest possible scan
+      // in answer to the narrowest possible request. Zero now means a
+      // zero-length window, which is what it reads as.
+      // NaN is not a window, and it is the case the previous fix missed:
+      // Math.max(0, NaN) is NaN, every comparison against NaN is false, so the
+      // filter passes EVERY file. Measured: sinceDays NaN read 17,537 files in
+      // 32.8s — the same unbounded sweep this guard exists to prevent, reached
+      // by a different door. The old guard caught it with Number.isFinite and
+      // the replacement dropped that check.
+      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
       const cutoff =
-        Number.isFinite(sinceDays) && sinceDays > 0
-          ? Date.now() - sinceDays * 86_400_000
-          : undefined;
+        sinceDays === Infinity
+          ? undefined
+          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
 
       let filesScanned = 0;
       for (const file of files) {

--- a/src/lib/localUsage/codexReader.ts
+++ b/src/lib/localUsage/codexReader.ts
@@ -198,11 +198,23 @@ export async function createCodexReader(): Promise<LocalUsageReader> {
       const files: string[] = [];
       await collectRollouts(sessionsRoot(), files);
 
-      const sinceDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      // Only Infinity means "no time filter". A non-positive sinceDays used to
+      // leave the cutoff undefined and read EVERYTHING — measured at 17,534
+      // files and 35.9s for `sinceDays: 0`, which is the widest possible scan
+      // in answer to the narrowest possible request. Zero now means a
+      // zero-length window, which is what it reads as.
+      // NaN is not a window, and it is the case the previous fix missed:
+      // Math.max(0, NaN) is NaN, every comparison against NaN is false, so the
+      // filter passes EVERY file. Measured: sinceDays NaN read 17,537 files in
+      // 32.8s — the same unbounded sweep this guard exists to prevent, reached
+      // by a different door. The old guard caught it with Number.isFinite and
+      // the replacement dropped that check.
+      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
       const cutoff =
-        Number.isFinite(sinceDays) && sinceDays > 0
-          ? Date.now() - sinceDays * 86_400_000
-          : undefined;
+        sinceDays === Infinity
+          ? undefined
+          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
 
       let filesScanned = 0;
       for (const file of files) {

--- a/src/lib/localUsage/openCodeReader.ts
+++ b/src/lib/localUsage/openCodeReader.ts
@@ -140,11 +140,29 @@ export async function createOpenCodeReader(): Promise<LocalUsageReader> {
         return { cliId: CLI_ID, totals, filesScanned: 0, errors };
       }
 
-      const sinceDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      // Only Infinity means "no time filter". A non-positive sinceDays used to
+      // leave the cutoff undefined and read EVERYTHING — measured at 17,534
+      // files and 35.9s for `sinceDays: 0`, which is the widest possible scan
+      // in answer to the narrowest possible request. Zero now means a
+      // zero-length window, which is what it reads as.
+      // NaN is not a window, and it is the case the previous fix missed:
+      // Math.max(0, NaN) is NaN, every comparison against NaN is false, so the
+      // filter passes EVERY file. Measured: sinceDays NaN read 17,537 files in
+      // 32.8s — the same unbounded sweep this guard exists to prevent, reached
+      // by a different door. The old guard caught it with Number.isFinite and
+      // the replacement dropped that check.
+      //
+      // On this reader NaN was worse than an unbounded scan: the value went
+      // into the SQL text, and SQLite parses a bare NaN as an identifier —
+      // "no such column: NaN" — so the whole scan failed rather than
+      // over-reading. The cutoff is a bound parameter now, so a value can
+      // never be SQL syntax whatever it is.
+      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
+      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
       const cutoffMs =
-        Number.isFinite(sinceDays) && sinceDays > 0
-          ? Date.now() - sinceDays * 86_400_000
-          : 0;
+        sinceDays === Infinity
+          ? 0
+          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
 
       let db: LocalUsageSqliteDatabase | undefined;
       try {
@@ -153,9 +171,13 @@ export async function createOpenCodeReader(): Promise<LocalUsageReader> {
         // Filtered in SQL rather than in JS. `time_created` is epoch ms, and
         // the table holds thousands of rows whose `data` blobs are large — the
         // point of the time window is not reading them at all.
+        // Bound parameter, not interpolation. A number spliced into SQL text
+        // is still SQL text: NaN parsed as an identifier and failed the whole
+        // scan with "no such column: NaN". A bound value cannot become syntax
+        // whatever it holds.
         const rows = db
-          .prepare(`SELECT data FROM message WHERE time_created >= ${cutoffMs}`)
-          .all() as Array<{ data?: string }>;
+          .prepare("SELECT data FROM message WHERE time_created >= ?")
+          .all(cutoffMs) as Array<{ data?: string }>;
 
         for (const row of rows) {
           if (typeof row.data !== "string") {

--- a/src/lib/types/localUsage.ts
+++ b/src/lib/types/localUsage.ts
@@ -150,7 +150,7 @@ export type LocalUsageAggregateReport = {
   generatedAt: string;
   /** Only CLIs whose store was detected AND scanned appear here. */
   totals: Partial<Record<LocalUsageCliId, LocalUsageTotals>>;
-  /** CLIs that were registered but produced nothing, and why. */
+  /** CLIs whose reader could not be created, detected, or scanned, and why. */
   failures: LocalUsageReaderFailure[];
   /** CLIs with no local store on this machine — absent, not failed. */
   notInstalled: LocalUsageCliId[];
@@ -192,7 +192,7 @@ export type LocalUsageCodexSessionRollup = {
  * called keeps that check small and honest.
  */
 export type LocalUsageSqliteDatabase = {
-  prepare: (sql: string) => { all: () => unknown[] };
+  prepare: (sql: string) => { all: (...params: unknown[]) => unknown[] };
   close: () => void;
 };
 

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -993,6 +993,68 @@ async function runAllTests(): Promise<void> {
     );
   });
 
+  await test("a non-positive sinceDays is an empty window, not a full sweep", async () => {
+    // The guard used to be `sinceDays > 0`, which left the cutoff undefined
+    // for 0 and for negatives and read every transcript on the machine.
+    // Measured on release before the fix: sinceDays 0 scanned 17,534 files in
+    // 35.9s — the widest possible scan in answer to the narrowest possible
+    // request, and on a 9.7 GB store that is not a harmless surprise.
+    //
+    // Infinity is the only full-sweep signal now. The CLI's `--since 0`
+    // still means all history, because the command translates it to Infinity
+    // before it reaches a reader — that is a CLI convention, not a reader
+    // one, and the two no longer have to agree by accident.
+    const home = writeFixtureHome([
+      assistantLine("msg_W", "claude-sonnet-4-5", {
+        input_tokens: 5,
+        output_tokens: 9,
+      }),
+    ]);
+    try {
+      const [zero, negative, notANumber, negInfinite, infinite] =
+        await withHome(home, async () => [
+          await readAllLocalUsage({ sinceDays: 0 }),
+          await readAllLocalUsage({ sinceDays: -5 }),
+          // NaN is the case the first version of this fix missed:
+          // Math.max(0, NaN) is NaN and every comparison against NaN is false,
+          // so the filter passed every file — 17,537 of them, measured. The
+          // guard it replaced caught this with Number.isFinite.
+          await readAllLocalUsage({ sinceDays: NaN }),
+          await readAllLocalUsage({ sinceDays: -Infinity }),
+          await readAllLocalUsage({ sinceDays: Infinity }),
+        ]);
+
+      assert(
+        (zero.totals["claude-code"]?.requests ?? 0) === 0,
+        `sinceDays 0 read transcripts — got ${zero.totals["claude-code"]?.requests} turns instead of 0`,
+      );
+      assert(
+        (negative.totals["claude-code"]?.requests ?? 0) === 0,
+        `a negative sinceDays read transcripts — got ${negative.totals["claude-code"]?.requests} turns instead of 0`,
+      );
+      assert(
+        (notANumber.totals["claude-code"]?.requests ?? 0) === 0,
+        "a NaN sinceDays read transcripts instead of nothing",
+      );
+      assert(
+        (negInfinite.totals["claude-code"]?.requests ?? 0) === 0,
+        "a -Infinity sinceDays read transcripts instead of nothing",
+      );
+      // The control: without this, a reader that simply returned nothing for
+      // every window would pass every assertion above.
+      assert(
+        (infinite.totals["claude-code"]?.requests ?? 0) === 1,
+        `Infinity stopped being a full sweep — expected 1 turn, got ${infinite.totals["claude-code"]?.requests}`,
+      );
+      log(
+        "a non-positive window reads nothing; Infinity still reads everything",
+        "green",
+      );
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   await test("repeated scans of the same data agree", async () => {
     // The reader keeps a per-file dedup map. If any of it leaked across calls,
     // a second scan of identical input would drift.


### PR DESCRIPTION
## The bug

`readAllLocalUsage({ sinceDays: 0 })` read **every transcript on the machine**. Measured on release:

```
sinceDays: 0   ->  17,534 files, 35.9s
```

That's the widest possible scan in answer to the narrowest possible request, against a store that is 9.7 GB here. A negative value did the same.

The guard was `Number.isFinite(sinceDays) && sinceDays > 0`, which leaves the cutoff `undefined` for anything non-positive — disabling the filter entirely. The intent was that `Infinity` means "no filter"; `0` fell through the same door by accident.

## The fix

`Infinity` is now the only full-sweep signal, and the window is clamped at zero. Applied to all three readers, which shared the expression.

```
sinceDays: 0          ->  0 files,      1.9s
sinceDays: -5         ->  0 files,      0.5s
sinceDays: Infinity   ->  17,537 files  (full sweep intact)
```

**The CLI is unaffected and stays as documented.** `neurolink usage local --since 0` still means all history, because the command translates `0` to `Infinity` before it reaches a reader. That's a CLI convention rather than a reader one, and the two no longer have to agree by coincidence.

## Also here

`LocalUsageAggregateReport.failures` was documented as "CLIs that were registered but produced nothing". A failure is specifically a reader that could not be created, detected, or scanned — an absent store is reported under `notInstalled`. Conflating them misleads a caller about which of the two they're looking at.

## Proof

The new case asserts both directions. **Without the `Infinity` control, a reader that returned nothing for every window would satisfy the zero and negative assertions** — so the control is what makes the test mean anything.

Confirmed by restoring the old guard:

```
old guard   ✗ sinceDays 0 read transcripts — got 1 turns instead of 0
fixed       ✓ 16 passed
```

## Gates

```
tsc --noEmit       0 errors
pnpm run lint      0 errors
test:local-usage   16 passed, 0 failed
```

Found by CodeRabbit on #1482 after that PR had merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restricting local usage scans to a selected CLI.
  * Added validation for empty or unknown CLI filters and JSON output.

* **Bug Fixes**
  * Corrected local usage scanning for zero, negative, invalid, and infinite time-window values.
  * Applied consistent time-window behavior across supported local usage sources.

* **Documentation**
  * Clarified that usage report failures include readers that could not be created, detected, or scanned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->