### PR TITLE
refactor(providers): keep the absorbed pump rejection out of the dark

### DIFF
--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -65,6 +65,7 @@ import {
 } from "../../types/index.js";
 import { classifyProviderError } from "../../utils/errorClassifier.js";
 import { logger } from "../../utils/logger.js";
+import { drainDetachedPump } from "../../utils/drainDetachedPump.js";
 import {
   ANTHROPIC_ELISION_NOTE,
   planAnthropicLoopReclaim,
@@ -2261,14 +2262,14 @@ export class AnthropicProvider extends BaseProvider {
       // formatted one the caller received, which is why the existing
       // `loopPromise.catch` guard below does not cover it.
       //
-      // Same shape googleAiStudio/client.ts and googleVertex/client.ts already
-      // use at every one of their pump sites; Anthropic was the only provider
-      // missing it.
+      // Every detached-drain site in the codebase now goes through
+      // drainDetachedPump(), which adopts the rejection and logs the reason at
+      // debug instead of discarding it silently.
       let result;
       try {
         result = await resultPromise;
       } catch (error) {
-        await pump.catch(() => {});
+        await drainDetachedPump(pump, "Anthropic");
         throw error;
       }
       await pump;

--- a/src/lib/providers/googleAiStudio/client.ts
+++ b/src/lib/providers/googleAiStudio/client.ts
@@ -48,6 +48,7 @@ import {
 } from "../../types/index.js";
 import { ERROR_CODES, NeuroLinkError } from "../../utils/errorHandling.js";
 import { logger } from "../../utils/logger.js";
+import { drainDetachedPump } from "../../utils/drainDetachedPump.js";
 import { createGeminiLoopAdapter } from "../../core/geminiLoopAdapter.js";
 import { runAgenticLoop } from "../../core/loopEngine.js";
 import { DEFAULT_TOOL_MAX_RETRIES } from "../../core/constants.js";
@@ -1199,7 +1200,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
               try {
                 engineResult = await resultPromise;
               } catch (error) {
-                await pump.catch(() => {});
+                await drainDetachedPump(pump, "GoogleAIStudio");
                 logger.error("[GoogleAIStudio] Native SDK error", error);
                 throw this.handleProviderError(error);
               }
@@ -1656,7 +1657,7 @@ export class GoogleAIStudioProvider extends BaseProvider {
           try {
             engineResult = await resultPromise;
           } catch (error) {
-            await drain.catch(() => {});
+            await drainDetachedPump(drain, "GoogleAIStudio");
             logger.error("[GoogleAIStudio] Native SDK generate error", error);
             throw this.handleProviderError(error);
           }

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -77,6 +77,7 @@ import {
   processUnifiedFilesArray,
 } from "../../utils/messageBuilder.js";
 import { logger } from "../../utils/logger.js";
+import { drainDetachedPump } from "../../utils/drainDetachedPump.js";
 import {
   GEMINI_ELISION_NOTE,
   planGeminiLoopReclaim,
@@ -2408,7 +2409,7 @@ export class GoogleVertexProvider extends BaseProvider {
       // rethrow the very error the branch below has already decided to absorb —
       // which is what turned both turn-clock cases into failures instead of
       // clean deadline exits.
-      await pump.catch(() => {});
+      await drainDetachedPump(pump, "GoogleVertex");
       if (turnFailure !== undefined) {
         // A mid-drain abort surfaces as an AbortError. End gracefully into the
         // terminal block instead of re-throwing — a re-throw would route the
@@ -3421,7 +3422,7 @@ export class GoogleVertexProvider extends BaseProvider {
       try {
         engineResult = await resultPromise;
       } catch (error) {
-        await pump.catch(() => {});
+        await drainDetachedPump(pump, "GoogleVertex");
         // A mid-drain abort surfaces as an AbortError. End gracefully into the
         // terminal block instead of re-throwing — a re-throw would route the
         // caller's abort into a second unbounded fallback stream().
@@ -4837,7 +4838,7 @@ export class GoogleVertexProvider extends BaseProvider {
         // Drained tolerantly and exactly once: when a turn ends by abort the
         // channel rejects too, and re-awaiting a settled rejection would rethrow
         // the error the branch below has already decided to absorb.
-        await pump.catch(() => {});
+        await drainDetachedPump(pump, "GoogleVertex");
         if (turnFailure !== undefined) {
           if (internalAbort.signal.aborted || isAbortError(turnFailure)) {
             wasAborted = true;
@@ -6072,7 +6073,7 @@ export class GoogleVertexProvider extends BaseProvider {
     } catch (error) {
       turnFailure = error;
     }
-    await pump.catch(() => {});
+    await drainDetachedPump(pump, "GoogleVertex");
     if (turnFailure !== undefined) {
       if (internalAbort.signal.aborted || isAbortError(turnFailure)) {
         wasAborted = true;

--- a/src/lib/utils/drainDetachedPump.ts
+++ b/src/lib/utils/drainDetachedPump.ts
@@ -1,0 +1,45 @@
+import { logger } from "./logger.js";
+
+/**
+ * Await a detached stream pump, swallowing its rejection but not its evidence.
+ *
+ * Several providers drain their engine's channel with a pump started outside
+ * the promise chain the caller awaits:
+ *
+ *   const pump = (async () => { for await (const chunk of stream) { ... } })();
+ *   const result = await resultPromise;   // can throw
+ *   await pump;                           // never reached if it does
+ *
+ * When the turn fails, `resultPromise` and the pump reject together — the
+ * engine calls `channel.error(err)` before closing — so the pump must be
+ * adopted on the error path too. Nothing adopting it is not a cosmetic leak:
+ * an unhandled rejection TERMINATES the process, so a caller who correctly
+ * try/catches the streaming error still dies. That was a real bug in the
+ * Anthropic path.
+ *
+ * The established remedy is `await pump.catch(() => {})`, which every site
+ * already uses. The gap this closes is the second half: `() => {}` throws the
+ * reason away, so the raw upstream error — the one carrying the provider's
+ * actual wire response — was invisible in traces at every one of the seven
+ * sites (six named `pump`, plus one named `drain` in googleAiStudio's
+ * non-streaming path, which a search for `pump` does not find). It is logged at DEBUG rather than WARN deliberately: on a failing turn
+ * this reason is almost always a duplicate of the error the caller is already
+ * being handed, and on an aborted turn it is the expected AbortError. It is
+ * diagnostic detail, not a new event worth alerting on.
+ *
+ * Behaviour is otherwise identical to `await pump.catch(() => {})`: it awaits,
+ * it never rethrows.
+ */
+export async function drainDetachedPump(
+  pump: Promise<unknown>,
+  providerLabel: string,
+): Promise<void> {
+  try {
+    await pump;
+  } catch (error) {
+    logger.debug(
+      `[${providerLabel}] detached stream pump rejected; reason absorbed because the turn's own error is authoritative`,
+      error,
+    );
+  }
+}


### PR DESCRIPTION
Follow-up to #1531, taken the way the review there suggested — normalize every site at once rather than making one provider the odd one out.

## What was already right, and what wasn't

Providers that drain an engine channel with a **detached pump** must adopt its rejection on the error path, or an unhandled rejection terminates the caller's process. Every site already does that, via `await pump.catch(() => {})`.

This closes the other half. `() => {}` throws the reason away — so the raw upstream error, the one carrying the provider's actual wire response and distinct from the formatted error the caller receives, was invisible in traces at every site.

All of them now go through one helper, `drainDetachedPump()`: awaits, never rethrows, logs the absorbed reason at **debug**.

Debug rather than warn is deliberate. On a failing turn this reason is almost always a duplicate of the error the caller is already being handed, and on an aborted turn it is the expected `AbortError`. It's diagnostic detail, not a new event worth alerting on.

## Seven sites, not six

A search for `pump` finds six. googleAiStudio's **non-streaming** path runs the identical shape under the name `drain` (`googleAiStudio/client.ts:1650`) — same detached IIFE, same swallow-all catch, same hazard — and is invisible to that grep. It's included here.

| file | sites |
| --- | --- |
| `googleAiStudio/client.ts` | `pump` + `drain` |
| `anthropic/client.ts` | `pump` |
| `googleVertex/client.ts` | 4 × `pump` |

After this change, `grep -rE "\.catch\(\(\) => \{\}\)" src/lib/providers/` returns nothing.

## No new test, deliberately

Behaviour is intentionally unchanged, and the guarantee that matters already has a test. Both still hold against this build:

- the existing subprocess regression test reports `a streaming error does not kill the caller's process — exit=0 signal=none`
- the unhandled-rejection probe measures **0**, with the consumer still receiving the same formatted `RateLimitError`

A test asserting that a debug line was emitted would pin the logging call rather than the behaviour, and log-assertion suites here are exactly where a spy on the wrong module copy has bitten before.

## Verification

build 0 errors · `check:tools-tests` 0 errors · `pnpm run lint` **0 errors** · mocked provider contract suite **66 passed / 0 failed** · `test:provider-structure` PASS · docs regenerated with both halves, zero drift.

Exit codes were read from the runner itself rather than through a pipe.
