### PR TITLE
test(fixtures): stop simulated failures from being classified as skips

### DIFF
--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -7075,7 +7075,7 @@ exit 127
       const originalFetch = globalThis.fetch;
       const secretUrl = "https://example.com/img.png?token=SUPERSECRET123";
       globalThis.fetch = (async () => {
-        throw new Error("simulated network failure");
+        throw new Error("synthetic fetch fault (fixture)");
       }) as typeof fetch;
       try {
         await imageUtils.urlToBase64DataUri(secretUrl, { maxAttempts: 1 });
@@ -7087,7 +7087,7 @@ exit 127
         // pins down the full redacted message, not just a fragment of it.
         return (
           msg ===
-          "Failed to download and convert URL to base64 (https://example.com/img.png): simulated network failure"
+          "Failed to download and convert URL to base64 (https://example.com/img.png): synthetic fetch fault (fixture)"
         );
       } finally {
         globalThis.fetch = originalFetch;

--- a/test/continuous-test-suite-tool-routing-semantic.ts
+++ b/test/continuous-test-suite-tool-routing-semantic.ts
@@ -666,7 +666,7 @@ await test("granularity:server + embedding (large catalog): excludes entire unpi
 
 await test("fail open: embedFn that throws → resolveToolRoutingExclusions does NOT throw", async () => {
   const throwingEmbedFn = async (): Promise<number[][]> => {
-    throw new Error("embedding service unavailable");
+    throw new Error("synthetic embedding fault (fixture)");
   };
 
   let llmCalled = false;

--- a/test/continuous-test-suite-tool-routing.ts
+++ b/test/continuous-test-suite-tool-routing.ts
@@ -211,7 +211,7 @@ await test("fails open when pick is fully hallucinated", async () => {
 
 await test("fails open when the router call throws", async () => {
   const generateFn = async () => {
-    throw new Error("network error");
+    throw new Error("synthetic transport fault (fixture)");
   };
   const excluded = await resolveToolRoutingExclusions(
     baseParams({
@@ -373,7 +373,7 @@ await test("emitDecision fires with outcome=failed-open-error when router throws
   };
 
   const generateFn = async () => {
-    throw new Error("network failure");
+    throw new Error("synthetic transport fault (fixture)");
   };
   await resolveToolRoutingExclusions(
     baseParams({


### PR DESCRIPTION
## What

Four test fixtures threw errors whose messages match `isExpectedProviderError()`, which `defineSuite`'s `test()` uses to downgrade a thrown error from **FAIL to SKIP**.

```
"network error"                  tool-routing            (fails-open test)
"network failure"                tool-routing
"embedding service unavailable"  tool-routing-semantic
"simulated network failure"      bugfixes                (stubbed fetch)
```

## Why it matters, given nothing is broken today

Those errors are currently caught by the code under test, so no suite is affected right now. The hazard is what happens when that stops being true.

`tool-routing.ts:214` is literally *"fails open when the router call throws"* — it exists to catch a regression where the router stops swallowing a thrown call. If that regression landed, the fixture's `"network error"` would propagate into `test()`'s catch:

```ts
const isSkip = err instanceof Skip || msg.startsWith("SKIP:") || isExpectedProviderError(msg);
if (isSkip) { skipped++; ... }
```

match, and be reported as **skipped**. The suite exits 0, and the regression is invisible in the one test written to detect it. CLAUDE.md documents this hazard explicitly and notes the risk is for new assertions; this is the same trap on the fixture side.

## Verified against the real classifier, not by eye

```
network error / network failure / embedding service unavailable /
simulated network failure                    -> isExpectedProviderError TRUE
synthetic transport fault (fixture) /
synthetic embedding fault (fixture) /
synthetic fetch fault (fixture)              -> FALSE
```

## Deliberately not changed

The `model-pool` fixtures keep their provider-shaped wording (`"rate limit exceeded, please retry after 60s"`, `"too many requests"`, `"unauthorized: invalid api key provided"`). Their comment states the point: *"classifyProviderError still reads it as rate_limit"* — the text **is** the assertion there, not incidental. Renaming would delete what those tests check.

`auth.ts`'s `"SKIP: Provider not available"` is an intentional skip signal.

## One knock-on, called out

A bugfixes assertion pins the full redacted message end to end and embedded the old fixture text. It is updated in step — which is why that file shows two changed lines rather than one. I found it because the raw string count was 2 while my throw-site match was 1; without that check the rename would have desynchronised the assertion from the fixture and broken the test.

## Verification

`bugfixes` 280 PASS, `tool-routing` 42 PASS, `tool-routing-semantic` 31 PASS. Typecheck 4822 files / 0 errors, lint 0 errors / 56 pre-existing warnings.

Scope note: this came from re-running the audit CLAUDE.md describes across all 86 suites — 464 literal assertion/throw messages scanned, 11 raw matches, all inspected. Seven were intentional (model-pool's classification fixtures, auth's skip signal); four are fixed here. No genuine assertion message was misclassified, which matches the earlier audit's conclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated simulated network, embedding, and routing error fixtures with consistent transport-fault wording.
  * Adjusted expected test messages to match the revised fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->