### PR TITLE
test(anthropic): stop the process-survival case passing on the wrong failure

### DIFF
--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -2403,13 +2403,27 @@ async function runAnthropicSection(): Promise<void> {
       );
       const { NeuroLink } = await import(${JSON.stringify(distUrl)});
       const nl = new NeuroLink({ conversationMemory: { enabled: false } });
-      let caught = false;
+      let caught;
       try {
         const r = await nl.stream({ provider: "anthropic", model: ${JSON.stringify(model)}, input: { text: "ping" }, disableTools: true });
         for await (const c of r.stream) { void c; }
-      } catch { caught = true; }
+      } catch (e) { caught = e; }
       await new Promise((r) => setTimeout(r, 600));
-      if (!caught) { console.log("NO_ERROR"); process.exit(3); }
+      if (caught === undefined) { console.log("NO_ERROR"); process.exit(3); }
+      // Surviving is only meaningful if the run actually reached the failure
+      // this test is about. Accepting ANY error made the case vacuous: a
+      // pre-request or configuration failure never creates a detached-pump
+      // rejection to survive, yet still landed in the catch. Demonstrated by
+      // making fetch throw instead of returning the 429 — the child printed
+      // SURVIVED off a NetworkError and the assertion passed having exercised
+      // nothing. Pin the identity so only the real path can report success.
+      const name = caught?.constructor?.name;
+      const text = String(caught?.message ?? "");
+      const tags = text.split("[anthropic]").length - 1;
+      if (name !== "RateLimitError" || tags !== 1) {
+        console.log("WRONG_ERROR", name, "tags=" + tags);
+        process.exit(4);
+      }
       console.log("SURVIVED");
     `;
     const res = spawnSync(
@@ -2421,6 +2435,12 @@ async function runAnthropicSection(): Promise<void> {
         killSignal: "SIGKILL",
       },
     );
+    // Child exit codes: 0 = survived the real failure · 1 = the process was
+    // killed by the unhandled rejection (the bug) · 3 = nothing threw at all
+    // · 4 = something threw, but not the failure under test. Only 0 counts.
+    // The detail below stays free of payload text on purpose — record()'s
+    // skip classifier reads message content, so quoting a provider-ish string
+    // into it can downgrade a genuine failure to a skip.
     const survived =
       res.status === 0 && (res.stdout ?? "").includes("SURVIVED");
     record(


### PR DESCRIPTION
Found by sweeping **unresolved review threads on already-merged PRs** — an open CodeRabbit thread on #1531, the PR that added this very test. The finding was correct.

## The hole

The subprocess regression test for the detached-pump crash accepted **any** thrown error as evidence the caller's process survived:

```js
} catch { caught = true; }
if (!caught) { console.log("NO_ERROR"); process.exit(3); }
console.log("SURVIVED");
```

Surviving is only meaningful if the run actually reached the failure the test is about. A pre-request or configuration failure never creates a detached-pump rejection to survive, yet still lands in that catch — so the case could report a passing regression guard having exercised nothing.

## Demonstrated, not argued

Child logic left alone; `fetch` made to throw instead of returning the 429:

```
ACTUAL_ERROR: NetworkError [anthropic] Connection error: ... simulated ...
SURVIVED            <- exit 0, assertion passes, bug never exercised
```

## The fix

The caught error must be a `RateLimitError` carrying exactly one `[anthropic]` tag before the child reports success.

Worth noting the **tag count alone would not have caught the case above** — that `NetworkError` message also carries one `[anthropic]` tag. The class name is the discriminating half.

## Non-vacuous in both directions

That's the whole point of the change, so both were measured:

| scenario | result |
| --- | --- |
| wrong failure (`fetch` throws) | child exits **4**, `WRONG_ERROR NetworkError` |
| real bug (pump guard reverted) | test **fails**, `exit=1` — the process death itself |
| fixed code, real 429 | test **passes**, `exit=0` |

Child exit codes are documented at the assertion: `0` survived · `1` killed by the unhandled rejection · `3` nothing threw · `4` wrong failure.

The recorded detail still carries no payload text, deliberately — `record()`'s skip classifier reads message content, and a provider-ish string there can downgrade a genuine failure to a skip.

## Verification

build 0 errors · `check:tools-tests` 0 errors · `pnpm run lint` **0 errors** · mocked provider contract suite **67 passed / 0 failed** · `test:provider-structure` PASS.

Exit codes were read from the runner itself rather than through a pipe.
