### PR TITLE
ci(review): dismiss Yama's superseded verdicts once a fresh review lands

### DIFF
--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -20,6 +20,17 @@
 # BLOCKED verdict (per .yama/config.yaml `blockingCriteria`) or the review cannot
 # complete. Ordinary review comments / CHANGES_REQUESTED do not fail the check.
 #
+# Stale-verdict hygiene: Yama's reviews pin to the commit they reviewed, and a
+# CHANGES_REQUESTED from a superseded head keeps reviewDecision red even after
+# the findings were fixed and a fresh review ran — historically that verdict
+# could only be cleared by a human dismissing it (#1509, #1513, #1542). The
+# "Dismiss superseded verdicts" step below clears the bot's OWN
+# CHANGES_REQUESTED reviews from older commits, but only after this run
+# produced a verdict for the current head, only when the run was not
+# cancelled, and only while the PR head still matches the head this run
+# reviewed — stale signal is only ever replaced, never removed, and a
+# cancelled or superseded run never dismisses anything.
+#
 # Required repository secrets (Settings → Secrets and variables → Actions):
 #   YAMA_GITHUB_TOKEN : a REAL GitHub PAT — fine-grained with
 #                       "Pull requests: Read and write" + "Contents: Read"
@@ -206,6 +217,51 @@ jobs:
             exit 1
           fi
           echo "✅ Yama review passed (decision=${DECISION})."
+
+      # A review pins to the commit it reviewed. Once THIS run has produced a
+      # verdict for the current head, any CHANGES_REQUESTED the bot posted on
+      # an older head is superseded — but GitHub keeps it in reviewDecision
+      # until someone dismisses it, and the concurrency setup means the run
+      # that would have replaced it can end up cancelled and un-rerunnable.
+      # Dismiss the bot's own stale verdicts here. Guarded on a non-empty
+      # decision so a failed review never deletes the only signal; uses
+      # !cancelled() — not always() — so a run cancelled by a newer push
+      # never dismisses anything (that push's own run owns dismissal), while
+      # a BLOCKED verdict (which exits the enforce step non-zero) still
+      # counts as a fresh verdict for the current head.
+      - name: Dismiss superseded verdicts
+        if: ${{ !cancelled() && steps.gate.outputs.run == 'true' && steps.yama.outputs.decision != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.YAMA_GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Fully non-fatal: dismissal is hygiene, not the review. Any API
+        # failure leaves the stale verdict for a human, same as before.
+        run: |
+          set -uo pipefail
+          # Belt to !cancelled()'s braces: if the PR head has already moved
+          # past the head this run reviewed, a newer run owns dismissal —
+          # dismissing here could remove the newer head's own fresh verdict.
+          LIVE_HEAD="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .head.sha 2>/dev/null)" || { echo "::warning::Could not read the live PR head; skipping stale-verdict dismissal."; exit 0; }
+          if [ "${LIVE_HEAD}" != "${HEAD_SHA}" ]; then
+            echo "PR head moved (${HEAD_SHA} -> ${LIVE_HEAD}) — the newer run owns dismissal; skipping."
+            exit 0
+          fi
+          ME="$(gh api user --jq .login 2>/dev/null)" || { echo "::warning::Could not resolve the bot login; skipping stale-verdict dismissal."; exit 0; }
+          STALE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" --paginate \
+            --jq ".[] | select(.user.login == \"${ME}\" and .state == \"CHANGES_REQUESTED\" and .commit_id != \"${HEAD_SHA}\") | .id" 2>/dev/null)" || { echo "::warning::Could not list reviews; skipping stale-verdict dismissal."; exit 0; }
+          if [ -z "${STALE}" ]; then
+            echo "No stale ${ME} verdicts to dismiss."
+            exit 0
+          fi
+          for RID in ${STALE}; do
+            if gh api -X PUT "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews/${RID}/dismissals" \
+                 -f message="Superseded — the head moved to ${HEAD_SHA} and a fresh Yama review ran on it." >/dev/null 2>&1; then
+              echo "Dismissed stale review ${RID}."
+            else
+              echo "::warning::Could not dismiss stale review ${RID} (left for a human)."
+            fi
+          done
 
       # Persist review state for the next push on this PR (incremental review).
       - name: Save review state


### PR DESCRIPTION
## What

A Yama `CHANGES_REQUESTED` pins to the commit it reviewed. After a force-push fixes the findings, the stale verdict keeps `reviewDecision` red until a human dismisses it — and the workflow's `cancel-in-progress` concurrency means the run that would have replaced it can end up cancelled, with GitHub refusing a rerun. That exact sequence has needed manual dismissal on #1509, #1513, and #1542.

New non-fatal **Dismiss superseded verdicts** step after the verdict gate:

- Once **this** run has produced a verdict for the current head, dismiss the bot's own `CHANGES_REQUESTED` reviews pinned to older commits.
- Guarded on a non-empty `decision`, so a failed or cancelled review never deletes the only signal — stale signal is only ever **replaced**, never removed.
- Runs on `always()` because a BLOCKED verdict exits the enforce step non-zero but is still a fresh verdict for the current head.
- Every API call is non-fatal: any failure leaves the stale verdict for a human, exactly as today.

## Context

`Yama PR Review` is currently `disabled_manually` (since 2026-08-25 ~06:23Z). This PR has **zero runtime effect while it stays disabled** — re-enabling remains the operator's decision. It removes the stale-verdict trap before the workflow goes back on.

YAML parse + Prettier clean; workflow-only change, no SDK surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically dismisses outdated change-request reviews after a current pull request review verdict is issued.
  * Cleanup also supports blocked verdicts while excluding cancelled or superseded review runs.
  * Review cleanup failures are handled safely without interrupting the overall review process.

* **Documentation**
  * Added guidance for managing outdated review verdicts and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->