### PR TITLE
feat(providers): ride the SSE wire for LiteLLM generate()

### DIFF
--- a/docs/api/type-aliases/OpenAICompatBuildBodyArgs.md
+++ b/docs/api/type-aliases/OpenAICompatBuildBodyArgs.md
@@ -8,7 +8,7 @@
 
 > **OpenAICompatBuildBodyArgs** = `object`
 
-Defined in: [types/openaiCompatible.ts:318](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L318)
+Defined in: [types/openaiCompatible.ts:322](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L322)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/openaiCompatible.ts:318](https://github.com/juspay/neurolink/
 
 > **modelId**: `string`
 
-Defined in: [types/openaiCompatible.ts:319](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L319)
+Defined in: [types/openaiCompatible.ts:323](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L323)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/openaiCompatible.ts:319](https://github.com/juspay/neurolink/
 
 > **messages**: [`OpenAICompatChatMessage`](OpenAICompatChatMessage.md)[]
 
-Defined in: [types/openaiCompatible.ts:320](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L320)
+Defined in: [types/openaiCompatible.ts:324](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L324)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/openaiCompatible.ts:320](https://github.com/juspay/neurolink/
 
 > **options**: `object`
 
-Defined in: [types/openaiCompatible.ts:321](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L321)
+Defined in: [types/openaiCompatible.ts:325](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L325)
 
 #### maxTokens?
 
@@ -78,7 +78,7 @@ explicit channel for non-OpenAI knobs (e.g. NVIDIA NIM's `top_k` /
 
 > `optional` **tools?**: [`OpenAICompatChatTool`](OpenAICompatChatTool.md)[]
 
-Defined in: [types/openaiCompatible.ts:338](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L338)
+Defined in: [types/openaiCompatible.ts:342](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L342)
 
 ---
 
@@ -86,7 +86,7 @@ Defined in: [types/openaiCompatible.ts:338](https://github.com/juspay/neurolink/
 
 > `optional` **toolChoice?**: [`OpenAICompatToolChoiceWire`](OpenAICompatToolChoiceWire.md)
 
-Defined in: [types/openaiCompatible.ts:339](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L339)
+Defined in: [types/openaiCompatible.ts:343](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L343)
 
 ---
 
@@ -94,7 +94,7 @@ Defined in: [types/openaiCompatible.ts:339](https://github.com/juspay/neurolink/
 
 > **streaming**: `boolean`
 
-Defined in: [types/openaiCompatible.ts:340](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L340)
+Defined in: [types/openaiCompatible.ts:344](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L344)
 
 ---
 
@@ -102,4 +102,4 @@ Defined in: [types/openaiCompatible.ts:340](https://github.com/juspay/neurolink/
 
 > `optional` **responseFormat?**: [`OpenAICompatResponseFormat`](OpenAICompatResponseFormat.md)
 
-Defined in: [types/openaiCompatible.ts:341](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L341)
+Defined in: [types/openaiCompatible.ts:345](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L345)

--- a/docs/api/type-aliases/OpenAICompatSSEResult.md
+++ b/docs/api/type-aliases/OpenAICompatSSEResult.md
@@ -51,3 +51,23 @@ Defined in: [types/openaiCompatible.ts:260](https://github.com/juspay/neurolink/
 > `optional` **usage?**: [`OpenAICompatUsage`](OpenAICompatUsage.md)
 
 Defined in: [types/openaiCompatible.ts:267](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L267)
+
+---
+
+### id?
+
+> `optional` **id?**: `string`
+
+Defined in: [types/openaiCompatible.ts:269](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L269)
+
+Response id from the first stream chunk that carried one.
+
+---
+
+### model?
+
+> `optional` **model?**: `string`
+
+Defined in: [types/openaiCompatible.ts:271](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L271)
+
+Served model from the first stream chunk that carried one.

--- a/docs/api/type-aliases/OpenAICompatStreamChunk.md
+++ b/docs/api/type-aliases/OpenAICompatStreamChunk.md
@@ -8,7 +8,7 @@
 
 > **OpenAICompatStreamChunk** = `object`
 
-Defined in: [types/openaiCompatible.ts:275](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L275)
+Defined in: [types/openaiCompatible.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L279)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/openaiCompatible.ts:275](https://github.com/juspay/neurolink/
 
 > **content**: `string`
 
-Defined in: [types/openaiCompatible.ts:275](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L275)
+Defined in: [types/openaiCompatible.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L279)
 
 ---
 
@@ -24,4 +24,4 @@ Defined in: [types/openaiCompatible.ts:275](https://github.com/juspay/neurolink/
 
 > `optional` **reasoning?**: `string`
 
-Defined in: [types/openaiCompatible.ts:275](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L275)
+Defined in: [types/openaiCompatible.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L279)

--- a/docs/api/type-aliases/OpenAICompatStreamLifecycleListeners.md
+++ b/docs/api/type-aliases/OpenAICompatStreamLifecycleListeners.md
@@ -8,7 +8,7 @@
 
 > **OpenAICompatStreamLifecycleListeners** = `object`
 
-Defined in: [types/openaiCompatible.ts:350](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L350)
+Defined in: [types/openaiCompatible.ts:354](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L354)
 
 Per-stream lifecycle listeners returned from an OpenAIChatCompletionsProvider
 subclass's `onStreamStart` hook. Every property is optional — provide only
@@ -21,7 +21,7 @@ the deferred analytics promises.
 
 > `optional` **onUsage?**: (`usage`) => `void`
 
-Defined in: [types/openaiCompatible.ts:357](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L357)
+Defined in: [types/openaiCompatible.ts:361](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L361)
 
 Fired once the deferred usage promise resolves with the final aggregated
 token counts. promptTokens is the UNCACHED remainder; cacheReadTokens
@@ -44,7 +44,7 @@ reasoningTokens is a subset of completionTokens.
 
 > `optional` **onFinish?**: (`reason`, `capturedError?`) => `void`
 
-Defined in: [types/openaiCompatible.ts:363](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L363)
+Defined in: [types/openaiCompatible.ts:367](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L367)
 
 Fired once the deferred finish promise resolves. `reason` is "stop",
 "length", "tool-calls", "content-filter", or "error". When the loop

--- a/docs/api/type-aliases/StreamLoopArgs.md
+++ b/docs/api/type-aliases/StreamLoopArgs.md
@@ -8,7 +8,7 @@
 
 > **StreamLoopArgs** = `object`
 
-Defined in: [types/openaiCompatible.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L291)
+Defined in: [types/openaiCompatible.ts:295](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L295)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/openaiCompatible.ts:291](https://github.com/juspay/neurolink/
 
 > **maxSteps**: `number`
 
-Defined in: [types/openaiCompatible.ts:292](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L292)
+Defined in: [types/openaiCompatible.ts:296](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L296)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/openaiCompatible.ts:292](https://github.com/juspay/neurolink/
 
 > **modelId**: `string`
 
-Defined in: [types/openaiCompatible.ts:293](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L293)
+Defined in: [types/openaiCompatible.ts:297](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L297)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/openaiCompatible.ts:293](https://github.com/juspay/neurolink/
 
 > **url**: `string`
 
-Defined in: [types/openaiCompatible.ts:294](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L294)
+Defined in: [types/openaiCompatible.ts:298](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L298)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/openaiCompatible.ts:294](https://github.com/juspay/neurolink/
 
 > **fetchImpl**: _typeof_ `fetch`
 
-Defined in: [types/openaiCompatible.ts:295](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L295)
+Defined in: [types/openaiCompatible.ts:299](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L299)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/openaiCompatible.ts:295](https://github.com/juspay/neurolink/
 
 > **abortSignal**: `AbortSignal` \| `undefined`
 
-Defined in: [types/openaiCompatible.ts:296](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L296)
+Defined in: [types/openaiCompatible.ts:300](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L300)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/openaiCompatible.ts:296](https://github.com/juspay/neurolink/
 
 > **options**: [`StreamOptions`](StreamOptions.md)
 
-Defined in: [types/openaiCompatible.ts:297](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L297)
+Defined in: [types/openaiCompatible.ts:301](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L301)
 
 ---
 
@@ -64,7 +64,7 @@ Defined in: [types/openaiCompatible.ts:297](https://github.com/juspay/neurolink/
 
 > **conversation**: [`OpenAICompatChatMessage`](OpenAICompatChatMessage.md)[]
 
-Defined in: [types/openaiCompatible.ts:298](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L298)
+Defined in: [types/openaiCompatible.ts:302](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L302)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [types/openaiCompatible.ts:298](https://github.com/juspay/neurolink/
 
 > **openAITools**: [`OpenAICompatChatTool`](OpenAICompatChatTool.md)[] \| `undefined`
 
-Defined in: [types/openaiCompatible.ts:299](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L299)
+Defined in: [types/openaiCompatible.ts:303](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L303)
 
 ---
 
@@ -80,7 +80,7 @@ Defined in: [types/openaiCompatible.ts:299](https://github.com/juspay/neurolink/
 
 > **openAIToolChoice**: [`OpenAICompatToolChoiceWire`](OpenAICompatToolChoiceWire.md) \| `undefined`
 
-Defined in: [types/openaiCompatible.ts:300](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L300)
+Defined in: [types/openaiCompatible.ts:304](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L304)
 
 ---
 
@@ -88,7 +88,7 @@ Defined in: [types/openaiCompatible.ts:300](https://github.com/juspay/neurolink/
 
 > **toolsRecord**: `Record`\<`string`, `Tool`\>
 
-Defined in: [types/openaiCompatible.ts:301](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L301)
+Defined in: [types/openaiCompatible.ts:305](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L305)
 
 ---
 
@@ -96,7 +96,7 @@ Defined in: [types/openaiCompatible.ts:301](https://github.com/juspay/neurolink/
 
 > `optional` **toolNameFromWire?**: `Map`\<`string`, `string`\>
 
-Defined in: [types/openaiCompatible.ts:303](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L303)
+Defined in: [types/openaiCompatible.ts:307](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L307)
 
 Wire → registered tool-name map when sanitization was needed (see buildWireToolNameMaps).
 
@@ -106,7 +106,7 @@ Wire → registered tool-name map when sanitization was needed (see buildWireToo
 
 > **emitter**: `TypedEventEmitter`\<[`NeuroLinkEvents`](NeuroLinkEvents.md)\> \| `undefined`
 
-Defined in: [types/openaiCompatible.ts:304](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L304)
+Defined in: [types/openaiCompatible.ts:308](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L308)
 
 ---
 
@@ -114,7 +114,7 @@ Defined in: [types/openaiCompatible.ts:304](https://github.com/juspay/neurolink/
 
 > **toolsUsed**: `string`[]
 
-Defined in: [types/openaiCompatible.ts:305](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L305)
+Defined in: [types/openaiCompatible.ts:309](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L309)
 
 ---
 
@@ -122,7 +122,7 @@ Defined in: [types/openaiCompatible.ts:305](https://github.com/juspay/neurolink/
 
 > **toolExecutionSummaries**: [`ToolExecutionSummaryInternal`](ToolExecutionSummaryInternal.md)[]
 
-Defined in: [types/openaiCompatible.ts:306](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L306)
+Defined in: [types/openaiCompatible.ts:310](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L310)
 
 ---
 
@@ -130,7 +130,7 @@ Defined in: [types/openaiCompatible.ts:306](https://github.com/juspay/neurolink/
 
 > **pushChunk**: (`chunk`) => `void`
 
-Defined in: [types/openaiCompatible.ts:307](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L307)
+Defined in: [types/openaiCompatible.ts:311](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L311)
 
 #### Parameters
 
@@ -148,7 +148,7 @@ Defined in: [types/openaiCompatible.ts:307](https://github.com/juspay/neurolink/
 
 > **closeChannel**: () => `void`
 
-Defined in: [types/openaiCompatible.ts:309](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L309)
+Defined in: [types/openaiCompatible.ts:313](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L313)
 
 Signals the channel that no further chunks will arrive (success or error path alike).
 
@@ -162,7 +162,7 @@ Signals the channel that no further chunks will arrive (success or error path al
 
 > **resolveUsage**: (`u`) => `void`
 
-Defined in: [types/openaiCompatible.ts:310](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L310)
+Defined in: [types/openaiCompatible.ts:314](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L314)
 
 #### Parameters
 
@@ -190,7 +190,7 @@ Defined in: [types/openaiCompatible.ts:310](https://github.com/juspay/neurolink/
 
 > **resolveFinish**: (`reason`) => `void`
 
-Defined in: [types/openaiCompatible.ts:315](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L315)
+Defined in: [types/openaiCompatible.ts:319](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L319)
 
 #### Parameters
 

--- a/docs/api/type-aliases/ToolExecutionSummaryInternal.md
+++ b/docs/api/type-aliases/ToolExecutionSummaryInternal.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionSummaryInternal** = `object`
 
-Defined in: [types/openaiCompatible.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L279)
+Defined in: [types/openaiCompatible.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L283)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/openaiCompatible.ts:279](https://github.com/juspay/neurolink/
 
 > **toolCallId**: `string`
 
-Defined in: [types/openaiCompatible.ts:280](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L280)
+Defined in: [types/openaiCompatible.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L284)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/openaiCompatible.ts:280](https://github.com/juspay/neurolink/
 
 > **toolName**: `string`
 
-Defined in: [types/openaiCompatible.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L281)
+Defined in: [types/openaiCompatible.ts:285](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L285)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/openaiCompatible.ts:281](https://github.com/juspay/neurolink/
 
 > **input**: `unknown`
 
-Defined in: [types/openaiCompatible.ts:282](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L282)
+Defined in: [types/openaiCompatible.ts:286](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L286)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/openaiCompatible.ts:282](https://github.com/juspay/neurolink/
 
 > `optional` **output?**: `unknown`
 
-Defined in: [types/openaiCompatible.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L283)
+Defined in: [types/openaiCompatible.ts:287](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L287)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/openaiCompatible.ts:283](https://github.com/juspay/neurolink/
 
 > `optional` **error?**: `string`
 
-Defined in: [types/openaiCompatible.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L284)
+Defined in: [types/openaiCompatible.ts:288](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L288)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/openaiCompatible.ts:284](https://github.com/juspay/neurolink/
 
 > **startTime**: `Date`
 
-Defined in: [types/openaiCompatible.ts:285](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L285)
+Defined in: [types/openaiCompatible.ts:289](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L289)
 
 ---
 
@@ -64,4 +64,4 @@ Defined in: [types/openaiCompatible.ts:285](https://github.com/juspay/neurolink/
 
 > **endTime**: `Date`
 
-Defined in: [types/openaiCompatible.ts:286](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L286)
+Defined in: [types/openaiCompatible.ts:290](https://github.com/juspay/neurolink/blob/release/src/lib/types/openaiCompatible.ts#L290)

--- a/src/lib/providers/litellm/client.ts
+++ b/src/lib/providers/litellm/client.ts
@@ -340,6 +340,21 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
   }
 
   /**
+   * generate() rides the SSE wire for LiteLLM: deployments commonly sit
+   * behind proxies/tunnels (e.g. Cloudflare, which 524s an origin that is
+   * silent for ~100s), and a non-streaming completion from a slow model
+   * sends nothing until it is fully done. Streaming keeps bytes flowing for
+   * the whole generation while the base class aggregates into the same
+   * complete result — structuredData coercion, tool calls, stopReason,
+   * usage and the JSON damage flags are unchanged for callers.
+   * Escape hatch: NEUROLINK_LITELLM_SSE_GENERATE=false restores the plain
+   * JSON wire.
+   */
+  protected useStreamingWireForGenerate(): boolean {
+    return process.env.NEUROLINK_LITELLM_SSE_GENERATE !== "false";
+  }
+
+  /**
    * Gemini 2.5 models on LiteLLM have a known compatibility issue with
    * `max_tokens` — strip it before the wire body is built. Applies to
    * both streaming and non-streaming paths.

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -200,6 +200,22 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   }
 
   /**
+   * When true, `doGenerate` puts `stream: true` on the wire and aggregates
+   * the SSE stream into the SAME complete result the JSON wire returns —
+   * callers still get one awaited result with structuredData coercion, tool
+   * calls, finish reason and usage intact. Bytes then flow continuously, so
+   * proxy/tunnel idle limits (e.g. Cloudflare's ~100s 524 on tunneled
+   * gateways) cannot kill a slow completion, and the request timeout is
+   * re-armed on every chunk (idle semantics) instead of capping total
+   * duration. Default false: some OpenAI-compatible backends mishandle
+   * `stream_options` or omit usage on streams, so each provider opts in
+   * deliberately. LiteLLM overrides this to true.
+   */
+  protected useStreamingWireForGenerate(): boolean {
+    return false;
+  }
+
+  /**
    * Hook to adjust the fully-built wire request body before it is sent, on
    * both the streaming and non-streaming paths. Default identity. Override for
    * provider/model quirks that can't be expressed through buildBody options —
@@ -541,6 +557,8 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     const resolveWireMaxTokens = this.resolveWireMaxTokens.bind(this);
     const suppressResponseFormatWithTools =
       this.suppressResponseFormatWithTools.bind(this);
+    const useStreamingWireForGenerate =
+      this.useStreamingWireForGenerate.bind(this);
     const getTimeoutForOptions = (
       opts: Record<string, unknown> | undefined,
     ): number => this.getTimeout((opts ?? {}) as never);
@@ -606,6 +624,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
           baseMessages,
           wireTools,
         );
+        // SSE wire for generate (opt-in per provider): stream on the wire,
+        // aggregate below into the same complete response the JSON wire
+        // yields. See useStreamingWireForGenerate.
+        const sseWire = useStreamingWireForGenerate();
         const body = ensureJsonWordInBody(
           adjustRequestBody(
             buildBody({
@@ -629,7 +651,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
                     ),
                   }
                 : {}),
-              streaming: false,
+              streaming: sseWire,
               ...(responseFormat ? { responseFormat } : {}),
             }),
             modelId,
@@ -663,6 +685,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             timeoutController?.controller.signal,
           );
         let json: OpenAICompatChatResponse;
+        // Whether the response we end up consuming is SSE. Starts as the
+        // provider's wire preference; the 400 fallback below can flip it
+        // when a backend rejects `stream`/`stream_options` outright.
+        let wireIsStreaming = sseWire;
         try {
           let res = await fetchImpl(url, {
             method: "POST",
@@ -686,13 +712,13 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             // attempt, so the configured timeout caps the overall call —
             // matching the streaming path, which reuses its composed signal
             // for the retry.
-            const retryBody =
+            const typedErr = apiErr as Error & {
+              statusCode?: number;
+              responseBody?: string;
+            };
+            let retryBody =
               res.status === 400
                 ? (() => {
-                    const typedErr = apiErr as Error & {
-                      statusCode?: number;
-                      responseBody?: string;
-                    };
                     const overflowCorrected = correctBodyAfterContextOverflow(
                       body,
                       typedErr,
@@ -703,6 +729,24 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
                     );
                   })()
                 : undefined;
+            // SSE-wire net: a backend that rejects streaming itself (the 400
+            // names `stream`/`stream_options`) gets ONE retry on the plain
+            // JSON wire. Gated on the error text so a genuine bad request
+            // isn't replayed just to fail identically a second time.
+            if (
+              !retryBody &&
+              sseWire &&
+              res.status === 400 &&
+              /stream/i.test(typedErr.responseBody ?? "")
+            ) {
+              const {
+                stream: _stream,
+                stream_options: _streamOptions,
+                ...jsonWireBody
+              } = body;
+              retryBody = jsonWireBody;
+              wireIsStreaming = false;
+            }
             if (!retryBody) {
               throw apiErr;
             }
@@ -723,7 +767,62 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
           // after cleanup(), so a response whose headers arrived but whose
           // body stalled mid-transfer was bounded by nothing but the caller's
           // outer wall-clock.
-          json = (await res.json()) as OpenAICompatChatResponse;
+          if (wireIsStreaming) {
+            if (!res.body) {
+              throw new Error(
+                `${providerName}: streaming generate response had no body`,
+              );
+            }
+            // Idle-timeout semantics: every raw chunk re-arms the timeout,
+            // so the configured window bounds silence, not total duration —
+            // the whole point of the SSE wire is that a slow-but-alive
+            // completion keeps the connection (and the timer) fed.
+            const monitored = timeoutController
+              ? res.body.pipeThrough(
+                  new TransformStream<Uint8Array, Uint8Array>({
+                    transform(chunk, controller) {
+                      timeoutController.reset();
+                      controller.enqueue(chunk);
+                    },
+                  }),
+                )
+              : res.body;
+            const sse = await parseSSEStream(monitored, () => {});
+            // Re-shape the aggregate into the JSON-wire response so every
+            // line below this point (content parts, finish-reason mapping,
+            // usage clamping, response metadata) is shared verbatim between
+            // the two wires and cannot drift.
+            json = {
+              ...(sse.id ? { id: sse.id } : {}),
+              ...(sse.model ? { model: sse.model } : {}),
+              choices: [
+                {
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: sse.text.length > 0 ? sse.text : null,
+                    ...(sse.reasoning ? { reasoning: sse.reasoning } : {}),
+                    ...(sse.toolCalls.size > 0
+                      ? {
+                          tool_calls: [...sse.toolCalls.values()].map((tc) => ({
+                            id: tc.id,
+                            type: "function" as const,
+                            function: {
+                              name: tc.name,
+                              arguments: tc.argsBuffered,
+                            },
+                          })),
+                        }
+                      : {}),
+                  },
+                  finish_reason: sse.finishReason ?? "stop",
+                },
+              ],
+              ...(sse.usage ? { usage: sse.usage } : {}),
+            };
+          } else {
+            json = (await res.json()) as OpenAICompatChatResponse;
+          }
         } finally {
           timeoutController?.cleanup();
           disposeComposedSignal();

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -665,6 +665,12 @@ export const parseSSEStream = async (
     if (chunk.usage) {
       result.usage = chunk.usage;
     }
+    if (chunk.id && !result.id) {
+      result.id = chunk.id;
+    }
+    if (chunk.model && !result.model) {
+      result.model = chunk.model;
+    }
     const choice = chunk.choices?.[0];
     if (!choice) {
       return;

--- a/src/lib/types/openaiCompatible.ts
+++ b/src/lib/types/openaiCompatible.ts
@@ -265,6 +265,10 @@ export type OpenAICompatSSEResult = {
     | "content_filter"
     | null;
   usage?: OpenAICompatUsage;
+  /** Response id from the first stream chunk that carried one. */
+  id?: string;
+  /** Served model from the first stream chunk that carried one. */
+  model?: string;
 };
 
 // Reasoning deltas ride alongside an always-present (empty) `content` string

--- a/src/lib/utils/timeout.ts
+++ b/src/lib/utils/timeout.ts
@@ -431,6 +431,13 @@ export function createTimeoutController(
 ): {
   controller: AbortController;
   cleanup: () => void;
+  /**
+   * Re-arm the timeout window from now. Streaming consumers call this on
+   * every chunk so the timeout bounds *idle* time rather than total
+   * duration — a slow-but-alive upstream is not killed mid-generation.
+   * No-op once the controller has already aborted.
+   */
+  reset: () => void;
   timeoutMs: number;
 } | null {
   const timeoutMs = parseTimeout(timeout);
@@ -441,7 +448,7 @@ export function createTimeoutController(
 
   const controller = new AbortController();
 
-  const timer = setTimeout(() => {
+  const fire = () => {
     // NOTE: we cannot stamp the AI SDK's ai.streamText/ai.generateText span
     // from here — the setTimeout callback runs in the async context captured
     // at schedule time, which is BEFORE the AI SDK span exists. Instead we
@@ -456,13 +463,23 @@ export function createTimeoutController(
         operation,
       ),
     );
-  }, timeoutMs);
+  };
+
+  let timer = setTimeout(fire, timeoutMs);
 
   const cleanup = () => {
     clearTimeout(timer);
   };
 
-  return { controller, cleanup, timeoutMs };
+  const reset = () => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    clearTimeout(timer);
+    timer = setTimeout(fire, timeoutMs);
+  };
+
+  return { controller, cleanup, reset, timeoutMs };
 }
 
 /**

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -392,6 +392,278 @@ async function runOpenAICompatSection(): Promise<void> {
 }
 
 // ───────────────────────────────────────────────────────────────────────
+// Section: LiteLLM generate() over the SSE wire
+// (useStreamingWireForGenerate: doGenerate sends stream:true, aggregates
+//  the SSE into the same complete result the JSON wire yields — the fix
+//  for tunnel idle timeouts killing slow non-streaming completions.)
+// ───────────────────────────────────────────────────────────────────────
+
+function sseBody(chunks: unknown[]): string {
+  return (
+    chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join("") +
+    "data: [DONE]\n\n"
+  );
+}
+
+async function runLiteLLMSSESection(): Promise<void> {
+  console.log("\n=== LLM litellm (generate over SSE wire) ===");
+  const section = "LLM litellm";
+
+  setEnv("LITELLM_API_KEY", "test-fake-litellm-credential");
+  // Non-default port so a real proxy on localhost:4000 can never absorb a
+  // call the mock table should have caught.
+  setEnv("LITELLM_BASE_URL", "http://127.0.0.1:4009");
+  setEnv("NEUROLINK_LITELLM_SSE_GENERATE", undefined);
+
+  const { NeuroLink } = await import("../dist/index.js");
+
+  // ensureModelLimits fires GET /model/info before generation.
+  const modelInfoRoute = {
+    method: "GET",
+    url: "127.0.0.1:4009/model/info",
+    respond: { status: 200, json: { data: [] } },
+  };
+
+  // ── Happy path: stream:true on the wire, multi-chunk text aggregates ──
+  try {
+    await withMocks(
+      [
+        modelInfoRoute,
+        {
+          method: "POST",
+          url: "127.0.0.1:4009/chat/completions",
+          respond: {
+            status: 200,
+            contentType: "text/event-stream",
+            text: sseBody([
+              {
+                id: "chatcmpl-sse-1",
+                model: "qwen-mock",
+                choices: [
+                  {
+                    index: 0,
+                    delta: { role: "assistant", content: "po" },
+                    finish_reason: null,
+                  },
+                ],
+              },
+              {
+                choices: [
+                  { index: 0, delta: { content: "ng" }, finish_reason: null },
+                ],
+              },
+              { choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+              {
+                choices: [],
+                usage: {
+                  prompt_tokens: 7,
+                  completion_tokens: 2,
+                  total_tokens: 9,
+                },
+              },
+            ]),
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const result = await nl.generate({
+          provider: "litellm",
+          model: "qwen-mock",
+          input: { text: "ping" },
+          disableTools: true,
+        });
+        const chat = calls.find((c) => c.url.includes("/chat/completions"));
+        expect(chat !== undefined, "chat/completions call captured");
+        const body = (chat?.bodyJson ?? {}) as {
+          stream?: boolean;
+          stream_options?: { include_usage?: boolean };
+        };
+        expectEq(body.stream, true, "wire body stream flag");
+        expectEq(
+          body.stream_options?.include_usage,
+          true,
+          "stream_options.include_usage",
+        );
+        expectEq(result.content, "pong", "aggregated content");
+        expectEq(result.usage?.input, 7, "usage input tokens");
+        expectEq(result.usage?.output, 2, "usage output tokens");
+      },
+    );
+    record(results, `${section}: generate() rides the SSE wire`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: generate() rides the SSE wire`,
+      false,
+      String(err),
+    );
+  }
+
+  // ── Schema-bound generate: structuredData coerced from streamed text ──
+  try {
+    await withMocks(
+      [
+        modelInfoRoute,
+        {
+          method: "POST",
+          url: "127.0.0.1:4009/chat/completions",
+          respond: {
+            status: 200,
+            contentType: "text/event-stream",
+            text: sseBody([
+              {
+                choices: [
+                  {
+                    index: 0,
+                    delta: { role: "assistant", content: '{"answer":' },
+                    finish_reason: null,
+                  },
+                ],
+              },
+              {
+                choices: [
+                  {
+                    index: 0,
+                    delta: { content: '"42"}' },
+                    finish_reason: null,
+                  },
+                ],
+              },
+              { choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+            ]),
+          },
+        },
+      ],
+      async () => {
+        const { z } = await import("zod");
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const result = await nl.generate({
+          provider: "litellm",
+          model: "qwen-mock",
+          input: { text: "answer in json" },
+          schema: z.object({ answer: z.string() }),
+          disableTools: true,
+        });
+        const structured = result.structuredData as
+          | { answer?: string }
+          | undefined;
+        expectEq(structured?.answer, "42", "structuredData.answer");
+      },
+    );
+    record(results, `${section}: schema-bound SSE yields structuredData`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: schema-bound SSE yields structuredData`,
+      false,
+      String(err),
+    );
+  }
+
+  // ── Backend that rejects streaming: one retry on the plain JSON wire ──
+  try {
+    await withMocks(
+      [
+        modelInfoRoute,
+        {
+          method: "POST",
+          url: "127.0.0.1:4009/chat/completions",
+          respond: (call) => {
+            const body = call.bodyJson as { stream?: boolean };
+            if (body.stream) {
+              return {
+                status: 400,
+                json: {
+                  error: { message: "stream is not supported for this model" },
+                },
+              };
+            }
+            return {
+              status: 200,
+              json: openAIChatResponse("pong", "qwen-mock"),
+            };
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const result = await nl.generate({
+          provider: "litellm",
+          model: "qwen-mock",
+          input: { text: "ping" },
+          disableTools: true,
+        });
+        expectEq(result.content, "pong", "content after JSON-wire retry");
+        const chatCalls = calls.filter((c) =>
+          c.url.includes("/chat/completions"),
+        );
+        expectEq(chatCalls.length, 2, "streamed attempt + JSON-wire retry");
+        const retryBody = (chatCalls[1]?.bodyJson ?? {}) as {
+          stream?: boolean;
+          stream_options?: unknown;
+        };
+        expectEq(retryBody.stream, undefined, "retry body has no stream flag");
+        expectEq(
+          retryBody.stream_options,
+          undefined,
+          "retry body has no stream_options",
+        );
+      },
+    );
+    record(results, `${section}: stream-rejecting backend falls back`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: stream-rejecting backend falls back`,
+      false,
+      String(err),
+    );
+  }
+
+  // ── Escape hatch: NEUROLINK_LITELLM_SSE_GENERATE=false → JSON wire ──
+  try {
+    setEnv("NEUROLINK_LITELLM_SSE_GENERATE", "false");
+    await withMocks(
+      [
+        modelInfoRoute,
+        {
+          method: "POST",
+          url: "127.0.0.1:4009/chat/completions",
+          respond: {
+            status: 200,
+            json: openAIChatResponse("pong", "qwen-mock"),
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const result = await nl.generate({
+          provider: "litellm",
+          model: "qwen-mock",
+          input: { text: "ping" },
+          disableTools: true,
+        });
+        const chat = calls.find((c) => c.url.includes("/chat/completions"));
+        const body = (chat?.bodyJson ?? {}) as { stream?: boolean };
+        expectEq(body.stream, undefined, "escape hatch restores JSON wire");
+        expectEq(result.content, "pong", "JSON-wire content");
+      },
+    );
+    record(results, `${section}: SSE escape hatch restores JSON wire`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: SSE escape hatch restores JSON wire`,
+      false,
+      String(err),
+    );
+  } finally {
+    setEnv("NEUROLINK_LITELLM_SSE_GENERATE", undefined);
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
 // Section: Replicate LLM (predict-then-poll via /v1/models/{model}/predictions)
 // ───────────────────────────────────────────────────────────────────────
 
@@ -2013,6 +2285,7 @@ async function main(): Promise<void> {
 
   try {
     await runOpenAICompatSection();
+    await runLiteLLMSSESection();
     await runReplicateLLMSection();
     await runEmbeddingsSection();
     await runImageGenSection();


### PR DESCRIPTION
## Summary
A non-streaming completion sends no bytes until it is fully done, so a proxy/tunnel idle limit (e.g. Cloudflare's ~100s 524 on tunneled LiteLLM gateways) kills any slow model — this is what fails the Yama review on qwen3.8-27b (see PR #1514). Callers like Yama cannot switch to `stream()` because their schema-bound contract needs the complete `GenerateResult` (`structuredData`, `toolExecutions`, `stopReason`, `usage`, JSON damage flags).

Fix: `doGenerate` in the OpenAI-compat base can now opt into `stream: true` on the wire (new `useStreamingWireForGenerate()` hook, default false; LiteLLM opts in) and aggregates the SSE via the existing `parseSSEStream` into the exact JSON-wire response shape — everything downstream (content parts, finish-reason mapping, usage clamping, schema coercion) is shared verbatim between the two wires, so callers see zero behavioral change beyond surviving slow completions.

- Request timeout now re-arms on every chunk (idle semantics) instead of capping total duration — `createTimeoutController` gained `reset()`.
- A backend whose 400 names `stream`/`stream_options` gets one retry on the plain JSON wire.
- Escape hatch: `NEUROLINK_LITELLM_SSE_GENERATE=false` restores the plain JSON wire.

## Test plan
- [x] `pnpm run check` + `check:tools-tests` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run test:providers-mocked` — 58/58, including 4 new contract tests: stream flags on the wire body, multi-chunk aggregation + usage, schema-bound `structuredData` from streamed JSON, stream-rejection fallback, and the env escape hatch
- [x] Non-litellm providers unaffected (hook defaults to false; existing mocked contract tests still pass on the JSON wire)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LiteLLM generation now uses streaming responses by default.
  * Streamed results preserve response details, usage, reasoning, tool calls, and structured output.
  * Streaming automatically retries with a standard request when unsupported.
  * Set `NEUROLINK_LITELLM_SSE_GENERATE=false` to restore JSON requests.

* **Bug Fixes**
  * Improved timeout handling during long-running streamed responses.
  * Preserved response IDs and model information from streamed results.

* **Tests**
  * Added coverage for streaming, usage aggregation, structured output, fallback behavior, and the configuration override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->