### PR TITLE
docs(ci): correct why test:proxy is held out, and record what CI found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,12 +848,57 @@ jobs:
           # has a 60s per-test bound, which is the likeliest thing to give way
           # under a long sequence. Worth 7 assertions to whoever diagnoses it.
           #
-          # Two candidates that pass locally are deliberately absent, and the
-          # reason is the whole point of measuring rather than assuming:
-          # test:proxy passes with credentials (74 passed / 6 skipped) and
-          # FAILS without them (68 passed / 5 failed / 7 skipped), and
-          # test:multimodal:sdk exits non-zero with no summary. Either would
-          # have looked safe from a run on a developer machine.
+          # test:multimodal:sdk is deliberately absent: it exits non-zero with
+          # no summary, and would have looked safe from a run on a developer
+          # machine.
+          #
+          # test:proxy stays out too, but the recorded reason for it was
+          # wrong, and the real one only showed up in CI.
+          #
+          # The old reading was that it "passes with credentials (74/6) and
+          # fails without them (68/5/7)". Those conditions are the wrong way
+          # round, and the axis is not credentials at all.
+          #
+          # It neutralises its own environment before anything else runs — a
+          # mkdtemp HOME, USERPROFILE and XDG_CONFIG_HOME, and it deletes
+          # ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, OPENAI_API_KEY and
+          # GOOGLE_API_KEY outright unless NEUROLINK_PROXY_TEST_ALLOW_LIVE=1.
+          # Ambient credentials therefore cannot reach it, which is why running
+          # it with and without them produces byte-identical results.
+          #
+          # The failing condition is the opt-in one, not the bare one:
+          #
+          #   default (keys deleted by the suite)   74 passed / 6 skipped / 0 failed
+          #   NEUROLINK_PROXY_TEST_ALLOW_LIVE=1     75 passed / 0 skipped / 5 failed
+          #
+          # and those five are live round-trips failing on the account's credit
+          # balance, not on anything the suite does. CI never sets that
+          # variable, so CI gets the first row.
+          #
+          # It was wired in on that basis — seven local runs across five
+          # environments, all 74/6/0 — and CI disagreed on the first attempt:
+          #
+          #   local  (7 runs, 5 environments)   74 passed / 0 failed / 6 skipped
+          #   CI     (run 33021689979)          71 passed / 1 FAILED / 8 skipped
+          #
+          # The single failure is "Attribution: the request log records the
+          # calling CLI", asserting "request log carried no attribution for the
+          # unknown caller". It sends two requests under different
+          # user-agents, then reads the proxy's request log back and expects a
+          # record for each; in CI the unknown-caller record was absent. Note
+          # the skip count also moves, 6 to 8, so the environments differ in
+          # more than that one case.
+          #
+          # Local green across many environments is not evidence about CI: no
+          # local configuration reproduced it. Whoever picks this up starts
+          # from a named failing case rather than from a guess, and should
+          # check whether the log write races the read-back. CI measured the
+          # suite at 37s, so weight it there and not at the 80s that was
+          # extrapolated from local timings.
+          #
+          # The 55669 in that suite is a config string it writes into client
+          # config files and asserts on — never a request target — so an
+          # operator's own proxy listening there does not affect it.
           #
           # test:model-not-found-retryable is also absent: it skips entirely
           # without credentials, so it could only ever no-op here — the same


### PR DESCRIPTION
**Revised after CI disagreed with me.** The wire-in has been taken back out; what remains is comment-only.

## The recorded reason was wrong

It read: *"passes with credentials (74/6) and fails without them (68/5/7)"*. Those conditions are **the wrong way round**, and credentials are not the axis at all.

The suite neutralises its own environment before anything else runs — a `mkdtemp` HOME, and it **deletes** `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` unless `NEUROLINK_PROXY_TEST_ALLOW_LIVE=1`. Ambient credentials cannot reach it, which is why with and without give byte-identical results. The failing condition is the **opt-in** one, and those failures are live round-trips reporting *"credit balance is too low"* — the account, not the suite.

## But the suite still stays out, for a reason only CI could show

I wired it in on the strength of seven local runs across five deliberately-varied environments. CI disagreed on the first attempt:

| | result |
|---|---|
| local — 7 runs, 5 environments | 74 passed / **0 failed** / 6 skipped |
| CI — [run 33021689979](https://github.com/juspay/neurolink/actions/runs/33021689979) | 71 passed / **1 FAILED** / 8 skipped |

The single failure is **"Attribution: the request log records the calling CLI"**, asserting *"request log carried no attribution for the unknown caller"*. It sends three requests under different user-agents, reads the proxy's request log back, and expects a record for each; in CI the unknown-caller record was absent. The **skip count moves too, 6 → 8**, so the environments differ in more than that one case.

**Seven green local runs were not evidence about CI**, and no local configuration reproduced the failure. The non-blocking job is what surfaced it — which is exactly what it is for.

What is left behind is a **named failing case and a specific thing to check** — whether the log write races the read-back — instead of the inverted reason that was there before. CI also measured the suite at **37s**, so weight it there rather than at the 80s I extrapolated from local timings.

## Scope

Comment-only after the revert: the weighted suite list is **byte-identical to release at 28 entries**, and **zero non-comment lines change**. Both checked.

No longer conflicts with #1568 or #1571 — the `SUITES` list is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Clarified the conditions under which the proxy suite runs in CI, including credential isolation and optional live-service testing.
  - Documented recent CI results, including an intermittent attribution-log failure and expected live-test credit-balance failures.
  - Recorded the suite’s measured CI runtime to improve test-run visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->