### PR TITLE
fix(proxy-clients): keep the true original when a migration is interrupted

### DIFF
--- a/src/cli/proxy-clients/openCode.ts
+++ b/src/cli/proxy-clients/openCode.ts
@@ -184,12 +184,25 @@ async function resolveOpenCodeSnapshot(
   /** Which store supplied it — restore may only delete the one it consumed. */
   source: "scoped" | "in-file" | "unscoped" | null;
 }> {
+  // An in-file legacy record outranks everything, because its presence means
+  // more than "here is a snapshot": the config still carries `__proxy_*` keys,
+  // so the previous migration did not complete. That record is the only one
+  // that predates the proxy, and on a migration run it is guaranteed to
+  // disagree with a scoped snapshot — the old writer's block has `models: {}`
+  // while the new writer's `written` carries the full map, so valuesMatch() is
+  // always false and shouldCaptureSnapshot() re-captures. Re-capturing there
+  // adopts the proxy's OWN block as the user's "original" and discards the
+  // real one, silently and permanently.
+  //
+  // Reachable whenever apply() wrote the scoped snapshot and then failed to
+  // write opencode.json: applyAllClients() catches per-client errors, so the
+  // retry runs against a config still holding the legacy keys.
+  if (inFileLegacy !== null) {
+    return { snapshot: inFileLegacy, source: "in-file" };
+  }
   const scoped = await readSnapshotFile(getOpenCodeSnapshotPath());
   if (scoped !== null) {
     return { snapshot: scoped, source: "scoped" };
-  }
-  if (inFileLegacy !== null) {
-    return { snapshot: inFileLegacy, source: "in-file" };
   }
   const unscoped = await readSnapshotFile(getLegacyOpenCodeSnapshotPath());
   return unscoped === null

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -3810,6 +3810,98 @@ async function testGeminiRecapturesStaleSnapshot(): Promise<boolean> {
 }
 
 /**
+ * A migration that was interrupted must not adopt the proxy's own block as the
+ * user's original.
+ *
+ * apply() writes the external snapshot before opencode.json. If the config
+ * write then fails — reachable, because applyAllClients() catches each
+ * client's error and carries on — the retry runs against a config that still
+ * holds the legacy `__proxy_*` keys. The scoped snapshot from the failed
+ * attempt used to win precedence there, and on a migration run it is
+ * *guaranteed* to disagree with what is on disk: the old writer's block has
+ * `models: {}` while the new writer's `written` carries the full map, so
+ * valuesMatch() is always false and shouldCaptureSnapshot() re-captures. The
+ * re-capture then records the OLD PROXY BLOCK as the user's original and drops
+ * the real one the in-file record was still holding. Silent and permanent.
+ *
+ * Not an unlucky mismatch — structural to the migration path, which is exactly
+ * the path where the in-file record is the only copy of the truth.
+ */
+async function testOpenCodeInterruptedMigrationKeepsTrueOriginal(): Promise<boolean> {
+  const { __openCodeTestHooks } =
+    await import("../src/cli/proxy-clients/openCode.js");
+  const prevHome = process.env.HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "neurolink-oc-interrupt-"),
+  );
+  try {
+    process.env.HOME = root;
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    fs.mkdirSync(path.join(root, "config", "opencode"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".neurolink"), { recursive: true });
+    const url = "http://127.0.0.1:55669/v1";
+    const userOriginal = {
+      id: "neurolink",
+      marker: "true-user-original",
+      options: { baseURL: "https://the-users-own-endpoint" },
+    };
+    // The old writer's output: models empty, plus the in-file legacy keys.
+    const oldProxyBlock = {
+      id: "neurolink",
+      name: "NeuroLink Proxy",
+      npm: "@ai-sdk/openai-compatible",
+      env: [],
+      models: {},
+      options: { baseURL: url, apiKey: "neurolink-proxy" },
+    };
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeConfigPath(),
+      JSON.stringify({
+        provider: { neurolink: oldProxyBlock },
+        __proxy_original_neurolink: userOriginal,
+        __proxy_written_neurolink: oldProxyBlock,
+      }),
+    );
+    // The state a failed config write leaves behind: scoped snapshot landed,
+    // its `written` carries the NEW block, so it cannot match what is on disk.
+    fs.writeFileSync(
+      __openCodeTestHooks.getOpenCodeSnapshotPath(),
+      JSON.stringify({
+        original: userOriginal,
+        written: { ...oldProxyBlock, models: { "claude-haiku-4-5": {} } },
+      }),
+    );
+
+    await __openCodeTestHooks.setOpenCodeProxySettings(url);
+
+    const snap = JSON.parse(
+      fs.readFileSync(__openCodeTestHooks.getOpenCodeSnapshotPath(), "utf8"),
+    ) as { original?: { marker?: string } };
+    if (snap.original?.marker !== "true-user-original") {
+      log(
+        "an interrupted migration replaced the user's original with the proxy's own block",
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = prevXdg;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
  * Regression: a stale snapshot must never outlive the value it describes.
  *
  * The snapshot-on-first-touch guard exists so a second apply() cannot record
@@ -7459,6 +7551,11 @@ const tests: TestFunction[] = [
   {
     name: "OpenCode: this config's snapshot outranks the global fallback",
     fn: testOpenCodePrefersInFileSnapshotOverGlobalFallback,
+    category: "proxy-config",
+  },
+  {
+    name: "OpenCode: an interrupted migration keeps the true original",
+    fn: testOpenCodeInterruptedMigrationKeepsTrueOriginal,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
## The bug

An interrupted OpenCode migration replaces the user's original provider block with the proxy's own — silently and permanently. Live in **12.4.0**.

`apply()` writes the external snapshot before `opencode.json`. If the config write then fails — reachable, because `applyAllClients()` catches each client's error and carries on — the retry runs against a config that still holds the legacy `__proxy_*` keys. The scoped snapshot from the failed attempt won precedence there.

**The mismatch is structural, not unlucky.** On a migration run the on-disk block is the *old* writer's, with `models: {}`, while the new writer's `written` carries the full nine-model map. So `valuesMatch()` is always false, `shouldCaptureSnapshot()` always re-captures, and the re-capture records the old proxy block as the user's "original" — discarding the real one the in-file record was still holding. That is exactly the path where the in-file record is the only surviving copy of the truth.

Reproduced against released code before changing anything:

```
config:   provider.neurolink = old proxy block, __proxy_original_neurolink = USER
scoped:   { original: USER, written: <block with non-empty models> }
apply()
→ snapshot.original becomes the OLD PROXY BLOCK
TRUE ORIGINAL LOST: true
```

## The fix

An in-file legacy record now outranks the scoped snapshot. Its presence means more than "a snapshot exists": the config still carries the legacy keys, so the previous migration did not complete, and that record is the only one predating the proxy.

Ordering the two stores was not enough. The condition being encoded is **"legacy keys present ⇒ migration incomplete"**, and the comment says so — otherwise the next reviewer sees a bare precedence list that contradicts the one requested during #1589's review and flips it back.

## Why not just swap the two writes

Deliberately not done. `takeLegacySnapshot()` has already stripped the in-file keys in memory, so a successful config write followed by a *failed snapshot write* would lose the original from both places. Snapshot-first is the safer order; the precedence rule is what makes the retry correct.

## Provenance

This is the mirror of a hazard already fixed in `clearOpenCodeProxySettings()` during #1589's review, where deletion was deferred until after the config write. `apply()` was never checked for the same shape. Found by an independent audit of the merged PR — **not** by the thirteen tests added with it, none of which cover a write failure during a first migration.

## Verification

```
proxy suite  88 passed · 0 failed · 6 skipped
build 0 · check 0 · lint 0 errors · docs drift 0
```

Regression test verified non-vacuous: reverting only the precedence change fails it and the suite exits 1.

```
✗ OpenCode: an interrupted migration keeps the true original
  an interrupted migration replaced the user's original with the proxy's own block
```

The three neighbouring precedence tests from #1589 still pass unchanged, so this narrows the rule without inverting the property that review asked for (the shared unscoped file must never outrank a record belonging to this config).