### PR TITLE
test(harness): treat a hang as a failure in ten more offline suites

### DIFF
--- a/test/continuous-test-suite-anthropic-streaming-retry.ts
+++ b/test/continuous-test-suite-anthropic-streaming-retry.ts
@@ -39,6 +39,9 @@ import { defineSuite, assert } from "./helpers/harness.js";
 
 const { test, runSuite, section } = defineSuite(
   "Anthropic streaming retry parity",
+  {
+    offline: true,
+  },
 );
 
 /** Env vars this suite mutates — saved/restored around every test so

--- a/test/continuous-test-suite-codex.ts
+++ b/test/continuous-test-suite-codex.ts
@@ -56,7 +56,9 @@ import { __testHooks } from "../src/lib/server/routes/codexProxyRoutes.js";
 import type { CodexRuntimeAccount } from "../src/lib/types/index.js";
 import { assert, assertEqual, defineSuite, runCLI } from "./helpers/harness.js";
 
-const { test, runSuite } = defineSuite("Codex Pool Engine");
+const { test, runSuite } = defineSuite("Codex Pool Engine", {
+  offline: true,
+});
 
 /** Fixed clock so reset arithmetic is deterministic. */
 const NOW = 1_800_000_000_000;

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -30,7 +30,9 @@ import * as path from "path";
 import { defineSuite, log } from "./helpers/harness.js";
 import type { LocalUsageScanResult } from "../src/lib/types/index.js";
 
-const { test, runSuite } = defineSuite("Local Usage");
+const { test, runSuite } = defineSuite("Local Usage", {
+  offline: true,
+});
 
 const sdk = await import("../dist/index.js");
 const { readAllLocalUsage, getLocalUsageDescriptors, createLocalUsageReader } =

--- a/test/continuous-test-suite-model-manifests.ts
+++ b/test/continuous-test-suite-model-manifests.ts
@@ -54,7 +54,9 @@ import type { ProviderModelManifestEntry } from "../dist/types/model.js";
 // Fail loudly rather than silently testing a stale build.
 assertDistFresh();
 
-const { test, runSuite } = defineSuite("Model Manifests");
+const { test, runSuite } = defineSuite("Model Manifests", {
+  offline: true,
+});
 
 const {
   resolveManifestEntry,

--- a/test/continuous-test-suite-openai-compat-streaming-retry.ts
+++ b/test/continuous-test-suite-openai-compat-streaming-retry.ts
@@ -55,6 +55,9 @@ import { defineSuite, assert } from "./helpers/harness.js";
 
 const { test, runSuite, section } = defineSuite(
   "OpenAI-compat streaming retry parity",
+  {
+    offline: true,
+  },
 );
 
 function sseChunk(text: string): string {

--- a/test/continuous-test-suite-provider-fallback-latency.ts
+++ b/test/continuous-test-suite-provider-fallback-latency.ts
@@ -29,7 +29,9 @@ import { installMockFetch } from "./utils/mockFetch.js";
 import { NeuroLink } from "../dist/index.js";
 import type { GenerateOptions } from "../src/lib/types/index.js";
 
-const { test, runSuite } = defineSuite("Provider fallback latency");
+const { test, runSuite } = defineSuite("Provider fallback latency", {
+  offline: true,
+});
 
 // ---------------------------------------------------------------------------
 // Environment: fake keys, deterministic api_key auth, no proxy.

--- a/test/continuous-test-suite-stt-unit.ts
+++ b/test/continuous-test-suite-stt-unit.ts
@@ -64,7 +64,9 @@ import {
 } from "../dist/index.js";
 import type { STTHandler, STTResult } from "../dist/index.js";
 
-const { test, runSuite } = defineSuite("STTProcessor (via generate())");
+const { test, runSuite } = defineSuite("STTProcessor (via generate())", {
+  offline: true,
+});
 
 // Every synthetic provider name used by this suite is prefixed so it can
 // never collide with a real vendor handler (whisper, deepgram, ...) that

--- a/test/continuous-test-suite-vertex-claude-characterization.ts
+++ b/test/continuous-test-suite-vertex-claude-characterization.ts
@@ -57,6 +57,9 @@ new NodeTracerProvider({
 
 const { test, section, runSuite } = defineSuite(
   "Vertex Claude loop characterization",
+  {
+    offline: true,
+  },
 );
 
 const { NeuroLink } = await import("../dist/index.js");

--- a/test/continuous-test-suite-vertex-loop-characterization.ts
+++ b/test/continuous-test-suite-vertex-loop-characterization.ts
@@ -44,7 +44,12 @@ import { assertDistFresh } from "./helpers/distFreshness.js";
 
 assertDistFresh();
 
-const { test, section, runSuite } = defineSuite("Vertex loop characterization");
+const { test, section, runSuite } = defineSuite(
+  "Vertex loop characterization",
+  {
+    offline: true,
+  },
+);
 
 const { NeuroLink } = await import("../dist/index.js");
 

--- a/test/continuous-test-suite-video-generation-unit.ts
+++ b/test/continuous-test-suite-video-generation-unit.ts
@@ -82,7 +82,9 @@ import {
 import { NeuroLink, VideoProcessor } from "../dist/index.js";
 import type { VideoGenerationResult, VideoHandler } from "../dist/index.js";
 
-const { test, runSuite } = defineSuite("VideoProcessor (via generate())");
+const { test, runSuite } = defineSuite("VideoProcessor (via generate())", {
+  offline: true,
+});
 
 // Video-mode dispatch never reaches the network (BaseProvider short-circuits
 // on output.mode === "video" before any LLM call), so the provider only


### PR DESCRIPTION
Takes `offline: true` from eleven suites to **twenty-one**.

The harness reports a per-test timeout as a SKIP, so a hung test leaves its suite printing `RESULT: PASS` with exit 0. That default is correct for a live suite, which genuinely cannot distinguish a hung SDK from a hung upstream. It is wrong for a suite that has no upstream, where a timeout has exactly one remaining explanation. This is the failure mode that let the `interleaveTTSStream` deadlock sit in CI for a day.

## Selection was measured, not inferred

Each candidate ran under a preload hooking `net.Socket.prototype.connect` and `tls.connect` — the socket layer, so undici and native `fetch` cannot slip past the way they can past a `globalThis.fetch` stub. The probe was first proven to catch a known-external call before any result from it was trusted.

**Flagged (10)** — no external connection observed:
`vertex-loop-characterization`, `vertex-claude-characterization`, `openai-compat-streaming-retry`, `anthropic-streaming-retry`, `video-generation-unit`, `local-usage`, `provider-fallback-latency`, `codex`, `stt-unit`, `model-manifests`

**Not flagged (4)** — real external calls, where a timeout can legitimately be an upstream:

| suite | hosts contacted |
|---|---|
| `auth`, `dynamic` | `aiplatform.googleapis.com`, `oauth2.googleapis.com` |
| `credentials` | `api.openai.com` — three real `generate()` calls |
| `provider-descriptors` | eighteen hosts, `api.groq.com` through `bedrock-runtime` |

That last row corrects a written assumption. `provider-descriptors` had been recorded as scoring high on credential markers *"purely because it holds a data table of env var names."* It contacts eighteen external hosts. Flagging it on that reasoning would have converted real upstream outages into test failures.

## Two questions this settles

**Local stand-in servers.** The `vertex-*-characterization` and `*-streaming-retry` suites bind a server on loopback and point the SDK at it. Measurement confirms no external connection, and a server the suite owns cannot suffer an outage — so a timeout there is a code hang and the flag applies.

**`registry.npmjs.org`.** It appeared in several runs. A stack capture placed every one of those connections inside npm's own `@npmcli/agent` — the toolchain's update check, not the suite. Suites already carrying the flag show the same pattern, so it discriminates nothing.

## Evidence

- All ten pass credential-free: **116 assertions, 0 failed, 0 skipped**.
- Flag placement verified by walking to `defineSuite`'s matching paren rather than by grep: **21 of 21 inside the call, 0 misplaced**.
- Classifier proven live: a hanging test injected into `model-manifests` reported `✗ … RESULT: FAIL` and **exit 1**, where before it would have been `⊘` and exit 0. Probe reverted, file confirmed clean.
- `check:tools-tests`, eslint and prettier all clean.

Deliberately left alone: `tool-reliability` and `autoresearch` are live-tier; `openai-compat-catalog` does not use `defineSuite`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated continuous test suites to run in offline mode.
  * Improved test reliability and determinism by avoiding external network-dependent checks.
  * Existing retry, mocking, streaming, and assertion behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->