### PR TITLE
docs(testing): tell readers to run tsx through pnpm exec, as the scripts do

### DIFF
--- a/.claude/skills/adding-tests.md
+++ b/.claude/skills/adding-tests.md
@@ -13,7 +13,7 @@ description: Use when adding tests for a new modality (vision/embeddings/TTS/STT
 
 Tests are **plain `tsx` scripts** — no Jest/Vitest. Every suite is a single
 `test/continuous-test-suite-<domain>.ts` file invoked via
-`npx tsx <path>` or `pnpm run test:<domain>`. All shared logic lives in
+`pnpm exec tsx <path>` or `pnpm run test:<domain>`. All shared logic lives in
 `test/helpers/*.ts`. The harness defines a tri-state result:
 
 - **PASS** — test fn returns/resolves normally
@@ -92,7 +92,7 @@ import "dotenv/config";
  *
  * <1-3 sentence description of what's covered>
  *
- * Run: pnpm run build && npx tsx test/continuous-test-suite-<name>.ts
+ * Run: pnpm run build && pnpm exec tsx test/continuous-test-suite-<name>.ts
  *      pnpm run test:<name>
  */
 
@@ -367,7 +367,7 @@ Add the new `test:<name>` script alias to `package.json` and slot it
 into the right pipeline string. Example for a new live suite:
 
 ```jsonc
-"test:my-feature": "npx tsx test/continuous-test-suite-my-feature.ts",
+"test:my-feature": "pnpm exec tsx test/continuous-test-suite-my-feature.ts",
 "test:live": "pnpm run test:providers && ... && pnpm run test:my-feature"
 ```
 
@@ -384,7 +384,7 @@ pnpm run envguard      # envGuard pattern coverage (80/80 must PASS)
 pnpm run build         # CLI + SDK
 
 # Direct invocation of the affected suite:
-npx tsx test/continuous-test-suite-<name>.ts --provider=<p>
+pnpm exec tsx test/continuous-test-suite-<name>.ts --provider=<p>
 
 # If you added a provider:
 pnpm run test:matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ pnpm run test:autoresearch       # E2E + live (live half skips without keys)
 # does not make it a gate.
 
 # Run a single suite directly
-npx tsx test/continuous-test-suite-<name>.ts
+pnpm exec tsx test/continuous-test-suite-<name>.ts
 
 # Environment
 pnpm run env:validate     # Validate .env setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,7 @@ pnpm test:proxy           # Claude proxy
 pnpm test:bugfixes        # Regression fixtures
 
 # Run a single suite directly
-npx tsx test/continuous-test-suite-<name>.ts
+pnpm exec tsx test/continuous-test-suite-<name>.ts
 ```
 
 ### 📁 Test File Structure
@@ -373,11 +373,11 @@ pnpm cli --version
 pnpm test
 
 # Focus on a specific domain suite
-npx tsx test/continuous-test-suite-providers.ts
-npx tsx test/continuous-test-suite-rag.ts
+pnpm exec tsx test/continuous-test-suite-providers.ts
+pnpm exec tsx test/continuous-test-suite-rag.ts
 
 # Run an individual issue regression suite
-npx tsx test/continuous-test-suite-issue-01-model-access.ts
+pnpm exec tsx test/continuous-test-suite-issue-01-model-access.ts
 ```
 
 #### **CI/CD Workflow**
@@ -411,7 +411,7 @@ pnpm test:rag             # RAG pipeline validation
 
 ```bash
 # Run an individual suite directly with tsx
-npx tsx test/continuous-test-suite-<name>.ts
+pnpm exec tsx test/continuous-test-suite-<name>.ts
 
 # Check environment setup
 pnpm run env:validate

--- a/docs/agents/TESTING.md
+++ b/docs/agents/TESTING.md
@@ -69,13 +69,13 @@ test/fixtures/agents/
 
 ```bash
 # Run the continuous integration test suite
-npx tsx test/continuous-test-suite-agents.ts
+pnpm exec tsx test/continuous-test-suite-agents.ts
 
 # With verbose output
-VERBOSE=true npx tsx test/continuous-test-suite-agents.ts
+VERBOSE=true pnpm exec tsx test/continuous-test-suite-agents.ts
 
 # With a specific provider
-TEST_PROVIDER=openai npx tsx test/continuous-test-suite-agents.ts
+TEST_PROVIDER=openai pnpm exec tsx test/continuous-test-suite-agents.ts
 ```
 
 ### Run All NeuroLink Tests (includes agent suite)
@@ -92,7 +92,7 @@ pnpm run test:coverage
 ```yaml
 # Example GitHub Actions config
 - name: Run Agent Tests
-  run: npx tsx test/continuous-test-suite-agents.ts
+  run: pnpm exec tsx test/continuous-test-suite-agents.ts
   env:
     TEST_PROVIDER: vertex
     GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
@@ -206,7 +206,7 @@ function createMockSdk(options?: {
 ### Enable Verbose Logging
 
 ```bash
-VERBOSE=true npx tsx test/continuous-test-suite-agents.ts
+VERBOSE=true pnpm exec tsx test/continuous-test-suite-agents.ts
 ```
 
 ### Isolate a Single Test
@@ -253,7 +253,7 @@ Ensure the project is built before running the suite:
 
 ```bash
 pnpm run build
-npx tsx test/continuous-test-suite-agents.ts
+pnpm exec tsx test/continuous-test-suite-agents.ts
 ```
 
 ### Tests Timing Out
@@ -261,7 +261,7 @@ npx tsx test/continuous-test-suite-agents.ts
 Set a longer timeout via the environment, or check provider rate limits:
 
 ```bash
-TEST_PROVIDER=openai OPENAI_API_KEY=sk-... npx tsx test/continuous-test-suite-agents.ts
+TEST_PROVIDER=openai OPENAI_API_KEY=sk-... pnpm exec tsx test/continuous-test-suite-agents.ts
 ```
 
 ## Related Documentation

--- a/docs/agents/VERIFICATION.md
+++ b/docs/agents/VERIFICATION.md
@@ -26,7 +26,7 @@ Configure at least one of:
 
 ## Integration Test Verification
 
-Run: `npx tsx test/continuous-test-suite-agents.ts`
+Run: `pnpm exec tsx test/continuous-test-suite-agents.ts`
 
 ### Agent Class Integration
 
@@ -152,16 +152,16 @@ examples.
 
 ## Final Verification Summary
 
-| Category             | Method                                         | Status |
-| -------------------- | ---------------------------------------------- | ------ |
-| Agent Class          | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| AgentNetwork         | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| MessageBus           | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| HubSpokeTopology     | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| MeshTopology         | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| HierarchicalTopology | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
-| CLI Commands         | Manual smoke test (`neurolink agent --help`)   | ?      |
-| Integration          | `npx tsx test/continuous-test-suite-agents.ts` | ?      |
+| Category             | Method                                               | Status |
+| -------------------- | ---------------------------------------------------- | ------ |
+| Agent Class          | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| AgentNetwork         | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| MessageBus           | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| HubSpokeTopology     | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| MeshTopology         | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| HierarchicalTopology | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
+| CLI Commands         | Manual smoke test (`neurolink agent --help`)         | ?      |
+| Integration          | `pnpm exec tsx test/continuous-test-suite-agents.ts` | ?      |
 
 ## Sign-Off
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -79,7 +79,7 @@ pnpm run check
 
 ```bash
 # Test CLI
-npx tsx src/cli/index.ts generate "Hello world"
+pnpm exec tsx src/cli/index.ts generate "Hello world"
 
 # Run example scripts
 pnpm run example:basic

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -188,7 +188,7 @@ pnpm test:mcp             # MCP HTTP transport
 pnpm test:context         # Context compaction + file handling
 
 # Run a single suite directly
-npx tsx test/continuous-test-suite-<name>.ts
+pnpm exec tsx test/continuous-test-suite-<name>.ts
 ```
 
 ## 🎨 Code Style & Standards

--- a/docs/features/claude-subscription-testing.md
+++ b/docs/features/claude-subscription-testing.md
@@ -437,7 +437,7 @@ Anthropic subscription scenarios — OAuth, API key, tier validation — are exe
 pnpm run test:credentials
 
 # Or run the underlying tsx file directly with extra logging
-DEBUG=1 npx tsx test/continuous-test-suite-credentials.ts
+DEBUG=1 pnpm exec tsx test/continuous-test-suite-credentials.ts
 ```
 
 > **Note:** NeuroLink does not use vitest; all tests are tsx scripts orchestrated via the `continuous-test-suite-*.ts` files. There is no `test:coverage` / `test:integration` / `test:subscription` script — see [`test/TESTING_SCRIPTS.md`](https://github.com/juspay/neurolink/blob/main/test/TESTING_SCRIPTS.md) for the full list of available suites.

--- a/docs/features/mcp-enhancements.md
+++ b/docs/features/mcp-enhancements.md
@@ -2674,7 +2674,7 @@ The MCP enhancements include a comprehensive continuous test suite covering all 
 ### Running the Test Suite
 
 ```bash
-npx tsx test/continuous-test-suite-mcp.ts --provider=vertex
+pnpm exec tsx test/continuous-test-suite-mcp.ts --provider=vertex
 ```
 
 ### Environment Variables

--- a/docs/features/rag.md
+++ b/docs/features/rag.md
@@ -1042,12 +1042,12 @@ type RAGConfig = {
 
 ```bash
 # Enable verbose logging for RAG operations
-DEBUG=neurolink:rag:* npx tsx your-script.ts
+DEBUG=neurolink:rag:* pnpm exec tsx your-script.ts
 
 # Log specific components
-DEBUG=neurolink:rag:chunker npx tsx your-script.ts
-DEBUG=neurolink:rag:reranker npx tsx your-script.ts
-DEBUG=neurolink:rag:hybrid npx tsx your-script.ts
+DEBUG=neurolink:rag:chunker pnpm exec tsx your-script.ts
+DEBUG=neurolink:rag:reranker pnpm exec tsx your-script.ts
+DEBUG=neurolink:rag:hybrid pnpm exec tsx your-script.ts
 ```
 
 ## API Reference

--- a/docs/implementation-guides/14-rag-document-processing.md
+++ b/docs/implementation-guides/14-rag-document-processing.md
@@ -417,7 +417,7 @@ export { prepareRAGTool } from "./rag/ragIntegration.js";
 pnpm run test:rag
 
 # Run the suite directly with tsx if you want extra logging
-npx tsx test/continuous-test-suite-rag.ts
+pnpm exec tsx test/continuous-test-suite-rag.ts
 ```
 
 > NeuroLink runs all suites via `tsx`; there is no vitest runner. RAG-specific scenarios (chunkers, rerankers, metadata) are exercised by `continuous-test-suite-rag.ts`.

--- a/docs/provider-integration/09-test-suite-spec.md
+++ b/docs/provider-integration/09-test-suite-spec.md
@@ -133,7 +133,7 @@ import "dotenv/config";
  * Each provider's tests SKIP cleanly when its env var is missing so this suite
  * runs green in CI without credentials.
  *
- * Run with: npx tsx test/continuous-test-suite-new-providers.ts
+ * Run with: pnpm exec tsx test/continuous-test-suite-new-providers.ts
  */
 
 import { NeuroLink } from "../dist/index.js";
@@ -310,9 +310,9 @@ await test("3.X deepseek per-call apiKey override", async () => {
 ### 4c. `package.json` — add `test:new-providers`
 
 ```diff
-   "test:providers": "npx tsx test/continuous-test-suite-providers.ts",
-+  "test:new-providers": "npx tsx test/continuous-test-suite-new-providers.ts",
-   "test:rag": "npx tsx test/continuous-test-suite-rag.ts",
+   "test:providers": "pnpm exec tsx test/continuous-test-suite-providers.ts",
++  "test:new-providers": "pnpm exec tsx test/continuous-test-suite-new-providers.ts",
+   "test:rag": "pnpm exec tsx test/continuous-test-suite-rag.ts",
 ```
 
 Optional: extend `test:ci`:

--- a/docs/provider-integration/14-voice-speech-integration.md
+++ b/docs/provider-integration/14-voice-speech-integration.md
@@ -336,7 +336,7 @@ Test suite: `test/continuous-test-suite-voice.ts` (1 822 lines, NEW)
 The suite is invoked as:
 
 ```bash
-npx tsx test/continuous-test-suite-voice.ts --provider=vertex
+pnpm exec tsx test/continuous-test-suite-voice.ts --provider=vertex
 ```
 
 It covers 15 test items via the consumer API only — no direct provider class calls:
@@ -444,7 +444,7 @@ pnpm run cli generate --stt --stt-provider whisper --input-audio recording.wav \
   --tts --tts-provider openai-tts --provider openai
 
 # Full test suite (requires Vertex credentials)
-npx tsx test/continuous-test-suite-voice.ts --provider=vertex
+pnpm exec tsx test/continuous-test-suite-voice.ts --provider=vertex
 ```
 
 ---

--- a/docs/provider-integration/21-adding-new-modality.md
+++ b/docs/provider-integration/21-adding-new-modality.md
@@ -680,8 +680,8 @@ const tests = [
 **File:** `package.json` — add `test:avatar` script:
 
 ```diff
- "test:voice": "npx tsx test/continuous-test-suite-voice.ts",
-+"test:avatar": "npx tsx test/continuous-test-suite-avatar.ts",
+ "test:voice": "pnpm exec tsx test/continuous-test-suite-voice.ts",
++"test:avatar": "pnpm exec tsx test/continuous-test-suite-avatar.ts",
 ```
 
 ### Step 11 — Documentation

--- a/docs/rag/CONFIGURATION.md
+++ b/docs/rag/CONFIGURATION.md
@@ -717,7 +717,7 @@ const finalResults = await reranker.rerank(searchResults, query, { topK: 5 });
 
 ```bash
 # Enable verbose logging
-DEBUG=neurolink:rag:* npx tsx your-script.ts
+DEBUG=neurolink:rag:* pnpm exec tsx your-script.ts
 ```
 
 ---

--- a/docs/rag/TESTING.md
+++ b/docs/rag/TESTING.md
@@ -40,10 +40,10 @@ export OPENAI_API_KEY=your_api_key
 
 ```bash
 # Run the continuous RAG test suite
-npx tsx test/continuous-test-suite-rag.ts
+pnpm exec tsx test/continuous-test-suite-rag.ts
 
 # With verbose output
-VERBOSE=true npx tsx test/continuous-test-suite-rag.ts
+VERBOSE=true pnpm exec tsx test/continuous-test-suite-rag.ts
 ```
 
 ### Run Unit Tests (Vitest)
@@ -170,7 +170,7 @@ test/
 Enable verbose logging:
 
 ```bash
-VERBOSE=true DEBUG=neurolink:rag:* npx tsx test/continuous-test-suite-rag.ts
+VERBOSE=true DEBUG=neurolink:rag:* pnpm exec tsx test/continuous-test-suite-rag.ts
 ```
 
 ## Adding New Tests

--- a/docs/rag/VERIFICATION.md
+++ b/docs/rag/VERIFICATION.md
@@ -270,7 +270,7 @@ Test with documents of varying sizes:
 ### Run Continuous Test Suite
 
 ```bash
-npx tsx test/continuous-test-suite-rag.ts
+pnpm exec tsx test/continuous-test-suite-rag.ts
 ```
 
 | Test Suite          | Status   |

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -80,10 +80,10 @@ These files are referenced in `examples/csv-analysis.ts` and `examples/pdf-analy
 
 ```bash
 # Run CSV examples
-npx tsx examples/csv-analysis.ts
+pnpm exec tsx examples/csv-analysis.ts
 
 # Run PDF examples
-npx tsx examples/pdf-analysis.ts
+pnpm exec tsx examples/pdf-analysis.ts
 
 # Or use files directly with the CLI
 # CSV:

--- a/examples/rag-examples.md
+++ b/examples/rag-examples.md
@@ -268,7 +268,7 @@ basicChunkingExample().catch(console.error);
 Run it:
 
 ```bash
-npx tsx examples/basic-chunking.ts
+pnpm exec tsx examples/basic-chunking.ts
 ```
 
 ### 3.2 Document Processing with MDocument
@@ -318,7 +318,7 @@ mdocumentExample().catch(console.error);
 Run it:
 
 ```bash
-npx tsx examples/mdocument-example.ts
+pnpm exec tsx examples/mdocument-example.ts
 ```
 
 ### 3.3 Hybrid Search (BM25 + Mock Vectors)
@@ -410,7 +410,7 @@ hybridSearchExample().catch(console.error);
 Run it:
 
 ```bash
-npx tsx examples/hybrid-search-example.ts
+pnpm exec tsx examples/hybrid-search-example.ts
 ```
 
 ### 3.4 Reranking Results
@@ -504,7 +504,7 @@ rerankingExample().catch(console.error);
 Run it:
 
 ```bash
-npx tsx examples/reranking-example.ts
+pnpm exec tsx examples/reranking-example.ts
 ```
 
 ### 3.5 Graph RAG
@@ -597,7 +597,7 @@ graphRAGExample().catch(console.error);
 Run it:
 
 ```bash
-npx tsx examples/graph-rag-example.ts
+pnpm exec tsx examples/graph-rag-example.ts
 ```
 
 ### 3.6 Full RAG Pipeline with generate() (Requires API Key)
@@ -713,10 +713,10 @@ Run it:
 ```bash
 # With API key
 export GOOGLE_API_KEY=your-key
-npx tsx examples/rag-with-generate.ts
+pnpm exec tsx examples/rag-with-generate.ts
 
 # Without API key (will show setup instructions)
-npx tsx examples/rag-with-generate.ts
+pnpm exec tsx examples/rag-with-generate.ts
 ```
 
 ---

--- a/test/README.md
+++ b/test/README.md
@@ -39,7 +39,7 @@ pnpm run test:credentials
 pnpm run test:mcp:full
 
 # Direct invocation:
-npx tsx test/continuous-test-suite-<name>.ts [--provider=vertex] [--model=gpt-4o]
+pnpm exec tsx test/continuous-test-suite-<name>.ts [--provider=vertex] [--model=gpt-4o]
 ```
 
 ## 2. Tiers

--- a/test/TESTING_SCRIPTS.md
+++ b/test/TESTING_SCRIPTS.md
@@ -13,12 +13,12 @@ This directory contains automated testing scripts for validating NeuroLink funct
 
 ```bash
 # Test a single provider
-npx tsx test/continuous-test-suite.ts --provider openai
-npx tsx test/continuous-test-suite.ts --provider anthropic
-npx tsx test/continuous-test-suite.ts --provider vertex
+pnpm exec tsx test/continuous-test-suite.ts --provider openai
+pnpm exec tsx test/continuous-test-suite.ts --provider anthropic
+pnpm exec tsx test/continuous-test-suite.ts --provider vertex
 
 # Run from project root
-npx tsx test/continuous-test-suite.ts --provider <provider-name>
+pnpm exec tsx test/continuous-test-suite.ts --provider <provider-name>
 ```
 
 #### Supported Providers
@@ -251,10 +251,10 @@ Test one provider comprehensively:
 
 ```bash
 # Test OpenAI thoroughly
-npx tsx test/continuous-test-suite.ts --provider openai
+pnpm exec tsx test/continuous-test-suite.ts --provider openai
 
 # Test Vertex AI thoroughly
-npx tsx test/continuous-test-suite.ts --provider vertex
+pnpm exec tsx test/continuous-test-suite.ts --provider vertex
 ```
 
 ### 3. Full Suite (15-20 minutes)
@@ -312,7 +312,7 @@ cat /tmp/neurolink-sequential-tests/test-openai.log
 cat /tmp/neurolink-sequential-tests/test-vertex.log
 
 # Single provider test (run manually with output)
-npx tsx test/continuous-test-suite.ts --provider openai 2>&1 | tee test-output.log
+pnpm exec tsx test/continuous-test-suite.ts --provider openai 2>&1 | tee test-output.log
 ```
 
 ### Common Issues
@@ -386,7 +386,7 @@ Error: Cannot find module 'dist/cli/index.js'
 
 ```bash
 # Test specific provider you're working on
-npx tsx test/continuous-test-suite.ts --provider <your-provider>
+pnpm exec tsx test/continuous-test-suite.ts --provider <your-provider>
 ```
 
 ### CI/CD Integration


### PR DESCRIPTION
#1507 moved every entry point off `npx` — 93 call sites across `package.json`, `ci.yml`, `release.yml` and the commit-msg hook — because **`npx` prefers a local binary but silently falls back to fetching from the registry** when it can't resolve one, running a different version than the lockfile pins without a prompt. `pnpm exec` only ever runs the local binary and fails loudly when it's absent.

**The scripts moved. The instructions didn't.** 0 of 195 `package.json` scripts still contain `npx`, while the documents telling people how to run those same tools kept saying `npx tsx` — including `CLAUDE.md`, which an agent reads before every task in this repo.

**65 occurrences across 21 files** that exist to tell someone how to run something *now*: `CLAUDE.md`, `CONTRIBUTING.md`, the `test/`, `docs/agents/` and `docs/rag/` testing guides, the provider-integration guides, the examples READMEs, and `.claude/skills/adding-tests.md`.

## Three categories deliberately untouched

**Dated plans and records** — `docs/superpowers/plans/**`, `docs/plans/**`, `memory-bank/**`, and anything with a `YYYY-MM-DD` in its name — keep `npx tsx`. **21 files, 257 occurrences.** They describe what was done at the time; editing them would falsify a record to satisfy a convention that postdates it.

**`npx @juspay/neurolink` and `npx neurolink` stay, everywhere.** Those run the **published** package without installing it — exactly what `npx` is for, and what a reader following those instructions does not have locally. Converting them would have broken every one. **794 and 75 occurrences**, preserved and asserted on during the edit rather than hoped for.

**The two example READMEs that ship without a lockfile** — `examples/sagemaker/README.md` (6 occurrences) and `examples/autoresearch/README.md` (1) — keep `npx tsx`. Neither directory has a `package.json`, so `pnpm exec tsx` there resolves nothing and fails; `npx` is the only form that works for a reader who has cloned the repo but not installed at the root. This is the exception CodeRabbit flagged on this PR, and it is why the counts above are 65/21 rather than 72/23.

## Scope

Docs only — 21 files, **0 under `src/`, 0 non-markdown**. Prettier realigned one table in `docs/agents/VERIFICATION.md` because `pnpm exec tsx` is wider than `npx tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test, verification, development, and example commands to use `pnpm exec tsx`.
  * Standardized command examples across guides and READMEs for more consistent execution.
  * Updated provider, RAG, voice, data, and AutoResearch examples to follow the same command format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
