### PR TITLE
ci(lint): lint the whole project, not just src/ and one test glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,28 @@ jobs:
           echo "🔍 Running ESLint validation with controlled warning limits..."
           npx eslint src/ --max-warnings=300
           npx eslint test/continuous-test-suite*.ts test/zod-schema-test-function.ts --max-warnings=10
+          # Everything else, errors only.
+          #
+          # The two runs above cover src/ and the continuous-test-suite glob, and
+          # nothing else in the repo was linted by CI at all: scripts/, tools/,
+          # eslint-rules/, test/helpers/ (18 files) and any test file outside that
+          # glob. `pnpm run lint` does lint the whole project, but CI never calls
+          # it — it is a pre-commit hook only, and `--no-verify` skips that.
+          #
+          # This mattered beyond coverage: the custom rules assume a full-project
+          # view. unique-type-names can only detect a duplicate if it sees both
+          # declarations, and its own comment claimed "the pre-push/CI run on the
+          # full project catches everything" — pre-push does not lint, and CI did
+          # not run on the full project, so that net did not exist.
+          #
+          # No warning ceiling here on purpose: the scoped runs above already own
+          # the warning budgets, and duplicating one would let a warning limit be
+          # tightened in one place and silently loosened in another. This run
+          # exists to catch ERRORS anywhere, which is what the custom rules emit.
+          #
+          # Free to add today, measured rather than assumed: `npx eslint .`
+          # currently reports 0 errors / 56 warnings and exits 0.
+          npx eslint .
 
       - name: 🔒 Security & Environment Validation
         run: |

--- a/eslint-rules/unique-type-names.cjs
+++ b/eslint-rules/unique-type-names.cjs
@@ -10,9 +10,22 @@
  * rule invocations. ESLint loads the plugin once per process, so a single
  * `pnpm run lint` sees every file and can report duplicates.
  *
- * Caveat: when running ESLint on a subset of files (e.g., lint-staged on a
- * partial diff), this rule only checks that subset. The pre-push/CI run on
- * the full project catches everything.
+ * Caveat: when running ESLint on a subset of files (e.g. lint-staged on a
+ * partial diff), this rule only checks that subset — a duplicate is invisible
+ * unless BOTH declarations are in the same run.
+ *
+ * This comment used to say "the pre-push/CI run on the full project catches
+ * everything". That was not true in either half. `.husky/pre-push` runs
+ * check:deps, build and three test suites, and lints nothing. CI ran
+ * `eslint src/` and `eslint test/continuous-test-suite*.ts`, never
+ * `pnpm run lint`, so scripts/, tools/, eslint-rules/ and test/helpers/ were
+ * not linted at all and no run saw the whole project. The only full-project
+ * lint was the pre-commit hook, which `--no-verify` skips.
+ *
+ * CI now also runs a plain `npx eslint .` (errors only) so a whole-project view
+ * exists somewhere that a local flag cannot bypass. Keep that in mind before
+ * narrowing CI's lint scope again: it is load-bearing for this rule rather
+ * than merely thorough.
  */
 
 "use strict";


### PR DESCRIPTION
## What

CI ran two scoped ESLint invocations and **never** `pnpm run lint`:

```
npx eslint src/ --max-warnings=300
npx eslint test/continuous-test-suite*.ts test/zod-schema-test-function.ts --max-warnings=10
```

So `scripts/`, `tools/`, `eslint-rules/`, `test/helpers/` (18 files) and any test file outside that glob were **not linted by CI at all**. The only full-project lint is the pre-commit hook, which `--no-verify` skips.

## Why this is more than missing coverage

The custom rules assume a full-project view. `unique-type-names` can only detect a duplicate when it sees **both** declarations in one run, and its own comment said:

> The pre-push/CI run on the full project catches everything.

Neither half of that was true:

- `.husky/pre-push` runs `check:deps`, `build` and three test suites. It lints nothing.
- CI never ran on the full project.

So the safety net that comment describes did not exist, and a rule whose whole purpose is cross-file detection was running against partial views in the one place that gates merges. The comment is corrected to describe what actually exists, with a note that CI's scope is now load-bearing for the rule rather than merely thorough.

## Why add rather than replace

The new `npx eslint .` sits alongside the existing two instead of replacing them, so their warning budgets stay exactly where they are. Collapsing them into one would mean a single ceiling governing both `src/` (300) and the test glob (10) — an easy way to tighten a limit in one place and silently loosen it in another.

The new run carries no `--max-warnings` deliberately: its job is to catch **errors** anywhere, which is what the custom rules emit. Warning budgets remain owned by the scoped runs.

## This turns nothing red

Measured, not assumed:

```
npx eslint .                              0 errors, 56 warnings, exit 0
npx eslint src/ --max-warnings=300        exit 0
npx eslint test/continuous-test-suite*.ts …  exit 0
```

Prettier remains covered by the separate `format:check` step. YAML re-parsed after the edit.

## How this was found

Auditing the custom lint rules for the "reports success without doing the work" shape this PR series has been chasing. The rules themselves are clean — no rule swallows an exception, and their early returns are legitimate scoping. The defect was one level up: the gate that runs them could not see most of the repo.