### PR TITLE
fix(media): propagate cancellation through the video generation chain

### DIFF
--- a/docs/api/classes/VertexVideoHandler.md
+++ b/docs/api/classes/VertexVideoHandler.md
@@ -6,7 +6,7 @@
 
 # Class: VertexVideoHandler
 
-Defined in: [adapters/video/vertexVideoHandler.ts:998](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L998)
+Defined in: [adapters/video/vertexVideoHandler.ts:1085](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1085)
 
 Class wrapper around the standalone Vertex Veo functions, conforming to
 the `VideoHandler` contract so it can register with `VideoProcessor`.
@@ -36,7 +36,7 @@ them directly.
 
 > `readonly` **maxDurationSeconds**: `8` = `8`
 
-Defined in: [adapters/video/vertexVideoHandler.ts:999](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L999)
+Defined in: [adapters/video/vertexVideoHandler.ts:1086](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1086)
 
 Maximum video duration in seconds supported by this provider.
 
@@ -50,7 +50,7 @@ Maximum video duration in seconds supported by this provider.
 
 > `readonly` **supportedAspectRatios**: readonly (`"9:16"` \| `"16:9"`)[]
 
-Defined in: [adapters/video/vertexVideoHandler.ts:1000](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1000)
+Defined in: [adapters/video/vertexVideoHandler.ts:1087](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1087)
 
 Supported aspect ratios.
 
@@ -64,7 +64,7 @@ Supported aspect ratios.
 
 > `readonly` **supportedResolutions**: readonly (`"720p"` \| `"1080p"`)[]
 
-Defined in: [adapters/video/vertexVideoHandler.ts:1004](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1004)
+Defined in: [adapters/video/vertexVideoHandler.ts:1091](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1091)
 
 Supported output resolutions.
 
@@ -78,7 +78,7 @@ Supported output resolutions.
 
 > **isConfigured**(): `boolean`
 
-Defined in: [adapters/video/vertexVideoHandler.ts:1009](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1009)
+Defined in: [adapters/video/vertexVideoHandler.ts:1096](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1096)
 
 Validate the provider is configured (auth, base URL, etc.).
 
@@ -96,7 +96,7 @@ Validate the provider is configured (auth, base URL, etc.).
 
 > **generate**(`image`, `prompt`, `options`, `region?`): `Promise`\<[`VideoGenerationResult`](../type-aliases/VideoGenerationResult.md)\>
 
-Defined in: [adapters/video/vertexVideoHandler.ts:1013](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1013)
+Defined in: [adapters/video/vertexVideoHandler.ts:1100](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1100)
 
 Generate a single video clip from an input image and prompt.
 
@@ -142,7 +142,7 @@ Buffer + metadata
 
 > **generateTransition**(`firstFrame`, `lastFrame`, `prompt`, `options?`, `region?`): `Promise`\<`Buffer`\<`ArrayBufferLike`\>\>
 
-Defined in: [adapters/video/vertexVideoHandler.ts:1022](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1022)
+Defined in: [adapters/video/vertexVideoHandler.ts:1109](https://github.com/juspay/neurolink/blob/release/src/lib/adapters/video/vertexVideoHandler.ts#L1109)
 
 Optional — generate a transition clip between two frames (Director Mode).
 

--- a/docs/api/classes/VideoProcessor.md
+++ b/docs/api/classes/VideoProcessor.md
@@ -178,7 +178,7 @@ options-bag overload.
 
 > `static` **generateTransition**(`provider`, `firstFrame`, `lastFrame`, `prompt`, `options?`, `region?`): `Promise`\<`Buffer`\<`ArrayBufferLike`\>\>
 
-Defined in: [utils/videoProcessor.ts:229](https://github.com/juspay/neurolink/blob/release/src/lib/utils/videoProcessor.ts#L229)
+Defined in: [utils/videoProcessor.ts:243](https://github.com/juspay/neurolink/blob/release/src/lib/utils/videoProcessor.ts#L243)
 
 Generate a transition clip via the registered handler (Director Mode).
 

--- a/docs/api/type-aliases/KlingTaskResponse.md
+++ b/docs/api/type-aliases/KlingTaskResponse.md
@@ -8,7 +8,7 @@
 
 > **KlingTaskResponse** = `object`
 
-Defined in: [types/video.ts:125](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L125)
+Defined in: [types/video.ts:130](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L130)
 
 Kling (PiAPI) task status response.
 
@@ -18,7 +18,7 @@ Kling (PiAPI) task status response.
 
 > `optional` **status?**: `string`
 
-Defined in: [types/video.ts:126](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L126)
+Defined in: [types/video.ts:131](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L131)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/video.ts:126](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **video_url?**: `string`
 
-Defined in: [types/video.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L127)
+Defined in: [types/video.ts:132](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L132)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/video.ts:127](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **output?**: `object`
 
-Defined in: [types/video.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L128)
+Defined in: [types/video.ts:133](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L133)
 
 #### video_url?
 
@@ -46,4 +46,4 @@ Defined in: [types/video.ts:128](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/video.ts:129](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L129)
+Defined in: [types/video.ts:134](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L134)

--- a/docs/api/type-aliases/RunwayTaskResponse.md
+++ b/docs/api/type-aliases/RunwayTaskResponse.md
@@ -8,7 +8,7 @@
 
 > **RunwayTaskResponse** = `object`
 
-Defined in: [types/video.ts:135](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L135)
+Defined in: [types/video.ts:140](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L140)
 
 Runway task status response.
 
@@ -18,7 +18,7 @@ Runway task status response.
 
 > `optional` **status?**: `string`
 
-Defined in: [types/video.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L136)
+Defined in: [types/video.ts:141](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L141)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/video.ts:136](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **output?**: `string`[] \| `string`
 
-Defined in: [types/video.ts:137](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L137)
+Defined in: [types/video.ts:142](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L142)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/video.ts:137](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/video.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L138)
+Defined in: [types/video.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L143)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/video.ts:138](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **failure?**: `string`
 
-Defined in: [types/video.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L139)
+Defined in: [types/video.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L144)

--- a/docs/api/type-aliases/VideoHandler.md
+++ b/docs/api/type-aliases/VideoHandler.md
@@ -8,7 +8,7 @@
 
 > **VideoHandler** = `object`
 
-Defined in: [types/video.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L66)
+Defined in: [types/video.ts:71](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L71)
 
 Handler contract for video generation providers.
 
@@ -26,7 +26,7 @@ total-deadline for image-to-video predictLongRunning APIs is
 
 > `readonly` `optional` **maxDurationSeconds?**: `number`
 
-Defined in: [types/video.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L103)
+Defined in: [types/video.ts:108](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L108)
 
 Maximum video duration in seconds supported by this provider.
 
@@ -36,7 +36,7 @@ Maximum video duration in seconds supported by this provider.
 
 > `readonly` `optional` **supportedAspectRatios?**: readonly (`"9:16"` \| `"16:9"` \| `"1:1"` \| `"4:3"` \| `"3:4"`)[]
 
-Defined in: [types/video.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L106)
+Defined in: [types/video.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L111)
 
 Supported aspect ratios.
 
@@ -46,7 +46,7 @@ Supported aspect ratios.
 
 > `readonly` `optional` **supportedResolutions?**: readonly (`"480p"` \| `"720p"` \| `"1080p"` \| `"4k"`)[]
 
-Defined in: [types/video.ts:115](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L115)
+Defined in: [types/video.ts:120](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L120)
 
 Supported output resolutions.
 
@@ -56,7 +56,7 @@ Supported output resolutions.
 
 > **generate**(`image`, `prompt`, `options`, `region?`): `Promise`\<[`VideoGenerationResult`](VideoGenerationResult.md)\>
 
-Defined in: [types/video.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L76)
+Defined in: [types/video.ts:81](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L81)
 
 Generate a single video clip from an input image and prompt.
 
@@ -98,7 +98,7 @@ Buffer + metadata
 
 > `optional` **generateTransition**(`firstFrame`, `lastFrame`, `prompt`, `options?`, `region?`): `Promise`\<`Buffer`\<`ArrayBufferLike`\>\>
 
-Defined in: [types/video.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L91)
+Defined in: [types/video.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L96)
 
 Optional — generate a transition clip between two frames (Director Mode).
 
@@ -139,7 +139,7 @@ Providers without first-and-last-frame interpolation omit this method;
 
 > **isConfigured**(): `boolean`
 
-Defined in: [types/video.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L100)
+Defined in: [types/video.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L105)
 
 Validate the provider is configured (auth, base URL, etc.).
 

--- a/docs/api/type-aliases/VideoTransitionOptions.md
+++ b/docs/api/type-aliases/VideoTransitionOptions.md
@@ -18,11 +18,22 @@ Used by handlers that support first-and-last-frame interpolation
 
 ## Properties
 
+### abortSignal?
+
+> `optional` **abortSignal?**: `AbortSignal`
+
+Defined in: [types/video.ts:52](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L52)
+
+Per-call cancellation signal forwarded to provider requests and polling
+loops — same contract as `VideoOutputOptions.abortSignal`.
+
+---
+
 ### aspectRatio?
 
 > `optional` **aspectRatio?**: `"9:16"` \| `"16:9"` \| `"1:1"` \| `string`
 
-Defined in: [types/video.ts:48](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L48)
+Defined in: [types/video.ts:53](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L53)
 
 ---
 
@@ -30,7 +41,7 @@ Defined in: [types/video.ts:48](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **resolution?**: `"720p"` \| `"1080p"`
 
-Defined in: [types/video.ts:49](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L49)
+Defined in: [types/video.ts:54](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L54)
 
 ---
 
@@ -38,7 +49,7 @@ Defined in: [types/video.ts:49](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **audio?**: `boolean`
 
-Defined in: [types/video.ts:50](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L50)
+Defined in: [types/video.ts:55](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L55)
 
 ---
 
@@ -46,6 +57,6 @@ Defined in: [types/video.ts:50](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **durationSeconds?**: `4` \| `6` \| `8`
 
-Defined in: [types/video.ts:52](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L52)
+Defined in: [types/video.ts:57](https://github.com/juspay/neurolink/blob/release/src/lib/types/video.ts#L57)
 
 Duration of the transition clip (Veo accepts 4, 6, or 8). Default 4.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:skills": "pnpm exec tsx test/continuous-test-suite-skills.ts",
     "test:servers": "pnpm exec tsx test/continuous-test-suite-servers.ts",
     "test:tool-reliability": "pnpm exec tsx test/continuous-test-suite-tool-reliability.ts",
+    "test:video-abort": "pnpm exec tsx test/continuous-test-suite-video-abort.ts",
     "test:tts": "pnpm exec tsx test/continuous-test-suite-tts.ts",
     "test:tts:unit": "pnpm exec tsx test/continuous-test-suite-tts-unit.ts",
     "test:stt:unit": "pnpm exec tsx test/continuous-test-suite-stt-unit.ts",

--- a/src/lib/adapters/video/klingVideoHandler.ts
+++ b/src/lib/adapters/video/klingVideoHandler.ts
@@ -93,7 +93,7 @@ export class KlingVideoHandler implements VideoHandler {
     }
 
     const startTime = Date.now();
-    const abortSignal = (options as { abortSignal?: AbortSignal }).abortSignal;
+    const abortSignal = options.abortSignal;
 
     // 1. Submit job.
     const taskId = await this.submitJob(image, prompt, options);

--- a/src/lib/adapters/video/runwayVideoHandler.ts
+++ b/src/lib/adapters/video/runwayVideoHandler.ts
@@ -96,7 +96,7 @@ export class RunwayVideoHandler implements VideoHandler {
     }
 
     const startTime = Date.now();
-    const abortSignal = (options as { abortSignal?: AbortSignal }).abortSignal;
+    const abortSignal = options.abortSignal;
     const taskId = await this.submitTask(image, prompt, options);
     const videoUrl = await this.pollUntilComplete(taskId, abortSignal);
     const buffer = await this.downloadVideo(videoUrl);

--- a/src/lib/adapters/video/vertexVideoHandler.ts
+++ b/src/lib/adapters/video/vertexVideoHandler.ts
@@ -384,6 +384,7 @@ export async function generateVideoWithVertex(
   const durationSeconds = options.length || 6; // 4, 6, or 8
   const aspectRatio = options.aspectRatio || "16:9";
   const generateAudio = options.audio ?? true;
+  const abortSignal = options.abortSignal;
 
   logger.debug("Starting Vertex video generation", {
     project,
@@ -437,9 +438,13 @@ export async function generateVideoWithVertex(
 
     logger.debug("Sending video generation request", { endpoint });
 
-    // Create abort controller for request timeout
+    // Create abort controller for request timeout, chained onto the
+    // caller's cancellation signal so either source stops the request.
     const controller = new AbortController();
     const requestTimeout = setTimeout(() => controller.abort(), 30000); // 30s request timeout
+    const requestSignal = abortSignal
+      ? AbortSignal.any([abortSignal, controller.signal])
+      : controller.signal;
 
     // Start long-running operation
     let response: Response;
@@ -451,11 +456,21 @@ export async function generateVideoWithVertex(
           "Content-Type": "application/json; charset=utf-8",
         },
         body: JSON.stringify(requestBody),
-        signal: controller.signal,
+        signal: requestSignal,
       });
     } catch (error) {
       clearTimeout(requestTimeout);
       if (isAbortError(error)) {
+        if (abortSignal?.aborted) {
+          throw new VideoError({
+            code: VIDEO_ERROR_CODES.GENERATION_FAILED,
+            message: "Vertex video generation aborted by caller",
+            category: ErrorCategory.EXECUTION,
+            severity: ErrorSeverity.MEDIUM,
+            retriable: false,
+            context: { provider: "vertex", endpoint },
+          });
+        }
         throw new VideoError({
           code: VIDEO_ERROR_CODES.GENERATION_FAILED,
           message: "Video generation request timed out after 30 seconds",
@@ -511,6 +526,7 @@ export async function generateVideoWithVertex(
       project,
       location,
       Math.max(1000, remainingTime), // Ensure at least 1 second timeout
+      abortSignal,
     );
 
     const processingTime = Date.now() - startTime;
@@ -649,9 +665,13 @@ async function makePollRequest(
   operationName: string,
   accessToken: string,
   timeoutMs: number = 30000,
+  abortSignal?: AbortSignal,
 ): Promise<VertexOperationResult> {
   const controller = new AbortController();
   const requestTimeout = setTimeout(() => controller.abort(), timeoutMs);
+  const requestSignal = abortSignal
+    ? AbortSignal.any([abortSignal, controller.signal])
+    : controller.signal;
 
   let response: Response;
   try {
@@ -662,11 +682,21 @@ async function makePollRequest(
         "Content-Type": "application/json; charset=utf-8",
       },
       body: JSON.stringify({ operationName }), // Pass operation name in body
-      signal: controller.signal,
+      signal: requestSignal,
     });
   } catch (error) {
     clearTimeout(requestTimeout);
     if (isAbortError(error)) {
+      if (abortSignal?.aborted) {
+        throw new VideoError({
+          code: VIDEO_ERROR_CODES.GENERATION_FAILED,
+          message: "Vertex poll for operation aborted by caller",
+          category: ErrorCategory.EXECUTION,
+          severity: ErrorSeverity.MEDIUM,
+          retriable: false,
+          context: { provider: "vertex", operationName },
+        });
+      }
       throw new VideoError({
         code: VIDEO_ERROR_CODES.GENERATION_FAILED,
         message: `Poll request timed out after ${timeoutMs}ms`,
@@ -725,15 +755,17 @@ async function pollVideoOperation(
   project: string,
   location: string,
   timeoutMs: number,
+  abortSignal?: AbortSignal,
 ): Promise<Buffer> {
-  return pollOperation(
-    VEO_MODEL,
+  return pollOperation({
+    modelOrEndpoint: VEO_MODEL,
     operationName,
     accessToken,
     project,
     location,
     timeoutMs,
-  );
+    abortSignal,
+  });
 }
 
 // ============================================================================
@@ -761,6 +793,7 @@ export async function generateTransitionWithVertex(
   lastFrame: Buffer,
   prompt: string,
   options: {
+    abortSignal?: AbortSignal;
     aspectRatio?: "9:16" | "16:9" | "1:1" | string;
     resolution?: "720p" | "1080p";
     audio?: boolean;
@@ -776,6 +809,7 @@ export async function generateTransitionWithVertex(
   const aspectRatio = options.aspectRatio || "16:9";
   const resolution = options.resolution || "720p";
   const generateAudio = options.audio ?? true;
+  const abortSignal = options.abortSignal;
 
   logger.debug("Starting transition clip generation", {
     model: VEO_FAST_MODEL,
@@ -820,6 +854,9 @@ export async function generateTransitionWithVertex(
 
     const controller = new AbortController();
     const requestTimeout = setTimeout(() => controller.abort(), 30000);
+    const requestSignal = abortSignal
+      ? AbortSignal.any([abortSignal, controller.signal])
+      : controller.signal;
 
     let response: Response;
     try {
@@ -830,11 +867,20 @@ export async function generateTransitionWithVertex(
           "Content-Type": "application/json; charset=utf-8",
         },
         body: JSON.stringify(requestBody),
-        signal: controller.signal,
+        signal: requestSignal,
       });
     } catch (error) {
       clearTimeout(requestTimeout);
       if (isAbortError(error)) {
+        if (abortSignal?.aborted) {
+          throw new VideoError({
+            code: VIDEO_ERROR_CODES.DIRECTOR_TRANSITION_FAILED,
+            message: "Vertex transition generation aborted by caller",
+            category: ErrorCategory.EXECUTION,
+            severity: ErrorSeverity.MEDIUM,
+            retriable: false,
+          });
+        }
         throw new VideoError({
           code: VIDEO_ERROR_CODES.DIRECTOR_TRANSITION_FAILED,
           message: "Transition generation request timed out after 30 seconds",
@@ -881,6 +927,7 @@ export async function generateTransitionWithVertex(
       project,
       location,
       Math.max(1000, remainingTime),
+      abortSignal,
     );
 
     logger.debug("Transition clip generated", {
@@ -909,15 +956,35 @@ export async function generateTransitionWithVertex(
  * Common polling helper that handles both video and transition operations.
  * Accepts a model name to construct the appropriate endpoint.
  */
-async function pollOperation(
-  modelOrEndpoint: string,
-  operationName: string,
-  accessToken: string,
-  project: string,
-  location: string,
-  timeoutMs: number,
-): Promise<Buffer> {
+async function pollOperation(args: {
+  modelOrEndpoint: string;
+  operationName: string;
+  accessToken: string;
+  project: string;
+  location: string;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+}): Promise<Buffer> {
+  const {
+    modelOrEndpoint,
+    operationName,
+    accessToken,
+    project,
+    location,
+    timeoutMs,
+    abortSignal,
+  } = args;
   const startTime = Date.now();
+
+  const makeAbortedError = (): VideoError =>
+    new VideoError({
+      code: VIDEO_ERROR_CODES.GENERATION_FAILED,
+      message: "Vertex poll for operation aborted by caller",
+      category: ErrorCategory.EXECUTION,
+      severity: ErrorSeverity.MEDIUM,
+      retriable: false,
+      context: { provider: "vertex", operationName },
+    });
 
   // Global endpoint uses aiplatform.googleapis.com (no region prefix),
   // same pattern as the predictLongRunning endpoint at line 374
@@ -928,10 +995,16 @@ async function pollOperation(
   const pollEndpoint = `https://${pollHost}/v1/projects/${project}/locations/${location}/publishers/google/models/${modelOrEndpoint}:fetchPredictOperation`;
 
   while (Date.now() - startTime < timeoutMs) {
+    if (abortSignal?.aborted) {
+      throw makeAbortedError();
+    }
+
     const result = await makePollRequest(
       pollEndpoint,
       operationName,
       accessToken,
+      undefined,
+      abortSignal,
     );
 
     if (result.done) {
@@ -943,7 +1016,19 @@ async function pollOperation(
       elapsed: Date.now() - startTime,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    // Abortable sleep — a caller abort mid-interval must not wait out the
+    // full poll interval before being observed.
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = (): void => {
+        clearTimeout(timer);
+        reject(makeAbortedError());
+      };
+      const timer = setTimeout(() => {
+        abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, POLL_INTERVAL_MS);
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   throw new VideoError({
@@ -966,15 +1051,17 @@ async function pollTransitionOperation(
   project: string,
   location: string,
   timeoutMs: number,
+  abortSignal?: AbortSignal,
 ): Promise<Buffer> {
-  return pollOperation(
-    VEO_FAST_MODEL,
+  return pollOperation({
+    modelOrEndpoint: VEO_FAST_MODEL,
     operationName,
     accessToken,
     project,
     location,
     timeoutMs,
-  );
+    abortSignal,
+  });
 }
 
 // ============================================================================
@@ -1031,6 +1118,7 @@ export class VertexVideoHandler implements VideoHandler {
       lastFrame,
       prompt,
       {
+        abortSignal: options?.abortSignal,
         aspectRatio: options?.aspectRatio,
         resolution: options?.resolution,
         audio: options?.audio,

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -3003,6 +3003,11 @@ export abstract class BaseProvider implements AIProvider {
     // shared timeout helper so standard video gen honors the caller's
     // timeout the same way director mode does (see above ~Line 2062).
     const videoTimeout = options.timeout ?? 600_000; // 10 min default
+    // Thread the caller's cancellation signal into the handler chain —
+    // output.video.abortSignal (video-scoped) wins over the request-level
+    // options.abortSignal, matching the general per-field precedence.
+    const videoAbortSignal =
+      options.output?.video?.abortSignal ?? options.abortSignal;
     const videoResult = await this.executeWithTimeout(
       () =>
         VideoProcessor.generate(requestedProvider, {
@@ -3010,6 +3015,7 @@ export abstract class BaseProvider implements AIProvider {
           image: imageBuffer,
           prompt,
           region: options.region,
+          abortSignal: videoAbortSignal,
         }),
       { timeout: videoTimeout, operationType: "generate" },
     );

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -45,6 +45,11 @@ export type VideoGenerateOptions = VideoOutputOptions & {
  * `generateTransition` method on `VideoHandler`.
  */
 export type VideoTransitionOptions = {
+  /**
+   * Per-call cancellation signal forwarded to provider requests and polling
+   * loops — same contract as `VideoOutputOptions.abortSignal`.
+   */
+  abortSignal?: AbortSignal;
   aspectRatio?: "9:16" | "16:9" | "1:1" | string;
   resolution?: "720p" | "1080p";
   audio?: boolean;

--- a/src/lib/utils/videoProcessor.ts
+++ b/src/lib/utils/videoProcessor.ts
@@ -145,6 +145,16 @@ export class VideoProcessor {
         }
       : optionsOrImage;
     const { image, prompt, region, ...videoOptions } = bag;
+    // A fired timeout must also cancel the handler's own request/polling
+    // loop — otherwise the caller sees the rejection while a ghost
+    // generation keeps polling (and possibly billing) for the rest of the
+    // render. Chain the internal controller onto any caller-supplied
+    // signal so both cancellation sources reach the handler.
+    const timeoutAbort = new AbortController();
+    const abortSignal = videoOptions.abortSignal
+      ? AbortSignal.any([videoOptions.abortSignal, timeoutAbort.signal])
+      : timeoutAbort.signal;
+    const handlerOptions: VideoOutputOptions = { ...videoOptions, abortSignal };
     const span = SpanSerializer.createSpan(
       SpanType.MEDIA_GENERATION,
       "video.generate",
@@ -182,7 +192,7 @@ export class VideoProcessor {
       // video generation is legitimately slow, so the deadline is generous —
       // but a wedged handler must error, never hang the caller forever.
       const result = await withTimeout(
-        handler.generate(image, prompt, videoOptions, region),
+        handler.generate(image, prompt, handlerOptions, region),
         VIDEO_GENERATION_TIMEOUT_MS,
         `Video generation via "${provider}" timed out after ${VIDEO_GENERATION_TIMEOUT_MS}ms`,
       );
@@ -195,6 +205,10 @@ export class VideoProcessor {
       );
       return result;
     } catch (err: unknown) {
+      // Cancel the ghost: on timeout the handler promise is still pending;
+      // aborting here stops its polling loop. On handler-originated errors
+      // the promise has already settled, so the abort is a no-op.
+      timeoutAbort.abort();
       const ended = SpanSerializer.endSpan(
         span,
         SpanStatus.ERROR,
@@ -266,6 +280,17 @@ export class VideoProcessor {
       });
     }
 
+    // Same ghost-cancellation contract as generate(): a fired timeout
+    // aborts the handler's polling loop, chained onto any caller signal.
+    const timeoutAbort = new AbortController();
+    const abortSignal = options?.abortSignal
+      ? AbortSignal.any([options.abortSignal, timeoutAbort.signal])
+      : timeoutAbort.signal;
+    const handlerOptions: VideoTransitionOptions = {
+      ...(options ?? {}),
+      abortSignal,
+    };
+
     try {
       // Same bound as generate(): a wedged transition must error, not hang.
       return await withTimeout(
@@ -273,13 +298,14 @@ export class VideoProcessor {
           firstFrame,
           lastFrame,
           prompt,
-          options,
+          handlerOptions,
           region,
         ),
         VIDEO_GENERATION_TIMEOUT_MS,
         `Video transition via "${provider}" timed out after ${VIDEO_GENERATION_TIMEOUT_MS}ms`,
       );
     } catch (err: unknown) {
+      timeoutAbort.abort();
       if (err instanceof VideoError) {
         throw err;
       }

--- a/test/continuous-test-suite-video-abort.ts
+++ b/test/continuous-test-suite-video-abort.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — Video generation cancellation (abortSignal).
+ *
+ * ALL-DIST module graph (rule 15): `VideoProcessor` comes from
+ * `../dist/index.js` — the same shipped surface providers and SDK callers
+ * use. Determinism note (the rule-15 exception, stated per the repo
+ * guideline): cancellation timing cannot be exercised through a live
+ * provider call — a real render neither aborts on cue nor does so
+ * deterministically — so these cases register stub handlers through the
+ * PUBLIC `VideoProcessor.registerHandler()` surface (the exact path
+ * `ProviderRegistry._doRegister()` uses) and drive `generate()` /
+ * `generateTransition()` end-to-end through the processor. What determinism
+ * buys: the suite can prove the processor always hands its handlers a live
+ * AbortSignal, that a caller's signal chains through to the handler, and
+ * that an abort settles the call in milliseconds instead of the 600s bound.
+ *
+ * Run: npx tsx test/continuous-test-suite-video-abort.ts
+ *      pnpm run test:video-abort
+ */
+import { defineSuite, logSection, assert } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("Video Abort Signal");
+
+// A rejection caused by an abort must land well inside this window — the
+// whole point is that cancellation does not wait out the 600s timeout.
+const ABORT_SETTLE_BUDGET_MS = 5_000;
+
+type StubOptions = {
+  abortSignal?: AbortSignal;
+};
+
+const minimalResult = {
+  data: Buffer.from("stub-bytes"),
+  mediaType: "video/mp4" as const,
+};
+
+/** Never settles until the received signal aborts, then rejects. */
+function settleOnAbort(signal: AbortSignal | undefined): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const fail = (): void => reject(new Error("stub handler observed abort"));
+    if (!signal) {
+      return; // hangs forever — the suite would time out, failing loudly
+    }
+    if (signal.aborted) {
+      fail();
+      return;
+    }
+    signal.addEventListener("abort", fail, { once: true });
+  });
+}
+
+async function main(): Promise<void> {
+  logSection("Video Abort Signal");
+
+  const { VideoProcessor } = await import("../dist/index.js");
+
+  await test("processor always hands the handler a live AbortSignal (the timeout ghost-cancellation channel), even when the caller passes none", async () => {
+    let received: StubOptions | undefined;
+    VideoProcessor.registerHandler("abort-stub-capture", {
+      isConfigured: () => true,
+      generate: (
+        _image: Buffer,
+        _prompt: string,
+        options: StubOptions,
+      ): Promise<typeof minimalResult> => {
+        received = options;
+        return Promise.resolve(minimalResult);
+      },
+    });
+
+    const result = await VideoProcessor.generate("abort-stub-capture", {
+      image: Buffer.from("img"),
+      prompt: "p",
+    });
+    assert(result.data.length > 0, "stub result did not round-trip");
+    assert(
+      received?.abortSignal instanceof AbortSignal,
+      "handler did not receive an AbortSignal in its options",
+    );
+    assert(
+      received?.abortSignal?.aborted === false,
+      "handler's signal was already aborted before any timeout fired",
+    );
+  });
+
+  await test("a caller's abort chains through the processor to the handler and settles the call fast", async () => {
+    VideoProcessor.registerHandler("abort-stub-caller", {
+      isConfigured: () => true,
+      generate: (
+        _image: Buffer,
+        _prompt: string,
+        options: StubOptions,
+      ): Promise<typeof minimalResult> => settleOnAbort(options.abortSignal),
+    });
+
+    const caller = new AbortController();
+    const started = Date.now();
+    setTimeout(() => caller.abort(), 50);
+
+    let rejected = false;
+    try {
+      await VideoProcessor.generate("abort-stub-caller", {
+        image: Buffer.from("img"),
+        prompt: "p",
+        abortSignal: caller.signal,
+      });
+    } catch {
+      rejected = true;
+    }
+    const elapsed = Date.now() - started;
+    assert(rejected, "generate resolved despite the caller aborting");
+    assert(
+      elapsed < ABORT_SETTLE_BUDGET_MS,
+      "abort took longer than the settle budget — signal not chained",
+    );
+  });
+
+  await test("a pre-aborted caller signal rejects generate immediately", async () => {
+    VideoProcessor.registerHandler("abort-stub-preaborted", {
+      isConfigured: () => true,
+      generate: (
+        _image: Buffer,
+        _prompt: string,
+        options: StubOptions,
+      ): Promise<typeof minimalResult> => settleOnAbort(options.abortSignal),
+    });
+
+    const caller = new AbortController();
+    caller.abort();
+    const started = Date.now();
+
+    let rejected = false;
+    try {
+      await VideoProcessor.generate("abort-stub-preaborted", {
+        image: Buffer.from("img"),
+        prompt: "p",
+        abortSignal: caller.signal,
+      });
+    } catch {
+      rejected = true;
+    }
+    const elapsed = Date.now() - started;
+    assert(rejected, "generate resolved despite a pre-aborted signal");
+    assert(
+      elapsed < ABORT_SETTLE_BUDGET_MS,
+      "pre-aborted signal was not observed promptly",
+    );
+  });
+
+  await test("generateTransition chains the caller's abort the same way", async () => {
+    VideoProcessor.registerHandler("abort-stub-transition", {
+      isConfigured: () => true,
+      generate: (): Promise<typeof minimalResult> =>
+        Promise.resolve(minimalResult),
+      generateTransition: (
+        _first: Buffer,
+        _last: Buffer,
+        _prompt: string,
+        options?: StubOptions,
+      ): Promise<Buffer> => settleOnAbort(options?.abortSignal),
+    });
+
+    const caller = new AbortController();
+    const started = Date.now();
+    setTimeout(() => caller.abort(), 50);
+
+    let rejected = false;
+    try {
+      await VideoProcessor.generateTransition(
+        "abort-stub-transition",
+        Buffer.from("first"),
+        Buffer.from("last"),
+        "p",
+        { abortSignal: caller.signal },
+      );
+    } catch {
+      rejected = true;
+    }
+    const elapsed = Date.now() - started;
+    assert(rejected, "generateTransition resolved despite the caller aborting");
+    assert(
+      elapsed < ABORT_SETTLE_BUDGET_MS,
+      "transition abort took longer than the settle budget",
+    );
+  });
+
+  runSuite();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Closes the cancellation gap CodeRabbit flagged on #1542 (deferred there because it touches the handler implementations):

- **Ghost renders cancelled on timeout** — `VideoProcessor.generate()` / `generateTransition()` chain an internal `AbortController` onto any caller-supplied signal via `AbortSignal.any` and abort it on the way out of a failed call. Previously a fired 600s timeout rejected the caller while the handler's polling loop kept hitting the provider (and possibly billing) for the rest of the job.
- **The caller's signal now actually arrives** — `handleVideoGeneration` threads `output.video.abortSignal ?? options.abortSignal` into the handler bag. `VideoOutputOptions.abortSignal` already existed and kling/runway already honored it, but nothing upstream ever set it.
- **Vertex handler wired end-to-end** — it previously ignored cancellation entirely. The signal now reaches the `predictLongRunning` request, every poll request, a top-of-iteration abort check, and an abortable inter-poll sleep — for both video and transition generation. Caller aborts surface as non-retriable `VideoError`s distinguished from the 30s per-request timeout.
- **`VideoTransitionOptions` gains `abortSignal`**; the `VertexVideoHandler` wrapper forwards it.
- **Stale casts removed** — kling/runway's `(options as { abortSignal?: AbortSignal })` casts are gone now that the field is properly typed on the options they receive.

## Tests

New no-API suite `test/continuous-test-suite-video-abort.ts` (+ `test:video-abort` script), all-dist per rule 15 with the determinism exception declared in its header. 4 cases pin: the processor always hands handlers a live signal (the ghost-cancellation channel exists even with no caller signal), a caller abort chains through and settles in milliseconds rather than the 600s bound, a pre-aborted signal short-circuits, and transitions get the same contract. Sanity-checked per the repo guideline: breaking an assertion reports ✗ and exits 1 (not ⊘).

## Verification

- `pnpm run check` — 0 errors; `pnpm run lint` — clean (fixed a max-params hit by converting `pollOperation` to an args object)
- `pnpm run build` clean; suite 4/4 against fresh dist
- `pnpm run docs:api` regenerated last