### PR TITLE
fix(localUsage): close the third door into an unbounded transcript scan

### DIFF
--- a/src/lib/localUsage/claudeCodeReader.ts
+++ b/src/lib/localUsage/claudeCodeReader.ts
@@ -36,9 +36,9 @@ import type {
   LocalUsageTotals,
 } from "../types/index.js";
 import { calculateCost, hasPricing } from "../utils/pricing.js";
+import { resolveScanCutoffMs } from "./scanWindow.js";
 
 const CLI_ID = "claude-code" as const;
-const DEFAULT_SINCE_DAYS = 30;
 const PROVIDER = "anthropic";
 
 function projectsRoot(): string {
@@ -230,12 +230,7 @@ export async function createClaudeCodeReader(): Promise<LocalUsageReader> {
       // 32.8s — the same unbounded sweep this guard exists to prevent, reached
       // by a different door. The old guard caught it with Number.isFinite and
       // the replacement dropped that check.
-      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
-      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
-      const cutoff =
-        sinceDays === Infinity
-          ? undefined
-          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
+      const cutoff = resolveScanCutoffMs(options?.sinceDays);
 
       let filesScanned = 0;
       for (const file of files) {

--- a/src/lib/localUsage/codexReader.ts
+++ b/src/lib/localUsage/codexReader.ts
@@ -40,9 +40,9 @@ import type {
   LocalUsageScanResult,
   LocalUsageTotals,
 } from "../types/index.js";
+import { resolveScanCutoffMs } from "./scanWindow.js";
 
 const CLI_ID = "codex" as const;
-const DEFAULT_SINCE_DAYS = 30;
 
 function sessionsRoot(): string {
   return join(homedir(), ".codex", "sessions");
@@ -209,12 +209,7 @@ export async function createCodexReader(): Promise<LocalUsageReader> {
       // 32.8s — the same unbounded sweep this guard exists to prevent, reached
       // by a different door. The old guard caught it with Number.isFinite and
       // the replacement dropped that check.
-      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
-      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
-      const cutoff =
-        sinceDays === Infinity
-          ? undefined
-          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
+      const cutoff = resolveScanCutoffMs(options?.sinceDays);
 
       let filesScanned = 0;
       for (const file of files) {

--- a/src/lib/localUsage/openCodeReader.ts
+++ b/src/lib/localUsage/openCodeReader.ts
@@ -45,9 +45,9 @@ import type {
   LocalUsageScanResult,
   LocalUsageTotals,
 } from "../types/index.js";
+import { resolveScanCutoffMs } from "./scanWindow.js";
 
 const CLI_ID = "opencode" as const;
-const DEFAULT_SINCE_DAYS = 30;
 
 function databasePath(): string {
   return join(homedir(), ".local", "share", "opencode", "opencode.db");
@@ -157,12 +157,9 @@ export async function createOpenCodeReader(): Promise<LocalUsageReader> {
       // "no such column: NaN" — so the whole scan failed rather than
       // over-reading. The cutoff is a bound parameter now, so a value can
       // never be SQL syntax whatever it is.
-      const requestedDays = options?.sinceDays ?? DEFAULT_SINCE_DAYS;
-      const sinceDays = Number.isNaN(requestedDays) ? 0 : requestedDays;
-      const cutoffMs =
-        sinceDays === Infinity
-          ? 0
-          : Date.now() - Math.max(0, sinceDays) * 86_400_000;
+      // `?? 0` because this value becomes a SQL parameter: an unbounded scan
+      // is expressed as "since the epoch", never as a non-finite number.
+      const cutoffMs = resolveScanCutoffMs(options?.sinceDays) ?? 0;
 
       let db: LocalUsageSqliteDatabase | undefined;
       try {

--- a/src/lib/localUsage/scanWindow.ts
+++ b/src/lib/localUsage/scanWindow.ts
@@ -1,0 +1,47 @@
+/**
+ * One definition of "how far back does a local-usage scan reach".
+ *
+ * This calculation lived in three copies — claudeCodeReader, codexReader and
+ * openCodeReader — and has been wrong three separate times, each a different
+ * door into the same failure: an unbounded sweep of every transcript on the
+ * machine in answer to the narrowest possible request.
+ *
+ *   sinceDays: 0          left the cutoff undefined       17,534 files, 35.9s
+ *   sinceDays: NaN        Math.max(0, NaN) is NaN, and every comparison
+ *                         against NaN is false, so the filter passed
+ *                         everything                       17,537 files, 32.8s
+ *   sinceDays: MAX_VALUE  MAX_VALUE * 86_400_000 overflows to Infinity, so the
+ *                         cutoff became -Infinity and every file passed
+ *
+ * Three fixes in three files each closed one door and left the others open.
+ * The logic lives here once now, so the next door closes everywhere at once.
+ *
+ * Contract: `Infinity` is the ONLY value meaning all-history. Anything that is
+ * not a usable finite window — NaN, negative, or so large the arithmetic stops
+ * being finite — collapses to a zero-length window, which is what a
+ * nonsensical request should read as.
+ */
+export const DEFAULT_SINCE_DAYS = 30;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * @returns the epoch-ms cutoff a scan must not read past, or `undefined` for an
+ * unbounded (all-history) scan — which only `Infinity` produces.
+ */
+export function resolveScanCutoffMs(
+  sinceDays: number | undefined,
+  defaultDays: number = DEFAULT_SINCE_DAYS,
+): number | undefined {
+  const requested = sinceDays ?? defaultDays;
+  const days = Number.isNaN(requested) ? 0 : requested;
+  if (days === Infinity) {
+    return undefined;
+  }
+  const span = Math.max(0, days) * MS_PER_DAY;
+  // A finite `days` can still produce a non-finite span: Number.MAX_VALUE and
+  // anything near it overflow on the multiply. Treat that as no window rather
+  // than letting `Date.now() - Infinity` become -Infinity, which every
+  // timestamp compares as newer than.
+  return Date.now() - (Number.isFinite(span) ? span : 0);
+}

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -1011,18 +1011,33 @@ async function runAllTests(): Promise<void> {
       }),
     ]);
     try {
-      const [zero, negative, notANumber, negInfinite, infinite] =
-        await withHome(home, async () => [
-          await readAllLocalUsage({ sinceDays: 0 }),
-          await readAllLocalUsage({ sinceDays: -5 }),
-          // NaN is the case the first version of this fix missed:
-          // Math.max(0, NaN) is NaN and every comparison against NaN is false,
-          // so the filter passed every file — 17,537 of them, measured. The
-          // guard it replaced caught this with Number.isFinite.
-          await readAllLocalUsage({ sinceDays: NaN }),
-          await readAllLocalUsage({ sinceDays: -Infinity }),
-          await readAllLocalUsage({ sinceDays: Infinity }),
-        ]);
+      const [
+        zero,
+        negative,
+        notANumber,
+        negInfinite,
+        overflowMax,
+        overflowHuge,
+        infinite,
+      ] = await withHome(home, async () => [
+        await readAllLocalUsage({ sinceDays: 0 }),
+        await readAllLocalUsage({ sinceDays: -5 }),
+        // NaN is the case the first version of this fix missed:
+        // Math.max(0, NaN) is NaN and every comparison against NaN is false,
+        // so the filter passed every file — 17,537 of them, measured. The
+        // guard it replaced caught this with Number.isFinite.
+        await readAllLocalUsage({ sinceDays: NaN }),
+        await readAllLocalUsage({ sinceDays: -Infinity }),
+        // A FINITE sinceDays whose window arithmetic is not finite — the
+        // third door into the same unbounded sweep, after 0 and NaN.
+        // Number.MAX_VALUE * 86_400_000 overflows to Infinity, so the cutoff
+        // became Date.now() - Infinity = -Infinity and every timestamp
+        // compares as newer than it. Measured before the fix, against a
+        // fixture dated months earlier: it read the file.
+        await readAllLocalUsage({ sinceDays: Number.MAX_VALUE }),
+        await readAllLocalUsage({ sinceDays: 1e308 }),
+        await readAllLocalUsage({ sinceDays: Infinity }),
+      ]);
 
       assert(
         (zero.totals["claude-code"]?.requests ?? 0) === 0,
@@ -1039,6 +1054,14 @@ async function runAllTests(): Promise<void> {
       assert(
         (negInfinite.totals["claude-code"]?.requests ?? 0) === 0,
         "a -Infinity sinceDays read transcripts instead of nothing",
+      );
+      assert(
+        (overflowMax.totals["claude-code"]?.requests ?? 0) === 0,
+        "a Number.MAX_VALUE sinceDays read transcripts instead of nothing",
+      );
+      assert(
+        (overflowHuge.totals["claude-code"]?.requests ?? 0) === 0,
+        "a 1e308 sinceDays read transcripts instead of nothing",
       );
       // The control: without this, a reader that simply returned nothing for
       // every window would pass every assertion above.


### PR DESCRIPTION
## The bug

`resolveScanCutoff` computed `Date.now() - sinceDays * 86_400_000`. With a very large
`sinceDays` the multiplication overflows to `Infinity`, so the cutoff becomes `-Infinity`
and **every file on disk compares as newer** — the bounded scan silently becomes an
unbounded one.

```
Number.MAX_VALUE * 86_400_000  ->  Infinity
Date.now() - Infinity          ->  -Infinity   // every mtimeMs passes
```

Measured against a fixture dated January 2026, where a bounded window must read **0**:

| `sinceDays` | before | after | expected |
| --- | --- | --- | --- |
| `Number.MAX_VALUE` | 2 | **0** | 0 |
| `1e308` | 2 | **0** | 0 |
| `Infinity` | 2 | 2 | 2 — documented all-history escape hatch, unchanged |
| `7` | 0 | 0 | 0 |

## Why a shared helper instead of a fourth patch

This is the **third** door into the same unbounded scan. `0` and `NaN` were each fixed
before — but the window logic lived in three copies (`claudeCodeReader`, `codexReader`,
`openCodeReader`), so each fix had to close one door in three places, and this one was
missed in all three.

This change extracts `src/lib/localUsage/scanWindow.ts` as the single source of truth and
rewires all three readers to it. `openCodeReader` coalesces `undefined` to `0` because the
value becomes a SQL parameter. `Infinity` continues to mean "all history" by returning
`undefined` rather than a numeric cutoff.

## Verification

- **Non-vacuity proven** — reverting the readers while keeping the tests fails with
  `a Number.MAX_VALUE sinceDays read transcripts instead of nothing`.
- build 0 errors · `check:tools-tests` 0 errors · `pnpm run lint` **0 errors**
- local-usage suite 20/20 · mocked provider contract 63/63
- docs regenerated with **both** halves (`docs:api` + `prettier --write docs/api`) — zero drift

## Known flake, deliberately left out

The suite's existing `sinceDays 0` assertion races the fixture's mtime at millisecond
granularity (the fixture is stamped `Date.now()`; a zero-length window's cutoff is also
`Date.now()`). Observed once in five runs, then seven consecutive clean runs. The fix is to
backdate the fixture via `utimesSync`; that is an unrelated edit and gets its own PR rather
than riding along on a verified fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local usage scanning with consistent handling of time-window settings.
  - Prevented invalid or overflowing date values from producing unreliable scan results.
  - Preserved full-history scans when explicitly requested.

- **Tests**
  - Added coverage for extreme time-window values and overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->