### PR TITLE
fix(core): classify provider errors that surface during stream iteration

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -31,6 +31,7 @@ import {
   isAbortError,
   NeuroLinkError,
 } from "../utils/errorHandling.js";
+import { ProviderError } from "../types/index.js";
 import { sanitizeErrorCause } from "../utils/logSanitize.js";
 import { createAnalytics as buildAnalytics } from "./analytics.js";
 import { ErrorCategory, ErrorSeverity } from "../constants/enums.js";
@@ -113,6 +114,51 @@ function getLifecycleMiddlewareConfig(
  * Abstract base class for all AI providers
  * Tools are integrated as first-class citizens - always available by default
  */
+/**
+ * Marks an error as already run through `formatProviderError`.
+ *
+ * `handleProviderError` is NOT idempotent — measured: feeding its own output back in
+ * degrades a specific classification into a generic one, because it copies `statusCode`
+ * onto the formatted error, so a second pass re-matches the bare 429 rule while the more
+ * specific rule (which keyed on the raw body) no longer can:
+ *
+ *   pass 1  ProviderError  "[openai] OpenAI quota exhausted — this will not resolve by retrying..."
+ *   pass 2  RateLimitError "[openai] OpenAI rate limit exceeded. Please try again later."
+ *
+ * Since the stream path can now reach a classifier that other paths already reached, that
+ * second pass became possible and had to be made impossible.
+ *
+ * Same `Symbol.for` stamping technique as `utils/lifecycleCallbacks.ts` and for the same
+ * reason: it survives across module copies where a closed-over WeakSet would not, and a
+ * frozen error degrades to one extra classification rather than a throw.
+ */
+const PROVIDER_ERROR_CLASSIFIED = Symbol.for(
+  "neurolink.providerErrorClassified",
+);
+
+function markProviderErrorClassified(error: unknown): void {
+  if (error === null || typeof error !== "object") {
+    return;
+  }
+  try {
+    Object.defineProperty(error, PROVIDER_ERROR_CLASSIFIED, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  } catch {
+    // Non-extensible error — worst case is one redundant classification.
+  }
+}
+
+function isProviderErrorClassified(error: unknown): boolean {
+  if (error === null || typeof error !== "object") {
+    return false;
+  }
+  return (error as Record<symbol, unknown>)[PROVIDER_ERROR_CLASSIFIED] === true;
+}
+
 export abstract class BaseProvider implements AIProvider {
   // Not `readonly` because providers that auto-discover the model from a
   // /v1/models endpoint (lm-studio, llamacpp) need to update modelName after
@@ -503,11 +549,14 @@ export abstract class BaseProvider implements AIProvider {
   ): StreamResult {
     const lifecycle = getLifecycleMiddlewareConfig(options);
 
-    if (!lifecycle?.onChunk && !lifecycle?.onFinish && !lifecycle?.onError) {
-      return result;
-    }
-
-    const { onChunk, onFinish, onError } = lifecycle;
+    // No early return when there are no callbacks. This wrapper is the only point
+    // every provider's stream passes through unconditionally (the real-streaming path
+    // plus all three fake-streaming paths), and returning `result` untouched here is
+    // exactly why a provider error that surfaces during ITERATION reached the consumer
+    // unclassified: the object handed back was the provider's own generator, by
+    // reference, and every layer below is a proven passthrough. The callbacks below are
+    // each individually guarded, so with none registered this only adds the catch.
+    const { onChunk, onFinish, onError } = lifecycle ?? {};
     const startTime = Date.now();
     const originalStream = result.stream;
     // Lifecycle callbacks are awaited with a bounded deadline so callers
@@ -537,6 +586,11 @@ export abstract class BaseProvider implements AIProvider {
         logger.warn(`[lifecycle] ${label} callback error:`, e);
       }
     };
+
+    // Arrow, like `safeFire` above: the generator is a plain function expression, so
+    // `this` is not bound inside it.
+    const classifyStreamError = (e: unknown): Error =>
+      this.classifyStreamError(e);
 
     const wrappedStream = (async function* () {
       let accumulated = "";
@@ -598,7 +652,7 @@ export abstract class BaseProvider implements AIProvider {
             "onError",
           );
         }
-        throw err;
+        throw classifyStreamError(err);
       }
     })();
 
@@ -2230,6 +2284,66 @@ export abstract class BaseProvider implements AIProvider {
    * original identity so that isAbortError() can detect them in
    * retry/fallback loops (directProviderGeneration, performMCPGenerationRetries).
    */
+  /**
+   * Classify an error that escaped while the consumer was ITERATING a stream.
+   *
+   * `stream()` only awaits the CONSTRUCTION of the provider's stream object, and a provider
+   * that discovers its failure lazily throws on first pull instead — so the raw upstream
+   * error reached the consumer with no provider tag and no classification, while the same
+   * failure through `generate()` was classified normally. Measured on OpenAI:
+   *
+   *   streaming      "You have no credits remaining."
+   *   non-streaming  "[openai] OpenAI quota exhausted — this will not resolve by retrying..."
+   *
+   * Three guards. Only the third is load-bearing against today's code; the first two are
+   * deliberate depth against a hazard that is real but not currently reachable. Measured,
+   * rather than assumed — see the note after the list.
+   *
+   * 1. ALREADY STAMPED — everything that went through `handleProviderError` carries the mark,
+   *    including the two formatters whose results escape the ProviderError hierarchy
+   *    (`amazonSagemaker` returns SageMakerError, `replicate` returns NeuroLinkError; both
+   *    extend Error directly). Without this they would be classified a second time and
+   *    degraded.
+   * 2. ALREADY A ProviderError — covers providers that call `formatProviderError` DIRECTLY,
+   *    bypassing `handleProviderError` and therefore the stamp. Anthropic does this in its
+   *    own streaming catch (`anthropic/client.ts`), and its result is a ProviderError.
+   * 3. HAS AN HTTP STATUS — without this, an ordinary bug is relabelled as a provider
+   *    failure. `classifyProviderError` ends in an unconditional catch-all
+   *    (`utils/errorClassifier.ts`: `if (!rule) return new ProviderError(...)`) that is not
+   *    gated on the error having come off the wire. Measured with the guard absent:
+   *      TypeError "Cannot read properties of undefined (reading 'content')"
+   *        became  ProviderError "[openai] openai error: Cannot read properties of undefined..."
+   *    which would hide a real defect behind a plausible provider message.
+   *
+   * WHY 1 AND 2 ARE NOT CURRENTLY REACHABLE, and why they stay anyway. A statusCode is
+   * attached to a formatted error in exactly one place — `handleProviderError` below — and
+   * that same method applies the stamp. So a ProviderError carrying a status is always
+   * stamped (caught by guard 1's own condition), and a ProviderError produced by a direct
+   * `formatProviderError` call carries no status, so guard 3 already returns it untouched.
+   * Verified by disabling guards 1 and 2 together, rebuilding, and re-running: the mocked
+   * provider contract suite stayed 64/64 and a mocked Anthropic streaming 429 was
+   * byte-identical (`RateLimitError`, one `[anthropic]` prefix).
+   *
+   * They remain because the hazard they cover is measured and real: `handleProviderError`
+   * is NOT idempotent — it copies statusCode onto its own output, so a second pass
+   * re-matches the bare 429 rule and DEGRADES the classification:
+   *   pass 1  ProviderError  "...quota exhausted — this will not resolve by retrying..."
+   *   pass 2  RateLimitError "...rate limit exceeded..."
+   * The day any provider attaches a status to an error it formats itself, guard 3 stops
+   * covering that case and this degradation becomes live. Cheap insurance, not dead code —
+   * but do not cite guards 1 and 2 as proven-by-failure the way guard 3 is.
+   */
+  protected classifyStreamError(error: unknown): Error {
+    const err = error instanceof Error ? error : new Error(String(error));
+    if (isProviderErrorClassified(err) || err instanceof ProviderError) {
+      return err;
+    }
+    if (duckTypedStatusCode(err) === undefined) {
+      return err;
+    }
+    return this.handleProviderError(err);
+  }
+
   protected handleProviderError(error: unknown): Error {
     if (isAbortError(error)) {
       // Preserve AbortError identity — never wrap in provider-specific formatting
@@ -2309,6 +2423,10 @@ export abstract class BaseProvider implements AIProvider {
       // Non-blocking — telemetry failures shouldn't mask the original error
     }
 
+    // Stamp AFTER formatting so any later catch site can tell this error has
+    // already been classified. Deliberately not applied to the AbortError
+    // passthrough above — that returns the original error untouched.
+    markProviderErrorClassified(formatted);
     return formatted;
   }
 

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -1843,14 +1843,15 @@ async function runOpenAISection(): Promise<void> {
   // (openaiChatCompletionsBase.ts:1438), so a retry fix proven only on the
   // non-streaming path says nothing about it. This pins that it holds there.
   //
-  // Only the retry is asserted, deliberately. The streaming path never runs
-  // formatProviderError at all — openaiChatCompletionsBase declares it
-  // abstract and throws the raw provider error instead, so NO error of any
-  // type or provider is classified on that path. That is a pre-existing,
-  // provider-wide gap rather than anything about quota, and asserting the
-  // classified message here would be asserting a fix this change does not
-  // make. Measured: a streaming quota 429 surfaces "You have no credits
-  // remaining ..." verbatim.
+  // The classification assertion below used to be weaker, with a note claiming
+  // the streaming path never classified anything. That note named the wrong
+  // mechanism. What actually happened: BaseProvider.stream() awaits only the
+  // CONSTRUCTION of the provider's stream, and a provider that discovers its
+  // failure lazily throws on first pull instead — and
+  // wrapStreamWithLifecycleCallbacks early-returned the provider's own generator
+  // BY REFERENCE whenever no lifecycle callbacks were registered, so no layer
+  // downstream ever held a catch it could classify in. That early return is gone
+  // and this case now pins the classified message.
   // ─────────────────────────────────────────────────────────────────────
   try {
     await withMocks(
@@ -1892,11 +1893,14 @@ async function runOpenAISection(): Promise<void> {
         } catch (err) {
           msg = err instanceof Error ? err.message : String(err);
         }
-        // Whatever wording surfaces, it must not claim this is a rate limit.
+        // The same classified message the non-streaming path produces. This
+        // fails against the raw upstream text streaming used to surface.
         record(
           results,
-          `${section}: streaming quota error is never called a rate limit`,
-          msg !== null && !/rate\s*limit/i.test(msg),
+          `${section}: streaming quota error is classified like generate()`,
+          msg !== null &&
+            msg.includes("OpenAI quota exhausted") &&
+            !/rate\s*limit/i.test(msg),
           msg === null ? "no error thrown" : `msg='${msg.slice(0, 120)}'`,
         );
         record(
@@ -1910,7 +1914,64 @@ async function runOpenAISection(): Promise<void> {
   } catch (err) {
     record(
       results,
-      `${section}: streaming quota error is never called a rate limit`,
+      `${section}: streaming quota error is classified like generate()`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── Guard on the streaming classification above. Classifying stream errors
+  // means running a provider's rule table over whatever escapes the iterator,
+  // and classifyProviderError ends in an UNCONDITIONAL catch-all
+  // (`if (!rule) return new ProviderError(...)`) that is not gated on the
+  // error having come off the wire. Without a status check, an ordinary bug
+  // is relabelled as a provider failure and hidden behind a plausible
+  // message — measured, with the guard removed:
+  //   TypeError "Cannot read properties of undefined (reading 'content')"
+  //     became ProviderError "[openai] openai error: Cannot read properties..."
+  // This case fails if that guard is ever dropped.
+  // ─────────────────────────────────────────────────────────────────────
+  try {
+    const boom = () => {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'content')",
+      );
+    };
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => boom()) as typeof globalThis.fetch;
+    try {
+      const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+      let name: string | null = null;
+      let msg: string | null = null;
+      try {
+        const r = await nl.stream({
+          provider: "openai",
+          model,
+          input: { text: "ping" },
+          disableTools: true,
+        });
+        for await (const chunk of r.stream) {
+          void chunk;
+        }
+      } catch (err) {
+        name = err instanceof Error ? err.constructor.name : typeof err;
+        msg = err instanceof Error ? err.message : String(err);
+      }
+      record(
+        results,
+        `${section}: a bug with no HTTP status is not relabelled as a provider error`,
+        name !== null &&
+          name !== "ProviderError" &&
+          !/^\[openai\]/.test(msg ?? ""),
+        name === null ? "no error thrown" : `surfaced as ${name}`,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  } catch (err) {
+    record(
+      results,
+      `${section}: a bug with no HTTP status is not relabelled as a provider error`,
       false,
       err instanceof Error ? err.message : String(err),
     );


### PR DESCRIPTION
A provider failure reached streaming consumers as raw upstream text, while the identical failure through `generate()` was classified normally:

```
streaming       You have no credits remaining.
non-streaming   [openai] OpenAI quota exhausted — this will not resolve by retrying.
                Check your plan and billing details at ...
```

## Mechanism

Four hypotheses were disproved by instrumentation before the real one turned up. Recording them so nobody re-treads the path:

1. *"`formatProviderError` is never called on the stream path"* — false, `baseProvider.ts:445` calls it.
2. *"the substring gate at `baseProvider.ts:434-443` misses OpenAI's credit wording"* — false; re-ran with a message containing the literal word `quota`, still raw.
3. *"the fix site is the `throw err` in `wrapStreamWithLifecycleCallbacks`"* — false; added a method there, stubbed it, **0 calls**.
4. *"`wrapStreamWithLifecycleCallbacks` isn't applied"* — false; stubbed it, **exactly 1 call**.

3 and 4 were both individually correct and jointly misleading. The actual chain:

`stream()` awaits only the **construction** of the provider's stream. `openaiChatCompletionsBase` returns an *uninvoked* async generator, so the failure is discovered lazily on first pull and `stream()`'s own try/catch never fires. `wrapStreamWithLifecycleCallbacks` then hit its early return — no `onChunk`/`onFinish`/`onError` registered — and handed back **the provider's own generator by reference**, so the wrapping generator holding the only capable catch was never built. Everything downstream is a proven passthrough: `neurolink.ts:10077` re-throws the same object and `createMCPStream` passes the stream through unwrapped.

Verified by reference identity: the object thrown at `executeStream`'s boundary is `===` the object the consumer's `for await` catches.

## The fix

The early return no longer discards error handling. That wrapper is the only point every provider's stream passes through unconditionally — four call sites, all in this file, method is `private`, covering the real-streaming path and all three fake-streaming paths. One change instead of ~20 provider files with differently shaped generators.

Classification is guarded three ways, **each proven necessary by its own measurement**:

| guard | evidence it is required |
| --- | --- |
| already stamped | `handleProviderError` is not idempotent: pass 1 → `ProviderError "quota exhausted"`, pass 2 → `RateLimitError "rate limit exceeded"`. It copies `statusCode` onto its output, so a second pass re-matches the bare 429 rule. The stamp covers the two formatters whose results escape the `ProviderError` hierarchy (`amazonSagemaker` → `SageMakerError`, `replicate` → `NeuroLinkError`, both extending `Error` directly). |
| already a `ProviderError` | covers providers calling `formatProviderError` **directly**, bypassing the stamp — Anthropic does this in its own streaming catch. |
| has an HTTP status | without it an ordinary bug is relabelled: `classifyProviderError` ends in an unconditional catch-all. Measured with the clause removed: `TypeError "Cannot read properties of undefined (reading 'content')"` became `ProviderError "[openai] openai error: ..."`. |

The `AbortError` passthrough is deliberately left unstamped so `isAbortError()` still detects aborts.

## Verification

Four end-to-end cases, each in its own process:

```
openai quota, tools off     ProviderError  [openai] OpenAI quota exhausted ...
openai quota, tools ON      ProviderError  [openai] OpenAI quota exhausted ...
anthropic 429               RateLimitError [anthropic] rate limit exceeded ...
                            byte-identical to unpatched — not double-classified
plain TypeError, no status  TypeError, unchanged
```

Both new tests confirmed **non-vacuous** by deleting exactly what each guards — removing the fix fails the classification case; removing only the statusCode clause fails the mislabel case.

`pnpm run build` 0 errors · `check:tools-tests` 0 errors · `lint` 0 errors · mocked provider contract suite **64 passed / 0 failed** · `test:provider-structure` PASS · `docs/api` regenerated with both halves, **zero drift**.

## Known, not addressed here

Vertex double-formats its errors — `handleProviderError` runs 5× for one failure and the message comes out `[vertex] ... [vertex] ...`. A short-circuit at the top of `handleProviderError` fixes it (prefixes 2 → 1, suite still 64/64, measured then reverted). It depends on the stamp this PR introduces, so it belongs as a follow-up on top of this rather than bundled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling so provider-related errors are classified consistently.
  * Preserved programming and cancellation errors without incorrectly relabeling them.
  * Improved quota error messages for streaming requests.
  * Prevented duplicate classification of already-formatted provider errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->