### PR TITLE
docs(lint): correct the rationale I shipped for the full-project ESLint run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,27 +62,29 @@ jobs:
           echo "🔍 Running ESLint validation with controlled warning limits..."
           npx eslint src/ --max-warnings=300
           npx eslint test/continuous-test-suite*.ts test/zod-schema-test-function.ts --max-warnings=10
-          # Everything else, errors only.
+          # Everything else ESLint is configured to see, errors only.
           #
-          # The two runs above cover src/ and the continuous-test-suite glob, and
-          # nothing else in the repo was linted by CI at all: scripts/, tools/,
-          # eslint-rules/, test/helpers/ (18 files) and any test file outside that
-          # glob. `pnpm run lint` does lint the whole project, but CI never calls
-          # it — it is a pre-commit hook only, and `--no-verify` skips that.
+          # The two runs above cover src/ and the continuous-test-suite glob.
+          # `eslint .` adds 46 files CI never linted, measured by diffing the
+          # file lists rather than guessed:
           #
-          # This mattered beyond coverage: the custom rules assume a full-project
-          # view. unique-type-names can only detect a duplicate if it sees both
-          # declarations, and its own comment claimed "the pre-push/CI run on the
-          # full project catches everything" — pre-push does not lint, and CI did
-          # not run on the full project, so that net did not exist.
+          #   eslint-rules 13 | test 25 (outside the glob) | docs-site 5
+          #   tools 1 | landing 1 | .pnpmfile.cjs 1
           #
-          # No warning ceiling here on purpose: the scoped runs above already own
-          # the warning budgets, and duplicating one would let a warning limit be
-          # tightened in one place and silently loosened in another. This run
-          # exists to catch ERRORS anywhere, which is what the custom rules emit.
+          # Note what this does NOT add. `scripts/**` is in the ignores list in
+          # eslint.config.js, so no ESLint run covers it. And every custom
+          # `neurolink/*` rule is enabled only for `files: ["src/**/*.ts", ...]`,
+          # so those rules were never short of coverage — `eslint src/` already
+          # gave them everything they inspect. The value here is the generic
+          # rules reaching the lint rules themselves and the untested test files,
+          # not rescuing a custom rule from a partial view.
           #
-          # Free to add today, measured rather than assumed: `npx eslint .`
-          # currently reports 0 errors / 56 warnings and exits 0.
+          # No warning ceiling on purpose: the scoped runs above own the warning
+          # budgets, and duplicating one would let a limit be tightened in one
+          # place and silently loosened in another.
+          #
+          # Free to add, measured: `npx eslint .` reports 0 errors / 56 warnings
+          # and exits 0.
           npx eslint .
 
       - name: 🔒 Security & Environment Validation

--- a/eslint-rules/unique-type-names.cjs
+++ b/eslint-rules/unique-type-names.cjs
@@ -14,18 +14,16 @@
  * partial diff), this rule only checks that subset — a duplicate is invisible
  * unless BOTH declarations are in the same run.
  *
- * This comment used to say "the pre-push/CI run on the full project catches
- * everything". That was not true in either half. `.husky/pre-push` runs
- * check:deps, build and three test suites, and lints nothing. CI ran
- * `eslint src/` and `eslint test/continuous-test-suite*.ts`, never
- * `pnpm run lint`, so scripts/, tools/, eslint-rules/ and test/helpers/ were
- * not linted at all and no run saw the whole project. The only full-project
- * lint was the pre-commit hook, which `--no-verify` skips.
+ * What that means in practice, checked rather than assumed: this rule returns
+ * early for any file outside `src/lib/types/` (see `isInsideTypesFolder`), and
+ * every `neurolink` rule is enabled only for a files glob rooted at `src`.
+ * So CI's `eslint src/` already gives this rule a complete view — a duplicate
+ * introduced in `src/lib/types/` is caught by that run alone, verified by
+ * planting one and watching it fail.
  *
- * CI now also runs a plain `npx eslint .` (errors only) so a whole-project view
- * exists somewhere that a local flag cannot bypass. Keep that in mind before
- * narrowing CI's lint scope again: it is load-bearing for this rule rather
- * than merely thorough.
+ * `.husky/pre-push` lints nothing, and the pre-commit hook's full-project lint
+ * is skippable with `--no-verify`, but neither matters here: the scoped CI run
+ * is sufficient for this rule. The lint-staged caveat above is the real one.
  */
 
 "use strict";


### PR DESCRIPTION
## Why this exists

#1516 added `npx eslint .` to CI and justified it with a claim that does not hold. This corrects the record and the comments, and keeps the step for the reason it actually has.

## What I got wrong

I asserted that the custom rules needed a full-project view, and that `unique-type-names` had been "running on partial views in the only place that gates merges". Neither is true:

- `unique-type-names` returns early for any file outside `src/lib/types/` (`isInsideTypesFolder`), and every `neurolink` rule is enabled only for a files glob rooted at `src`.
- So `eslint src/` already gave those rules complete coverage.

Verified rather than reasoned about — planting a duplicate `GenerateResult` in `src/lib/types/`:

```
npx eslint src/ --max-warnings=300
  error  Type name "GenerateResult" is already declared in src/lib/types/__dup_probe.ts …
  exit 1
```

The pre-existing scoped run catches it alone. The full-project run was never load-bearing for that rule.

I also wrote that false claim **into `unique-type-names.cjs`**, where it would have misled whoever read it next — the same trap as the dead-file comment I removed in #1503, authored by me a day later.

## What is actually true, measured

`eslint .` adds 46 files CI never linted, from diffing the linted file lists:

```
eslint-rules 13 | test 25 (outside the glob) | docs-site 5
tools 1 | landing 1 | .pnpmfile.cjs 1
```

Worth having — it lints the lint rules themselves and 25 test files — but for the generic rules, not for rescuing a custom rule.

The limit is now recorded too: `scripts/**` sits in `eslint.config.js`'s ignores, so **no** ESLint run covers it, including this one. I had implied otherwise.

## How it surfaced

By trying to prove my own claim instead of assuming it. I planted a duplicate in a previously-unlinted directory expecting the new run to catch it; it did not, and chasing why exposed the scoping.

## One self-inflicted break, fixed here

The corrected comment initially contained the string `"src/**/*.ts"`. Inside a JSDoc block the `*/` in that glob terminates the comment, so `eslint .` exited **2** with `SyntaxError: Unexpected token '*'` — the lint config would not load at all. Caught immediately by running `eslint .` after the edit. Reworded to avoid the sequence.

## Verification

```
node -e "require('./eslint-rules/unique-type-names.cjs')"   parses OK
npx eslint .                                                exit 0
npx eslint src/ --max-warnings=300                          exit 0
prettier --check                                            clean
YAML                                                        re-parsed
```

Comments only — no behavioural change to the workflow step or the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified linting coverage and warning status in continuous integration.
  * Documented the scope and coverage of the unique type-names validation rule.
  * Updated notes on lint-staged limitations and file coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->