### PR TITLE
docs(claude): correct the required-checks list — there are five, on two layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,8 +340,28 @@ directive in the body — that gap is exactly how this got through.
 
 ### ⚠️ Required status checks and the release bot
 
-`release` carries required status checks (`test`, `provider-safety-net`,
-`build-check`, `🔒 Single Commit Policy Validation`) with **no bypass actors**.
+`release` carries **five** required status checks, and they live on **two
+different layers** that GitHub enforces as a union:
+
+| check                                | ruleset `11413189` | classic branch protection |
+| ------------------------------------ | ------------------ | ------------------------- |
+| `test`                               | ✅                 | ✅                        |
+| `provider-safety-net`                | ✅                 | ✅                        |
+| `build-check`                        | ✅                 | ✅                        |
+| `🔒 Single Commit Policy Validation` | ✅                 | ✅                        |
+| `security-suites`                    | ❌                 | ✅                        |
+
+**Querying only the ruleset API under-reports the list.** `gh api
+repos/juspay/neurolink/rulesets/11413189` returns four contexts and no mention
+of `security-suites`; `gh api repos/juspay/neurolink/branches/release/protection`
+returns all five. Check both, or you will conclude a required check is optional
+— and a red `security-suites` will block a merge you were sure it could not.
+
+The two layers also differ in who can bypass them. The ruleset has
+`bypass_actors: []`, so its four are unbypassable by anyone. Classic protection
+has `enforce_admins: false`, so the classic layer — which is the only place
+`security-suites` is required — does not apply to admins. Net effect: four
+checks nobody can bypass, plus a fifth that a repository admin can.
 
 Anything that pushes **directly** to `release` — rather than through a PR —
 carries no check runs, so every required check reads as missing and the push is
@@ -352,6 +372,9 @@ GH013: Repository rule violations found for refs/heads/release
 - 4 of 4 required status checks are expected.
 ! [remote rejected]   HEAD -> release
 ```
+
+(That message is quoted verbatim from the original failure and counts only the
+ruleset's four — another reason the ruleset view alone is misleading.)
 
 This blocked publishing entirely when the checks were first enabled, because
 `@semantic-release/git` pushed the version bump back to the branch. The usual


### PR DESCRIPTION
CLAUDE.md lists four required status checks on `release`. There are **five**. The fifth is `security-suites`, and the reason it went unrecorded is worth documenting because it will mislead the next person the same way.

## Two layers, and the APIs disagree

Classic branch protection and rulesets both apply to this branch, and GitHub enforces the **union**:

```
$ gh api repos/juspay/neurolink/rulesets/11413189
    test
    provider-safety-net
    build-check
    🔒 Single Commit Policy Validation                     (4)

$ gh api repos/juspay/neurolink/branches/release/protection
    test
    provider-safety-net
    build-check
    🔒 Single Commit Policy Validation
    security-suites                                        (5)
```

Anyone checking only the ruleset — the newer, more discoverable API — concludes `security-suites` is optional. It is not: a red one blocks the merge. The doc now carries a table naming which layer requires each check, so drift in either becomes visible instead of silent.

## "No bypass actors" was also half true

The same query surfaced a second inaccuracy in the paragraph. CLAUDE.md said the checks have "no bypass actors". That describes the ruleset (`bypass_actors: []`) and not the whole picture:

- ruleset: `bypass_actors: []` → its four cannot be bypassed by anyone
- classic protection: `enforce_admins: false` → does not apply to admins

Classic is the **only** layer requiring `security-suites`. So the accurate statement is four checks nobody can bypass, plus a fifth that a repository admin can. The doc now says which is which rather than collapsing them into one claim.

## The quoted error is left alone, with a note

The existing `GH013: ... 4 of 4 required status checks are expected` block is a real captured failure, so it stays verbatim. It now carries a note that its count reflects the ruleset alone — which is itself another instance of the same trap, sitting inside the section that was meant to teach it.

## Why this matters beyond tidiness

This section exists to stop people making wrong assumptions about what gates a merge. As written it produced exactly that: a check treated as advisory when it blocks, and a bypass claim that is true of one layer and false of the other. Both are the kind of error that only shows up at the moment someone is trying to land something.

Documentation only — no code, no behaviour change. `pnpm run lint` → 0 errors. `CLAUDE.md` is not a typedoc source, so `docs/api` is unaffected.
