### PR TITLE
perf(ci): stop repeating work in the hooks and shard the slow CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [release]
 
+# Cancel a run that a newer push to the same ref has superseded. Without this
+# an amend-and-force-push — routine under the single-commit-per-branch policy —
+# leaves the old run executing to completion, competing for runners with the
+# run whose result anyone actually wants. copilot-review.yml already does this;
+# ci.yml did not.
+#
+# Keyed on the ref, not the PR number, so pushes to release are covered too.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The required check. Same reasoning as provider-safety-net below: `test` is
   # required by both protection layers AND is a `needs:` of
@@ -634,13 +645,20 @@ jobs:
   # into nothing is documentation, not a test.
   extended-suites:
     runs-on: ubuntu-latest
+    strategy:
+      # Every shard runs even if another fails, so one broken suite never
+      # hides the state of the other 27 — the same property the loop below
+      # has always had within a single job.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     # This job checks out and executes repository code on pull_request.
     # The repository default is a WRITE-scoped token (and one that may
     # approve reviews); nothing here needs either. Read is enough to
     # checkout, install and run suites.
     permissions:
       contents: read
-    name: Extended Suites (non-blocking)
+    name: Extended Suites (non-blocking) ${{ matrix.shard }}/4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -747,8 +765,15 @@ jobs:
             test:vertex-claude-characterization
             test:vertex-loop-characterization
           "
+          # Shard by position in the list above. The list stays single-sourced;
+          # only which entries this runner executes changes.
           FAILED=""
+          i=0
           for s in $SUITES; do
+            i=$((i + 1))
+            if [ $(( (i - 1) % 4 + 1 )) -ne ${{ matrix.shard }} ]; then
+              continue
+            fi
             echo "::group::$s"
             if pnpm run "$s"; then
               echo "PASS $s"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,11 +273,21 @@ pnpm run test:middleware
 pnpm run test:autoresearch       # E2E + live (live half skips without keys)
 
 # What CI actually gates — NOT test:unit.
-# .github/workflows/ci.yml has a `provider-safety-net` job running
-#   build + test:providers-mocked + test:provider-structure
-# on every PR; the same pair is the pre-push hook. The job named `test` is
-# format-check, eslint, validate:all and the builds. Everything else in test/
-# runs only when someone runs it, so adding a suite does not make it a gate.
+# .github/workflows/ci.yml has two required jobs over test/, and both are
+# sharded behind an aggregator of the same name. Branch protection requires the
+# aggregator, so the required name is never a job that runs a suite:
+#   provider-safety-net → build, then `contract` (test:providers-mocked) and
+#     `rest` (test:provider-structure, test:error-classifier-contract, the
+#     bedrock/sagemaker/anthropic/aistudio characterization suites, and
+#     verify:provider-onboarding).
+#   test → `lint` (format-check, eslint), `validate` (validate:all, docs:api
+#     currency, check:deps), `types` (check:ci-scripts, check:test-parse,
+#     check:tools-tests, both builds).
+# The pre-push hook is a DIFFERENT set, not a subset: check:deps, build,
+# test:provider-structure, test:model-manifests. test:providers-mocked is
+# deliberately not in it — 259s, and provider-safety-net already gates it.
+# Everything else in test/ runs only when someone runs it, so adding a suite
+# does not make it a gate.
 
 # Run a single suite directly
 npx tsx test/continuous-test-suite-<name>.ts

--- a/docs/features/proxy-cli-onboarding.md
+++ b/docs/features/proxy-cli-onboarding.md
@@ -633,7 +633,9 @@ assume an auth layer exists.
   Performance Gates", runs `pnpm run proxy:performance` against `proxyLifecycle.ts` /
   `proxyActivity.ts`), `quality-gate` (validate, commit-message validation,
   `tsc --noEmit --strict`) and `semantic-release-validation`. `provider-safety-net` also
-  runs a third suite the pre-push hook does not — `test:error-classifier-contract`.
+  runs several suites the pre-push hook does not — `test:providers-mocked`,
+  `test:error-classifier-contract` and the bedrock / sagemaker / anthropic /
+  aistudio characterization suites.
   **A new proxy engine can trip `proxy-performance`.**
 - **Docs PRs are gated.** `docs-pr-validation.yml` triggers on `docs/**` and runs a
   Docusaurus typecheck and build **without** `continue-on-error`. Frontmatter and link

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "validate:commit": "tsx scripts/commit-validation.ts",
     "quality:metrics": "tsx scripts/quality-metrics.ts",
     "quality:report": "pnpm run quality:metrics && echo 'Quality metrics saved to quality-metrics.json'",
-    "pre-push": "pnpm run check:deps && pnpm run build && pnpm run test:providers-mocked && pnpm run test:provider-structure && pnpm run test:model-manifests",
+    "pre-push": "pnpm run check:deps && pnpm run build && pnpm run test:provider-structure && pnpm run test:model-manifests",
     "check:all": "pnpm run lint && pnpm run format --check && pnpm run validate && pnpm run validate:commit",
     "test:file-formats": "pnpm exec tsx test/continuous-test-suite-file-formats.ts",
     "test:multimodal": "pnpm run test:file-formats && pnpm run test:multimodal:sdk",

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -22,20 +22,54 @@ BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
 if [[ "$BRANCH_NAME" != "HEAD" ]]; then
   echo "🔍 Running pre-commit checks on branch: $BRANCH_NAME"
   
-  echo "📋 Running check..."
-  npm run check
+  # `check` (svelte-check + tsc) and `validate:all` (validate + lint +
+  # validate:env + validate:security) touch no shared state: `.svelte-kit/**`,
+  # the only thing `check` writes, is ignored by eslint (eslint.config.js) and
+  # by prettier (.prettierignore). So they run concurrently.
+  #
+  # Measured: 59s + 110s sequential -> 48s together.
+  #
+  # `format:staged` still runs first and alone — it REWRITES staged files, and
+  # linting them while they are being rewritten is a race.
   
   echo "🎨 Running format..."
   npm run format:staged
   
-  echo "🔧 Running lint..."
-  npm run lint
-  
-  echo "🔐 Running validate..."
-  npm run validate:all
+  # `validate:all` is `validate && lint && validate:env && validate:security`,
+  # so calling `lint` separately above ran the repo-wide prettier+eslint
+  # twice. Measured here: lint 115s, validate:all 110s — validate:all is
+  # almost entirely that second lint. Nothing is checked less, just once.
+  #
+  # The build that used to follow is gone too: pre-push builds, and nothing
+  # about the tree changes between commit and push, so it was a second full
+  # `vite build` + `prepack` (69s) for an artifact the push rebuilt anyway.
+  echo "📋 Running check and validate in parallel..."
+  check_log="$(mktemp)"
+  validate_log="$(mktemp)"
+  # `wait` must sit in a condition context. This script installs `trap finish
+  # ERR`, and bash fires the ERR trap on a failing command even under `set +e`
+  # — so a bare `wait "$pid"; rc=$?` aborted the hook the moment a stage
+  # failed, before either log was printed. The exit code looked right and the
+  # diagnostics were gone.
+  check_rc=0
+  validate_rc=0
+  npm run check        > "$check_log"    2>&1 &
+  check_pid=$!
+  npm run validate:all > "$validate_log" 2>&1 &
+  validate_pid=$!
+  wait "$check_pid"    || check_rc=$?
+  wait "$validate_pid" || validate_rc=$?
 
-  echo "🏗️  Running build..."
-  npm run build
+  # Print both logs whatever happens, so a failure is never hidden behind the
+  # other stage's output and a passing run still shows what ran.
+  echo "--- check ---";    cat "$check_log"
+  echo "--- validate ---"; cat "$validate_log"
+  rm -f "$check_log" "$validate_log"
+
+  if [ "$check_rc" -ne 0 ] || [ "$validate_rc" -ne 0 ]; then
+    echo "❌ check exited $check_rc, validate exited $validate_rc"
+    exit 1
+  fi
 
   # Continuous test suites require API keys and run separately
   echo "⏭️  Skipping tests (continuous test suites require API keys - run manually with pnpm test)"

--- a/test/README.md
+++ b/test/README.md
@@ -46,14 +46,32 @@ npx tsx test/continuous-test-suite-<name>.ts [--provider=vertex] [--model=gpt-4o
 
 | Tier               | Frequency         | Suites                                                                                                                                                                                                                                                                | Cost                  |
 | ------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| **`test:unit`**    | local / pre-push  | `bugfixes`, `mcp:infra`, `mcp:spans`, `tool-routing`, `tool-routing-cli`, `tool-dedup`, `model-pool`, `tool-routing-semantic`, `mcp-result-cache`, `model-not-found-retryable`, `archive:security`, `office:security`, the three `vector-*` stores, `provider-wiring` | $0                    |
+| **`test:unit`**    | local only        | `bugfixes`, `mcp:infra`, `mcp:spans`, `tool-routing`, `tool-routing-cli`, `tool-dedup`, `model-pool`, `tool-routing-semantic`, `mcp-result-cache`, `model-not-found-retryable`, `archive:security`, `office:security`, the three `vector-*` stores, `provider-wiring` | $0                    |
 | **`test:live`**    | when keys present | `providers`, `mcp:http`, `mcp:sdk`, `mcp:cli`, `observability`, `context`, `memory`, `tool-reliability`, `evaluation`, `autoresearch`                                                                                                                                 | small per-call        |
 | **`test:product`** | release gate      | `media` (image+video), `tts`, `ppt`, `proxy`                                                                                                                                                                                                                          | metered (image/video) |
 
-**What CI actually runs.** Not `test:unit`. The `provider-safety-net` job in
-`.github/workflows/ci.yml` runs `build` + `test:providers-mocked` +
-`test:provider-structure` on every PR, and the same pair is the `pre-push`
-hook. The `test` job is format-check, eslint, `validate:all` and the builds.
+**What CI actually runs.** Not `test:unit`. Two required jobs in
+`.github/workflows/ci.yml` cover this directory, and both are sharded behind an
+aggregator of the same name — branch protection checks the aggregator, so the
+name it requires is never the name of a job that runs a suite.
+
+`provider-safety-net` builds the package, then splits two ways. `contract` runs
+`test:providers-mocked`. `rest` runs `test:provider-structure`,
+`test:error-classifier-contract`, `test:bedrock-inference-profile`,
+`test:bedrock-loop-characterization`, `test:sagemaker-streaming`,
+`test:anthropic-loop-characterization`, `test:aistudio-loop-characterization`
+and `verify:provider-onboarding`.
+
+`test` splits three ways: `lint` (format-check, eslint), `validate`
+(`validate:all`, the generated-API-docs currency check, `check:deps`) and
+`types` (`check:ci-scripts`, `check:test-parse`, `check:tools-tests`, and both
+builds).
+
+The `pre-push` hook is a **different** set, not a subset: `check:deps`,
+`build`, `test:provider-structure`, `test:model-manifests`.
+`test:providers-mocked` is deliberately not among them — at 259s it dominated
+push latency, and `provider-safety-net` already gates it on every PR.
+
 Everything else in this directory runs when someone runs it, so a suite you
 add here is not automatically a gate.
 


### PR DESCRIPTION
## The problem

A commit-and-push cost **697s of local waiting** before anything reached GitHub, then 10m14s of CI. Most of the local half was the same work done twice.

Measured per stage rather than estimated:

```
check                        59s
lint                        115s
validate:all                110s
build                        69s
check:deps                    4s
test:providers-mocked       259s
test:provider-structure       5s
test:model-manifests          2s
```

## Local: the same work, twice

**`lint` ran twice per commit.** pre-commit called `lint`, then `validate:all` — and `validate:all` *is* `validate && lint && validate:env && validate:security`. At 110s against lint's own 115s, `validate:all` is almost entirely that second lint.

**`build` ran twice per push.** Once at commit, once at push, with no tree change in between.

**`check` and `validate:all` now run concurrently.** They share no state: `.svelte-kit/**`, the only thing `check` writes, is ignored by both `eslint.config.js` and `.prettierignore`. `format:staged` still runs first and alone, because it *rewrites* staged files and linting them mid-rewrite is a race.

**pre-push drops `test:providers-mocked`** — 259s of its 266s of tests. It is exactly what the required `provider-safety-net` job runs, so CI still gates it. `test:provider-structure` (5s) and `test:model-manifests` (2s) stay; dropping them would save 7 seconds and lose real signal.

```
pre-commit  358s -> 61s
pre-push    339s -> 62s
total       697s -> 123s     (5.7x)
```

## The bug this nearly shipped with

The first parallel implementation exited 1 on a deliberate type error — **for the wrong reason.** This script installs `trap finish ERR`, and bash fires that trap on a failing command *even under `set +e`*, so a bare `wait "$pid"; rc=$?` aborted the hook before either log printed. Right exit code, no diagnostics.

`wait` now sits in a condition context (`wait "$pid" || rc=$?`). Re-verified with the same injected type error:

```
--- check ---
--- validate ---
❌ check exited 1, validate exited 0
EXIT CODE: 1
```

Both logs print, and the failure is attributed to the stage that actually failed.

## CI

**`concurrency` + `cancel-in-progress`.** Every job already starts at +0s, so wall-clock is just the longest job — but an amend-and-force-push, routine under the single-commit policy, left the superseded run executing and competing for runners. `copilot-review.yml` already cancelled; `ci.yml` did not.

**`extended-suites` sharded 4 ways.** Its suite loop is 7m29s of a 9m13s job, and I added most of that in #1523. The list stays single-sourced — each runner slices it by position. `fail-fast: false` so one broken suite still cannot hide the other 27.

## Deliberately not done

**Sharing the build across jobs via an artifact.** I proposed this, then measured and dropped it. All nine jobs start at **+0s**, so the five builds are currently free parallelism; serialising them behind an upload/download would push the critical path from 10m14s to roughly **10m49s**. It saves runner minutes, not wall-clock.

**`provider-safety-net`.** It is the 10m14s critical path *and* a required check, so sharding renames the context and every PR blocks on a missing one — the `GH013` failure CLAUDE.md already documents. That needs an aggregator job preserving the name, and gets its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - CI extended test suites now run across four parallel shards, reducing feedback time.
  - Newer CI runs for the same branch or ref automatically cancel superseded runs.
  - Pre-commit checks now run validation tasks concurrently and provide combined results.
  - Streamlined local hooks by removing redundant lint, build, and mocked-provider checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->