### PR TITLE
feat(lint): enforce Critical Rule 6 — formatProviderError must return, never throw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,22 +61,23 @@ These are non-negotiable. Violating them breaks the build or introduces bugs.
 
     **The one exception is determinism.** A test may sit outside this rule only when it needs deterministic control that a live call cannot give — a pure translation table, a fixed set of inputs, a recorded backend. The vector-store suites are the standing example: they drive real backends (pglite in-process Postgres, recorded fixtures) and cover filter-dialect translation that no live `generate()` could be made to emit. Convenience, speed, and "it is easier to assert on the internal" are not exceptions. When you take the exception, say so in the file's header and name what determinism buys.
 
-**Enforcement:** Rules 2 and 7-15 are enforced via ESLint. Rules 2, 7-13 and 15 use custom rules in `eslint-rules/`; rule 14 uses core `no-restricted-syntax` AST selectors in `eslint.config.js`. Run `pnpm run lint` (or the pre-commit hook) — no shell scripts, no regex heuristics, everything AST-based.
+**Enforcement:** Rules 2, 6 and 7-15 are enforced via ESLint. Rules 2, 6, 7-13 and 15 use custom rules in `eslint-rules/`; rule 14 uses core `no-restricted-syntax` AST selectors in `eslint.config.js`. Run `pnpm run lint` (or the pre-commit hook) — no shell scripts, no regex heuristics, everything AST-based.
 
 Rule 15's determinism exception is the `allow` list on `neurolink/e2e-tests-only` in `eslint.config.js`. Adding a file to it is a review decision, and the file's own header must say what determinism buys — it is not a way to silence the rule. The rule ignores type-only imports (`import type`, and `{ type A }` where every specifier is type-only) because they are erased and assert nothing.
 
-| Rule     | ESLint rule                              |
-| -------- | ---------------------------------------- |
-| 2        | `neurolink/no-local-type-alias`          |
-| 7        | `neurolink/no-interface`                 |
-| 8        | `neurolink/no-types-suffix-filename`     |
-| 9        | `neurolink/unique-type-names`            |
-| 10       | `neurolink/types-barrel-exports-only`    |
-| 11 & 11b | `neurolink/no-local-types-folder`        |
-| 12       | `neurolink/no-type-export-outside-types` |
-| 13       | `neurolink/barrel-type-imports`          |
-| 14       | `no-restricted-syntax` (AST selectors)   |
-| 15       | `neurolink/e2e-tests-only`               |
+| Rule     | ESLint rule                               |
+| -------- | ----------------------------------------- |
+| 2        | `neurolink/no-local-type-alias`           |
+| 6        | `neurolink/format-provider-error-returns` |
+| 7        | `neurolink/no-interface`                  |
+| 8        | `neurolink/no-types-suffix-filename`      |
+| 9        | `neurolink/unique-type-names`             |
+| 10       | `neurolink/types-barrel-exports-only`     |
+| 11 & 11b | `neurolink/no-local-types-folder`         |
+| 12       | `neurolink/no-type-export-outside-types`  |
+| 13       | `neurolink/barrel-type-imports`           |
+| 14       | `no-restricted-syntax` (AST selectors)    |
+| 15       | `neurolink/e2e-tests-only`                |
 
 ---
 

--- a/eslint-rules/format-provider-error-returns.cjs
+++ b/eslint-rules/format-provider-error-returns.cjs
@@ -1,0 +1,101 @@
+/**
+ * Rule 6: `formatProviderError` must RETURN an error, never throw one.
+ *
+ * The method's job is to turn a provider's raw failure into a typed Error that
+ * the caller then decides what to do with — usually `throw this.formatProviderError(e)`
+ * at the call site, sometimes recording it as data instead. A formatter that
+ * throws takes that decision away and, worse, throws from inside a catch block,
+ * which replaces the original failure with whatever the formatter produced.
+ *
+ * The consequence is specific rather than stylistic: `baseProvider` calls
+ * `this.formatProviderError(error)` and then inspects the returned value before
+ * deciding how to surface it. If the formatter throws, that inspection never
+ * runs and the surrounding error-handling path is skipped entirely.
+ *
+ * Detects a `throw` anywhere in the body of a `formatProviderError`
+ * implementation, including nested blocks — a throw inside an `if` or a `catch`
+ * inside the formatter escapes just as readily as one at the top.
+ *
+ * Exempts nothing. A formatter that genuinely cannot produce an Error should
+ * return a generic one, which is what every existing implementation does.
+ *
+ * The abstract declarations in `baseProvider` and `openaiChatCompletionsBase`
+ * have no body and are not matched.
+ *
+ * Status when added: 24 implementations across src/lib/providers, zero
+ * violations. This rule is a ratchet to keep it that way — CLAUDE.md listed
+ * Rule 6 as unenforced while every other critical rule had a lint.
+ */
+
+"use strict";
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "`formatProviderError` must return the error, never throw it (Critical Rule 6).",
+    },
+    schema: [],
+    messages: {
+      mustReturn:
+        "`formatProviderError` must RETURN the error, not throw it. The caller decides whether to throw — a formatter that throws skips the caller's handling entirely. See CLAUDE.md Critical Rule 6.",
+    },
+  },
+
+  create(context) {
+    /** Depth of formatProviderError bodies we are currently inside. */
+    let depth = 0;
+
+    const isFormatter = (node) => {
+      // method shorthand: `formatProviderError(error) { ... }`
+      if (node.parent && node.parent.type === "MethodDefinition") {
+        return (
+          node.parent.key && node.parent.key.name === "formatProviderError"
+        );
+      }
+      // property assignment: `formatProviderError = (error) => { ... }`
+      if (node.parent && node.parent.type === "PropertyDefinition") {
+        return (
+          node.parent.key && node.parent.key.name === "formatProviderError"
+        );
+      }
+      // plain function declaration
+      if (node.type === "FunctionDeclaration" && node.id) {
+        return node.id.name === "formatProviderError";
+      }
+      // `const formatProviderError = function/arrow`
+      if (node.parent && node.parent.type === "VariableDeclarator") {
+        return node.parent.id && node.parent.id.name === "formatProviderError";
+      }
+      return false;
+    };
+
+    const enter = (node) => {
+      if (isFormatter(node)) {
+        depth += 1;
+      }
+    };
+    const exit = (node) => {
+      if (isFormatter(node)) {
+        depth -= 1;
+      }
+    };
+
+    return {
+      FunctionDeclaration: enter,
+      "FunctionDeclaration:exit": exit,
+      FunctionExpression: enter,
+      "FunctionExpression:exit": exit,
+      ArrowFunctionExpression: enter,
+      "ArrowFunctionExpression:exit": exit,
+
+      ThrowStatement(node) {
+        if (depth > 0) {
+          context.report({ node, messageId: "mustReturn" });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/index.cjs
+++ b/eslint-rules/index.cjs
@@ -7,6 +7,7 @@
  * or the file path (for filesystem / naming rules).
  *
  * Rules:
+ *   neurolink/format-provider-error-returns → Rule 6: formatProviderError returns, never throws.
  *   neurolink/no-interface                → Rule 7: No `interface` (except declare merging).
  *   neurolink/no-types-suffix-filename    → Rule 8: No "Types"/"Type" suffix in filenames.
  *   neurolink/unique-type-names           → Rule 9: Globally unique names in src/lib/types/.
@@ -23,6 +24,7 @@
 
 module.exports = {
   rules: {
+    "format-provider-error-returns": require("./format-provider-error-returns.cjs"),
     "no-interface": require("./no-interface.cjs"),
     "no-types-suffix-filename": require("./no-types-suffix-filename.cjs"),
     "unique-type-names": require("./unique-type-names.cjs"),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,7 @@ export default [
       // NeuroLink custom type-engineering rules (CLAUDE.md Critical Rules)
       // All rules (7-13) enforced via ESLint — zero shell scripts.
       // ======================================================================
+      "neurolink/format-provider-error-returns": "error", // Rule 6
       "neurolink/no-interface": "error", // Rule 7
       "neurolink/no-types-suffix-filename": "error", // Rule 8
       "neurolink/unique-type-names": "error", // Rule 9


### PR DESCRIPTION
## What

CLAUDE.md's enforcement table lists rules 2 and 7–14 as lint-enforced. **Rule 6 was the odd one out** — documented as non-negotiable, checked by nobody. This adds `neurolink/format-provider-error-returns`.

## Why it matters concretely

`baseProvider` calls `this.formatProviderError(error)` and then inspects the returned value before deciding how to surface it. A formatter that *throws* skips that inspection entirely — and does so from inside a catch block, replacing the original provider failure with whatever the formatter produced. The caller loses both the decision and the original error.

## Audited before writing the rule

24 implementations across `src/lib/providers`, **zero violations**. So this is a ratchet rather than a cleanup: it turns nothing red today and stops the first regression.

## The detector was proven before being trusted

A `throw` planted inside lmStudio's formatter:

```
74:18  error  `formatProviderError` must RETURN the error, not throw it …
       neurolink/format-provider-error-returns
exit 1
```

and removing it returns exit 0. Without that step I would only have shown that a rule which reports nothing reports nothing.

## Seven RuleTester cases

Each states its expected outcome up front, so a silent rule cannot pass:

```
throw at the top of a method                     -> flagged
throw nested inside an if                        -> flagged
throw inside a catch within the formatter        -> flagged
arrow property form                              -> flagged
returns an Error                                 -> clean
throw in a DIFFERENT method                      -> clean
caller doing `throw this.formatProviderError(e)` -> clean
```

The last two are the ones worth having. The rule must not fire at the **call site**, where throwing the formatted error is exactly right — that distinction is the whole point of Rule 6, and a naive "no throw near formatProviderError" check would get it backwards.

## Scope note

Nested throws are covered deliberately: a `throw` inside an `if` or a `catch` within the formatter escapes just as readily as one at the top, so the rule tracks function depth rather than scanning only the immediate body.

## Verification

```
typecheck   4822 files / 0 errors
eslint .    exit 0
```

Contributes no warnings — the repo's count is unchanged at 57, verified by comparing the per-rule breakdown against clean release rather than against my own earlier note, which was stale (56).