### PR TITLE
fix(test): assert the React hooks through the subpath that publishes them

### DIFF
--- a/test/continuous-test-suite-client.ts
+++ b/test/continuous-test-suite-client.ts
@@ -1076,7 +1076,21 @@ async function testReactHooksExports(): Promise<boolean | null> {
   logTest("React hooks are importable", "TESTING");
 
   try {
-    const clientModule = await import("../dist/index.js");
+    // Import the way a consumer does, through the published subpath.
+    //
+    // This asserted against "../dist/index.js" — the root barrel — where the
+    // hooks are not exported and should not be: putting React on the default
+    // entry would pull it into every consumer of the package. They are
+    // published under the "./client" subpath, so the test failed permanently
+    // while the code was correct.
+    //
+    // Using the package specifier rather than "../dist/client/index.js" covers
+    // one thing more: it resolves through the "exports" map in package.json, so
+    // a broken or mis-pathed subpath entry fails here too. Node resolves this
+    // by self-reference to this repo's own build — verified as
+    // <repo>/dist/client/index.js, with no @juspay in node_modules to shadow
+    // it — so it is still the built output rule 15 requires, not src.
+    const clientModule = await import("@juspay/neurolink/client");
 
     const hooks = [
       "NeuroLinkProvider",


### PR DESCRIPTION
## The bug

The React-hooks case imported `../dist/index.js` — the **root barrel** — and asserted eight hooks are exported there:

```ts
const clientModule = await import("../dist/index.js");
const hooks = ["NeuroLinkProvider", "useNeuroLinkClient", "useChat", ...];
```

They are not on the root barrel, and should not be — putting React on the default entry pulls it into every consumer of the package. They are published under the **`./client`** subpath.

So the assertion failed permanently while the code was correct. `test:client` has been reporting **12 passed / 1 failed** on `release`. It went unnoticed because `test:client` is one of the **59 of 84** suite scripts CI never runs.

## Why the package specifier, not a relative path

`import("@juspay/neurolink/client")` rather than `import("../dist/client/index.js")` covers one thing more: resolution goes **through the `exports` map in `package.json`**, so a broken or mis-pathed subpath entry fails here too.

Node resolves it by self-reference to this repo's own build — confirmed as `<repo>/dist/client/index.js` via `import.meta.resolve`, with no `@juspay` in `node_modules` to shadow it. So it is still the built output rule 15 requires, not `src`.

## Proven in both directions

|  | old test | new test |
|---|---|---|
| code as-is | **FAIL** — the bug | **PASS** |
| `exports["./client"]` repointed at a missing file | n/a | **FAIL** |

The second row is what justifies the package specifier. With `./client` pointed at a nonexistent file:

```
[FAIL] React hooks are importable — Cannot find module .../dist/client/WRONG.js
✗ React hooks exports
Passed: 12   Failed: 1   RESULT: FAIL
```

A relative `dist` import would have passed straight through that.

## Result

```
before   Passed: 12   Failed: 1   RESULT: FAIL
after    Passed: 13   Failed: 0   RESULT: PASS
```

Both hook cases now pass, including the one that proves wiring:

```
[PASS] React hooks are importable — All 8 hooks exported as functions
[PASS] React hooks invocation — useChat() outside renderer threw React-internal hook error
```

One test file. No `src` change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated export validation to use the package’s public client entry point.
  * Added coverage confirming that calling the chat hook outside a valid React renderer produces the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->