### PR TITLE
fix(scripts): bound the git and scanner subprocesses that gate CI and commits

### DIFF
--- a/scripts/build-validations.ts
+++ b/scripts/build-validations.ts
@@ -18,6 +18,9 @@ import ts from "typescript";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/** Ceiling for the security-check subprocess. See the note at its call site. */
+const SECURITY_SCAN_TIMEOUT_MS = 300_000;
+
 class NeuroLinkBuildValidator {
   errors: string[];
   warnings: string[];
@@ -138,6 +141,32 @@ class NeuroLinkBuildValidator {
         cwd: this.rootDir,
         encoding: "utf8",
         stdio: "pipe",
+        // This runs inside `validate:all`, which CI's `test` job gates on, and
+        // the child shells out to external scanners (gitleaks, ripgrep). With
+        // no bound, one wedged scanner hangs the job to its own limit with
+        // stdio piped, so nothing is printed while it hangs.
+        //
+        // 300s against a measured 3s locally: deliberately far above a normal
+        // run, because a cold CI runner fetching gitleaks and walking full git
+        // history is legitimately slower, and it must also stay above the
+        // per-scanner bounds inside security-check.ts so a healthy child is
+        // never killed by its parent.
+        //
+        // SIGKILL because a timeout otherwise sends SIGTERM and keeps waiting.
+        //
+        // WHAT THIS DOES NOT DO: the signal goes to the shell this spawns, not
+        // to the tree beneath it — npx, tsx, node, and whatever scanner that
+        // node process has running. Those are not in this process group and can
+        // outlive the kill as orphans. So this bound guarantees that THIS
+        // validator returns; it does not guarantee the machine is idle
+        // afterwards.
+        //
+        // Bounding the descendants is the child's own job, and security-check.ts
+        // does it at the point where the scanners are actually spawned, which is
+        // the only place their pids are known. Treat this as the outer of two
+        // independent bounds rather than as complete cleanup on its own.
+        timeout: SECURITY_SCAN_TIMEOUT_MS,
+        killSignal: "SIGKILL",
       });
 
       // Parse security check results for critical secrets
@@ -166,13 +195,35 @@ class NeuroLinkBuildValidator {
       }
     } catch (error: unknown) {
       // Security validation failed - this is critical for build validation
-      const execError = error as { status?: number; message?: string };
+      const execError = error as {
+        status?: number;
+        message?: string;
+        code?: string;
+        signal?: string;
+      };
+      const timedOut =
+        execError.code === "ETIMEDOUT" || execError.signal === "SIGKILL";
       if (execError.status === 1) {
         this.errors.push(
           "Security validation failed - critical issues detected",
         );
         this.errors.push(
           "   Fix security issues before building: pnpm run validate:security",
+        );
+      } else if (timedOut) {
+        // An ERROR, not a warning, and the distinction is the whole point of
+        // the bound above. Only `errors` fail this validator; `warnings` print
+        // and the build proceeds. A killed scan reports no findings, so
+        // classifying it as a warning would mean adding the timeout had
+        // converted a hung security gate into a passing one — the same trap
+        // the gitleaks path inside security-check.ts had to be fixed for.
+        //
+        // A scan that did not finish is not a scan that found nothing.
+        this.errors.push(
+          `Security validation exceeded ${SECURITY_SCAN_TIMEOUT_MS / 1000}s and was killed - the scan did not complete, so its result cannot be trusted`,
+        );
+        this.errors.push(
+          "   Investigate with: pnpm run validate:security",
         );
       } else {
         this.warnings.push(

--- a/scripts/commit-validation.ts
+++ b/scripts/commit-validation.ts
@@ -54,6 +54,20 @@ const SEMANTIC_TYPES = [
  */
 const SEMANTIC_COMMIT_PATTERN = /^([a-z]+)(\([a-zA-Z0-9\-\/]+\)):\s(.+)$/i;
 
+/**
+ * Ceiling for the local git queries below.
+ *
+ * This script runs from a husky hook on every commit AND in two workflows, so
+ * an unbounded git call blocks committing entirely and stalls the Single Commit
+ * Policy check with it. `execSync` blocks the event loop, so the symptom is a
+ * frozen terminal with no output rather than a slow one. Ten seconds matches
+ * the bound already used for the same purpose in scripts/security-check.ts.
+ *
+ * Both call sites already sit in a try/catch that reports "Unable to retrieve
+ * commit message", so a timeout surfaces as that rather than as a crash.
+ */
+const GIT_TIMEOUT_MS = 10_000;
+
 class CommitValidator {
   errors: string[];
   warnings: string[];
@@ -99,6 +113,8 @@ class CommitValidator {
       // Try to get from git commit message file
       const gitDir = execSync("git rev-parse --git-dir", {
         encoding: "utf8",
+        timeout: GIT_TIMEOUT_MS,
+        killSignal: "SIGKILL",
       }).trim();
       const commitMsgFile = path.join(gitDir, "COMMIT_EDITMSG");
 
@@ -111,6 +127,8 @@ class CommitValidator {
       // Try to get the last commit message
       const lastCommit = execSync('git log -1 --pretty=format:"%s"', {
         encoding: "utf8",
+        timeout: GIT_TIMEOUT_MS,
+        killSignal: "SIGKILL",
       });
       return lastCommit.trim();
     } catch (_error: unknown) {


### PR DESCRIPTION
## What

Three unbounded `execSync` calls, in the two scripts that gate the build and every commit:

| File | Calls | Gates |
|---|---|---|
| `scripts/build-validations.ts` | 1 | `validate:all` → CI's `test` job |
| `scripts/commit-validation.ts` | 2 | husky pre-commit + 2 workflows |

## Why

`execSync` blocks the event loop. A wedged child does not make these slow — it freezes them outright, and `stdio: "pipe"` means nothing is printed while it hangs. `commit-validation.ts` runs on **every commit**, so an unbounded git call there blocks committing entirely and stalls the Single Commit Policy check with it.

## The numbers are measured, not guessed

`build-validations.ts` shells out to `security-check.ts`, which itself invokes gitleaks and ripgrep. Timed locally:

```
npx tsx scripts/security-check.ts   ->  exit 0, 3s
```

Bounded at **300s** — deliberately far above that, because a cold CI runner fetching gitleaks and walking full git history is legitimately slower, and because it must stay above the per-scanner bounds so a healthy child is never killed by its parent.

The two git queries in `commit-validation.ts` are bounded at **10s**, matching the bound already used for exactly this purpose by the `git()` helper in `security-check.ts` — an existing in-repo convention rather than a new number.

## `killSignal: "SIGKILL"` on all three

A timeout otherwise sends SIGTERM and keeps waiting, so against a child that ignores SIGTERM the call never returns and the bound buys nothing. Measured directly against a child installing an empty SIGTERM handler:

```
timeout 2s, default SIGTERM      -> never returned
timeout 2s + killSignal SIGKILL  -> returned at 2.0s, ETIMEDOUT
```

## Verification

- `pnpm run validate` → exit 0, 4s, "Ready for build!"
- `pnpm run validate:commit` → exit 0, "COMMIT VALIDATION PASSED!"
- typecheck 4822 files / 0 errors, prettier clean, eslint 0 errors / 56 pre-existing warnings
- Disjoint from #1498 by file — verified with `comm`, no shared paths, so the two can land in either order.

Both call sites in `commit-validation.ts` already sit in a `try/catch` reporting "Unable to retrieve commit message", so a timeout surfaces through that path rather than as a crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent security scans from running indefinitely.
  * Added timeout handling for commit-message retrieval operations.
  * Improved termination of stalled validation processes for more reliable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->