### PR TITLE
fix(rag): await registration before reading factory metadata

### DIFF
--- a/docs/api/functions/createChunker.md
+++ b/docs/api/functions/createChunker.md
@@ -8,7 +8,7 @@
 
 > **createChunker**(`strategyOrAlias`, `config?`): `Promise`\<[`Chunker`](../type-aliases/Chunker.md)\>
 
-Defined in: [rag/ChunkerFactory.ts:411](https://github.com/juspay/neurolink/blob/release/src/lib/rag/ChunkerFactory.ts#L411)
+Defined in: [rag/ChunkerFactory.ts:430](https://github.com/juspay/neurolink/blob/release/src/lib/rag/ChunkerFactory.ts#L430)
 
 Convenience function to create a chunker
 

--- a/src/lib/rag/ChunkerFactory.ts
+++ b/src/lib/rag/ChunkerFactory.ts
@@ -326,9 +326,22 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
   }
 
   /**
-   * Get metadata for a chunker
+   * Get metadata for a chunker.
+   *
+   * Awaits registration first. `metadataMap` and the alias map are populated by
+   * `registerAll()`, which only runs via the async `ensureInitialized()` — and
+   * the only place that awaited it was `create()`. So on a fresh process this
+   * returned `undefined` for every strategy until something happened to build a
+   * chunker first, and returned real metadata after. Order-dependent, silent,
+   * and `undefined` rather than a throw.
+   *
+   * `createChunker()` and `getAvailableStrategies()` were already async for
+   * exactly this reason; these readers were the ones that had not caught up.
    */
-  getChunkerMetadata(strategyOrAlias: string): ChunkerMetadata | undefined {
+  async getChunkerMetadata(
+    strategyOrAlias: string,
+  ): Promise<ChunkerMetadata | undefined> {
+    await this.ensureInitialized();
     const resolvedName = this.resolveName(strategyOrAlias);
     return this.metadataMap.get(resolvedName);
   }
@@ -336,8 +349,10 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
   /**
    * Get default configuration for a chunker
    */
-  getDefaultConfig(strategyOrAlias: string): ChunkerConfig | undefined {
-    const metadata = this.getChunkerMetadata(strategyOrAlias);
+  async getDefaultConfig(
+    strategyOrAlias: string,
+  ): Promise<ChunkerConfig | undefined> {
+    const metadata = await this.getChunkerMetadata(strategyOrAlias);
     return metadata?.defaultConfig;
   }
 
@@ -352,14 +367,16 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
   /**
    * Get all aliases mapped to their strategies
    */
-  getStrategyAliases(): Map<string, string> {
+  async getStrategyAliases(): Promise<Map<string, string>> {
+    await this.ensureInitialized();
     return this.getAliases();
   }
 
   /**
    * Check if a strategy exists
    */
-  hasStrategy(strategyOrAlias: string): boolean {
+  async hasStrategy(strategyOrAlias: string): Promise<boolean> {
+    await this.ensureInitialized();
     const resolved = this.resolveName(strategyOrAlias);
     return this.has(resolved);
   }
@@ -367,7 +384,8 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
   /**
    * Get chunkers suitable for a use case
    */
-  getChunkersForUseCase(useCase: string): ChunkingStrategy[] {
+  async getChunkersForUseCase(useCase: string): Promise<ChunkingStrategy[]> {
+    await this.ensureInitialized();
     const matches: ChunkingStrategy[] = [];
     const useCaseLower = useCase.toLowerCase();
 
@@ -387,7 +405,8 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
   /**
    * Get all chunker metadata
    */
-  getAllMetadata(): Map<string, ChunkerMetadata> {
+  async getAllMetadata(): Promise<Map<string, ChunkerMetadata>> {
+    await this.ensureInitialized();
     return new Map(this.metadataMap);
   }
 
@@ -427,7 +446,7 @@ export async function getAvailableStrategies(): Promise<ChunkingStrategy[]> {
  */
 export function getChunkerMetadata(
   strategyOrAlias: string,
-): ChunkerMetadata | undefined {
+): Promise<ChunkerMetadata | undefined> {
   return chunkerFactory.getChunkerMetadata(strategyOrAlias);
 }
 
@@ -436,6 +455,6 @@ export function getChunkerMetadata(
  */
 export function getDefaultConfig(
   strategyOrAlias: string,
-): ChunkerConfig | undefined {
+): Promise<ChunkerConfig | undefined> {
   return chunkerFactory.getDefaultConfig(strategyOrAlias);
 }

--- a/src/lib/rag/reranker/RerankerFactory.ts
+++ b/src/lib/rag/reranker/RerankerFactory.ts
@@ -441,7 +441,10 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get metadata for a reranker
    */
-  getRerankerMetadata(typeOrAlias: string): RerankerMetadata | undefined {
+  async getRerankerMetadata(
+    typeOrAlias: string,
+  ): Promise<RerankerMetadata | undefined> {
+    await this.ensureInitialized();
     const resolvedName = this.resolveName(typeOrAlias) as RerankerType;
     return this.metadataMap.get(resolvedName);
   }
@@ -449,8 +452,10 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get default configuration for a reranker
    */
-  getDefaultConfig(typeOrAlias: string): Partial<RerankerConfig> | undefined {
-    const metadata = this.getRerankerMetadata(typeOrAlias);
+  async getDefaultConfig(
+    typeOrAlias: string,
+  ): Promise<Partial<RerankerConfig> | undefined> {
+    const metadata = await this.getRerankerMetadata(typeOrAlias);
     return metadata?.defaultConfig;
   }
 
@@ -465,14 +470,16 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get all aliases mapped to their types
    */
-  getTypeAliases(): Map<string, string> {
+  async getTypeAliases(): Promise<Map<string, string>> {
+    await this.ensureInitialized();
     return this.getAliases();
   }
 
   /**
    * Check if a type exists
    */
-  hasType(typeOrAlias: string): boolean {
+  async hasType(typeOrAlias: string): Promise<boolean> {
+    await this.ensureInitialized();
     const resolved = this.resolveName(typeOrAlias);
     return this.has(resolved);
   }
@@ -480,7 +487,8 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get rerankers suitable for a use case
    */
-  getRerankersForUseCase(useCase: string): RerankerType[] {
+  async getRerankersForUseCase(useCase: string): Promise<RerankerType[]> {
+    await this.ensureInitialized();
     const matches: RerankerType[] = [];
     const useCaseLower = useCase.toLowerCase();
 
@@ -499,7 +507,8 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get rerankers that don't require external APIs
    */
-  getLocalRerankers(): RerankerType[] {
+  async getLocalRerankers(): Promise<RerankerType[]> {
+    await this.ensureInitialized();
     const matches: RerankerType[] = [];
 
     for (const [type, metadata] of this.metadataMap) {
@@ -514,7 +523,8 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get rerankers that don't require AI models
    */
-  getModelFreeRerankers(): RerankerType[] {
+  async getModelFreeRerankers(): Promise<RerankerType[]> {
+    await this.ensureInitialized();
     const matches: RerankerType[] = [];
 
     for (const [type, metadata] of this.metadataMap) {
@@ -529,7 +539,8 @@ export class RerankerFactory extends BaseFactory<Reranker, RerankerConfig> {
   /**
    * Get all reranker metadata
    */
-  getAllMetadata(): Map<RerankerType, RerankerMetadata> {
+  async getAllMetadata(): Promise<Map<RerankerType, RerankerMetadata>> {
+    await this.ensureInitialized();
     return new Map(this.metadataMap);
   }
 
@@ -570,7 +581,7 @@ export async function getAvailableRerankerTypes(): Promise<RerankerType[]> {
  */
 export function getRerankerMetadata(
   typeOrAlias: string,
-): RerankerMetadata | undefined {
+): Promise<RerankerMetadata | undefined> {
   return rerankerFactory.getRerankerMetadata(typeOrAlias);
 }
 
@@ -579,6 +590,6 @@ export function getRerankerMetadata(
  */
 export function getRerankerDefaultConfig(
   typeOrAlias: string,
-): Partial<RerankerConfig> | undefined {
+): Promise<Partial<RerankerConfig> | undefined> {
   return rerankerFactory.getDefaultConfig(typeOrAlias);
 }

--- a/test/continuous-test-suite-rag.ts
+++ b/test/continuous-test-suite-rag.ts
@@ -395,7 +395,7 @@ async function testChunkerFactory(): Promise<boolean | null> {
   // Test 5: Metadata retrieval
   logSubsection("Metadata Retrieval");
   try {
-    const metadata = getChunkerMetadata("recursive");
+    const metadata = await getChunkerMetadata("recursive");
     if (
       metadata &&
       metadata.description &&
@@ -426,7 +426,7 @@ async function testChunkerFactory(): Promise<boolean | null> {
   // Test 6: Default config
   logSubsection("Default Configuration");
   try {
-    const config = getDefaultConfig("recursive");
+    const config = await getDefaultConfig("recursive");
     if (config && typeof config.maxSize === "number") {
       logTest("Get default config", "PASS", `maxSize: ${config.maxSize}`);
       recordResult({ name: "Get default config", status: "PASS" });
@@ -772,7 +772,7 @@ async function testRerankerFactory(): Promise<boolean | null> {
   // Test 4: Reranker metadata
   logSubsection("Reranker Metadata");
   try {
-    const metadata = getRerankerMetadata("simple");
+    const metadata = await getRerankerMetadata("simple");
     if (
       metadata &&
       metadata.description &&
@@ -847,7 +847,7 @@ async function testRerankerFactory(): Promise<boolean | null> {
   // Test 6: Model-free and local rerankers
   logSubsection("Model-Free Rerankers");
   try {
-    const modelFree = rerankerFactory.getModelFreeRerankers();
+    const modelFree = await rerankerFactory.getModelFreeRerankers();
     if (modelFree.includes("simple")) {
       logTest(
         "Get model-free rerankers",


### PR DESCRIPTION
## The bug

`ChunkerFactory.getChunkerMetadata()` and `getDefaultConfig()` are **synchronous** reads of `metadataMap`. That map is only populated by `registerAll()`, which runs solely through the **async** `ensureInitialized()` — and the only place that awaited it was `create()` (`src/lib/core/infrastructure/baseFactory.ts:41`).

So on a fresh process both return `undefined` for every strategy, and start returning real metadata the moment anything happens to construct a chunker first. Order-dependent, silent, and `undefined` rather than a throw.

Proven cold, in a process that does nothing else:

```
chunker  metadata: undefined
chunker  config  : undefined
reranker metadata: undefined
reranker config  : undefined
```

**`RerankerFactory` has the identical defect.** Its equivalent test passes only because an earlier test in the same section calls `createReranker()` and warms the map — reorder that section and it fails. That test was never real coverage.

## The fix

`createChunker()`, `getAvailableStrategies()` and `getAvailableTypes()` were **already** async and already awaited `ensureInitialized()`, for exactly this reason. This makes the rest of each factory's read surface match rather than inventing a new pattern:

| factory | now awaits initialization |
|---|---|
| `ChunkerFactory` | `getChunkerMetadata`, `getDefaultConfig`, `getStrategyAliases`, `hasStrategy`, `getChunkersForUseCase`, `getAllMetadata` |
| `RerankerFactory` | `getRerankerMetadata`, `getDefaultConfig`, `getTypeAliases`, `hasType`, `getRerankersForUseCase`, `getLocalRerankers`, `getModelFreeRerankers`, `getAllMetadata` |

## Not a public API break

These are not reachable from the built barrel at runtime:

```
getChunkerMetadata       undefined
getDefaultConfig         undefined
getFactoryDefaultConfig  undefined
ChunkerFactory           undefined
chunkerFactory           undefined
```

The only callers anywhere are `test/continuous-test-suite-rag.ts` and the internal re-export barrels. `getStrategyAliases` and `getChunkersForUseCase` have **zero** callers outside the factory itself.

## Verification

`pnpm run test:rag`: **98 passed / 2 failed → 100 passed / 0 failed.**

```
✗ Get chunker metadata   — Incomplete metadata      (before)
✗ Get default config     — Invalid config returned  (before)
```

Those failures were **real**, not test bugs. They went unnoticed because `test:rag` is one of the **59 of 84** suite scripts CI never runs.

- `pnpm run check` — 4824 files, 0 errors
- `pnpm run check:tools-tests` — clean
- `pnpm run lint` — 0 errors

The two `await`s this needed in `test/` were caught by the `tools/`+`test/` typecheck gate from #1488, including one call site in a section I had not read — `rerankerFactory.getModelFreeRerankers()`.
