### PR TITLE
ci(test): run the four agent suites #1560 added, and stop the MCP tax failing one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -760,7 +760,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       # Every shard runs even if another fails, so one broken suite never
-      # hides the state of the other 27 — the same property the loop below
+      # hides the state of the other 37 — the same property the loop below
       # has always had within a single job.
       fail-fast: false
       matrix:
@@ -833,7 +833,7 @@ jobs:
           # fixtures or mocked fetch, so a suite that starts making real network
           # calls fails here rather than silently costing money and flaking.
           #
-          # The list below grew from 8 to 28. The 20 added were not picked by
+          # The list below grew from 8 to 38. The 30 added were not picked by
           # reading them: every suite script that CI never invoked was run with
           # the environment fully stripped — `env -i` plus
           # DOTENV_CONFIG_PATH=/dev/null, checked to actually suppress .env —
@@ -927,6 +927,10 @@ jobs:
           # spread is 1s to 367s, so equal counts gave shards of 33s and 485s.
           SUITES="
             test:tts:unit@367
+            test:agent-delegation@78
+            test:background-commands@23
+            test:agent-tasks@13
+            test:artifact-banking@13
             test:multimodal:sdk@110
             test:agents@7
             test:media-registry-collisions@3

--- a/test/continuous-test-suite-agent-delegation.ts
+++ b/test/continuous-test-suite-agent-delegation.ts
@@ -28,6 +28,18 @@
  * Run: pnpm run test:agent-delegation [--provider=vertex]
  */
 
+// The repo's tracked .mcp-config.json declares a `filesystem` server started
+// via `npx -y @modelcontextprotocol/server-filesystem`, with autoDiscovery and
+// autoRegister on, so every NeuroLink this suite builds tries to start it and
+// waits the full 60s MCP client timeout when it cannot. That is not merely
+// slow here: measured credential-free, this suite took 356s and reported one
+// FAILURE — "a finished worker must show as ready without being collected" —
+// because the stalls perturbed the very timing the case asserts on. With this
+// set it is 41s and 19/19. test:hitl and test:multimodal:sdk set it the same
+// way; test:proxy sets it only in the environment of the CLI subprocesses it
+// spawns, not for its own instances.
+process.env.NEUROLINK_SKIP_MCP = "true";
+
 import {
   defineSuite,
   assert,

--- a/test/continuous-test-suite-agent-tasks.ts
+++ b/test/continuous-test-suite-agent-tasks.ts
@@ -17,6 +17,12 @@
  * Run: pnpm run test:agent-tasks [--provider=vertex]
  */
 
+// See test:hitl and test:multimodal:sdk: the tracked .mcp-config.json makes
+// every NeuroLink instance wait the full 60s MCP client timeout when the
+// filesystem server cannot start. Measured here at 68s without this and 7s
+// with it, same assertions either way.
+process.env.NEUROLINK_SKIP_MCP = "true";
+
 import { defineSuite, assert, assertEqual, Skip } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
 import { NeuroLink } from "../dist/index.js";

--- a/test/continuous-test-suite-artifact-banking.ts
+++ b/test/continuous-test-suite-artifact-banking.ts
@@ -23,6 +23,12 @@
  * Run: pnpm run test:artifact-banking [--provider=vertex]
  */
 
+// See test:hitl and test:multimodal:sdk: the tracked .mcp-config.json makes
+// every NeuroLink instance wait the full 60s MCP client timeout when the
+// filesystem server cannot start. Measured here at 68s without this and 7s
+// with it, same assertions either way.
+process.env.NEUROLINK_SKIP_MCP = "true";
+
 import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";

--- a/test/continuous-test-suite-background-commands.ts
+++ b/test/continuous-test-suite-background-commands.ts
@@ -53,6 +53,7 @@ assertDistFresh();
 
 const { test, runSuite, section } = defineSuite("Background Commands", {
   perTestTimeoutMs: 90_000,
+  offline: true,
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
#1560 landed `test:agent-delegation`, `test:agent-tasks`, `test:artifact-banking` and `test:background-commands`. All four have `package.json` scripts. **None was named by any workflow**, so **93 assertions executed nowhere** — the condition `ci.yml` already describes in its own words, *"A suite wired into nothing is documentation, not a test"*, recurring within hours of the last round of it being fixed.

## The MCP tax doesn't just make suites slow — it makes one of them fail

Measured credential-free under a socket-layer preload, `mkdtemp` HOME, empty `CLOUDSDK_CONFIG`, `.env` suppressed:

| suite | time | result | 60s MCP timeouts |
|---|---|---|---|
| `agent-delegation` | **356s** | 18 passed / **1 FAILED** | **11** |
| `agent-tasks` | 68s | 23 passed | 1 |
| `artifact-banking` | 68s | 16 passed | 1 |
| `background-commands` | 13s | 35 passed | 0 |

The delegation failure reads as a real defect — *"a finished worker must show as ready without being collected"* — and **is not one**. That case asserts on task-lifecycle timing, and eleven sixty-second stalls moved the worker's state transition outside the window it checks.

**With `NEUROLINK_SKIP_MCP` set: 41s, 19/19.**

C3 characterised this tax as making a suite slow enough to be killed by an outer bound. It also makes timing-sensitive suites report **false failures** — the more expensive half, because a slow suite gets investigated and a failing one gets blamed on the code under test.

## What changed

The three that build `NeuroLink` instances now set `NEUROLINK_SKIP_MCP`, as `test:proxy` and `test:multimodal:sdk` already do.

`background-commands` doesn't need it — it never triggered the load — and it's the only one of the four reaching **no external host at all**, so it's the only one that gets `offline: true`. The other three still contact `aiplatform`/`oauth2.googleapis.com` (and `api.openai.com` for delegation), where a timeout can legitimately be an upstream rather than a hang, so they're deliberately left unflagged — the same distinction applied to `auth`, `dynamic`, `credentials` and `provider-descriptors`.

## Verification

All four green through their `package.json` scripts with **zero** MCP timeouts · assignment loop places all **32** suites, 0 duplicates · offline-flag placement checked by walking to `defineSuite`'s matching paren · eslint 0 errors · `check:tools-tests` clean · prettier clean.

Weights are 1.9× local timings (the `test:tts:unit` ratio) — estimates, to be replaced from the first real run via the log-timestamp method above the list.

## Merge order

Fourth PR touching the `SUITES` block, after #1568, #1571 and #1574. Each later one is a small rebase in that list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for agent delegation, background commands, agent tasks, and artifact banking.
  * Expanded automated validation across multimodal SDK, agent, media registry, video cancellation, routing, and request resolution scenarios.
  * Improved test reliability by enabling offline operation and bypassing unavailable optional service connections.
  * Reduced test execution time when optional services cannot start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->