### PR TITLE
fix(tools): address scaffold review findings from #1582

### DIFF
--- a/docs/provider-integration/tiers/tier-2-catalog-entry.md
+++ b/docs/provider-integration/tiers/tier-2-catalog-entry.md
@@ -16,7 +16,7 @@ catalog shape.
 ## Files touched (end state)
 
 Twelve touchpoints (14 files — rows 6 and 11 span two files each), not
-the six this table originally listed — the cerebras pilot (PR
+the seven this table originally listed — the cerebras pilot (PR
 #1561/#1564) found every one of rows 6-12 the hard way (findings #3-#5:
 two by compiler, three by CI-only test pins).
 
@@ -349,9 +349,10 @@ each one caught a real defect on the cerebras pilot:
    is what `structuredOutputWithTools: false` records. Don't copy
    another provider's flags on vibes.
 4. **Live matrix** — with a working key:
-   `npx tsx test/continuous-test-suite-provider-matrix.ts --provider=<name>`
-   must pass 4/4 (generate, stream, tool calling, structured output), and
-   a bare `node dist/cli/index.js generate "..." --provider <name>` must
+   `npx tsx test/continuous-test-suite-provider-matrix.ts --provider=cerebras`
+   (substitute your provider id) must pass 4/4 (generate, stream, tool
+   calling, structured output), and a bare
+   `node dist/cli/index.js generate "..." --provider cerebras` must
    resolve the default model. The pilot's first live run was 2/4 and
    surfaced an SDK-wide bug (`tool_choice` emitted on tools-less
    requests — fixed in #1564 and now pinned by the mocked suite), which

--- a/tools/scaffold-provider.ts
+++ b/tools/scaffold-provider.ts
@@ -46,6 +46,14 @@ type ScaffoldInput = {
   out: string;
 };
 
+// Every CLI-derived value embedded in a generated TypeScript string literal
+// goes through this: JSON.stringify yields a valid, correctly-escaped TS
+// string literal even when the flag value contains quotes or backslashes.
+// (`name` itself is NAME_PATTERN-validated and safe to embed raw.)
+function tsString(value: string): string {
+  return JSON.stringify(value);
+}
+
 function toConstantCase(name: string): string {
   return name.toUpperCase().replace(/-/g, "_");
 }
@@ -133,7 +141,7 @@ function modelsEnumSnippet(input: ScaffoldInput): string {
  * pilot shipped one as its default). Record the probe date here.
  */
 export enum ${pascal}Models {
-  ${toModelConstant(input.defaultModel)} = "${input.defaultModel}",
+  ${toModelConstant(input.defaultModel)} = ${tsString(input.defaultModel)},
 }
 `;
 }
@@ -145,14 +153,14 @@ function providerConfigSnippet(input: ScaffoldInput): string {
 export function create${pascal}Config(): ProviderConfigOptions {
   return {
     providerName: "${pascal}",
-    envVarName: "${input.envVar}",
+    envVarName: ${tsString(input.envVar)},
     setupUrl: "TODO: vendor API-keys page",
     description: "API key",
     instructions: [
       "1. Visit: TODO vendor API-keys page",
       "2. Sign in / create an account (TODO: note whether the free tier requires a payment method — cerebras does)",
       "3. Create a new API key",
-      "4. Set ${input.envVar} in your .env file",
+      ${tsString(`4. Set ${input.envVar} in your .env file`)},
     ],
   };
 }
@@ -162,17 +170,17 @@ export function create${pascal}Config(): ProviderConfigOptions {
 function descriptorSnippet(input: ScaffoldInput): string {
   const constant = toConstantCase(input.name);
   const camelKey = toCamelCase(input.name);
-  const aliasesLiteral = input.aliases.map((a) => `"${a}"`).join(", ");
+  const aliasesLiteral = input.aliases.map(tsString).join(", ");
   return `  {
     name: AIProviderName.${constant},
     aliases: [${aliasesLiteral}] as const,
     credentialsKey: "${camelKey}",
     envVars: {
-      apiKey: "${input.envVar}",
+      apiKey: ${tsString(input.envVar)},
       baseURL: "${constant}_BASE_URL",
       model: "${constant}_MODEL",
     },
-    defaultModel: "${input.defaultModel}", // convention: swap for the ${toPascalCase(input.name)}Models enum member
+    defaultModel: ${tsString(input.defaultModel)}, // convention: swap for the ${toPascalCase(input.name)}Models enum member
     toolSupport: "native",
     localRuntime: false,
     healthCheck: "env-only",
@@ -191,15 +199,15 @@ function catalogEntrySnippet(input: ScaffoldInput): string {
   const pascal = toPascalCase(input.name);
   const modelConstant = toModelConstant(input.defaultModel);
   const aliasesLiteral = [input.name, ...input.aliases]
-    .map((a) => `"${a}"`)
+    .map(tsString)
     .join(", ");
   const baseURLLine = input.baseURL
-    ? `    defaultBaseURL: "${input.baseURL}",`
+    ? `    defaultBaseURL: ${tsString(input.baseURL)},`
     : `    // defaultBaseURL: "https://api.<vendor>.com/v1", // or computedBaseURL — see the type`;
   return `  {
     providerName: AIProviderName.${constant},
     aliases: [${aliasesLiteral}],
-    apiKeyEnvVar: "${input.envVar}",
+    apiKeyEnvVar: ${tsString(input.envVar)},
     baseURLEnvVar: "${constant}_BASE_URL",
 ${baseURLLine}
     configOptions: create${pascal}Config(),
@@ -254,7 +262,7 @@ export class ${className} extends BaseProvider {
     _region?: string,
     credentials?: NeurolinkCredentials["${camelKey}"],
   ) {
-    super(modelName ?? "${input.defaultModel}", AIProviderName.${constant}, sdk);
+    super(modelName ?? ${tsString(input.defaultModel)}, AIProviderName.${constant}, sdk);
     // TODO: resolve apiKey/baseURL from credentials -> env -> default,
     // build the wire client, implement executeStream()/doGenerate().
   }
@@ -276,10 +284,10 @@ function mockedTestSectionSnippet(input: ScaffoldInput): string {
 // cerebras row:
 {
   provider: "${input.name}",
-  envVar: "${input.envVar}",
+  envVar: ${tsString(input.envVar)},
   urlMatch: "<host>/v1/chat/completions", // TODO: real host
   authPrefix: "Bearer ",
-  model: "${input.defaultModel}",
+  model: ${tsString(input.defaultModel)},
   authErrorMatch: /${input.name}|401|unauthor|api key/i,
   rateLimitErrorMatch: /${input.name}|rate.?limit|429/i,
 },
@@ -369,7 +377,7 @@ generated under this directory for Tier 1.
   // (cerebras pilot, finding #2).
   const registrationLine =
     input.tier === 2
-      ? '- [ ] Splice catalog-entry.ts.snippet into OPENAI_COMPAT_CATALOG (src/lib/providers/openaiCompatCatalog.ts) and bump its "N zero-quirk providers" header comment. Do NOT add a providerRegistry.ts block — the catalog loop registers every row.'
+      ? `- [ ] Splice catalog-entry.ts.snippet into OPENAI_COMPAT_CATALOG (src/lib/providers/openaiCompatCatalog.ts), add the create${toPascalCase(input.name)}Config and ${toPascalCase(input.name)}Models imports it references at the top of that file, and bump its "N zero-quirk providers" header comment. Do NOT add a providerRegistry.ts block — the catalog loop registers every row.`
       : "- [ ] Move provider-class.ts.snippet to src/lib/providers/<name>.ts, fill in the TODOs, and add one ProviderFactory.registerProvider() block in src/lib/factories/providerRegistry.ts (dynamic import — Critical Rule 1)";
   return `# Manual checklist for "${input.name}" (Tier ${input.tier})
 


### PR DESCRIPTION
Four findings CodeRabbit raised on #1582's amended head (after the force-push re-review; #1582 was merged before they were adjudicated — this PR closes them out, each verified against the merged code):

1. **Count correction** — the tier-2 guide's previous files-touched table had seven entries, not six.
2. **Shell-safe commands** — `--provider=<name>` copied literally is parsed as input redirection; replaced with the concrete cerebras invocation + substitute note.
3. **Template escaping** — every CLI-derived value in a generated TS string literal now goes through a `JSON.stringify` helper; verified with a hostile `--defaultModel` containing a quote, backslash and backtick (generates valid TS).
4. **Import instructions** — the Tier-2 catalog checklist step now tells authors to add the `create<Name>Config` / `<Name>Models` imports the spliced entry references.

Checks: lint, check:tools-tests green; scaffold dummy runs verified for tier 2 and the hostile-input case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tier 2 provider onboarding guide with the complete set of required touchpoints.
  * Added concrete Cerebras examples for live matrix verification commands.
  * Expanded the manual checklist to include required configuration and model imports.

* **Bug Fixes**
  * Improved generated provider scaffolding so CLI-provided values are safely preserved in TypeScript snippets.
  * Updated generated checklist content to align with the catalog-entry setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->