### PR TITLE
feat(models): the five metadata stores read the manifests as their source of truth

### DIFF
--- a/docs/api/functions/calculateCost.md
+++ b/docs/api/functions/calculateCost.md
@@ -8,7 +8,7 @@
 
 > **calculateCost**(`provider`, `model`, `usage`): `number`
 
-Defined in: [utils/pricing.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L875)
+Defined in: [utils/pricing.ts:938](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L938)
 
 Calculate the dollar cost of a generate/stream call based on token usage.
 Returns 0 if the provider/model combination is not in the pricing table.

--- a/docs/api/functions/hasPricing.md
+++ b/docs/api/functions/hasPricing.md
@@ -8,7 +8,7 @@
 
 > **hasPricing**(`provider`, `model`): `boolean`
 
-Defined in: [utils/pricing.ts:930](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L930)
+Defined in: [utils/pricing.ts:993](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L993)
 
 ## Parameters
 

--- a/src/lib/adapters/providerImageAdapter.ts
+++ b/src/lib/adapters/providerImageAdapter.ts
@@ -6,6 +6,7 @@
 import type { Content, ImageWithAltText } from "../types/index.js";
 import { ImageProcessor } from "../utils/imageProcessor.js";
 import { logger } from "../utils/logger.js";
+import { resolveManifestEntryStrict } from "../models/manifestRegistry.js";
 
 /**
  * Simplified logger for essential error reporting only
@@ -669,6 +670,29 @@ export class ProviderImageAdapter {
         process.env.ANTHROPIC_BASE_URL
       ) {
         return true;
+      }
+
+      // Manifest is the source of truth when it has an entry for this exact
+      // model or a declared alias ONLY — strict, no prefix fallback: a
+      // manifest "gpt-4" prefix hit must never shadow the legacy table's
+      // explicit "gpt-4-vision-preview" row, and a fabricated id must not
+      // borrow a real family's capabilities. Everything without a real
+      // manifest match falls through to the legacy tables below unchanged.
+      const manifestEntry = resolveManifestEntryStrict(
+        normalizedProvider,
+        model ?? "",
+      );
+      if (manifestEntry) {
+        if (!model) {
+          return true;
+        }
+        if (manifestEntry.vision) {
+          return true;
+        }
+        if (PROXY_PROVIDERS.has(normalizedProvider)) {
+          return true;
+        }
+        return false;
       }
 
       const supportedModels =

--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -13,6 +13,7 @@
 
 import { DynamicModelProvider } from "../core/dynamicModels.js";
 import { logger } from "../utils/logger.js";
+import { resolveManifestEntryStrict } from "../models/manifestRegistry.js";
 
 /** Default context window when provider/model is unknown */
 export const DEFAULT_CONTEXT_WINDOW = 128_000;
@@ -518,10 +519,24 @@ export function clearRuntimeOutputCeilings(): void {
  *  0.5 Runtime-discovered windows (registerRuntimeContextWindow) — real
  *      per-model limits fetched from the serving infrastructure (LiteLLM
  *      `/model/info`)
- *  1. Exact model match under provider in static registry
- *  2. Prefix match under provider in static registry
- *  3. Provider's _default in static registry
- *  4. Global DEFAULT_CONTEXT_WINDOW
+ *  1. Manifest exact/alias match ONLY (resolveManifestEntryStrict — no prefix, see
+ *     src/lib/models/manifestRegistry.ts) — the emerging single source of
+ *     truth for per-model metadata. Deliberately consulted for a REAL match
+ *     only (never the manifest's synthesized/generic default): most provider
+ *     manifests are still "minimal" stubs holding nothing but a provider-wide
+ *     default (e.g. vertex.ts, together-ai.ts) and none of the per-model
+ *     overrides — including Vertex's Claude "claude-" prefix catch-all below,
+ *     which exists specifically to stop an unlisted Claude-on-Vertex model
+ *     from inheriting Gemini's 1,048,576 default — that still live only in
+ *     MODEL_CONTEXT_WINDOWS. Falling back to a manifest-wide default here
+ *     would silently drop that coverage. When a manifest DOES carry a real
+ *     entry for this model, it wins even if it disagrees with the legacy
+ *     table (e.g. Mistral's manifest supersedes the coarser, older
+ *     MODEL_CONTEXT_WINDOWS.mistral values).
+ *  2. Exact model match under provider in static registry
+ *  3. Prefix match under provider in static registry
+ *  4. Provider's _default in static registry
+ *  5. Global DEFAULT_CONTEXT_WINDOW
  */
 export function getContextWindowSize(provider: string, model?: string): number {
   // Step 0: Check dynamic model registry first.
@@ -554,6 +569,25 @@ export function getContextWindowSize(provider: string, model?: string): number {
   // Static fallback chain — normalize aliases first so "lmstudio" / "llama.cpp" /
   // "nvidianim" find their canonical entries instead of falling back to default.
   const canonical = normalizeProviderForLookup(provider);
+
+  // Step 1: Manifest real-entry lookup (exact id, alias, or longest-prefix —
+  // see resolveManifestEntryStrict's docblock). Tries the alias-normalized
+  // provider key first, then the raw provider string, mirroring the
+  // `MODEL_CONTEXT_WINDOWS[canonical] ?? MODEL_CONTEXT_WINDOWS[provider]`
+  // double-lookup below — MANIFEST_REGISTRY is keyed by the same hyphenated
+  // AIProviderName forms (e.g. "together-ai") that normalizeProviderForLookup
+  // strips and PROVIDER_ALIAS_MAP doesn't cover, so callers passing the raw
+  // enum value still resolve. Only a genuine match short-circuits; a miss
+  // falls straight through to the untouched legacy cascade below.
+  if (model) {
+    const manifestEntry =
+      resolveManifestEntryStrict(canonical, model) ??
+      resolveManifestEntryStrict(provider, model);
+    if (manifestEntry) {
+      return manifestEntry.contextWindow;
+    }
+  }
+
   const providerWindows =
     MODEL_CONTEXT_WINDOWS[canonical] ?? MODEL_CONTEXT_WINDOWS[provider];
   if (!providerWindows) {

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -3,6 +3,17 @@
  * Single source of truth for all default values
  */
 
+import type { ProviderModelManifest } from "../types/index.js";
+import { anthropicManifest } from "../models/manifests/anthropic.js";
+import { openaiManifest } from "../models/manifests/openai.js";
+import { googleAiManifest } from "../models/manifests/google-ai.js";
+import { vertexManifest } from "../models/manifests/vertex.js";
+import { bedrockManifest } from "../models/manifests/bedrock.js";
+import { azureManifest } from "../models/manifests/azure.js";
+import { mistralManifest } from "../models/manifests/mistral.js";
+import { ollamaManifest } from "../models/manifests/ollama.js";
+import { litellmManifest } from "../models/manifests/litellm.js";
+
 // Image Generation Model Identifiers
 // Used to detect if a model is an image generation model (not text generation).
 // `isImageGenerationModel(name)` (below) does boundary-aware matching:
@@ -188,34 +199,86 @@ export const PROVIDER_CONFIG = {
   },
 };
 
-// Provider-specific maxTokens limits
+/**
+ * Per-model output-token overrides for a manifest, keyed by canonical model
+ * id. The manifest's synthetic "_default" entry is excluded — the
+ * provider-level `default` in PROVIDER_MAX_TOKENS already carries that role,
+ * and is left as the hand-authored value below rather than replaced with
+ * this data (a provider's `_default` entry, when present, is a minimal
+ * catch-all sized for an unlisted/gateway model id, not a considered
+ * provider-wide ceiling).
+ */
+function maxTokensOverridesFrom(
+  manifest: ProviderModelManifest,
+): Record<string, number> {
+  const overrides: Record<string, number> = {};
+  for (const [id, entry] of Object.entries(manifest.models)) {
+    if (id === "_default") {
+      continue;
+    }
+    overrides[id] = entry.maxOutputTokens;
+  }
+  return overrides;
+}
+
+// Provider-specific maxTokens limits. Each provider's `default` is the
+// original hand-authored ceiling (unchanged); per-model keys are generated
+// from that provider's manifest (src/lib/models/manifests/) so
+// getSafeMaxTokens()'s existing per-model lookup (tokenLimits.ts) actually
+// has data to find instead of always falling through to the coarse
+// `default`. This resolves the historical disagreement between
+// getSafeMaxTokens("anthropic", "claude-opus-4-6") (used to return the flat
+// 64000) and resolveClaudeMaxTokens("claude-opus-4-6") (tokenLimits.ts's
+// regex ladder, correctly 32000 for the Opus family) — the manifest's own
+// per-model maxOutputTokens now wins for every listed model, on every
+// provider below, not just Anthropic.
+//
+// Manifests are imported directly from src/lib/models/manifests/ rather
+// than through manifestRegistry.ts's aggregator: manifestRegistry.ts
+// imports PROVIDER_MAX_TOKENS from this file (to size the synthetic
+// `_default` entry for manifests that don't declare their own), so
+// importing the aggregator back here would form a constants.ts <->
+// manifestRegistry.ts import cycle whose safety depends on which module a
+// given entrypoint happens to reach first — an ES module TDZ hazard, not
+// something a type-checker catches. The individual manifest files have no
+// dependency on this module (only on the ProviderModelManifest type), so
+// reaching past the aggregator avoids the cycle entirely.
 export const PROVIDER_MAX_TOKENS = {
   anthropic: {
     default: 64000,
+    ...maxTokensOverridesFrom(anthropicManifest),
   },
   openai: {
     default: 128000,
+    ...maxTokensOverridesFrom(openaiManifest),
   },
   "google-ai": {
     default: 64000,
+    ...maxTokensOverridesFrom(googleAiManifest),
   },
   vertex: {
     default: 64000,
+    ...maxTokensOverridesFrom(vertexManifest),
   },
   bedrock: {
     default: 64000,
+    ...maxTokensOverridesFrom(bedrockManifest),
   },
   azure: {
     default: 128000,
+    ...maxTokensOverridesFrom(azureManifest),
   },
   mistral: {
     default: 128000,
+    ...maxTokensOverridesFrom(mistralManifest),
   },
   ollama: {
     default: 64000,
+    ...maxTokensOverridesFrom(ollamaManifest),
   },
   litellm: {
     default: 128000,
+    ...maxTokensOverridesFrom(litellmManifest),
   },
   default: 64000,
 };

--- a/src/lib/models/anthropicModels.ts
+++ b/src/lib/models/anthropicModels.ts
@@ -10,6 +10,7 @@ import type {
   AnthropicModelMetadata,
 } from "../types/index.js";
 import { ModelAccessError } from "../types/index.js";
+import { anthropicManifest } from "./manifests/anthropic.js";
 
 // Re-export runtime value for convenience
 export { ModelAccessError };
@@ -42,6 +43,15 @@ export enum AnthropicModel {
 
   // Claude Sonnet 4.6
   CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
+
+  // Claude Opus 4.5
+  CLAUDE_OPUS_4_5 = "claude-opus-4-5-20251101",
+
+  // Claude Sonnet 4.5
+  CLAUDE_SONNET_4_5 = "claude-sonnet-4-5-20250929",
+
+  // Claude 4.5 Haiku
+  CLAUDE_HAIKU_4_5 = "claude-haiku-4-5-20251001",
 
   // Claude 3 Opus (Legacy flagship)
   CLAUDE_3_OPUS = "claude-3-opus-20240229",
@@ -100,138 +110,108 @@ export const MODEL_TIER_ACCESS: Record<ClaudeSubscriptionTier, string[]> = {
 // ============================================================================
 
 /**
- * Model metadata by model ID
- *
- * Comprehensive mapping of each Anthropic model's metadata,
- * including display names, context windows, vision support, and extended thinking.
+ * Model metadata by model ID, derived from the anthropic manifest
+ * (src/lib/models/manifests/anthropic.ts) so this catalog can no longer
+ * silently drift from the canonical source. Family/description fields —
+ * not tracked by the manifest — are supplied by the small per-id lookups
+ * below, unchanged from their pre-migration values.
  */
-export const MODEL_METADATA: Record<string, AnthropicModelMetadata> = {
-  // Claude 3 Haiku (Legacy)
-  [AnthropicModel.CLAUDE_3_HAIKU]: {
-    displayName: "Claude 3 Haiku",
-    contextWindow: 200000,
-    maxOutputTokens: 4096,
-    supportsVision: true,
-    supportsExtendedThinking: false,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: true,
-    family: "haiku",
-    description: "Fast and efficient model for simple tasks",
-  },
-
-  // Claude 3.5 Haiku
-  [AnthropicModel.CLAUDE_3_5_HAIKU]: {
-    displayName: "Claude 3.5 Haiku",
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    supportsVision: false,
-    supportsExtendedThinking: false,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "haiku",
-    description: "Improved fast model with better performance",
-  },
-
-  // Claude 3.5 Sonnet
-  [AnthropicModel.CLAUDE_3_5_SONNET]: {
-    displayName: "Claude 3.5 Sonnet",
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    supportsVision: true,
-    supportsExtendedThinking: false,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "sonnet",
-    description: "Balanced model for most tasks",
-  },
-
-  // Claude 3.5 Sonnet V2
-  [AnthropicModel.CLAUDE_3_5_SONNET_V2]: {
-    displayName: "Claude 3.5 Sonnet V2",
-    contextWindow: 200000,
-    maxOutputTokens: 8192,
-    supportsVision: true,
-    supportsExtendedThinking: false,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "sonnet",
-    description: "Updated Sonnet with improved capabilities",
-  },
-
-  // Claude Sonnet 4
-  [AnthropicModel.CLAUDE_SONNET_4]: {
-    displayName: "Claude Sonnet 4",
-    contextWindow: 200000,
-    maxOutputTokens: 64000,
-    supportsVision: true,
-    supportsExtendedThinking: true,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "sonnet",
-    description: "Latest Sonnet with extended thinking support",
-  },
-
-  // Claude 3 Opus (Legacy)
-  [AnthropicModel.CLAUDE_3_OPUS]: {
-    displayName: "Claude 3 Opus",
-    contextWindow: 200000,
-    maxOutputTokens: 4096,
-    supportsVision: true,
-    supportsExtendedThinking: false,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: true,
-    family: "opus",
-    description: "Legacy flagship model for complex tasks",
-  },
-
-  // Claude Opus 4
-  [AnthropicModel.CLAUDE_OPUS_4]: {
-    displayName: "Claude Opus 4",
-    contextWindow: 200000,
-    maxOutputTokens: 64000,
-    supportsVision: true,
-    supportsExtendedThinking: true,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "opus",
-    description: "Latest flagship model with advanced reasoning",
-  },
-
-  // Claude Sonnet 4.6
-  [AnthropicModel.CLAUDE_SONNET_4_6]: {
-    displayName: "Claude Sonnet 4.6",
-    contextWindow: 1000000,
-    maxOutputTokens: 64000,
-    supportsVision: true,
-    supportsExtendedThinking: true,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "sonnet",
-    description: "Claude 4.6 Sonnet with 1M context window",
-  },
-
-  // Claude Opus 4.6
-  [AnthropicModel.CLAUDE_OPUS_4_6]: {
-    displayName: "Claude Opus 4.6",
-    contextWindow: 1000000,
-    maxOutputTokens: 64000,
-    supportsVision: true,
-    supportsExtendedThinking: true,
-    supportsToolUse: true,
-    supportsStreaming: true,
-    deprecated: false,
-    family: "opus",
-    description: "Claude 4.6 Opus flagship with 1M context window",
-  },
+const FAMILY_BY_MODEL: Record<string, AnthropicModelMetadata["family"]> = {
+  [AnthropicModel.CLAUDE_3_HAIKU]: "haiku",
+  [AnthropicModel.CLAUDE_3_5_HAIKU]: "haiku",
+  [AnthropicModel.CLAUDE_3_5_SONNET]: "sonnet",
+  [AnthropicModel.CLAUDE_3_5_SONNET_V2]: "sonnet",
+  [AnthropicModel.CLAUDE_SONNET_4]: "sonnet",
+  [AnthropicModel.CLAUDE_SONNET_4_6]: "sonnet",
+  [AnthropicModel.CLAUDE_3_OPUS]: "opus",
+  [AnthropicModel.CLAUDE_OPUS_4]: "opus",
+  [AnthropicModel.CLAUDE_OPUS_4_6]: "opus",
+  [AnthropicModel.CLAUDE_OPUS_4_5]: "opus",
+  [AnthropicModel.CLAUDE_SONNET_4_5]: "sonnet",
+  [AnthropicModel.CLAUDE_HAIKU_4_5]: "haiku",
 };
+
+const DESCRIPTION_BY_MODEL: Record<string, string> = {
+  [AnthropicModel.CLAUDE_3_HAIKU]: "Fast and efficient model for simple tasks",
+  [AnthropicModel.CLAUDE_3_5_HAIKU]:
+    "Improved fast model with better performance",
+  [AnthropicModel.CLAUDE_3_5_SONNET]: "Balanced model for most tasks",
+  [AnthropicModel.CLAUDE_3_5_SONNET_V2]:
+    "Updated Sonnet with improved capabilities",
+  [AnthropicModel.CLAUDE_SONNET_4]:
+    "Latest Sonnet with extended thinking support",
+  [AnthropicModel.CLAUDE_3_OPUS]: "Legacy flagship model for complex tasks",
+  [AnthropicModel.CLAUDE_OPUS_4]:
+    "Latest flagship model with advanced reasoning",
+  [AnthropicModel.CLAUDE_SONNET_4_6]:
+    "Claude 4.6 Sonnet with 1M context window",
+  [AnthropicModel.CLAUDE_OPUS_4_6]:
+    "Claude 4.6 Opus flagship with 1M context window",
+  [AnthropicModel.CLAUDE_OPUS_4_5]: "Claude 4.5 Opus flagship model",
+  [AnthropicModel.CLAUDE_SONNET_4_5]: "Claude 4.5 Sonnet balanced model",
+  [AnthropicModel.CLAUDE_HAIKU_4_5]: "Claude 4.5 Haiku fast model",
+};
+
+const DEPRECATED_MODELS = new Set<string>([
+  AnthropicModel.CLAUDE_3_HAIKU,
+  AnthropicModel.CLAUDE_3_OPUS,
+]);
+
+/**
+ * CLAUDE_3_5_SONNET_V2's enum value ("claude-3-5-sonnet-v2-20241022") is a
+ * synthetic id minted only inside this file, pre-dating the manifest — it
+ * never was a real Anthropic wire id and has no row anywhere else in the
+ * codebase (pricing.ts, contextWindows.ts, VISION_CAPABILITIES all key off
+ * "claude-3-5-sonnet-20241022" for both v1 and v2). Route the manifest
+ * lookup to the real entry instead of inventing a duplicate manifest row
+ * for the same model; the enum member's name and exported value are left
+ * untouched.
+ */
+const MANIFEST_ID_OVERRIDES: Record<string, string> = {
+  [AnthropicModel.CLAUDE_3_5_SONNET_V2]: AnthropicModel.CLAUDE_3_5_SONNET,
+};
+
+/**
+ * displayName override applied only where routing through
+ * MANIFEST_ID_OVERRIDES would otherwise silently rename a model the caller
+ * already knows by its pre-migration display name (avoids user-visible
+ * naming churn, same principle the manifest itself documents for its
+ * pre-existing MODEL_REGISTRY-derived ids).
+ */
+const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+  [AnthropicModel.CLAUDE_3_5_SONNET_V2]: "Claude 3.5 Sonnet V2",
+};
+
+function metadataFromManifest(model: string): AnthropicModelMetadata {
+  const manifestId = MANIFEST_ID_OVERRIDES[model] ?? model;
+  const entry = anthropicManifest.models[manifestId];
+  if (!entry) {
+    throw new Error(
+      `metadataFromManifest: no manifest entry for "${model}" — add it to ` +
+        `src/lib/models/manifests/anthropic.ts before referencing it here`,
+    );
+  }
+  return {
+    displayName: DISPLAY_NAME_OVERRIDES[model] ?? entry.displayName ?? model,
+    contextWindow: entry.contextWindow,
+    maxOutputTokens: entry.maxOutputTokens,
+    supportsVision: entry.vision,
+    supportsExtendedThinking: entry.reasoning ?? false,
+    supportsToolUse: entry.functionCalling,
+    supportsStreaming: true,
+    deprecated: DEPRECATED_MODELS.has(model),
+    family: FAMILY_BY_MODEL[model] ?? "sonnet",
+    description: DESCRIPTION_BY_MODEL[model] ?? entry.displayName ?? model,
+  };
+}
+
+export const MODEL_METADATA: Record<string, AnthropicModelMetadata> =
+  Object.fromEntries(
+    Object.values(AnthropicModel).map((model) => [
+      model,
+      metadataFromManifest(model),
+    ]),
+  );
 
 // ============================================================================
 // DEFAULT MODELS BY TIER
@@ -524,15 +504,21 @@ export function getLatestModelsByFamily(): Record<
 
   // Priority order for each family (latest first based on model version)
   const familyPriority: Record<AnthropicModelMetadata["family"], string[]> = {
-    haiku: [AnthropicModel.CLAUDE_3_5_HAIKU, AnthropicModel.CLAUDE_3_HAIKU],
+    haiku: [
+      AnthropicModel.CLAUDE_HAIKU_4_5,
+      AnthropicModel.CLAUDE_3_5_HAIKU,
+      AnthropicModel.CLAUDE_3_HAIKU,
+    ],
     sonnet: [
       AnthropicModel.CLAUDE_SONNET_4_6,
+      AnthropicModel.CLAUDE_SONNET_4_5,
       AnthropicModel.CLAUDE_SONNET_4,
       AnthropicModel.CLAUDE_3_5_SONNET_V2,
       AnthropicModel.CLAUDE_3_5_SONNET,
     ],
     opus: [
       AnthropicModel.CLAUDE_OPUS_4_6,
+      AnthropicModel.CLAUDE_OPUS_4_5,
       AnthropicModel.CLAUDE_OPUS_4,
       AnthropicModel.CLAUDE_3_OPUS,
     ],

--- a/src/lib/models/manifestRegistry.ts
+++ b/src/lib/models/manifestRegistry.ts
@@ -120,6 +120,36 @@ function applyFamilyRules(
  * "llama3.2:latest" or OpenRouter's "openai/gpt-4o"), then undefined.
  * Family rules are applied on top of whichever entry matched.
  */
+/**
+ * Like resolveManifestEntryExact but WITHOUT the longest-prefix fallback:
+ * exact canonical id or declared alias only. For consumers where a prefix
+ * hit can steal precedence from a more-specific legacy row — boolean
+ * capability checks above all (a manifest "gpt-4" prefix match must never
+ * shadow the legacy table's explicit "gpt-4-vision-preview" vision row).
+ * Family rules still apply to a real match.
+ */
+export function resolveManifestEntryStrict(
+  provider: string,
+  model: string,
+): ProviderModelManifestEntry | undefined {
+  const manifest = MANIFEST_REGISTRY[provider];
+  if (!manifest) {
+    return undefined;
+  }
+  const exact = manifest.models[model];
+  if (exact) {
+    return applyFamilyRules(manifest, model, exact);
+  }
+  const aliasMatch = Object.entries(manifest.models).find(
+    ([canonicalId, entry]) =>
+      canonicalId !== "_default" && entry.aliases.includes(model),
+  );
+  if (aliasMatch) {
+    return applyFamilyRules(manifest, model, aliasMatch[1]);
+  }
+  return undefined;
+}
+
 export function resolveManifestEntryExact(
   provider: string,
   model: string,

--- a/src/lib/models/manifests/anthropic.ts
+++ b/src/lib/models/manifests/anthropic.ts
@@ -30,9 +30,11 @@ export const anthropicManifest: ProviderModelManifest = {
       displayName: "Claude Sonnet 5",
       contextWindow: 1_000_000,
       maxOutputTokens: 64_000,
-      // No pricingPerMTok: genuinely absent from PRICING.anthropic today.
-      // Do not invent a rate — hasPricing()/findRates() (pricing.ts) must
-      // keep reporting this model as unpriced.
+      // No pricingPerMTok DELIBERATELY: PRICING.anthropic carries real
+      // rates for this id, and findRates() is manifest-first with a legacy
+      // fallback — omitting the rate here defers to that table instead of
+      // duplicating it, and keeps this entry out of the manifest-derived
+      // MODEL_REGISTRY rows (which only admit priced entries).
       vision: true,
       functionCalling: true,
       reasoning: true,

--- a/src/lib/models/manifests/azure.ts
+++ b/src/lib/models/manifests/azure.ts
@@ -79,7 +79,12 @@ export const azureManifest: ProviderModelManifest = {
       contextWindow: 200000,
       maxOutputTokens: 32768,
       pricingPerMTok: { input: 1.25, output: 10 },
-      vision: true,
+      // Azure publishes no such model (the registry row is deprecated for
+      // exactly that reason, modelRegistry.ts ~2550), and vision was
+      // deliberately removed from VISION_CAPABILITIES for it — this entry
+      // was generated from the registry BEFORE that fix and must not
+      // re-advertise a capability an undeployable id cannot have.
+      vision: false,
       functionCalling: true,
       reasoning: true,
       jsonMode: true,

--- a/src/lib/models/modelRegistry.ts
+++ b/src/lib/models/modelRegistry.ts
@@ -20,12 +20,22 @@ import type {
   JsonValue,
   ModelCapabilities,
   ModelInfo,
+  ModelPerformance,
+  ProviderModelManifestEntry,
 } from "../types/index.js";
+import {
+  getAllManifestProviders,
+  getManifestForProvider,
+} from "./manifestRegistry.js";
 
 /**
- * Comprehensive model registry
+ * Comprehensive model registry — hand-authored base. Every id defined here
+ * that the manifest doesn't also carry a priced entry for stays exactly as
+ * authored below; see buildManifestDerivedEntries()/MODEL_REGISTRY's
+ * docblock further down for how the two are merged and why (Task 9, model
+ * metadata consolidation plan).
  */
-export const MODEL_REGISTRY: Record<string, ModelInfo> = {
+const LEGACY_MODEL_REGISTRY: Record<string, ModelInfo> = {
   // OpenAI Models
   [OpenAIModels.GPT_4O]: {
     id: OpenAIModels.GPT_4O,
@@ -2547,6 +2557,139 @@ export const MODEL_REGISTRY: Record<string, ModelInfo> = {
   // Note: Azure models like O3, O4-mini, GPT-4o share IDs with OpenAI and use the OpenAI registry entries
 };
 
+function deriveSpeed(id: string): ModelPerformance["speed"] {
+  if (/mini|nano|haiku|flash|lite/i.test(id)) {
+    return "fast";
+  }
+  if (/opus|^o1|^o3|-pro$/i.test(id)) {
+    return "slow";
+  }
+  return "medium";
+}
+
+function deriveQuality(
+  entry: ProviderModelManifestEntry,
+): ModelPerformance["quality"] {
+  return entry.reasoning ? "high" : "medium";
+}
+
+/**
+ * Builds the manifest-derived slice of MODEL_REGISTRY: every manifest model
+ * that carries pricingPerMTok (ModelInfo.pricing is a required field, and
+ * the manifest's pricingPerMTok is deliberately optional for un-priced
+ * models like claude-sonnet-5 — see ProviderModelManifestEntry's docblock),
+ * excluding each provider's synthetic "_default" entry.
+ *
+ * performance/useCases/category use entry.curated verbatim when present —
+ * the ids that already had a hand-tuned LEGACY_MODEL_REGISTRY row before
+ * this migration (5 Anthropic, 20 OpenAI) carry that exact triple forward
+ * unchanged. Every other entry has no curated block and falls back to
+ * mechanical derivation from the tracked capability flags.
+ */
+function buildManifestDerivedEntries(): Record<string, ModelInfo> {
+  const entries: Record<string, ModelInfo> = {};
+  for (const provider of getAllManifestProviders()) {
+    const manifest = getManifestForProvider(provider);
+    if (!manifest) {
+      continue;
+    }
+    for (const [id, entry] of Object.entries(manifest.models)) {
+      if (id === "_default" || !entry.pricingPerMTok) {
+        continue;
+      }
+      // Keep-first on cross-manifest id collisions (Azure/OpenAI share ids):
+      // getAllManifestProviders() order is deterministic, and silently
+      // overwriting an earlier provider's row would make "which provider owns
+      // this id" depend on iteration order.
+      if (entries[id]) {
+        logger.debug(
+          `[modelRegistry] Manifest id collision: "${id}" already derived from ${entries[id].provider}; keeping first, skipping ${provider}`,
+        );
+        continue;
+      }
+      const reasoningScore = entry.reasoning ? 9 : 6;
+      const legacyRow = LEGACY_MODEL_REGISTRY[id];
+      entries[id] = {
+        id,
+        name: entry.displayName ?? id,
+        provider: provider as AIProviderName,
+        description: entry.displayName ?? id,
+        capabilities: {
+          vision: entry.vision,
+          functionCalling: entry.functionCalling,
+          codeGeneration: true,
+          reasoning: entry.reasoning ?? false,
+          multimodal: entry.vision || entry.nativeAudio === true,
+          streaming: true,
+          jsonMode: entry.jsonMode ?? false,
+          samplingParams: entry.samplingParams,
+        },
+        pricing: {
+          inputCostPer1K: entry.pricingPerMTok.input / 1000,
+          outputCostPer1K: entry.pricingPerMTok.output / 1000,
+          currency: "USD",
+        },
+        performance: entry.curated?.performance ?? {
+          speed: deriveSpeed(id),
+          quality: deriveQuality(entry),
+          accuracy: deriveQuality(entry),
+        },
+        limits: {
+          maxContextTokens: entry.contextWindow,
+          maxOutputTokens: entry.maxOutputTokens,
+          // Rate limits are operational knowledge the manifests don't track;
+          // carry the hand-authored value forward rather than dropping it.
+          ...(legacyRow?.limits?.maxRequestsPerMinute !== undefined
+            ? { maxRequestsPerMinute: legacyRow.limits.maxRequestsPerMinute }
+            : {}),
+        },
+        useCases: entry.curated?.useCases ?? {
+          coding: entry.functionCalling ? 8 : 5,
+          creative: entry.vision ? 7 : 6,
+          analysis: reasoningScore,
+          conversation: 7,
+          reasoning: reasoningScore,
+          translation: 6,
+          summarization: 7,
+        },
+        aliases: entry.aliases,
+        // Deprecation and release dates are editorial facts the manifests do
+        // not track — a manifest-priced model must not silently un-deprecate
+        // a row the hand-authored registry explicitly flagged.
+        deprecated: legacyRow?.deprecated ?? false,
+        ...(legacyRow?.releaseDate !== undefined
+          ? { releaseDate: legacyRow.releaseDate }
+          : {}),
+        isLocal:
+          provider === "ollama" ||
+          provider === "lm-studio" ||
+          provider === "llamacpp",
+        category:
+          entry.curated?.category ??
+          (entry.reasoning ? "reasoning" : "general"),
+      };
+    }
+  }
+  return entries;
+}
+
+/**
+ * Public MODEL_REGISTRY: the manifest-derived entries merged over the
+ * hand-authored LEGACY_MODEL_REGISTRY base. Spread order matters — manifest
+ * entries are spread last, so a manifest-priced model wins outright
+ * (whole-entry replacement, not a per-field merge) over a legacy row with
+ * the same id. Any legacy id the manifest doesn't also price (no
+ * pricingPerMTok, or no manifest entry at all — e.g. AnthropicModels.
+ * CLAUDE_OPUS_5/CLAUDE_FABLE_5, which have no manifest counterpart yet)
+ * passes through unchanged, which is what keeps resolveSamplingParams/
+ * modelSupportsSamplingParams behaviour identical for those "non-manifest"
+ * models: their capabilities.samplingParams (or absence of it) is untouched.
+ */
+export const MODEL_REGISTRY: Record<string, ModelInfo> = {
+  ...LEGACY_MODEL_REGISTRY,
+  ...buildManifestDerivedEntries(),
+};
+
 /**
  * Model aliases registry for quick resolution
  */
@@ -2776,14 +2919,21 @@ export function getModelsByProvider(provider: AIProviderName): ModelInfo[] {
 }
 
 /**
- * Get available providers
+ * Get available providers.
+ *
+ * Deliberately does NOT derive from MODEL_REGISTRY membership: a registry
+ * keyed only by "real, priced, named models" under-reports providers whose
+ * manifest carries only a `_default` entry (the minimal-tier providers —
+ * e.g. voyage, jina, stability — have no priced named model and so
+ * contribute zero MODEL_REGISTRY rows). Reading getAllManifestProviders()
+ * directly gives every provider NeuroLink actually knows a manifest for,
+ * decoupled from MODEL_REGISTRY membership entirely. Manifest keys are
+ * literally the AIProviderName enum's kebab-case values by construction
+ * (see manifestRegistry.ts), so the cast is a same-value relabel, not a
+ * narrowing assumption.
  */
 export function getAvailableProviders(): AIProviderName[] {
-  const providers = new Set<AIProviderName>();
-  Object.values(MODEL_REGISTRY).forEach((model) => {
-    providers.add(model.provider);
-  });
-  return Array.from(providers);
+  return getAllManifestProviders() as AIProviderName[];
 }
 
 /**

--- a/src/lib/utils/pricing.ts
+++ b/src/lib/utils/pricing.ts
@@ -1,4 +1,8 @@
 import type { TokenUsage } from "../types/index.js";
+import {
+  getManifestForProvider,
+  resolveManifestEntryExact,
+} from "../models/manifestRegistry.js";
 
 /**
  * Per-token pricing data (USD per token). Updated Feb 2026.
@@ -746,6 +750,25 @@ function isVersionOnlySuffix(model: string, key: string): boolean {
   return VERSION_SUFFIX_RE.test(model.slice(key.length));
 }
 
+/**
+ * Whether `model` matches a provider manifest by the manifest's own
+ * canonical id or by one of its declared aliases — deliberately excludes
+ * resolveManifestEntryExact's longest-prefix fallback. See the call site in
+ * findRates for why the prefix path is unsafe to use for pricing precedence.
+ */
+function isManifestNamedMatch(provider: string, model: string): boolean {
+  const manifest = getManifestForProvider(provider);
+  if (!manifest) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(manifest.models, model)) {
+    return true;
+  }
+  return Object.values(manifest.models).some((entry) =>
+    entry.aliases.includes(model),
+  );
+}
+
 function findRates(
   provider: string,
   model: string,
@@ -812,6 +835,46 @@ function findRates(
     stripped === "bedrock" || stripped === "amazonbedrock"
       ? model.replace(/^.*\banthropic\./, "")
       : model;
+
+  // Manifest-backed exact/alias match takes precedence over legacy PRICING
+  // (see Task 8 of the model metadata consolidation plan). Deliberately
+  // gated to a NAMED match only (manifest's own id or a declared alias) —
+  // never resolveManifestEntryExact's longest-prefix fallback. The
+  // manifest's model set is coarser-grained than PRICING's for several
+  // live ids today (e.g. openai's manifest names only "gpt-5" while
+  // PRICING.openai carries distinct exact entries for
+  // gpt-5.1/5.4/5.5/5.6-sol/terra/luna); letting the manifest's prefix
+  // match run first would silently steal a more specific PRICING entry's
+  // rate — confirmed: resolveManifestEntryExact("openai", "gpt-5.4")
+  // prefix-matches onto the "gpt-5" entry, $1.25/$10 instead of the
+  // correct $2.5/$15. Everything the manifest doesn't name exactly or
+  // alias — including a named entry with no pricingPerMTok, e.g.
+  // claude-sonnet-5 — falls straight through to PRICING's unchanged
+  // exact+prefix match below, which is exactly "legacy PRICING as the
+  // fallback for entries the manifest lacks."
+  if (isManifestNamedMatch(normalizedProvider, modelKey)) {
+    const manifestEntry = resolveManifestEntryExact(
+      normalizedProvider,
+      modelKey,
+    );
+    if (manifestEntry?.pricingPerMTok) {
+      if (matchKind) {
+        matchKind.exact = true;
+      }
+      return {
+        input: manifestEntry.pricingPerMTok.input / 1_000_000,
+        output: manifestEntry.pricingPerMTok.output / 1_000_000,
+        cacheRead:
+          manifestEntry.pricingPerMTok.cacheRead !== undefined
+            ? manifestEntry.pricingPerMTok.cacheRead / 1_000_000
+            : undefined,
+        cacheCreation:
+          manifestEntry.pricingPerMTok.cacheWrite !== undefined
+            ? manifestEntry.pricingPerMTok.cacheWrite / 1_000_000
+            : undefined,
+      };
+    }
+  }
 
   // Exact match
   if (providerPricing[modelKey]) {

--- a/test/continuous-test-suite-model-manifests.ts
+++ b/test/continuous-test-suite-model-manifests.ts
@@ -6,33 +6,37 @@ import "dotenv/config";
  *
  * Zero-API structural checks over MANIFEST_REGISTRY (src/lib/models/manifestRegistry.ts)
  * and its resolver, resolveManifestEntry/resolveManifestEntryExact. Covers the
- * resolution cascade (exact id -> alias -> prefix -> family rule -> default)
- * and the output-ceiling invariant (maxOutputTokens must never exceed the
- * relevant contextWindow) across every registered provider manifest.
+ * resolution cascade (exact id -> alias -> prefix -> family rule -> default),
+ * the output-ceiling invariant (maxOutputTokens must never exceed the
+ * relevant contextWindow) across every registered provider manifest, and —
+ * for every manifest model that carries verified pricing — that the
+ * manifest's per-model data actually reaches every real consumer:
+ * getContextWindowSize, calculateCost, MODEL_REGISTRY,
+ * ProviderImageAdapter.supportsVision, and PROVIDER_MAX_TOKENS. That last
+ * group is the model-metadata consolidation plan's core promise (a single
+ * source of truth every consumer agrees with), and the whole reason the
+ * manifest exists rather than five hand-maintained tables.
  *
  * ## Why this reaches into `dist/` directly (CLAUDE.md rule 15)
  *
- * manifestRegistry.ts has no consumer yet, by design: this PR (model-metadata
- * consolidation, Task 5) is purely additive and deliberately does not migrate
- * any existing code onto the manifest. Confirmed empty blast radius —
- * `dist/index.js` contains no reference to manifestRegistry, and no file
- * under `src/lib/` outside `models/manifestRegistry.ts` /
- * `models/manifests/*` calls `resolveManifestEntry`, `resolveManifestEntryExact`,
- * or reads `MANIFEST_REGISTRY`. There is therefore no `generate()`/`stream()`/
- * CLI path that reaches this resolver at all today — the alias-resolution
- * bug this suite was written to catch (a bare model name silently losing its
- * real contextWindow/vision/functionCalling data to the provider default) is
- * unreachable from any public surface until a future PR wires a consumer
- * onto the manifest. Once a consumer migrates, this suite should be converted
- * (or retired in favor of assertions on that consumer's public output) per
- * rule 15's own guidance that internals reachable only from the inside need
- * a public surface, not a unit test.
- *
- * This is not the rule 15 `allow`-list exception (deterministic control a
- * live call can't give) — it is the same "drive a specific compiled dist
- * module that isn't re-exported from dist/index.js" pattern already used by
- * continuous-test-suite.ts (AccountPool, ModelRouter, the cloaking plugins),
- * -credentials.ts (ProviderFactory/ProviderRegistry), -provider-structure.ts
+ * manifestRegistry.ts is no longer "no consumer yet" — contextWindows.ts,
+ * pricing.ts, modelRegistry.ts, providerImageAdapter.ts, and core/constants.ts
+ * all resolve against it now. But of those five consumer surfaces only
+ * `calculateCost`/`hasPricing` are re-exported from `dist/index.js`;
+ * `getContextWindowSize`, `MODEL_REGISTRY`, `ProviderImageAdapter`, and
+ * `PROVIDER_MAX_TOKENS` are internal to their own modules and never reach
+ * the package's public API. There is therefore still no `generate()`/
+ * `stream()`/CLI call that exercises any of those four by name — a caller
+ * only ever observes their combined, provider-specific effect (the context
+ * actually sent, the image accepted or rejected). Asserting on that
+ * combined effect per model would mean live provider calls per sampled
+ * model, which is exactly the "convenience, not a rule-15 exception" trap
+ * this rule warns against, not a way to reach the same guarantee more
+ * honestly. Reaching directly into the compiled internal modules is the
+ * same "drive a specific compiled dist module that isn't re-exported from
+ * dist/index.js" pattern already used by continuous-test-suite.ts
+ * (AccountPool, ModelRouter, the cloaking plugins), -credentials.ts
+ * (ProviderFactory/ProviderRegistry), -provider-structure.ts
  * (providerRegistry.js) and others, none of which are on the `allow` list.
  * Every import below resolves under `../dist/...` — the compiled
  * artifact, not raw TypeScript source — so it stays a single module graph
@@ -45,6 +49,7 @@ import "dotenv/config";
 
 import { assert, assertNotNull, defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
+import type { ProviderModelManifestEntry } from "../dist/types/model.js";
 
 // Fail loudly rather than silently testing a stale build.
 assertDistFresh();
@@ -57,6 +62,59 @@ const {
   getManifestForProvider,
   getAllManifestProviders,
 } = await import("../dist/models/manifestRegistry.js");
+
+// The five consumers the model-metadata consolidation plan promises will
+// all agree with the manifest. Only calculateCost/hasPricing are on
+// dist/index.js's public surface (see the file header) — the rest are
+// pulled from their own compiled modules, same as MANIFEST_REGISTRY above.
+const { getContextWindowSize } =
+  await import("../dist/constants/contextWindows.js");
+const { calculateCost } = await import("../dist/index.js");
+const { MODEL_REGISTRY } = await import("../dist/models/modelRegistry.js");
+const { ProviderImageAdapter } =
+  await import("../dist/adapters/providerImageAdapter.js");
+const { PROVIDER_MAX_TOKENS } = await import("../dist/core/constants.js");
+
+type ManifestSample = {
+  provider: string;
+  id: string;
+  entry: ProviderModelManifestEntry;
+};
+
+/**
+ * Every manifest model that carries verified pricing (`pricingPerMTok`) —
+ * the same filter `buildManifestDerivedEntries()` (modelRegistry.ts) uses to
+ * decide which manifest entries win a MODEL_REGISTRY row. Un-priced entries
+ * are deliberately excluded: MODEL_REGISTRY doesn't carry them at all, so
+ * there is nothing there to agree or disagree with, and calculateCost falls
+ * through to legacy PRICING for them by design (see pricing.ts's findRates).
+ *
+ * Resolved via resolveManifestEntryExact rather than the raw
+ * `manifest.models[id]` value, because that's what every real consumer
+ * (getContextWindowSize, pricing.ts, providerImageAdapter.ts) actually reads
+ * — family rules apply on top of the raw entry, so comparing against the
+ * unresolved entry could pass or fail on a rule that never touches these
+ * canonical ids today but is free to start doing so later.
+ */
+function collectPricedManifestSample(): ManifestSample[] {
+  const sample: ManifestSample[] = [];
+  for (const provider of getAllManifestProviders()) {
+    const manifest = getManifestForProvider(provider);
+    if (!manifest) {
+      continue;
+    }
+    for (const id of Object.keys(manifest.models)) {
+      if (id === "_default") {
+        continue;
+      }
+      const resolved = resolveManifestEntryExact(provider, id);
+      if (resolved?.pricingPerMTok) {
+        sample.push({ provider, id, entry: resolved });
+      }
+    }
+  }
+  return sample;
+}
 
 await test("Alias resolves to its canonical entry, not the default", async () => {
   // ollama's "llama3.2:latest" entry declares "llama3.2" as a bare-name
@@ -192,6 +250,211 @@ await test("Every alias points at a real key in its own manifest, never dangling
   assert(
     failures.length === 0,
     `${failures.length} alias/canonical-id collision(s) found`,
+  );
+});
+
+await test("getContextWindowSize agrees with the manifest for every priced model", async () => {
+  const sample = collectPricedManifestSample();
+  assert(sample.length > 0, "no priced manifest models found to sample");
+
+  const failures: string[] = [];
+  for (const { provider, id, entry } of sample) {
+    const windowSize = getContextWindowSize(provider, id);
+    if (windowSize !== entry.contextWindow) {
+      failures.push(
+        `${provider}/${id}: getContextWindowSize returned ${windowSize}, manifest says ${entry.contextWindow}`,
+      );
+    }
+  }
+  assert(
+    failures.length === 0,
+    `${failures.length} model(s) where getContextWindowSize disagrees with the manifest: ${failures.join("; ")}`,
+  );
+});
+
+await test("PROVIDER_MAX_TOKENS agrees with the manifest's maxOutputTokens for every priced model", async () => {
+  const sample = collectPricedManifestSample();
+  const failures: string[] = [];
+  for (const { provider, id, entry } of sample) {
+    const providerLimits =
+      PROVIDER_MAX_TOKENS[provider as keyof typeof PROVIDER_MAX_TOKENS];
+    if (typeof providerLimits !== "object" || providerLimits === null) {
+      // Provider has no per-model table in PROVIDER_MAX_TOKENS at all —
+      // nothing to compare. None of today's priced providers hit this
+      // (anthropic/openai/azure/bedrock/mistral/google-ai all do), but a
+      // future manifest could price a model under a provider
+      // maxTokensOverridesFrom() doesn't cover yet.
+      continue;
+    }
+    const perModel = (providerLimits as Record<string, number>)[id];
+    if (perModel === undefined) {
+      failures.push(`${provider}/${id}: no PROVIDER_MAX_TOKENS override`);
+      continue;
+    }
+    if (perModel !== entry.maxOutputTokens) {
+      failures.push(
+        `${provider}/${id}: PROVIDER_MAX_TOKENS says ${perModel}, manifest says ${entry.maxOutputTokens}`,
+      );
+    }
+  }
+  assert(
+    failures.length === 0,
+    `${failures.length} model(s) where PROVIDER_MAX_TOKENS disagrees with the manifest: ${failures.join("; ")}`,
+  );
+});
+
+await test("Pricing lookup (calculateCost) agrees with the manifest's pricingPerMTok for every priced model", async () => {
+  const sample = collectPricedManifestSample();
+  const failures: string[] = [];
+  for (const { provider, id, entry } of sample) {
+    const pricing = entry.pricingPerMTok;
+    if (!pricing) {
+      continue; // collectPricedManifestSample already filters to priced entries; narrows the type only.
+    }
+    // 1,000,000 input (or output) tokens against $/MTok rates reduces to
+    // "cost equals the manifest's own rate" — no unit conversion to get wrong.
+    const inputCost = calculateCost(provider, id, {
+      input: 1_000_000,
+      output: 0,
+      total: 1_000_000,
+    });
+    const outputCost = calculateCost(provider, id, {
+      input: 0,
+      output: 1_000_000,
+      total: 1_000_000,
+    });
+    if (Math.abs(inputCost - pricing.input) > 1e-6) {
+      failures.push(
+        `${provider}/${id}: calculateCost input rate ${inputCost} disagrees with manifest ${pricing.input}`,
+      );
+    }
+    if (Math.abs(outputCost - pricing.output) > 1e-6) {
+      failures.push(
+        `${provider}/${id}: calculateCost output rate ${outputCost} disagrees with manifest ${pricing.output}`,
+      );
+    }
+  }
+  assert(
+    failures.length === 0,
+    `${failures.length} model(s) where pricing lookup disagrees with the manifest: ${failures.join("; ")}`,
+  );
+});
+
+await test("MODEL_REGISTRY agrees with the manifest entry for every priced model", async () => {
+  const sample = collectPricedManifestSample();
+  const failures: string[] = [];
+  for (const { provider, id, entry } of sample) {
+    const modelInfo = MODEL_REGISTRY[id];
+    if (!modelInfo) {
+      failures.push(`${provider}/${id}: missing from MODEL_REGISTRY`);
+      continue;
+    }
+    if (modelInfo.provider !== provider) {
+      failures.push(
+        `${provider}/${id}: MODEL_REGISTRY entry belongs to provider ${modelInfo.provider} instead`,
+      );
+    }
+    if (modelInfo.limits.maxContextTokens !== entry.contextWindow) {
+      failures.push(
+        `${provider}/${id}: MODEL_REGISTRY maxContextTokens ${modelInfo.limits.maxContextTokens} disagrees with manifest ${entry.contextWindow}`,
+      );
+    }
+    if (modelInfo.limits.maxOutputTokens !== entry.maxOutputTokens) {
+      failures.push(
+        `${provider}/${id}: MODEL_REGISTRY maxOutputTokens ${modelInfo.limits.maxOutputTokens} disagrees with manifest ${entry.maxOutputTokens}`,
+      );
+    }
+    if (modelInfo.capabilities.vision !== entry.vision) {
+      failures.push(
+        `${provider}/${id}: MODEL_REGISTRY vision ${modelInfo.capabilities.vision} disagrees with manifest ${entry.vision}`,
+      );
+    }
+    if (modelInfo.capabilities.functionCalling !== entry.functionCalling) {
+      failures.push(
+        `${provider}/${id}: MODEL_REGISTRY functionCalling ${modelInfo.capabilities.functionCalling} disagrees with manifest ${entry.functionCalling}`,
+      );
+    }
+    const pricing = entry.pricingPerMTok;
+    if (pricing) {
+      const registryInputPerMTok = modelInfo.pricing.inputCostPer1K * 1000;
+      const registryOutputPerMTok = modelInfo.pricing.outputCostPer1K * 1000;
+      if (Math.abs(registryInputPerMTok - pricing.input) > 1e-6) {
+        failures.push(
+          `${provider}/${id}: MODEL_REGISTRY input pricing ${registryInputPerMTok} disagrees with manifest ${pricing.input}`,
+        );
+      }
+      if (Math.abs(registryOutputPerMTok - pricing.output) > 1e-6) {
+        failures.push(
+          `${provider}/${id}: MODEL_REGISTRY output pricing ${registryOutputPerMTok} disagrees with manifest ${pricing.output}`,
+        );
+      }
+    }
+  }
+  assert(
+    failures.length === 0,
+    `${failures.length} model(s) where MODEL_REGISTRY disagrees with the manifest: ${failures.join("; ")}`,
+  );
+});
+
+await test("ProviderImageAdapter.supportsVision agrees with the manifest's vision flag for every priced model", async () => {
+  const sample = collectPricedManifestSample();
+  const failures: string[] = [];
+  for (const { provider, id, entry } of sample) {
+    // supportsVision always returns true for a manifest-covered model
+    // under a proxy provider (litellm/openrouter) — the proxy's upstream,
+    // not the manifest, decides real vision support there. None of
+    // today's priced manifest entries live under a proxy provider; guard
+    // it explicitly so this stays true if that changes.
+    if (provider === "litellm" || provider === "openrouter") {
+      continue;
+    }
+    // Same escape hatch for Anthropic routed through a local proxy
+    // (ANTHROPIC_BASE_URL) — supportsVision defers to the upstream there
+    // too, by design (see providerImageAdapter.ts). A dev .env with this
+    // set (common when a local Claude Code proxy is running) would
+    // otherwise report a false disagreement that has nothing to do with
+    // manifest consistency.
+    if (provider === "anthropic" && process.env.ANTHROPIC_BASE_URL) {
+      continue;
+    }
+    const supports = ProviderImageAdapter.supportsVision(provider, id);
+    if (supports !== entry.vision) {
+      failures.push(
+        `${provider}/${id}: supportsVision returned ${supports}, manifest says ${entry.vision}`,
+      );
+    }
+  }
+  assert(
+    failures.length === 0,
+    `${failures.length} model(s) where supportsVision disagrees with the manifest: ${failures.join("; ")}`,
+  );
+});
+
+await test("manifest lookups never shadow more-specific legacy rows or bless fabricated ids", async () => {
+  // Review regressions, both runtime-confirmed before the strict resolver:
+  // (1) a manifest "gpt-4" PREFIX hit stole precedence from the legacy
+  // table's explicit gpt-4-vision-preview vision row; (2) a fabricated id
+  // borrowed a real family's capabilities via the same prefix fallback.
+  assert(
+    ProviderImageAdapter.supportsVision("openai", "gpt-4-vision-preview") ===
+      true,
+    "legacy vision row was shadowed by a manifest prefix match",
+  );
+  assert(
+    ProviderImageAdapter.supportsVision("azure", "gpt-5-turbo") === false,
+    "a fabricated model id borrowed vision from a manifest family prefix",
+  );
+});
+
+await test("a manifest-priced entry carries the legacy registry's deprecation flag", async () => {
+  // gpt-4 is priced in the openai manifest AND explicitly deprecated in the
+  // hand-authored registry; the manifest-derived row must not un-deprecate
+  // it (whole-entry replacement used to hardcode deprecated: false).
+  const entry = MODEL_REGISTRY["gpt-4"];
+  assertNotNull(entry, "gpt-4 missing from MODEL_REGISTRY");
+  assert(
+    entry?.deprecated === true,
+    "manifest-derived gpt-4 row dropped the legacy deprecated flag",
   );
 });
 


### PR DESCRIPTION
Plan 06 tasks 6–11 + 14 — the store-migration half of the metadata consolidation, closing the roadmap's largest remaining gap. Manifest data now wins wherever it exists; models the manifests do not carry keep their legacy values byte-for-byte.

## The migrations

- **anthropicModels.ts** — `MODEL_METADATA` derived from the anthropic manifest, with enum↔manifest coverage self-asserting at module load; three missing 4.5-gen enum members added; the synthetic `claude-3-5-sonnet-v2` id routed via a scoped override table. Fixes the opus `maxOutputTokens` 64000→32000 drift as a side effect.
- **contextWindows.ts / pricing.ts** — manifest **strict** exact/alias lookup first, the full legacy cascade unchanged as fallback. Strict matters: the registry's resolver carries a longest-prefix fallback that would let a manifest family entry shadow a more-specific legacy row, and its `_default` synthesis would erase legacy per-model values wholesale — both verified live against the actual manifests (e.g. the vertex `claude-` 200K incident-fix in the legacy table stays load-bearing) and avoided.
- **modelRegistry.ts** — `MODEL_REGISTRY` = legacy base + manifest-derived priced entries. The review round hardened the merge: legacy **deprecation** and releaseDate carry forward (a manifest row must not silently un-deprecate `gpt-4`), rate limits carry into `limits`, and cross-manifest id collisions keep-first with a debug line instead of iteration-order roulette.
- **providerImageAdapter.ts** — manifest vision consulted on strict match only: a `gpt-4` prefix hit must never shadow the legacy table's explicit `gpt-4-vision-preview` row (runtime-confirmed regression during review, now pinned). The azure manifest's generated `gpt-5-turbo` entry also re-advertised vision on an undeployable id — corrected at the source with the registry row's own reasoning.
- **core/constants.ts** — `PROVIDER_MAX_TOKENS` gains per-model overrides derived from the manifests over the provider-level literal defaults.

## Verification

- model-manifests suite extended to pin the consolidation: store-vs-manifest consistency sweeps plus the three review regressions (prefix shadowing, fabricated-id vision, deprecation carry) — **14/14**
- providers-mocked **66/66** · provider-descriptors **49/49** · typecheck 0 errors · docs/api regenerated