### PR TITLE
fix(litellm): close the gateway-portability gaps found in grid e2e testing

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -6,7 +6,7 @@
 
 # Class: NeuroLink
 
-Defined in: [neurolink.ts:609](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L609)
+Defined in: [neurolink.ts:610](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L610)
 
 ## Constructors
 
@@ -14,7 +14,7 @@ Defined in: [neurolink.ts:609](https://github.com/juspay/neurolink/blob/release/
 
 > **new NeuroLink**(`config?`): `NeuroLink`
 
-Defined in: [neurolink.ts:1254](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1254)
+Defined in: [neurolink.ts:1255](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1255)
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: [neurolink.ts:1254](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **conversationMemory?**: `ConversationMemoryManager` \| `RedisConversationMemoryManager` \| `null`
 
-Defined in: [neurolink.ts:712](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L712)
+Defined in: [neurolink.ts:713](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L713)
 
 ## Accessors
 
@@ -42,7 +42,7 @@ Defined in: [neurolink.ts:712](https://github.com/juspay/neurolink/blob/release/
 
 > **get** **tasks**(): `TaskManager`
 
-Defined in: [neurolink.ts:1415](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1415)
+Defined in: [neurolink.ts:1416](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L1416)
 
 TaskManager — scheduled and self-running tasks.
 Lazy-initialized on first access. Configurable via constructor `tasks` option.
@@ -61,7 +61,7 @@ lazily inside TaskManager on first operation.
 
 > **generate**(`optionsOrPrompt`): `Promise`\<[`GenerateResult`](../type-aliases/GenerateResult.md)\>
 
-Defined in: [neurolink.ts:4277](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L4277)
+Defined in: [neurolink.ts:4278](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L4278)
 
 Generate AI response with comprehensive feature support.
 
@@ -191,7 +191,7 @@ When HITL approval is denied
 
 > **getSkillsManager**(): [`SkillsManager`](SkillsManager.md) \| `null`
 
-Defined in: [neurolink.ts:2257](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L2257)
+Defined in: [neurolink.ts:2258](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L2258)
 
 Programmatic access to the skills subsystem (search/list/get/mutations).
 Returns null when skills are not configured or failed to initialize.
@@ -206,7 +206,7 @@ Returns null when skills are not configured or failed to initialize.
 
 > **getObservabilityConfig**(): [`ObservabilityConfig`](../type-aliases/ObservabilityConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:3489](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3489)
+Defined in: [neurolink.ts:3490](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3490)
 
 Get observability configuration
 
@@ -220,7 +220,7 @@ Get observability configuration
 
 > **isTelemetryEnabled**(): `boolean`
 
-Defined in: [neurolink.ts:3497](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3497)
+Defined in: [neurolink.ts:3498](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3498)
 
 Check if Langfuse telemetry is enabled
 Centralized utility to avoid duplication across providers
@@ -235,7 +235,7 @@ Centralized utility to avoid duplication across providers
 
 > **getTelemetryStatus**(): `object`
 
-Defined in: [neurolink.ts:3509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3509)
+Defined in: [neurolink.ts:3510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3510)
 
 Get comprehensive telemetry status including Langfuse, OTel, and exporter health
 
@@ -289,7 +289,7 @@ Get comprehensive telemetry status including Langfuse, OTel, and exporter health
 
 > **getMetrics**(): [`MetricsSummary`](../type-aliases/MetricsSummary.md)
 
-Defined in: [neurolink.ts:3564](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3564)
+Defined in: [neurolink.ts:3565](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3565)
 
 Get aggregated observability metrics (latency, tokens, cost, success rate)
 
@@ -303,7 +303,7 @@ Get aggregated observability metrics (latency, tokens, cost, success rate)
 
 > **getSpans**(): [`SpanData`](../type-aliases/SpanData.md)[]
 
-Defined in: [neurolink.ts:3571](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3571)
+Defined in: [neurolink.ts:3572](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3572)
 
 Get all recorded spans
 
@@ -317,7 +317,7 @@ Get all recorded spans
 
 > **getTraces**(): [`TraceView`](../type-aliases/TraceView.md)[]
 
-Defined in: [neurolink.ts:3578](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3578)
+Defined in: [neurolink.ts:3579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3579)
 
 Get traces (spans grouped by traceId with parent-child hierarchy)
 
@@ -331,7 +331,7 @@ Get traces (spans grouped by traceId with parent-child hierarchy)
 
 > **resetMetrics**(): `void`
 
-Defined in: [neurolink.ts:3585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3585)
+Defined in: [neurolink.ts:3586](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3586)
 
 Reset all collected metrics and spans
 
@@ -345,7 +345,7 @@ Reset all collected metrics and spans
 
 > **recordMetricsSpan**(`span`): `void`
 
-Defined in: [neurolink.ts:3592](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3592)
+Defined in: [neurolink.ts:3593](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3593)
 
 Record a span for metrics tracking
 
@@ -365,7 +365,7 @@ Record a span for metrics tracking
 
 > **getProviderMetrics**(`options?`): `Promise`\<[`ProviderMetricsResult`](../type-aliases/ProviderMetricsResult.md)\>
 
-Defined in: [neurolink.ts:3603](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3603)
+Defined in: [neurolink.ts:3604](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3604)
 
 Get provider metrics analysis
 Retrieves aggregated performance, token usage, latency, and success rates per provider.
@@ -390,7 +390,7 @@ Comprehensive provider metrics result
 
 > **getCostAnalysis**(`options?`): `Promise`\<[`CostAnalysisResult`](../type-aliases/CostAnalysisResult.md)\>
 
-Defined in: [neurolink.ts:3618](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3618)
+Defined in: [neurolink.ts:3619](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3619)
 
 Get cost analysis breakdown
 Analyzes AI generation costs across requested groups and provides future projections.
@@ -415,7 +415,7 @@ Detailed cost analysis breakdown
 
 > **getTeamAnalytics**(`options?`): `Promise`\<[`TeamAnalyticsResult`](../type-aliases/TeamAnalyticsResult.md)\>
 
-Defined in: [neurolink.ts:3631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3631)
+Defined in: [neurolink.ts:3632](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3632)
 
 Get team-wide usage analytics
 Retrieves request counts, unique active users, provider breakdown, and quality scoring.
@@ -440,7 +440,7 @@ Comprehensive team analytics report
 
 > **initializeLangfuseObservability**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:3673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3673)
+Defined in: [neurolink.ts:3674](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3674)
 
 Public method to initialize Langfuse observability
 This method can be called externally to ensure Langfuse is properly initialized
@@ -455,7 +455,7 @@ This method can be called externally to ensure Langfuse is properly initialized
 
 > **shutdown**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:3703](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3703)
+Defined in: [neurolink.ts:3704](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L3704)
 
 Gracefully shutdown NeuroLink and all MCP connections
 
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6335](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6335)
+Defined in: [neurolink.ts:6358](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6358)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8707](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8707)
+Defined in: [neurolink.ts:8730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8730)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:8790](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8790)
+Defined in: [neurolink.ts:8813](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8813)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9680)
+Defined in: [neurolink.ts:9703](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9703)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9698)
+Defined in: [neurolink.ts:9721](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9721)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12109)
+Defined in: [neurolink.ts:12132](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12132)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12125](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12125)
+Defined in: [neurolink.ts:12148](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12148)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -856,7 +856,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12136](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12136)
+Defined in: [neurolink.ts:12159](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12159)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -874,7 +874,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12147](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12147)
+Defined in: [neurolink.ts:12170](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12170)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -898,7 +898,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12164](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12164)
+Defined in: [neurolink.ts:12187](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12187)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -924,7 +924,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12209](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12209)
+Defined in: [neurolink.ts:12232](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12232)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -976,7 +976,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12288](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12288)
+Defined in: [neurolink.ts:12311](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12311)
 
 Emit tool start event with execution tracking
 
@@ -1012,7 +1012,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12339](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12339)
+Defined in: [neurolink.ts:12362](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12362)
 
 Emit tool end event with execution summary
 
@@ -1064,7 +1064,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12420](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12420)
+Defined in: [neurolink.ts:12443](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12443)
 
 Get current tool execution contexts for stream metadata
 
@@ -1078,7 +1078,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12427](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12427)
+Defined in: [neurolink.ts:12450](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12450)
 
 Get tool execution history
 
@@ -1092,7 +1092,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12434](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12434)
+Defined in: [neurolink.ts:12457](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12457)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1106,7 +1106,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12450](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12450)
+Defined in: [neurolink.ts:12473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12473)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1152,7 +1152,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12591](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12591)
+Defined in: [neurolink.ts:12614](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12614)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1175,7 +1175,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12606](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12606)
+Defined in: [neurolink.ts:12629](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12629)
 
 Get the current tool execution context
 
@@ -1191,7 +1191,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12615](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12615)
+Defined in: [neurolink.ts:12638](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12638)
 
 Clear the tool execution context
 
@@ -1205,7 +1205,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12627](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12627)
+Defined in: [neurolink.ts:12650](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12650)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1230,7 +1230,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12650](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12650)
+Defined in: [neurolink.ts:12673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12673)
 
 Unregister a custom tool
 
@@ -1254,7 +1254,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12668](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12668)
+Defined in: [neurolink.ts:12691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12691)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1279,7 +1279,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:12681](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12681)
+Defined in: [neurolink.ts:12704](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12704)
 
 Get all registered tool middlewares
 
@@ -1293,7 +1293,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12688](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12688)
+Defined in: [neurolink.ts:12711](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12711)
 
 Flush any pending batched tool calls immediately
 
@@ -1307,7 +1307,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12697](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12697)
+Defined in: [neurolink.ts:12720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12720)
 
 Get the current MCP enhancements configuration
 
@@ -1321,7 +1321,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12720)
+Defined in: [neurolink.ts:12743](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12743)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1371,7 +1371,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:12756](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12756)
+Defined in: [neurolink.ts:12779](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12779)
 
 Get all registered custom tools
 
@@ -1387,7 +1387,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12894](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12894)
+Defined in: [neurolink.ts:12917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12917)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1416,7 +1416,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:12938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12938)
+Defined in: [neurolink.ts:12961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12961)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1439,7 +1439,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12965](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12965)
+Defined in: [neurolink.ts:12988](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12988)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1469,7 +1469,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:12981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12981)
+Defined in: [neurolink.ts:13004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13004)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1485,7 +1485,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:12993](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12993)
+Defined in: [neurolink.ts:13016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13016)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1566,7 +1566,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:13997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13997)
+Defined in: [neurolink.ts:14020](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14020)
 
 ##### Returns
 
@@ -1578,7 +1578,7 @@ Defined in: [neurolink.ts:13997](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14179](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14179)
+Defined in: [neurolink.ts:14202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14202)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1601,7 +1601,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14360](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14360)
+Defined in: [neurolink.ts:14383](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14383)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1625,7 +1625,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14392](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14392)
+Defined in: [neurolink.ts:14415](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14415)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1649,7 +1649,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14401)
+Defined in: [neurolink.ts:14424](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14424)
 
 Get list of all available AI provider names
 
@@ -1665,7 +1665,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14411](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14411)
+Defined in: [neurolink.ts:14434](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14434)
 
 Validate if a provider name is supported
 
@@ -1689,7 +1689,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14424](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14424)
+Defined in: [neurolink.ts:14447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14447)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1705,7 +1705,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14494](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14494)
+Defined in: [neurolink.ts:14517](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14517)
 
 List all configured MCP servers with their status
 
@@ -1721,7 +1721,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14509)
+Defined in: [neurolink.ts:14532](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14532)
 
 Test connectivity to a specific MCP server
 
@@ -1745,7 +1745,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14550)
+Defined in: [neurolink.ts:14573](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14573)
 
 Check if a provider has the required environment variables configured
 
@@ -1769,7 +1769,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14576](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14576)
+Defined in: [neurolink.ts:14599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14599)
 
 Perform comprehensive health check on a specific provider
 
@@ -1813,7 +1813,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14622](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14622)
+Defined in: [neurolink.ts:14645](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14645)
 
 Check health of all supported providers
 
@@ -1851,7 +1851,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14666](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14666)
+Defined in: [neurolink.ts:14689](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14689)
 
 Get a summary of provider health across all supported providers
 
@@ -1867,7 +1867,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:14713](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14713)
+Defined in: [neurolink.ts:14736](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14736)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1889,7 +1889,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:14724](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14724)
+Defined in: [neurolink.ts:14747](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14747)
 
 Get execution metrics for all tools
 
@@ -1905,7 +1905,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:14768](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14768)
+Defined in: [neurolink.ts:14791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14791)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1928,7 +1928,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:14781](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14781)
+Defined in: [neurolink.ts:14804](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14804)
 
 Get circuit breaker status for all tools
 
@@ -1944,7 +1944,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:14816](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14816)
+Defined in: [neurolink.ts:14839](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14839)
 
 Reset circuit breaker for a specific tool
 
@@ -1966,7 +1966,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:14833](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14833)
+Defined in: [neurolink.ts:14856](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14856)
 
 Clear all tool execution metrics
 
@@ -1980,7 +1980,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:14842](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14842)
+Defined in: [neurolink.ts:14865](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14865)
 
 Get comprehensive tool health report
 
@@ -1996,7 +1996,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14997)
+Defined in: [neurolink.ts:15020](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15020)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2013,7 +2013,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15017](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15017)
+Defined in: [neurolink.ts:15040](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15040)
 
 Get conversation memory statistics (public API)
 
@@ -2027,7 +2027,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15044](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15044)
+Defined in: [neurolink.ts:15067](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15067)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2051,7 +2051,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15100](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15100)
+Defined in: [neurolink.ts:15123](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15123)
 
 Clear conversation history for a specific session (public API)
 
@@ -2071,7 +2071,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15126](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15126)
+Defined in: [neurolink.ts:15149](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15149)
 
 Clear all conversation history (public API)
 
@@ -2085,7 +2085,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15154)
+Defined in: [neurolink.ts:15177](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15177)
 
 List all conversation sessions with metadata (public API)
 
@@ -2109,7 +2109,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15203](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15203)
+Defined in: [neurolink.ts:15226](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15226)
 
 Export a single session with full history and metadata (public API)
 
@@ -2145,7 +2145,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15288](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15288)
+Defined in: [neurolink.ts:15311](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15311)
 
 Export all sessions for a user (public API)
 
@@ -2181,7 +2181,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15352](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15352)
+Defined in: [neurolink.ts:15375](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15375)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2229,7 +2229,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15422](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15422)
+Defined in: [neurolink.ts:15445](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15445)
 
 Check if tool execution storage is available.
 
@@ -2250,7 +2250,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15432](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15432)
+Defined in: [neurolink.ts:15455](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15455)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2279,7 +2279,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15473)
+Defined in: [neurolink.ts:15496](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15496)
 
 Replace the entire messages array for a session.
 
@@ -2313,7 +2313,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15521](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15521)
+Defined in: [neurolink.ts:15544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15544)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2350,7 +2350,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15552)
+Defined in: [neurolink.ts:15575](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15575)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2381,7 +2381,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15639](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15639)
+Defined in: [neurolink.ts:15662](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15662)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2406,7 +2406,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:15691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15691)
+Defined in: [neurolink.ts:15714](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15714)
 
 List all external MCP servers
 
@@ -2422,7 +2422,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:15720](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15720)
+Defined in: [neurolink.ts:15743](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15743)
 
 Get external MCP server status
 
@@ -2446,7 +2446,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:15734](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15734)
+Defined in: [neurolink.ts:15757](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15757)
 
 Execute a tool from an external MCP server
 
@@ -2490,7 +2490,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15831](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15831)
+Defined in: [neurolink.ts:15854](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15854)
 
 Get all tools from external MCP servers
 
@@ -2506,7 +2506,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15840](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15840)
+Defined in: [neurolink.ts:15863](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15863)
 
 Get tools from a specific external MCP server
 
@@ -2530,7 +2530,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:15849](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15849)
+Defined in: [neurolink.ts:15872](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15872)
 
 Test connection to an external MCP server
 
@@ -2554,7 +2554,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:15877](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15877)
+Defined in: [neurolink.ts:15900](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15900)
 
 Get external MCP server manager statistics
 
@@ -2594,7 +2594,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15892](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15892)
+Defined in: [neurolink.ts:15915](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15915)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2609,7 +2609,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15930](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15930)
+Defined in: [neurolink.ts:15953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15953)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2640,7 +2640,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15958](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15958)
+Defined in: [neurolink.ts:15981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15981)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2678,7 +2678,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:15981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15981)
+Defined in: [neurolink.ts:16004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16004)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2707,7 +2707,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16006](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16006)
+Defined in: [neurolink.ts:16029](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16029)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2737,7 +2737,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16033](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16033)
+Defined in: [neurolink.ts:16056](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16056)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2769,7 +2769,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16061](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16061)
+Defined in: [neurolink.ts:16084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16084)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2846,7 +2846,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16102](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16102)
+Defined in: [neurolink.ts:16125](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16125)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2927,7 +2927,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16141](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16141)
+Defined in: [neurolink.ts:16164](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16164)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -2957,7 +2957,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16163](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16163)
+Defined in: [neurolink.ts:16186](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16186)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -2998,7 +2998,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16202)
+Defined in: [neurolink.ts:16225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16225)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3039,7 +3039,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16225)
+Defined in: [neurolink.ts:16248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16248)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3071,7 +3071,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16464](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16464)
+Defined in: [neurolink.ts:16487](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16487)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3122,7 +3122,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:16556](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16556)
+Defined in: [neurolink.ts:16579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16579)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3224,7 +3224,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:16694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16694)
+Defined in: [neurolink.ts:16717](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16717)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3293,7 +3293,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:16780](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16780)
+Defined in: [neurolink.ts:16803](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16803)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3354,7 +3354,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:16826](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16826)
+Defined in: [neurolink.ts:16849](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16849)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3380,7 +3380,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:16849](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16849)
+Defined in: [neurolink.ts:16872](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16872)
 
 Get details of a specific evaluation preset.
 
@@ -3416,7 +3416,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:16899](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16899)
+Defined in: [neurolink.ts:16922](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16922)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3468,7 +3468,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:16961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16961)
+Defined in: [neurolink.ts:16984](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16984)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3542,7 +3542,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:16993](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16993)
+Defined in: [neurolink.ts:17016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17016)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3582,7 +3582,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17082](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17082)
+Defined in: [neurolink.ts:17105](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17105)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3632,7 +3632,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17101](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17101)
+Defined in: [neurolink.ts:17124](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17124)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3665,7 +3665,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17117)
+Defined in: [neurolink.ts:17140](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17140)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3690,7 +3690,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17135](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17135)
+Defined in: [neurolink.ts:17158](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17158)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3728,7 +3728,7 @@ The registered tool name
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:17157](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17157)
+Defined in: [neurolink.ts:17180](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17180)
 
 Execute an agent network with the given input.
 
@@ -3773,7 +3773,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:17181](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17181)
+Defined in: [neurolink.ts:17204](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17204)
 
 Stream agent network execution with real-time events.
 
@@ -3817,7 +3817,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:17205](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17205)
+Defined in: [neurolink.ts:17228](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17228)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -3845,7 +3845,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:17224](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17224)
+Defined in: [neurolink.ts:17247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17247)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -3873,7 +3873,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:17242](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17242)
+Defined in: [neurolink.ts:17265](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17265)
 
 Create a MessageBus for inter-agent communication.
 
@@ -3901,7 +3901,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17257](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17257)
+Defined in: [neurolink.ts:17280](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17280)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -3917,7 +3917,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:17444](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17444)
+Defined in: [neurolink.ts:17467](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17467)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -3934,7 +3934,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:17452](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17452)
+Defined in: [neurolink.ts:17475](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17475)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -3959,7 +3959,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:17503](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17503)
+Defined in: [neurolink.ts:17526](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17526)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -3988,7 +3988,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:17545](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17545)
+Defined in: [neurolink.ts:17568](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17568)
 
 Check if a session needs compaction.
 
@@ -4016,7 +4016,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17582](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17582)
+Defined in: [neurolink.ts:17605](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17605)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4038,7 +4038,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:17630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17630)
+Defined in: [neurolink.ts:17653](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17653)
 
 Get the currently configured authentication provider
 
@@ -4052,7 +4052,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17671](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17671)
+Defined in: [neurolink.ts:17694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17694)
 
 Set the current authentication context for request handling.
 
@@ -4079,7 +4079,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:17686](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17686)
+Defined in: [neurolink.ts:17709](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17709)
 
 Get the current authentication context.
 
@@ -4095,7 +4095,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17694)
+Defined in: [neurolink.ts:17717](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17717)
 
 Clear the current authentication context
 
@@ -4109,7 +4109,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:17708](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17708)
+Defined in: [neurolink.ts:17731](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17731)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -445,6 +445,67 @@ export class ModelsCommandFactory {
         models = models.filter((model) => !model.deprecated);
       }
 
+      // Live-discovery fallback: providers that resolve their catalog at
+      // runtime (litellm, ollama, openai-compatible gateways) have no static
+      // registry rows, so a scoped `models list --provider litellm` printed
+      // "Found 0 models" while generate/stream against those models worked.
+      // When the static registry is empty for a single requested provider,
+      // ask the provider itself.
+      if (
+        models.length === 0 &&
+        argv.provider &&
+        (Array.isArray(argv.provider) ? argv.provider : [argv.provider])
+          .length === 1
+      ) {
+        const providerName = String(
+          Array.isArray(argv.provider) ? argv.provider[0] : argv.provider,
+        );
+        try {
+          const { AIProviderFactory } =
+            await import("../../lib/core/factory.js");
+          const provider = (await AIProviderFactory.createProvider(
+            providerName,
+          )) as { getAvailableModels?: () => Promise<string[]> };
+          const liveIds =
+            typeof provider.getAvailableModels === "function"
+              ? await provider.getAvailableModels()
+              : [];
+          if (liveIds.length > 0) {
+            if (spinner) {
+              spinner.succeed(
+                `Found ${liveIds.length} models (live from ${providerName})`,
+              );
+            }
+            if (argv.format === "json") {
+              logger.always(
+                JSON.stringify(
+                  liveIds.map((id) => ({
+                    id,
+                    provider: providerName,
+                    source: "live",
+                  })),
+                  null,
+                  2,
+                ),
+              );
+            } else {
+              logger.always(
+                chalk.bold(
+                  `\n📋 Models exposed by ${providerName} (live discovery):\n`,
+                ),
+              );
+              for (const id of liveIds) {
+                logger.always(`  ${id}`);
+              }
+            }
+            return;
+          }
+        } catch {
+          // Live discovery is best-effort — fall through to the static
+          // (empty) listing rather than turning a listing into an error.
+        }
+      }
+
       if (spinner) {
         spinner.succeed(`Found ${models.length} models`);
       }

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -2,6 +2,7 @@ import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { directAgentTools } from "../agent/directTools.js";
 import type { AIProviderName } from "../constants/enums.js";
 import { defaultProviderFor } from "../factories/mediaHandlerCatalog.js";
+import { PROVIDER_DESCRIPTORS_BY_NAME } from "../factories/providerDescriptors.js";
 import type { EvaluationData } from "../index.js";
 import { MiddlewareFactory } from "../middleware/factory.js";
 import { modelSupports } from "../models/modelRegistry.js";
@@ -1744,14 +1745,26 @@ export abstract class BaseProvider implements AIProvider {
     messages: ModelMessage[],
     tools: Record<string, Tool>,
   ): Promise<EnhancedGenerateResult> {
-    // Apply a defensive default timeout (3 min) when the caller didn't pass
-    // one. Without this guard, AI SDK's generateText() will wait forever on
+    // Apply a defensive default timeout when the caller didn't pass one.
+    // Without this guard, AI SDK's generateText() will wait forever on
     // an upstream that accepts the connection but never produces a response
     // (observed against the litellm gateway when a request triggers the
     // team-access denial path — connection stays open, no response is sent,
     // and the matrix test hangs the entire suite). Callers can still pass
     // a larger value (e.g. video generation passes 10 min).
-    const effectiveTimeout = options.timeout ?? 180_000;
+    //
+    // A provider descriptor may declare a LARGER generate budget than the
+    // 3-min floor (litellm: 300s — slow proxied models routinely need more
+    // than 180s end-to-end even while streaming). The declared value only
+    // ever raises the default, never lowers it: several descriptors carry
+    // aspirational sub-180s numbers (openai 30s, bedrock 45s) that were
+    // never enforced on this path, and enforcing them now would break
+    // long-running generations that have always been allowed.
+    const descriptorGenerateMs = PROVIDER_DESCRIPTORS_BY_NAME.get(
+      this.providerName,
+    )?.timeouts?.generateMs;
+    const effectiveTimeout =
+      options.timeout ?? Math.max(descriptorGenerateMs ?? 0, 180_000);
     const timeoutController = createTimeoutController(
       effectiveTimeout,
       this.providerName,

--- a/src/lib/core/modules/GenerationHandler.ts
+++ b/src/lib/core/modules/GenerationHandler.ts
@@ -1053,7 +1053,10 @@ export class GenerationHandler {
             toolsUsed.push(toolName);
 
             let callArgs: StandardRecord = {};
-            if (tcRecord.args) {
+            if (tcRecord.input) {
+              // AI SDK v6 carries tool-call arguments as `input`.
+              callArgs = tcRecord.input as StandardRecord;
+            } else if (tcRecord.args) {
               callArgs = tcRecord.args as StandardRecord;
             } else if (tcRecord.arguments) {
               callArgs = tcRecord.arguments as StandardRecord;

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -325,6 +325,7 @@ import { ModelPool, classifyProviderError } from "./routing/index.js";
 import { ClassifierRouter } from "./routing/classifierRouter.js";
 import {
   looksLikeModelAccessDenied as sharedLooksLikeModelAccessDenied,
+  looksLikeModelNotFound as sharedLooksLikeModelNotFound,
   isNonRetryableProviderError as sharedIsNonRetryableProviderError,
   isNonRetryableForPool as sharedIsNonRetryableForPool,
 } from "./utils/providerErrorClassification.js";
@@ -4302,6 +4303,23 @@ Current user's request: ${currentInput}`;
     // String prompts are immutable, so they pass through.
     if (typeof optionsOrPrompt !== "string") {
       optionsOrPrompt = cloneOptionsForCallIsolation(optionsOrPrompt);
+      // The deprecated `conversationHistory` field is not wired into message
+      // building — messages passed there never reach the model, which reads
+      // as "the SDK forgot my context" rather than a caller bug. Warn loudly
+      // instead of failing silently; `conversationMessages` is the wired path.
+      const legacyOpts = optionsOrPrompt as {
+        conversationHistory?: unknown[];
+        conversationMessages?: unknown[];
+      };
+      if (
+        Array.isArray(legacyOpts.conversationHistory) &&
+        legacyOpts.conversationHistory.length > 0 &&
+        !legacyOpts.conversationMessages
+      ) {
+        logger.warn(
+          "[NeuroLink.generate] `conversationHistory` is deprecated and NOT passed to the model — use `conversationMessages` (ChatMessage[]) instead.",
+        );
+      }
     }
     // Retrieve once at the public call boundary so fallback attempts reuse the
     // same grounding block and internal preparation cannot inject it twice.
@@ -4501,10 +4519,15 @@ Current user's request: ${currentInput}`;
     // by-reference, so the retried options observe the same signal.
     const callerAborted = (): boolean =>
       (callOpts.abortSignal as AbortSignal | undefined)?.aborted === true;
+    // modelChain-only orchestration advances on two error shapes the next
+    // member can actually fix: access-denied (the original gate) and
+    // model-not-found ("Invalid model name" from a gateway that doesn't
+    // serve that member — a chain written for one LiteLLM deployment must
+    // not hard-fail on another just because a member is absent there).
     const shouldOrchestrateFallback = (err: unknown): boolean =>
       effectiveCallback
         ? !(isAbortError(err) && callerAborted())
-        : looksLikeModelAccessDenied(err);
+        : looksLikeModelAccessDenied(err) || sharedLooksLikeModelNotFound(err);
 
     if (!shouldOrchestrateFallback(lastError)) {
       throw lastError;

--- a/src/lib/providers/litellm/client.ts
+++ b/src/lib/providers/litellm/client.ts
@@ -477,9 +477,12 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
       {
         match: (ctx) => /ECONNREFUSED|Failed to fetch/.test(ctx.message),
         errorClass: NetworkError,
+        // Name the base URL this instance actually dialed — per-request
+        // credentials can override LITELLM_BASE_URL, and an error pointing
+        // at the env value sends the caller debugging the wrong host.
         message: () =>
           "LiteLLM proxy server not available. Please start the LiteLLM proxy server at " +
-          `${process.env.LITELLM_BASE_URL || "http://localhost:4000"}`,
+          redactUrlCredentials(this.config.baseURL),
       },
       {
         match: (ctx) => /API_KEY_INVALID|Invalid API key/.test(ctx.message),
@@ -548,7 +551,12 @@ export class LiteLLMProvider extends OpenAIChatCompletionsProvider {
   }
 
   private async fetchModelsFromAPI(): Promise<string[]> {
-    const modelsUrl = `${stripTrailingSlash(this.config.baseURL)}/v1/models`;
+    // Tolerate a `/v1`-suffixed base URL. Chat appends /chat/completions, so
+    // deployments are commonly configured with base = https://host/v1 — but
+    // appending /v1/models to that yields /v1/v1/models, which LiteLLM 404s,
+    // and discovery silently degrades to the hardcoded fallback list.
+    const root = stripTrailingSlash(this.config.baseURL).replace(/\/v1$/, "");
+    const modelsUrl = `${root}/v1/models`;
     const proxyFetch = createProxyFetch();
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);

--- a/src/lib/utils/providerErrorClassification.ts
+++ b/src/lib/utils/providerErrorClassification.ts
@@ -84,7 +84,11 @@ export function looksLikeModelNotFound(error: unknown): boolean {
       lower.includes("not_found_error") ||
       msg.includes("NOT_FOUND") ||
       lower.includes("does not exist") ||
-      lower.includes("unknown model")) &&
+      lower.includes("unknown model") ||
+      // LiteLLM's phrasing for a model id its router doesn't serve — a 400,
+      // not a 404: "Invalid model name passed in model=... Call `/v1/models`
+      // to view available models for your key."
+      lower.includes("invalid model name")) &&
     namesAModel
   );
 }

--- a/src/lib/utils/providerHealth.ts
+++ b/src/lib/utils/providerHealth.ts
@@ -1104,15 +1104,37 @@ export class ProviderHealthChecker {
       return;
     }
 
-    const availability = await this.checkLiteLLMAvailability({
-      model: this.getConfiguredLiteLLMModel(),
-      timeout,
-    });
+    // Only pin the availability check to a specific model when the user
+    // explicitly configured one. The fallback default ("openai/gpt-4o-mini")
+    // is a guess, not configuration — proxies that serve a different model
+    // set (every self-hosted gateway) were reported "Not configured" here
+    // while generate/stream against them worked fine with explicit models.
+    const configuredModel = process.env.LITELLM_MODEL;
+    let failureReason: string | undefined;
+    if (configuredModel) {
+      const availability = await this.checkLiteLLMAvailability({
+        model: configuredModel,
+        timeout,
+      });
+      if (!availability.available) {
+        failureReason = availability.reason ?? "unknown error";
+      }
+    } else {
+      // No configured model: a reachable proxy with any models counts.
+      try {
+        const models = await this.getLiteLLMAvailableModels(timeout);
+        if (models.length === 0) {
+          failureReason = "LiteLLM returned an empty model list";
+        }
+      } catch (error) {
+        failureReason = error instanceof Error ? error.message : String(error);
+      }
+    }
 
-    if (!availability.available) {
+    if (failureReason !== undefined) {
       healthStatus.isConfigured = false;
       healthStatus.configurationIssues.push(
-        `LiteLLM runtime check failed: ${availability.reason ?? "unknown error"}`,
+        `LiteLLM runtime check failed: ${failureReason}`,
       );
       healthStatus.recommendations.push(
         "Start the LiteLLM proxy and ensure the configured model is available from /v1/models",


### PR DESCRIPTION
## Summary
Eight fixes closing the gateway-portability gaps found while e2e-testing NeuroLink against a self-hosted LiteLLM gateway (grid.breezehq.dev) — full evidence in the test report artifact linked below.

- **Generate default timeout honors the descriptor**: `baseProvider` hard-coded `timeout ?? 180_000`, never consulting `providerDescriptors`' `generateMs`; litellm declares 300s. The declared value now raises the default (never lowers it — several descriptors carry aspirational sub-180s values that were never enforced).
- **Model-chain fall-through on "Invalid model name"**: a bare `modelChain` only advanced on access-denied errors; a member simply absent on a gateway (LiteLLM 400 "Invalid model name passed in model=…") hard-failed the whole call. `looksLikeModelNotFound` now recognizes the LiteLLM phrasing and the chain-only gate accepts it. Verified live walking two dead members to success.
- **`conversationHistory` deprecation warning**: the deprecated field is silently unwired; passing it now logs a WARN pointing at `conversationMessages`.
- **`provider status` false-negative**: litellm health was pinned to the default-model guess (`openai/gpt-4o-mini` present on the proxy); a reachable proxy with models now counts as configured unless `LITELLM_MODEL` is explicitly set and absent.
- **Live `models list` fallback**: a single requested provider with zero static-catalog rows now falls back to the provider's own `getAvailableModels()` (the litellm case: 9 live models vs "Found 0 models").
- **AI SDK v6 tool-args mapping**: step tool-calls carry args as `input` in v6; the extraction never read it, so `toolExecutions[].params` came back `{}`.
- **Unreachable-proxy error names the effective base URL** (per-request `credentials.litellm.baseURL` override), not the env var.
- **`/v1`-suffixed `LITELLM_BASE_URL` tolerated in model discovery**: discovery appended `/v1/models` to the base, so a `/v1` base yielded `/v1/v1/models` → 404 → silent hardcoded fallback list.

## Test plan
- `pnpm run check` clean · `pnpm run lint` 0 errors · `pnpm run build` clean (publint "All good")
- Pre-push gate green: `check:deps`, build, `test:provider-structure` 3/3, `test:model-manifests` 14/14
- `test:providers-mocked` 67/67, live capability matrix vs the gateway 4/4 (generate/stream/tools/structured)
- Every fix validated live against grid.breezehq.dev; full recorded evidence: https://claude.ai/code/artifact/f19e6955-abec-47bd-a6c9-d647266b695a
