### PR TITLE
docs(ci): correct two notes that no longer match the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,18 @@ on:
 # Cancel a run that a newer push to the same ref has superseded. Without this
 # an amend-and-force-push — routine under the single-commit-per-branch policy —
 # leaves the old run executing to completion, competing for runners with the
-# run whose result anyone actually wants. copilot-review.yml already does this;
-# ci.yml did not.
+# run whose result anyone actually wants.
 #
 # Keyed on the ref, not the PR number, so pushes to release are covered too.
+# That has a consequence worth knowing before debugging a cache miss: a
+# cancelled run saves no cache. When several merges land on release in quick
+# succession, only the surviving run writes the dist cache, so PRs opened in
+# the gap miss and build from scratch. That is correct but slower — and it
+# means a green run in that window is no evidence either way about the
+# restore-and-stamp path. The cache step itself still runs on a miss; it finds
+# no entry for the key and restores nothing, so the stamp step is skipped and
+# nothing depending on a restored dist was exercised. A cache step that ran is
+# not a cache that was restored.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,20 @@ has `enforce_admins: false`, so the classic layer — which is the only place
 `security-suites` is required — does not apply to admins. Net effect: four
 checks nobody can bypass, plus a fifth that a repository admin can.
 
+**A migration to rulesets would silently drop `security-suites`.** GitHub has
+been steering repositories off classic protection, and the migration is
+per-layer: switching classic off removes every requirement that exists only
+there. Four of the five are duplicated on the ruleset and would survive. The
+fifth is not, and would simply stop gating — no warning, no failed merge, no
+visible change on any pull request. What makes it invisible is that the check
+keeps running and keeps reporting: a green `security-suites` looks identical
+whether it is blocking the merge or merely describing it, and the way you find
+out it stopped blocking is that something red merges. Before disabling classic
+protection, add the context to ruleset `11413189` first and confirm with
+`gh api repos/juspay/neurolink/rulesets/11413189` that it comes back — the same
+call that under-reports the list today is the one that proves the migration is
+safe.
+
 Anything that pushes **directly** to `release` — rather than through a PR —
 carries no check runs, so every required check reads as missing and the push is
 declined:


### PR DESCRIPTION
Two documentation notes had drifted from what the repository actually does. Both verified against live state rather than against the notes.

## 1. `CLAUDE.md` — a rulesets migration would silently drop `security-suites`

The required-checks note already records that `release` carries five required checks across two layers, and that `security-suites` is required only on classic branch protection. It does not say what happens when that layer goes away.

| | contexts |
|---|---|
| ruleset `11413189` | `test`, `provider-safety-net`, `build-check`, `🔒 Single Commit Policy Validation` |
| classic protection | the same four, **plus `security-suites`** |

`bypass_actors: []` on the ruleset, `enforce_admins: false` on classic.

GitHub has been steering repositories off classic protection, and that migration is per-layer: switching classic off removes every requirement that exists only there. Four of the five are duplicated on the ruleset and survive. The fifth is not, and would simply stop gating.

**The failure is invisible by construction**, which is why it earns a paragraph. `security-suites` keeps running and keeps reporting after it stops blocking — a green check looks identical whether it is gating a merge or merely describing one. The way you would find out is that something red merges. The note now says to add the context to the ruleset *first* and confirm it with the same `gh api repos/juspay/neurolink/rulesets/11413189` call that under-reports the list today.

## 2. `ci.yml` — the concurrency comment cited a deleted workflow

That comment justified the concurrency block by citing `copilot-review.yml` as precedent. 208c8dba deleted that workflow, which left this comment as the **only** reference to it anywhere in the repository. The block’s reasoning stands without the citation, so the citation is removed rather than repointed.

It is replaced with something learned while debugging the dist-cache regression: **a cancelled run saves no cache.** Because this block cancels superseded runs on the same ref — pushes to `release` included — several merges landing in quick succession leave only the surviving run to write the dist cache. PRs opened in that gap miss and build from scratch. That is correct but slower, and it means a green run in that window is no evidence either way about the cache-restore path, because that path never executed.

That is precisely the reasoning someone needs when a cache miss looks like a bug, and it belongs next to the block that causes it.

Comments and documentation only — no behaviour change. `ci.yml` re-verified to parse, with all four required contexts present and unsharded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for migrating GitHub branch protection to rulesets.
  * Warned that disabling classic protection can remove the `security-suites` gate while checks continue reporting success.
  * Documented the required steps to add and verify this check in the appropriate ruleset before migration.
  * Clarified CI run cancellation behavior and how superseded runs may affect cache availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->