### PR TITLE
fix(localUsage): a window longer than history means everything, not nothing

### DIFF
--- a/src/lib/localUsage/scanWindow.ts
+++ b/src/lib/localUsage/scanWindow.ts
@@ -43,5 +43,8 @@ export function resolveScanCutoffMs(
   // anything near it overflow on the multiply. Treat that as no window rather
   // than letting `Date.now() - Infinity` become -Infinity, which every
   // timestamp compares as newer than.
-  return Date.now() - (Number.isFinite(span) ? span : 0);
+  if (!Number.isFinite(span)) {
+    return undefined;
+  }
+  return Date.now() - span;
 }

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -1051,12 +1051,14 @@ async function runAllTests(): Promise<void> {
         // guard it replaced caught this with Number.isFinite.
         await readAllLocalUsage({ sinceDays: NaN }),
         await readAllLocalUsage({ sinceDays: -Infinity }),
-        // A FINITE sinceDays whose window arithmetic is not finite — the
-        // third door into the same unbounded sweep, after 0 and NaN.
-        // Number.MAX_VALUE * 86_400_000 overflows to Infinity, so the cutoff
-        // became Date.now() - Infinity = -Infinity and every timestamp
-        // compares as newer than it. Measured before the fix, against a
-        // fixture dated months earlier: it read the file.
+        // A FINITE sinceDays whose window arithmetic overflows. These mean
+        // ALL HISTORY, exactly like Infinity: a window of 1e308 days is longer
+        // than any transcript store, so "everything" is the right answer and
+        // "nothing" is a wrong one. An earlier version of this suite asserted
+        // the opposite and pinned a non-monotonic cliff — 2.07e300 read
+        // everything, 2.09e300 read nothing, Infinity read everything again.
+        // Caught by running the CLI, not this suite: `usage local --since
+        // 999999999999` reported 518,576 turns and `--since 1e308` reported 39.
         await readAllLocalUsage({ sinceDays: Number.MAX_VALUE }),
         await readAllLocalUsage({ sinceDays: 1e308 }),
         await readAllLocalUsage({ sinceDays: Infinity }),
@@ -1079,12 +1081,25 @@ async function runAllTests(): Promise<void> {
         "a -Infinity sinceDays read transcripts instead of nothing",
       );
       assert(
-        (overflowMax.totals["claude-code"]?.requests ?? 0) === 0,
-        "a Number.MAX_VALUE sinceDays read transcripts instead of nothing",
+        (overflowMax.totals["claude-code"]?.requests ?? 0) === 1,
+        `a Number.MAX_VALUE sinceDays is a window longer than any history and must read everything — expected 1 turn, got ${overflowMax.totals["claude-code"]?.requests}`,
       );
       assert(
-        (overflowHuge.totals["claude-code"]?.requests ?? 0) === 0,
-        "a 1e308 sinceDays read transcripts instead of nothing",
+        (overflowHuge.totals["claude-code"]?.requests ?? 0) === 1,
+        `a 1e308 sinceDays must read everything, like Infinity — expected 1 turn, got ${overflowHuge.totals["claude-code"]?.requests}`,
+      );
+      // Monotonicity across the overflow boundary (~2.08e300 =
+      // Number.MAX_VALUE / 86_400_000). The two values straddle the point
+      // where the multiply stops being finite; a caller cannot see that
+      // boundary, so the answer must not change across it.
+      const [belowCliff, aboveCliff] = await Promise.all([
+        readAllLocalUsage({ sinceDays: 2.07e300 }),
+        readAllLocalUsage({ sinceDays: 2.09e300 }),
+      ]);
+      assert(
+        (belowCliff.totals["claude-code"]?.requests ?? 0) ===
+          (aboveCliff.totals["claude-code"]?.requests ?? 0),
+        `the overflow boundary changed the answer — below and above must agree`,
       );
       // The control: without this, a reader that simply returned nothing for
       // every window would pass every assertion above.


### PR DESCRIPTION
**This is my own regression**, introduced by the helper that closed the third unbounded-scan door, and found by running the CLI rather than the suite.

## The defect

An overflowing `sinceDays` read **nothing**, where the adjacent non-overflowing value read everything. Non-monotonic, across a boundary no caller can see:

```
sinceDays 2.07e300  → reads everything
sinceDays 2.09e300  → reads NOTHING      ← same intent, opposite answer
sinceDays Infinity  → reads everything
```

The cliff sits at `Number.MAX_VALUE / 86_400_000` (~2.08e300) — the point where `days * MS_PER_DAY` stops being finite.

## Why the original fix over-corrected

It treated "so large the arithmetic overflows" as equivalent to `NaN` and negative, collapsing all three to a zero-length window. Two of those are alike; the third is not.

`NaN` and negative are not windows at all. A span of 1e308 days **is** a window — one longer than any transcript store — so the correct answer is *everything*, and "nothing" is a wrong answer rather than a safe one.

I misread what the original defect was. The harm was an **unintended** unbounded sweep, where `0` and `NaN` read every transcript on the machine in answer to a narrow request. Reading everything is not itself the harm — `--since 0` does exactly that on purpose and is supported.

## Found through the CLI, because the suite pinned the wrong behaviour

```
usage local --since 999999999999   →  518,576 turns
usage local --since 1e308          →       39 turns
```

The suite passed the whole time — its assertion required `MAX_VALUE` to read nothing.

## After the fix — monotonic across the boundary

```
--since 7               109,145
--since 999999999999    521,353
--since 2.07e300        521,353
--since 2.09e300        521,353
--since 1e308           521,353
--since 0               521,355   (all history; live store, still growing)
```

## Tests

Both overflow assertions are inverted to expect all-history, and a new case pins monotonicity by straddling the boundary and requiring the two sides to agree.

**Non-vacuity confirmed** by reverting only `scanWindow.ts` and rebuilding — it fails with `a Number.MAX_VALUE sinceDays is a window longer than any history and must read everything — expected 1 turn, got 0`.

`NaN` and negative still collapse to a zero-length window, and the `Infinity` control case that stops a reader-returns-nothing regression from passing is untouched.

## Verification

build 0 errors · `check:tools-tests` 0 errors · `pnpm run lint` **0 errors** · local-usage suite exit 0 · mocked provider contract suite exit 0 · docs zero drift.

Exit codes read from each runner directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Very large usage-history time ranges now correctly scan all available history instead of returning no results.
  - Usage totals remain consistent across values near the time-range overflow boundary.

- **Tests**
  - Expanded coverage for oversized and boundary time-range values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->