### PR TITLE
fix(openai): stop reporting an exhausted quota as a retryable rate limit

### DIFF
--- a/src/lib/providers/openAI/client.ts
+++ b/src/lib/providers/openAI/client.ts
@@ -33,6 +33,7 @@ import { assertSafeUrl } from "../../utils/ssrfGuard.js";
 import { createTimeoutController } from "../../utils/timeout.js";
 import { stripTrailingSlash } from "../openaiChatCompletionsClient.js";
 import { OpenAIChatCompletionsProvider } from "../openaiChatCompletionsBase.js";
+import { isOpenAIQuotaExhaustedError } from "../../utils/providerRetry.js";
 
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
@@ -165,6 +166,24 @@ export class OpenAIProvider extends OpenAIChatCompletionsProvider {
           /Incorrect API key|Invalid API key/i.test(ctx.message)
             ? ctx.message
             : "Invalid OpenAI API key. Please check your OPENAI_API_KEY environment variable.",
+      },
+      // MUST precede the 429 rule below. OpenAI returns 429 for two
+      // unrelated conditions: transient throttling, and a permanently
+      // exhausted quota (out of credit, or a spend cap reached). Matching on
+      // the status code alone collapses them, and the resulting advice —
+      // "try again later" — is the one thing that can never resolve the
+      // second. The signal is the error TYPE, not the wording.
+      {
+        // One definition of "permanent billing state", in the helper. The
+        // earlier cut also tested `errorType === "insufficient_quota"` here,
+        // which is precisely the helper's own first branch — two places to
+        // keep in step for no benefit.
+        match: (ctx) => isOpenAIQuotaExhaustedError(ctx.error),
+        errorClass: ProviderError,
+        message:
+          "OpenAI quota exhausted — this will not resolve by retrying. " +
+          "Check your plan and billing details at " +
+          "https://platform.openai.com/account/billing",
       },
       {
         match: (ctx) =>

--- a/src/lib/utils/providerRetry.ts
+++ b/src/lib/utils/providerRetry.ts
@@ -130,7 +130,54 @@ export function extractRetryAfterMsFromError(
   return undefined;
 }
 
+/**
+ * An OpenAI-wire `insufficient_quota` error: the account is out of credit or
+ * has hit a spend cap.
+ *
+ * Exported and shared with the OpenAI error table so the retry predicate and
+ * the message a caller sees cannot disagree about what a permanent billing
+ * state looks like. The type is NOT a field on the error — OpenAI puts it
+ * inside the JSON response body, which the SDK keeps as a string — so any
+ * caller that needs it has to parse, and none should do so on its own.
+ *
+ * Deliberately keyed on the error TYPE, never on the word "quota". OpenAI and
+ * xAI send 429 + `type: "insufficient_quota"` for a permanent billing state,
+ * but other providers use "quota" for ordinary throttling — Google's 429 reads
+ * "Quota exceeded for quota metric ...", which IS retryable and must stay that
+ * way. Matching free text here would make Gemini throttling non-retryable and
+ * quietly remove a layer of resilience.
+ */
+export function isOpenAIQuotaExhaustedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const err = error as { type?: unknown; responseBody?: unknown };
+  if (err.type === "insufficient_quota") {
+    return true;
+  }
+  // The SDK keeps the raw payload as a string; the type lives inside it.
+  if (typeof err.responseBody === "string") {
+    try {
+      const parsed: unknown = JSON.parse(err.responseBody);
+      const inner = (parsed as { error?: { type?: unknown } } | null)?.error;
+      return inner?.type === "insufficient_quota";
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 export function isRetryableProviderError(error: unknown): boolean {
+  // Before every other branch, including the SDK's own flag: a 429 carrying
+  // `insufficient_quota` is marked retryable by the AI SDK because it only
+  // looks at the status code. Retrying it burns the full ladder — 3 attempts
+  // and ~20s of backoff, since no Retry-After accompanies these — on a state
+  // that cannot change until someone tops up the account.
+  if (isOpenAIQuotaExhaustedError(error)) {
+    return false;
+  }
+
   // Preferred path: use the AI SDK's own branded type check + isRetryable flag
   if (APICallError.isInstance(error)) {
     return error.isRetryable;

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -1717,6 +1717,204 @@ async function runOpenAISection(): Promise<void> {
       err instanceof Error ? err.message : String(err),
     );
   }
+
+  // ── 429 + insufficient_quota. OpenAI reuses 429 for a PERMANENT billing
+  // state, so this must not be reported as a rate limit and must not be
+  // retried. Two assertions, because the failures are independent: the advice
+  // given to the caller, and the work done before giving it.
+  // ─────────────────────────────────────────────────────────────────────
+  try {
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.openai.com/v1/chat/completions",
+          respond: {
+            status: 429,
+            json: {
+              error: {
+                message:
+                  "You exceeded your current quota, please check your plan and billing details.",
+                type: "insufficient_quota",
+                code: "insufficient_quota",
+              },
+            },
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        try {
+          await nl.generate({
+            provider: "openai",
+            model,
+            input: { text: "ping" },
+            disableTools: true,
+          });
+          record(
+            results,
+            `${section}: insufficient_quota is not reported as a rate limit`,
+            false,
+            "no error thrown",
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          record(
+            results,
+            `${section}: insufficient_quota is not reported as a rate limit`,
+            msg.includes("OpenAI quota exhausted") &&
+              !msg.includes("rate limit exceeded"),
+            `msg='${msg.slice(0, 120)}'`,
+          );
+        }
+        // A permanent condition must cost exactly one upstream call. Before
+        // this fix the ladder ran 3 attempts with ~20s of backoff every time.
+        record(
+          results,
+          `${section}: insufficient_quota is not retried`,
+          calls.length === 1,
+          `upstream attempts=${calls.length}`,
+        );
+      },
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: insufficient_quota is not reported as a rate limit`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── Guard on the fix above. The quota check keys on the error TYPE, never
+  // on the word "quota", because other providers use that word for ordinary
+  // throttling — Google's 429 reads "Quota exceeded for quota metric ...".
+  // A plain throttle whose MESSAGE mentions a quota must stay retryable; if
+  // this regresses, throttling silently stops being retried.
+  // ─────────────────────────────────────────────────────────────────────
+  try {
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.openai.com/v1/chat/completions",
+          respond: {
+            status: 429,
+            json: {
+              error: {
+                message:
+                  "Quota exceeded for quota metric 'requests per minute'",
+                type: "rate_limit_error",
+              },
+            },
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        try {
+          await nl.generate({
+            provider: "openai",
+            model,
+            input: { text: "ping" },
+            disableTools: true,
+          });
+        } catch {
+          // The error is expected; only the retry count is under test here.
+        }
+        record(
+          results,
+          `${section}: a throttle whose text mentions quota is still retried`,
+          calls.length > 1,
+          `upstream attempts=${calls.length}`,
+        );
+      },
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: a throttle whose text mentions quota is still retried`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── The streaming path has its OWN withProviderRetry call site
+  // (openaiChatCompletionsBase.ts:1438), so a retry fix proven only on the
+  // non-streaming path says nothing about it. This pins that it holds there.
+  //
+  // Only the retry is asserted, deliberately. The streaming path never runs
+  // formatProviderError at all — openaiChatCompletionsBase declares it
+  // abstract and throws the raw provider error instead, so NO error of any
+  // type or provider is classified on that path. That is a pre-existing,
+  // provider-wide gap rather than anything about quota, and asserting the
+  // classified message here would be asserting a fix this change does not
+  // make. Measured: a streaming quota 429 surfaces "You have no credits
+  // remaining ..." verbatim.
+  // ─────────────────────────────────────────────────────────────────────
+  try {
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.openai.com/v1/chat/completions",
+          respond: {
+            status: 429,
+            json: {
+              error: {
+                message:
+                  "You have no credits remaining. Add credits to continue using the API.",
+                type: "insufficient_quota",
+                code: "credit_balance_exhausted",
+              },
+            },
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        // null means nothing was thrown, which is itself a failure for this
+        // case — a 429 must not stream successfully. Keeping it distinct from
+        // a message stops the assertion below passing vacuously on a
+        // placeholder string.
+        let msg: string | null = null;
+        try {
+          const r = await nl.stream({
+            provider: "openai",
+            model,
+            input: { text: "ping" },
+            disableTools: true,
+          });
+          // The rejection may surface on the call or on first iteration.
+          for await (const chunk of r.stream) {
+            void chunk;
+          }
+        } catch (err) {
+          msg = err instanceof Error ? err.message : String(err);
+        }
+        // Whatever wording surfaces, it must not claim this is a rate limit.
+        record(
+          results,
+          `${section}: streaming quota error is never called a rate limit`,
+          msg !== null && !/rate\s*limit/i.test(msg),
+          msg === null ? "no error thrown" : `msg='${msg.slice(0, 120)}'`,
+        );
+        record(
+          results,
+          `${section}: streaming insufficient_quota is not retried`,
+          calls.length === 1,
+          `upstream attempts=${calls.length}`,
+        );
+      },
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: streaming quota error is never called a rate limit`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/test/helpers/envGuard.ts
+++ b/test/helpers/envGuard.ts
@@ -112,7 +112,14 @@ const PROVIDER_ERROR_FRAMINGS: RegExp[] = [
   /\[ollama\][^.]*?(?:not\s+running|cannot\s+connect|service)/i,
   /\[anthropic\][^.]*?(?:credit\s+balance|insufficient|quota|not\s+found|model.*?not\s+available)/i,
   /\[mistral\][^.]*?(?:authentication|invalid\s+api)/i,
-  /\[openai\][^.]*?(?:exceeded\s+your\s+current\s+quota|insufficient_quota|billing\s+details|tier|rate\s+limit)/i,
+  // `quota\s+exhausted` is the framing NeuroLink emits for OpenAI's
+  // `insufficient_quota` (an empty account or a spend cap). It is listed
+  // because the classifier stopped calling that condition a "rate limit":
+  // until then this entry matched it only by accident, through the word the
+  // misclassification happened to use. Keep it anchored to the `[openai]`
+  // prefix — the bare word "quota" must never match here, since Google's
+  // retryable throttle reads "Quota exceeded for quota metric ...".
+  /\[openai\][^.]*?(?:exceeded\s+your\s+current\s+quota|insufficient_quota|billing\s+details|tier|rate\s+limit|quota\s+exhausted)/i,
   // OpenAI's streaming-with-tools wrapper that NeuroLink emits when the
   // upstream chat-completion stream errors out. The underlying cause is
   // usually quota/billing/policy — surfacing as a generic "API error


### PR DESCRIPTION
OpenAI returns HTTP 429 for two unrelated conditions: transient throttling, and a **permanently** exhausted quota (out of credit, or a spend cap reached). The error table matched on the status code alone, so the second was reported as the first — and the advice it gave, "try again later", is the one thing that can never resolve it.

## Measured on a real out-of-credit account

Same call, both builds, live against `api.openai.com`:

| | elapsed | message |
|---|---|---|
| **before** (installed release 11.22.3) | **23.2s** | `OpenAI rate limit exceeded. Please try again later.` |
| **after** (this branch) | **1.0s** | `OpenAI quota exhausted — this will not resolve by retrying. Check your plan and billing details at …` |

The 23 seconds are the retry ladder. `MAX_PROVIDER_RETRIES` is 2 and OpenAI sends no `Retry-After` for these, so `NO_HINT_FLOOR_MS` applies twice: three upstream calls and ~20s of sleeping, **on every request**, for a state that cannot change until someone tops up the account.

## Two independent defects

**The message.** The 429 rule in `openAI/client.ts` had no quota case — although the same rule already exists for xAI in `openaiCompatCatalog.ts:130`, and for Cohere and Replicate. The direct provider was the gap.

**The retries.** This is the part that surprised me, and it is worth recording because the obvious fix would not have worked. The *classified* `RateLimitError` is already non-retryable — I probed it. The ladder never sees that error. It acts on the **raw** SDK error, where `isRetryableProviderError` consults `APICallError.isInstance(error) → error.isRetryable` **first**, and the AI SDK sets that flag from the status code alone. So the quota 429 was marked retryable before any NeuroLink logic ran. Neither changing the error class nor giving it a `retriable: false` field would have changed anything; the check has to short-circuit ahead of every branch.

## Keyed on the type, never the word "quota"

OpenAI and xAI send `type: "insufficient_quota"` for a permanent billing state. Other providers use "quota" for ordinary throttling — Google's 429 reads `Quota exceeded for quota metric …`, which **is** retryable.

Matching free text would have made Gemini throttling non-retryable and quietly removed a layer of resilience — a worse bug than the one being fixed. There is a test that fails if that regresses.

## The type is not where you would look for it

`errorObj.type` is undefined; OpenAI puts the type inside the JSON response body, which the SDK keeps as a **string**. The first cut of this fix checked `errorObj.type` and the message text, built cleanly, typechecked cleanly — and the classification test still failed. Both callers therefore have to parse the body, so the parsing lives in one exported helper rather than being written twice and drifting.

The live payload, for the record:

```json
{"error":{"message":"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
          "type":"insufficient_quota","param":null,"code":"credit_balance_exhausted"}}
```
HTTP 429.

A synthesized fixture with the type at the top level would have passed the new test and done nothing in production.

## Tests

Three cases added to the mocked provider-contract suite, which is a **required** CI gate via `provider-safety-net`:

```
✓ insufficient_quota is not reported as a rate limit
✓ insufficient_quota is not retried                      upstream attempts=1
✓ a throttle whose text mentions quota is still retried  upstream attempts=3
```

The retry assertions count upstream calls rather than measuring elapsed time, so they cannot be distorted by other load on the machine.

## Verification

- mocked provider contract suite: **57 passed / 0 failed**
- `test:provider-structure`: PASS
- `pnpm run build` exit 0 · `check` 0 errors · `check:tools-tests` 0 errors · `lint` 0 errors
- the live before/after above, against a genuinely empty account

`docs/api` is untouched deliberately: nothing under `docs/api/` references either changed file, so no documented symbol moved.
