### PR TITLE
fix(mcp): share process signal cleanup across ExternalServerManager instances

### DIFF
--- a/docs/api/classes/ExternalServerManager.md
+++ b/docs/api/classes/ExternalServerManager.md
@@ -6,10 +6,28 @@
 
 # Class: ExternalServerManager
 
-Defined in: [mcp/externalServerManager.ts:219](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L219)
+Defined in: [mcp/externalServerManager.ts:249](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L249)
 
-ExternalServerManager
-Core class for managing external MCP servers
+MCP (Model Context Protocol) Plugin Ecosystem
+
+Extensible plugin architecture based on research blueprint for
+transforming NeuroLink into a Universal AI Development Platform.
+
+## Example
+
+```typescript
+import { mcpEcosystem, readFile, writeFile } from "@juspay/neurolink";
+
+// Initialize the ecosystem
+await mcpEcosystem.initialize();
+
+// List available plugins
+const plugins = await mcpEcosystem.list();
+
+// Use filesystem operations
+const content = await readFile("README.md");
+await writeFile("output.txt", "Hello from MCP!");
+```
 
 ## Extends
 
@@ -21,7 +39,7 @@ Core class for managing external MCP servers
 
 > **new ExternalServerManager**(`config?`, `options?`): `ExternalServerManager`
 
-Defined in: [mcp/externalServerManager.ts:227](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L227)
+Defined in: [mcp/externalServerManager.ts:257](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L257)
 
 #### Parameters
 
@@ -49,7 +67,7 @@ Defined in: [mcp/externalServerManager.ts:227](https://github.com/juspay/neuroli
 
 > **setOutputNormalizer**(`normalizer`): `void`
 
-Defined in: [mcp/externalServerManager.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L284)
+Defined in: [mcp/externalServerManager.ts:316](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L316)
 
 Attach a McpOutputNormalizer to the underlying ToolDiscoveryService.
 All tool outputs will be measured and (if oversized) replaced with compact
@@ -71,7 +89,7 @@ surrogates before being returned to callers.
 
 > **setHITLManager**(`hitlManager?`): `void`
 
-Defined in: [mcp/externalServerManager.ts:297](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L297)
+Defined in: [mcp/externalServerManager.ts:329](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L329)
 
 Set HITL manager for human-in-the-loop safety mechanisms
 
@@ -93,7 +111,7 @@ HITL manager instance (optional, can be undefined to disable)
 
 > **getHITLManager**(): `HITLManager` \| `undefined`
 
-Defined in: [mcp/externalServerManager.ts:313](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L313)
+Defined in: [mcp/externalServerManager.ts:345](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L345)
 
 Get current HITL manager
 
@@ -107,7 +125,7 @@ Get current HITL manager
 
 > **getServerName**(`serverId`): `string`
 
-Defined in: [mcp/externalServerManager.ts:321](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L321)
+Defined in: [mcp/externalServerManager.ts:353](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L353)
 
 Resolve the human-readable server name for an event payload.
 Falls back to serverId if the instance or config.name isn't available.
@@ -128,7 +146,7 @@ Falls back to serverId if the instance or config.name isn't available.
 
 > **loadMCPConfiguration**(`configPath?`, `options?`): `Promise`\<[`ServerLoadResult`](../type-aliases/ServerLoadResult.md)\>
 
-Defined in: [mcp/externalServerManager.ts:333](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L333)
+Defined in: [mcp/externalServerManager.ts:365](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L365)
 
 Load MCP server configurations from .mcp-config.json file with parallel loading support
 Automatically registers servers found in the configuration
@@ -161,7 +179,7 @@ Promise resolving to { serversLoaded, errors }
 
 > **loadMCPConfigurationParallel**(`configPath?`): `Promise`\<[`ServerLoadResult`](../type-aliases/ServerLoadResult.md)\>
 
-Defined in: [mcp/externalServerManager.ts:348](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L348)
+Defined in: [mcp/externalServerManager.ts:380](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L380)
 
 Load MCP servers in parallel for improved performance
 
@@ -185,7 +203,7 @@ Promise resolving to batch operation result
 
 > **loadMCPConfigurationSequential**(`configPath?`): `Promise`\<[`ServerLoadResult`](../type-aliases/ServerLoadResult.md)\>
 
-Defined in: [mcp/externalServerManager.ts:530](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L530)
+Defined in: [mcp/externalServerManager.ts:562](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L562)
 
 Load MCP servers sequentially (original implementation for backward compatibility)
 
@@ -209,7 +227,7 @@ Promise resolving to batch operation result
 
 > **validateConfig**(`config`): [`ExternalMCPConfigValidation`](../type-aliases/ExternalMCPConfigValidation.md)
 
-Defined in: [mcp/externalServerManager.ts:687](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L687)
+Defined in: [mcp/externalServerManager.ts:719](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L719)
 
 Validate external MCP server configuration
 
@@ -231,7 +249,7 @@ Validate external MCP server configuration
 
 > **addServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [mcp/externalServerManager.ts:787](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L787)
+Defined in: [mcp/externalServerManager.ts:819](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L819)
 
 Add a new external MCP server - Backward compatibility overload
 
@@ -253,7 +271,7 @@ Add a new external MCP server - Backward compatibility overload
 
 > **addServer**(`serverId`, `serverInfo`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [mcp/externalServerManager.ts:795](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L795)
+Defined in: [mcp/externalServerManager.ts:827](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L827)
 
 Add a new external MCP server - Updated to accept MCPServerInfo
 
@@ -277,7 +295,7 @@ Add a new external MCP server - Updated to accept MCPServerInfo
 
 > **removeServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [mcp/externalServerManager.ts:965](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L965)
+Defined in: [mcp/externalServerManager.ts:997](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L997)
 
 Remove an external MCP server
 
@@ -297,7 +315,7 @@ Remove an external MCP server
 
 > **getServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [mcp/externalServerManager.ts:1521](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1521)
+Defined in: [mcp/externalServerManager.ts:1553](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1553)
 
 Get server instance - converted to ExternalMCPServerInstance for compatibility
 
@@ -317,7 +335,7 @@ Get server instance - converted to ExternalMCPServerInstance for compatibility
 
 > **getAllServers**(): `Map`\<`string`, [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>
 
-Defined in: [mcp/externalServerManager.ts:1550](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1550)
+Defined in: [mcp/externalServerManager.ts:1582](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1582)
 
 Get all servers - converted to ExternalMCPServerInstance for compatibility
 
@@ -331,7 +349,7 @@ Get all servers - converted to ExternalMCPServerInstance for compatibility
 
 > **listServers**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [mcp/externalServerManager.ts:1578](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1578)
+Defined in: [mcp/externalServerManager.ts:1610](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1610)
 
 List servers as MCPServerInfo - ZERO conversion needed
 
@@ -345,7 +363,7 @@ List servers as MCPServerInfo - ZERO conversion needed
 
 > **getServerStatuses**(): [`ExternalMCPServerHealth`](../type-aliases/ExternalMCPServerHealth.md)[]
 
-Defined in: [mcp/externalServerManager.ts:1585](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1585)
+Defined in: [mcp/externalServerManager.ts:1617](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1617)
 
 Get server statuses
 
@@ -359,7 +377,7 @@ Get server statuses
 
 > **shutdown**(): `Promise`\<`void`\>
 
-Defined in: [mcp/externalServerManager.ts:1614](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1614)
+Defined in: [mcp/externalServerManager.ts:1646](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1646)
 
 Shutdown all servers and clean up resources
 This method should be called during application shutdown to prevent memory leaks
@@ -374,7 +392,7 @@ This method should be called during application shutdown to prevent memory leaks
 
 > **destroy**(): `Promise`\<`void`\>
 
-Defined in: [mcp/externalServerManager.ts:1650](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1650)
+Defined in: [mcp/externalServerManager.ts:1683](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1683)
 
 Destroy the manager and all associated resources
 Alias for shutdown() to match the pattern used by other components
@@ -389,7 +407,7 @@ Alias for shutdown() to match the pattern used by other components
 
 > **getStatistics**(): `object`
 
-Defined in: [mcp/externalServerManager.ts:1657](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1657)
+Defined in: [mcp/externalServerManager.ts:1690](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1690)
 
 Get manager statistics
 
@@ -427,7 +445,7 @@ Get manager statistics
 
 > **executeTool**(`serverId`, `toolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [mcp/externalServerManager.ts:1870](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1870)
+Defined in: [mcp/externalServerManager.ts:1903](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L1903)
 
 Execute a tool on a specific server
 
@@ -461,7 +479,7 @@ Execute a tool on a specific server
 
 > **getAllTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [mcp/externalServerManager.ts:2049](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2049)
+Defined in: [mcp/externalServerManager.ts:2082](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2082)
 
 Get all tools from all servers
 
@@ -475,7 +493,7 @@ Get all tools from all servers
 
 > **getServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [mcp/externalServerManager.ts:2056](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2056)
+Defined in: [mcp/externalServerManager.ts:2089](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2089)
 
 Get tools for a specific server
 
@@ -495,7 +513,7 @@ Get tools for a specific server
 
 > **getToolDiscovery**(): `ToolDiscoveryService`
 
-Defined in: [mcp/externalServerManager.ts:2063](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2063)
+Defined in: [mcp/externalServerManager.ts:2096](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/externalServerManager.ts#L2096)
 
 Get tool discovery service
 

--- a/src/lib/mcp/externalServerManager.ts
+++ b/src/lib/mcp/externalServerManager.ts
@@ -216,6 +216,36 @@ function isValidExternalMCPServerConfig(
  * ExternalServerManager
  * Core class for managing external MCP servers
  */
+/**
+ * Process-signal cleanup, shared across every manager instance.
+ *
+ * Each delegated worker constructs its own NeuroLink and therefore its own
+ * manager; registering SIGINT/SIGTERM/beforeExit per instance leaked listeners
+ * (never removed) and crossed Node's 10-listener default on multi-worker runs.
+ * One process-level trio walks the live set instead; `shutdown()` removes the
+ * instance from the set, so a disposed manager costs nothing.
+ */
+const liveManagers = new Set<ExternalServerManager>();
+let processCleanupInstalled = false;
+
+const shutdownLiveManagers = (): void => {
+  for (const manager of liveManagers) {
+    void manager.shutdown();
+  }
+};
+
+const registerManagerForProcessCleanup = (
+  manager: ExternalServerManager,
+): void => {
+  liveManagers.add(manager);
+  if (!processCleanupInstalled) {
+    processCleanupInstalled = true;
+    process.on("SIGINT", shutdownLiveManagers);
+    process.on("SIGTERM", shutdownLiveManagers);
+    process.on("beforeExit", shutdownLiveManagers);
+  }
+};
+
 export class ExternalServerManager extends EventEmitter {
   private servers: Map<string, RuntimeMCPServerInfo> = new Map();
   private config: Required<ExternalMCPManagerConfig>;
@@ -270,10 +300,12 @@ export class ExternalServerManager extends EventEmitter {
       });
     });
 
-    // Handle process cleanup
-    process.on("SIGINT", () => this.shutdown());
-    process.on("SIGTERM", () => this.shutdown());
-    process.on("beforeExit", () => this.shutdown());
+    // Handle process cleanup through the SHARED handler set: one trio of process
+    // listeners for every manager, however many instances a run constructs.
+    // Per-instance `process.on(...)` here crossed Node's 10-listener default as
+    // soon as an agent delegated to a handful of workers (each worker builds its
+    // own NeuroLink, which builds its own manager) and warned MaxListenersExceeded.
+    registerManagerForProcessCleanup(this);
   }
 
   /**
@@ -1617,6 +1649,7 @@ export class ExternalServerManager extends EventEmitter {
     }
 
     this.isShuttingDown = true;
+    liveManagers.delete(this);
     mcpLogger.info("[ExternalServerManager] Shutting down all servers...");
 
     const shutdownPromises = Array.from(this.servers.keys()).map((serverId) =>

--- a/test/continuous-test-suite-mcp-infra.ts
+++ b/test/continuous-test-suite-mcp-infra.ts
@@ -268,6 +268,49 @@ async function testCoreMCPExports(): Promise<void> {
   }
 }
 
+async function testExternalServerManagerSignalListeners(): Promise<void> {
+  logSection("ExternalServerManager Signal Listener Tests");
+
+  try {
+    // Regression: each manager used to register its own SIGINT/SIGTERM/beforeExit
+    // handlers and never remove them, so a run that constructed one manager per
+    // delegated worker crossed Node's 10-listener default and warned
+    // MaxListenersExceeded. The handlers are shared now: however many managers
+    // exist, the process carries at most ONE cleanup listener per signal.
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      beforeExit: process.listenerCount("beforeExit"),
+    };
+    const managers = Array.from(
+      { length: 14 },
+      () => new ExternalServerManager(),
+    );
+    recordTest(
+      "14 managers add at most one SIGINT listener",
+      process.listenerCount("SIGINT") <= before.sigint + 1,
+    );
+    recordTest(
+      "14 managers add at most one SIGTERM listener",
+      process.listenerCount("SIGTERM") <= before.sigterm + 1,
+    );
+    recordTest(
+      "14 managers add at most one beforeExit listener",
+      process.listenerCount("beforeExit") <= before.beforeExit + 1,
+    );
+    await Promise.all(managers.map((manager) => manager.shutdown()));
+    const late = new ExternalServerManager();
+    recordTest(
+      "a manager constructed after shutdowns still adds no extra listener",
+      process.listenerCount("SIGINT") <= before.sigint + 1,
+    );
+    await late.shutdown();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    recordTest("ExternalServerManager signal listeners", false, false, msg);
+  }
+}
+
 // ============================================================
 // Part 1b — Extended MCP modules
 // ============================================================
@@ -1295,6 +1338,7 @@ await runSuite(async () => {
   await testToolCache();
   await testRequestBatcher();
   await testCoreMCPExports();
+  await testExternalServerManagerSignalListeners();
 
   // Part 1b — Extended MCP modules
   await testCircuitBreakerBlocking();


### PR DESCRIPTION
Every ExternalServerManager registered its own SIGINT/SIGTERM/beforeExit handlers in its constructor and never removed them. Each delegated worker constructs its own NeuroLink instance (and therefore its own manager), so any run with a handful of workers crossed Node's 10-listener default and warned MaxListenersExceeded — observed on every multi-worker agent run.

The trio of process listeners is now shared: one module-level handler set walks the live managers, `shutdown()` removes the instance from the set, and however many managers a process constructs, it carries at most one cleanup listener per signal.

Regression test in `continuous-test-suite-mcp-infra.ts`: 14 managers add at most one listener per signal, and a manager constructed after shutdowns adds none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process shutdown handling to prevent duplicate signal listeners when multiple external server managers are active.
  * Ensured cleanup remains reliable as managers are created and closed repeatedly.

* **Tests**
  * Added coverage verifying shared signal handling and preventing listener accumulation.

* **Documentation**
  * Updated the external server manager API guide with clearer references and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->