### PR TITLE
fix(providers): align cerebras with live roster and omit tool_choice without tools

### DIFF
--- a/docs/provider-integration/manifests/cerebras.json
+++ b/docs/provider-integration/manifests/cerebras.json
@@ -14,5 +14,5 @@
     "test/continuous-test-suite-providers-mocked.ts"
   ],
   "mockedContractSection": "LLM cerebras",
-  "manualTestStatus": "ci-mocked-only"
+  "manualTestStatus": "live-verified 2026-08-27: provider-matrix 4/4 (generate, stream, tools, structured output) against api.cerebras.ai on gpt-oss-120b; tools+response_format exclusivity confirmed by live 400 probe"
 }

--- a/src/lib/constants/enums.ts
+++ b/src/lib/constants/enums.ts
@@ -1180,19 +1180,15 @@ export enum GroqModels {
  * Cerebras inference models (wafer-scale, OpenAI-compatible API).
  * @see https://inference-docs.cerebras.ai/introduction
  *
- * Note the vendor's inconsistent id scheme: `llama3.1-8b` has no dash
- * after "llama", while `llama-3.3-70b` does — both are the DOCUMENTED
- * ids, not typos.
+ * Roster verified against a live authenticated `/v1/models` on 2026-08-27:
+ * only these two ids are served. The llama/qwen models the vendor docs
+ * once listed are retired and now 404.
  */
 export enum CerebrasModels {
-  /** Llama 3.3 70B — production default */
-  LLAMA_3_3_70B = "llama-3.3-70b",
-  /** Llama 3.1 8B — low-latency tier (vendor id has no dash after "llama") */
-  LLAMA_3_1_8B = "llama3.1-8b",
-  /** Qwen 3 32B */
-  QWEN_3_32B = "qwen-3-32b",
-  /** OpenAI GPT-OSS 120B (open-weight) */
+  /** OpenAI GPT-OSS 120B (open-weight) — production default */
   GPT_OSS_120B = "gpt-oss-120b",
+  /** Google Gemma 4 31B */
+  GEMMA_4_31B = "gemma-4-31b",
 }
 
 /**

--- a/src/lib/factories/providerDescriptors.ts
+++ b/src/lib/factories/providerDescriptors.ts
@@ -405,7 +405,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
       baseURL: "CEREBRAS_BASE_URL",
       model: "CEREBRAS_MODEL",
     },
-    defaultModel: CerebrasModels.LLAMA_3_3_70B,
+    defaultModel: CerebrasModels.GPT_OSS_120B,
     toolSupport: "native",
     localRuntime: false,
     healthCheck: "env-only",

--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -619,7 +619,12 @@ export const buildBody = (
   if (tools) {
     body.tools = tools;
   }
-  if (toolChoice !== undefined) {
+  // tool_choice is only meaningful alongside a non-empty tools array, and
+  // strict OpenAI-compatible backends (probed live on Cerebras 2026-08-27)
+  // reject it outright with 400 wrong_api_format when tools are absent:
+  // "'tool_choice' is only allowed when 'tools' are specified". Omitting it
+  // is behavior-identical on lenient backends.
+  if (toolChoice !== undefined && tools && tools.length > 0) {
     body.tool_choice = toolChoice;
   }
   if (responseFormat) {

--- a/src/lib/providers/openaiCompatCatalog.ts
+++ b/src/lib/providers/openaiCompatCatalog.ts
@@ -62,16 +62,11 @@ export const OPENAI_COMPAT_CATALOG: readonly OpenAICompatCatalogEntry[] = [
     defaultBaseURL: "https://api.cerebras.ai/v1",
     configOptions: createCerebrasConfig(),
     modelEnvVar: "CEREBRAS_MODEL",
-    defaultModel: CerebrasModels.LLAMA_3_3_70B,
-    registryDefaultModel: CerebrasModels.LLAMA_3_3_70B,
+    defaultModel: CerebrasModels.GPT_OSS_120B,
+    registryDefaultModel: CerebrasModels.GPT_OSS_120B,
     registryDefaultModelChecksEnvVar: true,
-    fallbackModelName: CerebrasModels.LLAMA_3_1_8B,
-    fallbackModels: [
-      CerebrasModels.LLAMA_3_3_70B,
-      CerebrasModels.LLAMA_3_1_8B,
-      CerebrasModels.QWEN_3_32B,
-      CerebrasModels.GPT_OSS_120B,
-    ],
+    fallbackModelName: CerebrasModels.GEMMA_4_31B,
+    fallbackModels: [CerebrasModels.GPT_OSS_120B, CerebrasModels.GEMMA_4_31B],
     errorRules: [
       {
         // Probed live 2026-08-26: a bad key gets HTTP 401 with body

--- a/src/lib/utils/modelChoices.ts
+++ b/src/lib/utils/modelChoices.ts
@@ -340,17 +340,13 @@ const TOP_MODELS_CONFIG: Record<
   ],
   [AIProviderName.CEREBRAS]: [
     {
-      model: CerebrasModels.LLAMA_3_3_70B,
-      description: "Recommended - Production default; wafer-scale speed",
-    },
-    {
-      model: CerebrasModels.LLAMA_3_1_8B,
-      description: "Lowest latency tier",
-    },
-    { model: CerebrasModels.QWEN_3_32B, description: "Qwen 3 32B" },
-    {
       model: CerebrasModels.GPT_OSS_120B,
-      description: "OpenAI GPT-OSS 120B (open-weight)",
+      description:
+        "Recommended - OpenAI GPT-OSS 120B (open-weight); wafer-scale speed",
+    },
+    {
+      model: CerebrasModels.GEMMA_4_31B,
+      description: "Google Gemma 4 31B",
     },
   ],
   [AIProviderName.COHERE]: [

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -162,7 +162,7 @@ const OPENAI_COMPAT_PROVIDERS: OpenAICompatSpec[] = [
     envVar: "CEREBRAS_API_KEY",
     urlMatch: "api.cerebras.ai/v1/chat/completions",
     authPrefix: "Bearer ",
-    model: "llama-3.3-70b",
+    model: "gpt-oss-120b",
     authErrorMatch: /cerebras|401|unauthor|api key/i,
     rateLimitErrorMatch: /cerebras|rate.?limit|429/i,
   },
@@ -274,6 +274,13 @@ async function runOpenAICompatProvider(spec: OpenAICompatSpec): Promise<void> {
         expect(typeof body === "object", "body is JSON object");
         expectEq(body.model, spec.model, "body.model");
         expect(Array.isArray(body.messages), "body.messages is array");
+        // Strict backends (probed live on Cerebras 2026-08-27) reject
+        // tool_choice with 400 wrong_api_format when tools are absent, so a
+        // tools-less request must not carry it.
+        expect(
+          !("tool_choice" in (body as Record<string, unknown>)),
+          "tool_choice must be absent when the request carries no tools",
+        );
 
         expect(
           (result.content ?? "").toLowerCase().includes("pong"),

--- a/test/helpers/providerMatrix.ts
+++ b/test/helpers/providerMatrix.ts
@@ -439,6 +439,25 @@ export const PROVIDERS: Record<string, ProviderEntry> = {
     videoGeneration: false,
     tts: false,
   },
+  cerebras: {
+    name: "cerebras",
+    // Live roster probed 2026-08-27: only gemma-4-31b and gpt-oss-120b —
+    // the llama/qwen models the initial catalog listed are retired (404).
+    defaultModel: "gpt-oss-120b",
+    envVars: ["CEREBRAS_API_KEY"],
+    text: true,
+    streaming: true,
+    tools: true,
+    toolsWithStreaming: true,
+    structuredOutput: true,
+    structuredOutputWithTools: false, // JSON-mode + tool-calling: assume Groq-like exclusivity until proven live
+    vision: false, // text-only model roster
+    embeddings: false,
+    thinking: false,
+    imageGeneration: false,
+    videoGeneration: false,
+    tts: false,
+  },
   cohere: {
     name: "cohere",
     // Use the dated variant — the bare `command-r-plus` alias was retired


### PR DESCRIPTION
## What

Live end-to-end verification of the cerebras pilot (#1561) against api.cerebras.ai surfaced two defects, both fixed here:

### 1. Stale model roster
An authenticated `/v1/models` probe (2026-08-27) returns only `gpt-oss-120b` and `gemma-4-31b` — the llama/qwen ids the vendor docs once listed are retired and now 404. This PR aligns `CerebrasModels`, the catalog defaults/fallbacks, CLI model choices, the descriptor default and the mocked-contract spec with the live roster (`gpt-oss-120b` default).

### 2. `tool_choice` sent without `tools`
`buildBody` emitted `tool_choice` on tools-less requests (e.g. `disableTools`), which strict OpenAI-compatible backends reject with **400 wrong_api_format**: *"'tool_choice' is only allowed when 'tools' are specified"* (probed live on Cerebras). The field is now emitted only alongside a non-empty tools array — behavior-identical on lenient backends. Every OpenAI-compat row of the mocked contract suite now asserts `tool_choice` is absent from tools-less requests.

## Live proof (after both fixes)

- `provider-matrix --provider=cerebras`: **4/4 PASS** — generate, stream, tool calling, structured output — real calls to api.cerebras.ai in 11.14s
- CLI `generate --provider cerebras` resolves the new default model with no explicit `--model`
- `tools`+`response_format` exclusivity assumed in the matrix row is now **confirmed** by a live 400 probe (`"tools" is incompatible with "response_format"`)
- Mocked contract suite: 70/70; break-one-assertion ritual on the new assertion: 9 rows fail, exit 1, restored
- `verify:provider-onboarding`: ✓ cerebras 1/1

## Checks run locally
`pnpm run check`, `check:tools-tests`, `lint`, `build`, mocked suite, matrix suite, docs:api regenerated (zero net diff after prettier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cerebras support for the Gemma 4 31B model.
  - Updated available Cerebras model choices to reflect currently supported offerings.
  - Set GPT-OSS 120B as the recommended and default Cerebras model, with Gemma 4 31B as a fallback.

- **Bug Fixes**
  - Improved compatibility with strict OpenAI-compatible providers by omitting tool-selection settings when no tools are configured.
  - Verified Cerebras support for text generation, streaming, tools, and structured output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->