### PR TITLE
fix(github): stop settings.yml from removing required checks if it is applied

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -170,6 +170,25 @@ labels:
     description: "Extra attention is needed"
 
 # Branch protection rules
+# ⚠️ This file is NOT what currently gates merges on `release`.
+#
+# It is consumed by https://github.com/repository-settings/app, which
+# reconciles on every push to the default branch. Live protection has five
+# required contexts; the list below had four, one of which
+# ("Yama PR Review") points at a workflow that is disabled. An active app
+# would therefore have overwritten live protection long ago — it has not, so
+# the app is not installed or not running here.
+#
+# That makes this file documentation which two workflows already treat as
+# authoritative (yama-review.yml says "keep the two in sync";
+# live-matrix.yml cites "settings.yml's branch-protection contexts"), while
+# it had silently drifted. The contexts below are now reconciled against
+# live, so installing the app would preserve the gates rather than remove
+# them.
+#
+# Check before trusting it:
+#   gh api repos/juspay/neurolink/branches/release/protection \
+#     --jq '.required_status_checks.contexts[]'
 branches:
   - name: release
     protection:
@@ -179,29 +198,18 @@ branches:
           - "test"
           - "build-check"
           - "provider-safety-net"
-          # AI code review — fails only on a Yama BLOCKED verdict (see
-          # .github/workflows/yama-review.yml + yama.config.yaml).
-          - "Yama PR Review"
-      enforce_admins: false
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-      restrictions: null
-      allow_force_pushes: false
-      allow_deletions: false
-
-  - name: release
-    protection:
-      required_status_checks:
-        strict: true
-        contexts:
-          - "test"
-          - "build-check"
-          - "provider-safety-net"
-          # AI code review — fails only on a Yama BLOCKED verdict (see
-          # .github/workflows/yama-review.yml + yama.config.yaml).
-          - "Yama PR Review"
+          - "🔒 Single Commit Policy Validation"
+          # Classic-protection only. Absent from ruleset 11413189, so a
+          # ruleset-only query reports it optional — see CLAUDE.md's
+          # "Required status checks and the release bot".
+          - "security-suites"
+          # "Yama PR Review" is deliberately NOT listed. The workflow is
+          # state=disabled_manually (backlog D1), and a required check whose
+          # workflow never runs can never report — applying it would block
+          # every pull request permanently, which is the
+          # "GH013 ... required status checks are expected" failure applied
+          # to the whole queue at once. Re-add it in the same change that
+          # re-enables the workflow, not before.
       enforce_admins: false
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
`.github/settings.yml` is consumed by [repository-settings/app](https://github.com/repository-settings/app), which reconciles branch protection on **every push to the default branch**. Its `release` block listed four required contexts. Live protection has five, and the two disagree in both directions:

| | contexts |
|---|---|
| **live** | `test`, `provider-safety-net`, `build-check`, `🔒 Single Commit Policy Validation`, `security-suites` |
| **the file** | `test`, `build-check`, `provider-safety-net`, **`Yama PR Review`** |

Applying that file would have **dropped `security-suites` and `🔒 Single Commit Policy Validation`**, and **required `Yama PR Review` — a workflow that is `state=disabled_manually`** (backlog D1).

A required check whose workflow never runs can never report, so that one entry would block **every open pull request, permanently** — the `GH013 … required status checks are expected` failure this repo already documents, applied to the whole queue at once rather than to a single push.

## Why it hasn't fired

The app is **not active here**. An installed app would have overwritten live protection long ago; live still carries the context the file lacks, which is the evidence. A loaded gun, not a firing one — and nothing would have warned anyone, because **a settings file that is never applied looks exactly like one that is**.

Two workflows already treat it as authoritative while it had drifted: `yama-review.yml` says *"keep the two in sync"*, and `live-matrix.yml` cites *"settings.yml's branch-protection contexts"*.

## What changed

- **Contexts reconciled against live** — verified as a **set comparison**, not by diffing sorted output: the emoji in one context name collates differently between two `sort` invocations and made an identical pair look different.
- **`Yama PR Review` deliberately left out**, with a comment saying why and when to restore it — in the same change that re-enables the workflow, not before.
- **The `release` block appeared twice, byte for byte.** Whatever consumes it would have used one of them and nobody had said which. Now once.
- A header note records that live is the truth today, that the app appears inactive, and the one command that settles it.

One file. YAML re-parsed after every edit and after prettier; `enforce_admins`, review requirements and the rest of the block are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository settings documentation to reflect current release branch protection.
  * Reconciled documented required checks with the active validation and security checks.
  * Documented the conditions for restoring the previously disabled review requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->