### PR TITLE
refactor(providers): route replicate and vertex overrides through resolveRequestKind

### DIFF
--- a/src/lib/core/resolveRequestKind.ts
+++ b/src/lib/core/resolveRequestKind.ts
@@ -9,11 +9,10 @@ import type { RequestKind, RequestKindInput } from "../types/index.js";
  * stream()/runGenerateInActiveContext (image/video/tts-direct routing) call
  * this instead of independently re-deriving the decision.
  *
- * NOT yet the only copy: replicate.ts's generate() override and
- * googleVertex/client.ts's native dispatch (~6672-6718) still carry their
- * own provider-internal versions — the Vertex one with a cruder
- * startsWith() image match. Migrating those two is queued follow-up work;
- * until it lands, an edit to this precedence table does not reach them.
+ * Also the only copy at the provider-override level: replicate.ts's
+ * generate() override and googleVertex/client.ts's generate()/stream()
+ * overrides (which bypass BaseProvider's paths) call this too, so an edit
+ * to this precedence table reaches every dispatch site.
  *
  * Precedence, checked in order:
  *   1. output.mode (music/avatar/video/ppt) — an explicit mode always wins.

--- a/src/lib/providers/googleVertex/client.ts
+++ b/src/lib/providers/googleVertex/client.ts
@@ -20,9 +20,9 @@ import {
   DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
   DEFAULT_TOOL_MAX_RETRIES,
   GLOBAL_LOCATION_MODELS,
-  IMAGE_GENERATION_MODELS,
   TOOL_STORAGE_TIMEOUT_MS,
 } from "../../core/constants.js";
+import { resolveRequestKind } from "../../core/resolveRequestKind.js";
 import { ModelConfigurationManager } from "../../core/modelConfiguration.js";
 import { isSchemaComplexityError } from "../../core/modules/structuredOutputPolicy.js";
 import {
@@ -6582,12 +6582,11 @@ export class GoogleVertexProvider extends BaseProvider {
     const modelName =
       options.model || this.modelName || getDefaultVertexModel();
 
-    // Check if this is an image generation model - image models don't support streaming
-    const isImageModel = IMAGE_GENERATION_MODELS.some((m) =>
-      modelName.toLowerCase().startsWith(m.toLowerCase()),
-    );
-
-    if (isImageModel) {
+    // Image-generation requests can't stream — fall back to generate.
+    // Same single dispatch decision as generate(): resolveRequestKind
+    // keeps dual-mode models streaming text when the caller explicitly
+    // asked for a non-image output.format.
+    if (resolveRequestKind(options, modelName) === "image") {
       logger.warn(
         "[GoogleVertex] Image generation models don't support streaming, falling back to generate",
         { model: modelName },
@@ -6664,13 +6663,21 @@ export class GoogleVertexProvider extends BaseProvider {
       async (generateSpan) => {
         const generateStartTime = Date.now();
 
+        // One dispatch decision for the whole override: Vertex's generate()
+        // bypasses BaseProvider.generate(), so it re-runs the same
+        // resolveRequestKind() the core call sites use rather than keeping
+        // a hand-rolled copy of the precedence (which had drifted: tts
+        // checked before image, and a cruder case-insensitive startsWith
+        // image match without boundary awareness).
+        const requestKind = resolveRequestKind(options, modelName);
+
         // Video-mode requests must route through BaseProvider's
         // handleVideoGeneration (which loads the Veo 3 adapter). Vertex's
         // native @google/genai path is text/image only — without this
         // gate, video requests fall through to gemini-2.5-flash and the
         // model politely declines ("I cannot create animations") instead
         // of producing video bytes.
-        if (options.output?.mode === "video") {
+        if (requestKind === "video") {
           logger.info(
             "[GoogleVertex] Routing video-mode generate to handleVideoGeneration",
             { model: modelName },
@@ -6698,7 +6705,7 @@ export class GoogleVertexProvider extends BaseProvider {
         // (synthesise the input text directly; no LLM call). BaseProvider's
         // standard generate() does the same dispatch — we replicate it here
         // because Vertex's override bypasses that path.
-        if (options.tts?.enabled && !options.tts?.useAiResponse) {
+        if (requestKind === "tts-direct") {
           logger.info(
             "[GoogleVertex] Routing TTS direct-synthesis to handleDirectTTSSynthesis",
             { model: modelName },
@@ -6711,12 +6718,11 @@ export class GoogleVertexProvider extends BaseProvider {
           return ttsResult;
         }
 
-        // Check if this is an image generation model - route to executeImageGeneration without tools
-        const isImageModel = IMAGE_GENERATION_MODELS.some((m) =>
-          modelName.toLowerCase().startsWith(m.toLowerCase()),
-        );
-
-        if (isImageModel) {
+        // Image-generation models route to executeImageGeneration without
+        // tools. resolveRequestKind also carries the dual-mode exception:
+        // an explicit non-image output.format keeps models like
+        // gemini-3.1-flash-image-preview on the text path.
+        if (requestKind === "image") {
           logger.info(
             "[GoogleVertex] Routing image generation model to executeImageGeneration",
             { model: modelName },

--- a/src/lib/providers/replicate.ts
+++ b/src/lib/providers/replicate.ts
@@ -5,6 +5,7 @@ import {
   ReplicateModels,
 } from "../constants/enums.js";
 import { BaseProvider } from "../core/baseProvider.js";
+import { resolveRequestKind } from "../core/resolveRequestKind.js";
 import { getReplicateAuth } from "../adapters/replicate/auth.js";
 import {
   downloadPredictionOutput,
@@ -174,24 +175,20 @@ export class ReplicateProvider extends BaseProvider {
         ? { prompt: optionsOrPrompt }
         : optionsOrPrompt;
 
-    const { isImageGenerationModel } = await import("../core/constants.js");
-
-    // Delegate special output modes to base class (which never calls getAISDKModel for these)
+    // Delegate media kinds to the base class (which never calls
+    // getAISDKModel for these). resolveRequestKind owns the precedence —
+    // including the dual-mode exception where an explicit non-image
+    // output.format keeps an image-gen model on the text path. "ppt" and
+    // "tts-direct" deliberately stay on the local text path below:
+    // super.generate() would hit prepareGenerationContext() →
+    // getAISDKModel(), which throws for Replicate.
+    const kind = resolveRequestKind(options, this.modelName);
     if (
-      options.output?.mode === "video" ||
-      options.output?.mode === "avatar" ||
-      options.output?.mode === "music"
+      kind === "video" ||
+      kind === "avatar" ||
+      kind === "music" ||
+      kind === "image"
     ) {
-      return super.generate(options, _analysisSchema);
-    }
-
-    // Image-gen models: delegate to base which calls executeImageGeneration()
-    const isImageModel = isImageGenerationModel(this.modelName);
-    const requestsNonImageOutput =
-      options.output?.format === "json" ||
-      options.output?.format === "structured" ||
-      options.output?.format === "text";
-    if (isImageModel && !requestsNonImageOutput) {
       return super.generate(options, _analysisSchema);
     }
 


### PR DESCRIPTION
## What

Retires the last two provider-internal copies of the request-kind dispatch decision, completing the consolidation #1542 started:

- **`replicate.ts` generate() override** — the hand-rolled mode checks (`output.mode` video/avatar/music) and the dynamic-imported `isImageGenerationModel` + `requestsNonImageOutput` block are replaced by one `resolveRequestKind()` call. `ppt` / `tts-direct` deliberately stay on replicate's local text path: `super.generate()` would hit `prepareGenerationContext()` → `getAISDKModel()`, which throws for Replicate by design (predictions API, not AI-SDK).
- **`googleVertex/client.ts` generate() override** — the three sequential gates (video mode, tts-direct, image model) now branch on a single `resolveRequestKind()` decision. This retires the cruder case-insensitive `startsWith()` image match in favour of the shared boundary-aware `isImageGenerationModel` table, and aligns Vertex with the core precedence (mode > image > tts-direct), including the dual-mode exception where an explicit non-image `output.format` keeps a model like `gemini-3.1-flash-image-preview` on the text path.
- **`googleVertex/client.ts` stream() override** — same swap for its image-fallback check; `IMAGE_GENERATION_MODELS` is no longer imported directly.
- **`resolveRequestKind.ts`** — the "NOT yet the only copy" caveat in the doc comment is now stale and updated to say the precedence table reaches every dispatch site.

## Verification

- `pnpm run check` — 0 errors
- `pnpm run lint` — exit 0
- `pnpm run build` + `pnpm run test:providers-mocked` — 67/67
- `test/continuous-test-suite-resolve-request-kind.ts` — 16/16
- `pnpm run docs:api` regenerated last — no drift

Queued follow-up from the provider-redesign backlog (plan 09 residue).