### PR TITLE
docs(ci): security-suites is a required check, not advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,18 +391,40 @@ jobs:
         if: matrix.group == 'rest'
         run: pnpm run verify:provider-onboarding
 
-  # Advisory only — deliberately NOT in the required-checks list.
+  # REQUIRED. A red run here blocks the merge.
   #
-  # The archive and office security suites drive real malicious inputs (zip
-  # bombs, path traversal, XXE-shaped office documents) through the public
-  # surface. They were wired into `test:unit`, but nothing in CI has ever run
-  # `test:unit`, so they had never executed on a pull request.
+  # This comment used to say the opposite — "advisory only … a red run here is
+  # information, not a gate" — and it was correct when written. The branch
+  # protection change it was waiting for has since been made, and nothing
+  # updated the note, so the file spent that time telling anyone debugging a red
+  # `security-suites` that they could ignore it. On the suites that drive zip
+  # bombs, path traversal and XXE-shaped documents, that is the worst possible
+  # thing to be wrong about.
   #
-  # Running them here makes the result visible on every PR. Making them
-  # *blocking* is a separate, deliberate step: it needs the check added to the
-  # branch protection rule on `release`, which is a repository settings change
-  # and cannot be done from this file. Until someone makes that change, a red
-  # run here is information, not a gate.
+  # Where it is required is worth knowing, because the two protection layers
+  # disagree and GitHub enforces their union:
+  #
+  #   classic branch protection   test · provider-safety-net · build-check ·
+  #                               🔒 Single Commit Policy Validation · security-suites
+  #   ruleset 11413189            the same four, WITHOUT security-suites
+  #
+  # So `gh api repos/juspay/neurolink/rulesets/11413189` reports four contexts
+  # and no mention of this job — querying the ruleset alone still says it is
+  # optional. Use `gh api repos/juspay/neurolink/branches/release/protection`,
+  # or check both. CLAUDE.md's "Required status checks and the release bot"
+  # section covers the same trap from the other direction.
+  #
+  # One real consequence of living only on the classic layer: that layer has
+  # `enforce_admins: false`, so this is the one required check a repository
+  # admin can bypass. The ruleset's four have `bypass_actors: []` and nobody can.
+  #
+  # A migration off classic protection would silently drop this check — the job
+  # keeps running and keeps reporting green, so nothing looks different until
+  # something red merges. Add the context to the ruleset first.
+  #
+  # The suites themselves were wired into `test:unit`, which no workflow ever
+  # invoked, so before this job existed they had never executed on a pull
+  # request at all.
   #
   # Both suites are credential-free by construction — they never call a model.
   security-suites:


### PR DESCRIPTION
The comment above the job said **"Advisory only — deliberately NOT in the required-checks list"**, closing with *"a red run here is information, not a gate"*.

That was true when written. The branch-protection change it was waiting for **has since been made**, and nothing updated the note.

So the file has been telling anyone debugging a red `security-suites` that they can ignore it — on the suites that drive **zip bombs, path traversal and XXE-shaped office documents** through the public surface. Of everything in this workflow to be wrong about, that is the worst.

## Ground truth, both layers

They disagree, and GitHub enforces the union:

| layer | contexts |
|---|---|
| classic branch protection | `test` · `provider-safety-net` · `build-check` · `🔒 Single Commit Policy Validation` · **`security-suites`** |
| ruleset `11413189` | the same four, **without** `security-suites` |

Querying the ruleset alone still reports this job as optional — which is plausibly how the note survived someone checking it. The comment now names both commands and points at CLAUDE.md's section on the same trap.

## Two consequences recorded with it

- Living only on the classic layer makes this **the one required check an admin can bypass** — that layer has `enforce_admins: false`, while the ruleset's four have `bypass_actors: []` and nobody can.
- **A migration off classic protection would silently drop it.** The job keeps running and keeps reporting green, so nothing looks different until something red merges.

## What I deliberately did not change

The neighbouring **"Deliberately NOT a required status check"** on `extended-suites` is left exactly as it is. I checked it against the same two APIs: `extended-suites` appears in **neither** layer, so that comment is still true. Correcting it would have been the same class of error in the other direction.

## Scope

Comment-only. The **weighted suite list and the job set are byte-identical to release**, and **zero non-comment lines change** — all three checked, not assumed. No conflict with the other open `ci.yml` PRs, which touch the extended-suites region.

The same false claim was independently found in the published dependency-ledger artifact and corrected there too. Finding it twice is why it is worth a commit of its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the security checks’ required and blocking status.
  * Documented differences between classic branch protection and ruleset enforcement.
  * Added warnings about administrative bypasses and potential check loss during migration.
  * Recorded the previous test wiring for improved workflow context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->