### PR TITLE
feat(stream): make the maxSteps no-output fallback opt-outable

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -625,7 +625,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12058](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12058)
+Defined in: [neurolink.ts:12069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12069)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -831,7 +831,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12074](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12074)
+Defined in: [neurolink.ts:12085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12085)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -854,7 +854,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12085)
+Defined in: [neurolink.ts:12096](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12096)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -872,7 +872,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12096](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12096)
+Defined in: [neurolink.ts:12107](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12107)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -896,7 +896,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12113](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12113)
+Defined in: [neurolink.ts:12124](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12124)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -922,7 +922,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12158](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12158)
+Defined in: [neurolink.ts:12169](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12169)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -974,7 +974,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12237](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12237)
+Defined in: [neurolink.ts:12248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12248)
 
 Emit tool start event with execution tracking
 
@@ -1010,7 +1010,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12288](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12288)
+Defined in: [neurolink.ts:12299](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12299)
 
 Emit tool end event with execution summary
 
@@ -1062,7 +1062,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12369](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12369)
+Defined in: [neurolink.ts:12380](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12380)
 
 Get current tool execution contexts for stream metadata
 
@@ -1076,7 +1076,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12376](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12376)
+Defined in: [neurolink.ts:12387](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12387)
 
 Get tool execution history
 
@@ -1090,7 +1090,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12383](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12383)
+Defined in: [neurolink.ts:12394](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12394)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1104,7 +1104,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12399](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12399)
+Defined in: [neurolink.ts:12410](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12410)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1150,7 +1150,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12540](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12540)
+Defined in: [neurolink.ts:12551](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12551)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1173,7 +1173,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12555](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12555)
+Defined in: [neurolink.ts:12566](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12566)
 
 Get the current tool execution context
 
@@ -1189,7 +1189,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12564](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12564)
+Defined in: [neurolink.ts:12575](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12575)
 
 Clear the tool execution context
 
@@ -1203,7 +1203,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12576](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12576)
+Defined in: [neurolink.ts:12587](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12587)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1228,7 +1228,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12599)
+Defined in: [neurolink.ts:12610](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12610)
 
 Unregister a custom tool
 
@@ -1252,7 +1252,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12617](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12617)
+Defined in: [neurolink.ts:12628](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12628)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1277,7 +1277,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:12630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12630)
+Defined in: [neurolink.ts:12641](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12641)
 
 Get all registered tool middlewares
 
@@ -1291,7 +1291,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12637](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12637)
+Defined in: [neurolink.ts:12648](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12648)
 
 Flush any pending batched tool calls immediately
 
@@ -1305,7 +1305,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12646)
+Defined in: [neurolink.ts:12657](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12657)
 
 Get the current MCP enhancements configuration
 
@@ -1319,7 +1319,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12669](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12669)
+Defined in: [neurolink.ts:12680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12680)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1369,7 +1369,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:12705](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12705)
+Defined in: [neurolink.ts:12716](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12716)
 
 Get all registered custom tools
 
@@ -1385,7 +1385,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12843](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12843)
+Defined in: [neurolink.ts:12854](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12854)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1414,7 +1414,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:12887](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12887)
+Defined in: [neurolink.ts:12898](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12898)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1437,7 +1437,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12914](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12914)
+Defined in: [neurolink.ts:12925](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12925)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1467,7 +1467,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12930](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12930)
+Defined in: [neurolink.ts:12941](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12941)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1483,7 +1483,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:12942](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12942)
+Defined in: [neurolink.ts:12953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12953)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1564,7 +1564,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:13946](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13946)
+Defined in: [neurolink.ts:13957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13957)
 
 ##### Returns
 
@@ -1576,7 +1576,7 @@ Defined in: [neurolink.ts:13946](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14128](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14128)
+Defined in: [neurolink.ts:14139](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14139)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1599,7 +1599,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14309](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14309)
+Defined in: [neurolink.ts:14320](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14320)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1623,7 +1623,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14341](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14341)
+Defined in: [neurolink.ts:14352](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14352)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1647,7 +1647,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14350](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14350)
+Defined in: [neurolink.ts:14361](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14361)
 
 Get list of all available AI provider names
 
@@ -1663,7 +1663,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14360](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14360)
+Defined in: [neurolink.ts:14371](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14371)
 
 Validate if a provider name is supported
 
@@ -1687,7 +1687,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14373](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14373)
+Defined in: [neurolink.ts:14384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14384)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1703,7 +1703,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14443](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14443)
+Defined in: [neurolink.ts:14454](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14454)
 
 List all configured MCP servers with their status
 
@@ -1719,7 +1719,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14458](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14458)
+Defined in: [neurolink.ts:14469](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14469)
 
 Test connectivity to a specific MCP server
 
@@ -1743,7 +1743,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14499](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14499)
+Defined in: [neurolink.ts:14510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14510)
 
 Check if a provider has the required environment variables configured
 
@@ -1767,7 +1767,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14525](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14525)
+Defined in: [neurolink.ts:14536](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14536)
 
 Perform comprehensive health check on a specific provider
 
@@ -1811,7 +1811,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14571](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14571)
+Defined in: [neurolink.ts:14582](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14582)
 
 Check health of all supported providers
 
@@ -1849,7 +1849,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14615](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14615)
+Defined in: [neurolink.ts:14626](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14626)
 
 Get a summary of provider health across all supported providers
 
@@ -1865,7 +1865,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:14662](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14662)
+Defined in: [neurolink.ts:14673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14673)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1887,7 +1887,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:14673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14673)
+Defined in: [neurolink.ts:14684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14684)
 
 Get execution metrics for all tools
 
@@ -1903,7 +1903,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:14717](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14717)
+Defined in: [neurolink.ts:14728](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14728)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1926,7 +1926,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:14730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14730)
+Defined in: [neurolink.ts:14741](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14741)
 
 Get circuit breaker status for all tools
 
@@ -1942,7 +1942,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:14765](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14765)
+Defined in: [neurolink.ts:14776](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14776)
 
 Reset circuit breaker for a specific tool
 
@@ -1964,7 +1964,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:14782](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14782)
+Defined in: [neurolink.ts:14793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14793)
 
 Clear all tool execution metrics
 
@@ -1978,7 +1978,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:14791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14791)
+Defined in: [neurolink.ts:14802](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14802)
 
 Get comprehensive tool health report
 
@@ -1994,7 +1994,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14946](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14946)
+Defined in: [neurolink.ts:14957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14957)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2011,7 +2011,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:14966](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14966)
+Defined in: [neurolink.ts:14977](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14977)
 
 Get conversation memory statistics (public API)
 
@@ -2025,7 +2025,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:14993](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14993)
+Defined in: [neurolink.ts:15004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15004)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2049,7 +2049,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15049](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15049)
+Defined in: [neurolink.ts:15060](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15060)
 
 Clear conversation history for a specific session (public API)
 
@@ -2069,7 +2069,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15075](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15075)
+Defined in: [neurolink.ts:15086](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15086)
 
 Clear all conversation history (public API)
 
@@ -2083,7 +2083,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15103](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15103)
+Defined in: [neurolink.ts:15114](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15114)
 
 List all conversation sessions with metadata (public API)
 
@@ -2107,7 +2107,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15152](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15152)
+Defined in: [neurolink.ts:15163](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15163)
 
 Export a single session with full history and metadata (public API)
 
@@ -2143,7 +2143,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15237](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15237)
+Defined in: [neurolink.ts:15248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15248)
 
 Export all sessions for a user (public API)
 
@@ -2179,7 +2179,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15301](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15301)
+Defined in: [neurolink.ts:15312](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15312)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2227,7 +2227,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15371](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15371)
+Defined in: [neurolink.ts:15382](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15382)
 
 Check if tool execution storage is available.
 
@@ -2248,7 +2248,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15381](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15381)
+Defined in: [neurolink.ts:15392](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15392)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2277,7 +2277,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15422](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15422)
+Defined in: [neurolink.ts:15433](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15433)
 
 Replace the entire messages array for a session.
 
@@ -2311,7 +2311,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15470)
+Defined in: [neurolink.ts:15481](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15481)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2348,7 +2348,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15501](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15501)
+Defined in: [neurolink.ts:15512](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15512)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2379,7 +2379,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15588](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15588)
+Defined in: [neurolink.ts:15599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15599)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2404,7 +2404,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:15640](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15640)
+Defined in: [neurolink.ts:15651](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15651)
 
 List all external MCP servers
 
@@ -2420,7 +2420,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:15669](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15669)
+Defined in: [neurolink.ts:15680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15680)
 
 Get external MCP server status
 
@@ -2444,7 +2444,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:15683](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15683)
+Defined in: [neurolink.ts:15694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15694)
 
 Execute a tool from an external MCP server
 
@@ -2488,7 +2488,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15780](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15780)
+Defined in: [neurolink.ts:15791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15791)
 
 Get all tools from external MCP servers
 
@@ -2504,7 +2504,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15789](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15789)
+Defined in: [neurolink.ts:15800](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15800)
 
 Get tools from a specific external MCP server
 
@@ -2528,7 +2528,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:15798](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15798)
+Defined in: [neurolink.ts:15809](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15809)
 
 Test connection to an external MCP server
 
@@ -2552,7 +2552,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:15826](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15826)
+Defined in: [neurolink.ts:15837](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15837)
 
 Get external MCP server manager statistics
 
@@ -2592,7 +2592,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15841](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15841)
+Defined in: [neurolink.ts:15852](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15852)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2607,7 +2607,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15879](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15879)
+Defined in: [neurolink.ts:15890](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15890)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2638,7 +2638,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15907](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15907)
+Defined in: [neurolink.ts:15918](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15918)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2676,7 +2676,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15930](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15930)
+Defined in: [neurolink.ts:15941](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15941)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2705,7 +2705,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15955](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15955)
+Defined in: [neurolink.ts:15966](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15966)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2735,7 +2735,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15982](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15982)
+Defined in: [neurolink.ts:15993](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15993)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2767,7 +2767,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16010](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16010)
+Defined in: [neurolink.ts:16021](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16021)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2844,7 +2844,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16051](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16051)
+Defined in: [neurolink.ts:16062](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16062)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2925,7 +2925,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16090](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16090)
+Defined in: [neurolink.ts:16101](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16101)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -2955,7 +2955,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16112](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16112)
+Defined in: [neurolink.ts:16123](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16123)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -2996,7 +2996,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16151](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16151)
+Defined in: [neurolink.ts:16162](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16162)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3037,7 +3037,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16174](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16174)
+Defined in: [neurolink.ts:16185](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16185)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3069,7 +3069,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16413](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16413)
+Defined in: [neurolink.ts:16424](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16424)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3120,7 +3120,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:16505](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16505)
+Defined in: [neurolink.ts:16516](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16516)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3222,7 +3222,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:16643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16643)
+Defined in: [neurolink.ts:16654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16654)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3291,7 +3291,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:16729](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16729)
+Defined in: [neurolink.ts:16740](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16740)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3352,7 +3352,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:16775](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16775)
+Defined in: [neurolink.ts:16786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16786)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3378,7 +3378,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:16798](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16798)
+Defined in: [neurolink.ts:16809](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16809)
 
 Get details of a specific evaluation preset.
 
@@ -3414,7 +3414,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:16848](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16848)
+Defined in: [neurolink.ts:16859](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16859)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3466,7 +3466,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:16910](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16910)
+Defined in: [neurolink.ts:16921](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16921)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3540,7 +3540,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:16942](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16942)
+Defined in: [neurolink.ts:16953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16953)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3580,7 +3580,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17031](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17031)
+Defined in: [neurolink.ts:17042](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17042)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3630,7 +3630,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17050](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17050)
+Defined in: [neurolink.ts:17061](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17061)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3663,7 +3663,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17066](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17066)
+Defined in: [neurolink.ts:17077](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17077)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3688,7 +3688,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17084)
+Defined in: [neurolink.ts:17095](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17095)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3726,7 +3726,7 @@ The registered tool name
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:17106](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17106)
+Defined in: [neurolink.ts:17117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17117)
 
 Execute an agent network with the given input.
 
@@ -3771,7 +3771,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:17130](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17130)
+Defined in: [neurolink.ts:17141](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17141)
 
 Stream agent network execution with real-time events.
 
@@ -3815,7 +3815,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:17154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17154)
+Defined in: [neurolink.ts:17165](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17165)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -3843,7 +3843,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:17173](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17173)
+Defined in: [neurolink.ts:17184](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17184)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -3871,7 +3871,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:17191](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17191)
+Defined in: [neurolink.ts:17202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17202)
 
 Create a MessageBus for inter-agent communication.
 
@@ -3899,7 +3899,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17206](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17206)
+Defined in: [neurolink.ts:17217](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17217)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -3915,7 +3915,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:17393](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17393)
+Defined in: [neurolink.ts:17404](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17404)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -3932,7 +3932,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:17401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17401)
+Defined in: [neurolink.ts:17412](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17412)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -3957,7 +3957,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:17452](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17452)
+Defined in: [neurolink.ts:17463](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17463)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -3986,7 +3986,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:17494](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17494)
+Defined in: [neurolink.ts:17505](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17505)
 
 Check if a session needs compaction.
 
@@ -4014,7 +4014,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17531](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17531)
+Defined in: [neurolink.ts:17542](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17542)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4036,7 +4036,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:17579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17579)
+Defined in: [neurolink.ts:17590](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17590)
 
 Get the currently configured authentication provider
 
@@ -4050,7 +4050,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17620](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17620)
+Defined in: [neurolink.ts:17631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17631)
 
 Set the current authentication context for request handling.
 
@@ -4077,7 +4077,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:17635](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17635)
+Defined in: [neurolink.ts:17646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17646)
 
 Get the current authentication context.
 
@@ -4093,7 +4093,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17643)
+Defined in: [neurolink.ts:17654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17654)
 
 Clear the current authentication context
 
@@ -4107,7 +4107,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:17657](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17657)
+Defined in: [neurolink.ts:17668](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17668)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/type-aliases/AISDKUsage.md
+++ b/docs/api/type-aliases/AISDKUsage.md
@@ -8,7 +8,7 @@
 
 > **AISDKUsage** = `object`
 
-Defined in: [types/stream.ts:900](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L900)
+Defined in: [types/stream.ts:912](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L912)
 
 Raw usage data from Vercel AI SDK.
 
@@ -26,7 +26,7 @@ extractTokenUsage() in tokenUtils.ts already handles both shapes.
 
 > `optional` **promptTokens?**: `number`
 
-Defined in: [types/stream.ts:902](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L902)
+Defined in: [types/stream.ts:914](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L914)
 
 #### Deprecated
 
@@ -38,7 +38,7 @@ AI SDK v4 name — use inputTokens
 
 > `optional` **completionTokens?**: `number`
 
-Defined in: [types/stream.ts:904](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L904)
+Defined in: [types/stream.ts:916](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L916)
 
 #### Deprecated
 
@@ -50,7 +50,7 @@ AI SDK v4 name — use outputTokens
 
 > `optional` **totalTokens?**: `number`
 
-Defined in: [types/stream.ts:906](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L906)
+Defined in: [types/stream.ts:918](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L918)
 
 #### Deprecated
 
@@ -62,7 +62,7 @@ AI SDK v4 name — use totalTokens
 
 > `optional` **inputTokens?**: `number`
 
-Defined in: [types/stream.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L908)
+Defined in: [types/stream.ts:920](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L920)
 
 AI SDK v6 name for prompt / input tokens
 
@@ -72,6 +72,6 @@ AI SDK v6 name for prompt / input tokens
 
 > `optional` **outputTokens?**: `number`
 
-Defined in: [types/stream.ts:910](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L910)
+Defined in: [types/stream.ts:922](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L922)
 
 AI SDK v6 name for completion / output tokens

--- a/docs/api/type-aliases/EnhancedStreamProvider.md
+++ b/docs/api/type-aliases/EnhancedStreamProvider.md
@@ -8,7 +8,7 @@
 
 > **EnhancedStreamProvider** = `object`
 
-Defined in: [types/stream.ts:847](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L847)
+Defined in: [types/stream.ts:859](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L859)
 
 Enhanced provider type with stream method
 
@@ -18,7 +18,7 @@ Enhanced provider type with stream method
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](StreamResult.md)\>
 
-Defined in: [types/stream.ts:848](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L848)
+Defined in: [types/stream.ts:860](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L860)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/stream.ts:848](https://github.com/juspay/neurolink/blob/relea
 
 > **getName**(): `string`
 
-Defined in: [types/stream.ts:849](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L849)
+Defined in: [types/stream.ts:861](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L861)
 
 #### Returns
 
@@ -48,7 +48,7 @@ Defined in: [types/stream.ts:849](https://github.com/juspay/neurolink/blob/relea
 
 > **isAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [types/stream.ts:850](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L850)
+Defined in: [types/stream.ts:862](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L862)
 
 #### Returns
 

--- a/docs/api/type-aliases/ResponseMetadata.md
+++ b/docs/api/type-aliases/ResponseMetadata.md
@@ -8,7 +8,7 @@
 
 > **ResponseMetadata** = `object`
 
-Defined in: [types/stream.ts:932](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L932)
+Defined in: [types/stream.ts:944](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L944)
 
 Response metadata from stream
 
@@ -18,7 +18,7 @@ Response metadata from stream
 
 > `optional` **id?**: `string`
 
-Defined in: [types/stream.ts:933](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L933)
+Defined in: [types/stream.ts:945](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L945)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/stream.ts:933](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **model?**: `string`
 
-Defined in: [types/stream.ts:934](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L934)
+Defined in: [types/stream.ts:946](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L946)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/stream.ts:934](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **timestamp?**: `number` \| `Date`
 
-Defined in: [types/stream.ts:935](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L935)
+Defined in: [types/stream.ts:947](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L947)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/stream.ts:935](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/stream.ts:936](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L936)
+Defined in: [types/stream.ts:948](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L948)

--- a/docs/api/type-aliases/StreamAnalyticsCollector.md
+++ b/docs/api/type-aliases/StreamAnalyticsCollector.md
@@ -8,7 +8,7 @@
 
 > **StreamAnalyticsCollector** = `object`
 
-Defined in: [types/stream.ts:917](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L917)
+Defined in: [types/stream.ts:929](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L929)
 
 Stream analytics collector type
 
@@ -18,7 +18,7 @@ Stream analytics collector type
 
 > **collectUsage**(`result`): `Promise`\<[`TokenUsage`](TokenUsage.md)\>
 
-Defined in: [types/stream.ts:918](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L918)
+Defined in: [types/stream.ts:930](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L930)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/stream.ts:918](https://github.com/juspay/neurolink/blob/relea
 
 > **collectMetadata**(`result`): `Promise`\<[`ResponseMetadata`](ResponseMetadata.md)\>
 
-Defined in: [types/stream.ts:919](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L919)
+Defined in: [types/stream.ts:931](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L931)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [types/stream.ts:919](https://github.com/juspay/neurolink/blob/relea
 
 > **createAnalytics**(`provider`, `model`, `result`, `startTime`, `context?`): `Promise`\<[`AnalyticsData`](AnalyticsData.md)\>
 
-Defined in: [types/stream.ts:920](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L920)
+Defined in: [types/stream.ts:932](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L932)
 
 #### Parameters
 

--- a/docs/api/type-aliases/StreamOptions.md
+++ b/docs/api/type-aliases/StreamOptions.md
@@ -624,11 +624,28 @@ Used by the Claude proxy so the proxy itself can own fallback order.
 
 ---
 
+### fallbackOnMaxSteps?
+
+> `optional` **fallbackOnMaxSteps?**: `boolean`
+
+Defined in: [types/stream.ts:493](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L493)
+
+Whether a turn that ended at the caller's own `maxSteps` bound may still
+trigger the internal no-output provider fallback. Reaching `maxSteps` is
+a budget the caller set, not a provider failure, but such a turn can end
+with no text output and would otherwise be retried on a different
+provider — spending that provider's tokens because the caller's own
+budget ran out. Set `false` to surface the capped turn as-is
+(`metadata.stopReason === "step-cap"`). Default (unset/true) preserves
+the existing fallback behaviour.
+
+---
+
 ### skipToolPromptInjection?
 
 > `optional` **skipToolPromptInjection?**: `boolean`
 
-Defined in: [types/stream.ts:489](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L489)
+Defined in: [types/stream.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L501)
 
 Skip injecting tool schemas into the system prompt.
 When true, tools are ONLY passed natively via the provider's `tools` parameter,
@@ -641,7 +658,7 @@ Default: false (backward compatible — tool schemas are injected into system pr
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/stream.ts:492](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L492)
+Defined in: [types/stream.ts:504](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L504)
 
 ---
 
@@ -649,7 +666,7 @@ Defined in: [types/stream.ts:492](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/stream.ts:493](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L493)
+Defined in: [types/stream.ts:505](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L505)
 
 ---
 
@@ -657,7 +674,7 @@ Defined in: [types/stream.ts:493](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **context?**: [`UnknownRecord`](UnknownRecord.md)
 
-Defined in: [types/stream.ts:494](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L494)
+Defined in: [types/stream.ts:506](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L506)
 
 ---
 
@@ -665,7 +682,7 @@ Defined in: [types/stream.ts:494](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/stream.ts:497](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L497)
+Defined in: [types/stream.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L509)
 
 ---
 
@@ -673,7 +690,7 @@ Defined in: [types/stream.ts:497](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/stream.ts:498](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L498)
+Defined in: [types/stream.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L510)
 
 ---
 
@@ -681,7 +698,7 @@ Defined in: [types/stream.ts:498](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/stream.ts:499](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L499)
+Defined in: [types/stream.ts:511](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L511)
 
 #### role
 
@@ -697,7 +714,7 @@ Defined in: [types/stream.ts:499](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **factoryConfig?**: `object`
 
-Defined in: [types/stream.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L502)
+Defined in: [types/stream.ts:514](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L514)
 
 #### domainType?
 
@@ -725,7 +742,7 @@ Defined in: [types/stream.ts:502](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **streaming?**: `object`
 
-Defined in: [types/stream.ts:516](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L516)
+Defined in: [types/stream.ts:528](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L528)
 
 #### enabled?
 
@@ -753,7 +770,7 @@ Defined in: [types/stream.ts:516](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/stream.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L525)
+Defined in: [types/stream.ts:537](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L537)
 
 ---
 
@@ -761,7 +778,7 @@ Defined in: [types/stream.ts:525](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/stream.ts:528](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L528)
+Defined in: [types/stream.ts:540](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L540)
 
 ---
 
@@ -769,7 +786,7 @@ Defined in: [types/stream.ts:528](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflow?**: `string`
 
-Defined in: [types/stream.ts:531](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L531)
+Defined in: [types/stream.ts:543](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L543)
 
 ---
 
@@ -777,7 +794,7 @@ Defined in: [types/stream.ts:531](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflowConfig?**: [`WorkflowConfig`](WorkflowConfig.md)
 
-Defined in: [types/stream.ts:532](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L532)
+Defined in: [types/stream.ts:544](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L544)
 
 ---
 
@@ -785,7 +802,7 @@ Defined in: [types/stream.ts:532](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **enableSummarization?**: `boolean`
 
-Defined in: [types/stream.ts:534](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L534)
+Defined in: [types/stream.ts:546](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L546)
 
 ---
 
@@ -793,7 +810,7 @@ Defined in: [types/stream.ts:534](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **maxBudgetUsd?**: `number`
 
-Defined in: [types/stream.ts:549](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L549)
+Defined in: [types/stream.ts:561](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L561)
 
 Maximum cumulative cost (USD) for this session.
 Once the session spend reaches this limit, subsequent stream() calls
@@ -814,7 +831,7 @@ const result = await neurolink.stream({
 
 > `optional` **rag?**: [`RAGConfig`](RAGConfig.md)
 
-Defined in: [types/stream.ts:569](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L569)
+Defined in: [types/stream.ts:581](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L581)
 
 RAG (Retrieval-Augmented Generation) configuration.
 
@@ -840,7 +857,7 @@ const stream = await neurolink.stream({
 
 > `optional` **fallbackProvider?**: `string`
 
-Defined in: [types/stream.ts:582](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L582)
+Defined in: [types/stream.ts:594](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L594)
 
 BZ-1341: Override fallback provider name (takes precedence over env/model config).
 
@@ -850,7 +867,7 @@ BZ-1341: Override fallback provider name (takes precedence over env/model config
 
 > `optional` **fallbackModel?**: `string`
 
-Defined in: [types/stream.ts:584](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L584)
+Defined in: [types/stream.ts:596](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L596)
 
 BZ-1341: Override fallback model name (takes precedence over env/model config).
 
@@ -860,7 +877,7 @@ BZ-1341: Override fallback model name (takes precedence over env/model config).
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/stream.ts:587](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L587)
+Defined in: [types/stream.ts:599](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L599)
 
 Callback invoked when streaming completes successfully.
 
@@ -870,7 +887,7 @@ Callback invoked when streaming completes successfully.
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/stream.ts:590](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L590)
+Defined in: [types/stream.ts:602](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L602)
 
 Callback invoked when streaming encounters an error.
 
@@ -880,7 +897,7 @@ Callback invoked when streaming encounters an error.
 
 > `optional` **onChunk?**: [`OnChunkCallback`](OnChunkCallback.md)
 
-Defined in: [types/stream.ts:593](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L593)
+Defined in: [types/stream.ts:605](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L605)
 
 Callback invoked for each streaming chunk.
 
@@ -890,7 +907,7 @@ Callback invoked for each streaming chunk.
 
 > `optional` **requestContext?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/stream.ts:596](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L596)
+Defined in: [types/stream.ts:608](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L608)
 
 Pre-validated user context for the request
 
@@ -900,7 +917,7 @@ Pre-validated user context for the request
 
 > `optional` **auth?**: `object`
 
-Defined in: [types/stream.ts:599](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L599)
+Defined in: [types/stream.ts:611](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L611)
 
 Raw auth token — validated by configured auth provider
 
@@ -914,7 +931,7 @@ Raw auth token — validated by configured auth provider
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/stream.ts:606](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L606)
+Defined in: [types/stream.ts:618](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L618)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -926,7 +943,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **providerFallback?**: (`error`) => `Promise`\<\{ `provider?`: `string`; `model?`: `string`; \} \| `null`\>
 
-Defined in: [types/stream.ts:618](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L618)
+Defined in: [types/stream.ts:630](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L630)
 
 Curator P2-3: per-call fallback callback. Overrides any
 instance-level `providerFallback` set on `new NeuroLink({...})`.
@@ -953,7 +970,7 @@ Return `{ provider, model }` to retry, `null` to bubble.
 
 > `optional` **modelChain?**: `string`[]
 
-Defined in: [types/stream.ts:628](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L628)
+Defined in: [types/stream.ts:640](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L640)
 
 Curator P2-3: per-call ordered model chain. Overrides any
 instance-level `modelChain`. Without an explicit `providerFallback`
@@ -966,7 +983,7 @@ other failures (network, 5xx, timeouts) bubble immediately.
 
 > `optional` **memory?**: `object`
 
-Defined in: [types/stream.ts:637](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L637)
+Defined in: [types/stream.ts:649](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L649)
 
 Per-call memory control.
 
@@ -1006,7 +1023,7 @@ Primary user is still determined by context.userId.
 
 > `optional` **piiDetection?**: `object`
 
-Defined in: [types/stream.ts:653](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L653)
+Defined in: [types/stream.ts:665](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L665)
 
 PII detection — scans and optionally redacts PII from input before the LLM call.
 
@@ -1040,7 +1057,7 @@ PII detection — scans and optionally redacts PII from input before the LLM cal
 
 > `optional` **responseValidation?**: `object`
 
-Defined in: [types/stream.ts:674](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L674)
+Defined in: [types/stream.ts:686](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L686)
 
 Response validation — validates accumulated stream content after completion.
 
@@ -1100,7 +1117,7 @@ Response validation — validates accumulated stream content after completion.
 
 > `optional` **inputValidation?**: `object`
 
-Defined in: [types/stream.ts:692](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L692)
+Defined in: [types/stream.ts:704](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L704)
 
 Input validation — validates input text before any processing.
 
@@ -1126,7 +1143,7 @@ Input validation — validates input text before any processing.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/stream.ts:700](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L700)
+Defined in: [types/stream.ts:712](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L712)
 
 #### Deprecated
 
@@ -1138,7 +1155,7 @@ Use `piiDetection`, `responseValidation`, and `inputValidation` instead.
 
 > `optional` **skills?**: [`SkillsCallOptions`](SkillsCallOptions.md)
 
-Defined in: [types/stream.ts:708](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L708)
+Defined in: [types/stream.ts:720](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L720)
 
 Per-call skills control. Only effective when the instance was
 constructed with `skills.enabled: true`. Lets a call disable the

--- a/docs/api/type-aliases/StreamResult.md
+++ b/docs/api/type-aliases/StreamResult.md
@@ -8,7 +8,7 @@
 
 > **StreamResult** = `object`
 
-Defined in: [types/stream.ts:715](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L715)
+Defined in: [types/stream.ts:727](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L727)
 
 Stream function result type - Primary output format for streaming
 Future-ready for multi-modal outputs while maintaining text focus
@@ -19,7 +19,7 @@ Future-ready for multi-modal outputs while maintaining text focus
 
 > `optional` **knowledge?**: [`KnowledgeGroundingMetadata`](KnowledgeGroundingMetadata.md)
 
-Defined in: [types/stream.ts:717](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L717)
+Defined in: [types/stream.ts:729](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L729)
 
 Knowledge-grounding diagnostics for this turn (present only when grounding ran).
 
@@ -29,7 +29,7 @@ Knowledge-grounding diagnostics for this turn (present only when grounding ran).
 
 > **stream**: `AsyncIterable`\<\{ `content`: `string`; `reasoning?`: `string`; \} \| [`StreamNoOutputSentinel`](StreamNoOutputSentinel.md) \| \{ `type`: `"audio"`; `audio`: [`AudioChunk`](AudioChunk.md); \} \| \{ `type`: `"tts_audio"`; `audio`: [`TTSChunk`](TTSChunk.md); \} \| \{ `type`: `"image"`; `imageOutput`: \{ `base64`: `string`; \}; \} \| \{ `content`: `string`; `type?`: `"preliminary"` \| `"final"`; \}\>
 
-Defined in: [types/stream.ts:718](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L718)
+Defined in: [types/stream.ts:730](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L730)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [types/stream.ts:718](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **provider?**: `string`
 
-Defined in: [types/stream.ts:733](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L733)
+Defined in: [types/stream.ts:745](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L745)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [types/stream.ts:733](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **model?**: `string`
 
-Defined in: [types/stream.ts:734](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L734)
+Defined in: [types/stream.ts:746](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L746)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [types/stream.ts:734](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **usage?**: [`TokenUsage`](TokenUsage.md)
 
-Defined in: [types/stream.ts:737](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L737)
+Defined in: [types/stream.ts:749](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L749)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [types/stream.ts:737](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/stream.ts:740](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L740)
+Defined in: [types/stream.ts:752](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L752)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [types/stream.ts:740](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **stopReason?**: [`GenerateStopReason`](GenerateStopReason.md)
 
-Defined in: [types/stream.ts:748](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L748)
+Defined in: [types/stream.ts:760](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L760)
 
 Why the agentic turn ended (see GenerateStopReason). For background-loop
 streams (native Vertex paths) prefer `metadata.stopReason` after draining
@@ -82,7 +82,7 @@ wrapper spreads can snapshot it before the loop finishes.
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/stream.ts:750](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L750)
+Defined in: [types/stream.ts:762](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L762)
 
 Verbatim provider finish/stop reason for the turn's terminal model call.
 
@@ -92,7 +92,7 @@ Verbatim provider finish/stop reason for the turn's terminal model call.
 
 > `optional` **toolCalls?**: [`StreamToolCall`](StreamToolCall.md)[]
 
-Defined in: [types/stream.ts:753](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L753)
+Defined in: [types/stream.ts:765](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L765)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [types/stream.ts:753](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolResults?**: [`StreamToolResult`](StreamToolResult.md)[]
 
-Defined in: [types/stream.ts:754](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L754)
+Defined in: [types/stream.ts:766](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L766)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [types/stream.ts:754](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolEvents?**: `AsyncIterable`\<[`ToolExecutionEvent`](ToolExecutionEvent.md)\>
 
-Defined in: [types/stream.ts:757](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L757)
+Defined in: [types/stream.ts:769](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L769)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [types/stream.ts:757](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolExecutions?**: [`ToolExecutionSummary`](ToolExecutionSummary.md)[]
 
-Defined in: [types/stream.ts:758](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L758)
+Defined in: [types/stream.ts:770](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L770)
 
 ---
 
@@ -124,7 +124,7 @@ Defined in: [types/stream.ts:758](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolsUsed?**: `string`[]
 
-Defined in: [types/stream.ts:759](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L759)
+Defined in: [types/stream.ts:771](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L771)
 
 ---
 
@@ -132,7 +132,7 @@ Defined in: [types/stream.ts:759](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/stream.ts:762](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L762)
+Defined in: [types/stream.ts:774](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L774)
 
 #### streamId?
 
@@ -212,7 +212,7 @@ Defined in: [types/stream.ts:762](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **analytics?**: [`AnalyticsData`](AnalyticsData.md) \| `Promise`\<[`AnalyticsData`](AnalyticsData.md)\>
 
-Defined in: [types/stream.ts:792](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L792)
+Defined in: [types/stream.ts:804](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L804)
 
 ---
 
@@ -220,7 +220,7 @@ Defined in: [types/stream.ts:792](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **evaluation?**: [`EvaluationData`](EvaluationData.md) \| `Promise`\<[`EvaluationData`](EvaluationData.md)\>
 
-Defined in: [types/stream.ts:793](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L793)
+Defined in: [types/stream.ts:805](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L805)
 
 ---
 
@@ -228,7 +228,7 @@ Defined in: [types/stream.ts:793](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **events?**: `object`[]
 
-Defined in: [types/stream.ts:796](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L796)
+Defined in: [types/stream.ts:808](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L808)
 
 #### Index Signature
 
@@ -252,7 +252,7 @@ Defined in: [types/stream.ts:796](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **workflow?**: `object`
 
-Defined in: [types/stream.ts:804](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L804)
+Defined in: [types/stream.ts:816](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L816)
 
 #### originalResponse
 
@@ -320,7 +320,7 @@ Defined in: [types/stream.ts:804](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **transcription?**: [`STTResult`](STTResult.md)
 
-Defined in: [types/stream.ts:832](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L832)
+Defined in: [types/stream.ts:844](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L844)
 
 STT transcription result (when stt option is used)
 
@@ -330,7 +330,7 @@ STT transcription result (when stt option is used)
 
 > `optional` **audio?**: `Promise`\<[`TTSResult`](TTSResult.md) \| `undefined`\>
 
-Defined in: [types/stream.ts:841](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L841)
+Defined in: [types/stream.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L853)
 
 TTS Mode 2 result (when `tts.enabled && tts.useAiResponse`).
 Resolves with the synthesized audio after the stream completes;

--- a/docs/api/type-aliases/StreamTextResult.md
+++ b/docs/api/type-aliases/StreamTextResult.md
@@ -8,7 +8,7 @@
 
 > **StreamTextResult** = `object`
 
-Defined in: [types/stream.ts:860](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L860)
+Defined in: [types/stream.ts:872](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L872)
 
 Stream text result from AI SDK (compatible with both v4 and v6)
 
@@ -22,7 +22,7 @@ This type accepts either shape so callers don't need casts.
 
 > **textStream**: `AsyncIterable`\<`string`\>
 
-Defined in: [types/stream.ts:861](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L861)
+Defined in: [types/stream.ts:873](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L873)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/stream.ts:861](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **fullStream?**: `AsyncIterable`\<`unknown`\>
 
-Defined in: [types/stream.ts:862](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L862)
+Defined in: [types/stream.ts:874](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L874)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/stream.ts:862](https://github.com/juspay/neurolink/blob/relea
 
 > **text**: `PromiseLike`\<`string`\>
 
-Defined in: [types/stream.ts:863](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L863)
+Defined in: [types/stream.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L875)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/stream.ts:863](https://github.com/juspay/neurolink/blob/relea
 
 > **usage**: `PromiseLike`\<[`AISDKUsage`](AISDKUsage.md) \| `undefined`\>
 
-Defined in: [types/stream.ts:864](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L864)
+Defined in: [types/stream.ts:876](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L876)
 
 ---
 
@@ -54,7 +54,7 @@ Defined in: [types/stream.ts:864](https://github.com/juspay/neurolink/blob/relea
 
 > **response**: `PromiseLike`\<\{ `id?`: `string`; `model?`: `string`; `timestamp?`: `number` \| `Date`; \} \| `undefined`\>
 
-Defined in: [types/stream.ts:865](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L865)
+Defined in: [types/stream.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L877)
 
 ---
 
@@ -62,7 +62,7 @@ Defined in: [types/stream.ts:865](https://github.com/juspay/neurolink/blob/relea
 
 > **finishReason**: `PromiseLike`\<`"stop"` \| `"length"` \| `"content-filter"` \| `"tool-calls"` \| `"error"` \| `"other"` \| `"unknown"`\>
 
-Defined in: [types/stream.ts:873](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L873)
+Defined in: [types/stream.ts:885](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L885)
 
 ---
 
@@ -70,7 +70,7 @@ Defined in: [types/stream.ts:873](https://github.com/juspay/neurolink/blob/relea
 
 > `optional` **toolResults?**: `PromiseLike`\<[`StreamToolResult`](StreamToolResult.md)[] \| `ReadonlyArray`\<`unknown`\>\>
 
-Defined in: [types/stream.ts:886](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L886)
+Defined in: [types/stream.ts:898](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L898)
 
 Tool results. Accepts both NeuroLink StreamToolResult[] and AI SDK TypedToolResult[],
 since the analytics collector passes them through as `unknown` anyway.
@@ -81,6 +81,6 @@ since the analytics collector passes them through as `unknown` anyway.
 
 > `optional` **toolCalls?**: `PromiseLike`\<[`StreamToolCall`](StreamToolCall.md)[] \| `ReadonlyArray`\<`unknown`\>\>
 
-Defined in: [types/stream.ts:890](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L890)
+Defined in: [types/stream.ts:902](https://github.com/juspay/neurolink/blob/release/src/lib/types/stream.ts#L902)
 
 Tool calls. Accepts both NeuroLink StreamToolCall[] and AI SDK TypedToolCall[].

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -9979,8 +9979,19 @@ Current user's request: ${currentInput}`;
           // Reviewer follow-up: fire fallback when no *non-sentinel*
           // output was produced — sentinel-only and truly empty streams
           // both qualify, but media-only streams (audio/image) do not.
+          //
+          // fallbackOnMaxSteps: false exempts one no-output shape — a turn
+          // the provider reports as ended at the caller's own maxSteps bound
+          // (metadata.stopReason "step-cap", a mutable reference the native
+          // loops fill by drain time). That bound is the caller's budget,
+          // not a provider failure, and retrying it on another provider
+          // spends that provider's tokens to exceed a budget the caller set.
+          const cappedByCallerBudget =
+            enhancedOptions.fallbackOnMaxSteps === false &&
+            providerStreamMetadata?.stopReason === "step-cap";
           if (
             realOutputChunks === 0 &&
+            !cappedByCallerBudget &&
             !metadata.fallbackAttempted &&
             !enhancedOptions.disableInternalFallback &&
             streamState.toolCalls.length === 0 &&

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -1878,6 +1878,14 @@ export class AnthropicProvider extends BaseProvider {
     const toolsUsed: string[] = [];
     const streamStartTime = Date.now();
 
+    // Mutable-reference contract from StreamResult.metadata: created before
+    // the loop and filled once the turn drains, because wrapper spreads
+    // snapshot top-level result fields before the loop resolves. This is how
+    // the Gemini/Vertex native paths already report their resolved outcome;
+    // without it a consumer (e.g. the SDK's no-output fallback gate) cannot
+    // tell a step-capped turn from a failed one.
+    const turnMetadata: NonNullable<StreamResult["metadata"]> = {};
+
     // Hoisted out of runLoop so the error path can resolve the usage
     // accumulated by steps that completed BEFORE the failure — those steps
     // were billed and must not be reported as zero.
@@ -2251,6 +2259,23 @@ export class AnthropicProvider extends BaseProvider {
       totalCacheWrite += result.usage.cacheWriteTokens ?? 0;
       lastStop = result.rawStopReason ?? lastStop;
 
+      turnMetadata.finishReason = result.finishReason;
+      if (result.rawStopReason) {
+        turnMetadata.rawFinishReason = result.rawStopReason;
+      }
+      // "tool-calls" after a drained turn means the model still wanted tools
+      // when the step budget ran out — the engine breaks at maxSteps, and a
+      // model turn that finished normally maps to "stop". The one other
+      // producer of stop_reason "tool_use" at turn end is a final_result
+      // call (structured output), which `finalResultText` identifies, so it
+      // must not read as a capped turn.
+      if (
+        result.finishReason === "tool-calls" &&
+        finalResultText === undefined
+      ) {
+        turnMetadata.stopReason = "step-cap";
+      }
+
       resolveUsage(buildDeferredUsage());
       resolveFinish(lastStop ?? "stop");
     };
@@ -2348,6 +2373,7 @@ export class AnthropicProvider extends BaseProvider {
       model: this.modelName,
       toolCalls: [],
       toolResults: [],
+      metadata: turnMetadata,
       // Wire the deferred usage/finish promises into the analytics collector
       // (mirrors openaiChatCompletionsBase). Without this the loop computed a
       // fully correct aggregate that was consumed only by the OTel span —

--- a/src/lib/types/stream.ts
+++ b/src/lib/types/stream.ts
@@ -481,6 +481,18 @@ export type StreamOptions = {
   disableInternalFallback?: boolean;
 
   /**
+   * Whether a turn that ended at the caller's own `maxSteps` bound may still
+   * trigger the internal no-output provider fallback. Reaching `maxSteps` is
+   * a budget the caller set, not a provider failure, but such a turn can end
+   * with no text output and would otherwise be retried on a different
+   * provider — spending that provider's tokens because the caller's own
+   * budget ran out. Set `false` to surface the capped turn as-is
+   * (`metadata.stopReason === "step-cap"`). Default (unset/true) preserves
+   * the existing fallback behaviour.
+   */
+  fallbackOnMaxSteps?: boolean;
+
+  /**
    * Skip injecting tool schemas into the system prompt.
    * When true, tools are ONLY passed natively via the provider's `tools` parameter,
    * avoiding duplicate tool definitions (~30K tokens savings per call).

--- a/test/continuous-test-suite-anthropic-loop-characterization.ts
+++ b/test/continuous-test-suite-anthropic-loop-characterization.ts
@@ -615,4 +615,76 @@ await test("a native loop turn records the provider attempt count on the active 
   );
 });
 
+section("step cap vs internal fallback");
+
+await test("fallbackOnMaxSteps: false surfaces a capped turn instead of retrying it", async () => {
+  // A step-capped turn produces no text, so the SDK's no-output gate would
+  // retry the whole request on the fallback route — spending a second turn
+  // to exceed a budget the caller set deliberately. fallbackOnMaxSteps:
+  // false marks the cap as the caller's own bound and keeps the turn.
+  //
+  // The fallback route is pinned back at this same stand-in, so a fired
+  // fallback is directly visible as a SECOND capped turn: exactly 3 calls
+  // proves the gate never fired (removing the gate clause flips this to 6).
+  const server = await startStandIn((i) =>
+    toolTurn("lookup", { n: i }, `toolu_${i}`),
+  );
+  const restore = withAnthropicEnv(server.port);
+  // The per-call route below outranks these, but clear them anyway so a
+  // developer .env cannot change what a *fired* fallback would do.
+  const savedFallbackEnv = {
+    provider: process.env.FALLBACK_PROVIDER,
+    model: process.env.FALLBACK_MODEL,
+  };
+  delete process.env.FALLBACK_PROVIDER;
+  delete process.env.FALLBACK_MODEL;
+  const counter = { calls: 0 };
+  let resolvedStopReason: unknown;
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "keep going" },
+      provider: "anthropic",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 3,
+      disableTools: false,
+      tools: customTool(counter),
+      fallbackOnMaxSteps: false,
+      // Deterministic route: if the gate fires anyway, the retry lands back
+      // on this stand-in and doubles the call count.
+      fallbackProvider: "anthropic",
+      fallbackModel: MODEL,
+    });
+    for await (const chunk of result.stream) {
+      void chunk;
+    }
+    // metadata is the mutable-reference contract: the loop resolves
+    // stopReason onto this same object by the time the stream is drained.
+    resolvedStopReason = result.metadata?.stopReason;
+  } catch {
+    // The call count is what is pinned.
+  } finally {
+    restore();
+    if (savedFallbackEnv.provider !== undefined) {
+      process.env.FALLBACK_PROVIDER = savedFallbackEnv.provider;
+    }
+    if (savedFallbackEnv.model !== undefined) {
+      process.env.FALLBACK_MODEL = savedFallbackEnv.model;
+    }
+    await server.close();
+  }
+  console.log(
+    `    [diagnostic] capped-no-fallback: calls=${server.calls.length} toolExecs=${counter.calls} stopReason=${String(resolvedStopReason)}`,
+  );
+  assert(
+    server.calls.length === 3,
+    `a capped turn with fallbackOnMaxSteps:false should stop at 3 calls, made ${server.calls.length}`,
+  );
+  assert(
+    resolvedStopReason === "step-cap",
+    "the capped turn should surface stopReason step-cap to the caller",
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
Implements the user's D9 ruling: **make it configurable, default = current behaviour.**

## What

Reaching the caller's own `maxSteps` bound ends a tool-looping turn with no text output, and the SDK's no-output gate then retries the whole request on a different provider — spending a second provider's tokens because the caller's own budget ran out. Observed on #1390's CI divergence: a capped Anthropic turn answered by Vertex. That bound is a budget the caller set deliberately, not a provider failure.

New per-call stream option **`fallbackOnMaxSteps`** (unset/`true` = today's behaviour, fully backward compatible): when `false`, a no-output turn the provider reports as step-capped is surfaced as-is (`metadata.stopReason === "step-cap"`) instead of retried. The gate reads the existing mutable-reference metadata contract that native loops fill by drain time.

Direct Anthropic never filled that contract, so its stream path now reports `metadata.finishReason` / `rawFinishReason` and stamps `stopReason: "step-cap"` when the drained turn ended on `tool-calls` **without** a `final_result` — a `final_result` turn shares `stop_reason: tool_use` and must not read as capped.

SDK-only for now; no CLI flag (can follow if wanted).

## How it is pinned

New case in the anthropic loop characterization suite (7/7): the per-call fallback route is pointed **back at the same local stand-in**, so a fired fallback is directly visible as a second capped turn.

**Mutation-verified both directions:** removing the gate clause → the stand-in receives 6 calls instead of 3 and the case fails with exit 1; restoring → 7/7 exit 0.

## Verification

- typecheck: 4823 files, 0 errors; eslint: 0 errors (7 warnings all pre-existing max-lines-per-function on the same oversized functions)
- anthropic loop characterization 7/7, vertex-claude characterization 8/8, loop-engine 35/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether streams capped by the maximum step limit trigger provider fallback.
  * Capped streams can now be returned as-is with a `step-cap` status.

* **Bug Fixes**
  * Improved streaming metadata to accurately report completion and stop reasons.
  * Prevented unnecessary fallback when a stream ends due to the caller’s configured step limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->