### PR TITLE
fix(tools): align provider scaffold and tier-2 guide with pilot findings

### DIFF
--- a/docs/provider-integration/tiers/tier-2-catalog-entry.md
+++ b/docs/provider-integration/tiers/tier-2-catalog-entry.md
@@ -15,15 +15,42 @@ catalog shape.
 
 ## Files touched (end state)
 
-| #   | File                                              | Change                                                                                                               |
-| --- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| 1   | `src/lib/constants/enums.ts`                      | One new `AIProviderName` member                                                                                      |
-| 2   | `src/lib/providers/openaiCompatCatalog.ts`        | One `OpenAICompatCatalogEntry` object appended to `OPENAI_COMPAT_CATALOG`                                            |
-| 3   | `src/lib/utils/providerConfig.ts`                 | One `create<Name>Config()` helper returning `ProviderConfigOptions` (referenced from Step 1's `configOptions` field) |
-| 4   | `src/lib/factories/providerDescriptors.ts`        | One `ProviderDescriptor` object appended to `PROVIDER_DESCRIPTORS`                                                   |
-| 5   | `src/lib/types/providers.ts`                      | One new `NeurolinkCredentials["<key>"]` slice                                                                        |
-| 6   | `test/continuous-test-suite-providers-mocked.ts`  | One mocked-contract section (happy-path + 401)                                                                       |
-| 7   | `docs/provider-integration/manifests/<name>.json` | New manifest (see `../manifests/README.md`)                                                                          |
+Twelve touchpoints (14 files — rows 6 and 11 span two files each), not
+the six this table originally listed — the cerebras pilot (PR
+#1561/#1564) found every one of rows 6-12 the hard way (findings #3-#5:
+two by compiler, three by CI-only test pins).
+
+| #   | File                                                                                                   | Change                                                                                                                   |
+| --- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| 1   | `src/lib/constants/enums.ts`                                                                           | One new `AIProviderName` member AND a `<Name>Models` enum (live-roster-verified ids)                                     |
+| 2   | `src/lib/providers/openaiCompatCatalog.ts`                                                             | One `OpenAICompatCatalogEntry` appended to `OPENAI_COMPAT_CATALOG` (+ bump the "N zero-quirk providers" header comment)  |
+| 3   | `src/lib/utils/providerConfig.ts`                                                                      | One `create<Name>Config()` helper returning `ProviderConfigOptions` (referenced from Step 1's `configOptions` field)     |
+| 4   | `src/lib/factories/providerDescriptors.ts`                                                             | One `ProviderDescriptor` object appended to `PROVIDER_DESCRIPTORS`                                                       |
+| 5   | `src/lib/types/providers.ts`                                                                           | One new `NeurolinkCredentials["<key>"]` slice                                                                            |
+| 6   | `src/lib/models/manifests/<name>.ts` + `src/lib/models/manifestRegistry.ts`                            | Minimal model manifest (copy `groq.ts`'s `_default` pattern) + registry wiring                                           |
+| 7   | `src/lib/utils/modelChoices.ts`                                                                        | Entries in BOTH exhaustive `Record<AIProviderName,...>` tables + the `<Name>Models` import (compiler-enforced)           |
+| 8   | `src/cli/commands/setup.ts`                                                                            | `<key>: create<Name>Config()` in `EXTRA_PROVIDER_CONFIGS` + import (pinned by the wiring suite — see "Count pins" below) |
+| 9   | `test/continuous-test-suite-providers-mocked.ts`                                                       | One `OPENAI_COMPAT_PROVIDERS` spec row (happy-path + 401 + rate-limit)                                                   |
+| 10  | `test/helpers/providerMatrix.ts`                                                                       | One capability row — flags must be live-verified, not assumed (see "Live verification" below)                            |
+| 11  | `test/continuous-test-suite-provider-wiring.ts` + `test/continuous-test-suite-provider-descriptors.ts` | The five count/roster pins — see "Count pins" below                                                                      |
+| 12  | `docs/provider-integration/manifests/<name>.json`                                                      | New manifest (see `../manifests/README.md`)                                                                              |
+
+## Count pins that WILL fire on any new provider
+
+Five assertions across two suites pin the provider roster and fail the
+moment `AIProviderName` grows. **Local `pnpm run check` does not
+typecheck `test/` — the CI `test-shards (types)` job does, via
+`pnpm run check:tools-tests`** — so run that locally or you find pins
+one CI lap at a time (the cerebras pilot burned two laps this way):
+
+- `provider-wiring`: `KNOWN_CREDENTIAL_KEYS` must gain the new key
+  (compile-time `satisfies Record<keyof NeurolinkCredentials, undefined>`
+  pin), the `EXTRA_PROVIDER_CONFIGS` wizard-coverage count + test name
+  must be bumped, and the `getAvailableProviders` test name carries the
+  total-provider count.
+- `provider-descriptors`: the `getAllDescriptors` total and the
+  `apiKeyFormatPattern`-absent count both bump by one for a typical
+  Tier 2 entry.
 
 Notice `src/lib/factories/providerRegistry.ts` isn't in this table. That's
 the point of the catalog path, and it's live today: `_doRegister()` already
@@ -56,14 +83,18 @@ unless marked optional; see `type OpenAICompatCatalogEntry` in
   defaultBaseURL: "https://api.cerebras.ai/v1",
   configOptions: createCerebrasConfig(), // ProviderConfigOptions — see below
   modelEnvVar: "CEREBRAS_MODEL",
-  defaultModel: "llama3.1-70b",
-  registryDefaultModel: "llama3.1-70b",
+  // Model ids from a LIVE authenticated /v1/models probe, referenced via
+  // the <Name>Models enum — never from vendor docs. The pilot's first cut
+  // used documented-but-retired llama ids and 404'd on first live call.
+  defaultModel: CerebrasModels.GPT_OSS_120B,
+  registryDefaultModel: CerebrasModels.GPT_OSS_120B,
   registryDefaultModelChecksEnvVar: true,
-  fallbackModelName: "llama3.1-8b",
-  fallbackModels: ["llama3.1-70b", "llama3.1-8b"],
+  fallbackModelName: CerebrasModels.GEMMA_4_31B,
+  fallbackModels: [CerebrasModels.GPT_OSS_120B, CerebrasModels.GEMMA_4_31B],
   errorRules: [
     // Add vendor-specific rules only where the vendor's error bodies need a
-    // match beyond DEFAULT_ERROR_RULES — most Tier 2 providers only need:
+    // match beyond DEFAULT_ERROR_RULES. Probe the real 401 body keylessly
+    // (curl with a bad key) and cite its shape in the rule's comment:
     ...DEFAULT_ERROR_RULES,
   ],
 },
@@ -158,7 +189,7 @@ rule is its own assertion.
     baseURL: "CEREBRAS_BASE_URL",
     model: "CEREBRAS_MODEL",
   },
-  defaultModel: "llama3.1-70b",
+  defaultModel: CerebrasModels.GPT_OSS_120B,
   toolSupport: "native",
   localRuntime: false,
   healthCheck: "env-only",
@@ -254,8 +285,9 @@ today):
   envVar: "CEREBRAS_API_KEY",
   urlMatch: "api.cerebras.ai/v1/chat/completions",
   authPrefix: "Bearer ",
-  model: "llama3.1-70b",
+  model: "gpt-oss-120b",
   authErrorMatch: /cerebras|401|unauthor|api key/i,
+  rateLimitErrorMatch: /cerebras|rate.?limit|429/i,
 },
 ```
 
@@ -279,17 +311,57 @@ and 401 mapping for you without any bespoke test code.
     "src/lib/utils/providerConfig.ts",
     "src/lib/factories/providerDescriptors.ts",
     "src/lib/types/providers.ts",
-    "test/continuous-test-suite-providers-mocked.ts"
+    "src/lib/models/manifests/cerebras.ts",
+    "src/lib/models/manifestRegistry.ts",
+    "src/lib/utils/modelChoices.ts",
+    "src/cli/commands/setup.ts",
+    "test/continuous-test-suite-providers-mocked.ts",
+    "test/helpers/providerMatrix.ts",
+    "test/continuous-test-suite-provider-wiring.ts",
+    "test/continuous-test-suite-provider-descriptors.ts"
   ],
   "mockedContractSection": "LLM cerebras",
   "manualTestStatus": "not-tested"
 }
 ```
 
+`manualTestStatus` starts as `"not-tested"` and gets flipped to a dated
+live-verified note once the live matrix passes (see below) — the shipped
+`manifests/cerebras.json` shows the end state.
+
+## Live verification
+
+The mocked gates prove the wire contract, not the commercial reality.
+Three live checks are mandatory before (and one loop after) merging —
+each one caught a real defect on the cerebras pilot:
+
+1. **Roster probe first** — authenticated `GET <baseURL>/models`. Pick
+   `defaultModel`/`fallbackModels` from what the API serves TODAY.
+   Vendor docs listed four cerebras models; the live roster had two, and
+   the documented default 404'd (finding #7).
+2. **Billing policy** — confirm how a working key is obtained. Cerebras
+   has no keyless free tier: even the "$5 free credits" require saving a
+   payment card (finding #8). Record this in the provider-config
+   instructions so the setup wizard tells the truth.
+3. **Capability probes** — before filling the `providerMatrix.ts` row,
+   probe `tools` + `response_format` in one request; strict backends 400
+   (`"tools" is incompatible with "response_format"` on cerebras), which
+   is what `structuredOutputWithTools: false` records. Don't copy
+   another provider's flags on vibes.
+4. **Live matrix** — with a working key:
+   `npx tsx test/continuous-test-suite-provider-matrix.ts --provider=<name>`
+   must pass 4/4 (generate, stream, tool calling, structured output), and
+   a bare `node dist/cli/index.js generate "..." --provider <name>` must
+   resolve the default model. The pilot's first live run was 2/4 and
+   surfaced an SDK-wide bug (`tool_choice` emitted on tools-less
+   requests — fixed in #1564 and now pinned by the mocked suite), which
+   is exactly why this step exists.
+
 ## Verification commands
 
 ```bash
 pnpm run check
+pnpm run check:tools-tests   # typechecks test/ — the CI types shard; plain `check` skips it
 pnpm run lint
 pnpm run test:providers-mocked
 pnpm run test:provider-structure
@@ -310,6 +382,8 @@ check after touching anything registry-adjacent. Add a case to
 `test:error-classifier-contract` first if your entry sets
 `timeoutErrorClass` or vendor-specific `errorRules` beyond
 `DEFAULT_ERROR_RULES` (see "Escape hatch: `timeoutErrorClass`" above).
-(`pnpm run verify:provider-onboarding` doesn't exist yet as of 2026-08-19
-— it's a follow-up change to this plan (Tasks 8-9). Until it lands, treat
-the rest as the enforced minimum.)
+
+When adding your mocked-suite section, run the break-one-assertion
+ritual: flip one assertion, confirm the suite reports `✗` and exits
+non-zero (not `⊘` skip — see the assertion-message hazard in CLAUDE.md),
+then restore it.

--- a/tools/scaffold-provider.ts
+++ b/tools/scaffold-provider.ts
@@ -11,7 +11,11 @@
  * Usage:
  *   npx tsx tools/scaffold-provider.ts --name=cerebras --tier=2 \
  *     --baseURL=https://api.cerebras.ai/v1 --envVar=CEREBRAS_API_KEY \
- *     --defaultModel=llama3.1-70b --aliases=cerebras-ai
+ *     --defaultModel=gpt-oss-120b --aliases=cerebras-ai
+ *
+ * Pick --defaultModel from a LIVE roster probe (authenticated GET
+ * /v1/models), never from vendor docs — the cerebras pilot shipped a
+ * documented-but-retired default that 404'd on first live call.
  *
  * pnpm script: pnpm run scaffold:provider -- --name=... --tier=... ...
  *
@@ -103,6 +107,58 @@ function enumEntrySnippet(input: ScaffoldInput): string {
   return `  ${toConstantCase(input.name)} = "${input.name}",\n`;
 }
 
+// Model ids can contain characters that aren't identifier-safe
+// ("gpt-oss-120b", "meta-llama/Llama-3.3"), so the derived enum member
+// collapses every non-alphanumeric run to one underscore. Enum member
+// names must be valid identifiers: a digit-leading result ("4o-mini" ->
+// "4O_MINI") gets an M_ prefix, and an id that normalizes to nothing
+// falls back to "MODEL".
+function toModelConstant(modelId: string): string {
+  const normalized = modelId
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (normalized === "") {
+    return "MODEL";
+  }
+  return /^[0-9]/.test(normalized) ? `M_${normalized}` : normalized;
+}
+
+function modelsEnumSnippet(input: ScaffoldInput): string {
+  const pascal = toPascalCase(input.name);
+  return `/**
+ * ${pascal} models.
+ * TODO: verify this roster against a live authenticated GET /v1/models
+ * before merging — vendor docs list retired ids that 404 (the cerebras
+ * pilot shipped one as its default). Record the probe date here.
+ */
+export enum ${pascal}Models {
+  ${toModelConstant(input.defaultModel)} = "${input.defaultModel}",
+}
+`;
+}
+
+function providerConfigSnippet(input: ScaffoldInput): string {
+  const pascal = toPascalCase(input.name);
+  return `// Splice into src/lib/utils/providerConfig.ts (see createGroqConfig
+// there for the currently-shipping pattern).
+export function create${pascal}Config(): ProviderConfigOptions {
+  return {
+    providerName: "${pascal}",
+    envVarName: "${input.envVar}",
+    setupUrl: "TODO: vendor API-keys page",
+    description: "API key",
+    instructions: [
+      "1. Visit: TODO vendor API-keys page",
+      "2. Sign in / create an account (TODO: note whether the free tier requires a payment method — cerebras does)",
+      "3. Create a new API key",
+      "4. Set ${input.envVar} in your .env file",
+    ],
+  };
+}
+`;
+}
+
 function descriptorSnippet(input: ScaffoldInput): string {
   const constant = toConstantCase(input.name);
   const camelKey = toCamelCase(input.name);
@@ -116,7 +172,7 @@ function descriptorSnippet(input: ScaffoldInput): string {
       baseURL: "${constant}_BASE_URL",
       model: "${constant}_MODEL",
     },
-    defaultModel: "${input.defaultModel}",
+    defaultModel: "${input.defaultModel}", // convention: swap for the ${toPascalCase(input.name)}Models enum member
     toolSupport: "native",
     localRuntime: false,
     healthCheck: "env-only",
@@ -124,15 +180,40 @@ function descriptorSnippet(input: ScaffoldInput): string {
 `;
 }
 
+// Field names below MUST match type OpenAICompatCatalogEntry in
+// src/lib/types/providers.ts exactly — this template once drifted
+// (provider/envBaseURLVar vs providerName/baseURLEnvVar) and, because
+// tools/** is excluded from `pnpm run check`, nothing caught it until a
+// human spliced the snippet (cerebras pilot, finding #1). If you change
+// the type, change this template in the same commit.
 function catalogEntrySnippet(input: ScaffoldInput): string {
   const constant = toConstantCase(input.name);
-  const baseURLLiteral = input.baseURL ? `"${input.baseURL}"` : "undefined";
+  const pascal = toPascalCase(input.name);
+  const modelConstant = toModelConstant(input.defaultModel);
+  const aliasesLiteral = [input.name, ...input.aliases]
+    .map((a) => `"${a}"`)
+    .join(", ");
+  const baseURLLine = input.baseURL
+    ? `    defaultBaseURL: "${input.baseURL}",`
+    : `    // defaultBaseURL: "https://api.<vendor>.com/v1", // or computedBaseURL — see the type`;
   return `  {
-    provider: AIProviderName.${constant},
-    defaultBaseURL: ${baseURLLiteral},
-    envBaseURLVar: "${constant}_BASE_URL",
-    defaultModel: "${input.defaultModel}",
-    fallbackModels: ["${input.defaultModel}"],
+    providerName: AIProviderName.${constant},
+    aliases: [${aliasesLiteral}],
+    apiKeyEnvVar: "${input.envVar}",
+    baseURLEnvVar: "${constant}_BASE_URL",
+${baseURLLine}
+    configOptions: create${pascal}Config(),
+    modelEnvVar: "${constant}_MODEL",
+    defaultModel: ${pascal}Models.${modelConstant},
+    registryDefaultModel: ${pascal}Models.${modelConstant},
+    registryDefaultModelChecksEnvVar: true,
+    fallbackModelName: ${pascal}Models.${modelConstant}, // TODO: second live model if the roster has one
+    fallbackModels: [${pascal}Models.${modelConstant}],
+    errorRules: [
+      // TODO: probe the vendor's real 401 body keylessly first (curl with a
+      // bad key) and add an auth rule citing that exact shape, then:
+      ...DEFAULT_ERROR_RULES,
+    ],
   },
 `;
 }
@@ -186,10 +267,32 @@ export class ${className} extends BaseProvider {
 }
 
 function mockedTestSectionSnippet(input: ScaffoldInput): string {
+  if (input.tier === 2) {
+    return `// --- ${toPascalCase(input.name)} (Tier 2) ---
+// Tier 2 needs ONE spec row appended to the OPENAI_COMPAT_PROVIDERS
+// array in test/continuous-test-suite-providers-mocked.ts — the shared
+// runner covers happy-path, 401 and 429 mapping (plus the tools-less
+// tool_choice-absence invariant) for every row. Adapt from the shipped
+// cerebras row:
+{
+  provider: "${input.name}",
+  envVar: "${input.envVar}",
+  urlMatch: "<host>/v1/chat/completions", // TODO: real host
+  authPrefix: "Bearer ",
+  model: "${input.defaultModel}",
+  authErrorMatch: /${input.name}|401|unauthor|api key/i,
+  rateLimitErrorMatch: /${input.name}|rate.?limit|429/i,
+},
+// REQUIRED: the row's "${MOCKED_SECTION_FIELD}" field must carry this
+// provider's name as real executable code — tools/verify-provider-onboarding.ts
+// strips comments before checking, so this snippet satisfies the gate only
+// once spliced in as code.
+`;
+  }
   return `// --- ${toPascalCase(input.name)} (Tier ${input.tier}) ---
 // TODO: this comment block is a placeholder, not a test — it must be
 // replaced, not pasted in as-is. Copy the nearest existing section in
-// test/continuous-test-suite-providers-mocked.ts (e.g. the groq or xai
+// test/continuous-test-suite-providers-mocked.ts (e.g. the deepseek
 // section) and adapt it:
 // 1. installMockFetch a route for POST <baseURL>/chat/completions
 // 2. assert the Authorization header and request body shape
@@ -259,10 +362,15 @@ generated under this directory for Tier 1.
 `;
   }
   const camelKey = toCamelCase(input.name);
-  const catalogOrClassLine =
+  // Tier 2 has NO registerProvider() block — the catalog loop in
+  // providerRegistry._doRegister() registers every OPENAI_COMPAT_CATALOG
+  // row generically (the registry's own comment says "not a new block
+  // here"). Telling Tier 2 authors to add one was checklist drift
+  // (cerebras pilot, finding #2).
+  const registrationLine =
     input.tier === 2
-      ? "- [ ] Splice catalog-entry.ts.snippet into OPENAI_COMPAT_CATALOG (src/lib/providers/openaiCompatCatalog.ts)"
-      : "- [ ] Move provider-class.ts.snippet to src/lib/providers/<name>.ts and fill in the TODOs";
+      ? '- [ ] Splice catalog-entry.ts.snippet into OPENAI_COMPAT_CATALOG (src/lib/providers/openaiCompatCatalog.ts) and bump its "N zero-quirk providers" header comment. Do NOT add a providerRegistry.ts block — the catalog loop registers every row.'
+      : "- [ ] Move provider-class.ts.snippet to src/lib/providers/<name>.ts, fill in the TODOs, and add one ProviderFactory.registerProvider() block in src/lib/factories/providerRegistry.ts (dynamic import — Critical Rule 1)";
   return `# Manual checklist for "${input.name}" (Tier ${input.tier})
 
 Full guide: docs/provider-integration/${doc}
@@ -270,14 +378,67 @@ Full guide: docs/provider-integration/${doc}
 Generated files under this directory are STARTING POINTS, not finished
 code — review every TODO before copy-pasting into src/.
 
-- [ ] Splice enum-entry.ts.snippet into src/lib/constants/enums.ts
-${catalogOrClassLine}
+## Live probes FIRST (before writing any code)
+
+- [ ] Roster: authenticated GET <baseURL>/models (keyless first if no key
+      yet, re-verify once you have one). Pick defaultModel/fallbacks from
+      what the API actually serves TODAY — vendor docs list retired ids
+      that 404 (cerebras pilot shipped one as its default).
+- [ ] Billing policy: confirm how a working key is obtained (free tier?
+      card required for "free" credits? — cerebras requires one).
+- [ ] Auth shape: curl with a bad key, record the real 401 body in the
+      catalog entry's auth errorRule comment.
+
+## Source touchpoints (the original checklist listed 6 of these 12 — findings #3-#5)
+
+- [ ] Splice enum-entry.ts.snippet into AIProviderName AND
+      models-enum.ts.snippet as a <Name>Models enum (src/lib/constants/enums.ts)
+${registrationLine}
+- [ ] Splice provider-config.ts.snippet into src/lib/utils/providerConfig.ts
 - [ ] Splice descriptor-entry.ts.snippet into PROVIDER_DESCRIPTORS (src/lib/factories/providerDescriptors.ts)
 - [ ] Add a NeurolinkCredentials["${camelKey}"] slice in src/lib/types/providers.ts
-- [ ] Add one ProviderFactory.registerProvider() block in src/lib/factories/providerRegistry.ts (dynamic import — Critical Rule 1)
-- [ ] Move mocked-test-section.ts.snippet into test/continuous-test-suite-providers-mocked.ts and finish the TODOs
-- [ ] Fill in manifest.json (addedInPR, filesTouched) and move it to docs/provider-integration/manifests/${input.name}.json
-- [ ] pnpm run check && pnpm run lint && pnpm run test:providers-mocked && pnpm run verify:provider-onboarding
+- [ ] Add src/lib/models/manifests/${input.name}.ts (copy groq.ts's minimal
+      _default pattern) and wire it in src/lib/models/manifestRegistry.ts
+- [ ] Add entries in BOTH exhaustive Record<AIProviderName,...> tables in
+      src/lib/utils/modelChoices.ts (+ the <Name>Models import) — the
+      compiler forces this the moment the enum member exists
+- [ ] Add ${camelKey}: create${toPascalCase(input.name)}Config() to
+      EXTRA_PROVIDER_CONFIGS in src/cli/commands/setup.ts (+ import)
+
+## Test touchpoints — including the five count/roster pins that WILL fire
+
+- [ ] Move mocked-test-section.ts.snippet into
+      test/continuous-test-suite-providers-mocked.ts and finish the TODOs
+- [ ] Add a row to test/helpers/providerMatrix.ts — capability flags must
+      be honest (verify structuredOutputWithTools with a live
+      tools+response_format probe, don't assume)
+- [ ] test/continuous-test-suite-provider-wiring.ts: add the key to
+      KNOWN_CREDENTIAL_KEYS (compile-time pin) AND bump the
+      EXTRA_PROVIDER_CONFIGS wizard-coverage count + test name AND the
+      getAvailableProviders count in its test name
+- [ ] test/continuous-test-suite-provider-descriptors.ts: bump the
+      getAllDescriptors total AND the apiKeyFormatPattern-absent count
+- [ ] pnpm run check:tools-tests — the CI types shard typechecks test/;
+      plain \`pnpm run check\` does NOT, so these pins otherwise fail
+      only in CI (cerebras pilot, finding #4)
+
+## Docs + gates
+
+- [ ] Fill in manifest.json (addedInPR, filesTouched) and move it to
+      docs/provider-integration/manifests/${input.name}.json
+- [ ] pnpm run check && pnpm run check:tools-tests && pnpm run lint &&
+      pnpm run build && pnpm run test:providers-mocked &&
+      pnpm run test:provider-structure && pnpm run verify:provider-onboarding
+- [ ] Break-one-assertion ritual on any new suite section: flip one
+      assertion, confirm ✗ + non-zero exit (not ⊘ skip), restore
+
+## Live verification (with a working key)
+
+- [ ] npx tsx test/continuous-test-suite-provider-matrix.ts --provider=${input.name}
+      — 4/4: generate, stream, tool calling, structured output
+- [ ] CLI: node dist/cli/index.js generate "..." --provider ${input.name}
+      (no --model — proves the default resolves live)
+- [ ] Flip the manifest's manualTestStatus to a dated live-verified note
 `;
 }
 
@@ -291,8 +452,16 @@ function main(): void {
       enumEntrySnippet(input),
     );
     writeFileSync(
+      join(input.out, "models-enum.ts.snippet"),
+      modelsEnumSnippet(input),
+    );
+    writeFileSync(
       join(input.out, "descriptor-entry.ts.snippet"),
       descriptorSnippet(input),
+    );
+    writeFileSync(
+      join(input.out, "provider-config.ts.snippet"),
+      providerConfigSnippet(input),
     );
   }
   if (input.tier === 2) {


### PR DESCRIPTION
## What

The cerebras pilot (#1561, live-verified in #1564) exercised the provider-onboarding playbook end-to-end and surfaced ten findings. This PR folds them back into `tools/scaffold-provider.ts` and `docs/provider-integration/tiers/tier-2-catalog-entry.md` so the next provider doesn't rediscover any of them.

## Scaffold tool

- **Finding #1** — the catalog-entry template emitted a shape that doesn't compile (`provider`/`envBaseURLVar`/`fallbackModels`-only vs the real `providerName`/`apiKeyEnvVar`/`baseURLEnvVar`/`configOptions`/`errorRules`). Rewritten field-for-field against `type OpenAICompatCatalogEntry`, with a comment binding template to type (tools/** is outside `pnpm run check`, so drift is silent).
- **Finding #2** — the Tier-2 checklist told authors to add a `providerRegistry.ts` block; the catalog loop registers every row. Now tier-conditional: Tier 2 explicitly says *don't*, Tier 3/4 keep the step.
- **Findings #3–#5** — checklist expanded from 6 to the real 12 touchpoints: `<Name>Models` enum, providerConfig factory, models manifest + registry wiring, modelChoices' two exhaustive Record tables, `setup.ts` EXTRA_PROVIDER_CONFIGS, providerMatrix row, and the five count/roster pins across the wiring + descriptors suites — plus the `check:tools-tests` warning (local `check` skips `test/`; the CI types shard doesn't — the pilot burned two CI laps on this).
- **Findings #7–#9** — new live-probe steps: authenticated `/v1/models` roster BEFORE choosing models (the pilot's documented default was retired and 404'd), billing-policy check (cerebras' "free" credits require a card), keyless 401 shape probe, live matrix 4/4, tools+response_format exclusivity probe, manifest `manualTestStatus` flip.
- Two new generated snippets (`models-enum`, `provider-config`); the Tier-2 mocked-test snippet now shows the `OPENAI_COMPAT_PROVIDERS` spec-row pattern (incl. `rateLimitErrorMatch`) instead of telling authors to copy a bespoke section.

## Tier-2 guide

Files-touched table 7 → 12 rows; new **Count pins** and **Live verification** sections; worked examples updated to the shipped live-roster cerebras values (old examples used the retired llama ids); stale "verify:provider-onboarding doesn't exist yet" note replaced with the break-one-assertion ritual; `check:tools-tests` added to the verification commands.

## Verification

- Scaffold run for a dummy tier-2 and tier-3 provider: all 8 snippet files generate, catalog snippet matches the type field-for-field, checklists render correctly per tier.
- `pnpm run lint`, `pnpm run check:tools-tests` (after rebuild), `pnpm run build` — all green. No `src/` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Tier 2 provider onboarding guidance to cover required configuration, model, capability, registration, and testing files.
  * Added live model verification procedures and updated examples with current models.
  * Expanded validation instructions, including tooling checks and mocked-suite verification.

* **New Features**
  * Improved provider scaffolding with model enums, configuration snippets, catalog defaults, fallback models, and test templates.
  * Added live-probe requirements and more comprehensive generated checklists for provider integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->