### PR TITLE
fix(bench): floor the usage-stats flush sample count

### DIFF
--- a/tools/testing/proxyUsageStatsBenchmark.ts
+++ b/tools/testing/proxyUsageStatsBenchmark.ts
@@ -24,7 +24,20 @@ const MAX_FLUSH_MS = Number(process.env.PROXY_STATS_MAX_FLUSH_MS ?? 250);
  * touched nothing near the proxy. A budget with that much headroom failing does
  * not mean the code regressed, it means one disk write got descheduled.
  */
-const FLUSH_SAMPLES = Number(process.env.PROXY_STATS_FLUSH_SAMPLES ?? 7);
+// Floored like every other sample count in this file, and for a reason worth
+// stating: `percentile([])` returns 0, so a run configured with 0 flush samples
+// reports flushMs = 0, which SATISFIES the flush budget below. The benchmark
+// would pass its flush gate having never timed a flush. Someone trimming this
+// down to speed CI up would silently disable a budget rather than loosen it.
+const configuredFlushSamples = Number(
+  process.env.PROXY_STATS_FLUSH_SAMPLES ?? 7,
+);
+const FLUSH_SAMPLES = Math.max(
+  1,
+  Number.isFinite(configuredFlushSamples)
+    ? Math.floor(configuredFlushSamples)
+    : 7,
+);
 const MAX_HEAP_GROWTH_BYTES = Number(
   process.env.PROXY_STATS_MAX_HEAP_GROWTH_BYTES ?? 16 * 1024 * 1024,
 );


### PR DESCRIPTION
## What

`FLUSH_SAMPLES` in `proxyUsageStatsBenchmark.ts` was read straight from the environment with no floor, while `REQUESTS` and every other sample count in that file go through `Math.max`.

## Why the asymmetry matters

`percentile([])` returns 0:

```js
percentile([], 0.5) = 0   ->   0 <= 250 (budget) = true
```

So a run configured with `PROXY_STATS_FLUSH_SAMPLES=0` reports `flushMs = 0`, which **satisfies** the flush budget. The benchmark passes its flush gate having never timed a single flush, and the output looks indistinguishable from a healthy run.

Someone trimming the sample count to make CI faster would silently disable a budget rather than loosen it — which is the failure mode this whole series has been removing: a check that is green because it did not look.

## The fix

Floored to 1, with non-finite input falling back to the default, matching how `REQUESTS` is already handled in the same file:

```
unset -> 7    0 -> 1    -3 -> 1    abc -> 7    2 -> 2
```

## Scope, and what I checked but did not change

This came from auditing the other three benchmarks after #1512 fixed the rolling-handoff one. The others are fine, and I verified rather than assumed:

- `proxyTransportBenchmark` and `proxyLifecycleBenchmark` floor their request counts with `Math.max`, so their percentile arrays cannot be empty by configuration.
- `proxyTransportBenchmark` does not wrap its sample requests in `try/catch`, so a failed request throws and exits non-zero — fail-closed, if accidentally so.
- The `catch` blocks in those files are a 502 fixture handler and a platform-specific descriptor probe, neither of which feeds a gate.

## Verification

Benchmark still runs: exit 0, `flushMs` 0.85ms against the 250ms budget, `passed: true`. Typecheck 4822 files / 0 errors, lint 0 errors / 56 pre-existing warnings.