### PR TITLE
fix(bedrock): pass abortSignal to the transport, not just to the loop

### DIFF
--- a/src/lib/providers/amazonBedrock/loopAdapter.ts
+++ b/src/lib/providers/amazonBedrock/loopAdapter.ts
@@ -340,6 +340,14 @@ export function createBedrockLoopAdapter(config: {
                   ...commandInput,
                   modelId: effectiveModelId,
                 }),
+                // Hand the signal to the transport, not just to the loop.
+                // `abortSignal` is documented public API, and loopEngine
+                // already honours it — but only *between* steps. Without this
+                // the HTTP request stays in flight after an abort until it
+                // answers or STEP_TIMEOUT_MS (120s) elapses, because nothing
+                // ever told the socket. `@smithy/types` HttpHandlerOptions
+                // takes the same AbortSignal the adapter is already given.
+                { abortSignal: signal },
               ),
               STEP_TIMEOUT_MS,
               new Error("Bedrock API call timed out"),
@@ -361,6 +369,10 @@ export function createBedrockLoopAdapter(config: {
                 ...commandInput,
                 modelId: effectiveModelId,
               }),
+              // As above: the streaming send needs the signal too, so an
+              // abort tears down the eventstream connection rather than
+              // leaving it open for the rest of the step budget.
+              { abortSignal: signal },
             ),
             STEP_TIMEOUT_MS,
             new Error("Bedrock streaming API call timed out"),


### PR DESCRIPTION
`abortSignal` is documented public API. `loopEngine` mirrors it into an internal controller and checks it at step boundaries, so an abort stops the loop *between* steps — but the HTTP request already in flight was never told, because both Converse call sites invoked `client.send()` with no second argument. `@smithy/types` `HttpHandlerOptions` accepts an `abortSignal`, and `executeStep` is already handed the very signal it needs.

## The consequence is observable — demonstrated for the first time

A local HTTP/2 server accepts a request and never answers. Abort fires at 1000ms.

|  | request reached server | client outcome | **server saw stream close** |
|---|---|---|---|
| **without** `{ abortSignal }` | ✅ +10ms | still waiting when the harness cap fired at **8002ms** | **never — still open** |
| **with** `{ abortSignal }` | ✅ +1ms | `AbortError` at **1002ms** | **1002ms** |

Both runs assert the request actually reached the server *before* reading anything into the result. An absence-based check without that precondition is exactly how an earlier probe in this repo reported a leak on a run where nothing had been sent at all.

Without the parameter the socket stays open for the remainder of the step budget — `STEP_TIMEOUT_MS` is 120s.

## Why three earlier attempts concluded there was no difference

They were wrong for a findable reason: they stood up **HTTP/1.1** servers. The Bedrock client speaks HTTP/2, so the request died with `Protocol error` in 10ms and never left the machine — and a probe that reads "socket never closed" on a request that was never sent reports a leak that isn't there.

The `providers-mocked` suite documents the same underlying fact from the other direction, in its own note: *"AWS SDK v3's `@smithy/node-http-handler` uses native Node http/http2/https, not `globalThis.fetch`."*

## Scope

Bedrock only, deliberately. SageMaker has the same defect but not the same shape — its transport calls live in `sagemaker/client.ts`, not the `streaming.ts` polling check, and reaching them needs an `abortSignal` field on `InvokeEndpointParams` plus threading from `language-model.ts`. Separate change.

## Verification

- `bedrock-loop-characterization` **12/12**
- `bedrock-inference-profile` **5/5**
- `providers-mocked` **70 passed · 0 failed (of 70)**
- `tsc --noEmit --strict` clean, compared against a stashed baseline of the same tree (both 0 — an unqualified run reports 566 errors purely from a missing `svelte-kit sync`)
- eslint + prettier clean

Behaviour is unchanged when no signal is aborted: the parameter is optional on the SDK side and the adapter already receives a live `AbortSignal` on every step.