### PR TITLE
chore(lint): let ESLint see scripts/ and tools/, and fix what it found

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
       sourceType: "module",
       globals: {
         // Node.js globals
+        structuredClone: "readonly",
         process: "readonly",
         Buffer: "readonly",
         __dirname: "readonly",
@@ -207,6 +208,108 @@ export default [
       indent: "off",
       quotes: "off",
       semi: "off",
+    },
+  },
+  {
+    // scripts/ and tools/ were invisible to ESLint in two separate ways, and
+    // removing them from `ignores` only fixed one. Nothing here matched a `.ts`
+    // file outside src/ and test/, so even un-ignored they parsed under no
+    // configuration at all and "passed" by never being read. Of 70 TypeScript
+    // files across the two directories, ESLint was reporting on zero.
+    //
+    // That is the blind spot tsconfig.ci-scripts.json was created for: the
+    // provider onboarding gate shipped asserting a field that does not exist,
+    // its catalog lookup silently produced {undefined}, and half a required
+    // check never ran — in tools/verify-provider-onboarding.ts, a file gating a
+    // required status check that nothing typechecked and nothing linted.
+    //
+    // No `project`, for the same reason test/**/*.ts has none: these files sit
+    // outside the root tsconfig, so type-aware rules cannot run on them. This
+    // is the syntactic tier — unused vars, undefined globals, empty catches —
+    // which is the tier that caught the real defects in this tree anyway.
+    files: ["scripts/**/*.ts", "tools/**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+      globals: {
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        global: "readonly",
+        console: "readonly",
+        fetch: "readonly",
+        structuredClone: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        URL: "readonly",
+        TextDecoder: "readonly",
+        TextEncoder: "readonly",
+        AbortController: "readonly",
+        AbortSignal: "readonly",
+        Response: "readonly",
+        ReadableStream: "readonly",
+        // Scripts that emit or drive browser code reference these in type
+        // positions and in generated snippets; they are not Node globals.
+        window: "readonly",
+        document: "readonly",
+        // The NodeJS namespace appears in type positions (NodeJS.Timeout).
+        NodeJS: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      "no-unused-vars": "off",
+      // Mirrors the src/ options, plus caughtErrorsIgnorePattern. The tree
+      // already writes `catch (_error)` to mean "deliberately unused", but no
+      // block declared that pattern, so typescript-eslint's caughtErrors: "all"
+      // default flagged the very convention the code was following.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+          args: "after-used",
+          vars: "local",
+        },
+      ],
+      "no-undef": "error",
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
+  {
+    // .cjs matched no configuration at all, so semantic-release-format-plugin.cjs
+    // — which runs in the release pipeline — was never linted. It needs its own
+    // block rather than joining the .js/.mjs one: that block declares
+    // sourceType "module", under which `require` and `module` are undefined.
+    files: ["**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        console: "readonly",
+        require: "readonly",
+        module: "writable",
+        exports: "writable",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        setImmediate: "readonly",
+      },
     },
   },
   {
@@ -491,7 +594,6 @@ export default [
       "docs/cli-recordings/**",
       "docs/visual-content/**",
       "neurolink-demo/**",
-      "scripts/**",
       "memory-bank/**",
       "archive/**",
       "examples/**",

--- a/scripts/audit-skips.ts
+++ b/scripts/audit-skips.ts
@@ -25,6 +25,9 @@ type SuiteTally = {
   fails: Array<{ name: string; reason: string }>;
 };
 
+// ESC is the ANSI introducer; stripping colour codes is this pattern's
+// whole purpose, so the control character is the point, not an accident.
+// eslint-disable-next-line no-control-regex
 const ANSI = /\[[0-9;]*m/g;
 
 function stripAnsi(line: string): string {
@@ -54,9 +57,9 @@ function parseLog(file: string): SuiteTally {
       const m = /^\s*[✗❌]\s+(.*?)$/.exec(line);
       const reason = (lines[i + 1] || "").trim().replace(/^→\s*/, "");
       tally.fails.push({ name: (m?.[1] || "").trim(), reason });
-    } else if (/^\s*[⊘⏭️]\s+/.test(line)) {
+    } else if (/^\s*(?:⊘|⏭️)\s+/.test(line)) {
       tally.skip++;
-      const m = /^\s*[⊘⏭️]\s+(.*?)(?:\s+\((.*)\))?$/.exec(line);
+      const m = /^\s*(?:⊘|⏭️)\s+(.*?)(?:\s+\((.*)\))?$/.exec(line);
       const name = (m?.[1] || "").trim();
       const inline = (m?.[2] || "").trim();
       const reason = inline || (lines[i + 1] || "").trim();

--- a/scripts/benchmarkThreeProviders.ts
+++ b/scripts/benchmarkThreeProviders.ts
@@ -112,7 +112,7 @@ async function benchmarkProvider(providerName: string): Promise<ProviderResult> 
         try {
           const startTime = Date.now();
 
-          const response = await provider.generate({
+          await provider.generate({
             input: { text: promptConfig.prompt },
             maxTokens: promptConfig.maxTokens,
             temperature: 0.7,

--- a/scripts/build-browser.mjs
+++ b/scripts/build-browser.mjs
@@ -319,10 +319,10 @@ const catchAllPlugin = {
 
     build.onResolve({ filter: /.*/ }, (args) => {
       const p = args.path;
-      if (p.startsWith('.') || p.startsWith('/')) return undefined;
-      if (isNodeBuiltin(p)) return { path: p, namespace: 'node-stub' };
-      if (isOtel(p)) return { path: p, namespace: 'otel-stub' };
-      if (isNpmStub(p) || isHono(p)) return { path: p, namespace: 'npm-stub' };
+      if (p.startsWith('.') || p.startsWith('/')) {return undefined;}
+      if (isNodeBuiltin(p)) {return { path: p, namespace: 'node-stub' };}
+      if (isOtel(p)) {return { path: p, namespace: 'otel-stub' };}
+      if (isNpmStub(p) || isHono(p)) {return { path: p, namespace: 'npm-stub' };}
       return undefined;
     });
 

--- a/scripts/build-validations.ts
+++ b/scripts/build-validations.ts
@@ -9,7 +9,7 @@
  * Part of Build Rule Enforcement System - Phase 1
  */
 
-import { execSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -114,13 +114,9 @@ class NeuroLinkBuildValidator {
       return this.fileCache.get(filePath)!;
     }
 
-    try {
-      const content = fs.readFileSync(filePath, "utf8");
-      this.fileCache.set(filePath, content);
-      return content;
-    } catch (error) {
-      throw error;
-    }
+    const content = fs.readFileSync(filePath, "utf8");
+    this.fileCache.set(filePath, content);
+    return content;
   }
 
   // Get TypeScript files recursively using Node.js fs

--- a/scripts/collapse-cli-lib-duplicate.mjs
+++ b/scripts/collapse-cli-lib-duplicate.mjs
@@ -3,7 +3,7 @@
  * Collapse the dist/lib/** duplicate produced by `tsc --project tsconfig.cli.json`.
  *
  * Why this exists: tsconfig.cli.json sets rootDir:"./src" and includes BOTH
- * src/cli/**​/*.ts and src/lib/**​/*.ts — the latter is required so the CLI's
+ * src/cli/**\/*.ts and src/lib/**\/*.ts — the latter is required so the CLI's
  * ~258 relative "../lib/..." imports type-check. As a side effect, tsc
  * re-emits the entire src/lib tree a second time at dist/lib/**, on top of
  * the already-flattened dist/** tree svelte-package produced moments earlier
@@ -12,7 +12,7 @@
  * ships inside the published tarball for no reason.
  *
  * What this script does, in order:
- *   1. Walks dist/cli/**​/*.{js,d.ts} and rewrites every relative import/
+ *   1. Walks dist/cli/**\/*.{js,d.ts} and rewrites every relative import/
  *      require/dynamic-import specifier of the shape "(../)+lib/..." so it
  *      points at the already-flattened dist/** tree instead of dist/lib/**
  *      (i.e. it deletes the "lib/" path segment — dist/cli and dist/lib are

--- a/scripts/commit-validation.ts
+++ b/scripts/commit-validation.ts
@@ -52,7 +52,7 @@ const SEMANTIC_TYPES = [
  * - scope: letters, numbers, hyphens, and slashes (no spaces for consistency)
  * - description: any character sequence after colon and space
  */
-const SEMANTIC_COMMIT_PATTERN = /^([a-z]+)(\([a-zA-Z0-9\-\/]+\)):\s(.+)$/i;
+const SEMANTIC_COMMIT_PATTERN = /^([a-z]+)(\([a-zA-Z0-9\-/]+\)):\s(.+)$/i;
 
 /**
  * Ceiling for the local git queries below.
@@ -183,7 +183,7 @@ class CommitValidator {
     }
 
     // Validate scope format (letters, numbers, hyphens, slashes - no spaces for consistency)
-    const scopePattern = /^[a-zA-Z0-9\-\/]+$/;
+    const scopePattern = /^[a-zA-Z0-9\-/]+$/;
     if (!scopePattern.test(scope)) {
       this.addError(`Invalid scope format: "${scope}"`);
       this.addError(

--- a/scripts/comprehensiveTest.ts
+++ b/scripts/comprehensiveTest.ts
@@ -153,7 +153,7 @@ class ComprehensiveTester {
         "Model Server Health Check",
         { timeout: 10000 }
       );
-    } catch (error) {
+    } catch {
       this.log("Model server test skipped (server not running)", "warning");
     }
     

--- a/scripts/correctedSdkTest.ts
+++ b/scripts/correctedSdkTest.ts
@@ -174,7 +174,7 @@ async function testCorrectSDK(): Promise<void> {
       console.log('\n🔧 TESTING createAIProvider');
       
       try {
-        const basicProvider = await createAIProvider('google-ai');
+        await createAIProvider('google-ai');
         log('createAIProvider()', 'SUCCESS', 'Basic provider created');
       } catch (error: unknown) {
         log('createAIProvider()', 'FAILED', (error as Error).message);

--- a/scripts/createCliOverviewVideo.ts
+++ b/scripts/createCliOverviewVideo.ts
@@ -18,8 +18,8 @@ const OUTPUT_DIR = path.join(
   __dirname,
   "../docs/visual-content/videos/cli-videos/cli-overview",
 );
-const SCRIPT_DELAY = 2000; // 2 seconds between commands
-const VIDEO_DURATION = 30; // Target ~30 seconds
+const _SCRIPT_DELAY = 2000; // 2 seconds between commands
+const _VIDEO_DURATION = 30; // Target ~30 seconds
 
 type CLICommand = {
   command: string;
@@ -248,7 +248,7 @@ Commands:
         { stdio: "inherit" },
       );
       console.log(`✅ MP4 version saved: ${mp4Path}`);
-    } catch (error) {
+    } catch {
       console.log("⚠️ MP4 conversion failed, WebM version available");
     }
   }

--- a/scripts/createMcpVideos.ts
+++ b/scripts/createMcpVideos.ts
@@ -581,7 +581,7 @@ Step 4: Logging results (postgres server)
 /**
  * Create video for a single scenario
  */
-async function createScenarioVideo(browser, scenario) {
+async function _createScenarioVideo(browser, scenario) {
   const page = await browser.newPage();
 
   // Set viewport for video recording
@@ -707,7 +707,7 @@ async function generateMCPVideos() {
               if (action.selector) {
                 try {
                   await page.click(action.selector, { timeout: 5000 });
-                } catch (error) {
+                } catch {
                   console.log(
                     `⚠️  Click failed for ${action.selector}, continuing...`,
                   );

--- a/scripts/createThreeProviderDemos.ts
+++ b/scripts/createThreeProviderDemos.ts
@@ -172,7 +172,7 @@ async function main() {
     if (!response.ok) {
       throw new Error("Demo server not responding");
     }
-  } catch (error) {
+  } catch {
     console.error("❌ Demo server is not running!");
     console.log("Please start the demo server first:");
     console.log("  cd neurolink-demo && npm install && npm start");

--- a/scripts/e2eTestThreeProviders.ts
+++ b/scripts/e2eTestThreeProviders.ts
@@ -81,7 +81,7 @@ async function testProvider(providerName) {
       });
       spinner.fail("❌ Error handling test failed - should have thrown error");
       testResult.tests.push({ name: "Error Handling", status: "failed" });
-    } catch (error) {
+    } catch {
       spinner.succeed("✅ Error handling working correctly");
       testResult.tests.push({ name: "Error Handling", status: "passed" });
     }

--- a/scripts/neurolink-demo-create-comprehensive-demo-videos.ts
+++ b/scripts/neurolink-demo-create-comprehensive-demo-videos.ts
@@ -317,7 +317,7 @@ async function checkServer() {
       console.log("✅ Demo server is running");
       return true;
     }
-  } catch (error) {
+  } catch {
     console.error("❌ Demo server is not running. Please start it first:");
     console.error("   cd neurolink-demo && node server.js");
     return false;

--- a/scripts/phase6ValidationCleanup.ts
+++ b/scripts/phase6ValidationCleanup.ts
@@ -7,7 +7,7 @@
 
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { writeFile, readFile, readdir, stat, unlink, mkdir } from "fs/promises";
+import { writeFile, readFile, stat, unlink, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { UniversalVisualContentGenerator } from "./generate-visual-content.js";
 
@@ -221,7 +221,7 @@ class Phase6ValidationCleanup {
       for (const scriptPath of this.oldScripts) {
         if (existsSync(scriptPath)) {
           const stats = await stat(scriptPath);
-          const archiveName = scriptPath.replace(/[\/\\]/g, "-");
+          const archiveName = scriptPath.replace(/[/\\]/g, "-");
           const archivePath = join(archiveDir, archiveName);
 
           if (!this.dryRun) {

--- a/scripts/quickVerification.ts
+++ b/scripts/quickVerification.ts
@@ -6,8 +6,7 @@
  */
 
 import { execSync } from "child_process";
-import { writeFileSync, existsSync, readdirSync } from "fs";
-import path from "path";
+import { writeFileSync, existsSync } from "fs";
 
 const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
 
@@ -27,7 +26,7 @@ function log(message: string, success = true): void {
 
 function runQuickTest(command: string, description: string): boolean {
   try {
-    const output = execSync(command, { encoding: 'utf8', timeout: 30000 });
+    execSync(command, { encoding: 'utf8', timeout: 30000 });
     log(`${description} - SUCCESS`);
     return true;
   } catch (error) {

--- a/scripts/sdkComprehensiveTest.ts
+++ b/scripts/sdkComprehensiveTest.ts
@@ -32,12 +32,11 @@ async function testSDK(): Promise<void> {
     // Test 1: Import SDK
     console.log('\n📦 TESTING SDK IMPORTS');
     
-    let neurolink, createBestAIProvider, NeuroLink;
+    let createBestAIProvider, NeuroLink;
     try {
       const sdk = await import('../dist/lib/index.js');
       createBestAIProvider = sdk.createBestAIProvider;
       NeuroLink = sdk.NeuroLink;
-      neurolink = sdk.default;
       log('SDK Import', 'SUCCESS', 'All imports successful');
     } catch (error: unknown) {
       log('SDK Import', 'FAILED', (error as Error).message);
@@ -168,7 +167,7 @@ async function testSDK(): Promise<void> {
     
     try {
       if (provider.stream) {
-        const stream = await provider.stream({ input: { text: 'Tell me a short joke' } });
+        await provider.stream({ input: { text: 'Tell me a short joke' } });
         log('stream() method', 'SUCCESS', 'Streaming method available');
       } else {
         log('stream() method', 'SKIPPED', 'Method not available on provider');
@@ -183,7 +182,7 @@ async function testSDK(): Promise<void> {
     try {
       await provider.generate({ input: { text: '' } }); // Empty prompt
       log('Empty Prompt Handling', 'UNCLEAR', 'Empty prompt accepted');
-    } catch (error: unknown) {
+    } catch {
       log('Empty Prompt Handling', 'SUCCESS', 'Properly rejected empty prompt');
     }
 
@@ -191,7 +190,7 @@ async function testSDK(): Promise<void> {
       const invalidProvider = createBestAIProvider('invalid-provider');
       await invalidProvider.generate({ input: { text: 'Test' } });
       log('Invalid Provider Handling', 'FAILED', 'Should have rejected invalid provider');
-    } catch (error: unknown) {
+    } catch {
       log('Invalid Provider Handling', 'SUCCESS', 'Properly rejected invalid provider');
     }
 

--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -1006,7 +1006,7 @@ class SecurityValidator {
               cleanContent.includes("xxx") ||
               cleanContent.includes("replace") ||
               cleanContent.includes("here") ||
-              /^[x\-_=<>\[\]{}()]{10,}$/.test(cleanContent)
+              /^[x\-_=<>[\]{}()]{10,}$/.test(cleanContent)
             );
           });
 

--- a/scripts/testThreeProviders.ts
+++ b/scripts/testThreeProviders.ts
@@ -151,7 +151,7 @@ async function performanceComparison() {
       performances.push({ provider: providerName, time, status: "success" });
 
       spinner.succeed(`${providerName}: ${time}ms`);
-    } catch (error) {
+    } catch {
       performances.push({ provider: providerName, time: 0, status: "failed" });
       spinner.fail(`${providerName}: Failed`);
     }

--- a/scripts/testUnifiedMcp.ts
+++ b/scripts/testUnifiedMcp.ts
@@ -6,7 +6,6 @@
 
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-import { readFile } from 'fs/promises';
 
 // Get project root
 const __filename = fileURLToPath(import.meta.url);

--- a/scripts/testing/executeAllTestsParallel.ts
+++ b/scripts/testing/executeAllTestsParallel.ts
@@ -13,7 +13,7 @@ try {
   // dotenv not available - this is fine for production
 }
 
-import { spawn, exec } from 'child_process';
+import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/test/fixtures/proxySocketWorker.cjs
+++ b/test/fixtures/proxySocketWorker.cjs
@@ -1,5 +1,3 @@
-/* global process, Buffer, setInterval, clearInterval, setTimeout, setImmediate */
-
 const http = require("node:http");
 
 const generation = Number(process.env.NEUROLINK_PROXY_WORKER_GENERATION);

--- a/tools/automation/shellConverter.ts
+++ b/tools/automation/shellConverter.ts
@@ -106,7 +106,9 @@ class ShellConverter {
       const files = await fs.readdir(this.scriptsDir);
       return files.filter((file) => file.endsWith(".sh"));
     } catch (error: any) {
-      throw new Error(`Failed to read scripts directory: ${error.message}`);
+      throw new Error(`Failed to read scripts directory: ${error.message}`, {
+        cause: error,
+      });
     }
   }
 
@@ -137,7 +139,9 @@ class ShellConverter {
       console.log(`✅ Created: ${jsPath}`);
       return jsPath;
     } catch (error: any) {
-      throw new Error(`Failed to convert ${shellFile}: ${error.message}`);
+      throw new Error(`Failed to convert ${shellFile}: ${error.message}`, {
+        cause: error,
+      });
     }
   }
 
@@ -308,7 +312,7 @@ const files = await glob.glob('${namePattern}', {
         const grepOptions = grepMatch[3] || "";
 
         // Convert common source commands
-        let sourceConversion = "";
+        let sourceConversion;
         if (sourceCommand.startsWith("cat ")) {
           const filePath = sourceCommand
             .substring(4)

--- a/tools/converted-scripts/scriptsCleanupHashNamedVideos.ts
+++ b/tools/converted-scripts/scriptsCleanupHashNamedVideos.ts
@@ -7,7 +7,6 @@
 
 import fs from "fs/promises";
 import path from "path";
-import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 import readline from "readline";
 
@@ -37,7 +36,7 @@ async function identify_files() {
   log_info("Scanning for hash-named video files...");
   try {
     await fs.access(DEMO_VIDEO_DIR);
-  } catch (error: any) {
+  } catch {
     log_error(`Video directory not found: ${DEMO_VIDEO_DIR}`);
     process.exit(1);
   }

--- a/tools/converted-scripts/scriptsConvertAllCastToGif.ts
+++ b/tools/converted-scripts/scriptsConvertAllCastToGif.ts
@@ -31,7 +31,7 @@ const log_error = (message: string) =>
 function check_agg_dependency() {
   try {
     execSync("command -v agg", { stdio: "ignore" });
-  } catch (error: any) {
+  } catch {
     log_error("'agg' tool not found. Please install it to continue.");
     log_info("Installation instructions: https://github.com/asciinema/agg");
     log_info(
@@ -103,7 +103,7 @@ async function run() {
       log_warning(`GIF already exists: ${gif_filename} - Skipping`);
       skip_count++;
       continue;
-    } catch (error: any) {
+    } catch {
       // File doesn't exist, proceed with conversion
     }
 

--- a/tools/converted-scripts/scriptsCreateCliRecordings.ts
+++ b/tools/converted-scripts/scriptsCreateCliRecordings.ts
@@ -42,7 +42,7 @@ async function run() {
   log_info("🔨 Building CLI...");
   try {
     execSync("pnpm run build:cli", { cwd: PROJECT_ROOT, stdio: "inherit" });
-  } catch (error: any) {
+  } catch {
     log_error("CLI build failed. Please check the build process.");
     process.exit(1);
   }

--- a/tools/converted-scripts/scriptsCreateSimpleCliRecordings.ts
+++ b/tools/converted-scripts/scriptsCreateSimpleCliRecordings.ts
@@ -42,7 +42,7 @@ async function run() {
   log_info("🔨 Building CLI...");
   try {
     execSync("pnpm run build:cli", { cwd: PROJECT_ROOT, stdio: "inherit" });
-  } catch (error: any) {
+  } catch {
     log_error("CLI build failed. Please check the build process.");
     process.exit(1);
   }

--- a/tools/converted-scripts/scriptsCreateSimpleWorkingRecordings.ts
+++ b/tools/converted-scripts/scriptsCreateSimpleWorkingRecordings.ts
@@ -84,7 +84,7 @@ async function run() {
   log_info("🔨 Building CLI...");
   try {
     execSync("npm run build", { cwd: PROJECT_ROOT, stdio: "inherit" });
-  } catch (error: any) {
+  } catch {
     log_error("CLI build failed.");
     process.exit(1);
   }

--- a/tools/converted-scripts/scriptsCreateWorkingCliRecordings.ts
+++ b/tools/converted-scripts/scriptsCreateWorkingCliRecordings.ts
@@ -67,7 +67,7 @@ async function run() {
   log_info("🔨 Building CLI...");
   try {
     execSync("npm run build", { cwd: PROJECT_ROOT, stdio: "inherit" });
-  } catch (error: any) {
+  } catch {
     log_error("CLI build failed.");
     process.exit(1);
   }
@@ -125,7 +125,7 @@ async function run() {
         { stdio: "ignore" },
       );
       log_success(`  ✅ Created ${base_name}.mp4 (high quality)`);
-    } catch (error: any) {
+    } catch {
       log_info(
         "`agg` failed or not found, falling back to ffmpeg placeholder.",
       );

--- a/tools/converted-scripts/scriptsGenerateAllVideos.ts
+++ b/tools/converted-scripts/scriptsGenerateAllVideos.ts
@@ -45,7 +45,7 @@ async function check_dependencies() {
         process.platform === "win32" ? `where ${cmd}` : `command -v ${cmd}`,
         { stdio: "ignore" },
       );
-    } catch (e) {
+    } catch {
       missing_deps.push(cmd);
     }
   }
@@ -72,7 +72,7 @@ async function check_demo_server() {
     execSync("curl -s --fail http://localhost:9876 > /dev/null 2>&1");
     log_success("Demo server is running");
     return true;
-  } catch (error: unknown) {
+  } catch {
     // The command fails if the server is not running
   }
   log_warning("Demo server is not running");
@@ -97,7 +97,7 @@ async function generate_sdk_videos() {
     await fs.access(scriptPath);
     execSync(`node "${scriptPath}"`, { cwd: DEMO_DIR, stdio: "inherit" });
     log_success("SDK demo videos generated");
-  } catch (error: unknown) {
+  } catch {
     log_warning(
       `SDK video generator script not found at ${scriptPath} - skipping`,
     );

--- a/tools/testing/adaptiveTestRunner.ts
+++ b/tools/testing/adaptiveTestRunner.ts
@@ -320,7 +320,7 @@ class AdaptiveTestRunner {
         // Fallback: check for recently modified files
         await this.detectRecentlyModified();
       }
-    } catch (error: any) {
+    } catch {
       console.log("⚠️  Git diff failed, using fallback strategy");
       await this.detectRecentlyModified();
     }
@@ -348,7 +348,7 @@ class AdaptiveTestRunner {
 
       this.results.changedFiles = Array.from(this.changedFiles);
       console.log(`📁 Using ${this.changedFiles.size} recently modified files`);
-    } catch (error: any) {
+    } catch {
       console.log("⚠️  Fallback detection failed, running critical tests only");
       this.config.criticalTests.forEach((pattern) =>
         this.changedFiles.add(pattern),


### PR DESCRIPTION
`scripts/` was invisible to ESLint in **two** separate ways, and the ignore-list entry was only one of them.

Removing `"scripts/**"` from `ignores` got **8** `.mjs`/`.cjs` files linted. The **70** TypeScript files stayed silent — no `files:` glob in this config matches a `.ts` path outside `src/` and `test/`, so they parsed under no configuration at all and "passed" by never being read. ESLint was reporting on **zero** of them. `tools/` had the same hole, and `.cjs` matched nothing anywhere, including the plugin that runs in the release pipeline.

That is the blind spot `tsconfig.ci-scripts.json` was created for, in its own words: the provider onboarding gate shipped asserting a field that does not exist, its catalog lookup silently produced `{undefined}`, and half a required check never ran — in `tools/verify-provider-onboarding.ts`, a file that **gates a required status check** and that nothing typechecked and nothing linted.

## Config

One block for `scripts/**/*.ts` + `tools/**/*.ts`, one for `**/*.cjs`.

- **No `project`** on the TS block, for the same reason `test/**/*.ts` has none: these files sit outside the root tsconfig, so type-aware rules cannot run. This is the syntactic tier — which is the tier that caught the real defects here anyway.
- **`.cjs` needs its own `sourceType: "commonjs"`.** Folding it into the `.js`/`.mjs` block would declare `require` and `module` undefined.
- **`no-unused-vars` mirrors the `src/` options plus `caughtErrorsIgnorePattern`.** The tree already writes `catch (_error)` to mean "deliberately unused", but no block had declared that pattern, so typescript-eslint's `caughtErrors: "all"` default was flagging the convention the code was following.

## Fallout: 98 errors, all fixed rather than exempted

22 unused catch bindings → bare `catch`; 7 unused imports removed; 5 bindings dropped **while keeping the call that produced them**; 3 dead declarations underscored.

## One is a real bug

`scripts/audit-skips.ts` matched skip markers with a character class holding `⏭️` — which is **two** code points, U+23ED plus a variation selector. A class of code points therefore meant *"⊘, or ⏭, or a lone U+FE0F"*:

| input | old `[⊘⏭️]` | new `(?:⊘|⏭️)` |
|---|---|---|
| `⊘ skipped` | ✅ | ✅ |
| `⏭️ skipped` | **❌ silently missed** | ✅ |
| bare variation selector | **⚠️ false match** | ✅ rejected |

This is a script whose job is auditing masked test skips, and it was itself masking them.

The other substantive fixes: a `try/catch` that only rethrew, two thrown errors that dropped their `cause`, and a `let` initialiser every branch overwrote.

## Two invisible characters needed care, not deletion

- The **zero-width spaces** in `collapse-cli-lib-duplicate.mjs` were load-bearing: they stopped `*/` inside a glob from closing the block comment. Deleting them would have broken the file. Replaced with an escaped slash that has no such sequence.
- The **ESC** in `audit-skips.ts` is the ANSI introducer and the entire point of the pattern, so it keeps a targeted disable with a reason.

`test/fixtures/proxySocketWorker.cjs` loses a `/* global */` directive that was inert while `.cjs` matched no config and became a redeclare error once it did. Those globals are now declared once, in the config.

## Verification

- `pnpm run lint` exits **0**, 0 errors repo-wide. The 57 remaining warnings are **all pre-existing in `src/`** (`no-non-null-assertion`, `max-lines-per-function`, `prefer-const`) — **none** in `scripts/` or `tools/`.
- `check:ci-scripts` and `check:tools-tests` both pass.
- `audit-skips.ts` and `commit-validation.ts` still run; the marker fix is demonstrated against both markers plus the stray-selector case.
- The four regex escape changes are proven behaviour-preserving **case by case**, not assumed — `commit-validation.ts` drives the commit hook, so "obviously identical" wasn't good enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Expanded linting coverage for project scripts and tooling.
  - Improved validation of JavaScript, TypeScript, and CommonJS files.
  - Added clearer error context when script conversion fails.

- **Reliability**
  - Corrected skip-marker and secret-detection pattern handling.
  - Preserved existing build, testing, benchmarking, and video-generation behavior while improving error handling consistency.

- **Code Quality**
  - Removed unused imports, variables, and redundant error bindings across maintenance tools and test utilities.
  - Standardized formatting and validation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->