### PR TITLE
fix(retry): never retry a turn the caller already cancelled

### DIFF
--- a/src/lib/utils/providerRetry.ts
+++ b/src/lib/utils/providerRetry.ts
@@ -15,7 +15,7 @@
  */
 
 import { type Span } from "@opentelemetry/api";
-import { NeuroLinkError } from "./errorHandling.js";
+import { NeuroLinkError, isAbortError } from "./errorHandling.js";
 import { logger } from "./logger.js";
 import { APICallError } from "./generationErrors.js";
 import { parseRetryAfterMs } from "./retryAfter.js";
@@ -168,7 +168,52 @@ export function isOpenAIQuotaExhaustedError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * True when `error` is an abort, or wraps one at any depth via `cause`.
+ *
+ * `isAbortError` alone is not enough here because it inspects one value, and
+ * by the time a provider failure reaches the retry wrapper it has usually been
+ * re-thrown inside a provider-specific error whose `name` no longer says
+ * "AbortError". The depth bound stops a self-referential or maliciously deep
+ * `cause` chain from hanging the classifier; nothing legitimate nests further.
+ */
+function isAbortLike(error: unknown, depth = 0): boolean {
+  if (depth > 8 || error === null || typeof error !== "object") {
+    return isAbortError(error);
+  }
+  if (isAbortError(error)) {
+    return true;
+  }
+  const { cause } = error as { cause?: unknown };
+  return cause === undefined || cause === error
+    ? false
+    : isAbortLike(cause, depth + 1);
+}
+
 export function isRetryableProviderError(error: unknown): boolean {
+  // Ahead of everything, for the same reason as the quota branch below but a
+  // worse failure: the caller has already walked away. Retrying a cancelled
+  // turn cannot succeed — the signal stays aborted, so every further attempt
+  // rejects without reaching the network — and it costs the full ladder,
+  // 2 retries at the NO_HINT_FLOOR_MS floor, before the turn ends.
+  //
+  // Measured on SageMaker before this guard: abort at 400ms, provider failed
+  // at 232ms with "Request aborted", then two more attempts 10s apart each
+  // failing in 1ms without a request leaving the process, and the turn finally
+  // threw at 21,996ms — 55x the time the cancellation should have taken, with
+  // `name` by then reading "Error" rather than "AbortError".
+  //
+  // The cause chain matters and is not defensive padding. Providers wrap
+  // transport failures in their own error class on the way up: SageMaker's
+  // handleSageMakerError() stamps an unrecognised error `statusCode: 500`
+  // while keeping the original as `cause`. That fabricated 500 is what made an
+  // abort look retryable here — the duck-typed status branch below reads it
+  // and returns true, outranking the wrapper's own `retryable: false`. Reading
+  // through `cause` finds the abort whatever wrapped it.
+  if (isAbortLike(error)) {
+    return false;
+  }
+
   // Before every other branch, including the SDK's own flag: a 429 carrying
   // `insufficient_quota` is marked retryable by the AI SDK because it only
   // looks at the status code. Retrying it burns the full ladder — 3 attempts


### PR DESCRIPTION
`isRetryableProviderError` has no notion of cancellation. An aborted turn
that reaches it wearing a 5xx is retried like any transient failure —
`MAX_PROVIDER_RETRIES` attempts at the `NO_HINT_FLOOR_MS` floor, each
rejecting immediately because the signal is still aborted, none of them
reaching the network.

This is defense in depth and, on this tree, changes no behaviour today.
That is worth stating plainly rather than implying a fix: the one path
that reached it was SageMaker, whose `handleSageMakerError()` stamps an
unrecognised error `statusCode: 500` while keeping the original as
`cause`, and #1566 stops that wrapping at the source. Measured after
#1566 and with this guard reverted, an aborted SageMaker turn still ends
in 529ms — so the provider fix alone is sufficient for the case we know
about, and this guard is not what makes it work.

It is still worth having, because the shape recurs. Any provider that
wraps a transport failure in its own error class and gives it a synthetic
5xx reproduces the bug exactly, and nothing about that pattern is
SageMaker-specific: the duck-typed status branch outranks the wrapper's
own `retryable: false`, which is never consulted for a non-NeuroLinkError.
The guard is placed ahead of every other branch for the same reason the
`insufficient_quota` guard already sits there — retrying cannot change
the outcome and costs the full ladder.

`isAbortError` alone is not enough, so this walks `cause`: by the time a
failure reaches the retry wrapper it has usually been re-thrown inside a
provider error whose `name` no longer says "AbortError". The walk is
depth-bounded and stops on a self-referential `cause`, which a hostile or
merely careless error object can otherwise turn into a hang in the
classifier.

No test. The behaviour it guards is unreachable on this tree — #1566
removed the only route to it — and a test that cannot fail without also
reverting a different PR would assert nothing. It is recorded here
instead, with the measurement that shows why it is currently inert.