### PR TITLE
fix(stream): keep cancellation teardown from throwing or killing the process

### DIFF
--- a/src/lib/utils/streamCancellation.ts
+++ b/src/lib/utils/streamCancellation.ts
@@ -23,6 +23,26 @@
 const STREAM_CANCEL = Symbol.for("neurolink.streamCancel");
 
 /**
+ * Swallow a rejection from a thenable teardown result.
+ *
+ * An unhandled rejection **terminates the process** — a caller doing everything
+ * right still dies, with the stack pointing at library internals it never
+ * called. Teardown runs after the consumer has stopped listening, so there is
+ * nobody left to hand the error to; dropping it is the only correct outcome,
+ * and dropping it deliberately is what keeps it from becoming fatal.
+ */
+function suppressRejection(result: unknown): void {
+  if (
+    result !== null &&
+    typeof result === "object" &&
+    typeof (result as PromiseLike<unknown>).then === "function" &&
+    typeof (result as Promise<unknown>).catch === "function"
+  ) {
+    void (result as Promise<unknown>).catch(() => {});
+  }
+}
+
+/**
  * Register `cancel` as `stream`'s teardown hook and return the same object.
  *
  * Non-enumerable so the property never shows up in spreads, `JSON.stringify`
@@ -65,7 +85,10 @@ export function cancelStream(stream: unknown): void {
     if (typeof hook !== "function") {
       return;
     }
-    (hook as () => void)();
+    // `attachStreamCancel` types the hook as `() => void`, but nothing stops a
+    // caller registering an `async` function — whose rejection would otherwise
+    // be unhandled, and therefore fatal to the process.
+    suppressRejection((hook as () => unknown)());
   } catch {
     // Teardown is best-effort by definition.
   }
@@ -81,18 +104,15 @@ export function cancelStream(stream: unknown): void {
 export function releaseIterator(iterator: {
   return?: (value?: unknown) => unknown;
 }): void {
-  if (typeof iterator.return !== "function") {
-    return;
-  }
   try {
-    const result = iterator.return(undefined);
-    if (
-      result &&
-      typeof (result as Promise<unknown>).catch === "function" &&
-      typeof (result as Promise<unknown>).then === "function"
-    ) {
-      void (result as Promise<unknown>).catch(() => {});
+    // Read the method inside the try, for the same reason `cancelStream` does:
+    // `iterator` is whatever an upstream handed us, and a Proxy trap or a
+    // throwing getter turns a property access into arbitrary user code.
+    const release = iterator.return;
+    if (typeof release !== "function") {
+      return;
     }
+    suppressRejection(release.call(iterator, undefined));
   } catch {
     // Best-effort, as above.
   }


### PR DESCRIPTION
Two follow-ups to #1550. Both were reviewed there, but the PR merged at `aeca4eb7` before these reached the branch, so they are not on `release`. Both sit on the teardown path, where the consumer has already stopped listening and there is nobody left to hand an error to.

## 1. An async cancel hook could kill the process

`attachStreamCancel` types its hook as `() => void`, but nothing stops a caller registering an `async` function — and `cancelStream` discarded the returned promise. A rejection from it is unhandled, and **an unhandled rejection terminates the process**.

That is the same class of failure #1531 fixed on the Anthropic stream path and `91b3eef4` fixed for four detached promises. A caller doing everything right dies, with a stack pointing at library internals it never called. Both call sites now route their result through a single suppressor.

## 2. `releaseIterator` read its accessor outside the `try`

`cancelStream` was hardened against exactly this in #1550 and its sibling was left as it was — which is worse than neither being hardened, because the pair then looks symmetric and the remaining one does not invite a second look.

`iterator` is whatever an upstream handed us. A Proxy trap or throwing getter turns a property access into arbitrary user code, thrown from a `finally`, replacing whatever outcome the caller was actually returning with a cleanup error.

## Verification

Against the hazards rather than by inspection:

```
✓ releaseIterator survived a throwing getter
✓ sync hook invoked (1)
✓ iterator.return invoked (1)
✓ no unhandled rejection
```

covering a rejecting async hook, a rejecting `return()`, a throwing symbol getter and a throwing `return` getter — with the ordinary paths still invoked exactly once.

`pnpm run check` clean (0 errors, 4850 files); `test:tts:unit` 43 passed.

Credit to CodeRabbit — both were its findings on #1550.