### PR TITLE
fix(core): honor inline conversationMessages on the MCP path and real RAG embeddings

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8751](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8751)
+Defined in: [neurolink.ts:8758](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8758)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:8834](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8834)
+Defined in: [neurolink.ts:8841](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8841)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9726](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9726)
+Defined in: [neurolink.ts:9733](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9733)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9744](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9744)
+Defined in: [neurolink.ts:9751](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9751)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12159](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12159)
+Defined in: [neurolink.ts:12166](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12166)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12175](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12175)
+Defined in: [neurolink.ts:12182](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12182)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -856,7 +856,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12186](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12186)
+Defined in: [neurolink.ts:12193](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12193)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -874,7 +874,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12197](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12197)
+Defined in: [neurolink.ts:12204](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12204)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -898,7 +898,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12214](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12214)
+Defined in: [neurolink.ts:12221](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12221)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -924,7 +924,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12259](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12259)
+Defined in: [neurolink.ts:12266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12266)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -976,7 +976,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12338](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12338)
+Defined in: [neurolink.ts:12345](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12345)
 
 Emit tool start event with execution tracking
 
@@ -1012,7 +1012,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12389](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12389)
+Defined in: [neurolink.ts:12396](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12396)
 
 Emit tool end event with execution summary
 
@@ -1064,7 +1064,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12470)
+Defined in: [neurolink.ts:12477](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12477)
 
 Get current tool execution contexts for stream metadata
 
@@ -1078,7 +1078,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12477](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12477)
+Defined in: [neurolink.ts:12484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12484)
 
 Get tool execution history
 
@@ -1092,7 +1092,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12484)
+Defined in: [neurolink.ts:12491](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12491)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1106,7 +1106,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12500](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12500)
+Defined in: [neurolink.ts:12507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12507)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1152,7 +1152,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12641](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12641)
+Defined in: [neurolink.ts:12648](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12648)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1175,7 +1175,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12656](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12656)
+Defined in: [neurolink.ts:12663](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12663)
 
 Get the current tool execution context
 
@@ -1191,7 +1191,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12665](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12665)
+Defined in: [neurolink.ts:12672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12672)
 
 Clear the tool execution context
 
@@ -1205,7 +1205,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12677](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12677)
+Defined in: [neurolink.ts:12684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12684)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1230,7 +1230,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12700](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12700)
+Defined in: [neurolink.ts:12707](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12707)
 
 Unregister a custom tool
 
@@ -1254,7 +1254,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12718](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12718)
+Defined in: [neurolink.ts:12725](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12725)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1279,7 +1279,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:12731](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12731)
+Defined in: [neurolink.ts:12738](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12738)
 
 Get all registered tool middlewares
 
@@ -1293,7 +1293,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12738](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12738)
+Defined in: [neurolink.ts:12745](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12745)
 
 Flush any pending batched tool calls immediately
 
@@ -1307,7 +1307,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12747](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12747)
+Defined in: [neurolink.ts:12754](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12754)
 
 Get the current MCP enhancements configuration
 
@@ -1321,7 +1321,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12770](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12770)
+Defined in: [neurolink.ts:12777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12777)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1371,7 +1371,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:12806](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12806)
+Defined in: [neurolink.ts:12813](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12813)
 
 Get all registered custom tools
 
@@ -1387,7 +1387,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:12944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12944)
+Defined in: [neurolink.ts:12951](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12951)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1416,7 +1416,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:12988](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12988)
+Defined in: [neurolink.ts:12995](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12995)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1439,7 +1439,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13015](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13015)
+Defined in: [neurolink.ts:13022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13022)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1469,7 +1469,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13031](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13031)
+Defined in: [neurolink.ts:13038](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13038)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1485,7 +1485,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13043](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13043)
+Defined in: [neurolink.ts:13050](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13050)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1566,7 +1566,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14073](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14073)
+Defined in: [neurolink.ts:14080](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14080)
 
 ##### Returns
 
@@ -1578,7 +1578,7 @@ Defined in: [neurolink.ts:14073](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14255](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14255)
+Defined in: [neurolink.ts:14262](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14262)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1601,7 +1601,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14436](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14436)
+Defined in: [neurolink.ts:14443](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14443)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1625,7 +1625,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14468](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14468)
+Defined in: [neurolink.ts:14475](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14475)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1649,7 +1649,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14477](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14477)
+Defined in: [neurolink.ts:14484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14484)
 
 Get list of all available AI provider names
 
@@ -1665,7 +1665,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14487](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14487)
+Defined in: [neurolink.ts:14494](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14494)
 
 Validate if a provider name is supported
 
@@ -1689,7 +1689,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14500](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14500)
+Defined in: [neurolink.ts:14507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14507)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1705,7 +1705,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14570)
+Defined in: [neurolink.ts:14577](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14577)
 
 List all configured MCP servers with their status
 
@@ -1721,7 +1721,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14585)
+Defined in: [neurolink.ts:14592](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14592)
 
 Test connectivity to a specific MCP server
 
@@ -1745,7 +1745,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14626](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14626)
+Defined in: [neurolink.ts:14633](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14633)
 
 Check if a provider has the required environment variables configured
 
@@ -1769,7 +1769,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14652](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14652)
+Defined in: [neurolink.ts:14659](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14659)
 
 Perform comprehensive health check on a specific provider
 
@@ -1813,7 +1813,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14698)
+Defined in: [neurolink.ts:14705](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14705)
 
 Check health of all supported providers
 
@@ -1851,7 +1851,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14742](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14742)
+Defined in: [neurolink.ts:14749](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14749)
 
 Get a summary of provider health across all supported providers
 
@@ -1867,7 +1867,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:14789](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14789)
+Defined in: [neurolink.ts:14796](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14796)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1889,7 +1889,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:14800](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14800)
+Defined in: [neurolink.ts:14807](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14807)
 
 Get execution metrics for all tools
 
@@ -1905,7 +1905,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:14844](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14844)
+Defined in: [neurolink.ts:14851](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14851)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1928,7 +1928,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:14857](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14857)
+Defined in: [neurolink.ts:14864](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14864)
 
 Get circuit breaker status for all tools
 
@@ -1944,7 +1944,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:14892](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14892)
+Defined in: [neurolink.ts:14899](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14899)
 
 Reset circuit breaker for a specific tool
 
@@ -1966,7 +1966,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:14909](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14909)
+Defined in: [neurolink.ts:14916](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14916)
 
 Clear all tool execution metrics
 
@@ -1980,7 +1980,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:14918](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14918)
+Defined in: [neurolink.ts:14925](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14925)
 
 Get comprehensive tool health report
 
@@ -1996,7 +1996,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15073](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15073)
+Defined in: [neurolink.ts:15080](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15080)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2013,7 +2013,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15093](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15093)
+Defined in: [neurolink.ts:15100](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15100)
 
 Get conversation memory statistics (public API)
 
@@ -2027,7 +2027,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15120](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15120)
+Defined in: [neurolink.ts:15127](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15127)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2051,7 +2051,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15176](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15176)
+Defined in: [neurolink.ts:15183](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15183)
 
 Clear conversation history for a specific session (public API)
 
@@ -2071,7 +2071,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15202)
+Defined in: [neurolink.ts:15209](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15209)
 
 Clear all conversation history (public API)
 
@@ -2085,7 +2085,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15230](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15230)
+Defined in: [neurolink.ts:15237](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15237)
 
 List all conversation sessions with metadata (public API)
 
@@ -2109,7 +2109,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15279](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15279)
+Defined in: [neurolink.ts:15286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15286)
 
 Export a single session with full history and metadata (public API)
 
@@ -2145,7 +2145,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15364](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15364)
+Defined in: [neurolink.ts:15371](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15371)
 
 Export all sessions for a user (public API)
 
@@ -2181,7 +2181,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15428](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15428)
+Defined in: [neurolink.ts:15435](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15435)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2229,7 +2229,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15498](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15498)
+Defined in: [neurolink.ts:15505](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15505)
 
 Check if tool execution storage is available.
 
@@ -2250,7 +2250,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15508)
+Defined in: [neurolink.ts:15515](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15515)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2279,7 +2279,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15549](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15549)
+Defined in: [neurolink.ts:15556](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15556)
 
 Replace the entire messages array for a session.
 
@@ -2313,7 +2313,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15597](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15597)
+Defined in: [neurolink.ts:15604](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15604)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2350,7 +2350,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15628](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15628)
+Defined in: [neurolink.ts:15635](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15635)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2381,7 +2381,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15715](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15715)
+Defined in: [neurolink.ts:15722](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15722)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2406,7 +2406,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:15767](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15767)
+Defined in: [neurolink.ts:15774](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15774)
 
 List all external MCP servers
 
@@ -2422,7 +2422,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:15796](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15796)
+Defined in: [neurolink.ts:15803](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15803)
 
 Get external MCP server status
 
@@ -2446,7 +2446,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:15810](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15810)
+Defined in: [neurolink.ts:15817](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15817)
 
 Execute a tool from an external MCP server
 
@@ -2490,7 +2490,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15922](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15922)
+Defined in: [neurolink.ts:15929](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15929)
 
 Get all tools from external MCP servers
 
@@ -2506,7 +2506,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:15931](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15931)
+Defined in: [neurolink.ts:15938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15938)
 
 Get tools from a specific external MCP server
 
@@ -2530,7 +2530,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:15940](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15940)
+Defined in: [neurolink.ts:15947](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15947)
 
 Test connection to an external MCP server
 
@@ -2554,7 +2554,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:15968](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15968)
+Defined in: [neurolink.ts:15975](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15975)
 
 Get external MCP server manager statistics
 
@@ -2594,7 +2594,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15983](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15983)
+Defined in: [neurolink.ts:15990](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15990)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2609,7 +2609,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16021](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16021)
+Defined in: [neurolink.ts:16028](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16028)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2640,7 +2640,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16049](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16049)
+Defined in: [neurolink.ts:16056](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16056)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2678,7 +2678,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16072](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16072)
+Defined in: [neurolink.ts:16079](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16079)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2707,7 +2707,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16097](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16097)
+Defined in: [neurolink.ts:16104](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16104)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2737,7 +2737,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16124](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16124)
+Defined in: [neurolink.ts:16131](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16131)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2769,7 +2769,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16152](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16152)
+Defined in: [neurolink.ts:16159](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16159)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2846,7 +2846,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16193](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16193)
+Defined in: [neurolink.ts:16200](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16200)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2927,7 +2927,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16232](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16232)
+Defined in: [neurolink.ts:16239](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16239)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -2957,7 +2957,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16254](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16254)
+Defined in: [neurolink.ts:16261](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16261)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -2998,7 +2998,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16293](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16293)
+Defined in: [neurolink.ts:16300](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16300)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3039,7 +3039,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16316](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16316)
+Defined in: [neurolink.ts:16323](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16323)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3071,7 +3071,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16555](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16555)
+Defined in: [neurolink.ts:16562](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16562)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3122,7 +3122,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:16647](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16647)
+Defined in: [neurolink.ts:16654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16654)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3224,7 +3224,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:16785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16785)
+Defined in: [neurolink.ts:16792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16792)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3293,7 +3293,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:16871](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16871)
+Defined in: [neurolink.ts:16878](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16878)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3354,7 +3354,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:16917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16917)
+Defined in: [neurolink.ts:16924](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16924)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3380,7 +3380,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:16940](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16940)
+Defined in: [neurolink.ts:16947](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16947)
 
 Get details of a specific evaluation preset.
 
@@ -3416,7 +3416,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:16990](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16990)
+Defined in: [neurolink.ts:16997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16997)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3468,7 +3468,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17052](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17052)
+Defined in: [neurolink.ts:17059](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17059)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3542,7 +3542,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17084)
+Defined in: [neurolink.ts:17091](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17091)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3582,7 +3582,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17173](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17173)
+Defined in: [neurolink.ts:17180](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17180)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3632,7 +3632,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17192](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17192)
+Defined in: [neurolink.ts:17199](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17199)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3665,7 +3665,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17208](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17208)
+Defined in: [neurolink.ts:17215](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17215)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3690,7 +3690,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17226](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17226)
+Defined in: [neurolink.ts:17233](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17233)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3728,7 +3728,7 @@ The registered tool name
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:17248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17248)
+Defined in: [neurolink.ts:17255](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17255)
 
 Execute an agent network with the given input.
 
@@ -3773,7 +3773,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:17272](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17272)
+Defined in: [neurolink.ts:17279](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17279)
 
 Stream agent network execution with real-time events.
 
@@ -3817,7 +3817,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:17296](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17296)
+Defined in: [neurolink.ts:17303](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17303)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -3845,7 +3845,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:17315](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17315)
+Defined in: [neurolink.ts:17322](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17322)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -3873,7 +3873,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:17333](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17333)
+Defined in: [neurolink.ts:17340](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17340)
 
 Create a MessageBus for inter-agent communication.
 
@@ -3901,7 +3901,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17348](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17348)
+Defined in: [neurolink.ts:17355](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17355)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -3917,7 +3917,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:17535](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17535)
+Defined in: [neurolink.ts:17542](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17542)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -3934,7 +3934,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:17543](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17543)
+Defined in: [neurolink.ts:17550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17550)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -3959,7 +3959,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:17594](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17594)
+Defined in: [neurolink.ts:17601](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17601)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -3988,7 +3988,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:17636](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17636)
+Defined in: [neurolink.ts:17643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17643)
 
 Check if a session needs compaction.
 
@@ -4016,7 +4016,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17673)
+Defined in: [neurolink.ts:17680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17680)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4038,7 +4038,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:17721](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17721)
+Defined in: [neurolink.ts:17728](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17728)
 
 Get the currently configured authentication provider
 
@@ -4052,7 +4052,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17762](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17762)
+Defined in: [neurolink.ts:17769](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17769)
 
 Set the current authentication context for request handling.
 
@@ -4079,7 +4079,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:17777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17777)
+Defined in: [neurolink.ts:17784](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17784)
 
 Get the current authentication context.
 
@@ -4095,7 +4095,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:17785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17785)
+Defined in: [neurolink.ts:17792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17792)
 
 Clear the current authentication context
 
@@ -4109,7 +4109,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:17799](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17799)
+Defined in: [neurolink.ts:17806](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17806)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -7560,10 +7560,17 @@ Current user's request: ${currentInput}`;
       hasCustomSystemPrompt: !!options.systemPrompt,
     });
 
-    const conversationMessages = (await getConversationMessages(
-      this.conversationMemory,
-      options,
-    )) as ChatMessage[];
+    // Caller-supplied conversationMessages win — mirroring
+    // directProviderGeneration. getConversationMessages() returns [] whenever
+    // no memory manager / session context is configured, which silently
+    // dropped an inline history on the MCP-first path (the default path for
+    // any bare `new NeuroLink()` with tools enabled) while the direct path
+    // honored it.
+    const conversationMessages = (
+      (options as TextGenerationOptions).conversationMessages?.length
+        ? (options as TextGenerationOptions).conversationMessages
+        : await getConversationMessages(this.conversationMemory, options)
+    ) as ChatMessage[];
     this.logMCPConversationSummary(requestId, conversationMessages);
 
     logger.debug("[Observability] Available tools for LLM", {

--- a/src/lib/rag/ragIntegration.ts
+++ b/src/lib/rag/ragIntegration.ts
@@ -313,9 +313,62 @@ async function _prepareRAGToolInner(
   const vectorStore = new InMemoryVectorStore();
   const indexName = "rag-index";
 
+  // When the caller configured an embedding provider/model, embed BOTH the
+  // index chunks and (below) the queries through that provider — previously
+  // those config fields had no runtime effect and retrieval always used the
+  // deterministic hash embedding, which is a lexical fingerprint rather than
+  // a semantic space. Index and query must share one embedding space, so the
+  // provider path replaces the hash path wholesale; any provider failure
+  // falls back to the hash for both sides.
+  const wantProviderEmbeddings = Boolean(embeddingProvider || embeddingModel);
+  const embedProviderName = embeddingProvider || fallbackProvider || "vertex";
+  const embedModelName = embeddingModel || "gemini-2.5-flash";
+  let embedFn = (text: string): Promise<number[]> =>
+    Promise.resolve(generateSimpleEmbedding(text, EMBEDDING_DIMENSION));
+  if (wantProviderEmbeddings) {
+    try {
+      const { AIProviderFactory } = await import("../core/factory.js");
+      const embedderProvider = (await AIProviderFactory.createProvider(
+        embedProviderName,
+        embedModelName,
+      )) as { embed?: (text: string, model?: string) => Promise<number[]> };
+      if (typeof embedderProvider.embed === "function") {
+        const providerEmbed = embedderProvider.embed.bind(embedderProvider);
+        embedFn = (text: string) => providerEmbed(text, embedModelName);
+      } else {
+        logger.warn(
+          `[RAG] Embedding provider '${embedProviderName}' has no embed(); falling back to hash embeddings`,
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        "[RAG] Failed to create embedding provider; falling back to hash embeddings",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    }
+  }
+
+  let chunkVectors: number[][];
+  try {
+    chunkVectors = await Promise.all(
+      allChunks.map((chunk) => embedFn(chunk.text)),
+    );
+  } catch (error) {
+    // One failed chunk must not leave a mixed-space index — flip the whole
+    // index AND all queries back to the hash space together.
+    logger.warn(
+      "[RAG] Provider embedding failed mid-index; falling back to hash embeddings for index and queries",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+    embedFn = (text: string) =>
+      Promise.resolve(generateSimpleEmbedding(text, EMBEDDING_DIMENSION));
+    chunkVectors = allChunks.map((chunk) =>
+      generateSimpleEmbedding(chunk.text, EMBEDDING_DIMENSION),
+    );
+  }
   const items = allChunks.map((chunk, i) => ({
     id: `rag-chunk-${i}`,
-    vector: generateSimpleEmbedding(chunk.text, EMBEDDING_DIMENSION),
+    vector: chunkVectors[i],
     metadata: {
       text: chunk.text,
       ...chunk.metadata,
@@ -362,11 +415,10 @@ async function _prepareRAGToolInner(
           },
         },
         async (span) => {
-          // For the in-memory store with simple embeddings,
-          // generate a query embedding using the same method
-          const queryEmbedding = generateSimpleEmbedding(
-            query,
-            EMBEDDING_DIMENSION,
+          // Query through the same embedding space the index was built in —
+          // provider embeddings when configured (and healthy), else the hash.
+          const queryEmbedding = await embedFn(query).catch(() =>
+            generateSimpleEmbedding(query, EMBEDDING_DIMENSION),
           );
 
           // Fetch more candidates than needed so diversity can select across files


### PR DESCRIPTION
## Summary
Two silent data-loss defects found by exhaustive live e2e testing (evidence artifact linked below), both provider-agnostic:

- **Inline `conversationMessages` dropped on the MCP-first path**: `prepareMCPGenerationContext` computed history only via `getConversationMessages(this.conversationMemory, options)`, which returns `[]` with no memory manager/session context — silently discarding a caller-supplied `ChatMessage[]` on the DEFAULT path (tools enabled). `directProviderGeneration` already prioritized the inline array; the MCP path now mirrors it. Observed live as "I don't have access to any conversation history" with tools on, correct recall with `disableTools: true`.
- **RAG `embeddingProvider`/`embeddingModel` had zero runtime effect**: the simplified `rag: { files }` path always indexed AND queried with the internal 128-dim hash embedding; the correctly-wired `createVectorQueryTool` was built but only its `.description` was read. When an embedding provider/model is configured, index chunks and queries now both embed through it (one embedding space — any provider failure flips both sides back to the hash together). Verified live: 5 real `POST /embeddings` calls (marqo-ecommerce-B, 512-dim) observed via fetch interception during one RAG generate, previously zero.

## Test plan
- `pnpm run check` clean · lint 0 errors · build clean · pre-push gate green
- Live validation vs grid.breezehq.dev both before (bug reproduced) and after (fixed) — full recorded evidence: https://claude.ai/code/artifact/f19e6955-abec-47bd-a6c9-d647266b695a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI generation to prioritize conversation context explicitly provided by callers.
  - Ensured retrieval-augmented search uses consistent embedding settings for indexed content and queries.
  - Added reliable fallback behavior when embedding services cannot initialize or encounter runtime errors.

- **Documentation**
  - Updated API reference links to point to the current source locations without changing public interfaces or documented behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->