### PR TITLE
fix(test): stop multimodal:sdk waiting 60s per instance on an MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,9 +848,18 @@ jobs:
           # has a 60s per-test bound, which is the likeliest thing to give way
           # under a long sequence. Worth 7 assertions to whoever diagnoses it.
           #
-          # test:multimodal:sdk is deliberately absent: it exits non-zero with
-          # no summary, and would have looked safe from a run on a developer
-          # machine.
+          # test:multimodal:sdk used to "exit non-zero with no summary", and
+          # the cause was never in the suite's assertions. The repo's tracked
+          # .mcp-config.json declares a `filesystem` server started via
+          # `npx -y @modelcontextprotocol/server-filesystem`, with
+          # autoDiscovery and autoRegister both on, so every NeuroLink the
+          # suite builds tried to start it and waited the full 60s MCP client
+          # timeout when it could not — once per instance, fourteen times.
+          # Measured: 11 such timeouts and still running past 20 minutes, which
+          # is why it was killed before printing anything. The suite now sets
+          # NEUROLINK_SKIP_MCP, as test:proxy already did, and finishes in 58s
+          # at 14/14. It does not test MCP; it tests whether a file handed to
+          # generate() reaches the model.
           #
           # test:proxy stays out too, but the recorded reason for it was
           # wrong, and the real one only showed up in CI.
@@ -918,6 +927,7 @@ jobs:
           # spread is 1s to 367s, so equal counts gave shards of 33s and 485s.
           SUITES="
             test:tts:unit@367
+            test:multimodal:sdk@110
             test:agents@7
             test:media-registry-collisions@3
             test:video-abort@3

--- a/test/continuous-test-suite-multimodal-sdk.ts
+++ b/test/continuous-test-suite-multimodal-sdk.ts
@@ -22,6 +22,16 @@
  * Run: npx tsx test/continuous-test-suite-multimodal-sdk.ts
  */
 
+// Set before dotenv, and before anything can construct a NeuroLink: the
+// repo's tracked .mcp-config.json declares a `filesystem` server started via
+// `npx -y @modelcontextprotocol/server-filesystem`, with autoDiscovery and
+// autoRegister both on. Every instance this suite builds therefore tries to
+// start it, and when it cannot, waits the full 60s MCP client timeout — once
+// per instance, fourteen times over. The suite does not test MCP; it tests
+// whether a file handed to generate() reaches the model. test:proxy already
+// sets this for the same reason.
+process.env.NEUROLINK_SKIP_MCP = "true";
+
 import "dotenv/config";
 import * as fs from "node:fs";
 import * as path from "node:path";


### PR DESCRIPTION
The suite *"exited non-zero with no summary"* — and the cause was never in its assertions.

The repo's **tracked** `.mcp-config.json` declares a `filesystem` server started via `npx -y @modelcontextprotocol/server-filesystem`, with `autoDiscovery` and `autoRegister` both on. Every `NeuroLink` the suite builds therefore tried to start it, and when it couldn't, waited the **full 60s MCP client timeout** — once per instance, fourteen times over.

| condition | result |
|---|---|
| as on `release` | **11 MCP timeouts logged, still running past 20 minutes**, no summary |
| `NEUROLINK_SKIP_MCP` set | **exit 0, 58s, 14 passed / 0 failed** |

Nothing was wrong with the tests. They were queued behind a column of one-minute waits, and whatever bound the sweep applied killed the process before it printed. From outside, that is *exactly* what "non-zero, no summary" looks like — which is why the cause stayed undiagnosed: the symptom names the harness, not the culprit.

## The fix

`process.env.NEUROLINK_SKIP_MCP = "true"`, set **before** `dotenv` and before anything can construct a `NeuroLink`, because the config is read at construction. `test:proxy` already does the same thing for the same reason — it was the only suite that did.

Skipping MCP costs this suite nothing: **it does not test MCP.** It tests whether a file handed to `generate()` reaches the model as usable content — detection, `MessageBuilder`, the provider adapter — and all fourteen cases assert exactly what they did before.

## Verification

14/14 with **zero** MCP timeouts · build exit 0 · `check:tools-tests` 0 errors · eslint + prettier clean · the workflow's own assignment loop places all **29** suites with no duplicates.

Weighted at **110s** — 58s measured locally × the ~1.9× local-to-CI ratio observed for `test:tts:unit`. An estimate; the first real run should replace it via the log-timestamp method documented above the list.

## Merge order

This is the **third** PR touching the `SUITES` block, after [#1568](https://github.com/juspay/neurolink/pull/1568) (rewrites all 28 weights) and [#1570](https://github.com/juspay/neurolink/pull/1570) (adds `test:proxy`). Suggested order: **#1568 → #1570 → this one.** Each later PR then needs at most a one-line rebase in that list. Flagging it rather than letting you find it at merge time.