### PR TITLE
fix(bench): fail the rolling proxy gate when worker metrics were never measured

### DIFF
--- a/tools/testing/proxyRollingHandoffBenchmark.ts
+++ b/tools/testing/proxyRollingHandoffBenchmark.ts
@@ -91,6 +91,10 @@ function readWorkerMetrics(file: string): WorkerMetricSample[] {
       .filter((line) => line.trim().length > 0)
       .map((line) => JSON.parse(line) as WorkerMetricSample);
   } catch {
+    // Callers MUST treat an empty result as "not measured", never as "measured
+    // zero" — see the workerMetricsCollected gate below. The worker is always
+    // spawned with NEUROLINK_PROXY_BENCH_METRICS_FILE set, so nothing here is
+    // the absence of work; it is the absence of a measurement.
     return [];
   }
 }
@@ -381,7 +385,19 @@ try {
   const cpuMicrosPerRequest = Number(
     ((cpu.user + cpu.system + workerCpuMicros) / totalRequests).toFixed(3),
   );
+  // An unreadable or empty metrics file yields zeros for worker CPU, peak heap
+  // and open descriptors — and every one of those zeros SATISFIES its threshold
+  // below, while also flattering cpuMicrosPerRequest. So losing the measurement
+  // made this benchmark greener, not redder: it would report `passed` having
+  // observed nothing at all about the worker.
+  //
+  // The worker is always launched with NEUROLINK_PROXY_BENCH_METRICS_FILE set,
+  // so no samples means the measurement failed, not that the worker was idle.
+  // Gate on having actually measured.
+  const workerMetricsCollected = workerMetrics.length > 0;
+
   const passed =
+    workerMetricsCollected &&
     droppedRequests === 0 &&
     sustainedFailures === 0 &&
     streamPreserved &&
@@ -400,6 +416,8 @@ try {
     `${JSON.stringify(
       {
         fixture: "cross-process-socket-handoff",
+        workerMetricsCollected,
+        workerMetricSamples: workerMetrics.length,
         warmupRequests: WARMUP_REQUESTS,
         measuredRequestsPerPath: REQUESTS,
         direct: { latency: directLatency, ttfb: directFirstByte },


### PR DESCRIPTION
## What

`proxyRollingHandoffBenchmark.ts` could report `passed` while having measured nothing about the worker process it exists to measure.

## The mechanism

`readWorkerMetrics` swallows a missing or unreadable file and returns `[]`. Every consumer then reduces to zero:

```ts
workerCpuMicros          = 0
workerPeakHeapBytes      = 0
workerPeakOpenDescriptors = 0
```

and each of those zeros **satisfies** its threshold in the `passed` conjunction:

```ts
workerPeakHeapBytes <= MAX_WORKER_PEAK_HEAP_BYTES        // 0 <= 96MB   true
workerPeakOpenDescriptors <= MAX_WORKER_OPEN_DESCRIPTORS // 0 <= 64     true
```

while the zeroed CPU also lowers `cpuMicrosPerRequest`. So losing the measurement made the gate **greener**, not redder.

## Why an empty file is not "the worker was idle"

The worker is always launched with `NEUROLINK_PROXY_BENCH_METRICS_FILE` set (line 240). No samples therefore means the measurement failed, not that there was nothing to measure. `passed` now requires `workerMetricsCollected`, and the emitted JSON carries `workerMetricsCollected` and `workerMetricSamples` so the two states are distinguishable in CI output rather than inferred.

## Demonstrated on both versions

By pointing the reader at a path that is never written, so the difference is the code and not the environment:

```
release   metrics missing -> exit 0    <- gate passed having measured nothing
this PR   metrics missing -> exit 1    workerMetricsCollected false, samples 0
this PR   normal run      -> exit 0    workerMetricsCollected true,  samples 2
```

The first line is the bug: a required-looking performance gate returning success on a measurement that never happened.

## Scope

One file. Found by auditing the scripts the CI gate job actually runs (`validate`, `validate:env`, `validate:security`, `proxy:performance`) for this same shape — the others are already covered by #1499, #1500, #1501 and #1509, and `env-validation.ts` was checked and found clean.

typecheck 4822 files / 0 errors, lint 0 errors / 56 pre-existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark result accuracy by distinguishing missing worker metrics from zero-valued measurements.
  * Benchmarks now require successful worker metric collection to pass.

* **Reporting**
  * JSON results now include metric collection status and the number of collected samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->