### PR TITLE
fix(tools): make the onboarding gate check providerMatrix too

### DIFF
--- a/tools/verify-provider-onboarding.ts
+++ b/tools/verify-provider-onboarding.ts
@@ -3,7 +3,7 @@
  * Provider Onboarding Completeness gate.
  *
  * For every AIProviderName member NOT in LEGACY_PROVIDERS (i.e. every
- * provider added after this gate existed), asserts the four required
+ * provider added after this gate existed), asserts the five required
  * onboarding artifacts landed together:
  *   1. A ProviderDescriptor entry (PROVIDER_DESCRIPTORS)
  *   2. Either an OpenAICompatCatalogEntry OR a concrete, registered
@@ -15,6 +15,12 @@
  *      *describes* the marker in a comment does not satisfy this check.
  *   4. A manifest file at docs/provider-integration/manifests/<name>.json
  *      (with tier4Justification present when tier === 4)
+ *   5. A capability entry in test/helpers/providerMatrix.ts — the file that
+ *      test:matrix, test:providers and test/helpers/skipIf.ts all read. Its
+ *      own header calls itself "the single source of truth for what each of
+ *      NeuroLink's providers supports" and lists "add an entry" as step 1 of
+ *      onboarding, but nothing enforced it: cerebras shipped in #1561 and the
+ *      capability sweep simply did not cover it.
  *
  * Zero network I/O, zero API keys, source-only — does not require
  * `pnpm run build` first (see docs/provider-integration/tiers/README.md
@@ -99,6 +105,88 @@ async function loadDescriptors(): Promise<ReadonlySet<string>> {
     PROVIDER_DESCRIPTORS: ReadonlyArray<{ name: string }>;
   };
   return new Set(mod.PROVIDER_DESCRIPTORS.map((d) => d.name));
+}
+
+/**
+ * Providers that predate this check and have no providerMatrix entry.
+ *
+ * Exactly one today: cerebras, which shipped in #1561 without an entry. PR
+ * #1564 adds it — remove this line when that lands, and the set becomes empty.
+ *
+ * A name listed here that HAS an entry produces a warning, not an error.
+ * Making it fatal would red-line every open pull request the moment someone
+ * closed a gap, which is the kind of self-inflicted CI outage this repo has
+ * already paid for once. The warning exists so the list cannot quietly rot —
+ * it earned its keep immediately: the first version of this set listed five
+ * more names, drawn from a scan whose regex did not allow quoted keys, and
+ * the note flagged all five as already present on the first run.
+ */
+const KNOWN_MATRIX_GAPS: ReadonlySet<string> = new Set(["cerebras"]);
+
+/**
+ * Read the provider keys out of test/helpers/providerMatrix.ts.
+ *
+ * Parsed from source rather than imported: the module pulls in test helpers,
+ * and this gate is deliberately source-only with zero network I/O so it can
+ * run without a build.
+ *
+ * Scanning is bounded to the `export const PROVIDERS` initializer, not the
+ * whole file. An earlier version matched any two-space-indented `key: {`
+ * anywhere, which a decoy proved unsafe: appending
+ *
+ *   export const UNRELATED_LOOKUP: Record<string, { note: string }> = {
+ *     cerebras: { note: "..." },
+ *   };
+ *
+ * made the gate report that cerebras had a matrix entry when it did not — a
+ * false pass on the exact condition this check exists to catch. Any object
+ * literal, or a matching line inside a block comment, could have done the same.
+ *
+ * Not finding the record is treated as a read error rather than an empty set,
+ * because "no providers found" and "the file moved" must not look alike here.
+ */
+function loadProviderMatrixNames(): {
+  names: ReadonlySet<string>;
+  readError?: string;
+} {
+  const path = join(REPO_ROOT, "test/helpers/providerMatrix.ts");
+  let src: string;
+  try {
+    src = readFileSync(path, "utf8");
+  } catch (err: unknown) {
+    return {
+      names: new Set(),
+      readError: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const lines = src.split("\n");
+  const start = lines.findIndex((line) =>
+    /^export const PROVIDERS\b/.test(line),
+  );
+  if (start === -1) {
+    return {
+      names: new Set(),
+      readError:
+        "no `export const PROVIDERS` declaration in test/helpers/providerMatrix.ts",
+    };
+  }
+  const names = new Set<string>();
+  for (let i = start + 1; i < lines.length; i += 1) {
+    // The record's own closing brace, at column 0. Entries are indented, so
+    // this cannot be one of them.
+    if (/^\};/.test(lines[i])) {
+      return { names };
+    }
+    const match = /^ {2}"?([a-zA-Z0-9_-]+)"?:\s*\{/.exec(lines[i]);
+    if (match) {
+      names.add(match[1]);
+    }
+  }
+  return {
+    names: new Set(),
+    readError:
+      "`export const PROVIDERS` in test/helpers/providerMatrix.ts is never closed at column 0",
+  };
 }
 
 async function loadCatalog(): Promise<ReadonlySet<string>> {
@@ -283,6 +371,7 @@ async function main(): Promise<void> {
   ]);
   const enumMembers = loadEnumMembers(enumMemberMap);
   const nativeClasses = loadNativeProviderNames(enumMemberMap);
+  const providerMatrix = loadProviderMatrixNames();
 
   const results: CheckResult[] = [];
   for (const provider of [...enumMembers].sort()) {
@@ -308,6 +397,18 @@ async function main(): Promise<void> {
         "no mocked-contract section in continuous-test-suite-providers-mocked.ts",
       );
     }
+    if (providerMatrix.readError) {
+      problems.push(
+        `could not read test/helpers/providerMatrix.ts: ${providerMatrix.readError}`,
+      );
+    } else if (
+      !providerMatrix.names.has(provider) &&
+      !KNOWN_MATRIX_GAPS.has(provider)
+    ) {
+      problems.push(
+        "no capability entry in test/helpers/providerMatrix.ts (test:matrix, test:providers and skipIf all read it, so the provider is invisible to the capability sweep)",
+      );
+    }
     const { manifest, problem: manifestProblem } = loadManifest(provider);
     if (!manifest) {
       problems.push(
@@ -318,6 +419,20 @@ async function main(): Promise<void> {
       problems.push("tier-4 manifest missing tier4Justification");
     }
     results.push({ provider, ok: problems.length === 0, problems });
+  }
+
+  // A gap that has been closed should not stay on the list. This is a warning,
+  // not a failure: turning it fatal would red-line every open pull request the
+  // moment someone did the right thing, and a stale list is a hygiene problem
+  // rather than a correctness one.
+  const closedGaps = [...KNOWN_MATRIX_GAPS]
+    .filter((name) => providerMatrix.names.has(name))
+    .sort();
+  if (closedGaps.length > 0) {
+    console.log(
+      "\nNote: these now have providerMatrix entries and can be dropped from " +
+        `KNOWN_MATRIX_GAPS in tools/verify-provider-onboarding.ts: ${closedGaps.join(", ")}`,
+    );
   }
 
   const failures = results.filter((r) => !r.ok);


### PR DESCRIPTION
`test/helpers/providerMatrix.ts` calls itself *"the single source of truth for what each of NeuroLink's providers supports"* and lists *"add an entry below"* as step one of onboarding. **Nothing enforced it.**

`cerebras` shipped in #1561 without one, so `test:matrix`, `test:providers` and `test/helpers/skipIf.ts` have all been blind to the newest provider — while a **required** check reported the onboarding complete.

The gate already knew about descriptors, catalog-or-class, the mocked contract section and the manifest. This adds the fifth artifact.

## The ratchet, and why it warns instead of failing

`KNOWN_MATRIX_GAPS` holds exactly one name — `cerebras`, which [#1564](https://github.com/juspay/neurolink/pull/1564) closes. Remove that line when it lands and the set is empty.

A listed name that **has** an entry produces a **warning, not a failure**. Making it fatal would red-line every open pull request the moment someone closed a gap, and this repo has already paid for one self-inflicted CI outage of exactly that shape (the ffmpeg install).

## That warning caught my own mistake before the commit existed

The first version of this set listed **five more** providers, taken from a scan whose regex didn't allow quoted keys — and `providerMatrix` writes exactly those five as `"google-ai":` rather than `google-ai:`.

The note flagged all five as already present **on the first run**. The real gap was always one provider, not six. A self-cleaning list that reports closed gaps is what turned my bad data into a two-minute correction instead of a committed falsehood.

## Proven by probe, three ways

A gate that cannot fail is worse than no gate:

| scenario | result |
|---|---|
| today's tree | exit **0**, no note |
| gap present, not on the list | exit **1**, names the missing artifact |
| listed gap since closed | exit **0** plus the note |

Parsed from source rather than imported, because the module pulls in test helpers and this gate is deliberately source-only with zero network I/O so it runs without a build.

`check:ci-scripts` clean, prettier clean, and the only file that changes is the gate itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider onboarding verification now detects providers missing required capability coverage.
  * Added warnings when previously known capability gaps have been resolved, helping keep onboarding checks current.
* **Documentation**
  * Updated onboarding requirements to include capability matrix coverage for applicable providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->