### PR TITLE
docs(ci): name the shared request log the attribution suite reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -961,7 +961,41 @@ jobs:
           #
           # The 55669 in that suite is a config string it writes into client
           # config files and asserts on — never a request target — so an
-          # operator's own proxy listening there does not affect it.
+          # operator's own proxy listening there does not affect it. That is
+          # correct: fetchProxy targets PROXY_PORT, which is 9876.
+          #
+          # It is also incomplete, in the direction that misleads. The suite is
+          # NOT isolated from a running proxy, because the coupling is the log
+          # file rather than the port. startProxy() spawns with neither --dev
+          # nor a HOME override, so its request log resolves to
+          # ~/.neurolink/logs/proxy-<date>.jsonl — the same append-only file an
+          # operator's own daemon writes to. testPerClientAttribution then
+          # stats that path via os.homedir(), sends its two requests, and reads
+          # back everything appended past the recorded offset. Both proxies'
+          # records land in that window: on the machine where this was checked,
+          # the last 4000 lines held 397 claude-code and 198 unknown entries,
+          # the latter being the test's own synthetic user-agent mixed in with
+          # live traffic.
+          #
+          # What that does and does not establish, stated separately because
+          # the difference is the whole value of it:
+          #
+          #   Established, by reading the spawn and confirmed in the log: the
+          #   read-back window is shared, unscoped, and not synchronised with
+          #   anything.
+          #
+          #   NOT established: that concurrency is the cause. The failure was
+          #   seen twice while other work drove a second proxy, but two
+          #   deliberate attempts to reproduce it — one with sustained load,
+          #   one with three parallel generators — both passed 88/0. Treat the
+          #   correlation as a lead, not a diagnosis.
+          #
+          # For CI the shared-log path is probably not it, since a runner has
+          # no second proxy; the race the paragraph above names remains the
+          # better hypothesis there. The value here is that the read-back has
+          # no synchronisation to rely on in either environment, and that an
+          # investigator should stop treating "no operator proxy on 55669" as
+          # evidence of isolation.
           #
           # test:model-not-found-retryable is also absent: it skips entirely
           # without credentials, so it could only ever no-op here — the same


### PR DESCRIPTION
## What this corrects

The attribution note added in #1570 tells the next investigator that an operator's own proxy cannot affect this suite. The reason it gives is **correct**; the conclusion it invites is not.

**Correct:** `fetchProxy` targets `PROXY_PORT`, which is `9876`. A daemon on 55669 is not a request target.

**Incomplete, in the direction that misleads:** the coupling is the log file, not the port.

```ts
// startProxy(): no --dev, no HOME override
spawn(node, [cli, "proxy", "start", "--port", "9876", "--quiet"],
      { env: { ...process.env, NEUROLINK_SKIP_MCP: "true", ... } })

// testPerClientAttribution():
const logsDir = path.join(os.homedir(), ".neurolink", "logs");
```

`resolveProxyPaths(dev=false)` puts `logsDir` at `~/.neurolink/logs`, so the suite's own proxy appends to the same file an operator's daemon does. The test stats that path, sends two requests, and reads back everything past the recorded offset.

Both proxies' records land in that window. On the machine where this was checked, the last 4000 lines held **397 `claude-code` and 198 `unknown`** entries — the latter being the test's own synthetic `some-unreleased-cli/9.9.9` interleaved with live traffic.

## Two claims, deliberately separated

**Established** — by reading the spawn, and confirmed against the log: the read-back window is shared, unscoped, and synchronised with nothing.

**NOT established** — that concurrency causes the failure. It was observed twice while other work drove a second proxy, but two deliberate reproductions — one with sustained load, one with three parallel generators — **both passed 88/0**.

That second half is why this is a note and not a fix.

## Why I'm flagging my own first pass as wrong

I initially reported "concurrent traffic against the same proxy" as the cause, and told a colleague it was. That was wrong twice over: wrong about the mechanism, because the port is 9876 and not 55669, and unsupported as a cause, because it does not reproduce on demand.

What survives verification is the structural coupling — checkable by reading two files, no race to win. That is what this commit records, and the failed reproductions are recorded alongside it so nobody re-derives the same false confidence.

## For CI specifically

The shared-log path is probably **not** the CI cause — a runner has no second proxy — so the write/read-back race the existing paragraph already names remains the better hypothesis there. What changes is that *"no operator proxy on 55669"* can no longer be read as evidence of isolation.

No behaviour change. YAML parses; `lint` 0 errors.