### PR TITLE
fix(core): format a provider failure once instead of five times

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -2413,6 +2413,24 @@ export abstract class BaseProvider implements AIProvider {
         ? error
         : new DOMException("The operation was aborted", "AbortError");
     }
+
+    // Already formatted by this method — hand it straight back. Formatting is
+    // NOT idempotent: formatProviderError prepends the provider tag every time,
+    // so a second pass produces
+    //   "[vertex] Google Vertex AI error: [vertex] Google Vertex AI error: ..."
+    // and, when a rule matched on statusCode the first time, can also DEGRADE
+    // the classification (a specific "quota exhausted" ProviderError re-matching
+    // the bare 429 rule as a generic RateLimitError) because the block below
+    // copies statusCode onto its own output.
+    //
+    // A single Vertex failure reaches here FIVE times for one logical error;
+    // this makes calls 2..5 cheap pass-throughs. `instanceof Error` rather than
+    // a cast: nothing but an Error is ever stamped, and an unstamped value
+    // simply falls through to formatting, which is the safe direction.
+    if (error instanceof Error && isProviderErrorClassified(error)) {
+      return error;
+    }
+
     const formatted = this.formatProviderError(error);
 
     // Preserve transport retry metadata across formatting. Provider

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env tsx
 import "dotenv/config";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Mocked Contract Test Suite for New Providers
@@ -2597,6 +2600,80 @@ async function runVertexSection(): Promise<void> {
     record(
       results,
       `${section}: setup`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── A single failure must be formatted ONCE. handleProviderError is not
+  // idempotent — formatProviderError prepends the provider tag every time it
+  // runs — and one Vertex failure reaches it FIVE times, so before the
+  // already-formatted short-circuit the message came out doubled:
+  //   "[vertex] Google Vertex AI error: [vertex] Google Vertex AI error: ..."
+  // Measured on the real path: provider tags 2 -> 1.
+  //
+  // GOOGLE_APPLICATION_CREDENTIALS must point at a real FILE holding an
+  // unparseable key, and that is the whole reason this case is shaped the way
+  // it is. Setting only GOOGLE_SERVICE_ACCOUNT_KEY to a mock is NOT enough:
+  // google-auth then falls through to Application Default Credentials, and on
+  // a developer machine with a gcloud login that SUCCEEDS — an earlier draft of
+  // this test came back with a real model completion ("Pong!"), i.e. it made a
+  // live API call and asserted nothing. Pointing at a bad key file fails inside
+  // the OpenSSL decoder before any network I/O, so this is hermetic everywhere
+  // and never depends on ambient credentials.
+  //
+  // Counting the TAG rather than matching wording is deliberate: the doubling
+  // is what regresses, and the decode message is OpenSSL's and free to change.
+  // NON-VACUOUS: drop the short-circuit and this reads 2.
+  // ─────────────────────────────────────────────────────────────────────
+  try {
+    const keyDir = mkdtempSync(join(tmpdir(), "neurolink-vertex-"));
+    const keyPath = join(keyDir, "fake-service-account.json");
+    writeFileSync(
+      keyPath,
+      JSON.stringify({
+        type: "service_account",
+        project_id: "mock-project",
+        private_key_id: "mock",
+        private_key:
+          "-----BEGIN PRIVATE KEY-----\nMOCK\n-----END PRIVATE KEY-----\n",
+        client_email: "mock@mock-project.iam.gserviceaccount.com",
+        token_uri: "https://oauth2.googleapis.com/token",
+      }),
+    );
+    setEnv("GOOGLE_APPLICATION_CREDENTIALS", keyPath);
+    setEnv("GOOGLE_VERTEX_PROJECT", "mock-project");
+    setEnv("GOOGLE_VERTEX_LOCATION", "us-central1");
+
+    const { NeuroLink } = await import("../dist/index.js");
+    const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+    let tags = -1;
+    let threw = false;
+    try {
+      const r = await nl.stream({
+        provider: "vertex",
+        model: "gemini-2.5-flash",
+        input: { text: "ping" },
+        disableTools: true,
+      });
+      for await (const chunk of r.stream) {
+        void chunk;
+      }
+    } catch (err) {
+      threw = true;
+      const m = err instanceof Error ? err.message : String(err);
+      tags = m.split("[vertex]").length - 1;
+    }
+    record(
+      results,
+      `${section}: a single failure carries exactly one provider tag`,
+      threw && tags === 1,
+      threw ? `saw ${tags} provider tags` : "no error thrown",
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: a single failure carries exactly one provider tag`,
       false,
       err instanceof Error ? err.message : String(err),
     );


### PR DESCRIPTION
## The bug

One Vertex failure reached `handleProviderError` **five times** and came back with the provider tag stamped twice:

```
[vertex] Google Vertex AI error: [vertex] Google Vertex AI error: error:1E08010C:DECODER routines::unsupported
```

`formatProviderError` prepends the provider tag on every run, so re-formatting an already-formatted error doubles it.

Uglier output is the visible half. The same non-idempotency can also **degrade a classification**: `handleProviderError` copies `statusCode` onto its own output, so a second pass re-matches the bare 429 rule and turns a specific `ProviderError "quota exhausted"` into a generic `RateLimitError "rate limit exceeded"`.

## The fix

The stamp that makes this detectable landed with #1530 — `classifyStreamError` already short-circuits on it. This applies the same test at the top of `handleProviderError`, so calls 2..5 become cheap pass-throughs.

Narrowed with `instanceof Error` rather than an assertion: nothing but an `Error` is ever stamped, and an unstamped value falls through to formatting, which is the safe direction.

## Measurement

Apply-and-revert on the real path (fake service-account key; decode fails inside OpenSSL before any network I/O):

| | provider tags |
| --- | --- |
| without the short-circuit | **2** |
| with the short-circuit | **1** |

Regression test proven non-vacuous the same way — removing the short-circuit and rebuilding fails it with `saw 2 provider tags`.

## One note on the test's shape, because the obvious version is silently wrong

It must point `GOOGLE_APPLICATION_CREDENTIALS` at a real **file** holding an unparseable key. Setting only `GOOGLE_SERVICE_ACCOUNT_KEY` to a mock is not enough: google-auth then falls through to Application Default Credentials, and on a developer machine with a gcloud login **that succeeds**.

An earlier draft did exactly that and came back with a real model completion (`"Pong!"`) — a live API call inside the mocked contract suite, asserting nothing. Pointing at a bad key file fails in the decoder before any network I/O, so the case is hermetic and never depends on ambient credentials.

## Verification

build 0 errors · `check:tools-tests` 0 errors · `pnpm run lint` **0 errors** · mocked provider contract suite **67 passed / 0 failed** · `test:provider-structure` PASS · docs regenerated with both halves, zero drift.

The suite's exit code was read from the suite itself rather than through a pipe — reading `grep`'s exit code instead of the runner's is how a process-killing crash hid behind a green local run earlier today.
