### PR TITLE
fix(scripts): stop the symbol diff from dropping calls and misreading failures

### DIFF
--- a/scripts/migration-symbol-diff.mjs
+++ b/scripts/migration-symbol-diff.mjs
@@ -59,6 +59,26 @@ function callsIn(source, fileName) {
   );
   const found = new Set();
   /**
+   * Strip the wrappers that change how a callee is spelled but not which
+   * symbol it names: `(trace.getActiveSpan)()`, `(x as Foo).bar()`,
+   * `maybe!.bar()`, `(x satisfies Foo).bar()`. Without this the walker falls
+   * through every branch below and records nothing — a silent drop, which is
+   * the exact failure this tool exists to report.
+   */
+  const unwrap = (expression) => {
+    let current = expression;
+    while (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isNonNullExpression(current) ||
+      ts.isTypeAssertionExpression?.(current) ||
+      ts.isSatisfiesExpression?.(current)
+    ) {
+      current = current.expression;
+    }
+    return current;
+  };
+  /**
    * The dotted path, but only while every link is a plain name: `trace`,
    * `trace.getActiveSpan`, `a.b.c`. Returns undefined the moment the chain
    * roots in something else — `foo().bar`, `arr[0].bar` — because the printed
@@ -66,7 +86,8 @@ function callsIn(source, fileName) {
    * this happily emitted a thirty-line `withTimeout(...).catch` as a symbol
    * name.
    */
-  const dottedName = (expression) => {
+  const dottedName = (raw) => {
+    const expression = unwrap(raw);
     if (ts.isIdentifier(expression)) {
       return expression.text;
     }
@@ -76,7 +97,8 @@ function callsIn(source, fileName) {
     }
     return undefined;
   };
-  const record = (expression) => {
+  const record = (raw) => {
+    const expression = unwrap(raw);
     if (ts.isIdentifier(expression)) {
       found.add(expression.text);
       return;
@@ -113,9 +135,15 @@ function callsIn(source, fileName) {
  * caller never asked while looking like a clean result.
  */
 function isAbsentPath(err) {
-  const text = `${err?.stderr ?? ""}${err?.message ?? ""}`;
+  // stderr ONLY. Node builds err.message as "Command failed: <argv>\n<stderr>",
+  // so it already contains stderr verbatim and adds nothing but the invocation
+  // text — which is caller-supplied. Matching a diagnostic regex against the
+  // caller's own arguments means a path like "does not exist in here.ts", or a
+  // typo'd revision whose command line happens to contain the wording, is
+  // reported as a clean absence instead of being rethrown. That is precisely
+  // the misread this function's contract above promises not to make.
   return /exists on disk, but not in|does not exist in|path .* does not exist/i.test(
-    text,
+    err?.stderr ?? "",
   );
 }
 


### PR DESCRIPTION
Two defects in `scripts/migration-symbol-diff.mjs`, both raised in review on #1452 and never addressed. They matter more than their size suggests: this script is a silent-drop detector, and each defect makes it silently drop.

## 1. A parenthesized or asserted callee recorded nothing

`record()` and `dottedName()` branched on `isIdentifier` / `isPropertyAccessExpression` / `isNewExpression` / `isCallExpression` and nothing else. A callee wrapped in parentheses or an assertion fell through every branch and was never added to the set — so the call is invisible on *both* sides of the diff, and deleting it outright reports no vanished symbol.

This is not a contrived shape. A dropped `trace.getActiveSpan()` is one of the two real regressions the script's own header cites as its reason to exist.

**Reproduced end-to-end** against a two-commit fixture where the call is written `(trace.getActiveSpan)()` and then deleted entirely:

```
before   src/thing.ts @ HEAD: 2 -> 0 called symbols; 2 vanished
            GONE: setAttribute
            GONE: span.setAttribute

after    src/thing.ts @ HEAD: 4 -> 0 called symbols; 4 vanished
            GONE: getActiveSpan
            GONE: setAttribute
            GONE: span.setAttribute
            GONE: trace.getActiveSpan
```

The release version is blind to the dropped span call. Fixed with an `unwrap()` applied at the head of both functions, covering parentheses, `as`, `!`, angle-bracket assertions and `satisfies`. The last two predicates are called optionally (`?.()`) because older TypeScript builds do not export them.

## 2. `isAbsentPath()` matched the caller's own arguments

It tested `` `${err.stderr}${err.message}` ``. Node builds `err.message` as `"Command failed: <argv>\n<stderr>"`, so it already contains stderr verbatim — the concatenation adds nothing but the invocation text, which is caller-supplied. Matching a diagnostic regex against the caller's arguments means a bad revision, or a path whose name contains the wording, is reported as a clean absence.

The function's own contract says the opposite:

> Deliberately narrow. A bad REVISION is not an absence — it is a typo in the invocation, and reporting it as "absent on one side" answers a question the caller never asked while looking like a clean result.

**Reproduced end-to-end** with a typo'd revision:

```
before   src/weird does not exist in here.ts @ totallybogusrev123:
           absent on one side of the commit
         no comparisons ran — every path was absent on one side

after    migration-symbol-diff: Command failed: git show
           totallybogusrev123^:src/weird does not exist in here.ts
```

Fixed by matching `err.stderr` alone.

## Verification

- Both reproductions run the real CLI against a scratch git repository — no stubs, no simulated errors.
- `pnpm run lint` → 0 errors (56 pre-existing warnings, all in unrelated files).
- One file changed, +32 / −4.
