### PR TITLE
fix(test): stop reporting crashed and unwritable-path cases as green

### DIFF
--- a/test/continuous-test-suite-archive-security.ts
+++ b/test/continuous-test-suite-archive-security.ts
@@ -155,14 +155,54 @@ await test("an ordinary archive still reaches the model through stream()", async
 const SAFE_MARKER = "SAFE_SIBLING_ENTRY_CONTENT";
 const SLIP_MARKER = "SECRET_SLIPPED_ENTRY_CONTENT";
 
+/**
+ * A zip-slip entry name paired with the absolute path a naive extractor would
+ * resolve it to.
+ *
+ * The two have to be derived from each other. This suite used to hard-code the
+ * canary at `path.join(dir, "..", <name>)` while the entry itself traversed six
+ * levels up into /tmp, so `!fs.existsSync(outside)` watched a location the
+ * entry never pointed at. It could not have failed even against an extractor
+ * that did write the file.
+ *
+ * The basename is unique per run because /tmp is shared: a canary left behind
+ * by another run would fail this suite for a reason unrelated to the code under
+ * test.
+ */
+function zipSlipCanary(label: string): { entry: string; resolved: string } {
+  const entry = `../../../../../../tmp/juspay-zip-slip-${label}-${process.pid}.txt`;
+  return { entry, resolved: path.resolve(dir, entry) };
+}
+
+/**
+ * Assert the traversal entry was *detected and rejected*, not merely absent.
+ *
+ * Checking that SLIP_MARKER never appears is necessary but not sufficient: it
+ * passes just as happily if the processor stopped reading archive entries at
+ * all, or failed to open that entry by accident. The summary the processor
+ * emits names the traversal as skipped and counts the surviving entries, so
+ * assert on both — that is what distinguishes a deliberate strip from a
+ * coincidence.
+ *
+ * Keep the payload out of these messages: defineSuite downgrades a throw to
+ * SKIP when the text matches isExpectedProviderError().
+ */
+function assertTraversalRejected(body: string): void {
+  assert(
+    /Path traversal detected/.test(body) && /entry skipped/.test(body),
+    "the processor did not report the path-traversal entry as detected and skipped",
+  );
+  assert(
+    /Total entries:\**\s*1\b/.test(body),
+    "the archive summary counted more than the one safe entry",
+  );
+}
+
 await test("a zip-slip entry is stripped before the request leaves — generate()", async () => {
-  const outside = path.join(dir, "..", "juspay-zip-slip-canary.txt");
+  const canary = zipSlipCanary("generate");
   const fixture = writeZipSlipZip(path.join(dir, "zip-slip-generate.zip"), [
     { name: "readme.txt", content: SAFE_MARKER },
-    {
-      name: "../../../../../../tmp/juspay-zip-slip-canary.txt",
-      content: SLIP_MARKER,
-    },
+    { name: canary.entry, content: SLIP_MARKER },
   ]);
   const server = await startMockChatServer();
   try {
@@ -186,14 +226,20 @@ await test("a zip-slip entry is stripped before the request leaves — generate(
       !body.includes(SLIP_MARKER),
       "the path-traversal entry's content must never reach the outbound request body",
     );
+    assertTraversalRejected(body);
+    // Forward guard, not live coverage. ArchiveProcessor parses entries in
+    // memory and makes no fs writes at all today, so this cannot fail against
+    // the current implementation; it is here for the day an on-disk extraction
+    // path is added. Watching the path the entry actually resolves to is what
+    // makes it worth keeping.
     assert(
-      !fs.existsSync(outside),
+      !fs.existsSync(canary.resolved),
       "the path-traversal entry must never be written outside the archive's own directory",
     );
   } finally {
     await server.close();
     try {
-      fs.rmSync(outside, { force: true });
+      fs.rmSync(canary.resolved, { force: true });
     } catch {
       /* ignore */
     }
@@ -201,13 +247,10 @@ await test("a zip-slip entry is stripped before the request leaves — generate(
 });
 
 await test("a zip-slip entry is stripped before the request leaves — stream()", async () => {
-  const outside = path.join(dir, "..", "juspay-zip-slip-canary-stream.txt");
+  const canary = zipSlipCanary("stream");
   const fixture = writeZipSlipZip(path.join(dir, "zip-slip-stream.zip"), [
     { name: "readme.txt", content: SAFE_MARKER },
-    {
-      name: "../../../../../../tmp/juspay-zip-slip-canary-stream.txt",
-      content: SLIP_MARKER,
-    },
+    { name: canary.entry, content: SLIP_MARKER },
   ]);
   const server = await startMockChatServer();
   try {
@@ -234,14 +277,20 @@ await test("a zip-slip entry is stripped before the request leaves — stream()"
       !body.includes(SLIP_MARKER),
       "the path-traversal entry's content must never reach the outbound request body",
     );
+    assertTraversalRejected(body);
+    // Forward guard, not live coverage. ArchiveProcessor parses entries in
+    // memory and makes no fs writes at all today, so this cannot fail against
+    // the current implementation; it is here for the day an on-disk extraction
+    // path is added. Watching the path the entry actually resolves to is what
+    // makes it worth keeping.
     assert(
-      !fs.existsSync(outside),
+      !fs.existsSync(canary.resolved),
       "the path-traversal entry must never be written outside the archive's own directory",
     );
   } finally {
     await server.close();
     try {
-      fs.rmSync(outside, { force: true });
+      fs.rmSync(canary.resolved, { force: true });
     } catch {
       /* ignore */
     }

--- a/test/continuous-test-suite.ts
+++ b/test/continuous-test-suite.ts
@@ -3853,24 +3853,40 @@ run();
       );
       return true;
     }
-    // Inner process timed out or crashed without printing anything useful —
-    // treat as SKIP because we cannot distinguish a real schema regression
-    // from a transient resource starvation under heavy concurrent test load.
-    if (result.code === -1 || result.stdout.trim() === "") {
+    // Only a child that left nothing to judge may be skipped.
+    //
+    // `runCommand` reports `code === -1` when the close event carried a signal
+    // instead of an exit code — an outside kill, e.g. the OOM killer under
+    // heavy concurrent load. That carries no verdict, and neither does a child
+    // that died before writing to either stream. Both stay SKIP.
+    //
+    // The old guard also skipped on `stdout === ""` alone. That is how a Node
+    // process normally fails: exit non-zero, stack trace on stderr, nothing on
+    // stdout. Every such crash — including a genuine schema regression — was
+    // reported green. A child that explained itself on stderr is diagnosable,
+    // so it is a failure.
+    //
+    // A timeout never reaches here: `runCommand` rejects on timeout, so it
+    // lands in the catch below and is reported as a FAIL with its own message.
+    const killedBySignal = result.code === -1;
+    const silent = result.stdout.trim() === "" && result.stderr.trim() === "";
+    if (killedBySignal || silent) {
       logTest(
         "Schema Output with 3+ Images (SDK)",
         "SKIP",
-        `inner process produced no output (exit=${result.code}); stderr=${(result.stderr || "").slice(0, 200)}`,
+        killedBySignal
+          ? "inner process was killed by a signal, so it produced no verdict"
+          : `inner process wrote nothing to either stream (exit=${result.code})`,
       );
       return null;
     }
-    const failLine = subprocessFailureDetail(result);
-    const detail =
-      `${failLine} | stderr=${(result.stderr || "").slice(0, 200)}`.slice(
-        0,
-        500,
-      );
-    logTest("Schema Output with 3+ Images (SDK)", "FAIL", detail);
+    // subprocessFailureDetail() already appends the tail of stderr when the
+    // child printed no FAIL line, so do not append it a second time here.
+    logTest(
+      "Schema Output with 3+ Images (SDK)",
+      "FAIL",
+      subprocessFailureDetail(result).slice(0, 500),
+    );
     return false;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## What

Three assertions in the test suite could not report a real failure. All three were raised in review on #1471 / #1428 and merged unaddressed.

### 1. A crashing child was reported as a skip (`continuous-test-suite.ts`)

The SKIP guard in the multi-image schema test fired on:

```ts
if (result.code === -1 || result.stdout.trim() === "") {
```

The second clause describes how a Node process normally fails — exit non-zero, stack trace on stderr, nothing on stdout. Every such crash, **including a genuine schema regression**, was reported as `SKIP` and the run stayed green.

Narrowed to the two cases that really carry no verdict:

| case | before | after |
|---|---|---|
| killed by a signal (`code === -1`) | SKIP | SKIP |
| nothing on stdout **or** stderr | SKIP | SKIP |
| exit non-zero, stack trace on stderr | **SKIP** | **FAIL** |

The old comment also claimed the guard handled timeouts. It does not: `runCommand` *rejects* on timeout, so a timeout lands in the `catch` and is already reported as a FAIL. Comment corrected.

### 2. The FAIL detail printed stderr twice (same function)

`subprocessFailureDetail()` already appends the tail of stderr when the child printed no FAIL line; the caller appended it again under a second label. The helper's other two call sites never did this — they are the model, and this one now matches them.

### 3. The zip-slip canary watched a path nothing targeted (`continuous-test-suite-archive-security.ts`)

Both zip-slip tests asserted on a canary at `path.join(dir, "..", <name>)`, while the malicious entry was named `../../../../../../tmp/<name>`. Those are different locations. The assertion could not have failed **even against an extractor that did write the file**.

The entry name and the resolved path are now derived from each other so they cannot drift, and the basename is unique per run because `/tmp` is shared between runs.

That check still cannot fail against today's code — `ArchiveProcessor` parses in memory and makes no `fs` writes at all — so it is now labelled as the forward guard it is, rather than presented as coverage. **Real coverage is added alongside it:**

```ts
assert(/Path traversal detected/.test(body) && /entry skipped/.test(body), ...);
assert(/Total entries:\**\s*1\b/.test(body), ...);
```

Without these, the existing `!body.includes(SLIP_MARKER)` check passes just as happily if the processor stopped reading archive entries altogether — it proves the content is absent, not that the traversal was *detected and rejected*.

## Verification

Checked what actually reaches the outbound body before writing the assertions. It contains, deliberately:

```
### Security Warnings
- Path traversal detected in entry: "../../../../../../tmp/..." - entry skipped
```

So the entry **name** is in the body on purpose — asserting its absence would have been wrong. That is why the assertions target the warning and the entry count instead.

Per the CLAUDE.md guidance on SKIP-vs-FAIL, the new assertion was broken on purpose to confirm it fails loudly rather than being downgraded:

```
✗ a zip-slip entry is stripped before the request leaves — generate()
✗ a zip-slip entry is stripped before the request leaves — stream()
Passed: 4   Failed: 2   RESULT: FAIL
```

Restored, the suite is 6/6.

- `pnpm run check` — 4824 files, 0 errors
- `pnpm run check:tools-tests` — clean
- `pnpm run lint` — 0 errors
- `pnpm run test:archive:security` — 6 passed (this runs on every PR under `security-suites`, no credentials needed)

## Scope

Two test files. No `src/` change, no public API change.
