### PR TITLE
fix(proxy-clients): collapse duplicate managed keys in Gemini's .env

### DIFF
--- a/src/cli/proxy-clients/gemini.ts
+++ b/src/cli/proxy-clients/gemini.ts
@@ -68,21 +68,53 @@ function upsertEnvVars(original: string, vars: Record<string, string>): string {
     // Match an assignment at line start, tolerating `export ` and surrounding
     // spaces. Anchored per-line so a key mentioned inside a comment or another
     // value is not rewritten.
-    const re = new RegExp(`^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=.*$`, "m");
     const line = `${key}=${value}`;
+    const all = new RegExp(
+      `^[ \t]*(?:export[ \t]+)?${key}[ \t]*=.*(?:\r?\n|$)`,
+      "gm",
+    );
+    const occurrences = text.match(all)?.length ?? 0;
+    if (occurrences === 0) {
+      text = `${text.length > 0 && !text.endsWith("\n") ? `${text}\n` : text}${line}\n`;
+      continue;
+    }
+    // Rewrite the FIRST occurrence in place — position is the user's and a
+    // byte-exact restore depends on keeping it — then drop any later ones.
+    //
+    // Dropping them is not tidiness. Gemini CLI's dotenv takes the LAST
+    // assignment: with a duplicate left in place our value is silently
+    // overridden and Gemini talks to Google while the writer reports success.
+    // Measured: a .env with the proxy URL first and a dead port second sent the
+    // request to the dead port.
+    let seen = 0;
     // A function replacement, never a string: `String.replace` expands `$&`,
     // `$1` and friends inside a replacement *string*, so a proxy key
     // containing `$&` would be stored as the matched assignment instead of
-    // itself. The callback form treats the value as literal.
-    text = re.test(text)
-      ? text.replace(re, () => line)
-      : `${text.length > 0 && !text.endsWith("\n") ? `${text}\n` : text}${line}\n`;
+    // itself.
+    text = text.replace(all, (match) => {
+      seen += 1;
+      if (seen > 1) {
+        return "";
+      }
+      // Re-emit the terminator that was matched, not an assumed LF. The regex
+      // captures `\r?\n`, and `"…\r\n".endsWith("\n")` is true, so testing for
+      // LF alone silently rewrote a CRLF line ending to LF — breaking the
+      // byte-exact round-trip this function's own contract promises, on the
+      // ordinary single-occurrence path rather than only on duplicates.
+      // Gemini CLI is cross-platform; a Windows-authored .env is not exotic.
+      const terminator = match.endsWith("\r\n")
+        ? "\r\n"
+        : match.endsWith("\n")
+          ? "\n"
+          : "";
+      return `${line}${terminator}`;
+    });
   }
   return text;
 }
 
 /**
- * Read the managed variables' values out of an `.env` body.
+ * Read the managed variables' effective values out of an `.env` body.
  *
  * Restore needs the original *values*, not the original file: replaying a
  * whole snapshot would discard everything the user changed after apply().
@@ -90,12 +122,16 @@ function upsertEnvVars(original: string, vars: Record<string, string>): string {
 function readManagedVars(envText: string): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {};
   for (const key of [BASE_URL_VAR, API_KEY_VAR]) {
-    const m = new RegExp(
-      `^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=(.*)$`,
-      "m",
-    ).exec(envText);
-    if (m) {
-      out[key] = m[1] ?? "";
+    // The LAST assignment, because that is the one dotenv resolves to. Reading
+    // the first would restore a value the CLI never actually used.
+    const all = [
+      ...envText.matchAll(
+        new RegExp(`^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=(.*)$`, "gm"),
+      ),
+    ];
+    const last = all[all.length - 1];
+    if (last) {
+      out[key] = last[1] ?? "";
     }
   }
   return out;
@@ -105,9 +141,12 @@ function readManagedVars(envText: string): Record<string, string | undefined> {
 function removeEnvVars(original: string, keys: string[]): string {
   let text = original;
   for (const key of keys) {
+    // Global: a duplicated key must be cleared everywhere. Removing only the
+    // first leaves a later assignment behind, and dotenv takes the LAST one —
+    // so a "restored" .env would still be pointing at the proxy.
     const re = new RegExp(
       `^[ \\t]*(?:export[ \\t]+)?${key}[ \\t]*=.*(?:\\r?\\n|$)`,
-      "m",
+      "gm",
     );
     text = text.replace(re, "");
   }
@@ -237,14 +276,16 @@ export async function clearGeminiProxySettings(
     return false;
   }
 
-  const configured = new RegExp(
-    `^[ \\t]*(?:export[ \\t]+)?${BASE_URL_VAR}[ \\t]*=[ \\t]*(.*)$`,
-    "m",
-  ).exec(current);
-  if (!configured) {
+  // The EFFECTIVE assignment, not the first one on the page. dotenv resolves
+  // the last, so a user who appended their own base URL after apply() has
+  // already repointed Gemini — even though our line is still sitting above
+  // theirs. Checking the first saw our value, passed the ownership test, and
+  // restore then deleted the endpoint the CLI was actually using.
+  const configuredUrl = readManagedVars(current)[BASE_URL_VAR];
+  if (configuredUrl === undefined) {
     return false;
   }
-  if (expectedBaseUrl && configured[1]?.trim() !== expectedBaseUrl) {
+  if (expectedBaseUrl && configuredUrl.trim() !== expectedBaseUrl) {
     // Pointed somewhere else — the user's choice, not ours to revert.
     logger.debug(
       "[proxy] Gemini clear: base URL is not the one we wrote, leaving it intact",

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -4058,6 +4058,196 @@ async function testCopilotEnvScriptSetsAModelId(): Promise<boolean> {
 }
 
 /**
+ * A duplicated key silently wins over ours.
+ *
+ * Gemini CLI resolves `.env` with dotenv, which takes the LAST assignment —
+ * measured, not assumed: a file listing the proxy URL first and a dead port
+ * second sent the request to the dead port. The helpers matched with "m" and
+ * no "g", so a pre-existing duplicate left our value overridden while apply()
+ * reported success and Gemini went on talking to Google.
+ *
+ * Restore has the mirror of it: clearing only the first occurrence leaves a
+ * later assignment still pointing at a proxy that is no longer running.
+ */
+async function testGeminiCollapsesDuplicateManagedKeys(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-dup-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:59999\nOTHER_TOOL=keep-me\nGOOGLE_GEMINI_BASE_URL=http://127.0.0.1:58888\n",
+    );
+
+    await geminiConfigurator.apply(url);
+    const applied = fs.readFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "utf8",
+    );
+    const matches = applied.match(/^GOOGLE_GEMINI_BASE_URL=.*$/gm) ?? [];
+    if (matches.length !== 1) {
+      log(
+        `apply left ${matches.length} base-URL assignments; dotenv resolves the last, so ours can be overridden`,
+        "red",
+      );
+      return false;
+    }
+    if (!matches[0]?.endsWith(url)) {
+      log("the surviving base-URL assignment is not the proxy's", "red");
+      return false;
+    }
+    if (!applied.includes("OTHER_TOOL=keep-me")) {
+      log("collapsing duplicates dropped an unrelated variable", "red");
+      return false;
+    }
+
+    // Restore puts back the value the user actually had — which here IS a base
+    // URL, their own, so its presence is correct. What must not survive is a
+    // second assignment or the proxy's value: dotenv resolves the last, so
+    // either would leave the CLI pointed somewhere the user did not choose.
+    await geminiConfigurator.restore(url);
+    const restored = fs.readFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "utf8",
+    );
+    const after = restored.match(/^GOOGLE_GEMINI_BASE_URL=.*$/gm) ?? [];
+    if (after.length !== 1) {
+      log(
+        `restore left ${after.length} base-URL assignments; dotenv resolves the last`,
+        "red",
+      );
+      return false;
+    }
+    if (after[0]?.includes(url)) {
+      log("restore left the proxy's base URL in place", "red");
+      return false;
+    }
+    if (!restored.includes("OTHER_TOOL=keep-me")) {
+      log("restore dropped an unrelated variable", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Ownership must be judged on the assignment the CLI actually resolves.
+ *
+ * dotenv takes the last one, so a user who appends their own
+ * GOOGLE_GEMINI_BASE_URL after apply() has already repointed Gemini — our line
+ * is still on the page but no longer in effect. Checking the first assignment
+ * saw our value, passed the ownership test, and restore then deleted the
+ * endpoint the CLI was using. Measured before the fix: the user's endpoint was
+ * gone and restore reported success.
+ */
+async function testGeminiRestoreRespectsAUserRepoint(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-repoint-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    fs.writeFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GEMINI_API_KEY=user-key\n",
+    );
+    await geminiConfigurator.apply(url);
+    fs.appendFileSync(
+      __geminiTestHooks.getGeminiEnvPath(),
+      "GOOGLE_GEMINI_BASE_URL=https://the-users-own-endpoint\n",
+    );
+
+    const restored = await geminiConfigurator.restore(url);
+    const after = fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8");
+    if (!after.includes("the-users-own-endpoint")) {
+      log(
+        "restore deleted the endpoint the user had repointed Gemini at",
+        "red",
+      );
+      return false;
+    }
+    if (restored !== false) {
+      log("restore claimed success on a config it does not own", "red");
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The round-trip must be byte-exact on CRLF too.
+ *
+ * The existing round-trip case fixtures an LF-only `.env`, which is precisely
+ * where a line-ending bug cannot show: replacing "\n" with "\n" is a no-op. A
+ * rewrite that captured the terminator and re-emitted a bare LF therefore
+ * passed it while silently converting CRLF to LF — and on the ordinary
+ * single-occurrence path, not just on duplicates. Gemini CLI is cross-platform,
+ * so a Windows-authored .env is not an exotic input.
+ *
+ * The suite had zero `\r` literals anywhere before this case.
+ */
+async function testGeminiRoundTripsCrlfExactly(): Promise<boolean> {
+  const { geminiConfigurator, __geminiTestHooks } =
+    await import("../src/cli/proxy-clients/gemini.js");
+  const prevHome = process.env.HOME;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "neurolink-gm-crlf-"));
+  try {
+    process.env.HOME = root;
+    fs.mkdirSync(path.join(root, ".gemini"), { recursive: true });
+    const url = "http://127.0.0.1:55669";
+    const original =
+      "FOO=bar\r\nGOOGLE_GEMINI_BASE_URL=http://original\r\nBAZ=qux\r\n";
+    fs.writeFileSync(__geminiTestHooks.getGeminiEnvPath(), original);
+
+    await geminiConfigurator.apply(url);
+    await geminiConfigurator.restore(url);
+
+    const back = fs.readFileSync(__geminiTestHooks.getGeminiEnvPath(), "utf8");
+    if (back !== original) {
+      // Naming the discrepancy, not printing the payload: a message quoting
+      // file content can match isExpectedProviderError() and downgrade a real
+      // failure to a skip.
+      const changed = back.includes("\r\nGOOGLE_GEMINI_BASE_URL")
+        ? "content"
+        : "line ending on the managed key";
+      log(
+        `CRLF .env did not round-trip byte-exactly — ${changed} differs`,
+        "red",
+      );
+      return false;
+    }
+    return true;
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
  * Regression: a stale snapshot must never outlive the value it describes.
  *
  * The snapshot-on-first-touch guard exists so a second apply() cannot record
@@ -7667,6 +7857,21 @@ const tests: TestFunction[] = [
   {
     name: "OpenCode: legacy in-file snapshot migrates and heals",
     fn: testOpenCodeMigratesLegacyInFileSnapshot,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: restore respects a user repoint",
+    fn: testGeminiRestoreRespectsAUserRepoint,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: a CRLF .env round-trips byte-exactly",
+    fn: testGeminiRoundTripsCrlfExactly,
+    category: "proxy-config",
+  },
+  {
+    name: "Gemini CLI: duplicate managed keys are collapsed",
+    fn: testGeminiCollapsesDuplicateManagedKeys,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
## The bug

Gemini CLI resolves `.env` with dotenv, which takes the **last** assignment of a duplicated key. The env helpers matched with `"m"` and no `"g"`, so they only ever touched the first.

Both failure modes are silent:

- **`apply()`** rewrote the first assignment and left a later one in place, so the user's stale value won — Gemini went on talking to Google while the writer reported success and the proxy printed a green check.
- **`restore()`** cleared only the first, leaving a second assignment still pointing at a proxy that is no longer running.

## Measured, because precedence is the whole point

```
.env:  GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:55669   (live proxy)
       GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:59999   (dead port)

gemini → "fetch failed"   ← used the DEAD port
```

Last-wins confirmed. Everything else follows from that.

## The fix

`apply()` rewrites the first occurrence **in place** — position is the user's, and the byte-exact round-trip depends on keeping it — then drops any later ones, so exactly one assignment survives and it is ours. `removeEnvVars` clears every occurrence. `readManagedVars` reads the **last** assignment, since restoring the first would put back a value the CLI never actually used.

Verified end to end: a `.env` already carrying the key twice, both pointing elsewhere, now routes through the proxy after `apply()` — `exit=0`, attempt-counter `delta=1` — with the unrelated variable untouched.

## Provenance

Reported by an independent audit of the merged PR as **unconfirmed**, on the grounds that the impact depended on dotenv precedence neither of us had checked. Checking it is what turned it from a lint-shaped nit into a silent-misrouting bug. Worth noting that "probably minor, unverified" was the right label at the time and the wrong conclusion to act on.

## One thing I got wrong

The regression test's first version asserted that **no** base URL survives restore, and it failed. The user's original file *had* one, so putting it back is correct — what must not survive is a *second* assignment or the *proxy's* value. The test was wrong, not the code. Flagging it because that version would have passed against a weaker fix that merely deleted everything.

## Gates

```
proxy suite  88 passed · 0 failed · 6 skipped
build 0 · check 0 · lint 0 errors · docs drift 0
```

Verified non-vacuous: reverting only the global-flag handling fails the test and the suite exits 1. Based on `67b15c35`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of duplicate Gemini proxy configuration entries.
  - Updates now preserve unrelated environment settings while keeping one managed assignment.
  - Restoring configuration removes all proxy entries and retains a single non-proxy setting.
  - User-appended endpoint overrides are respected during restoration.
  - Configuration files preserve their original line-ending format.

- **Tests**
  - Added coverage for duplicate cleanup, user overrides, unrelated settings, and CRLF round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->