### PR TITLE
fix(tts): stop early stream break from hanging the caller forever

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -50,6 +50,11 @@ import { resolveLifecycleTimeoutMs } from "../utils/lifecycleTimeout.js";
 import { logger } from "../utils/logger.js";
 import { interleaveTTSStream } from "../utils/ttsStream.js";
 import {
+  attachStreamCancel,
+  cancelStream,
+  releaseIterator,
+} from "../utils/streamCancellation.js";
+import {
   TimeoutError as AsyncTimeoutError,
   withTimeoutFn,
 } from "../utils/async/withTimeout.js";
@@ -593,11 +598,21 @@ export abstract class BaseProvider implements AIProvider {
     const classifyStreamError = (e: unknown): Error =>
       this.classifyStreamError(e);
 
+    // Hold the upstream iterator rather than letting `for await` create one
+    // internally, so the cancel hook below can close it directly. Iterating
+    // `upstreamIterable` is equivalent to iterating `originalStream` — same
+    // iterator, same early-exit `return()` semantics — it just leaves a handle
+    // reachable from outside the generator.
+    const upstreamIterator = originalStream[Symbol.asyncIterator]();
+    const upstreamIterable = {
+      [Symbol.asyncIterator]: () => upstreamIterator,
+    };
+
     const wrappedStream = (async function* () {
       let accumulated = "";
       let seq = 0;
       try {
-        for await (const chunk of originalStream) {
+        for await (const chunk of upstreamIterable) {
           const textPart =
             chunk &&
             typeof chunk === "object" &&
@@ -656,6 +671,16 @@ export abstract class BaseProvider implements AIProvider {
         throw classifyStreamError(err);
       }
     })();
+
+    // A consumer that breaks out of the stream cannot reach this generator
+    // through `.return()` while it is parked awaiting the provider — that
+    // request queues behind the in-flight `next()`. The hook closes the
+    // upstream directly and forwards the request to any wrapper below, so
+    // abandoning a stream really does release the provider connection.
+    attachStreamCancel(wrappedStream, () => {
+      cancelStream(originalStream);
+      releaseIterator(upstreamIterator);
+    });
 
     return { ...result, stream: wrappedStream };
   }

--- a/src/lib/utils/streamCancellation.ts
+++ b/src/lib/utils/streamCancellation.ts
@@ -1,0 +1,99 @@
+/**
+ * Out-of-band cancellation for chained async streams.
+ *
+ * `AsyncGenerator.prototype.return()` is the obvious way to tell a stream its
+ * consumer has gone away, and it does not work through a chain of generators.
+ * The request is *queued* behind whatever `next()` is already in flight; it
+ * cannot interrupt an `await`. A provider stream is wrapped several times
+ * (lifecycle in `baseProvider`, MCP and pool wrappers in `neurolink`), and
+ * during a pull every one of those layers is parked inside an `await` on the
+ * layer below. So none of them can unwind, the innermost source is never
+ * closed, and a teardown that waits for that to happen waits forever.
+ *
+ * This module is the side channel that does work. A wrapper registers a
+ * cancel callback on the stream object it returns; the callback closes its own
+ * upstream iterator and forwards the request further down. Because these are
+ * ordinary function calls rather than generator protocol, they run immediately
+ * — no queue, no dependence on any pending `next()` settling.
+ *
+ * Registration is optional and reading is defensive, so a stream that knows
+ * nothing about this behaves exactly as it did before.
+ */
+
+const STREAM_CANCEL = Symbol.for("neurolink.streamCancel");
+
+/**
+ * Register `cancel` as `stream`'s teardown hook and return the same object.
+ *
+ * Non-enumerable so the property never shows up in spreads, `JSON.stringify`
+ * or logging of a stream handle.
+ */
+export function attachStreamCancel<S extends object>(
+  stream: S,
+  cancel: () => void,
+): S {
+  Object.defineProperty(stream, STREAM_CANCEL, {
+    value: cancel,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return stream;
+}
+
+/**
+ * Invoke `stream`'s cancel hook if it has one.
+ *
+ * Never throws. This runs from `finally` blocks during teardown, where the
+ * consumer has already stopped listening — an exception here would replace
+ * whatever outcome the caller was actually returning with a cleanup error.
+ */
+export function cancelStream(stream: unknown): void {
+  if (stream === null || stream === undefined) {
+    return;
+  }
+  if (typeof stream !== "object" && typeof stream !== "function") {
+    return;
+  }
+  try {
+    // The property read is inside the try, not before it. Reading a symbol off
+    // an arbitrary object can execute user code — a Proxy trap or a throwing
+    // getter — and this function is documented as never throwing because it
+    // runs from teardown `finally` blocks, where an exception would replace
+    // the outcome the caller was actually returning with a cleanup error.
+    const hook = (stream as Record<symbol, unknown>)[STREAM_CANCEL];
+    if (typeof hook !== "function") {
+      return;
+    }
+    (hook as () => void)();
+  } catch {
+    // Teardown is best-effort by definition.
+  }
+}
+
+/**
+ * Close `iterator` without waiting for it and without surfacing a rejection.
+ *
+ * Deliberately not awaited: on a generator that is parked mid-`await` this
+ * promise may never settle, which is the whole failure this module exists to
+ * avoid. The call still propagates whenever the iterator can act on it.
+ */
+export function releaseIterator(iterator: {
+  return?: (value?: unknown) => unknown;
+}): void {
+  if (typeof iterator.return !== "function") {
+    return;
+  }
+  try {
+    const result = iterator.return(undefined);
+    if (
+      result &&
+      typeof (result as Promise<unknown>).catch === "function" &&
+      typeof (result as Promise<unknown>).then === "function"
+    ) {
+      void (result as Promise<unknown>).catch(() => {});
+    }
+  } catch {
+    // Best-effort, as above.
+  }
+}

--- a/src/lib/utils/ttsStream.ts
+++ b/src/lib/utils/ttsStream.ts
@@ -13,6 +13,7 @@ import {
   TTSProcessor,
 } from "./ttsProcessor.js";
 import { TimeoutError as AsyncTimeoutError } from "./async/withTimeout.js";
+import { cancelStream } from "./streamCancellation.js";
 
 function getStreamingTTSErrorDetails(
   error: unknown,
@@ -159,6 +160,22 @@ function aggregateTTSChunks(chunks: TTSChunk[]): TTSResult | undefined {
 }
 
 /**
+ * Upper bound on how long stream teardown may wait for upstream iterators to
+ * acknowledge `.return()`. Closing an iterator is bookkeeping, not work, so a
+ * responsive upstream finishes far inside this; an unresponsive one is exactly
+ * the case that must not block the consumer. The timer is unref'd so a pending
+ * grace period never by itself keeps the process alive.
+ */
+const RELEASE_GRACE_MS = 5_000;
+
+function releaseGraceTimer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, RELEASE_GRACE_MS);
+    timer.unref?.();
+  });
+}
+
+/**
  * Preserve source-stream backpressure while interleaving incremental TTS audio.
  * Source chunks are yielded before their derived audio, and TTS failures degrade
  * to the unchanged source stream.
@@ -269,6 +286,12 @@ export async function* interleaveTTSStream<T>(params: {
   } finally {
     if (!completed) {
       cancelled = true;
+      // Tell the upstream chain out of band, before asking politely via
+      // `.return()` below. When the consumer breaks mid-pull every wrapper
+      // beneath is parked inside an `await` and cannot process a queued
+      // `return()`, so this side channel is the only thing that actually
+      // reaches — and closes — the provider stream at the bottom.
+      cancelStream(stream);
     }
     textQueue.end();
     const releases: Promise<unknown>[] = [];
@@ -282,7 +305,19 @@ export async function* interleaveTTSStream<T>(params: {
         Promise.resolve().then(() => audioIterator.return?.(undefined)),
       );
     }
-    await Promise.allSettled(releases);
+    // Cleanup must not be able to outlive the consumer that abandoned this
+    // stream. `.return()` on an async generator parked inside an `await` is
+    // queued behind the in-flight `next()` and cannot interrupt it, so when an
+    // upstream pull never settles these promises settle *never* — not late.
+    // Awaiting them unbounded turned a consumer's `break` into a permanent
+    // hang: the caller's `for await` never returned, with no error and no way
+    // to defend against it from outside this module.
+    //
+    // The releases are still issued, and still propagate normally whenever the
+    // upstream is responsive — which is every case where awaiting them was
+    // doing anything useful. We only stop making the consumer's exit depend on
+    // an upstream that may never answer.
+    await Promise.race([Promise.allSettled(releases), releaseGraceTimer()]);
     if (!completed) {
       onComplete?.(undefined);
     }

--- a/test/continuous-test-suite-tts-unit.ts
+++ b/test/continuous-test-suite-tts-unit.ts
@@ -44,7 +44,13 @@ import type {
 } from "../dist/index.js";
 import { stub, withStubs } from "./helpers/stubs.js";
 
-const { test, runSuite } = defineSuite("TTSProcessor (unit)");
+// `offline: true` — this suite registers stub handlers and drives
+// createOfflineProvider; nothing in it touches a network. A test that never
+// finishes here is therefore a hang in the code under test, so the harness
+// reports a per-test timeout as a failure rather than the default skip.
+const { test, runSuite } = defineSuite("TTSProcessor (unit)", {
+  offline: true,
+});
 
 // ---------------------------------------------------------------------------
 // Registry hygiene (rule 4): snapshot every handler registered before this

--- a/test/helpers/harness.ts
+++ b/test/helpers/harness.ts
@@ -126,13 +126,33 @@ export type DefineSuiteOpts = {
   interTestDelayMs?: number;
   /**
    * Per-test wall-clock cap in ms. When a single `test()` body exceeds this,
-   * the suite aborts the test (treats it as FAIL) and proceeds with the next
-   * one. Without this, an upstream endpoint that accepts a connection but
-   * never responds blocks the entire suite indefinitely (observed against
-   * litellm's `team not allowed to access model` path on tool-calling tests).
+   * the suite aborts the test and proceeds with the next one. Without this, an
+   * upstream endpoint that accepts a connection but never responds blocks the
+   * entire suite indefinitely (observed against litellm's `team not allowed to
+   * access model` path on tool-calling tests).
    * Default: 240_000 (4 minutes).
+   *
+   * A timeout is classified as SKIP by default, because a live suite cannot
+   * distinguish an SDK bug from an upstream that simply never answered. See
+   * `offline` to opt out of that where the distinction is not real.
    */
   perTestTimeoutMs?: number;
+  /**
+   * Declare that this suite makes no network calls — stub handlers, offline
+   * providers, recorded fixtures only.
+   *
+   * A timeout then becomes a FAIL rather than a SKIP. The SKIP default exists
+   * because a live suite genuinely cannot tell a hung SDK from a hung upstream;
+   * with no upstream, that ambiguity does not exist and a test that never
+   * finished can only be a defect in this package.
+   *
+   * This is not a preference. A deadlock in `interleaveTTSStream` teardown sat
+   * in `tts:unit` reported as `⊘ skipped` — the suite printed RESULT: PASS and
+   * exited 0 on every CI run, so the feature that introduced it merged with its
+   * own headline test having never once passed, and 240s per run was spent
+   * waiting on it.
+   */
+  offline?: boolean;
 };
 
 function resolveOpts(name: string, defs: DefineSuiteOpts): SuiteOpts {
@@ -524,10 +544,12 @@ export function defineSuite(
   const startedAt = Date.now();
 
   const perTestTimeoutMs = defs.perTestTimeoutMs ?? 240_000;
-  // Sentinel used by the per-test timeout below; classified as SKIP (not
-  // FAIL) because the harness can't tell the difference between an SDK bug
-  // and an upstream that simply never responded.
+  // Sentinel used by the per-test timeout below. Classified as SKIP because a
+  // live suite can't tell an SDK bug from an upstream that never responded —
+  // unless the suite declares `offline`, where there is no upstream and the
+  // only remaining explanation is a defect here.
   const PER_TEST_TIMEOUT_SKIP_MARKER = "PER_TEST_TIMEOUT_SKIP";
+  const timeoutIsFailure = defs.offline === true;
 
   const test = async (testName: string, fn: TestFn): Promise<void> => {
     let timeoutId: NodeJS.Timeout | undefined;
@@ -535,7 +557,9 @@ export function defineSuite(
       timeoutId = setTimeout(() => {
         reject(
           new Error(
-            `SKIP: ${PER_TEST_TIMEOUT_SKIP_MARKER} — ${testName} exceeded ${perTestTimeoutMs}ms — upstream likely hung; aborting test`,
+            timeoutIsFailure
+              ? `${testName} exceeded ${perTestTimeoutMs}ms in an offline suite — nothing here waits on a network, so this is a hang in the code under test, not a slow upstream`
+              : `SKIP: ${PER_TEST_TIMEOUT_SKIP_MARKER} — ${testName} exceeded ${perTestTimeoutMs}ms — upstream likely hung; aborting test`,
           ),
         );
       }, perTestTimeoutMs);


### PR DESCRIPTION
Breaking out of a TTS-enabled stream blocked the consumer **permanently**.

```
pnpm run test:tts:unit    2.95s user    1% cpu    5:09.80 total
```

1% CPU over five minutes is not slow work — nothing was running. The process sat idle in teardown.

## Cause

`interleaveTTSStream`'s `finally` awaited `Promise.allSettled` on the source and audio iterators' `.return()`. **`.return()` on an async generator parked inside an `await` does not interrupt it** — the request is queued behind the in-flight `next()` and only runs when the generator next suspends. A provider stream is wrapped several times (lifecycle in `baseProvider`, MCP and pool wrappers in `neurolink`), and during a pull *every* layer sits in an `await` on the layer below. None can unwind, so those promises settle **never**, not late.

Instrumented, at the hang:

```
[PROBE] finally ENTERED completed=false nextSource=true nextAudio=true
[PROBE] awaiting allSettled of 2 release(s)
[PROBE] calling sourceIterator.return()
[PROBE] calling audioIterator.return()
   ⊘ (240s timeout — neither ever resolved)
```

## Fix

The generator protocol alone cannot express this, so there are two parts.

**`streamCancellation.ts`** adds an out-of-band channel. A wrapper registers a cancel callback on the stream object it returns; the callback closes its own upstream iterator and forwards the request downward. These are ordinary function calls, not generator protocol — they run immediately and never depend on a pending `next()` settling. `baseProvider` hoists its upstream iterator (iterating the hoisted handle is equivalent to iterating the original; it just leaves something reachable from outside the generator) and registers a hook. `interleaveTTSStream` fires it on abandonment before asking politely via `.return()`.

Registration is optional and reading it is defensive, so a stream that knows nothing about this behaves exactly as before.

**Teardown is also bounded.** Even with the channel, this module cannot assume every upstream cooperates, and a consumer's exit must not depend on one that may never answer. Releases are still issued and still propagate whenever the upstream is responsive.

```
test:tts:unit    327s exit 0, 1 skipped   →   83s exit 0, 43 passed
```

## The test had never passed

It and the cleanup it probes both arrived in `c1731025` (#1336). That PR's own CI shows:

```
⊘ consumer early-break stops queued TTS ingestion after one dispatched segment (PER_TEST_TIMEOUT_SKIP)
```

The feature merged green with its headline test having **never once succeeded**, and every CI run since spent 240s waiting on it.

## Which is the second change

The harness classified a per-test timeout as SKIP, reasoning it cannot distinguish an SDK bug from an upstream that never answered. True of a live suite. Not true of `tts:unit`, which drives stub handlers and `createOfflineProvider` and touches no network — there, a test that never finished can only be a defect in this package.

Suites can now declare `offline: true`, making a timeout a failure. `perTestTimeoutMs`'s own doc comment already claimed timeouts were "treated as FAIL", so the code was not matching its stated contract either.

Verified both directions with a throwaway suite that simply hangs:

| | result |
|---|---|
| `offline: true` | ✗ FAIL, exit 1 |
| `offline: false` | ⊘ skip, exit 0 — live suites unaffected |

## Regression checks

| suite | result |
|---|---|
| `test:providers-mocked` (CI gate) | 67 passed · 0 failed |
| `test:provider-structure` | 3 passed |
| `test:tts` | 17 passed |
| `pnpm run check` | 0 errors, 4850 files |
| `pnpm run lint` | 0 errors |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech stream cancellation when playback is interrupted.
  * Prevented stalled streams from hanging indefinitely during cleanup.
  * Ensured abandoned streams release their underlying resources more reliably.
  * Added a bounded cleanup period so playback can exit even when an upstream stream stops responding.

* **Tests**
  * Updated offline test handling so timeouts are reported as failures instead of being skipped.
  * Improved timeout reporting consistency for offline test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->