### PR TITLE
chore(quality): point the TODO markers at an issue that means something

### DIFF
--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -177,7 +177,7 @@ export abstract class BaseProvider implements AIProvider {
   protected modelName: string;
   protected readonly providerName: AIProviderName;
   protected readonly defaultTimeout: number = 30000; // 30 seconds
-  protected middlewareOptions?: MiddlewareFactoryOptions; // TODO(#1179): Implement global level middlewares that can be used
+  protected middlewareOptions?: MiddlewareFactoryOptions; // TODO(#1576): Implement global level middlewares that can be used
 
   // Tools are conditionally included based on centralized configuration
   protected readonly directTools = shouldDisableBuiltinTools()
@@ -2227,7 +2227,7 @@ export abstract class BaseProvider implements AIProvider {
   /**
    * Get AI SDK model with middleware applied
    * This method wraps the base model with any configured middleware
-   * TODO(#1179): Implement global level middlewares that can be used
+   * TODO(#1576): Implement global level middlewares that can be used
    */
   protected async getAISDKModelWithMiddleware(
     options: TextGenerationOptions | StreamOptions = {},

--- a/src/lib/evaluation/scorers/rule/formatScorer.ts
+++ b/src/lib/evaluation/scorers/rule/formatScorer.ts
@@ -508,7 +508,7 @@ export class FormatScorer extends BaseRuleScorer {
     // First check if it's valid JSON
     try {
       JSON.parse(text);
-      // TODO(#1179): Implement full JSON Schema validation
+      // TODO(#1576): Implement full JSON Schema validation
       // For now, just check it's valid JSON
       return { passed: true, score: 1.0 };
     } catch {

--- a/src/lib/mcp/mcpRegistryClient.ts
+++ b/src/lib/mcp/mcpRegistryClient.ts
@@ -319,7 +319,7 @@ export class MCPRegistryClient extends EventEmitter {
       return wellKnown;
     }
 
-    // TODO(#1179): Fetch from remote registry
+    // TODO(#1576): Fetch from remote registry
     return undefined;
   }
 

--- a/src/lib/mcp/toolRegistry.ts
+++ b/src/lib/mcp/toolRegistry.ts
@@ -1031,7 +1031,7 @@ export class MCPToolRegistry extends MCPRegistry {
     return removed;
   }
 
-  // TODO(#1179): Add FlexibleToolValidator class in next task
+  // TODO(#1576): Add FlexibleToolValidator class in next task
   // This will contain only universal safety checks (empty names, control characters, length limits)
 }
 

--- a/src/lib/middleware/utils/guardrailsUtils.ts
+++ b/src/lib/middleware/utils/guardrailsUtils.ts
@@ -417,7 +417,7 @@ export function applyContentFiltering(
 
       for (const pattern of badWordsConfig.regexPatterns) {
         try {
-          // TODO(#1179): Add blocking for overly complex or long patterns
+          // TODO(#1576): Add blocking for overly complex or long patterns
           if (pattern.length > 1000) {
             logger.warn(
               `[ContentFiltering:${context}] Regex pattern exceeds max length (1000 chars): "${pattern.substring(0, 50)}..."`,

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -12432,7 +12432,7 @@ Current user's request: ${currentInput}`;
   // ENHANCED: Tool Event Emission API
   // ========================================
 
-  // TODO(#1179): Add ToolExecutionEvent utility methods in future version
+  // TODO(#1576): Add ToolExecutionEvent utility methods in future version
   // Will provide structured event format for consistent tool event processing
 
   /**
@@ -12592,7 +12592,7 @@ Current user's request: ${currentInput}`;
     this.currentStreamToolExecutions = [];
   }
 
-  // TODO(#1179): Add getToolExecutionEvents() method in future version
+  // TODO(#1576): Add getToolExecutionEvents() method in future version
   // Will return properly formatted ToolExecutionEvent objects for structured event processing
 
   // ========================================

--- a/src/lib/rag/ChunkerFactory.ts
+++ b/src/lib/rag/ChunkerFactory.ts
@@ -237,7 +237,7 @@ export class ChunkerFactory extends BaseFactory<Chunker, ChunkerConfig> {
     this.registerChunker(
       "semantic",
       async (config?: ChunkerConfig) => {
-        // TODO(#1179): Implement dedicated SemanticChunker with LLM support
+        // TODO(#1576): Implement dedicated SemanticChunker with LLM support
         // For now, fall back to RecursiveChunker with semantic defaults
         const { RecursiveChunker } =
           await import("./chunkers/RecursiveChunker.js");

--- a/src/lib/server/websocket/WebSocketHandler.ts
+++ b/src/lib/server/websocket/WebSocketHandler.ts
@@ -466,7 +466,7 @@ export function createAgentWebSocketHandler(
       prompt: string;
       options?: unknown;
     };
-    // TODO(#1179): Implement generate using neurolink
+    // TODO(#1576): Implement generate using neurolink
     return { type: "response", data: `Received: ${prompt}` };
   });
 
@@ -475,7 +475,7 @@ export function createAgentWebSocketHandler(
       prompt: string;
       options?: unknown;
     };
-    // TODO(#1179): Implement streaming using neurolink
+    // TODO(#1576): Implement streaming using neurolink
     return { type: "stream_start", data: { prompt } };
   });
 
@@ -484,7 +484,7 @@ export function createAgentWebSocketHandler(
       toolName: string;
       args: unknown;
     };
-    // TODO(#1179): Implement tool call using neurolink
+    // TODO(#1576): Implement tool call using neurolink
     return { type: "tool_result", data: { toolName, result: null } };
   });
 

--- a/src/lib/workflow/config.ts
+++ b/src/lib/workflow/config.ts
@@ -450,7 +450,7 @@ export function getAllJudges(config: WorkflowConfig): JudgeConfig[] {
 
 /**
  * Calculate estimated workflow cost (placeholder)
- * TODO(#1179): Implement actual provider-specific pricing
+ * TODO(#1576): Implement actual provider-specific pricing
  * @param config - Workflow configuration
  * @param estimatedTokens - Estimated number of tokens for the request
  * @returns Estimated cost in USD

--- a/src/lib/workflow/core/workflowRegistry.ts
+++ b/src/lib/workflow/core/workflowRegistry.ts
@@ -22,7 +22,7 @@ const functionTag = "WorkflowRegistry";
 
 /**
  * In-memory workflow registry
- * TODO(#1179): Consider persistent storage in future phases
+ * TODO(#1576): Consider persistent storage in future phases
  */
 const workflowRegistry = new Map<string, RegistryEntry>();
 

--- a/src/lib/workflow/core/workflowRunner.ts
+++ b/src/lib/workflow/core/workflowRunner.ts
@@ -244,7 +244,7 @@ export async function runWorkflow(
             totalInputTokens: calculateInputTokens(ensembleResult.responses),
             totalOutputTokens: calculateOutputTokens(ensembleResult.responses),
             totalTokens: calculateTotalTokens(ensembleResult.responses),
-            byModel: [], // TODO(#1179): Populate per-model breakdown
+            byModel: [], // TODO(#1576): Populate per-model breakdown
           },
 
           // Additional metadata

--- a/src/lib/workflow/utils/workflowMetrics.ts
+++ b/src/lib/workflow/utils/workflowMetrics.ts
@@ -198,7 +198,7 @@ export function calculateModelMetrics(
 /**
  * Calculate consensus level between responses
  * NOTE: Placeholder implementation - uses response length similarity
- * TODO(#1179): Implement semantic similarity in Phase 2
+ * TODO(#1576): Implement semantic similarity in Phase 2
  */
 export function calculateConsensus(responses: EnsembleResponse[]): number {
   const successful = responses.filter((r) => r.status === "success");


### PR DESCRIPTION
The sixteen `TODO` markers in `src/` read `TODO(#1179)`. [#1179](https://github.com/juspay/neurolink/issues/1179) is an auto-generated Pattern Analysis finding titled *"todo-with-issue-reference: 1 finding(s)"* — the report that complained TODOs lacked issue references — and it is **closed**.

The timeline says the rest:

| | |
|---|---|
| `#1179` created | 2026-07-16T16:00:33Z |
| `80fd6ef9` *"add issue references to TODO/FIXME comments"* | 2026-07-28T02:27:49Z |
| `#1179` closed | 2026-07-28T02:27:51Z |

**Two seconds.** The citation points at the report that the citation itself closed. Anyone following it to find the plan finds a lint result about formatting.

## Why deleting the references would have been worse

The analysis is **external to this repo and recurring** — it filed the same rule again as [#1318](https://github.com/juspay/neurolink/issues/1318) on 2026-08-11. Untagging sixteen markers produces a fresh report and another round of meaningless numbers. That loop is what produced this state in the first place, and the untagged-TODO count in `src/` is currently 0, so the rule is satisfied today — just dishonestly.

## What they cite now

[**#1576**](https://github.com/juspay/neurolink/issues/1576), which exists, is open, and lists all sixteen with file, line and what each defers.

It is a **register, not a commitment**: anything genuinely planned deserves its own issue, anything not planned should have its marker deleted, and both are better than a citation resolving to a closed lint report. I opened it as part of this item — close it whenever it has served its purpose.

## Scope

**Comment text only.** 12 files, and `git diff -U0` confirms **0 non-comment lines changed**. No code, no behaviour. Untagged-TODO count stays 0. eslint 0 errors (4 pre-existing `max-lines-per-function` warnings in `neurolink.ts`, identical on release), prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal TODO references to point to the current tracking issue.
  * No user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->