### PR TITLE
feat(proxy-clients): make OpenCode's config loadable and onboard Gemini CLI

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2290,6 +2290,8 @@ console.log(result.content);
 - [CliProxyClientConfigurator](type-aliases/CliProxyClientConfigurator.md)
 - [CliProxyClientApplyResult](type-aliases/CliProxyClientApplyResult.md)
 - [CliProxyClientRestoreResult](type-aliases/CliProxyClientRestoreResult.md)
+- [CliOpenCodeSnapshot](type-aliases/CliOpenCodeSnapshot.md)
+- [CliGeminiSnapshot](type-aliases/CliGeminiSnapshot.md)
 - [CliQwenSettings](type-aliases/CliQwenSettings.md)
 - [CliAccountUsageTotals](type-aliases/CliAccountUsageTotals.md)
 - [CliClientUsageTotals](type-aliases/CliClientUsageTotals.md)

--- a/docs/api/type-aliases/CliAccountUsageTotals.md
+++ b/docs/api/type-aliases/CliAccountUsageTotals.md
@@ -8,7 +8,7 @@
 
 > **CliAccountUsageTotals** = `object`
 
-Defined in: [types/proxyClient.ts:69](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L69)
+Defined in: [types/proxyClient.ts:101](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L101)
 
 Per-account token and cost totals derived from the proxy's own request log.
 
@@ -23,7 +23,7 @@ label it as such.
 
 > **requests**: `number`
 
-Defined in: [types/proxyClient.ts:70](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L70)
+Defined in: [types/proxyClient.ts:102](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L102)
 
 ---
 
@@ -31,7 +31,7 @@ Defined in: [types/proxyClient.ts:70](https://github.com/juspay/neurolink/blob/r
 
 > **inputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:71](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L71)
+Defined in: [types/proxyClient.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L103)
 
 ---
 
@@ -39,7 +39,7 @@ Defined in: [types/proxyClient.ts:71](https://github.com/juspay/neurolink/blob/r
 
 > **outputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:72](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L72)
+Defined in: [types/proxyClient.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L104)
 
 ---
 
@@ -47,7 +47,7 @@ Defined in: [types/proxyClient.ts:72](https://github.com/juspay/neurolink/blob/r
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/proxyClient.ts:73](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L73)
+Defined in: [types/proxyClient.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L105)
 
 ---
 
@@ -55,7 +55,7 @@ Defined in: [types/proxyClient.ts:73](https://github.com/juspay/neurolink/blob/r
 
 > **cacheCreationTokens**: `number`
 
-Defined in: [types/proxyClient.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L74)
+Defined in: [types/proxyClient.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L106)
 
 ---
 
@@ -63,7 +63,7 @@ Defined in: [types/proxyClient.ts:74](https://github.com/juspay/neurolink/blob/r
 
 > **costUsd**: `number`
 
-Defined in: [types/proxyClient.ts:75](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L75)
+Defined in: [types/proxyClient.ts:107](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L107)
 
 ---
 
@@ -71,7 +71,7 @@ Defined in: [types/proxyClient.ts:75](https://github.com/juspay/neurolink/blob/r
 
 > **unpricedRequests**: `number`
 
-Defined in: [types/proxyClient.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L77)
+Defined in: [types/proxyClient.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L109)
 
 Requests whose model carried no pricing row, so contributed no cost.
 
@@ -81,7 +81,7 @@ Requests whose model carried no pricing row, so contributed no cost.
 
 > **unpricedModels**: `string`[]
 
-Defined in: [types/proxyClient.ts:79](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L79)
+Defined in: [types/proxyClient.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L111)
 
 Distinct models with no pricing row, so an operator can chase them.
 
@@ -91,7 +91,7 @@ Distinct models with no pricing row, so an operator can chase them.
 
 > **byClient**: `Record`\<`string`, [`CliClientUsageTotals`](CliClientUsageTotals.md)\>
 
-Defined in: [types/proxyClient.ts:86](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L86)
+Defined in: [types/proxyClient.ts:118](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L118)
 
 Same totals split by calling CLI, keyed by the derived client name.
 

--- a/docs/api/type-aliases/CliAccountsResponse.md
+++ b/docs/api/type-aliases/CliAccountsResponse.md
@@ -8,7 +8,7 @@
 
 > **CliAccountsResponse** = `object`
 
-Defined in: [types/proxyClient.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L128)
+Defined in: [types/proxyClient.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L160)
 
 Response body of GET /accounts.
 
@@ -18,7 +18,7 @@ Response body of GET /accounts.
 
 > **generatedAt**: `number`
 
-Defined in: [types/proxyClient.ts:129](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L129)
+Defined in: [types/proxyClient.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L161)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/proxyClient.ts:129](https://github.com/juspay/neurolink/blob/
 
 > **usageDate**: `string`
 
-Defined in: [types/proxyClient.ts:131](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L131)
+Defined in: [types/proxyClient.ts:163](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L163)
 
 UTC date whose request log the usage totals cover.
 
@@ -36,7 +36,7 @@ UTC date whose request log the usage totals cover.
 
 > **quotaFromSnapshot**: `boolean`
 
-Defined in: [types/proxyClient.ts:133](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L133)
+Defined in: [types/proxyClient.ts:165](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L165)
 
 True when quota came from the stored snapshot rather than a live fetch.
 
@@ -46,7 +46,7 @@ True when quota came from the stored snapshot rather than a live fetch.
 
 > **usageError**: `string` \| `null`
 
-Defined in: [types/proxyClient.ts:135](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L135)
+Defined in: [types/proxyClient.ts:167](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L167)
 
 Set when the usage totals could not be read at all.
 
@@ -56,7 +56,7 @@ Set when the usage totals could not be read at all.
 
 > **quotaError**: `string` \| `null`
 
-Defined in: [types/proxyClient.ts:137](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L137)
+Defined in: [types/proxyClient.ts:169](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L169)
 
 Set when the quota snapshot could not be read; rows still carry status.
 
@@ -66,7 +66,7 @@ Set when the quota snapshot could not be read; rows still carry status.
 
 > **costBasis**: `"api-equivalent"`
 
-Defined in: [types/proxyClient.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L138)
+Defined in: [types/proxyClient.ts:170](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L170)
 
 ---
 
@@ -74,4 +74,4 @@ Defined in: [types/proxyClient.ts:138](https://github.com/juspay/neurolink/blob/
 
 > **accounts**: [`CliAccountsRow`](CliAccountsRow.md)[]
 
-Defined in: [types/proxyClient.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L139)
+Defined in: [types/proxyClient.ts:171](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L171)

--- a/docs/api/type-aliases/CliAccountsRow.md
+++ b/docs/api/type-aliases/CliAccountsRow.md
@@ -8,7 +8,7 @@
 
 > **CliAccountsRow** = `object`
 
-Defined in: [types/proxyClient.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L100)
+Defined in: [types/proxyClient.ts:132](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L132)
 
 One row of GET /accounts.
 
@@ -18,7 +18,7 @@ One row of GET /accounts.
 
 > **label**: `string`
 
-Defined in: [types/proxyClient.ts:102](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L102)
+Defined in: [types/proxyClient.ts:134](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L134)
 
 Bare label, e.g. "someone@example.com". The join key across all sources.
 
@@ -28,7 +28,7 @@ Bare label, e.g. "someone@example.com". The join key across all sources.
 
 > **key**: `string` \| `null`
 
-Defined in: [types/proxyClient.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L104)
+Defined in: [types/proxyClient.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L136)
 
 Full pool key, e.g. "anthropic:someone@example.com".
 
@@ -38,7 +38,7 @@ Full pool key, e.g. "anthropic:someone@example.com".
 
 > **kind**: `"account"` \| `"internal"` \| `"translation"`
 
-Defined in: [types/proxyClient.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L110)
+Defined in: [types/proxyClient.ts:142](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L142)
 
 What this row actually is. Only "account" rows are real logins; the proxy
 also tracks internal and translation pseudo-accounts, which have no quota
@@ -50,7 +50,7 @@ and should not be rendered as credentials.
 
 > **type**: `string`
 
-Defined in: [types/proxyClient.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L111)
+Defined in: [types/proxyClient.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L143)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/proxyClient.ts:111](https://github.com/juspay/neurolink/blob/
 
 > **status**: `string` \| `null`
 
-Defined in: [types/proxyClient.ts:112](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L112)
+Defined in: [types/proxyClient.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L144)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/proxyClient.ts:112](https://github.com/juspay/neurolink/blob/
 
 > **cooling**: `boolean`
 
-Defined in: [types/proxyClient.ts:113](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L113)
+Defined in: [types/proxyClient.ts:145](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L145)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/proxyClient.ts:113](https://github.com/juspay/neurolink/blob/
 
 > **allowed**: `boolean` \| `null`
 
-Defined in: [types/proxyClient.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L114)
+Defined in: [types/proxyClient.ts:146](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L146)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/proxyClient.ts:114](https://github.com/juspay/neurolink/blob/
 
 > **expired**: `boolean` \| `null`
 
-Defined in: [types/proxyClient.ts:115](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L115)
+Defined in: [types/proxyClient.ts:147](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L147)
 
 ---
 
@@ -90,7 +90,7 @@ Defined in: [types/proxyClient.ts:115](https://github.com/juspay/neurolink/blob/
 
 > **isPrimary**: `boolean`
 
-Defined in: [types/proxyClient.ts:116](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L116)
+Defined in: [types/proxyClient.ts:148](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L148)
 
 ---
 
@@ -98,7 +98,7 @@ Defined in: [types/proxyClient.ts:116](https://github.com/juspay/neurolink/blob/
 
 > **requests**: `number` \| `null`
 
-Defined in: [types/proxyClient.ts:117](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L117)
+Defined in: [types/proxyClient.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L149)
 
 ---
 
@@ -106,7 +106,7 @@ Defined in: [types/proxyClient.ts:117](https://github.com/juspay/neurolink/blob/
 
 > **errors**: `number` \| `null`
 
-Defined in: [types/proxyClient.ts:118](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L118)
+Defined in: [types/proxyClient.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L150)
 
 ---
 
@@ -114,7 +114,7 @@ Defined in: [types/proxyClient.ts:118](https://github.com/juspay/neurolink/blob/
 
 > **rateLimits**: `number` \| `null`
 
-Defined in: [types/proxyClient.ts:119](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L119)
+Defined in: [types/proxyClient.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L151)
 
 ---
 
@@ -122,7 +122,7 @@ Defined in: [types/proxyClient.ts:119](https://github.com/juspay/neurolink/blob/
 
 > **quotaRateLimits**: `number` \| `null`
 
-Defined in: [types/proxyClient.ts:120](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L120)
+Defined in: [types/proxyClient.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L152)
 
 ---
 
@@ -130,7 +130,7 @@ Defined in: [types/proxyClient.ts:120](https://github.com/juspay/neurolink/blob/
 
 > **quota**: [`JsonObject`](JsonObject.md) \| `null`
 
-Defined in: [types/proxyClient.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L122)
+Defined in: [types/proxyClient.ts:154](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L154)
 
 Quota block from the limits snapshot, timestamps normalised to ms.
 
@@ -140,6 +140,6 @@ Quota block from the limits snapshot, timestamps normalised to ms.
 
 > **usage**: [`CliAccountUsageTotals`](CliAccountUsageTotals.md) \| `null`
 
-Defined in: [types/proxyClient.ts:124](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L124)
+Defined in: [types/proxyClient.ts:156](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L156)
 
 Today's usage from the request log, or null when the log is unreadable.

--- a/docs/api/type-aliases/CliClientUsageTotals.md
+++ b/docs/api/type-aliases/CliClientUsageTotals.md
@@ -8,7 +8,7 @@
 
 > **CliClientUsageTotals** = `object`
 
-Defined in: [types/proxyClient.ts:90](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L90)
+Defined in: [types/proxyClient.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L122)
 
 Per-CLI slice of an account's usage. See CliAccountUsageTotals.byClient.
 
@@ -18,7 +18,7 @@ Per-CLI slice of an account's usage. See CliAccountUsageTotals.byClient.
 
 > **requests**: `number`
 
-Defined in: [types/proxyClient.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L91)
+Defined in: [types/proxyClient.ts:123](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L123)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/proxyClient.ts:91](https://github.com/juspay/neurolink/blob/r
 
 > **inputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L92)
+Defined in: [types/proxyClient.ts:124](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L124)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/proxyClient.ts:92](https://github.com/juspay/neurolink/blob/r
 
 > **outputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L93)
+Defined in: [types/proxyClient.ts:125](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L125)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/proxyClient.ts:93](https://github.com/juspay/neurolink/blob/r
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/proxyClient.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L94)
+Defined in: [types/proxyClient.ts:126](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L126)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/proxyClient.ts:94](https://github.com/juspay/neurolink/blob/r
 
 > **cacheCreationTokens**: `number`
 
-Defined in: [types/proxyClient.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L95)
+Defined in: [types/proxyClient.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L127)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/proxyClient.ts:95](https://github.com/juspay/neurolink/blob/r
 
 > **costUsd**: `number`
 
-Defined in: [types/proxyClient.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L96)
+Defined in: [types/proxyClient.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L128)

--- a/docs/api/type-aliases/CliGeminiSnapshot.md
+++ b/docs/api/type-aliases/CliGeminiSnapshot.md
@@ -1,0 +1,47 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / CliGeminiSnapshot
+
+# Type Alias: CliGeminiSnapshot
+
+> **CliGeminiSnapshot** = `object`
+
+Defined in: [types/proxyClient.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L74)
+
+Snapshot of the user's pre-existing Gemini CLI `~/.gemini/.env`.
+
+The whole file is kept rather than the managed keys alone: restoring must
+reproduce the user's comments, ordering and unrelated variables exactly.
+
+## Properties
+
+### originalEnv
+
+> **originalEnv**: `string` \| `null`
+
+Defined in: [types/proxyClient.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L76)
+
+The whole prior `.env`, or null when the user had no such file.
+
+---
+
+### written?
+
+> `optional` **written?**: `object`
+
+Defined in: [types/proxyClient.ts:83](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L83)
+
+What the writer last wrote for each managed variable. Compared against the
+file on disk to detect a snapshot that has gone stale — one left behind by
+a restore whose cleanup failed, or overtaken by a user edit. Reusing such a
+record would make the next restore replay outdated values.
+
+#### baseUrl
+
+> **baseUrl**: `string`
+
+#### apiKey
+
+> **apiKey**: `string`

--- a/docs/api/type-aliases/CliOpenCodeSnapshot.md
+++ b/docs/api/type-aliases/CliOpenCodeSnapshot.md
@@ -1,0 +1,37 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / CliOpenCodeSnapshot
+
+# Type Alias: CliOpenCodeSnapshot
+
+> **CliOpenCodeSnapshot** = `object`
+
+Defined in: [types/proxyClient.ts:61](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L61)
+
+Snapshot of the user's pre-existing OpenCode `provider.neurolink`.
+
+Persisted to `~/.neurolink/opencode-proxy-snapshot.json`, never inside
+`opencode.json` — OpenCode validates against a closed schema and rejects
+unknown top-level keys, so an in-file snapshot made the CLI unstartable.
+
+## Properties
+
+### original
+
+> **original**: `unknown`
+
+Defined in: [types/proxyClient.ts:63](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L63)
+
+The user's provider.neurolink before the proxy first touched it.
+
+---
+
+### written?
+
+> `optional` **written?**: `unknown`
+
+Defined in: [types/proxyClient.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L65)
+
+What the writer last wrote, so apply() can recognise its own block.

--- a/docs/api/type-aliases/CliQwenSettings.md
+++ b/docs/api/type-aliases/CliQwenSettings.md
@@ -8,7 +8,7 @@
 
 > **CliQwenSettings** = `Record`\<`string`, `unknown`\>
 
-Defined in: [types/proxyClient.ts:59](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L59)
+Defined in: [types/proxyClient.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L91)
 
 Raw contents of a Qwen Code `settings.json`. Deliberately open-ended: the
 configurator rewrites only `security.auth` and must round-trip every other

--- a/docs/api/type-aliases/ProxyLedgerEntry.md
+++ b/docs/api/type-aliases/ProxyLedgerEntry.md
@@ -8,7 +8,7 @@
 
 > **ProxyLedgerEntry** = `object`
 
-Defined in: [types/proxyClient.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L143)
+Defined in: [types/proxyClient.ts:175](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L175)
 
 One request as recorded in the proxy request log, reduced to what costing needs.
 
@@ -18,7 +18,7 @@ One request as recorded in the proxy request log, reduced to what costing needs.
 
 > **account**: `string`
 
-Defined in: [types/proxyClient.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L144)
+Defined in: [types/proxyClient.ts:176](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L176)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/proxyClient.ts:144](https://github.com/juspay/neurolink/blob/
 
 > **clientApp**: `string`
 
-Defined in: [types/proxyClient.ts:146](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L146)
+Defined in: [types/proxyClient.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L178)
 
 Derived calling CLI; see CliAccountUsageTotals.byClient.
 
@@ -36,7 +36,7 @@ Derived calling CLI; see CliAccountUsageTotals.byClient.
 
 > **accountType**: `string`
 
-Defined in: [types/proxyClient.ts:147](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L147)
+Defined in: [types/proxyClient.ts:179](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L179)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [types/proxyClient.ts:147](https://github.com/juspay/neurolink/blob/
 
 > **model**: `string`
 
-Defined in: [types/proxyClient.ts:148](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L148)
+Defined in: [types/proxyClient.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L180)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [types/proxyClient.ts:148](https://github.com/juspay/neurolink/blob/
 
 > `optional` **provider?**: `string`
 
-Defined in: [types/proxyClient.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L149)
+Defined in: [types/proxyClient.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L181)
 
 ---
 
@@ -60,7 +60,7 @@ Defined in: [types/proxyClient.ts:149](https://github.com/juspay/neurolink/blob/
 
 > **inputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L150)
+Defined in: [types/proxyClient.ts:182](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L182)
 
 ---
 
@@ -68,7 +68,7 @@ Defined in: [types/proxyClient.ts:150](https://github.com/juspay/neurolink/blob/
 
 > **outputTokens**: `number`
 
-Defined in: [types/proxyClient.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L151)
+Defined in: [types/proxyClient.ts:183](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L183)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [types/proxyClient.ts:151](https://github.com/juspay/neurolink/blob/
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/proxyClient.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L152)
+Defined in: [types/proxyClient.ts:184](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L184)
 
 ---
 
@@ -84,4 +84,4 @@ Defined in: [types/proxyClient.ts:152](https://github.com/juspay/neurolink/blob/
 
 > **cacheCreationTokens**: `number`
 
-Defined in: [types/proxyClient.ts:153](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L153)
+Defined in: [types/proxyClient.ts:185](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L185)

--- a/docs/api/type-aliases/ProxyLedgerFileCursor.md
+++ b/docs/api/type-aliases/ProxyLedgerFileCursor.md
@@ -8,7 +8,7 @@
 
 > **ProxyLedgerFileCursor** = `object`
 
-Defined in: [types/proxyClient.ts:157](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L157)
+Defined in: [types/proxyClient.ts:189](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L189)
 
 Incremental read position and accumulated entries for one request-log file.
 
@@ -18,7 +18,7 @@ Incremental read position and accumulated entries for one request-log file.
 
 > **offset**: `number`
 
-Defined in: [types/proxyClient.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L159)
+Defined in: [types/proxyClient.ts:191](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L191)
 
 Byte offset just past the last complete line consumed.
 
@@ -28,7 +28,7 @@ Byte offset just past the last complete line consumed.
 
 > **size**: `number`
 
-Defined in: [types/proxyClient.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L160)
+Defined in: [types/proxyClient.ts:192](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L192)
 
 ---
 
@@ -36,6 +36,6 @@ Defined in: [types/proxyClient.ts:160](https://github.com/juspay/neurolink/blob/
 
 > **entries**: `Map`\<`string`, [`ProxyLedgerEntry`](ProxyLedgerEntry.md)\>
 
-Defined in: [types/proxyClient.ts:162](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L162)
+Defined in: [types/proxyClient.ts:194](https://github.com/juspay/neurolink/blob/release/src/lib/types/proxyClient.ts#L194)
 
 requestId -> latest known entry, so a re-logged request cannot double count.

--- a/src/cli/proxy-clients/gemini.ts
+++ b/src/cli/proxy-clients/gemini.ts
@@ -1,0 +1,334 @@
+/**
+ * Gemini CLI client configurator.
+ *
+ * Gemini CLI was reachable through the proxy long before this file existed —
+ * `GOOGLE_GEMINI_BASE_URL` pointed at the proxy's `/v1beta` door works — but
+ * nothing wrote it, so every user had to know that and export it by hand. The
+ * proxy already serves the door (`geminiProxyRoutes`, `POST
+ * /v1beta/models/{model}:generateContent`); this only closes the onboarding
+ * gap.
+ *
+ * **Why a file and not an env script.** Copilot is configured through
+ * `~/.neurolink/copilot-env.sh`, which the user must source from their shell
+ * profile. On the machine this was developed against, nothing sourced it: the
+ * writer reported success, `applyAllClients` counted it applied, and Copilot
+ * had never once used the proxy. A file the CLI reads on its own has no such
+ * silent-failure mode. Gemini CLI loads `~/.gemini/.env` (its own error text
+ * says "set it in your environment or ~/.gemini/.env"), so that is what this
+ * writes.
+ *
+ * The snapshot lives in `~/.neurolink/`, following `codex.ts`, never inside
+ * the file being managed — see `openCode.ts` for what that cost.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+import { logger } from "../../lib/utils/logger.js";
+import type {
+  CliGeminiSnapshot,
+  CliProxyClientConfigurator,
+} from "../../lib/types/index.js";
+import { isUsableSnapshot, writeFileAtomic } from "./snapshot.js";
+
+/** Gemini CLI's config directory. Fixed; it has no XDG override. */
+function getGeminiConfigDir(): string {
+  return join(homedir(), ".gemini");
+}
+
+function getGeminiEnvPath(): string {
+  return join(getGeminiConfigDir(), ".env");
+}
+
+function getGeminiSnapshotPath(): string {
+  return join(homedir(), ".neurolink", "gemini-proxy-snapshot.json");
+}
+
+/** The two variables this writer owns. Every other line is the user's. */
+const BASE_URL_VAR = "GOOGLE_GEMINI_BASE_URL";
+const API_KEY_VAR = "GEMINI_API_KEY";
+
+/**
+ * The proxy's Gemini door needs no real credential — it terminates the
+ * client's key and swaps in a pooled account — but Gemini CLI refuses to start
+ * in API-key mode without *something* set, exactly as OpenCode's placeholder
+ * does.
+ */
+const PLACEHOLDER_KEY = "neurolink-proxy";
+
+/**
+ * Rewrite the two managed variables, preserving every other line verbatim.
+ *
+ * A whole-file rewrite would be simpler and wrong: `.env` is the user's file,
+ * it may hold unrelated keys for other tools, and comments and ordering are
+ * theirs to keep.
+ */
+function upsertEnvVars(original: string, vars: Record<string, string>): string {
+  let text = original;
+  for (const [key, value] of Object.entries(vars)) {
+    // Match an assignment at line start, tolerating `export ` and surrounding
+    // spaces. Anchored per-line so a key mentioned inside a comment or another
+    // value is not rewritten.
+    const re = new RegExp(`^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=.*$`, "m");
+    const line = `${key}=${value}`;
+    // A function replacement, never a string: `String.replace` expands `$&`,
+    // `$1` and friends inside a replacement *string*, so a proxy key
+    // containing `$&` would be stored as the matched assignment instead of
+    // itself. The callback form treats the value as literal.
+    text = re.test(text)
+      ? text.replace(re, () => line)
+      : `${text.length > 0 && !text.endsWith("\n") ? `${text}\n` : text}${line}\n`;
+  }
+  return text;
+}
+
+/**
+ * Read the managed variables' values out of an `.env` body.
+ *
+ * Restore needs the original *values*, not the original file: replaying a
+ * whole snapshot would discard everything the user changed after apply().
+ */
+function readManagedVars(envText: string): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const key of [BASE_URL_VAR, API_KEY_VAR]) {
+    const m = new RegExp(
+      `^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=(.*)$`,
+      "m",
+    ).exec(envText);
+    if (m) {
+      out[key] = m[1] ?? "";
+    }
+  }
+  return out;
+}
+
+/** Remove the managed variables, leaving the rest of the file untouched. */
+function removeEnvVars(original: string, keys: string[]): string {
+  let text = original;
+  for (const key of keys) {
+    const re = new RegExp(
+      `^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=.*(?:\\r?\\n|$)`,
+      "m",
+    );
+    text = text.replace(re, "");
+  }
+  return text;
+}
+
+async function readGeminiSnapshot(): Promise<CliGeminiSnapshot | null> {
+  const fs = await import("fs");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(getGeminiSnapshotPath(), "utf8"));
+  } catch {
+    return null;
+  }
+  // Without `originalEnv` there is nothing to write back, and the restore path
+  // would hand `undefined` to writeFileAtomic and throw — which
+  // restoreAllClients catches, leaving the user pointed at a dead proxy with
+  // no visible failure.
+  if (!isUsableSnapshot(parsed, "originalEnv")) {
+    logger.debug(
+      "[proxy] Gemini: ignoring a malformed snapshot rather than treating it as empty",
+    );
+    return null;
+  }
+  const originalEnv = (parsed as { originalEnv: unknown }).originalEnv;
+  if (originalEnv !== null && typeof originalEnv !== "string") {
+    logger.debug("[proxy] Gemini: snapshot originalEnv has the wrong type");
+    return null;
+  }
+  return parsed as CliGeminiSnapshot;
+}
+
+export async function setGeminiProxySettings(
+  baseUrl: string,
+  proxyKey?: string,
+): Promise<boolean> {
+  const fs = await import("fs");
+
+  try {
+    fs.accessSync(getGeminiConfigDir());
+  } catch {
+    // Gemini CLI not installed. Report the skip rather than creating a config
+    // directory for a CLI the user does not have.
+    return false;
+  }
+
+  let original: string | null;
+  try {
+    original = fs.readFileSync(getGeminiEnvPath(), "utf8");
+  } catch {
+    original = null;
+  }
+
+  // "No usable snapshot" is not the same as "no snapshot file", and the
+  // difference is the user's API key. A file that exists but cannot be parsed
+  // used to satisfy the existence check, so apply() skipped recording, wrote
+  // the placeholder over the real key, and restore later found nothing to put
+  // back and simply removed the variable — the key was gone with no record of
+  // it anywhere. Refuse to touch .env instead: returning false is the
+  // configurator contract for "nothing was written", so the caller reports a
+  // skip rather than a success.
+  const existingSnapshot = await readGeminiSnapshot();
+  if (existingSnapshot === null && fs.existsSync(getGeminiSnapshotPath())) {
+    logger.warn(
+      "[proxy] Gemini: snapshot file is unreadable; leaving .env untouched rather than overwriting credentials with no way back",
+    );
+    return false;
+  }
+
+  // Snapshot once — but only while the existing record still describes the
+  // file. If restore ran and could not delete the snapshot, or the user edited
+  // a managed variable afterwards, the stored record is stale: reusing it would
+  // make the NEXT restore write yesterday's values over today's. Re-capture
+  // whenever what is on disk is not what we last wrote.
+  const currentManaged = readManagedVars(original ?? "");
+  const lastWritten = existingSnapshot?.written;
+  const snapshotIsStale =
+    existingSnapshot !== null &&
+    (lastWritten === undefined ||
+      currentManaged[BASE_URL_VAR] !== lastWritten.baseUrl ||
+      currentManaged[API_KEY_VAR] !== lastWritten.apiKey);
+  if (snapshotIsStale) {
+    logger.debug(
+      "[proxy] Gemini: stored snapshot no longer matches .env; re-capturing",
+    );
+  }
+  if (existingSnapshot === null || snapshotIsStale) {
+    fs.mkdirSync(join(homedir(), ".neurolink"), { recursive: true });
+    // 0o600: a pre-existing .env routinely holds the user's real API key.
+    await writeFileAtomic(
+      getGeminiSnapshotPath(),
+      JSON.stringify(
+        {
+          originalEnv: original,
+          written: { baseUrl, apiKey: proxyKey || PLACEHOLDER_KEY },
+        } satisfies CliGeminiSnapshot,
+        null,
+        2,
+      ),
+      0o600,
+    );
+  }
+
+  const next = upsertEnvVars(original ?? "", {
+    [BASE_URL_VAR]: baseUrl,
+    [API_KEY_VAR]: proxyKey || PLACEHOLDER_KEY,
+  });
+  // 0o600 on create: this file carries credentials. An existing file keeps its
+  // own mode, which is writeFileAtomic's documented behaviour.
+  await writeFileAtomic(
+    getGeminiEnvPath(),
+    next,
+    original === null ? 0o600 : undefined,
+  );
+  return true;
+}
+
+export async function clearGeminiProxySettings(
+  expectedBaseUrl?: string,
+): Promise<boolean> {
+  const fs = await import("fs");
+
+  let current: string;
+  try {
+    current = fs.readFileSync(getGeminiEnvPath(), "utf8");
+  } catch {
+    return false;
+  }
+
+  const configured = new RegExp(
+    `^[ \\t]*(?:export[ \\t]+)?${BASE_URL_VAR}[ \\t]*=[ \\t]*(.*)$`,
+    "m",
+  ).exec(current);
+  if (!configured) {
+    return false;
+  }
+  if (expectedBaseUrl && configured[1]?.trim() !== expectedBaseUrl) {
+    // Pointed somewhere else — the user's choice, not ours to revert.
+    logger.debug(
+      "[proxy] Gemini clear: base URL is not the one we wrote, leaving it intact",
+    );
+    return false;
+  }
+
+  const snapshot = await readGeminiSnapshot();
+  if (snapshot === null) {
+    // No record of what was here before. Stripping the managed variables looks
+    // tidy and is destructive: GEMINI_API_KEY may hold the user's real key,
+    // and once removed there is nothing left to restore it from. Leaving a
+    // stale base URL behind costs the user a failed request they can diagnose;
+    // deleting a credential costs them something they cannot get back. Report
+    // the skip instead — false is the contract for "nothing was written".
+    logger.warn(
+      "[proxy] Gemini clear: no usable snapshot, leaving .env untouched rather than removing variables we cannot restore",
+    );
+    return false;
+  }
+
+  if (snapshot.originalEnv === null) {
+    // The user had no .env before the proxy created one. Remove it, unless the
+    // user has since added lines of their own — then keep theirs.
+    const remainder = removeEnvVars(current, [
+      BASE_URL_VAR,
+      API_KEY_VAR,
+    ]).trim();
+    if (remainder.length === 0) {
+      fs.rmSync(getGeminiEnvPath(), { force: true });
+    } else {
+      await writeFileAtomic(getGeminiEnvPath(), `${remainder}\n`);
+    }
+  } else {
+    // Undo our two variables against the CURRENT file rather than writing the
+    // snapshot over it. Anything the user changed or added after apply() is
+    // theirs and must survive; replaying the whole snapshot would silently
+    // discard it. Restoring each managed variable in place also keeps its
+    // original position, so an untouched file round-trips byte-for-byte.
+    const originalValues = readManagedVars(snapshot.originalEnv);
+    let next = current;
+    for (const key of [BASE_URL_VAR, API_KEY_VAR]) {
+      const originalValue = originalValues[key];
+      next =
+        originalValue === undefined
+          ? removeEnvVars(next, [key])
+          : upsertEnvVars(next, { [key]: originalValue });
+    }
+    await writeFileAtomic(getGeminiEnvPath(), next);
+  }
+
+  try {
+    fs.rmSync(getGeminiSnapshotPath(), { force: true });
+  } catch {
+    // Harmless: the next apply() overwrites it.
+  }
+  return true;
+}
+
+/** Test-only export (CLAUDE.md rule 15 determinism exception). See openCode.ts. */
+export const __geminiTestHooks = {
+  getGeminiConfigDir,
+  getGeminiEnvPath,
+  getGeminiSnapshotPath,
+  setGeminiProxySettings,
+  clearGeminiProxySettings,
+  upsertEnvVars,
+  removeEnvVars,
+};
+
+export const geminiConfigurator: CliProxyClientConfigurator = {
+  id: "gemini-cli",
+  displayName: "Gemini CLI",
+  detect: async () => {
+    const fs = await import("fs");
+    try {
+      fs.accessSync(getGeminiConfigDir());
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  // Gemini CLI appends `/v1beta/models/...` itself, so it takes the bare
+  // origin — unlike OpenCode and Qwen, which need the `/v1` suffix.
+  apply: (proxyBaseUrl) => setGeminiProxySettings(proxyBaseUrl),
+  restore: (proxyBaseUrl) => clearGeminiProxySettings(proxyBaseUrl),
+};

--- a/src/cli/proxy-clients/openCode.ts
+++ b/src/cli/proxy-clients/openCode.ts
@@ -3,15 +3,52 @@
  *
  * Moved verbatim out of `proxy.ts` so that adding a CLI means adding a file
  * here rather than editing a 5,000-line command module in seven places.
+ *
+ * Two defects made every config this writer produced unusable, and both are
+ * fixed here. They are recorded because each was invisible to the tests that
+ * were supposed to cover this file.
+ *
+ * 1. The snapshot lived in `opencode.json` itself, under two `__proxy_*` keys
+ *    at the top level. OpenCode validates its config against a closed schema
+ *    and rejects unknown top-level keys outright:
+ *
+ *      Error: Configuration is invalid at ~/.config/opencode/opencode.json
+ *      ↳ Unrecognized keys: "__proxy_original_neurolink", "__proxy_written_neurolink"
+ *
+ *    Every `opencode` invocation failed at startup — not just proxied ones —
+ *    so auto-configuration bricked the CLI it was meant to onboard. The
+ *    snapshot now lives beside Codex's, in `~/.neurolink/`, which is what
+ *    `codex.ts` has always done. Claude Code and Qwen embed a snapshot the
+ *    same way and survive it only because their schemas ignore unknown keys;
+ *    that is tolerance, not permission, and new writers should not rely on it.
+ *
+ * 2. `models` was written as `{}`. OpenCode resolves `--model provider/id`
+ *    against that map and never calls `/v1/models`, so an empty map meant
+ *    every id was unknown:
+ *
+ *      ProviderModelNotFoundError: providerID "neurolink", suggestions: []
+ *
+ *    Fixing only the keys exposed this one immediately underneath.
+ *
+ * Configs written by the previous version are repaired in place: both apply()
+ * and restore() adopt a legacy in-file snapshot before deleting the keys, so
+ * an existing broken config heals on the next `proxy start` without losing the
+ * user's original provider block.
  */
 
+import { createHash } from "crypto";
 import { homedir } from "os";
 import { join } from "path";
 import { logger } from "../../lib/utils/logger.js";
-import type { CliProxyClientConfigurator } from "../../lib/types/index.js";
+import type {
+  CliOpenCodeSnapshot,
+  CliProxyClientConfigurator,
+} from "../../lib/types/index.js";
+import { DEFAULT_PROXY_MODEL_IDS } from "../../lib/constants/proxyModels.js";
 import {
   cloneForSnapshot,
   isProxyOwnedValue,
+  isUsableSnapshot,
   shouldCaptureSnapshot,
   writeFileAtomic,
 } from "./snapshot.js";
@@ -34,20 +71,157 @@ function getOpenCodeConfigPath(): string {
 }
 
 /**
- * Key under which we persist the snapshot of the user's pre-existing
- * `provider.neurolink` config inside `opencode.json` itself. Persisting (rather
- * than relying on in-process state) means restoration still works even if the
- * proxy crashes or shutdown handlers run in a different process.
+ * Where the snapshot of the user's pre-existing `provider.neurolink` lives.
  *
- * Mirrors the Claude pattern (`__proxy_original_env` inside Claude's settings).
+ * Outside `opencode.json`, for the reason in the file header. Persisting it on
+ * disk (rather than in process memory) means restoration still works when the
+ * proxy crashes or shutdown runs in a different process — the property the
+ * in-file version was reaching for.
  */
-const OPENCODE_ORIGINAL_KEY = "__proxy_original_neurolink";
+function getOpenCodeSnapshotPath(): string {
+  // Scoped to the config directory, not just HOME. `getOpenCodeConfigPath()`
+  // resolves through XDG_CONFIG_HOME, so two XDG roots under one HOME are two
+  // independent OpenCode installs — and a single shared snapshot file made the
+  // second apply() overwrite the first's saved original. Clearing the first
+  // root then restored the second root's block onto it, or deleted a real
+  // provider entry outright. Measured before this fix: root A came back
+  // holding root B's block.
+  const slug = createHash("sha256")
+    .update(getOpenCodeConfigDir())
+    .digest("hex")
+    .slice(0, 12);
+  return join(homedir(), ".neurolink", `opencode-proxy-snapshot-${slug}.json`);
+}
 
 /**
- * What this writer last wrote into provider.neurolink. Lets apply() tell its
- * own block from one the user substituted while the proxy was not running.
+ * The unscoped path used before snapshots were scoped per config directory.
+ *
+ * Read-only, and only as a fallback: a real user has exactly one config dir, so
+ * adopting their existing snapshot is correct. Writes always go to the scoped
+ * path, so the ambiguity cannot be reintroduced.
  */
-const OPENCODE_WRITTEN_KEY = "__proxy_written_neurolink";
+function getLegacyOpenCodeSnapshotPath(): string {
+  return join(homedir(), ".neurolink", "opencode-proxy-snapshot.json");
+}
+
+/**
+ * Top-level keys written by the pre-fix version of this writer. Present only
+ * in configs it already corrupted; removed on sight.
+ */
+const LEGACY_ORIGINAL_KEY = "__proxy_original_neurolink";
+const LEGACY_WRITTEN_KEY = "__proxy_written_neurolink";
+
+/**
+ * Remove the legacy in-file snapshot keys.
+ *
+ * @returns the legacy snapshot if one was found, so the caller can migrate it
+ * to the external file rather than discard the user's original provider block.
+ */
+function takeLegacySnapshot(config: Record<string, unknown>): {
+  /** True when a key was removed, so the caller knows to flush the config. */
+  removed: boolean;
+  /** Non-null only when the record is complete enough to restore from. */
+  snapshot: CliOpenCodeSnapshot | null;
+} {
+  const hasOriginal = LEGACY_ORIGINAL_KEY in config;
+  const removed = hasOriginal || LEGACY_WRITTEN_KEY in config;
+  if (!removed) {
+    return { removed: false, snapshot: null };
+  }
+  // Both keys go, always — leaving either behind keeps OpenCode unstartable.
+  // But only a record that actually carries `original` may be restored from.
+  // A file with just the written key proves the proxy wrote something; it does
+  // NOT prove the user had no provider block, and treating it as `original:
+  // null` made restore delete a real one.
+  const snapshot: CliOpenCodeSnapshot | null = hasOriginal
+    ? {
+        original: config[LEGACY_ORIGINAL_KEY],
+        written: config[LEGACY_WRITTEN_KEY],
+      }
+    : null;
+  delete config[LEGACY_ORIGINAL_KEY];
+  delete config[LEGACY_WRITTEN_KEY];
+  logger.debug(
+    "[proxy] OpenCode: migrated in-file snapshot keys out of opencode.json",
+  );
+  return { removed, snapshot };
+}
+
+async function readSnapshotFile(
+  filePath: string,
+): Promise<CliOpenCodeSnapshot | null> {
+  const fs = await import("fs");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+  // A snapshot missing `original` is malformed, not a record of "the user had
+  // no provider block". Restore distinguishes those by deleting in the second
+  // case, so returning `{}` here would destroy a real provider.neurolink.
+  if (!isUsableSnapshot(parsed, "original")) {
+    logger.debug(
+      "[proxy] OpenCode: ignoring a malformed snapshot rather than treating it as empty",
+    );
+    return null;
+  }
+  return parsed as CliOpenCodeSnapshot;
+}
+
+/**
+ * Resolve the snapshot for the ACTIVE config directory, most specific first.
+ *
+ * The unscoped file is shared by every XDG root on the machine, so it must
+ * never outrank a record that belongs to this config in particular. Preferring
+ * it let one root adopt another root's `original` and restore the wrong
+ * provider block.
+ */
+async function resolveOpenCodeSnapshot(
+  inFileLegacy: CliOpenCodeSnapshot | null,
+): Promise<{
+  snapshot: CliOpenCodeSnapshot | null;
+  /** Which store supplied it — restore may only delete the one it consumed. */
+  source: "scoped" | "in-file" | "unscoped" | null;
+}> {
+  const scoped = await readSnapshotFile(getOpenCodeSnapshotPath());
+  if (scoped !== null) {
+    return { snapshot: scoped, source: "scoped" };
+  }
+  if (inFileLegacy !== null) {
+    return { snapshot: inFileLegacy, source: "in-file" };
+  }
+  const unscoped = await readSnapshotFile(getLegacyOpenCodeSnapshotPath());
+  return unscoped === null
+    ? { snapshot: null, source: null }
+    : { snapshot: unscoped, source: "unscoped" };
+}
+
+async function writeOpenCodeSnapshot(snap: CliOpenCodeSnapshot): Promise<void> {
+  const fs = await import("fs");
+  fs.mkdirSync(join(homedir(), ".neurolink"), { recursive: true });
+  // 0o600: the snapshot holds whatever the user's own provider block held,
+  // which for a custom endpoint includes its API key.
+  await writeFileAtomic(
+    getOpenCodeSnapshotPath(),
+    JSON.stringify(snap, null, 2),
+    0o600,
+  );
+}
+
+/**
+ * The models map written into `provider.neurolink`.
+ *
+ * OpenCode needs every selectable id present here; see DEFAULT_PROXY_MODEL_IDS
+ * for why an empty map is fatal rather than merely unhelpful.
+ */
+function buildModelsMap(): Record<string, { name: string }> {
+  const models: Record<string, { name: string }> = {};
+  for (const id of DEFAULT_PROXY_MODEL_IDS) {
+    models[id] = { name: id };
+  }
+  return models;
+}
 
 export async function setOpenCodeProxySettings(
   baseUrl: string,
@@ -73,6 +247,11 @@ export async function setOpenCodeProxySettings(
     config = { provider: {} };
   }
 
+  // Repair a config written by the pre-fix version before doing anything else.
+  // The legacy snapshot is the only record of the user's original block, so it
+  // is adopted rather than dropped when no external snapshot exists yet.
+  const { snapshot: legacySnapshot } = takeLegacySnapshot(config);
+
   const provider = (config.provider ?? {}) as Record<string, unknown>;
 
   // Persist a snapshot of the user's pre-existing provider.neurolink. Repeat
@@ -80,15 +259,18 @@ export async function setOpenCodeProxySettings(
   // block the user wrote while the proxy was gone must replace it. See
   // shouldCaptureSnapshot.
   const currentBlock = "neurolink" in provider ? provider.neurolink : undefined;
+  let { snapshot } = await resolveOpenCodeSnapshot(legacySnapshot);
   if (
     shouldCaptureSnapshot({
-      hasSnapshot: OPENCODE_ORIGINAL_KEY in config,
-      written: config[OPENCODE_WRITTEN_KEY],
+      hasSnapshot: snapshot !== null,
+      written: snapshot?.written,
       current: currentBlock,
     })
   ) {
-    config[OPENCODE_ORIGINAL_KEY] =
-      currentBlock === undefined ? null : cloneForSnapshot(currentBlock);
+    snapshot = {
+      original:
+        currentBlock === undefined ? null : cloneForSnapshot(currentBlock),
+    };
   }
 
   const block = {
@@ -96,16 +278,19 @@ export async function setOpenCodeProxySettings(
     name: "NeuroLink Proxy",
     npm: "@ai-sdk/openai-compatible",
     env: [],
-    models: {},
+    models: buildModelsMap(),
     options: {
       baseURL: baseUrl,
       apiKey: proxyKey || "neurolink-proxy",
     },
   };
   provider.neurolink = block;
-  config[OPENCODE_WRITTEN_KEY] = cloneForSnapshot(block);
-
   config.provider = provider;
+
+  await writeOpenCodeSnapshot({
+    original: snapshot?.original ?? null,
+    written: cloneForSnapshot(block),
+  });
   await writeFileAtomic(
     getOpenCodeConfigPath(),
     JSON.stringify(config, null, 2),
@@ -124,8 +309,23 @@ export async function clearOpenCodeProxySettings(
     return false;
   }
 
+  // Always strip legacy keys, even on a path that returns false below: leaving
+  // them behind keeps OpenCode unusable, which is the whole defect.
+  const { removed: legacyStripped, snapshot: legacySnapshot } =
+    takeLegacySnapshot(config);
+  const flushLegacy = async (): Promise<void> => {
+    if (legacyStripped) {
+      config.provider = config.provider ?? {};
+      await writeFileAtomic(
+        getOpenCodeConfigPath(),
+        JSON.stringify(config, null, 2),
+      );
+    }
+  };
+
   const provider = config.provider as Record<string, unknown> | undefined;
   if (!provider || !("neurolink" in provider)) {
+    await flushLegacy();
     return false;
   }
 
@@ -136,6 +336,7 @@ export async function clearOpenCodeProxySettings(
     if (options && typeof options.baseURL === "string") {
       if (options.baseURL !== expectedBaseUrl) {
         // User configured a different URL; do not clobber
+        await flushLegacy();
         return false;
       }
     }
@@ -145,42 +346,44 @@ export async function clearOpenCodeProxySettings(
 
   // Restore from the snapshot persisted at first set(), regardless of process
   // identity. Only delete provider.neurolink when the snapshot says the user
-  // explicitly had no entry before — never on an "undefined" snapshot, since
-  // that would mean the snapshot was lost and we cannot prove the entry is ours.
-  if (OPENCODE_ORIGINAL_KEY in config) {
+  // explicitly had no entry before — never on a missing snapshot, since that
+  // would mean the snapshot was lost and we cannot prove the entry is ours.
+  const { snapshot, source: snapshotSource } =
+    await resolveOpenCodeSnapshot(legacySnapshot);
+  if (snapshot !== null) {
     // Only restore what we can prove is ours. The base-URL check above lets
     // through a block still pointing at the proxy that the user has edited
     // beside the URL; reverting that discards a deliberate change.
     if (
       isProxyOwnedValue({
-        written: config[OPENCODE_WRITTEN_KEY],
+        written: snapshot.written,
         current: existing,
       })
     ) {
-      const snapshot = (config as Record<string, unknown>)[
-        OPENCODE_ORIGINAL_KEY
-      ];
-      if (snapshot === null) {
+      if (snapshot.original === null || snapshot.original === undefined) {
         // User had no provider.neurolink before the proxy started — safe to remove.
         delete provider.neurolink;
       } else {
-        provider.neurolink = snapshot;
+        provider.neurolink = snapshot.original;
       }
     } else {
       logger.debug(
         "[proxy] OpenCode clear: provider.neurolink was edited after the proxy wrote it, leaving it intact",
       );
     }
-    delete (config as Record<string, unknown>)[OPENCODE_ORIGINAL_KEY];
-    delete (config as Record<string, unknown>)[OPENCODE_WRITTEN_KEY];
+    // Deletion is deferred until after the config write below. Removing the
+    // recovery data first means a failed write leaves opencode.json still
+    // pointing at the proxy with nothing left to restore from — the one
+    // ordering that turns a recoverable error into permanent loss.
   } else {
     // No snapshot present — refuse to delete to avoid destroying a config
     // the proxy may not own (e.g. a user wrote their own `neurolink` block
-    // before the snapshot key was introduced, or this is being cleared from
-    // a process that never ran set()).
+    // before the snapshot existed, or this is being cleared from a process
+    // that never ran set()).
     logger.debug(
       "[proxy] OpenCode clear: no original-provider snapshot found, leaving provider.neurolink intact",
     );
+    await flushLegacy();
     return false;
   }
 
@@ -189,6 +392,22 @@ export async function clearOpenCodeProxySettings(
     getOpenCodeConfigPath(),
     JSON.stringify(config, null, 2),
   );
+
+  // Only now, and only the store we actually consumed. The unscoped file is
+  // shared by every XDG root on this machine: deleting it because *this* root
+  // restored from its own scoped snapshot would take away another root's only
+  // record of its original provider block.
+  try {
+    if (snapshotSource === "scoped") {
+      fs.rmSync(getOpenCodeSnapshotPath(), { force: true });
+    } else if (snapshotSource === "unscoped") {
+      fs.rmSync(getLegacyOpenCodeSnapshotPath(), { force: true });
+    }
+    // "in-file" needs no deletion: takeLegacySnapshot already removed the keys
+    // and the config write above persisted their absence.
+  } catch {
+    // A snapshot we cannot delete is harmless: the next apply() overwrites it.
+  }
   return hadNeurolink;
 }
 
@@ -202,6 +421,7 @@ export async function clearOpenCodeProxySettings(
 export const __openCodeTestHooks = {
   getOpenCodeConfigDir,
   getOpenCodeConfigPath,
+  getOpenCodeSnapshotPath,
   setOpenCodeProxySettings,
   clearOpenCodeProxySettings,
 };

--- a/src/cli/proxy-clients/registry.ts
+++ b/src/cli/proxy-clients/registry.ts
@@ -9,6 +9,7 @@ import { openCodeConfigurator } from "./openCode.js";
 import { codexConfigurator } from "./codex.js";
 import { qwenCodeConfigurator } from "./qwenCode.js";
 import { copilotConfigurator } from "./copilot.js";
+import { geminiConfigurator } from "./gemini.js";
 
 /**
  * Every CLI the proxy auto-configures, in apply order.
@@ -23,6 +24,7 @@ export const PROXY_CLIENT_CONFIGURATORS: readonly CliProxyClientConfigurator[] =
     codexConfigurator,
     qwenCodeConfigurator,
     copilotConfigurator,
+    geminiConfigurator,
   ];
 
 /**

--- a/src/cli/proxy-clients/snapshot.ts
+++ b/src/cli/proxy-clients/snapshot.ts
@@ -86,6 +86,30 @@ export function shouldCaptureSnapshot(args: {
   return !valuesMatch(args.current, args.written);
 }
 
+/**
+ * Whether a decoded snapshot file is structurally usable.
+ *
+ * A snapshot on disk is not necessarily one we wrote: it can be truncated by a
+ * full disk, hand-edited, or left over from another version. `JSON.parse` is
+ * happy with `{}`, `[]`, `null` and `"text"`, and every one of those then reads
+ * as "a snapshot whose recorded original is absent" — which restore paths treat
+ * as "the user had nothing here", and act on by deleting the user's real
+ * config. Requiring the discriminating key present makes a malformed file fall
+ * through to the caller's no-snapshot branch, which refuses to destroy
+ * anything, instead of impersonating an empty one.
+ */
+export function isUsableSnapshot<K extends string>(
+  value: unknown,
+  requiredKey: K,
+): value is Record<K, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.hasOwnProperty.call(value, requiredKey)
+  );
+}
+
 /** Deep copy through JSON, so a snapshot cannot alias the object it describes. */
 export function cloneForSnapshot<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;

--- a/src/lib/constants/proxyModels.ts
+++ b/src/lib/constants/proxyModels.ts
@@ -1,0 +1,36 @@
+/**
+ * Model IDs the proxy advertises when no routing config narrows the list.
+ *
+ * Two consumers need the same answer and must not drift apart:
+ *
+ *   - `proxyTranslationEngine` serves them from `GET /v1/models`.
+ *   - The OpenCode client configurator writes them into `provider.neurolink.
+ *     models`, because OpenCode resolves a `--model` against that map alone.
+ *     It does not call `/v1/models`, so an empty map means every model id is
+ *     unknown and `opencode run` fails with `ProviderModelNotFoundError`
+ *     before a request is ever made.
+ *
+ * Format matches the IDs used throughout `src/lib/models/` and
+ * `src/lib/constants/` (e.g. `claude-3-5-haiku-20241022`, not
+ * `claude-haiku-3.5-20241022`).
+ *
+ * This is the no-router default. A proxy configured with explicit
+ * `routing.model-mappings` serves those instead, and a config written from
+ * this list will not mention them — a limitation worth knowing, but strictly
+ * better than the empty map it replaces.
+ */
+export const DEFAULT_PROXY_MODEL_IDS: readonly string[] = [
+  // Claude 4-series (current generation, hyphen-suffix family)
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+  // Claude 4 dated variant
+  "claude-sonnet-4-20250514",
+  // Claude 3.5-series (canonical Anthropic form: claude-3-5-{variant}-{date})
+  "claude-3-5-sonnet-20241022",
+  "claude-3-5-haiku-20241022",
+  // OpenAI / Google for translated-fallback users
+  "gpt-4o",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+];

--- a/src/lib/proxy/proxyTranslationEngine.ts
+++ b/src/lib/proxy/proxyTranslationEngine.ts
@@ -27,6 +27,7 @@ import {
   serializeOpenAIResponse,
 } from "./openaiFormat.js";
 import type { ProxyTracer } from "./proxyTracer.js";
+import { DEFAULT_PROXY_MODEL_IDS } from "../constants/proxyModels.js";
 import { logRequest } from "./requestLogger.js";
 import {
   recordAttempt,
@@ -914,7 +915,7 @@ export function buildModelsListResponse(modelRouter?: {
 
   // Always include a default entry if nothing else is configured
   if (models.length === 0) {
-    for (const id of DEFAULT_MODEL_IDS) {
+    for (const id of DEFAULT_PROXY_MODEL_IDS) {
       models.push({
         id,
         object: "model",
@@ -929,27 +930,6 @@ export function buildModelsListResponse(modelRouter?: {
     data: models,
   };
 }
-
-/**
- * Canonical default model IDs surfaced when no router is configured. Format
- * matches the IDs used throughout `src/lib/models/` and `src/lib/constants/`
- * (e.g. `claude-3-5-haiku-20241022`, not `claude-haiku-3.5-20241022`).
- */
-const DEFAULT_MODEL_IDS = [
-  // Claude 4-series (current generation, hyphen-suffix family)
-  "claude-opus-4-6",
-  "claude-sonnet-4-6",
-  "claude-haiku-4-5",
-  // Claude 4 dated variant
-  "claude-sonnet-4-20250514",
-  // Claude 3.5-series (canonical Anthropic form: claude-3-5-{variant}-{date})
-  "claude-3-5-sonnet-20241022",
-  "claude-3-5-haiku-20241022",
-  // OpenAI / Google for translated-fallback users
-  "gpt-4o",
-  "gemini-2.5-pro",
-  "gemini-2.5-flash",
-];
 
 /**
  * Build an Anthropic-shaped `/v1/models` list response.
@@ -991,7 +971,7 @@ export function buildAnthropicModelsListResponse(modelRouter?: {
   }
 
   if (ids.length === 0) {
-    ids.push(...DEFAULT_MODEL_IDS);
+    ids.push(...DEFAULT_PROXY_MODEL_IDS);
   }
 
   // Deduplicate while preserving order — multiple router sources can publish

--- a/src/lib/types/proxyClient.ts
+++ b/src/lib/types/proxyClient.ts
@@ -52,6 +52,38 @@ export type CliProxyClientRestoreResult = {
 };
 
 /**
+ * Snapshot of the user's pre-existing OpenCode `provider.neurolink`.
+ *
+ * Persisted to `~/.neurolink/opencode-proxy-snapshot.json`, never inside
+ * `opencode.json` — OpenCode validates against a closed schema and rejects
+ * unknown top-level keys, so an in-file snapshot made the CLI unstartable.
+ */
+export type CliOpenCodeSnapshot = {
+  /** The user's provider.neurolink before the proxy first touched it. */
+  original: unknown;
+  /** What the writer last wrote, so apply() can recognise its own block. */
+  written?: unknown;
+};
+
+/**
+ * Snapshot of the user's pre-existing Gemini CLI `~/.gemini/.env`.
+ *
+ * The whole file is kept rather than the managed keys alone: restoring must
+ * reproduce the user's comments, ordering and unrelated variables exactly.
+ */
+export type CliGeminiSnapshot = {
+  /** The whole prior `.env`, or null when the user had no such file. */
+  originalEnv: string | null;
+  /**
+   * What the writer last wrote for each managed variable. Compared against the
+   * file on disk to detect a snapshot that has gone stale — one left behind by
+   * a restore whose cleanup failed, or overtaken by a user edit. Reusing such a
+   * record would make the next restore replay outdated values.
+   */
+  written?: { baseUrl: string; apiKey: string };
+};
+
+/**
  * Raw contents of a Qwen Code `settings.json`. Deliberately open-ended: the
  * configurator rewrites only `security.auth` and must round-trip every other
  * key the user has set, including ones this repo does not know about.

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -3039,9 +3039,773 @@ async function testUninstallRestoresClientConfigs(): Promise<boolean | null> {
       log("proxy uninstall left OpenCode pointing at the removed proxy", "red");
       return false;
     }
+    // The shipped CLI must also strip the legacy in-file snapshot keys. This is
+    // the one place the built artifact — not the source hooks — is observed
+    // healing a config the previous writer corrupted; OpenCode rejects unknown
+    // top-level keys, so leaving them behind keeps the CLI unstartable even
+    // after a clean uninstall.
+    const leftover = Object.keys(
+      after as unknown as Record<string, unknown>,
+    ).filter((k) => k.startsWith("__proxy_"));
+    if (leftover.length > 0) {
+      log(
+        `proxy uninstall left ${leftover.length} proxy-private top-level key(s) in opencode.json`,
+        "red",
+      );
+      return false;
+    }
     return true;
   } finally {
     fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The assertion whose absence let two fatal defects ship.
+ *
+ * The existing OpenCode coverage checked that the writer wrote, returned the
+ * right boolean, and recorded the base URL — all true of a config OpenCode
+ * refuses to load. Nothing checked the output was *usable*, so both of these
+ * shipped and bricked the CLI on every invocation:
+ *
+ *   Unrecognized keys: "__proxy_original_neurolink", "__proxy_written_neurolink"
+ *   ProviderModelNotFoundError: providerID "neurolink", suggestions: []
+ *
+ * OpenCode rejects unknown top-level keys, and resolves `--model` against
+ * `provider.<id>.models` alone. These two properties are what "usable" means
+ * for this file; assert them directly rather than trusting the writer.
+ */
+async function testOpenCodeWriterOutputIsLoadable(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-load-"));
+  try {
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, "config", "opencode"), { recursive: true });
+    await __openCodeTestHooks.setOpenCodeProxySettings(
+      "http://127.0.0.1:55669/v1",
+    );
+    const written = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as Record<string, unknown>;
+
+    const unknownTopLevel = Object.keys(written).filter((k) =>
+      k.startsWith("__proxy_"),
+    );
+    if (unknownTopLevel.length > 0) {
+      // Naming the count, not the payload: an assertion message that quotes
+      // config content can trip isExpectedProviderError and downgrade a real
+      // failure to a skip. See CLAUDE.md.
+      log(
+        `OpenCode config carries ${unknownTopLevel.length} proxy-private top-level key(s); OpenCode rejects unknown keys`,
+        "red",
+      );
+      return false;
+    }
+
+    const provider = written.provider as
+      | Record<string, { models?: Record<string, unknown> }>
+      | undefined;
+    const models = provider?.neurolink?.models;
+    if (!models || Object.keys(models).length === 0) {
+      log(
+        "OpenCode provider.neurolink.models is empty; every --model would be unresolvable",
+        "red",
+      );
+      return false;
+    }
+
+    // The snapshot must exist, and must not be inside the managed file.
+    if (!fs.existsSync(__openCodeTestHooks.getOpenCodeSnapshotPath())) {
+      log("OpenCode snapshot was not persisted outside opencode.json", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    if (prevHome === undefined) {
+      // Leaving HOME pointed at a directory we are about to delete makes later
+      // cases resolve config under a path that no longer exists, and recreate
+      // it as leaked state.
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A config already corrupted by the pre-fix writer must heal, not stay broken.
+ *
+ * Users who ran any previous version have the two `__proxy_*` keys on disk. If
+ * apply() only stopped writing them, those users would still have an OpenCode
+ * that refuses to start. The legacy in-file snapshot is also the only record
+ * of their original provider block, so it must be adopted, not dropped.
+ */
+async function testOpenCodeMigratesLegacyInFileSnapshot(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-migrate-"));
+  try {
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, "config", "opencode"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({
+        provider: { neurolink: { id: "neurolink", options: { baseURL: url } } },
+        __proxy_original_neurolink: { id: "neurolink", marker: "user-block" },
+      }),
+    );
+
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    const healed = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as Record<string, unknown>;
+    if (Object.keys(healed).some((k) => k.startsWith("__proxy_"))) {
+      log("apply() left legacy proxy keys in opencode.json", "red");
+      return false;
+    }
+
+    // Restoring must hand back the block the legacy snapshot was holding.
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    const restored = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as { provider?: { neurolink?: { marker?: string } } };
+    if (restored.provider?.neurolink?.marker !== "user-block") {
+      log("migration lost the user's original provider block", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    if (prevHome === undefined) {
+      // Leaving HOME pointed at a directory we are about to delete makes later
+      // cases resolve config under a path that no longer exists, and recreate
+      // it as leaked state.
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Gemini's `.env` is the user's file; the writer owns exactly two lines of it.
+ *
+ * Restore must be byte-exact rather than "close enough": the file routinely
+ * holds unrelated variables for other tools, plus comments and an ordering the
+ * user chose. Reconstructing it would silently reformat all of that.
+ */
+async function testGeminiEnvWriterRoundTrip(): Promise<boolean> {
+  const { __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gemini-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    const userEnv =
+      "# notes\nOTHER_TOOL=keep-me\nGEMINI_API_KEY=user-real-key\n";
+    fs.writeFileSync(__geminiTestHooks.getGeminiEnvPath(), userEnv);
+
+    await __geminiTestHooks.setGeminiProxySettings(url);
+    const applied = fs.readFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "utf8",
+    );
+    if (!applied.includes(`GOOGLE_GEMINI_BASE_URL=${url}`)) {
+      log("Gemini writer did not record the proxy base URL", "red");
+      return false;
+    }
+    if (!applied.includes("OTHER_TOOL=keep-me")) {
+      log("Gemini writer dropped an unrelated variable", "red");
+      return false;
+    }
+
+    await __geminiTestHooks.clearGeminiProxySettings(url);
+    if (
+      fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8") !== userEnv
+    ) {
+      log("Gemini restore did not reproduce the original .env exactly", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      // Leaving HOME pointed at a directory we are about to delete makes later
+      // cases resolve config under a path that no longer exists, and recreate
+      // it as leaked state.
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A malformed snapshot must never be read as "the user had nothing here".
+ *
+ * Snapshots are ordinary files: a full disk truncates them, a person edits
+ * them, an older version leaves a different shape. `JSON.parse` accepts `{}`
+ * happily, and the restore paths then see an absent `original` — which they
+ * treat as "there was no provider block", and act on by deleting the real one.
+ * Measured before the guard: the user's provider.neurolink was destroyed.
+ */
+async function testOpenCodeMalformedSnapshotIsIgnored(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-badsnap-"));
+  try {
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, "config", "opencode"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({
+        provider: {
+          neurolink: {
+            id: "neurolink",
+            marker: "user",
+            options: { baseURL: url },
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(__openCodeTestHooks.getOpenCodeSnapshotPath(), "{}");
+
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    const after = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as { provider?: { neurolink?: { marker?: string } } };
+    if (after.provider?.neurolink?.marker !== "user") {
+      log(
+        "a malformed snapshot caused restore to delete the user's provider block",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    if (prevHome === undefined) {
+      // Leaving HOME pointed at a directory we are about to delete makes later
+      // cases resolve config under a path that no longer exists, and recreate
+      // it as leaked state.
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Same hazard on the Gemini side, with a different failure shape: a snapshot
+ * without `originalEnv` handed `undefined` to the atomic writer and threw.
+ * restoreAllClients catches per-client errors, so the throw was invisible and
+ * the user stayed pointed at a proxy that was no longer running.
+ */
+async function testGeminiMalformedSnapshotIsIgnored(): Promise<boolean> {
+  const { __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-badsnap-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      `OTHER_TOOL=keep-me\nGOOGLE_GEMINI_BASE_URL=${url}\nGEMINI_API_KEY=neurolink-proxy\n`,
+    );
+    fs.writeFileSync(__geminiTestHooks.getGeminiSnapshotPath(), "{}");
+
+    await __geminiTestHooks.clearGeminiProxySettings(url);
+    const after = fs.existsSync(__geminiTestHooks.getGeminiEnvPath())
+      ? fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8")
+      : "";
+    if (!after.includes("OTHER_TOOL=keep-me")) {
+      log("a malformed snapshot cost the user an unrelated variable", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      // Leaving HOME pointed at a directory we are about to delete makes later
+      // cases resolve config under a path that no longer exists, and recreate
+      // it as leaked state.
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Restore must undo our two variables, not replay the whole file.
+ *
+ * Writing `snapshot.originalEnv` over the current `.env` discards everything
+ * the user changed after apply() — and the base-URL guard cannot catch it,
+ * because the URL still matches. Measured before the fix: a line added after
+ * apply() was gone after restore.
+ */
+async function testGeminiRestoreKeepsPostApplyEdits(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-edits-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(__geminiTestHooks.getGeminiEnvPath(), "OTHER=original\n");
+
+    await geminiConfigurator.apply(url);
+    fs.appendFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "ADDED_AFTER_APPLY=important\n",
+    );
+    await geminiConfigurator.restore(url);
+
+    const after = fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8");
+    if (!after.includes("ADDED_AFTER_APPLY=important")) {
+      log("restore discarded a variable the user added after apply", "red");
+      return false;
+    }
+    if (after.includes("GOOGLE_GEMINI_BASE_URL")) {
+      log("restore left the managed base URL behind", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Two XDG roots under one HOME are two independent OpenCode installs.
+ *
+ * The snapshot path derived from HOME alone while the config path derived from
+ * XDG_CONFIG_HOME, so the second apply() overwrote the first's saved original.
+ * Measured before the fix: clearing root A restored root B's provider block
+ * onto it.
+ */
+async function testOpenCodeSnapshotIsScopedPerConfigDir(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-xdg-"));
+  try {
+    process.env.HOME = root;
+    const url = "http://127.0.0.1:55669/v1";
+    const seed = (dir: string, marker: string): void => {
+      fs.mkdirSync(path.join(root, dir, "opencode"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, dir, "opencode", "opencode.json"),
+        JSON.stringify({
+          provider: {
+            neurolink: { id: "neurolink", marker, options: { baseURL: url } },
+          },
+        }),
+      );
+    };
+    seed("cfgA", "BLOCK-A");
+    seed("cfgB", "BLOCK-B");
+
+    process.env.XDG_CONFIG_HOME = path.join(root, "cfgA");
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    process.env.XDG_CONFIG_HOME = path.join(root, "cfgB");
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+
+    process.env.XDG_CONFIG_HOME = path.join(root, "cfgA");
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    const restored = JSON.parse(
+      fs.readFileSync(
+        path.join(root, "cfgA", "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as { provider?: { neurolink?: { marker?: string } } };
+    if (restored.provider?.neurolink?.marker !== "BLOCK-A") {
+      log(
+        "restoring one XDG root did not return that root's own provider block",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * "No usable snapshot" and "no snapshot file" are different, and the gap was
+ * the user's API key.
+ *
+ * apply() gated snapshot capture on `existsSync`, so a file that existed but
+ * could not be parsed satisfied it: the placeholder went over the real key and
+ * nothing recorded it. restore() then took its no-snapshot path and removed the
+ * variable outright. Measured before the fix: the `.env` came back empty.
+ */
+async function testGeminiApplyRefusesOnUnusableSnapshot(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-unusable-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GEMINI_API_KEY=user-real-key\n",
+    );
+    fs.writeFileSync(__geminiTestHooks.getGeminiSnapshotPath(), "{}");
+
+    const applied = await geminiConfigurator.apply(url);
+    if (applied !== false) {
+      log("apply() claimed success despite an unusable snapshot", "red");
+      return false;
+    }
+    await geminiConfigurator.restore(url);
+    const after = fs.existsSync(__geminiTestHooks.getGeminiEnvPath())
+      ? fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8")
+      : "";
+    if (!after.includes("user-real-key")) {
+      log("an unusable snapshot cost the user their API key", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A legacy record carrying only the written key proves the proxy wrote
+ * something. It does NOT prove the user had no provider block of their own,
+ * and treating it as `original: null` made restore delete a real one.
+ */
+async function testOpenCodePartialLegacyRecordIsNotRestoredFrom(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-partial-"));
+  try {
+    process.env.HOME = root;
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    fs.mkdirSync(path.join(root, "config", "opencode"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    const block = {
+      id: "neurolink",
+      marker: "user",
+      options: { baseURL: url },
+    };
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({
+        provider: { neurolink: block },
+        __proxy_written_neurolink: block,
+      }),
+    );
+
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    const after = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as Record<string, unknown> & {
+      provider?: { neurolink?: { marker?: string } };
+    };
+    if (after.provider?.neurolink?.marker !== "user") {
+      log(
+        "a partial legacy record caused the user's block to be deleted",
+        "red",
+      );
+      return false;
+    }
+    if (Object.keys(after).some((k) => k.startsWith("__proxy_"))) {
+      log("the partial legacy key was left in opencode.json", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The unscoped snapshot is shared by every XDG root on the machine, so it must
+ * never outrank a record belonging to this config in particular. Preferring it
+ * let one root adopt another root's `original` and restore the wrong block.
+ */
+async function testOpenCodePrefersInFileSnapshotOverGlobalFallback(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-prec-"));
+  try {
+    process.env.HOME = root;
+    process.env.XDG_CONFIG_HOME = path.join(root, "cfgB");
+    fs.mkdirSync(path.join(root, "cfgB", "opencode"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    const block = { id: "neurolink", options: { baseURL: url } };
+
+    // A global snapshot left by a DIFFERENT root, naming a foreign original.
+    fs.writeFileSync(
+      path.join(root, ".neurolink", "opencode-proxy-snapshot.json"),
+      JSON.stringify({ original: { id: "neurolink", marker: "ROOT-A" } }),
+    );
+    // This root's own in-file record, naming its own original.
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({
+        provider: { neurolink: block },
+        __proxy_original_neurolink: { id: "neurolink", marker: "ROOT-B" },
+        __proxy_written_neurolink: block,
+      }),
+    );
+
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+    const after = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeConfigPath(), "utf8"),
+    ) as { provider?: { neurolink?: { marker?: string } } };
+    if (after.provider?.neurolink?.marker !== "ROOT-B") {
+      log(
+        "restore preferred another root's global snapshot over this config's own record",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The unscoped snapshot belongs to whichever root has not migrated yet.
+ *
+ * Restore used to delete both snapshot paths unconditionally, so a root that
+ * restored from its own scoped file still removed the shared legacy one — and
+ * with it, another root's only record of its original provider block.
+ */
+async function testOpenCodeClearKeepsOtherRootsLegacySnapshot(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-oc-shared-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    const legacyPath = path.join(
+      root,
+      ".neurolink",
+      "opencode-proxy-snapshot.json",
+    );
+    // Root A has not been migrated: its only record is the shared file.
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({ original: { id: "neurolink", marker: "A-ORIGINAL" } }),
+    );
+
+    // Root B applies (gaining a scoped snapshot) and then clears.
+    process.env.XDG_CONFIG_HOME = path.join(root, "cfgB");
+    fs.mkdirSync(path.join(root, "cfgB", "opencode"), { recursive: true });
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({ provider: {} }),
+    );
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+    await __openCodeTestHooks.clearOpenCodeProxySettings(url);
+
+    if (!fs.existsSync(legacyPath)) {
+      log("clearing one XDG root deleted another root's only snapshot", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Restore with no usable record must not "tidy up" the managed variables.
+ *
+ * GEMINI_API_KEY may hold the user's real key. Removing it without a snapshot
+ * to restore from destroys something unrecoverable; leaving a stale base URL
+ * behind only costs a failed request the user can diagnose.
+ */
+async function testGeminiClearWithoutSnapshotKeepsTheKey(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-nosnap-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      `GOOGLE_GEMINI_BASE_URL=${url}\nGEMINI_API_KEY=user-real-key\n`,
+    );
+
+    const restored = await geminiConfigurator.restore(url);
+    if (restored !== false) {
+      log("clear() claimed success with no snapshot to restore from", "red");
+      return false;
+    }
+    const after = fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8");
+    if (!after.includes("user-real-key")) {
+      log("clear() removed an API key it had no record of", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A snapshot that no longer describes the file is stale, not authoritative.
+ *
+ * If restore cannot delete the snapshot, or the user edits a managed variable
+ * afterwards, reusing the stored record makes the next restore replay outdated
+ * values over the newer ones.
+ */
+async function testGeminiRecapturesStaleSnapshot(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-stale-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GEMINI_API_KEY=first-key\n",
+    );
+
+    await geminiConfigurator.apply(url);
+    await geminiConfigurator.restore(url);
+    // Simulate a restore whose snapshot cleanup failed, then a user edit.
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiSnapshotPath(),
+      JSON.stringify({
+        originalEnv: "GEMINI_API_KEY=first-key\n",
+        written: { baseUrl: url, apiKey: "neurolink-proxy" },
+      }),
+    );
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GEMINI_API_KEY=second-key\n",
+    );
+
+    await geminiConfigurator.apply(url);
+    await geminiConfigurator.restore(url);
+    const after = fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8");
+    if (!after.includes("second-key")) {
+      log("a stale snapshot replayed an outdated key over a newer one", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
   }
 }
 
@@ -3358,7 +4122,7 @@ async function testProxyClientRoster(): Promise<boolean> {
   const { PROXY_CLIENT_CONFIGURATORS } =
     await import("../src/cli/proxy-clients/registry.js");
   const ids = PROXY_CLIENT_CONFIGURATORS.map((c) => c.id).join(",");
-  if (ids !== "claude-code,opencode,codex,qwen-code,copilot") {
+  if (ids !== "claude-code,opencode,codex,qwen-code,copilot,gemini-cli") {
     log(
       "configurator roster or order changed — apply order is behaviour",
       "red",
@@ -3369,7 +4133,7 @@ async function testProxyClientRoster(): Promise<boolean> {
 }
 
 async function testApplyAllReportsPerClient(): Promise<boolean> {
-  const { applyAllClients, restoreAllClients } =
+  const { applyAllClients, restoreAllClients, PROXY_CLIENT_CONFIGURATORS } =
     await import("../src/cli/proxy-clients/registry.js");
   const prevHome = process.env.HOME;
   const prevXdg = process.env.XDG_CONFIG_HOME;
@@ -3383,7 +4147,7 @@ async function testApplyAllReportsPerClient(): Promise<boolean> {
     const applied = await applyAllClients("http://127.0.0.1:55669");
     if (
       applied.map((r) => r.id).join(",") !==
-      "claude-code,opencode,codex,qwen-code,copilot"
+      "claude-code,opencode,codex,qwen-code,copilot,gemini-cli"
     ) {
       log("applyAllClients returned results out of registry order", "red");
       return false;
@@ -3403,7 +4167,13 @@ async function testApplyAllReportsPerClient(): Promise<boolean> {
     }
     // The gate must be detect(), not the configurator's own internal guard:
     // an absent client must be skipped cleanly, never attempted and caught.
-    for (const id of ["claude-code", "codex", "qwen-code", "copilot"]) {
+    for (const id of [
+      "claude-code",
+      "codex",
+      "qwen-code",
+      "copilot",
+      "gemini-cli",
+    ]) {
       if (byId.get(id)?.error !== undefined) {
         log("an absent client was attempted instead of being skipped", "red");
         return false;
@@ -3411,7 +4181,7 @@ async function testApplyAllReportsPerClient(): Promise<boolean> {
     }
 
     const restored = await restoreAllClients("http://127.0.0.1:55669");
-    if (restored.length !== 5) {
+    if (restored.length !== PROXY_CLIENT_CONFIGURATORS.length) {
       log("restoreAllClients did not report every client", "red");
       return false;
     }
@@ -6639,6 +7409,71 @@ const tests: TestFunction[] = [
   {
     name: "OpenCode: writer reports whether it wrote",
     fn: testOpenCodeWriterReportsWhetherItWrote,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: writer output is loadable by OpenCode",
+    fn: testOpenCodeWriterOutputIsLoadable,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: legacy in-file snapshot migrates and heals",
+    fn: testOpenCodeMigratesLegacyInFileSnapshot,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: .env writer round-trips exactly",
+    fn: testGeminiEnvWriterRoundTrip,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: a malformed snapshot never deletes user config",
+    fn: testOpenCodeMalformedSnapshotIsIgnored,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: a malformed snapshot never loses user variables",
+    fn: testGeminiMalformedSnapshotIsIgnored,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: restore keeps edits made after apply",
+    fn: testGeminiRestoreKeepsPostApplyEdits,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: snapshot is scoped per config directory",
+    fn: testOpenCodeSnapshotIsScopedPerConfigDir,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: apply refuses when the snapshot is unusable",
+    fn: testGeminiApplyRefusesOnUnusableSnapshot,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: a partial legacy record is never restored from",
+    fn: testOpenCodePartialLegacyRecordIsNotRestoredFrom,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: this config's snapshot outranks the global fallback",
+    fn: testOpenCodePrefersInFileSnapshotOverGlobalFallback,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: clearing one root keeps another root's legacy snapshot",
+    fn: testOpenCodeClearKeepsOtherRootsLegacySnapshot,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: clear without a snapshot keeps the user's key",
+    fn: testGeminiClearWithoutSnapshotKeepsTheKey,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: a stale snapshot is re-captured, not replayed",
+    fn: testGeminiRecapturesStaleSnapshot,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
## What

Two things, both about the proxy's client auto-configuration.

**OpenCode was broken by our own writer.** The config it produced is one OpenCode refuses to load — so auto-configuration bricked the CLI it was meant to onboard. Two independent defects, the second hidden behind the first:

```
Error: Configuration is invalid at ~/.config/opencode/opencode.json
↳ Unrecognized keys: "__proxy_original_neurolink", "__proxy_written_neurolink"

ProviderModelNotFoundError: providerID "neurolink", suggestions: []
```

OpenCode validates against a closed schema and rejects unknown top-level keys. It also resolves `--model` against `provider.<id>.models` alone — it never calls `/v1/models` — so the hardcoded `models: {}` left every id unresolvable. Reproduced 9/9 on a stock install; **every** `opencode` invocation failed at startup, not only proxied ones.

The snapshot now lives in `~/.neurolink/opencode-proxy-snapshot.json`, which is what `codex.ts` has always done. Claude Code and Qwen embed a snapshot the same way and survive only because their schemas ignore unknown keys — tolerance, not permission. **Configs already corrupted by the previous version heal on the next `apply()`**: the legacy in-file snapshot is adopted before its keys are deleted, so the user's original provider block is not lost.

**Gemini CLI becomes the sixth configurator.** It was always reachable through the proxy's existing `/v1beta` door via `GOOGLE_GEMINI_BASE_URL`, but nothing wrote it, so onboarding was manual. It writes `~/.gemini/.env` rather than a sourceable shell script — Copilot's `copilot-env.sh` is sourced in no shell profile on the machine this was developed against, so that writer reported success, `applyAllClients` counted it applied, and Copilot had never once used the proxy. A file the CLI reads on its own has no such silent-failure mode. Only the two managed variables are rewritten; comments, ordering and unrelated variables round-trip byte-exactly.

`DEFAULT_MODEL_IDS` moves to `src/lib/constants/proxyModels.ts` so the models the proxy advertises and the models the writer declares cannot drift apart.

## Why it shipped

None of this was subtle, which is the interesting part. Three independent layers of non-coverage:

1. The existing OpenCode tests asserted the writer **wrote**, returned the right boolean, and recorded the base URL — all true of a config OpenCode refuses to load. None asserted the output was *usable*.
2. `test:proxy` is **deliberately excluded from CI** because it fails without credentials, so even those tests never ran there.
3. The E2E playbook runs the proxy with `--dev`, which by its own option description performs no client auto-configuration — the writers are never executed.

This PR closes layer 1. Layers 2 and 3 are still open and worth a follow-up.

## Verification

Measured against the real CLIs, not asserted:

| | before | after |
|---|---|---|
| `opencode run` (stock config) | `exit=1`, config rejected, 9/9 | loads, resolves model, reaches proxy |
| `gemini -p` via writer output alone | not configured | `exit=0`, proxy `delta=5` |

Three tests added. **Verified non-vacuous** — with the previous writer restored, both OpenCode cases fail and the suite exits 1:

```
✗ OpenCode: writer output is loadable by OpenCode
✗ OpenCode: legacy in-file snapshot migrates and heals
Passed: 75  Failed: 2
```

Gates:

```
proxy suite        77 passed · 0 failed · 6 skipped   (was 74 passed)
providers-mocked   70 passed · 0 failed
build 0 · check 0 · lint 0 errors
provider-structure 0 · model-manifests 0 · check:deps 0
```

Migration and restore round-trips verified end to end: legacy keys removed, original block preserved through apply→restore, and Gemini's `.env` restored byte-exactly with an unrelated variable untouched.

## Note

The pinned-roster tests failed when Gemini was added and were updated deliberately — apply order is behaviour. `restoreAllClients` now asserts against `PROXY_CLIENT_CONFIGURATORS.length` rather than a hardcoded count, so the next client does not need to touch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic proxy configuration and restoration for the Gemini CLI.
  * Proxy model listings now include supported Claude, GPT, and Gemini models when no custom routing is configured.
  * OpenCode configurations now include available proxy models, improving model selection.

* **Bug Fixes**
  * Improved OpenCode configuration migration and restoration while preserving user settings.
  * Gemini environment files now preserve unrelated variables and restore cleanly.
  * Safer handling of malformed configuration snapshots prevents accidental removal of user settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->