### PR TITLE
perf(ci): re-measure the extended-suite weights from real CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,17 +970,55 @@ jobs:
           # This job is non-blocking on purpose. These are measured once, not
           # proven stable, and `security-suites` is a required check that
           # blocks every open pull request when it breaks.
-          # name@seconds, longest first. The weights are measured wall-clock
-          # from run 32808851519, and they affect BALANCE ONLY — never which
-          # suites run. A stale weight makes one shard slower; it can never
-          # cause a suite to be skipped or run twice. An entry with no @weight
-          # still runs, at an assumed 30s.
+          # name@seconds, longest first. The weights affect BALANCE ONLY —
+          # never which suites run. A stale weight makes one shard slower; it
+          # can never cause a suite to be skipped or run twice. An entry with
+          # no @weight still runs, at an assumed 30s.
+          #
+          # Refreshed 2026-08-27: median of 13 runs, read from this job's own
+          # logs. The previous set came from a single run (32808851519) and one
+          # entry had gone badly stale — test:tts:unit was still carrying 367s
+          # after the deadlock fix in #1550 cut it to a median of 140s, a 2.6x
+          # overstatement that survived because nothing re-measures.
+          #
+          # To re-measure, do NOT time these locally: a developer machine is
+          # faster than a runner AND has credentials, so suites that skip in CI
+          # do real work here. Measuring test:tts:unit locally gives ~73s
+          # against a CI median of 140s — wrong by nearly half, in the
+          # direction that would have made the imbalance look worse than it is.
+          # Read the real thing instead; the ::group:: markers below are
+          # timestamped in the raw job log:
+          #
+          #   gh api repos/juspay/neurolink/actions/jobs/<id>/logs | awk '
+          #     function secs(ts,   a) { split(substr(ts,12,8), a, ":")
+          #                              return a[1]*3600 + a[2]*60 + a[3] }
+          #     /##\[group\]test:/        { t=secs($1); n=$2; sub(/^##\[group\]/,"",n) }
+          #     /##\[endgroup\]/ && n!="" { d=secs($1)-t; if (d<0) d+=86400
+          #                              printf "%s@%d\n", n, d; n="" }'
+          #
+          # That prints `suite@seconds` — the exact shape of a SUITES line, so
+          # the output pastes straight in. It avoids gawk's mktime(), which BSD
+          # awk (macOS) does not have, and adds a day's seconds back when a job
+          # crosses midnight UTC. It was run against a captured log before being
+          # written down here, which the version it replaces was not: that one
+          # bound the timestamp only at ::group:: and never read the ::endgroup::
+          # one, so it printed a start time and a `##[group]`-prefixed name and
+          # never computed a duration at all.
+          #
+          # Take a median across several runs, not one sample: the observed
+          # per-suite range is wide (test:tts:unit spans 95s to 155s).
+          #
+          # Two entries are skip-times, not work-times. test:tool-reliability
+          # and test:autoresearch are live-tier and have no credentials here, so
+          # what is being weighted is how long they take to decide to skip. That
+          # is the correct number for THIS job, and the wrong number to reuse
+          # anywhere that runs them for real.
           #
           # Round-robin by list position was the previous scheme. It balances
           # the COUNT of suites, which is the wrong quantity: the measured
-          # spread is 1s to 367s, so equal counts gave shards of 33s and 485s.
+          # spread is 1s to 140s, so equal counts gave shards of 90s and 241s.
           SUITES="
-            test:tts:unit@367
+            test:tts:unit@140
             test:agent-delegation@78
             test:background-commands@23
             test:agent-tasks@13
@@ -991,33 +1029,33 @@ jobs:
             test:video-abort@3
             test:classifier-router@3
             test:resolve-request-kind@1
-            test:vertex-loop-characterization@96
-            test:tool-reliability@51
-            test:auth@45
-            test:vertex-claude-characterization@45
+            test:vertex-loop-characterization@100
+            test:tool-reliability@57
+            test:auth@50
+            test:vertex-claude-characterization@46
             test:openai-compat-catalog@24
-            test:openai-compat-streaming-retry@19
+            test:provider-descriptors@17
+            test:openai-compat-streaming-retry@16
             test:servers@16
-            test:anthropic-streaming-retry@15
-            test:provider-descriptors@14
-            test:adjust-body-after-400@12
             test:video:unit@12
+            test:adjust-body-after-400@10
+            test:anthropic-streaming-retry@10
             test:dynamic@10
             test:local-usage@8
-            test:provider-fallback-latency@5
-            test:codex@4
+            test:provider-fallback-latency@6
+            test:codex@5
             test:credentials@4
-            test:music:unit@4
             test:stt:unit@4
             test:avatar:unit@3
             test:mcp@3
+            test:model-manifests@3
+            test:music:unit@3
             test:provider-fallback@3
             test:realtime:unit@3
             test:tool-resolution@3
             test:autoresearch@2
             test:loop-engine@2
             test:handler-registry@1
-            test:model-manifests@1
           "
           # Normalise every entry to name@weight (missing or non-numeric
           # weights become 30), then sort by weight descending. Greedy


### PR DESCRIPTION
`test:tts:unit` still declared **367s**. The deadlock fix in #1550 landed **33 seconds** after #1546 measured it and cut the suite to a CI median of **140s** — a 2.6x overstatement that survived because nothing re-measures. All 28 weights are refreshed from the **median of 13 runs**, read out of this job's own logs via the timestamps on its `::group::` markers.

## The gain is small, and smaller than I claimed when I filed this

Scoring both plans against measured durations: **worst shard 145s → 141s.** About four seconds.

The reason is luck, not design. 140s happens to be almost exactly the ideal quarter-share of 561s, so LPT put `tts:unit` alone on a shard and that shard landed on the right number for the wrong reason.

What actually improves is that **the plan now matches reality** — verified by running the workflow's own assignment loop:

| | shard 1 | 2 | 3 | 4 | spread |
|---|---|---|---|---|---|
| **old plan** | 367 | 137 | 136 | 136 | 11s |
| **new plan** | 140 | 141 | 140 | 140 | **1s** |

Correcting only `tts:unit` would have changed **nothing at all** — it is still the largest entry and still lands alone — so the full refresh is the whole of the change.

## Verification

Run with the workflow's assignment loop **extracted verbatim, not reimplemented**: all 28 suites assigned, each exactly once, **1 / 8 / 10 / 9** per shard. The suite set is byte-identical to `release` — only numbers move. Weights affect balance only, never which suites run; a wrong one can make a shard slow, never skip or double-run a suite.

## The comment now says how to re-measure

The root cause is that nobody could. Two traps are written down:

- **Do not time these locally.** A developer machine is faster than a runner *and* has credentials, so suites that skip in CI do real work. `test:tts:unit` measures **~73s locally against a CI median of 140s** — wrong by nearly half, and wrong in the direction that makes the imbalance look *worse* than it is. I measured it locally first and would have shipped 73.
- **Take a median across runs.** `test:tts:unit` alone spans **95s to 155s**, so one observation can be off by 40%.

`test:tool-reliability` and `test:autoresearch` are weighted at their **skip** times — correct for this job, which has no credentials, and wrong to reuse anywhere that runs them for real. That is now stated next to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test suite timing data using measurements from multiple runs.
  * Improved test shard balancing to distribute workloads more evenly and reduce execution-time variance.
  * Clarified documentation around timing measurements, skipped suites, and shard assignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->