### PR TITLE
feat(media): one catalog, one registration path, catalog-derived choices

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1457,6 +1457,8 @@ console.log(result.content);
 - [McpOutputNormalizerConfig](type-aliases/McpOutputNormalizerConfig.md)
 - [McpOutputContext](type-aliases/McpOutputContext.md)
 - [NormalizedMcpOutput](type-aliases/NormalizedMcpOutput.md)
+- [MediaHandlerKind](type-aliases/MediaHandlerKind.md)
+- [MediaHandlerDescriptor](type-aliases/MediaHandlerDescriptor.md)
 - [MemorySqliteStorageConfig](type-aliases/MemorySqliteStorageConfig.md)
 - [MemoryRedisStorageConfig](type-aliases/MemoryRedisStorageConfig.md)
 - [MemoryS3StorageConfig](type-aliases/MemoryS3StorageConfig.md)
@@ -2943,6 +2945,7 @@ console.log(result.content);
 
 ### Other
 
+- [registerDefaultVideoHandlers](functions/registerDefaultVideoHandlers.md)
 - [isVertexVideoConfigured](functions/isVertexVideoConfigured.md)
 - [createAuthProvider](functions/createAuthProvider.md)
 - [runWithAuthContext](functions/runWithAuthContext.md)

--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6287](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6287)
+Defined in: [neurolink.ts:6299](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6299)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8659](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8659)
+Defined in: [neurolink.ts:8671](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8671)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:8742](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8742)
+Defined in: [neurolink.ts:8754](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8754)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9632](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9632)
+Defined in: [neurolink.ts:9644](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9644)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9650](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9650)
+Defined in: [neurolink.ts:9662](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9662)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12061](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12061)
+Defined in: [neurolink.ts:12073](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12073)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12077](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12077)
+Defined in: [neurolink.ts:12089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12089)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -856,7 +856,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12088](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12088)
+Defined in: [neurolink.ts:12100](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12100)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -874,7 +874,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12099](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12099)
+Defined in: [neurolink.ts:12111](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12111)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -898,7 +898,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12116](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12116)
+Defined in: [neurolink.ts:12128](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12128)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -924,7 +924,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12161](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12161)
+Defined in: [neurolink.ts:12173](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12173)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -976,7 +976,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12240)
+Defined in: [neurolink.ts:12252](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12252)
 
 Emit tool start event with execution tracking
 
@@ -1012,7 +1012,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12291](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12291)
+Defined in: [neurolink.ts:12303](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12303)
 
 Emit tool end event with execution summary
 
@@ -1064,7 +1064,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12372](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12372)
+Defined in: [neurolink.ts:12384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12384)
 
 Get current tool execution contexts for stream metadata
 
@@ -1078,7 +1078,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12379](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12379)
+Defined in: [neurolink.ts:12391](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12391)
 
 Get tool execution history
 
@@ -1092,7 +1092,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12386](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12386)
+Defined in: [neurolink.ts:12398](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12398)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1106,7 +1106,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12402](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12402)
+Defined in: [neurolink.ts:12414](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12414)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1152,7 +1152,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12543](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12543)
+Defined in: [neurolink.ts:12555](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12555)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1175,7 +1175,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12558](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12558)
+Defined in: [neurolink.ts:12570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12570)
 
 Get the current tool execution context
 
@@ -1191,7 +1191,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12567](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12567)
+Defined in: [neurolink.ts:12579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12579)
 
 Clear the tool execution context
 
@@ -1205,7 +1205,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12579)
+Defined in: [neurolink.ts:12591](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12591)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1230,7 +1230,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12602](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12602)
+Defined in: [neurolink.ts:12614](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12614)
 
 Unregister a custom tool
 
@@ -1254,7 +1254,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12620](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12620)
+Defined in: [neurolink.ts:12632](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12632)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1279,7 +1279,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:12633](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12633)
+Defined in: [neurolink.ts:12645](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12645)
 
 Get all registered tool middlewares
 
@@ -1293,7 +1293,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12640](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12640)
+Defined in: [neurolink.ts:12652](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12652)
 
 Flush any pending batched tool calls immediately
 
@@ -1307,7 +1307,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12649](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12649)
+Defined in: [neurolink.ts:12661](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12661)
 
 Get the current MCP enhancements configuration
 
@@ -1321,7 +1321,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12672)
+Defined in: [neurolink.ts:12684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12684)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1371,7 +1371,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:12708](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12708)
+Defined in: [neurolink.ts:12720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12720)
 
 Get all registered custom tools
 
@@ -1387,7 +1387,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12846](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12846)
+Defined in: [neurolink.ts:12858](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12858)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1416,7 +1416,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:12890](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12890)
+Defined in: [neurolink.ts:12902](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12902)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1439,7 +1439,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12917)
+Defined in: [neurolink.ts:12929](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12929)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1469,7 +1469,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12933](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12933)
+Defined in: [neurolink.ts:12945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12945)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1485,7 +1485,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:12945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12945)
+Defined in: [neurolink.ts:12957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12957)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1566,7 +1566,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:13949](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13949)
+Defined in: [neurolink.ts:13961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13961)
 
 ##### Returns
 
@@ -1578,7 +1578,7 @@ Defined in: [neurolink.ts:13949](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14131](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14131)
+Defined in: [neurolink.ts:14143](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14143)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1601,7 +1601,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14312](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14312)
+Defined in: [neurolink.ts:14324](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14324)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1625,7 +1625,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14344](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14344)
+Defined in: [neurolink.ts:14356](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14356)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1649,7 +1649,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14353](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14353)
+Defined in: [neurolink.ts:14365](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14365)
 
 Get list of all available AI provider names
 
@@ -1665,7 +1665,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14363](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14363)
+Defined in: [neurolink.ts:14375](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14375)
 
 Validate if a provider name is supported
 
@@ -1689,7 +1689,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14376](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14376)
+Defined in: [neurolink.ts:14388](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14388)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1705,7 +1705,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14446](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14446)
+Defined in: [neurolink.ts:14458](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14458)
 
 List all configured MCP servers with their status
 
@@ -1721,7 +1721,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14461](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14461)
+Defined in: [neurolink.ts:14473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14473)
 
 Test connectivity to a specific MCP server
 
@@ -1745,7 +1745,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14502](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14502)
+Defined in: [neurolink.ts:14514](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14514)
 
 Check if a provider has the required environment variables configured
 
@@ -1769,7 +1769,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14528](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14528)
+Defined in: [neurolink.ts:14540](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14540)
 
 Perform comprehensive health check on a specific provider
 
@@ -1813,7 +1813,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14574](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14574)
+Defined in: [neurolink.ts:14586](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14586)
 
 Check health of all supported providers
 
@@ -1851,7 +1851,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14618](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14618)
+Defined in: [neurolink.ts:14630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14630)
 
 Get a summary of provider health across all supported providers
 
@@ -1867,7 +1867,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:14665](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14665)
+Defined in: [neurolink.ts:14677](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14677)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1889,7 +1889,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:14676](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14676)
+Defined in: [neurolink.ts:14688](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14688)
 
 Get execution metrics for all tools
 
@@ -1905,7 +1905,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:14720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14720)
+Defined in: [neurolink.ts:14732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14732)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1928,7 +1928,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:14733](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14733)
+Defined in: [neurolink.ts:14745](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14745)
 
 Get circuit breaker status for all tools
 
@@ -1944,7 +1944,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:14768](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14768)
+Defined in: [neurolink.ts:14780](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14780)
 
 Reset circuit breaker for a specific tool
 
@@ -1966,7 +1966,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:14785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14785)
+Defined in: [neurolink.ts:14797](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14797)
 
 Clear all tool execution metrics
 
@@ -1980,7 +1980,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:14794](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14794)
+Defined in: [neurolink.ts:14806](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14806)
 
 Get comprehensive tool health report
 
@@ -1996,7 +1996,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14949](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14949)
+Defined in: [neurolink.ts:14961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14961)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2013,7 +2013,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:14969](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14969)
+Defined in: [neurolink.ts:14981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14981)
 
 Get conversation memory statistics (public API)
 
@@ -2027,7 +2027,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:14996](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14996)
+Defined in: [neurolink.ts:15008](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15008)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2051,7 +2051,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15052](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15052)
+Defined in: [neurolink.ts:15064](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15064)
 
 Clear conversation history for a specific session (public API)
 
@@ -2071,7 +2071,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15078](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15078)
+Defined in: [neurolink.ts:15090](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15090)
 
 Clear all conversation history (public API)
 
@@ -2085,7 +2085,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15106](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15106)
+Defined in: [neurolink.ts:15118](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15118)
 
 List all conversation sessions with metadata (public API)
 
@@ -2109,7 +2109,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15155](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15155)
+Defined in: [neurolink.ts:15167](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15167)
 
 Export a single session with full history and metadata (public API)
 
@@ -2145,7 +2145,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15240)
+Defined in: [neurolink.ts:15252](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15252)
 
 Export all sessions for a user (public API)
 
@@ -2181,7 +2181,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15304](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15304)
+Defined in: [neurolink.ts:15316](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15316)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2229,7 +2229,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15374](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15374)
+Defined in: [neurolink.ts:15386](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15386)
 
 Check if tool execution storage is available.
 
@@ -2250,7 +2250,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15384)
+Defined in: [neurolink.ts:15396](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15396)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2279,7 +2279,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15425](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15425)
+Defined in: [neurolink.ts:15437](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15437)
 
 Replace the entire messages array for a session.
 
@@ -2313,7 +2313,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15473)
+Defined in: [neurolink.ts:15485](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15485)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2350,7 +2350,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15504](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15504)
+Defined in: [neurolink.ts:15516](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15516)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2381,7 +2381,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15591](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15591)
+Defined in: [neurolink.ts:15603](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15603)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2406,7 +2406,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:15643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15643)
+Defined in: [neurolink.ts:15655](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15655)
 
 List all external MCP servers
 
@@ -2422,7 +2422,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:15672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15672)
+Defined in: [neurolink.ts:15684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15684)
 
 Get external MCP server status
 
@@ -2446,7 +2446,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:15686](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15686)
+Defined in: [neurolink.ts:15698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15698)
 
 Execute a tool from an external MCP server
 
@@ -2490,7 +2490,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15783](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15783)
+Defined in: [neurolink.ts:15795](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15795)
 
 Get all tools from external MCP servers
 
@@ -2506,7 +2506,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15792)
+Defined in: [neurolink.ts:15804](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15804)
 
 Get tools from a specific external MCP server
 
@@ -2530,7 +2530,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:15801](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15801)
+Defined in: [neurolink.ts:15813](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15813)
 
 Test connection to an external MCP server
 
@@ -2554,7 +2554,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:15829](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15829)
+Defined in: [neurolink.ts:15841](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15841)
 
 Get external MCP server manager statistics
 
@@ -2594,7 +2594,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15844](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15844)
+Defined in: [neurolink.ts:15856](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15856)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2609,7 +2609,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15882](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15882)
+Defined in: [neurolink.ts:15894](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15894)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2640,7 +2640,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15910](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15910)
+Defined in: [neurolink.ts:15922](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15922)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2678,7 +2678,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15933](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15933)
+Defined in: [neurolink.ts:15945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15945)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2707,7 +2707,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15958](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15958)
+Defined in: [neurolink.ts:15970](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15970)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2737,7 +2737,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15985](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15985)
+Defined in: [neurolink.ts:15997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15997)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2769,7 +2769,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16013](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16013)
+Defined in: [neurolink.ts:16025](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16025)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2846,7 +2846,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16054](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16054)
+Defined in: [neurolink.ts:16066](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16066)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2927,7 +2927,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16093](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16093)
+Defined in: [neurolink.ts:16105](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16105)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -2957,7 +2957,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16115](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16115)
+Defined in: [neurolink.ts:16127](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16127)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -2998,7 +2998,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16154)
+Defined in: [neurolink.ts:16166](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16166)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3039,7 +3039,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16177](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16177)
+Defined in: [neurolink.ts:16189](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16189)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3071,7 +3071,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16416](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16416)
+Defined in: [neurolink.ts:16428](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16428)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3122,7 +3122,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:16508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16508)
+Defined in: [neurolink.ts:16520](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16520)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3224,7 +3224,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:16646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16646)
+Defined in: [neurolink.ts:16658](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16658)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3293,7 +3293,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:16732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16732)
+Defined in: [neurolink.ts:16744](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16744)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3354,7 +3354,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:16778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16778)
+Defined in: [neurolink.ts:16790](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16790)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3380,7 +3380,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:16801](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16801)
+Defined in: [neurolink.ts:16813](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16813)
 
 Get details of a specific evaluation preset.
 
@@ -3416,7 +3416,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:16851](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16851)
+Defined in: [neurolink.ts:16863](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16863)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3468,7 +3468,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:16913](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16913)
+Defined in: [neurolink.ts:16925](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16925)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3542,7 +3542,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:16945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16945)
+Defined in: [neurolink.ts:16957](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16957)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3582,7 +3582,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17034](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17034)
+Defined in: [neurolink.ts:17046](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17046)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3632,7 +3632,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17053](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17053)
+Defined in: [neurolink.ts:17065](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17065)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3665,7 +3665,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17069)
+Defined in: [neurolink.ts:17081](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17081)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3690,7 +3690,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17087](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17087)
+Defined in: [neurolink.ts:17099](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17099)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3728,7 +3728,7 @@ The registered tool name
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:17109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17109)
+Defined in: [neurolink.ts:17121](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17121)
 
 Execute an agent network with the given input.
 
@@ -3773,7 +3773,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:17133](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17133)
+Defined in: [neurolink.ts:17145](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17145)
 
 Stream agent network execution with real-time events.
 
@@ -3817,7 +3817,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:17157](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17157)
+Defined in: [neurolink.ts:17169](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17169)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -3845,7 +3845,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:17176](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17176)
+Defined in: [neurolink.ts:17188](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17188)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -3873,7 +3873,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:17194](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17194)
+Defined in: [neurolink.ts:17206](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17206)
 
 Create a MessageBus for inter-agent communication.
 
@@ -3901,7 +3901,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17209](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17209)
+Defined in: [neurolink.ts:17221](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17221)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -3917,7 +3917,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:17396](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17396)
+Defined in: [neurolink.ts:17408](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17408)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -3934,7 +3934,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:17404](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17404)
+Defined in: [neurolink.ts:17416](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17416)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -3959,7 +3959,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:17455](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17455)
+Defined in: [neurolink.ts:17467](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17467)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -3988,7 +3988,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:17497](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17497)
+Defined in: [neurolink.ts:17509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17509)
 
 Check if a session needs compaction.
 
@@ -4016,7 +4016,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17534](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17534)
+Defined in: [neurolink.ts:17546](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17546)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4038,7 +4038,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:17582](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17582)
+Defined in: [neurolink.ts:17594](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17594)
 
 Get the currently configured authentication provider
 
@@ -4052,7 +4052,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17623](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17623)
+Defined in: [neurolink.ts:17635](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17635)
 
 Set the current authentication context for request handling.
 
@@ -4079,7 +4079,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:17638](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17638)
+Defined in: [neurolink.ts:17650](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17650)
 
 Get the current authentication context.
 
@@ -4095,7 +4095,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17646)
+Defined in: [neurolink.ts:17658](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17658)
 
 Clear the current authentication context
 
@@ -4109,7 +4109,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:17660](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17660)
+Defined in: [neurolink.ts:17672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17672)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/classes/ProviderRegistry.md
+++ b/docs/api/classes/ProviderRegistry.md
@@ -6,7 +6,7 @@
 
 # Class: ProviderRegistry
 
-Defined in: [factories/providerRegistry.ts:40](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L40)
+Defined in: [factories/providerRegistry.ts:41](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L41)
 
 Provider Registry - registers all providers with the factory
 This is where we migrate providers one by one to the new pattern
@@ -27,7 +27,7 @@ This is where we migrate providers one by one to the new pattern
 
 > `static` **realtimeRegistration**: `Record`\<`string`, `"ok"` \| `string`\> = `{}`
 
-Defined in: [factories/providerRegistry.ts:51](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L51)
+Defined in: [factories/providerRegistry.ts:52](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L52)
 
 NEW4: per-handler registration outcomes for the realtime voice
 providers. `"ok"` = registered; any other string = the error message.
@@ -39,7 +39,7 @@ Empty until the first `registerAllProviders()` call.
 
 > `static` **getRegistrationReport**(): `object`
 
-Defined in: [factories/providerRegistry.ts:58](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L58)
+Defined in: [factories/providerRegistry.ts:59](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L59)
 
 Returns a snapshot of voice provider registration outcomes so callers
 can detect at runtime which voice handlers are usable. Useful in
@@ -59,7 +59,7 @@ health-check endpoints and CI startup probes.
 
 > `static` **registerAllProviders**(): `Promise`\<`void`\>
 
-Defined in: [factories/providerRegistry.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L65)
+Defined in: [factories/providerRegistry.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L66)
 
 Register all providers with the factory
 
@@ -73,7 +73,7 @@ Register all providers with the factory
 
 > `static` **isRegistered**(): `boolean`
 
-Defined in: [factories/providerRegistry.ts:1037](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L1037)
+Defined in: [factories/providerRegistry.ts:811](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L811)
 
 Check if providers are registered
 
@@ -87,7 +87,7 @@ Check if providers are registered
 
 > `static` **clearRegistrations**(): `void`
 
-Defined in: [factories/providerRegistry.ts:1044](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L1044)
+Defined in: [factories/providerRegistry.ts:818](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L818)
 
 Clear registrations (for testing)
 
@@ -101,7 +101,7 @@ Clear registrations (for testing)
 
 > `static` **setOptions**(`options`): `void`
 
-Defined in: [factories/providerRegistry.ts:1057](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L1057)
+Defined in: [factories/providerRegistry.ts:831](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L831)
 
 Set registry options (should be called before initialization)
 
@@ -121,7 +121,7 @@ Set registry options (should be called before initialization)
 
 > `static` **getOptions**(): [`ProviderRegistryOptions`](../type-aliases/ProviderRegistryOptions.md)
 
-Defined in: [factories/providerRegistry.ts:1065](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L1065)
+Defined in: [factories/providerRegistry.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L839)
 
 Get current registry options
 

--- a/docs/api/functions/createAIProvider.md
+++ b/docs/api/functions/createAIProvider.md
@@ -8,7 +8,7 @@
 
 > **createAIProvider**(`providerName?`, `modelName?`): `Promise`\<[`AIProvider`](../type-aliases/AIProvider.md)\>
 
-Defined in: [index.ts:436](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L436)
+Defined in: [index.ts:437](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L437)
 
 Quick start factory function for creating AI provider instances.
 

--- a/docs/api/functions/createAIProviderWithFallback.md
+++ b/docs/api/functions/createAIProviderWithFallback.md
@@ -8,7 +8,7 @@
 
 > **createAIProviderWithFallback**(`primaryProvider?`, `fallbackProvider?`, `modelName?`): `Promise`\<[`ProviderPairResult`](../type-aliases/ProviderPairResult.md)\<[`AIProvider`](../type-aliases/AIProvider.md)\>\>
 
-Defined in: [index.ts:485](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L485)
+Defined in: [index.ts:486](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L486)
 
 Create provider with automatic fallback for production resilience.
 

--- a/docs/api/functions/createBestAIProvider.md
+++ b/docs/api/functions/createBestAIProvider.md
@@ -8,7 +8,7 @@
 
 > **createBestAIProvider**(`requestedProvider?`, `modelName?`): `Promise`\<[`AIProvider`](../type-aliases/AIProvider.md)\>
 
-Defined in: [index.ts:538](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L538)
+Defined in: [index.ts:539](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L539)
 
 Create the best available provider based on environment configuration.
 

--- a/docs/api/functions/generateText.md
+++ b/docs/api/functions/generateText.md
@@ -8,7 +8,7 @@
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [index.ts:952](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L952)
+Defined in: [index.ts:953](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L953)
 
 Legacy generateText function for backward compatibility.
 

--- a/docs/api/functions/getTelemetryStatus.md
+++ b/docs/api/functions/getTelemetryStatus.md
@@ -8,7 +8,7 @@
 
 > **getTelemetryStatus**(): `Promise`\<\{ `enabled`: `boolean`; `initialized`: `boolean`; `endpoint?`: `string`; `service?`: `string`; `version?`: `string`; \}\>
 
-Defined in: [index.ts:742](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L742)
+Defined in: [index.ts:743](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L743)
 
 ## Returns
 

--- a/docs/api/functions/initializeTelemetry.md
+++ b/docs/api/functions/initializeTelemetry.md
@@ -8,7 +8,7 @@
 
 > **initializeTelemetry**(): `Promise`\<`boolean`\>
 
-Defined in: [index.ts:733](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L733)
+Defined in: [index.ts:734](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L734)
 
 ## Returns
 

--- a/docs/api/functions/registerDefaultAvatarHandlers.md
+++ b/docs/api/functions/registerDefaultAvatarHandlers.md
@@ -8,7 +8,7 @@
 
 > **registerDefaultAvatarHandlers**(): `void`
 
-Defined in: [avatar/index.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/avatar/index.ts#L74)
+Defined in: [avatar/index.ts:89](https://github.com/juspay/neurolink/blob/release/src/lib/avatar/index.ts#L89)
 
 Register every shipped avatar handler whose backing credentials are
 present in the environment. Safe to call multiple times — existing

--- a/docs/api/functions/registerDefaultMusicHandlers.md
+++ b/docs/api/functions/registerDefaultMusicHandlers.md
@@ -8,7 +8,7 @@
 
 > **registerDefaultMusicHandlers**(): `void`
 
-Defined in: [music/index.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/music/index.ts#L85)
+Defined in: [music/index.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/music/index.ts#L95)
 
 Register every shipped music handler whose backing credentials are
 present in the environment. Safe to call multiple times — existing

--- a/docs/api/functions/registerDefaultRealtimeHandlers.md
+++ b/docs/api/functions/registerDefaultRealtimeHandlers.md
@@ -8,7 +8,7 @@
 
 > **registerDefaultRealtimeHandlers**(): `void`
 
-Defined in: [voice/index.ts:300](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L300)
+Defined in: [voice/index.ts:333](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L333)
 
 Register every shipped Realtime handler. Realtime handlers don't gate
 registration on isConfigured() because session-time API keys can be

--- a/docs/api/functions/registerDefaultSTTHandlers.md
+++ b/docs/api/functions/registerDefaultSTTHandlers.md
@@ -8,7 +8,7 @@
 
 > **registerDefaultSTTHandlers**(): `void`
 
-Defined in: [voice/index.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L284)
+Defined in: [voice/index.ts:317](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L317)
 
 Register every shipped STT handler whose backing credentials are
 present in the environment. Safe to call multiple times.

--- a/docs/api/functions/registerDefaultTTSHandlers.md
+++ b/docs/api/functions/registerDefaultTTSHandlers.md
@@ -8,7 +8,7 @@
 
 > **registerDefaultTTSHandlers**(): `void`
 
-Defined in: [voice/index.ts:269](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L269)
+Defined in: [voice/index.ts:302](https://github.com/juspay/neurolink/blob/release/src/lib/voice/index.ts#L302)
 
 Register every shipped TTS handler whose backing credentials are
 present in the environment. Safe to call multiple times.

--- a/docs/api/functions/registerDefaultVideoHandlers.md
+++ b/docs/api/functions/registerDefaultVideoHandlers.md
@@ -1,0 +1,19 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / registerDefaultVideoHandlers
+
+# Function: registerDefaultVideoHandlers()
+
+> **registerDefaultVideoHandlers**(): `void`
+
+Defined in: [adapters/video/index.ts:82](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/index.ts#L82)
+
+Register every shipped video handler whose backing credentials are
+present in the environment. Safe to call multiple times — existing
+registrations are preserved.
+
+## Returns
+
+`void`

--- a/docs/api/type-aliases/MediaHandlerDescriptor.md
+++ b/docs/api/type-aliases/MediaHandlerDescriptor.md
@@ -1,0 +1,35 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / MediaHandlerDescriptor
+
+# Type Alias: MediaHandlerDescriptor
+
+> **MediaHandlerDescriptor** = `object`
+
+Defined in: [types/mediaCatalog.ts:16](https://github.com/juspay/neurolink/blob/release/src/lib/types/mediaCatalog.ts#L16)
+
+## Properties
+
+### kind
+
+> `readonly` **kind**: [`MediaHandlerKind`](MediaHandlerKind.md)
+
+Defined in: [types/mediaCatalog.ts:17](https://github.com/juspay/neurolink/blob/release/src/lib/types/mediaCatalog.ts#L17)
+
+---
+
+### name
+
+> `readonly` **name**: `string`
+
+Defined in: [types/mediaCatalog.ts:18](https://github.com/juspay/neurolink/blob/release/src/lib/types/mediaCatalog.ts#L18)
+
+---
+
+### aliases?
+
+> `readonly` `optional` **aliases?**: readonly `string`[]
+
+Defined in: [types/mediaCatalog.ts:19](https://github.com/juspay/neurolink/blob/release/src/lib/types/mediaCatalog.ts#L19)

--- a/docs/api/type-aliases/MediaHandlerKind.md
+++ b/docs/api/type-aliases/MediaHandlerKind.md
@@ -1,0 +1,16 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / MediaHandlerKind
+
+# Type Alias: MediaHandlerKind
+
+> **MediaHandlerKind** = `"tts"` \| `"stt"` \| `"realtime"` \| `"video"` \| `"avatar"` \| `"music"`
+
+Defined in: [types/mediaCatalog.ts:8](https://github.com/juspay/neurolink/blob/release/src/lib/types/mediaCatalog.ts#L8)
+
+Types backing the static media-handler catalog
+(src/lib/factories/mediaHandlerCatalog.ts) — the single source of truth
+for provider names/aliases across the six media-generation ecosystems
+(TTS, STT, Realtime, Video, Avatar, Music).

--- a/docs/api/variables/VERSION.md
+++ b/docs/api/variables/VERSION.md
@@ -8,4 +8,4 @@
 
 > `const` **VERSION**: `"1.0.0"` = `"1.0.0"`
 
-Defined in: [index.ts:385](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L385)
+Defined in: [index.ts:386](https://github.com/juspay/neurolink/blob/release/src/lib/index.ts#L386)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -279,6 +279,15 @@ export default [
             // never exported from any package entry point — no public
             // surface at all (same reasoning as autoresearch above).
             "test/continuous-test-suite-handler-registry.ts",
+            // MEDIA_HANDLER_CATALOG / providerChoicesFor / defaultProviderFor
+            // (src/lib/factories/mediaHandlerCatalog.ts) are never re-exported
+            // from src/lib/index.ts — no package entry point resolves them,
+            // same "no public surface at all" reasoning as HandlerRegistry
+            // above. The suite's live-registration assertions (TTSProcessor.
+            // listProviders() etc.) still go through the real public surface
+            // via ../dist/index.js; only the catalog-internals reads need
+            // this exception.
+            "test/continuous-test-suite-media-registry-collisions.ts",
             // Filter-dialect translation no live generate() could emit.
             "test/continuous-test-suite-vector-chroma.ts",
             "test/continuous-test-suite-vector-pinecone.ts",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:mcp:cli": "pnpm exec tsx test/continuous-test-suite-mcp-cli.ts",
     "test:mcp:full": "pnpm run test:mcp:infra && pnpm run test:mcp:spans && pnpm run test:mcp:sdk && pnpm run test:mcp:cli && pnpm run test:mcp:http",
     "test:media": "pnpm exec tsx test/continuous-test-suite-media-gen.ts",
+    "test:media-registry-collisions": "pnpm exec tsx test/continuous-test-suite-media-registry-collisions.ts",
     "test:memory": "pnpm exec tsx test/continuous-test-suite-memory.ts",
     "test:openai-compat-streaming-retry": "pnpm exec tsx test/continuous-test-suite-openai-compat-streaming-retry.ts",
     "test:anthropic-streaming-retry": "pnpm exec tsx test/continuous-test-suite-anthropic-streaming-retry.ts",

--- a/src/cli/factories/commandFactory.ts
+++ b/src/cli/factories/commandFactory.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import ora from "ora";
 import type { Argv, CommandModule } from "yargs";
 import { ModelResolver } from "../../lib/models/modelResolver.js";
+import { providerChoicesFor } from "../../lib/factories/mediaHandlerCatalog.js";
 import type {
   ChunkingStrategy,
   JsonValue,
@@ -396,7 +397,7 @@ export class CLICommandFactory {
     },
     ttsProvider: {
       type: "string" as const,
-      choices: ["google-ai", "vertex", "openai-tts", "elevenlabs", "azure-tts"],
+      choices: providerChoicesFor("tts"),
       description: "TTS provider (overrides --provider for speech synthesis)",
     },
     ttsFormat: {
@@ -446,7 +447,7 @@ export class CLICommandFactory {
     },
     sttProvider: {
       type: "string" as const,
-      choices: ["whisper", "deepgram", "google-stt", "azure-stt"],
+      choices: providerChoicesFor("stt"),
       description: "STT provider to use",
     },
     sttLanguage: {
@@ -468,6 +469,7 @@ export class CLICommandFactory {
     },
     videoProvider: {
       type: "string" as const,
+      choices: providerChoicesFor("video"),
       description:
         "Video provider override (e.g., 'vertex' (default), 'kling', 'runway', 'replicate')",
     },
@@ -503,6 +505,7 @@ export class CLICommandFactory {
     // Avatar Generation options (D-ID, HeyGen, MuseTalk via Replicate)
     avatarProvider: {
       type: "string" as const,
+      choices: providerChoicesFor("avatar"),
       description:
         "Avatar provider (e.g., 'd-id' (default), 'heygen', 'replicate', 'musetalk')",
     },
@@ -545,6 +548,7 @@ export class CLICommandFactory {
     // Music Generation options (Beatoven, ElevenLabs, Lyria, MusicGen via Replicate)
     musicProvider: {
       type: "string" as const,
+      choices: providerChoicesFor("music"),
       description:
         "Music provider (e.g., 'beatoven' (default), 'elevenlabs-music', 'lyria', 'replicate', 'musicgen')",
     },

--- a/src/lib/adapters/video/index.ts
+++ b/src/lib/adapters/video/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Video Adapter Module — Image-to-Video Generation Integration for NeuroLink
+ *
+ * Provides video-generation capability across providers (Vertex Veo, Kling,
+ * Runway, Replicate-hosted video models).
+ *
+ * Use `VideoProcessor.generate(provider, image, prompt, options)` to
+ * dispatch to the registered handler for `provider`.
+ *
+ * Importing this module does NOT register any handlers as a side effect.
+ * Call `registerDefaultVideoHandlers()` explicitly (or go through
+ * `ProviderRegistry.registerAllProviders()`, which every documented
+ * `NeuroLink` entry point already calls) to register every shipped video
+ * handler whose backing API key is present in `process.env`. Registration
+ * is idempotent and silently skipped if a provider is already registered or
+ * its constructor throws.
+ *
+ * @module adapters/video
+ */
+
+import type { VideoHandler } from "../../types/index.js";
+import { MEDIA_HANDLER_CATALOG } from "../../factories/mediaHandlerCatalog.js";
+import { logger } from "../../utils/logger.js";
+import { VideoProcessor } from "../../utils/videoProcessor.js";
+
+export {
+  VIDEO_ERROR_CODES,
+  VideoError,
+  VideoProcessor,
+} from "../../utils/videoProcessor.js";
+
+// ============================================================================
+// HANDLER CLASSES
+// ============================================================================
+
+export { KlingVideoHandler } from "./klingVideoHandler.js";
+export { ReplicateVideoHandler } from "./replicateVideoHandler.js";
+export { RunwayVideoHandler } from "./runwayVideoHandler.js";
+export {
+  isVertexVideoConfigured,
+  VertexVideoHandler,
+} from "./vertexVideoHandler.js";
+
+// ============================================================================
+// AUTO-REGISTRATION
+// ============================================================================
+
+import { KlingVideoHandler } from "./klingVideoHandler.js";
+import { ReplicateVideoHandler } from "./replicateVideoHandler.js";
+import { RunwayVideoHandler } from "./runwayVideoHandler.js";
+import { VertexVideoHandler } from "./vertexVideoHandler.js";
+
+// Provider names are the Task-8 catalog's job — only the factory (which
+// needs the imported handler class) stays local to this module.
+const VIDEO_HANDLER_FACTORIES: Readonly<Record<string, () => VideoHandler>> = {
+  vertex: () => new VertexVideoHandler(),
+  kling: () => new KlingVideoHandler(),
+  runway: () => new RunwayVideoHandler(),
+  replicate: () => new ReplicateVideoHandler(),
+};
+
+const VIDEO_HANDLER_CANDIDATES: ReadonlyArray<{
+  readonly name: string;
+  readonly factory: () => VideoHandler;
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "video").map(
+  (entry) => {
+    const factory = VIDEO_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[video] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, factory };
+  },
+);
+
+/**
+ * Register every shipped video handler whose backing credentials are
+ * present in the environment. Safe to call multiple times — existing
+ * registrations are preserved.
+ */
+export function registerDefaultVideoHandlers(): void {
+  for (const { name, factory } of VIDEO_HANDLER_CANDIDATES) {
+    if (VideoProcessor.supports(name)) {
+      continue;
+    }
+    try {
+      const handler = factory();
+      if (!handler.isConfigured()) {
+        continue;
+      }
+      VideoProcessor.registerHandler(name, handler);
+    } catch (err) {
+      logger.debug(
+        `[video] ${name} auto-registration skipped: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/src/lib/avatar/index.ts
+++ b/src/lib/avatar/index.ts
@@ -7,15 +7,19 @@
  * Use `AvatarProcessor.generate(provider, options)` to dispatch to the
  * registered handler for `provider`.
  *
- * Importing this module also auto-registers every shipped avatar handler
- * whose backing API key is present in `process.env`. Registration is
- * idempotent and silently skipped if a provider is already registered or
+ * Importing this module does NOT register any handlers as a side effect.
+ * Call `registerDefaultAvatarHandlers()` explicitly (or go through
+ * `ProviderRegistry.registerAllProviders()`, which every documented
+ * `NeuroLink` entry point already calls) to register every shipped avatar
+ * handler whose backing API key is present in `process.env`. Registration
+ * is idempotent and silently skipped if a provider is already registered or
  * its constructor throws.
  *
  * @module avatar
  */
 
 import type { AvatarHandler } from "../types/index.js";
+import { MEDIA_HANDLER_CATALOG } from "../factories/mediaHandlerCatalog.js";
 import { logger } from "../utils/logger.js";
 import { AvatarProcessor } from "../utils/avatarProcessor.js";
 
@@ -52,19 +56,30 @@ import { DIDAvatar } from "./providers/DIDAvatar.js";
 import { HeyGenAvatar } from "./providers/HeyGenAvatar.js";
 import { ReplicateAvatar } from "./providers/ReplicateAvatar.js";
 
+// Provider names + aliases are the Task-8 catalog's job — only the factory
+// (which needs the imported handler class) stays local to this module.
+const AVATAR_HANDLER_FACTORIES: Readonly<Record<string, () => AvatarHandler>> =
+  {
+    "d-id": () => new DIDAvatar(),
+    heygen: () => new HeyGenAvatar(),
+    replicate: () => new ReplicateAvatar(),
+  };
+
 const AVATAR_HANDLER_CANDIDATES: ReadonlyArray<{
   readonly name: string;
   readonly aliases?: readonly string[];
   readonly factory: () => AvatarHandler;
-}> = [
-  { name: "d-id", factory: () => new DIDAvatar() },
-  { name: "heygen", factory: () => new HeyGenAvatar() },
-  {
-    name: "replicate",
-    aliases: ["musetalk"],
-    factory: () => new ReplicateAvatar(),
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "avatar").map(
+  (entry) => {
+    const factory = AVATAR_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[avatar] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, aliases: entry.aliases, factory };
   },
-];
+);
 
 /**
  * Register every shipped avatar handler whose backing credentials are
@@ -110,8 +125,3 @@ export function registerDefaultAvatarHandlers(): void {
     }
   }
 }
-
-// Run once at module import so consumers who follow the documented
-// `nl.generate(...)` flow get every configured handler without manually
-// calling `registerHandler`.
-registerDefaultAvatarHandlers();

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1,6 +1,7 @@
 import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { directAgentTools } from "../agent/directTools.js";
 import type { AIProviderName } from "../constants/enums.js";
+import { defaultProviderFor } from "../factories/mediaHandlerCatalog.js";
 import { isImageGenerationModel } from "./constants.js";
 import type { EvaluationData } from "../index.js";
 import { MiddlewareFactory } from "../middleware/factory.js";
@@ -2943,9 +2944,11 @@ export abstract class BaseProvider implements AIProvider {
     // Get prompt text
     const prompt = options.prompt || options.input?.text || "";
 
-    // Honor output.video.provider — when omitted, fall back to "vertex"
-    // for backward compatibility with the original implementation.
-    const requestedProvider = options.output?.video?.provider ?? "vertex";
+    // Honor output.video.provider — when omitted, fall back to the
+    // catalog-derived default (currently "vertex") for backward
+    // compatibility with the original implementation.
+    const requestedProvider =
+      options.output?.video?.provider ?? defaultProviderFor("video");
 
     if (!VideoProcessor.supports(requestedProvider)) {
       throw new VideoError({

--- a/src/lib/factories/mediaHandlerCatalog.ts
+++ b/src/lib/factories/mediaHandlerCatalog.ts
@@ -1,0 +1,74 @@
+import type {
+  MediaHandlerDescriptor,
+  MediaHandlerKind,
+} from "../types/index.js";
+
+/**
+ * Static catalog of every shipped media-handler provider, across all six
+ * ecosystems (TTS, STT, Realtime, Video, Avatar, Music). Pure data — no
+ * factory functions, no class imports — mirroring the
+ * src/lib/factories/providerDescriptors.ts pattern for text/image
+ * providers.
+ *
+ * Entries mirror providerRegistry.ts's hand-constructed TTS/STT/Realtime/
+ * Video/Avatar/Music registration blocks (registerAllProviders()) exactly —
+ * this file states today's truth, not an aspirational shape. Keep it in
+ * sync if those blocks change.
+ */
+export const MEDIA_HANDLER_CATALOG: readonly MediaHandlerDescriptor[] = [
+  // --- TTS ---
+  { kind: "tts", name: "google-ai", aliases: ["vertex"] },
+  { kind: "tts", name: "openai-tts" },
+  { kind: "tts", name: "elevenlabs", aliases: ["elevenlabs-tts"] },
+  { kind: "tts", name: "azure-tts" },
+  { kind: "tts", name: "fish-audio" },
+  { kind: "tts", name: "cartesia" },
+  // --- STT ---
+  { kind: "stt", name: "whisper", aliases: ["openai-stt"] },
+  { kind: "stt", name: "deepgram" },
+  { kind: "stt", name: "google-stt" },
+  { kind: "stt", name: "azure-stt" },
+  // --- Realtime ---
+  { kind: "realtime", name: "openai-realtime" },
+  { kind: "realtime", name: "gemini-live" },
+  // --- Video ---
+  { kind: "video", name: "vertex" },
+  { kind: "video", name: "kling" },
+  { kind: "video", name: "runway" },
+  { kind: "video", name: "replicate" },
+  // --- Avatar ---
+  { kind: "avatar", name: "d-id" },
+  { kind: "avatar", name: "replicate", aliases: ["musetalk"] },
+  { kind: "avatar", name: "heygen" },
+  // --- Music ---
+  { kind: "music", name: "beatoven" },
+  { kind: "music", name: "replicate", aliases: ["musicgen"] },
+  { kind: "music", name: "elevenlabs-music", aliases: ["elevenlabs-sound"] },
+  { kind: "music", name: "lyria" },
+] as const;
+
+/** Every selectable provider name for `kind`, primaries and aliases both. */
+export function providerChoicesFor(kind: MediaHandlerKind): string[] {
+  const choices: string[] = [];
+  for (const entry of MEDIA_HANDLER_CATALOG) {
+    if (entry.kind !== kind) {
+      continue;
+    }
+    choices.push(entry.name);
+    if (entry.aliases) {
+      choices.push(...entry.aliases);
+    }
+  }
+  return choices;
+}
+
+/** The first-listed primary provider name for `kind` — used as a fallback default. */
+export function defaultProviderFor(kind: MediaHandlerKind): string {
+  const first = MEDIA_HANDLER_CATALOG.find((entry) => entry.kind === kind);
+  if (!first) {
+    throw new Error(
+      `No media handler catalog entries registered for kind "${kind}"`,
+    );
+  }
+  return first.name;
+}

--- a/src/lib/factories/providerRegistry.ts
+++ b/src/lib/factories/providerRegistry.ts
@@ -32,6 +32,7 @@ import {
 import { PROVIDER_DESCRIPTORS_BY_NAME } from "./providerDescriptors.js";
 import { OPENAI_COMPAT_CATALOG } from "../providers/openaiCompatCatalog.js";
 import type { OpenAICompatCredentials } from "../types/index.js";
+import { providerChoicesFor } from "./mediaHandlerCatalog.js";
 
 /**
  * Provider Registry - registers all providers with the factory
@@ -642,19 +643,25 @@ export class ProviderRegistry {
 
       logger.debug("All AI providers registered successfully");
 
+      // ===== MEDIA HANDLER REGISTRATION =====
+      // Single registration path (Task 11): each ecosystem barrel (voice,
+      // adapters/video, avatar, music) owns its own provider-name catalog
+      // wiring (MEDIA_HANDLER_CATALOG, Task 8) and exposes an idempotent
+      // registerDefault*Handlers() function (Task 10) that constructs and
+      // registers every shipped handler whose backing credentials are
+      // present in process.env. This block's only job is to invoke each of
+      // the six functions via dynamic import — no hand-rolled
+      // `new XHandler()` + `registerHandler()` calls live here anymore.
+      // Each ecosystem keeps its own try/catch so one broken import can't
+      // take down the other five (matches the previous block's isolation).
+
       // ===== TTS HANDLER REGISTRATION =====
       try {
-        // Create handler instance and register explicitly
-        const { GoogleTTSHandler } =
-          await import("../adapters/tts/googleTTSHandler.js");
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-
-        const googleHandler = new GoogleTTSHandler();
-        TTSProcessor.registerHandler("google-ai", googleHandler);
-        TTSProcessor.registerHandler("vertex", googleHandler);
-
-        logger.debug("TTS handlers registered successfully", {
-          providers: ["google-ai", "vertex"],
+        const { registerDefaultTTSHandlers } =
+          await import("../voice/index.js");
+        registerDefaultTTSHandlers();
+        logger.debug("TTS handler registration attempted", {
+          providers: providerChoicesFor("tts"),
         });
       } catch (ttsError) {
         logger.warn(
@@ -667,114 +674,13 @@ export class ProviderRegistry {
         // Don't throw - TTS is optional functionality
       }
 
-      // New TTS providers
-      try {
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-        const { OpenAITTS } = await import("../voice/providers/OpenAITTS.js");
-        TTSProcessor.registerHandler("openai-tts", new OpenAITTS());
-      } catch (err) {
-        logger.debug(
-          `[ProviderRegistry] openai-tts registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      try {
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-        const { ElevenLabsTTS } =
-          await import("../voice/providers/ElevenLabsTTS.js");
-        const elevenLabsHandler = new ElevenLabsTTS();
-        TTSProcessor.registerHandler("elevenlabs", elevenLabsHandler);
-        TTSProcessor.registerHandler("elevenlabs-tts", elevenLabsHandler);
-      } catch (err) {
-        logger.debug(
-          `[ProviderRegistry] elevenlabs registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      try {
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-        const { AzureTTS } = await import("../voice/providers/AzureTTS.js");
-        TTSProcessor.registerHandler("azure-tts", new AzureTTS());
-      } catch (err) {
-        logger.debug(
-          `[ProviderRegistry] azure-tts registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      // Fish Audio and Cartesia also auto-register via the voice/index.ts
-      // barrel side-effect. The supports() guard here keeps registration
-      // idempotent across entry points — same handler, no overwrite warning.
-      try {
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-        if (!TTSProcessor.supports("fish-audio")) {
-          const { FishAudioTTS } =
-            await import("../voice/providers/FishAudioTTS.js");
-          TTSProcessor.registerHandler("fish-audio", new FishAudioTTS());
-        }
-      } catch (err) {
-        logger.debug(
-          `[ProviderRegistry] fish-audio registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      try {
-        const { TTSProcessor } = await import("../utils/ttsProcessor.js");
-        if (!TTSProcessor.supports("cartesia")) {
-          const { CartesiaTTS } =
-            await import("../voice/providers/CartesiaTTS.js");
-          TTSProcessor.registerHandler("cartesia", new CartesiaTTS());
-        }
-      } catch (err) {
-        logger.debug(
-          `[ProviderRegistry] cartesia registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
       // ===== STT HANDLER REGISTRATION =====
       try {
-        const { STTProcessor } = await import("../utils/sttProcessor.js");
-
-        try {
-          const { OpenAISTT } = await import("../voice/providers/OpenAISTT.js");
-          const openAISTT = new OpenAISTT();
-          STTProcessor.registerHandler("whisper", openAISTT);
-          STTProcessor.registerHandler("openai-stt", openAISTT);
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] whisper/openai-stt registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { DeepgramSTT } =
-            await import("../voice/providers/DeepgramSTT.js");
-          STTProcessor.registerHandler("deepgram", new DeepgramSTT());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] deepgram registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { GoogleSTT } = await import("../voice/providers/GoogleSTT.js");
-          STTProcessor.registerHandler("google-stt", new GoogleSTT());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] google-stt registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { AzureSTT } = await import("../voice/providers/AzureSTT.js");
-          STTProcessor.registerHandler("azure-stt", new AzureSTT());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] azure-stt registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        logger.debug("STT handlers registered successfully", {
-          providers: ["whisper", "deepgram", "google-stt", "azure-stt"],
+        const { registerDefaultSTTHandlers } =
+          await import("../voice/index.js");
+        registerDefaultSTTHandlers();
+        logger.debug("STT handler registration attempted", {
+          providers: providerChoicesFor("stt"),
         });
       } catch (sttError) {
         logger.warn(
@@ -788,46 +694,24 @@ export class ProviderRegistry {
 
       // ===== REALTIME HANDLER REGISTRATION =====
       try {
-        const { RealtimeProcessor } =
-          await import("../voice/RealtimeVoiceAPI.js");
+        const { registerDefaultRealtimeHandlers, RealtimeProcessor } =
+          await import("../voice/index.js");
+        registerDefaultRealtimeHandlers();
 
-        // M9 + NEW4: track per-handler registration outcomes so the final
-        // log accurately reflects which voice providers succeeded vs which
-        // were skipped — instead of unconditionally claiming "registered
-        // successfully" or hiding failures at debug level.
+        // M9 + NEW4: registerDefaultRealtimeHandlers() swallows per-handler
+        // construction failures internally (it's a shared, idempotent
+        // barrel function used by every entry point — see voice/index.ts),
+        // so the exact per-handler exception text the old inline block
+        // captured is no longer available here. Recover per-name pass/fail
+        // via supports() instead so getRegistrationReport() stays truthful
+        // for callers that poll it.
+        const realtimeNames = providerChoicesFor("realtime");
         const realtimeOutcomes: Record<string, "ok" | string> = {};
-
-        try {
-          const { OpenAIRealtime } =
-            await import("../voice/providers/OpenAIRealtime.js");
-          RealtimeProcessor.registerHandler(
-            "openai-realtime",
-            new OpenAIRealtime(),
-          );
-          realtimeOutcomes["openai-realtime"] = "ok";
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          realtimeOutcomes["openai-realtime"] = msg;
-          // M9: promote per-handler failures to error level so users can
-          // see which shipped voice provider failed to register at startup.
-          logger.error(
-            `[ProviderRegistry] openai-realtime registration failed: ${msg}`,
-          );
+        for (const name of realtimeNames) {
+          realtimeOutcomes[name] = RealtimeProcessor.supports(name)
+            ? "ok"
+            : "registration failed or handler unavailable";
         }
-
-        try {
-          const { GeminiLive } =
-            await import("../voice/providers/GeminiLive.js");
-          RealtimeProcessor.registerHandler("gemini-live", new GeminiLive());
-          realtimeOutcomes["gemini-live"] = "ok";
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          realtimeOutcomes["gemini-live"] = msg;
-          logger.error(
-            `[ProviderRegistry] gemini-live registration failed: ${msg}`,
-          );
-        }
-
         // NEW4: report the actual per-handler outcomes instead of an
         // unconditional success log. Stored on the registry so callers can
         // introspect via getRegistrationReport().
@@ -837,7 +721,7 @@ export class ProviderRegistry {
         );
         if (skipped.length === 0) {
           logger.info(
-            "[ProviderRegistry] Realtime handlers registered: openai-realtime, gemini-live",
+            `[ProviderRegistry] Realtime handlers registered: ${realtimeNames.join(", ")}`,
           );
         } else {
           logger.warn(
@@ -859,52 +743,12 @@ export class ProviderRegistry {
 
       // ===== VIDEO HANDLER REGISTRATION =====
       try {
-        const { VideoProcessor } = await import("../utils/videoProcessor.js");
-
-        try {
-          const { VertexVideoHandler } =
-            await import("../adapters/video/vertexVideoHandler.js");
-          VideoProcessor.registerHandler("vertex", new VertexVideoHandler());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] vertex video registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { KlingVideoHandler } =
-            await import("../adapters/video/klingVideoHandler.js");
-          VideoProcessor.registerHandler("kling", new KlingVideoHandler());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] kling video registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { RunwayVideoHandler } =
-            await import("../adapters/video/runwayVideoHandler.js");
-          VideoProcessor.registerHandler("runway", new RunwayVideoHandler());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] runway video registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { ReplicateVideoHandler } =
-            await import("../adapters/video/replicateVideoHandler.js");
-          VideoProcessor.registerHandler(
-            "replicate",
-            new ReplicateVideoHandler(),
-          );
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] replicate video registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        logger.debug("Video handlers registered");
+        const { registerDefaultVideoHandlers } =
+          await import("../adapters/video/index.js");
+        registerDefaultVideoHandlers();
+        logger.debug("Video handler registration attempted", {
+          providers: providerChoicesFor("video"),
+        });
       } catch (err) {
         logger.warn(
           `[ProviderRegistry] video registration block failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -913,41 +757,12 @@ export class ProviderRegistry {
 
       // ===== AVATAR HANDLER REGISTRATION =====
       try {
-        const { AvatarProcessor } = await import("../utils/avatarProcessor.js");
-
-        try {
-          const { DIDAvatar } =
-            await import("../avatar/providers/DIDAvatar.js");
-          AvatarProcessor.registerHandler("d-id", new DIDAvatar());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] d-id avatar registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { ReplicateAvatar } =
-            await import("../avatar/providers/ReplicateAvatar.js");
-          const replicateAvatar = new ReplicateAvatar();
-          AvatarProcessor.registerHandler("replicate", replicateAvatar);
-          AvatarProcessor.registerHandler("musetalk", replicateAvatar);
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] replicate avatar registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { HeyGenAvatar } =
-            await import("../avatar/providers/HeyGenAvatar.js");
-          AvatarProcessor.registerHandler("heygen", new HeyGenAvatar());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] heygen avatar registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        logger.debug("Avatar handlers registered");
+        const { registerDefaultAvatarHandlers } =
+          await import("../avatar/index.js");
+        registerDefaultAvatarHandlers();
+        logger.debug("Avatar handler registration attempted", {
+          providers: providerChoicesFor("avatar"),
+        });
       } catch (avatarError) {
         logger.warn(
           "Failed to register Avatar handlers - Avatar functionality will be unavailable",
@@ -962,53 +777,12 @@ export class ProviderRegistry {
 
       // ===== MUSIC HANDLER REGISTRATION =====
       try {
-        const { MusicProcessor } = await import("../utils/musicProcessor.js");
-
-        try {
-          const { BeatovenMusic } =
-            await import("../music/providers/BeatovenMusic.js");
-          MusicProcessor.registerHandler("beatoven", new BeatovenMusic());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] beatoven music registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { ReplicateMusic } =
-            await import("../music/providers/ReplicateMusic.js");
-          const replicateMusic = new ReplicateMusic();
-          MusicProcessor.registerHandler("replicate", replicateMusic);
-          MusicProcessor.registerHandler("musicgen", replicateMusic);
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] replicate music registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { ElevenLabsMusic } =
-            await import("../music/providers/ElevenLabsMusic.js");
-          const elevenLabsMusic = new ElevenLabsMusic();
-          MusicProcessor.registerHandler("elevenlabs-music", elevenLabsMusic);
-          MusicProcessor.registerHandler("elevenlabs-sound", elevenLabsMusic);
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] elevenlabs-music registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        try {
-          const { LyriaMusic } =
-            await import("../music/providers/LyriaMusic.js");
-          MusicProcessor.registerHandler("lyria", new LyriaMusic());
-        } catch (err) {
-          logger.debug(
-            `[ProviderRegistry] lyria music registration skipped: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-
-        logger.debug("Music handlers registered");
+        const { registerDefaultMusicHandlers } =
+          await import("../music/index.js");
+        registerDefaultMusicHandlers();
+        logger.debug("Music handler registration attempted", {
+          providers: providerChoicesFor("music"),
+        });
       } catch (musicError) {
         logger.warn(
           "Failed to register Music handlers - Music functionality will be unavailable",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -281,14 +281,15 @@ export {
   ReplicateAvatarHandler,
 } from "./avatar/index.js";
 
-// Video handlers (live under adapters/video; no separate video/ barrel)
-export { KlingVideoHandler } from "./adapters/video/klingVideoHandler.js";
-export { ReplicateVideoHandler } from "./adapters/video/replicateVideoHandler.js";
-export { RunwayVideoHandler } from "./adapters/video/runwayVideoHandler.js";
+// Video handlers
 export {
-  VertexVideoHandler,
   isVertexVideoConfigured,
-} from "./adapters/video/vertexVideoHandler.js";
+  KlingVideoHandler,
+  registerDefaultVideoHandlers,
+  ReplicateVideoHandler,
+  RunwayVideoHandler,
+  VertexVideoHandler,
+} from "./adapters/video/index.js";
 
 // Image generation + HITL — surfaced from their dedicated barrels
 export { ImageGenService } from "./image-gen/ImageGenService.js";

--- a/src/lib/music/index.ts
+++ b/src/lib/music/index.ts
@@ -7,15 +7,19 @@
  * Use `MusicProcessor.generate(provider, options)` to dispatch to the
  * registered handler for `provider`.
  *
- * Importing this module also auto-registers every shipped music handler
- * whose backing API key is present in `process.env`. Registration is
- * idempotent and silently skipped if a provider is already registered or
+ * Importing this module does NOT register any handlers as a side effect.
+ * Call `registerDefaultMusicHandlers()` explicitly (or go through
+ * `ProviderRegistry.registerAllProviders()`, which every documented
+ * `NeuroLink` entry point already calls) to register every shipped music
+ * handler whose backing API key is present in `process.env`. Registration
+ * is idempotent and silently skipped if a provider is already registered or
  * its constructor throws (e.g. missing optional native dependency).
  *
  * @module music
  */
 
 import type { MusicHandler } from "../types/index.js";
+import { MEDIA_HANDLER_CATALOG } from "../factories/mediaHandlerCatalog.js";
 import { logger } from "../utils/logger.js";
 import { MusicProcessor } from "../utils/musicProcessor.js";
 
@@ -58,24 +62,30 @@ import { ElevenLabsMusic } from "./providers/ElevenLabsMusic.js";
 import { LyriaMusic } from "./providers/LyriaMusic.js";
 import { ReplicateMusic } from "./providers/ReplicateMusic.js";
 
+// Provider names + aliases are the Task-8 catalog's job — only the factory
+// (which needs the imported handler class) stays local to this module.
+const MUSIC_HANDLER_FACTORIES: Readonly<Record<string, () => MusicHandler>> = {
+  beatoven: () => new BeatovenMusic(),
+  "elevenlabs-music": () => new ElevenLabsMusic(),
+  lyria: () => new LyriaMusic(),
+  replicate: () => new ReplicateMusic(),
+};
+
 const MUSIC_HANDLER_CANDIDATES: ReadonlyArray<{
   readonly name: string;
   readonly aliases?: readonly string[];
   readonly factory: () => MusicHandler;
-}> = [
-  { name: "beatoven", factory: () => new BeatovenMusic() },
-  {
-    name: "elevenlabs-music",
-    aliases: ["elevenlabs-sound"],
-    factory: () => new ElevenLabsMusic(),
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "music").map(
+  (entry) => {
+    const factory = MUSIC_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[music] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, aliases: entry.aliases, factory };
   },
-  { name: "lyria", factory: () => new LyriaMusic() },
-  {
-    name: "replicate",
-    aliases: ["musicgen"],
-    factory: () => new ReplicateMusic(),
-  },
-];
+);
 
 /**
  * Register every shipped music handler whose backing credentials are
@@ -122,8 +132,3 @@ export function registerDefaultMusicHandlers(): void {
     }
   }
 }
-
-// Run once at module import so consumers who follow the documented
-// `nl.generate(...)` flow get every configured handler without manually
-// calling `registerHandler`.
-registerDefaultMusicHandlers();

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5919,6 +5919,13 @@ Current user's request: ${currentInput}`;
         'output.music.provider is required (e.g. "beatoven", "elevenlabs-music", "lyria", "replicate").',
       );
     }
+    // This early-dispatch path never creates an AI provider, so
+    // ProviderRegistry.registerAllProviders() has NOT necessarily run —
+    // with the module-scope auto-registration retired, the handlers must
+    // be registered here explicitly. registerDefaultMusicHandlers() is
+    // idempotent (skip-if-registered), so the repeat call is free.
+    const { registerDefaultMusicHandlers } = await import("./music/index.js");
+    registerDefaultMusicHandlers();
     const { MusicProcessor } = await import("./utils/musicProcessor.js");
     const musicResult = await MusicProcessor.generate(providerName, {
       ...musicOptions,
@@ -5959,6 +5966,11 @@ Current user's request: ${currentInput}`;
         'output.avatar.provider is required (e.g. "d-id", "heygen", "replicate").',
       );
     }
+    // Same early-dispatch registration as generateWithMusic above: no AI
+    // provider is created on this path, so the retired module-scope
+    // auto-run must be replaced by an explicit (idempotent) call here.
+    const { registerDefaultAvatarHandlers } = await import("./avatar/index.js");
+    registerDefaultAvatarHandlers();
     const { AvatarProcessor } = await import("./utils/avatarProcessor.js");
     const avatarResult = await AvatarProcessor.generate(
       providerName,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -91,6 +91,7 @@ export * from "./video.js";
 export * from "./avatar.js";
 export * from "./music.js";
 export * from "./replicate.js";
+export * from "./mediaCatalog.js";
 
 // Safe-fetch helper types (SSRF-hardened download)
 export * from "./safeFetch.js";

--- a/src/lib/types/mediaCatalog.ts
+++ b/src/lib/types/mediaCatalog.ts
@@ -1,0 +1,20 @@
+/**
+ * Types backing the static media-handler catalog
+ * (src/lib/factories/mediaHandlerCatalog.ts) — the single source of truth
+ * for provider names/aliases across the six media-generation ecosystems
+ * (TTS, STT, Realtime, Video, Avatar, Music).
+ */
+
+export type MediaHandlerKind =
+  | "tts"
+  | "stt"
+  | "realtime"
+  | "video"
+  | "avatar"
+  | "music";
+
+export type MediaHandlerDescriptor = {
+  readonly kind: MediaHandlerKind;
+  readonly name: string;
+  readonly aliases?: readonly string[];
+};

--- a/src/lib/voice/index.ts
+++ b/src/lib/voice/index.ts
@@ -8,9 +8,13 @@
  * Use STTProcessor (src/lib/utils/sttProcessor.ts) for STT.
  * Use RealtimeProcessor for realtime voice sessions.
  *
- * Importing this module also auto-registers every shipped TTS / STT /
- * Realtime handler whose backing API key is present in `process.env`.
- * Registration is idempotent and silently skipped on failure.
+ * Importing this module does NOT register any handlers as a side effect.
+ * Call `registerDefaultTTSHandlers()` / `registerDefaultSTTHandlers()` /
+ * `registerDefaultRealtimeHandlers()` explicitly (or go through
+ * `ProviderRegistry.registerAllProviders()`, which every documented
+ * `NeuroLink` entry point already calls) to register every shipped handler
+ * whose backing API key is present in `process.env`. Registration is
+ * idempotent and silently skipped on failure.
  *
  * @module voice
  */
@@ -20,6 +24,7 @@ import type {
   STTHandler,
   TTSHandler,
 } from "../types/index.js";
+import { MEDIA_HANDLER_CATALOG } from "../factories/mediaHandlerCatalog.js";
 import { logger } from "../utils/logger.js";
 import { STTProcessor } from "../utils/sttProcessor.js";
 import { TTSProcessor } from "../utils/ttsProcessor.js";
@@ -164,51 +169,79 @@ import { OpenAISTT } from "./providers/OpenAISTT.js";
 import { GeminiLive } from "./providers/GeminiLive.js";
 import { OpenAIRealtime } from "./providers/OpenAIRealtime.js";
 
+// Provider names + aliases are the Task-8 catalog's job — only the factory
+// (which needs the imported handler class) stays local to this module.
+const TTS_HANDLER_FACTORIES: Readonly<Record<string, () => TTSHandler>> = {
+  // Google TTS doubles as both the AI Studio and Vertex TTS handler.
+  "google-ai": () => new GoogleTTSHandler(),
+  "openai-tts": () => new OpenAITTS(),
+  elevenlabs: () => new ElevenLabsTTS(),
+  "azure-tts": () => new AzureTTS(),
+  "fish-audio": () => new FishAudioTTS(),
+  cartesia: () => new CartesiaTTS(),
+};
+
 const TTS_HANDLER_CANDIDATES: ReadonlyArray<{
   readonly name: string;
   readonly aliases?: readonly string[];
   readonly factory: () => TTSHandler;
-}> = [
-  {
-    // Google TTS doubles as both the AI Studio and Vertex TTS handler.
-    name: "google-ai",
-    aliases: ["vertex"],
-    factory: () => new GoogleTTSHandler(),
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "tts").map(
+  (entry) => {
+    const factory = TTS_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[voice/tts] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, aliases: entry.aliases, factory };
   },
-  { name: "openai-tts", factory: () => new OpenAITTS() },
-  {
-    name: "elevenlabs",
-    aliases: ["elevenlabs-tts"],
-    factory: () => new ElevenLabsTTS(),
-  },
-  { name: "azure-tts", factory: () => new AzureTTS() },
-  { name: "fish-audio", factory: () => new FishAudioTTS() },
-  { name: "cartesia", factory: () => new CartesiaTTS() },
-];
+);
+
+const STT_HANDLER_FACTORIES: Readonly<Record<string, () => STTHandler>> = {
+  whisper: () => new OpenAISTT(),
+  deepgram: () => new DeepgramSTT(),
+  "google-stt": () => new GoogleSTT(),
+  "azure-stt": () => new AzureSTT(),
+};
 
 const STT_HANDLER_CANDIDATES: ReadonlyArray<{
   readonly name: string;
   readonly aliases?: readonly string[];
   readonly factory: () => STTHandler;
-}> = [
-  {
-    name: "whisper",
-    aliases: ["openai-stt"],
-    factory: () => new OpenAISTT(),
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "stt").map(
+  (entry) => {
+    const factory = STT_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[voice/stt] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, aliases: entry.aliases, factory };
   },
-  { name: "deepgram", factory: () => new DeepgramSTT() },
-  { name: "google-stt", factory: () => new GoogleSTT() },
-  { name: "azure-stt", factory: () => new AzureSTT() },
-];
+);
+
+const REALTIME_HANDLER_FACTORIES: Readonly<
+  Record<string, () => RealtimeHandler>
+> = {
+  "openai-realtime": () => new OpenAIRealtime(),
+  "gemini-live": () => new GeminiLive(),
+};
 
 const REALTIME_HANDLER_CANDIDATES: ReadonlyArray<{
   readonly name: string;
   readonly aliases?: readonly string[];
   readonly factory: () => RealtimeHandler;
-}> = [
-  { name: "openai-realtime", factory: () => new OpenAIRealtime() },
-  { name: "gemini-live", factory: () => new GeminiLive() },
-];
+}> = MEDIA_HANDLER_CATALOG.filter((entry) => entry.kind === "realtime").map(
+  (entry) => {
+    const factory = REALTIME_HANDLER_FACTORIES[entry.name];
+    if (!factory) {
+      throw new Error(
+        `[voice/realtime] no handler factory for catalog entry "${entry.name}"`,
+      );
+    }
+    return { name: entry.name, aliases: entry.aliases, factory };
+  },
+);
 
 function registerCandidates<H extends { isConfigured(): boolean }>(
   candidates: ReadonlyArray<{
@@ -307,10 +340,3 @@ export function registerDefaultRealtimeHandlers(): void {
     false,
   );
 }
-
-// Run once at module import so consumers who follow the documented
-// `nl.generate(...)` flow get every configured handler without manually
-// calling `registerHandler`.
-registerDefaultTTSHandlers();
-registerDefaultSTTHandlers();
-registerDefaultRealtimeHandlers();

--- a/test/continuous-test-suite-media-registry-collisions.ts
+++ b/test/continuous-test-suite-media-registry-collisions.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Media Handler Catalog / Registry Collision Guard.
+ *
+ * ALL-DIST module graph (rule 15): every import below resolves to
+ * `../dist/...`. `MEDIA_HANDLER_CATALOG` / `providerChoicesFor` /
+ * `defaultProviderFor` are not re-exported through `dist/index.js`, so they
+ * are imported from their own shipped module path
+ * (`../dist/factories/mediaHandlerCatalog.js`), the same pattern
+ * continuous-test-suite-provider-descriptors.ts already uses for
+ * `../dist/utils/providerUtils.js` and `../dist/cli/factories/
+ * commandFactory.js` — a real file inside the published `dist/` tree, just
+ * not re-exported from the package's root barrel.
+ *
+ * Superset of the original plan's Task 19 intent (guard the "replicate" key
+ * meaning four different things across four independent registries), tuned
+ * to what's actually verifiable through the built public surface rather than
+ * by importing test-double handlers into `src/`'s live processor classes:
+ *
+ *   1. Every name a live registry (TTSProcessor / STTProcessor /
+ *      RealtimeProcessor / VideoProcessor / MusicProcessor / AvatarProcessor)
+ *      actually resolves after `ProviderRegistry.registerAllProviders()`
+ *      belongs to that same kind's catalog entry — nothing gets registered
+ *      under a name the catalog doesn't know about for that kind. Realtime
+ *      registration isn't gated on `isConfigured()` (session credentials can
+ *      be supplied per-call), so its registered set is asserted to match the
+ *      catalog exactly; the other five kinds gate on credentials present in
+ *      this environment, so only the subset relationship is checked.
+ *   2. No catalog kind declares the same primary/alias name twice internally
+ *      — that would silently overwrite one entry's registration with another
+ *      inside the one `HandlerRegistry` instance backing that kind.
+ *   3. The only names reused ACROSS different kinds are the two the catalog
+ *      deliberately reuses on purpose: "replicate" (a distinct handler class
+ *      per kind in video/avatar/music — the plan's own running example) and
+ *      "vertex" (Google Cloud Vertex AI, both a TTS alias for google-ai and
+ *      the Video kind's own primary name). Every other name reused across
+ *      kinds is an unpinned regression this suite exists to catch.
+ *   4. Every kind's `defaultProviderFor()` result is itself a member of that
+ *      kind's own `providerChoicesFor()` list.
+ *
+ * Run: npx tsx test/continuous-test-suite-media-registry-collisions.ts
+ *      pnpm run test:media-registry-collisions
+ */
+import {
+  defineSuite,
+  logSection,
+  assert,
+  assertEqual,
+} from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("Media Registry Collision Guard");
+
+const ALL_KINDS = [
+  "tts",
+  "stt",
+  "realtime",
+  "video",
+  "avatar",
+  "music",
+] as const;
+type Kind = (typeof ALL_KINDS)[number];
+
+// The only two names this catalog deliberately reuses across more than one
+// kind, each mapped to the exact set of kinds it's expected to appear in.
+// See file header point 3 — anything outside this map reusing a name across
+// kinds is an unpinned collision, not a documented design decision.
+const EXPECTED_CROSS_KIND_NAMES: Readonly<Record<string, ReadonlySet<Kind>>> = {
+  replicate: new Set<Kind>(["video", "avatar", "music"]),
+  vertex: new Set<Kind>(["tts", "video"]),
+};
+
+await runSuite(async () => {
+  logSection("Catalog structural integrity");
+
+  await test("no kind declares the same primary/alias name twice", async () => {
+    const { MEDIA_HANDLER_CATALOG } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    for (const kind of ALL_KINDS) {
+      const seen = new Set<string>();
+      let duplicateFound = false;
+      for (const entry of MEDIA_HANDLER_CATALOG as ReadonlyArray<{
+        kind: string;
+        name: string;
+        aliases?: readonly string[];
+      }>) {
+        if (entry.kind !== kind) {
+          continue;
+        }
+        for (const key of [entry.name, ...(entry.aliases ?? [])]) {
+          const lower = key.toLowerCase();
+          if (seen.has(lower)) {
+            duplicateFound = true;
+          }
+          seen.add(lower);
+        }
+      }
+      assert(
+        !duplicateFound,
+        `kind "${kind}" has a duplicate primary/alias name within its own catalog entries`,
+      );
+    }
+  });
+
+  await test("names reused across kinds are limited to the two documented cases (replicate, vertex)", async () => {
+    const { MEDIA_HANDLER_CATALOG } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const kindsByName = new Map<string, Set<Kind>>();
+    for (const entry of MEDIA_HANDLER_CATALOG as ReadonlyArray<{
+      kind: Kind;
+      name: string;
+      aliases?: readonly string[];
+    }>) {
+      for (const key of [entry.name, ...(entry.aliases ?? [])]) {
+        const lower = key.toLowerCase();
+        const kinds = kindsByName.get(lower) ?? new Set<Kind>();
+        kinds.add(entry.kind);
+        kindsByName.set(lower, kinds);
+      }
+    }
+    const unexpectedCrossKindNames: string[] = [];
+    for (const [name, kinds] of kindsByName) {
+      if (kinds.size <= 1) {
+        continue;
+      }
+      const expected = EXPECTED_CROSS_KIND_NAMES[name];
+      const matchesExpected =
+        expected !== undefined &&
+        expected.size === kinds.size &&
+        [...kinds].every((k) => expected.has(k));
+      if (!matchesExpected) {
+        unexpectedCrossKindNames.push(name);
+      }
+    }
+    assertEqual(
+      unexpectedCrossKindNames.length,
+      0,
+      "an undocumented name is reused across more than one media-handler kind",
+    );
+    // The inverse direction: both documented cases must still actually be
+    // present with their full expected kind set, not silently reduced to one
+    // kind by a future catalog edit.
+    for (const [name, expectedKinds] of Object.entries(
+      EXPECTED_CROSS_KIND_NAMES,
+    )) {
+      const actualKinds = kindsByName.get(name);
+      assert(
+        actualKinds !== undefined && actualKinds.size === expectedKinds.size,
+        `expected cross-kind name "${name}" no longer spans its documented kind set`,
+      );
+    }
+  });
+
+  logSection("defaultProviderFor / providerChoicesFor coherence");
+
+  await test("every kind's default provider is itself one of that kind's own choices", async () => {
+    const { providerChoicesFor, defaultProviderFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    for (const kind of ALL_KINDS) {
+      const choices: string[] = providerChoicesFor(kind);
+      const fallback: string = defaultProviderFor(kind);
+      assert(
+        choices.includes(fallback),
+        `kind "${kind}"'s default provider is missing from its own choices list`,
+      );
+    }
+  });
+
+  logSection(
+    "Live registration: each registry only ever resolves names its own kind's catalog declares",
+  );
+
+  await test("registerAllProviders populates the six media registries without throwing", async () => {
+    const { ProviderRegistry } = await import("../dist/index.js");
+    await ProviderRegistry.registerAllProviders();
+    assert(true, "registerAllProviders resolved");
+  });
+
+  await test("TTSProcessor's registered names are a subset of the tts catalog", async () => {
+    const { TTSProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("tts") as string[]).map((n) => n.toLowerCase()),
+    );
+    for (const registered of TTSProcessor.listProviders() as string[]) {
+      assert(
+        catalogNames.has(registered.toLowerCase()),
+        "TTSProcessor has a registered name absent from the tts catalog",
+      );
+    }
+  });
+
+  await test("STTProcessor's registered names are a subset of the stt catalog", async () => {
+    const { STTProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("stt") as string[]).map((n) => n.toLowerCase()),
+    );
+    for (const registered of STTProcessor.listProviders() as string[]) {
+      assert(
+        catalogNames.has(registered.toLowerCase()),
+        "STTProcessor has a registered name absent from the stt catalog",
+      );
+    }
+  });
+
+  await test("VideoProcessor's registered names are a subset of the video catalog", async () => {
+    const { VideoProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("video") as string[]).map((n) => n.toLowerCase()),
+    );
+    for (const registered of VideoProcessor.listProviders() as string[]) {
+      assert(
+        catalogNames.has(registered.toLowerCase()),
+        "VideoProcessor has a registered name absent from the video catalog",
+      );
+    }
+  });
+
+  await test("MusicProcessor's registered names are a subset of the music catalog", async () => {
+    const { MusicProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("music") as string[]).map((n) => n.toLowerCase()),
+    );
+    for (const registered of MusicProcessor.listProviders() as string[]) {
+      assert(
+        catalogNames.has(registered.toLowerCase()),
+        "MusicProcessor has a registered name absent from the music catalog",
+      );
+    }
+  });
+
+  await test("AvatarProcessor's registered names are a subset of the avatar catalog", async () => {
+    const { AvatarProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("avatar") as string[]).map((n) => n.toLowerCase()),
+    );
+    for (const registered of AvatarProcessor.listProviders() as string[]) {
+      assert(
+        catalogNames.has(registered.toLowerCase()),
+        "AvatarProcessor has a registered name absent from the avatar catalog",
+      );
+    }
+  });
+
+  await test("RealtimeProcessor's registered set matches the realtime catalog exactly (registration isn't credential-gated)", async () => {
+    const { RealtimeProcessor } = await import("../dist/index.js");
+    const { providerChoicesFor } =
+      await import("../dist/factories/mediaHandlerCatalog.js");
+    const catalogNames = new Set(
+      (providerChoicesFor("realtime") as string[]).map((n) => n.toLowerCase()),
+    );
+    const registeredNames = new Set(
+      (RealtimeProcessor.getProviders() as string[]).map((n) =>
+        n.toLowerCase(),
+      ),
+    );
+    assertEqual(
+      registeredNames.size,
+      catalogNames.size,
+      "RealtimeProcessor registered-name count vs realtime catalog count",
+    );
+    let allCatalogNamesRegistered = true;
+    for (const name of catalogNames) {
+      if (!registeredNames.has(name)) {
+        allCatalogNamesRegistered = false;
+      }
+    }
+    assert(
+      allCatalogNamesRegistered,
+      "RealtimeProcessor is missing a realtime catalog name it should always register",
+    );
+  });
+
+  logSection("Cross-registry isolation for the documented 'replicate' reuse");
+
+  await test("'replicate' resolves independently in Video, Music and Avatar — supports() in one never implies the others", async () => {
+    const { VideoProcessor, MusicProcessor, AvatarProcessor } =
+      await import("../dist/index.js");
+    // Each of these booleans is independently true/false depending on this
+    // environment's own credentials — the invariant under test isn't "all
+    // three are configured", it's that querying one registry never throws
+    // and never silently reads through to another kind's registration.
+    const videoSupports: unknown = VideoProcessor.supports("replicate");
+    const musicSupports: unknown = MusicProcessor.supports("replicate");
+    const avatarSupports: unknown = AvatarProcessor.supports("replicate");
+    assert(
+      typeof videoSupports === "boolean",
+      "VideoProcessor.supports('replicate') did not return a boolean",
+    );
+    assert(
+      typeof musicSupports === "boolean",
+      "MusicProcessor.supports('replicate') did not return a boolean",
+    );
+    assert(
+      typeof avatarSupports === "boolean",
+      "AvatarProcessor.supports('replicate') did not return a boolean",
+    );
+  });
+});


### PR DESCRIPTION
Plan 09 tasks 8–11, 16–17, 19 — the registration half of the media consolidation, completing plan 09 together with #1542.

## What ships

- **`mediaHandlerCatalog.ts`** (task 8): pure-data catalog of all six media kinds' providers and aliases, derived from the ACTUAL registration code rather than the plan's stale example (avatar/music order differed); exports `providerChoicesFor()` / `defaultProviderFor()`.
- **Video adapter barrel** (task 9): `registerDefaultVideoHandlers()` joins its five siblings; handlers export through the barrel.
- **Single registration path** (tasks 10–11): the six module-scope auto-registration side effects are retired; `providerRegistry._doRegister()` calls the six `registerDefault*Handlers()` barrels, with registration-name parity enumerated before/after. **The review's CRITICAL caught the one orphaned path**: music/avatar generation dispatches through `maybeHandleEarlyGenerateResult` *before* any provider exists, so `registerAllProviders()` never runs there — both dispatch sites now call their (idempotent) `registerDefault*Handlers()` explicitly, with the mechanism documented in place.
- **Catalog-derived defaults and choices** (tasks 16–17): `baseProvider`'s hardcoded `"vertex"` video default becomes `defaultProviderFor("video")`; all five CLI `--*-provider` choices derive from `providerChoicesFor()` — **fish-audio and cartesia become selectable**, fixing the stale-choices bug.
- **Collision guard suite** (task 19): catalog↔registration parity, forbidden duplicates, default ∈ choices per kind — 11/11, break-one-assertion verified.

## Verification

typecheck 0 errors · collision suite 11/11 · eslint 0 errors on touched files · docs/api regenerated