### PR TITLE
test(harness): treat a hang as a failure in ten more offline suites

### DIFF
--- a/test/continuous-test-suite-adjust-body-after-400.ts
+++ b/test/continuous-test-suite-adjust-body-after-400.ts
@@ -41,6 +41,9 @@ import { defineSuite, assert } from "./helpers/harness.js";
 
 const { test, runSuite, section } = defineSuite(
   "adjustBodyAfter400 composition fix",
+  {
+    offline: true,
+  },
 );
 
 // A single crafted 400 body that is BOTH:

--- a/test/continuous-test-suite-avatar-unit.ts
+++ b/test/continuous-test-suite-avatar-unit.ts
@@ -69,7 +69,9 @@ import type {
   GenerateOptions,
 } from "../dist/index.js";
 
-const { test, runSuite } = defineSuite("AvatarProcessor (via generate())");
+const { test, runSuite } = defineSuite("AvatarProcessor (via generate())", {
+  offline: true,
+});
 
 const IMAGE = Buffer.from("fake-portrait-bytes");
 const AUDIO = Buffer.from("fake-audio-bytes");

--- a/test/continuous-test-suite-handler-registry.ts
+++ b/test/continuous-test-suite-handler-registry.ts
@@ -21,7 +21,9 @@
 import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
 import { HandlerRegistry } from "../src/lib/core/handlerRegistry.js";
 
-const { test, runSuite } = defineSuite("HandlerRegistry (unit)");
+const { test, runSuite } = defineSuite("HandlerRegistry (unit)", {
+  offline: true,
+});
 
 type StubHandler = { id: string };
 

--- a/test/continuous-test-suite-loop-engine.ts
+++ b/test/continuous-test-suite-loop-engine.ts
@@ -60,7 +60,9 @@ import type {
   Tool,
 } from "../src/lib/types/index.js";
 
-const { test, runSuite } = defineSuite("Agentic loop engine primitives");
+const { test, runSuite } = defineSuite("Agentic loop engine primitives", {
+  offline: true,
+});
 
 function mkTool(
   description: string,

--- a/test/continuous-test-suite-mcp-infra.ts
+++ b/test/continuous-test-suite-mcp-infra.ts
@@ -72,7 +72,9 @@ import type { McpCacheConfig } from "../src/lib/types/index.js";
 // Fail loudly rather than silently testing a stale build (see distFreshness.ts).
 assertDistFresh();
 
-const { recordTest, runSuite } = defineSuite("MCP Infrastructure");
+const { recordTest, runSuite } = defineSuite("MCP Infrastructure", {
+  offline: true,
+});
 
 /**
  * Dispose a NeuroLink instance from a `finally` block without masking the

--- a/test/continuous-test-suite-music-unit.ts
+++ b/test/continuous-test-suite-music-unit.ts
@@ -63,7 +63,9 @@ import {
 } from "../dist/index.js";
 import type { MusicHandler, MusicOptions, MusicResult } from "../dist/index.js";
 
-const { test, section, runSuite } = defineSuite("Music dispatch (generate)");
+const { test, section, runSuite } = defineSuite("Music dispatch (generate)", {
+  offline: true,
+});
 
 function makeStubHandler(overrides: Partial<MusicHandler> = {}): {
   handler: MusicHandler;

--- a/test/continuous-test-suite-provider-fallback.ts
+++ b/test/continuous-test-suite-provider-fallback.ts
@@ -30,6 +30,9 @@ import { NeuroLink } from "../dist/index.js";
 
 const { test, runSuite } = defineSuite(
   "Provider fallback + Anthropic proxy UA",
+  {
+    offline: true,
+  },
 );
 
 // ---------------------------------------------------------------------------

--- a/test/continuous-test-suite-realtime-unit.ts
+++ b/test/continuous-test-suite-realtime-unit.ts
@@ -55,7 +55,9 @@ import type {
   RealtimeSession,
 } from "../dist/index.js";
 
-const { test, runSuite } = defineSuite("RealtimeProcessor (unit)");
+const { test, runSuite } = defineSuite("RealtimeProcessor (unit)", {
+  offline: true,
+});
 
 const PROVIDER = "unit-test-realtime-provider";
 // RealtimeConfig["provider"] / RealtimeSession["provider"] are narrowed to a

--- a/test/continuous-test-suite-servers.ts
+++ b/test/continuous-test-suite-servers.ts
@@ -53,7 +53,9 @@ import {
   isCaseTimeout,
 } from "./helpers/harness.js";
 
-const { recordTest, runSuite } = defineSuite("Servers");
+const { recordTest, runSuite } = defineSuite("Servers", {
+  offline: true,
+});
 
 /** Print-only logTest shim. Counters are driven by recordTest in the runner. */
 function logTest(

--- a/test/continuous-test-suite-tool-resolution.ts
+++ b/test/continuous-test-suite-tool-resolution.ts
@@ -33,7 +33,9 @@ import { MCPToolRegistry, NeuroLink } from "../dist/index.js";
 import type { Tool, ToolInfo } from "../src/lib/types/index.js";
 import { defineSuite, logSection } from "./helpers/harness.js";
 
-const { test, runSuite } = defineSuite("Tool Resolution");
+const { test, runSuite } = defineSuite("Tool Resolution", {
+  offline: true,
+});
 
 function assertEqual(got: unknown, want: unknown, label: string): void {
   const g = JSON.stringify(got);


### PR DESCRIPTION
#1550 added `offline: true` to `defineSuite` — it turns a per-test timeout into a **FAIL** instead of the default **SKIP** — and applied it to exactly one suite. The mechanism existed everywhere; the coverage did not.

Every other offline suite still converts a hang into `⊘ skipped`, a green `RESULT: PASS` and exit 0. That is precisely how the `interleaveTTSStream` deadlock survived in CI for a day, cost 240s per run, and let #1336 merge with its own headline test having **never once passed**.

## Selection criterion — not the obvious one

Ten suites gain the flag. Each was checked to **make no network call at all**, rather than merely to pass without credentials. Those are different properties and only the first justifies the flag: a suite that calls a live endpoint and asserts on the auth error passes a credential-free sweep while still having an upstream that can legitimately hang. Classifying *its* timeout as a defect would be wrong.

| suite | `fetch()` | external URLs |
|---|---|---|
| `music-unit` | 0 | none |
| `avatar-unit` | 0 | none |
| `mcp-infra` | 0 | none |
| `provider-fallback` | 0 | none |
| `realtime-unit` | 0 | none |
| `tool-resolution` | 0 | none |
| `loop-engine` | 0 | none |
| `handler-registry` | 0 | none |
| `servers` | 0 | none |
| `adjust-body-after-400` | 0 | none |

## Deliberately not flagged

- **`tool-reliability`, `autoresearch`** — live-tier per CLAUDE.md. They pass credential-free by *skipping*; a timeout in them can legitimately be an upstream. These must never get this flag.
- **`openai-compat-catalog`** — does not use `defineSuite`.
- **Fourteen others** — carry local stand-in servers or env-var references and need reading one at a time. Batch-applying a heuristic is exactly what this PR avoids: `provider-descriptors` scores 51 "live markers" purely because it holds a data table of env var names.

## Verification

| check | result |
|---|---|
| all ten suites run | **227 assertions, 0 failed, 0 skipped** |
| `check:tools-tests` + eslint | clean |
| flag placement | verified by walking to the matching paren — 11/11 inside the `defineSuite` call, 0 misplaced |
| classifier proved live | injected hang → `✗ PROBE: deliberate hang` · `RESULT: FAIL` · exit 1 |

The last row is the load-bearing one: before this change that identical hang reported `⊘` and exit 0. Probe reverted, not committed.

Tracked as item **A1** in the session backlog ledger; 11 of ~26 eligible suites now covered, remainder enumerated there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multiple test suites to run in offline mode.
  * Improved test reliability by allowing local execution without external service access.
  * Preserved existing test coverage and behavior across processing, provider fallback, server, tool, and infrastructure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->