### PR TITLE
docs(core): make the stream-fallback comment tell the truth about its breadth

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -424,8 +424,14 @@ export abstract class BaseProvider implements AIProvider {
       // streaming implementation.
       return this.wrapStreamWithLifecycleCallbacks(realStreamResult, options);
     } catch (realStreamError) {
-      // Don't retry on terminal/abort errors — only fall back for
-      // "real streaming with tools is unsupported" style failures.
+      // The fallback is BROAD, not narrow: only the terminal errors listed
+      // below (abort, timeout, 401/403, quota, rate limit, authentication)
+      // re-throw. Every other failure — including a genuine configuration or
+      // programming error — is masked as a degraded fake stream whenever
+      // tools are enabled. Narrowing this to "streaming with tools is
+      // unsupported" failures would change behaviour for every provider at
+      // once, so it needs its own characterization PR first; until then this
+      // comment records what the code does, not what a narrower design would.
       const errMsg =
         realStreamError instanceof Error
           ? realStreamError.message


### PR DESCRIPTION
Closes backlog D0 per the user's decision: document reality rather than narrow the behaviour.

The comment above `BaseProvider.stream()`'s catch claimed the fallback only engages for "real streaming with tools is unsupported" style failures. The code re-throws ONLY abort/timeout/401/403/quota/rate-limit/authentication and falls back to fake streaming for **everything else**, masking genuine configuration and programming errors as a degraded stream. The rewritten comment states exactly that, and records that narrowing the breadth affects every provider at once and needs its own characterization PR first.

Comment-only change; no behaviour touched. Prettier clean, eslint 0 errors on the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified fallback behavior when real-time streaming encounters errors while tools are enabled.
  * Documented exceptions for terminal errors, including cancellations, timeouts, authorization failures, quota limits, and authentication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->