### PR TITLE
fix(ci): stamp cache-restored dist so the freshness guard doesn't kill every suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,22 @@ jobs:
           path: dist
           key: dist-${{ runner.os }}-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'tsconfig*.json', 'vite.config.ts', 'svelte.config.js', 'scripts/build-browser.mjs', 'scripts/collapse-cli-lib-duplicate.mjs') }}
 
+      # A cache HIT restores dist/ with the mtimes it was SAVED with, while
+      # actions/checkout stamps src/ with checkout time — so the repo's
+      # assertDistFresh guard reads a genuinely current dist as stale and kills
+      # every suite that imports it. The key above hashes src/** and every
+      # build input, so a hit proves dist matches this exact tree; re-stamping
+      # its mtimes is truthful, not a freshness bypass.
+      #
+      # That truth DEPENDS on the key being exact: never add `restore-keys`
+      # to the cache step above. A prefix match would restore a dist built
+      # from DIFFERENT sources, and this touch would then make
+      # assertDistFresh certify stale code as fresh — converting the guard's
+      # loud, correct abort into silently testing the wrong build.
+      - name: Stamp restored dist as fresh
+        if: matrix.group == 'types' && steps.dist-cache.outputs.cache-hit == 'true'
+        run: find dist -exec touch {} +
+
       - name: Build package
         if: matrix.group == 'types' && steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm run build
@@ -291,6 +307,22 @@ jobs:
         with:
           path: dist
           key: dist-${{ runner.os }}-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'tsconfig*.json', 'vite.config.ts', 'svelte.config.js', 'scripts/build-browser.mjs', 'scripts/collapse-cli-lib-duplicate.mjs') }}
+
+      # A cache HIT restores dist/ with the mtimes it was SAVED with, while
+      # actions/checkout stamps src/ with checkout time — so the repo's
+      # assertDistFresh guard reads a genuinely current dist as stale and kills
+      # every suite that imports it. The key above hashes src/** and every
+      # build input, so a hit proves dist matches this exact tree; re-stamping
+      # its mtimes is truthful, not a freshness bypass.
+      #
+      # That truth DEPENDS on the key being exact: never add `restore-keys`
+      # to the cache step above. A prefix match would restore a dist built
+      # from DIFFERENT sources, and this touch would then make
+      # assertDistFresh certify stale code as fresh — converting the guard's
+      # loud, correct abort into silently testing the wrong build.
+      - name: Stamp restored dist as fresh
+        if: steps.dist-cache.outputs.cache-hit == 'true'
+        run: find dist -exec touch {} +
 
       - name: Build package
         if: steps.dist-cache.outputs.cache-hit != 'true'
@@ -388,6 +420,22 @@ jobs:
         with:
           path: dist
           key: dist-${{ runner.os }}-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'tsconfig*.json', 'vite.config.ts', 'svelte.config.js', 'scripts/build-browser.mjs', 'scripts/collapse-cli-lib-duplicate.mjs') }}
+
+      # A cache HIT restores dist/ with the mtimes it was SAVED with, while
+      # actions/checkout stamps src/ with checkout time — so the repo's
+      # assertDistFresh guard reads a genuinely current dist as stale and kills
+      # every suite that imports it. The key above hashes src/** and every
+      # build input, so a hit proves dist matches this exact tree; re-stamping
+      # its mtimes is truthful, not a freshness bypass.
+      #
+      # That truth DEPENDS on the key being exact: never add `restore-keys`
+      # to the cache step above. A prefix match would restore a dist built
+      # from DIFFERENT sources, and this touch would then make
+      # assertDistFresh certify stale code as fresh — converting the guard's
+      # loud, correct abort into silently testing the wrong build.
+      - name: Stamp restored dist as fresh
+        if: steps.dist-cache.outputs.cache-hit == 'true'
+        run: find dist -exec touch {} +
 
       - name: Build package
         if: steps.dist-cache.outputs.cache-hit != 'true'
@@ -584,6 +632,22 @@ jobs:
           path: dist
           key: dist-${{ runner.os }}-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'tsconfig*.json', 'vite.config.ts', 'svelte.config.js', 'scripts/build-browser.mjs', 'scripts/collapse-cli-lib-duplicate.mjs') }}
 
+      # A cache HIT restores dist/ with the mtimes it was SAVED with, while
+      # actions/checkout stamps src/ with checkout time — so the repo's
+      # assertDistFresh guard reads a genuinely current dist as stale and kills
+      # every suite that imports it. The key above hashes src/** and every
+      # build input, so a hit proves dist matches this exact tree; re-stamping
+      # its mtimes is truthful, not a freshness bypass.
+      #
+      # That truth DEPENDS on the key being exact: never add `restore-keys`
+      # to the cache step above. A prefix match would restore a dist built
+      # from DIFFERENT sources, and this touch would then make
+      # assertDistFresh certify stale code as fresh — converting the guard's
+      # loud, correct abort into silently testing the wrong build.
+      - name: Stamp restored dist as fresh
+        if: steps.dist-cache.outputs.cache-hit == 'true'
+        run: find dist -exec touch {} +
+
       - name: Build (full — the CLI's collapse step needs the SDK output)
         if: steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm run build
@@ -694,6 +758,22 @@ jobs:
         with:
           path: dist
           key: dist-${{ runner.os }}-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'tsconfig*.json', 'vite.config.ts', 'svelte.config.js', 'scripts/build-browser.mjs', 'scripts/collapse-cli-lib-duplicate.mjs') }}
+
+      # A cache HIT restores dist/ with the mtimes it was SAVED with, while
+      # actions/checkout stamps src/ with checkout time — so the repo's
+      # assertDistFresh guard reads a genuinely current dist as stale and kills
+      # every suite that imports it. The key above hashes src/** and every
+      # build input, so a hit proves dist matches this exact tree; re-stamping
+      # its mtimes is truthful, not a freshness bypass.
+      #
+      # That truth DEPENDS on the key being exact: never add `restore-keys`
+      # to the cache step above. A prefix match would restore a dist built
+      # from DIFFERENT sources, and this touch would then make
+      # assertDistFresh certify stale code as fresh — converting the guard's
+      # loud, correct abort into silently testing the wrong build.
+      - name: Stamp restored dist as fresh
+        if: steps.dist-cache.outputs.cache-hit == 'true'
+        run: find dist -exec touch {} +
 
       - name: Build
         if: steps.dist-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fixes the repo-wide CI breakage introduced by #1532's dist caching, confirmed by its author (who has no competing fix and asked that this land).

## The bug

`actions/cache` restores `dist/` with the mtimes it was **saved** with, while `actions/checkout` stamps `src/` with checkout time. `assertDistFresh` compares exactly those mtimes, so on every cache **hit** it reads a genuinely current dist as stale and aborts every dist-importing suite before a single case runs:

- observed on #1535: `security-suites` ("newest src 3m ago, newest dist 26m ago") and `provider-safety-net-shards (rest)` ("newest src 16s ago, newest dist 23m ago"), both dying at `distFreshness.ts:104`
- reproduced independently by #1532's author on docs-only #1534

**Blast radius:** the cache key hashes `src/**` and every build input, so any PR touching one of them keys differently and can never hit the bad entry — which is why #1529/#1530 stayed green. The failing class is precisely PRs that change **no** build inputs: docs and workflow-only PRs.

## The fix

One `Stamp restored dist as fresh` step (`find dist -exec touch {} +`) after each of the five `Restore built dist` sites, guarded on `cache-hit` (and the matrix group where the restore itself is). The key's exactness proves a hit's dist was built from this very tree, so the stamp is truthful — **and each comment records that this depends on the key staying exact**: adding `restore-keys` later would let a prefix match restore a dist built from different sources, and the touch would then make `assertDistFresh` certify stale code as fresh. (Considered and rejected: `NEUROLINK_SKIP_DIST_FRESHNESS_CHECK=1`, which is sanctioned for artifact-restoration mtime loss but blinds the whole job including the cache-miss path; the stamp corrects only the mtime artifact and leaves the guard live.)

Rebased onto #1529's extended-suites sharding; verified all five restore/stamp pairs survive, including inside the new 4-way matrix. #1532's author will rerun docs-only #1534 after this merges as an end-to-end verification.