### PR TITLE
ci(test): run five suites that no workflow has ever invoked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,6 +851,11 @@ jobs:
           # spread is 1s to 367s, so equal counts gave shards of 33s and 485s.
           SUITES="
             test:tts:unit@367
+            test:agents@7
+            test:media-registry-collisions@3
+            test:video-abort@3
+            test:classifier-router@3
+            test:resolve-request-kind@1
             test:vertex-loop-characterization@96
             test:tool-reliability@51
             test:auth@45

--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
     "test:archive:security": "pnpm exec tsx test/continuous-test-suite-archive-security.ts",
     "test:office:security": "pnpm exec tsx test/continuous-test-suite-office-security.ts",
     "test:model-pool": "pnpm exec tsx test/continuous-test-suite-model-pool.ts",
+    "test:agents": "pnpm exec tsx test/continuous-test-suite-agents.ts",
     "test:classifier-router": "pnpm exec tsx test/continuous-test-suite-classifier-router.ts",
     "test:vector-chroma": "pnpm exec tsx test/continuous-test-suite-vector-chroma.ts",
     "test:vector-pgvector": "pnpm exec tsx test/continuous-test-suite-vector-pgvector.ts",

--- a/test/continuous-test-suite-classifier-router.ts
+++ b/test/continuous-test-suite-classifier-router.ts
@@ -33,7 +33,9 @@ import type {
 
 await assertDistFresh();
 
-const { test, runSuite } = defineSuite("ClassifierRouter");
+const { test, runSuite } = defineSuite("ClassifierRouter", {
+  offline: true,
+});
 
 /** Collects logger calls as `"debug:<message>"` / `"warn:<message>"` tags. */
 function makeSpyLogger(): { logger: ClassifierLogger; calls: string[] } {

--- a/test/continuous-test-suite-media-registry-collisions.ts
+++ b/test/continuous-test-suite-media-registry-collisions.ts
@@ -53,7 +53,9 @@ import { assertDistFresh } from "./helpers/distFreshness.js";
 
 assertDistFresh();
 
-const { test, runSuite } = defineSuite("Media Registry Collision Guard");
+const { test, runSuite } = defineSuite("Media Registry Collision Guard", {
+  offline: true,
+});
 
 const ALL_KINDS = [
   "tts",

--- a/test/continuous-test-suite-resolve-request-kind.ts
+++ b/test/continuous-test-suite-resolve-request-kind.ts
@@ -22,7 +22,9 @@
 import { defineSuite, assertEqual } from "./helpers/harness.js";
 import { resolveRequestKind } from "../src/lib/core/resolveRequestKind.js";
 
-const { test, runSuite } = defineSuite("resolveRequestKind (unit)");
+const { test, runSuite } = defineSuite("resolveRequestKind (unit)", {
+  offline: true,
+});
 
 await test("defaults to text with no hints", () => {
   assertEqual(

--- a/test/continuous-test-suite-video-abort.ts
+++ b/test/continuous-test-suite-video-abort.ts
@@ -25,7 +25,9 @@ import { assertDistFresh } from "./helpers/distFreshness.js";
 
 assertDistFresh();
 
-const { test, runSuite } = defineSuite("Video Abort Signal");
+const { test, runSuite } = defineSuite("Video Abort Signal", {
+  offline: true,
+});
 
 // A rejection caused by an abort must land well inside this window — the
 // whole point is that cancellation does not wait out the 600s timeout.


### PR DESCRIPTION
**87 assertions across five suites executed nowhere.**

`ci.yml` already states the principle — *"A suite wired into nothing is documentation, not a test"* — written after the OpenAI-compat catalog suite sat in no CI job, broke on any machine without `GROQ_API_KEY`, and nobody noticed. The same condition was live in five more places.

`test/continuous-test-suite-agents.ts` is the worst: **1624 lines** covering Agent, AgentNetwork, routing, MessageBus and CLI coverage, with **no `package.json` script at all**. It was reachable only by the literal command written in `docs/agents/TESTING.md`.

## Measured, not assumed

Under CI-like conditions — `mkdtemp` HOME, empty `CLOUDSDK_CONFIG`, `DOTENV_CONFIG_PATH=/dev/null` — with a preload hooking `net.Socket.prototype.connect` and `tls.connect`:

| suite | passed | time | external hosts |
|---|---|---|---|
| `agents` | 52 | 5s | **0** |
| `resolve-request-kind` | 16 | 0s | **0** |
| `media-registry-collisions` | 11 | 2s | **0** |
| `classifier-router` | 4 | 2s | **0** |
| `video-abort` | 4 | 2s | **0** |

None makes an external connection, and none pays the 60s MCP client timeout that `.mcp-config.json` imposes on suites building `NeuroLink` instances (the defect fixed in #1571). Cheap in the one place cheapness matters.

## The `agents` runner had to be proven first

It uses its own runner, not the shared harness, so it cannot take `offline: true` — and **a suite that cannot fail is worse than no suite**. I injected a deliberate failing result: it reported `PROBE deliberate failure: 0/1 passed`, `Failed: 1`, `Some tests failed!` and **exited 1**.

Worth recording that my *first* probe used the wrong result shape, crashed with a `TypeError`, and **still exited 1** — proving nothing. The exit code alone was not evidence; the reported failure is.

The four suites that do use `defineSuite` also gain `offline: true`, so a hang fails rather than reporting a green skip. Placement checked by walking to `defineSuite`'s matching paren, not by grep — **4/4 inside the call**.

## Verification

All five green through their `package.json` scripts · the workflow's own assignment loop places all **33** suites with **0 duplicates** · `package.json` still parses · `check:tools-tests`, eslint and prettier clean.

Weights are 1.9× the local timings, matching the ratio measured for `test:tts:unit` — estimates, to be replaced from the first real run via the log-timestamp method documented above the list.

## Merge order

Third PR touching the `SUITES` block, after [#1568](https://github.com/juspay/neurolink/pull/1568) (rewrites all 28 weights) and [#1571](https://github.com/juspay/neurolink/pull/1571) (adds `test:multimodal:sdk`). Suggested: **#1568 → #1571 → this**, each later one a small rebase in that list.

Given #1570 showed that local green is not evidence about CI, I'll treat this PR's own `extended-suites` result as the verdict and revert the wire-in if it comes back red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated test coverage with a new agents test suite.
  - Added media registry collision, video abort, classifier routing, and request-kind resolution suites to CI.
  - Improved CI distribution of test suites across parallel shards.
  - Enabled selected suites to run in offline environments for more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->