### PR TITLE
ci(test): run 20 more credential-free suites in extended-suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,12 @@ jobs:
   # into nothing is documentation, not a test.
   extended-suites:
     runs-on: ubuntu-latest
+    # This job checks out and executes repository code on pull_request.
+    # The repository default is a WRITE-scoped token (and one that may
+    # approve reviews); nothing here needs either. Read is enough to
+    # checkout, install and run suites.
+    permissions:
+      contents: read
     name: Extended Suites (non-blocking)
     steps:
       - name: Checkout code
@@ -529,6 +535,36 @@ jobs:
           # each of these suites drives the public API against stubs, local
           # fixtures or mocked fetch, so a suite that starts making real network
           # calls fails here rather than silently costing money and flaking.
+          #
+          # The list below grew from 8 to 28. The 20 added were not picked by
+          # reading them: every suite script that CI never invoked was run with
+          # the environment fully stripped — `env -i` plus
+          # DOTENV_CONFIG_PATH=/dev/null, checked to actually suppress .env —
+          # and only the ones that passed that way are here. They contribute
+          # 373 assertions.
+          #
+          # test:middleware is held back despite passing that sweep. Run inside
+          # this 21-suite sequence it failed 2 of 2 times; run alone, or
+          # immediately after test:mcp, it passed 3 of 3 at 7/7. So it is
+          # reproducible in context rather than flaky, and the cause is not the
+          # suite that precedes it — that hypothesis was tested and refuted. It
+          # has a 60s per-test bound, which is the likeliest thing to give way
+          # under a long sequence. Worth 7 assertions to whoever diagnoses it.
+          #
+          # Two candidates that pass locally are deliberately absent, and the
+          # reason is the whole point of measuring rather than assuming:
+          # test:proxy passes with credentials (74 passed / 6 skipped) and
+          # FAILS without them (68 passed / 5 failed / 7 skipped), and
+          # test:multimodal:sdk exits non-zero with no summary. Either would
+          # have looked safe from a run on a developer machine.
+          #
+          # test:model-not-found-retryable is also absent: it skips entirely
+          # without credentials, so it could only ever no-op here — the same
+          # reason it is held out of the security-suites job.
+          #
+          # This job is non-blocking on purpose. These are measured once, not
+          # proven stable, and `security-suites` is a required check that
+          # blocks every open pull request when it breaks.
           SUITES="
             test:openai-compat-catalog
             test:handler-registry
@@ -538,6 +574,26 @@ jobs:
             test:music:unit
             test:video:unit
             test:realtime:unit
+            test:adjust-body-after-400
+            test:anthropic-streaming-retry
+            test:auth
+            test:autoresearch
+            test:codex
+            test:credentials
+            test:dynamic
+            test:local-usage
+            test:loop-engine
+            test:mcp
+            test:model-manifests
+            test:openai-compat-streaming-retry
+            test:provider-descriptors
+            test:provider-fallback
+            test:provider-fallback-latency
+            test:servers
+            test:tool-reliability
+            test:tool-resolution
+            test:vertex-claude-characterization
+            test:vertex-loop-characterization
           "
           FAILED=""
           for s in $SUITES; do


### PR DESCRIPTION
## Why

**59 of the repo's 84 suite scripts never execute on a pull request.** That isn't theoretical — it is why, this week alone:

- `test:rag` sat at **98 passed / 2 failed** on `release` (fixed in #1505)
- `test:client`'s React-hooks case had been asserting against the wrong entry point long enough that nobody noticed (fixed in #1520)
- `test:tts` reported `no audio buffer in result` with the real cause visible only in a log line (fixed in #1522)

## How the 20 were chosen

Not by reading them. **Every suite script CI never invoked was run with the environment fully stripped** — `env -i` plus `DOTENV_CONFIG_PATH=/dev/null`, checked to actually suppress `.env` rather than assumed:

```
DOTENV_CONFIG_PATH=/dev/null  ->  OPENAI_API_KEY seen: false
(control)                     ->  OPENAI_API_KEY seen: true
```

Only suites that passed that way are included. They contribute **373 assertions**, roughly doubling this job's coverage (8 suites → 28).

## What was excluded, and why that matters

Two candidates pass on a developer machine and are deliberately absent — this is the whole argument for measuring rather than assuming:

| suite | with credentials | without |
|---|---|---|
| `test:proxy` | 74 passed / 6 skipped | **68 passed / 5 FAILED / 7 skipped** |
| `test:multimodal:sdk` | passes | **exits non-zero, no summary** |

Either would have looked safe from a local run and broken the job.

`test:model-not-found-retryable` is also absent: it skips entirely without credentials, so it could only ever no-op — the same reason it is held out of `security-suites`.

**`test:middleware` is held back despite passing the sweep.** Inside the full sequence it failed **2 of 2** runs; alone, or immediately after `test:mcp`, it passed **3 of 3** at 7/7. That is reproducible in context rather than flaky. The obvious hypothesis — that the preceding suite leaves servers behind — was tested and refuted (`test:mcp` PASS → `test:middleware` 7/7 PASS back to back). Its 60s per-test bound is the likeliest thing to give way over a long sequence. Worth 7 assertions to whoever diagnoses it.

## Why `extended-suites` and not `security-suites`

`security-suites` **is a required check** — worth stating precisely, because the ruleset alone does not show this:

```
ruleset 11413189            test, provider-safety-net, build-check, Single Commit Policy
classic branch protection   ...those four PLUS security-suites
```

GitHub enforces the union. These 20 suites are *measured once, not proven stable*, and a required check that breaks blocks every open pull request — the failure mode CLAUDE.md already records for ffmpeg. `extended-suites` is non-blocking and already exists for exactly this purpose: *"No provider credentials are set in this job, and that is the point."*

It also runs every suite before failing, so one break cannot hide the state of the others.

## Measurement conditions

Worth recording: the machine was **saturated throughout** — load average 31 on 18 cores, 6.6% idle, from unrelated processes. All 20 passed twice under that. Only `test:middleware` did not, which is why it is the sole exclusion on stability grounds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated validation to cover 20 additional passing test suites.
  - Improved suite selection for environments without credentials by excluding unsuitable or no-op checks.
  - Documented a known sequencing issue affecting middleware tests.

- **Chores**
  - Enhanced non-blocking continuous integration checks with clearer test execution guidance and broader coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->