### PR TITLE
fix(proxy): correct how the MSIE User-Agent was attributed, and guard the roster

### DIFF
--- a/src/lib/proxy/clientAttribution.ts
+++ b/src/lib/proxy/clientAttribution.ts
@@ -51,16 +51,40 @@ const CLIENT_PREFIXES: ReadonlyArray<readonly [string, string]> = [
  * - `OpenAI/JS 5.20.1` — the stock OpenAI JS SDK UA, sent by every caller of
  *   that SDK. Mapping it to Copilot would file unrelated OpenAI-SDK traffic
  *   under Copilot's name, which is worse than leaving it unattributed.
- * - `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` — a
- *   spoofed browser string. It looks like a fingerprint and is not one: it was
- *   captured from **both** Copilot CLI and Gemini CLI, so it identifies no
- *   client at all. (It also accounts for the largest single block of
- *   `unknown` rows in this machine's log, which is what made it tempting.)
+ - `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` — not a
+ *   CLI's User-Agent at all. This is what `curl` sends on a machine whose
+ *   `~/.curlrc` sets `user-agent`, so every curl-driven caller on such a host
+ *   shares it: scripts, agents, health probes. It accounted for the largest
+ *   single block of `unknown` rows in the log this table was measured against,
+ *   which is exactly what made it tempting.
+ *
+ *   Recorded because the first pass got this wrong in a way worth naming. The
+ *   string was seen arriving at two capture servers during Copilot CLI and
+ *   Gemini CLI runs and was written up as "sent by both CLIs". It was neither:
+ *   it was the aliveness `curl` fired at each capture server moments before
+ *   the CLI, picking up that host's curlrc. The paths gave it away on review —
+ *   the Gemini-side hit was a bare `GET /v1beta/models`, which is the probe's
+ *   URL and not one the CLI requests. A shared string across two unrelated
+ *   clients should have read as "shared dependency or shared tooling", not as
+ *   a property of either client.
  *
  * Copilot does send `x-initiator` and `x-interaction-type`, but neither is
  * exclusive to it either. Attributing it needs a signal nobody has found yet,
  * so it stays `unknown` and remains traceable through the stored raw header.
  */
+
+/**
+ * The client names this table can produce.
+ *
+ * Exported so a test can check the roster of CLIs the proxy configures against
+ * the roster it can actually name. Those two lists drifted apart silently once
+ * already: five configurators shipped while the table still knew only Claude
+ * Code, and nothing failed, because an unattributed client looks exactly like
+ * a quiet one.
+ */
+export function getMappedClientNames(): ReadonlySet<string> {
+  return new Set(CLIENT_PREFIXES.map(([, name]) => name));
+}
 
 /** Cap stored User-Agents. They are attacker-influenced and unbounded. */
 const MAX_USER_AGENT_CHARS = 200;

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -2706,13 +2706,12 @@ async function testPerClientAttribution(): Promise<boolean | null> {
   // None is invented, which is the standing rule for this table: a guessed
   // prefix that never matches is indistinguishable from one that works.
   //
-  // The last three are the ones that matter most. `OpenAI/JS` and the spoofed
-  // MSIE string are both sent by real CLIs we would like to name, and both
-  // MUST stay unknown: `OpenAI/JS` is the stock OpenAI SDK UA sent by every
-  // caller of that SDK, and the MSIE string was captured from Copilot CLI AND
-  // Gemini CLI, so it identifies no client at all. They are pinned here so a
-  // later "helpful" mapping fails this test instead of silently misfiling
-  // unrelated traffic.
+  // The last three MUST stay unknown, and are pinned so a later "helpful"
+  // mapping fails this test instead of silently misfiling unrelated traffic.
+  // `OpenAI/JS` is the stock OpenAI SDK UA, sent by every caller of that SDK —
+  // Copilot CLI among them, which is why Copilot cannot be named this way. The
+  // MSIE string is not a CLI's UA at all: it is what curl sends on a host whose
+  // ~/.curlrc sets one, so it is shared by every curl-driven caller there.
   const agents = [
     { ua: "claude-cli/2.1.223 (external, cli)", expect: "claude-code" },
     {
@@ -2726,8 +2725,9 @@ async function testPerClientAttribution(): Promise<boolean | null> {
     },
     { ua: "codex_exec/0.147.0 (Mac OS 26.6.0; arm64)", expect: "codex" },
     { ua: "some-unreleased-cli/9.9.9", expect: "unknown" },
-    // Copilot CLI, both of the strings it actually sends.
+    // Copilot CLI's own request.
     { ua: "OpenAI/JS 5.20.1", expect: "unknown" },
+    // Any curl caller on a host with a user-agent in ~/.curlrc.
     {
       ua: "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
       expect: "unknown",
@@ -2815,6 +2815,92 @@ async function testPerClientAttribution(): Promise<boolean | null> {
     return false;
   }
   log(`attributed ${seen.size} distinct clients from live traffic`, "green");
+  return true;
+}
+
+/**
+ * Every CLI the proxy configures must be one the proxy can also name.
+ *
+ * These two rosters are maintained in different files by different reflexes —
+ * you add a configurator to onboard a CLI, and you add a User-Agent prefix
+ * only once you have watched that CLI's traffic. They drifted apart in exactly
+ * that gap: five configurators shipped while CLIENT_PREFIXES still knew only
+ * Claude Code, so five of six CLIs were filed as "unknown" and the per-client
+ * usage feature reported one bucket while looking entirely healthy. Nothing
+ * failed, because an unattributed client is indistinguishable from a quiet one.
+ *
+ * So the check is structural rather than behavioural: adding a configurator
+ * now fails here until someone either measures its User-Agent or writes down
+ * why it cannot be measured.
+ */
+const UNATTRIBUTABLE_CLIENTS: ReadonlyMap<string, string> = new Map([
+  [
+    "copilot",
+    "sends the stock `OpenAI/JS <version>` SDK User-Agent, which every caller " +
+      "of that SDK sends; mapping it would misfile unrelated traffic",
+  ],
+]);
+
+async function testEveryConfiguredClientIsAttributable(): Promise<boolean> {
+  const { PROXY_CLIENT_CONFIGURATORS } =
+    await import("../src/cli/proxy-clients/registry.js");
+  const { getMappedClientNames } =
+    await import("../src/lib/proxy/clientAttribution.js");
+  const mapped = getMappedClientNames();
+
+  // Precondition. An empty or tiny roster would make every assertion below
+  // pass by having nothing to check, which is the failure mode this whole
+  // suite keeps rediscovering.
+  if (PROXY_CLIENT_CONFIGURATORS.length < 5) {
+    log(
+      "configurator roster looks truncated; the check would be vacuous",
+      "red",
+    );
+    return false;
+  }
+
+  for (const client of PROXY_CLIENT_CONFIGURATORS) {
+    if (mapped.has(client.id)) {
+      continue;
+    }
+    const reason = UNATTRIBUTABLE_CLIENTS.get(client.id);
+    if (!reason) {
+      log(
+        `a configured client has no User-Agent mapping and no recorded reason ` +
+          `for lacking one — measure its User-Agent and add the prefix, or add ` +
+          `it to UNATTRIBUTABLE_CLIENTS saying why that is impossible`,
+        "red",
+      );
+      return false;
+    }
+  }
+
+  // The exception list must not outlive its exceptions either: an entry for a
+  // client that has since been mapped, or removed, is stale documentation that
+  // would let a real regression hide behind it.
+  for (const id of UNATTRIBUTABLE_CLIENTS.keys()) {
+    const stillConfigured = PROXY_CLIENT_CONFIGURATORS.some((c) => c.id === id);
+    if (!stillConfigured) {
+      log(
+        "an unattributable-client exception names a client that is no longer configured",
+        "red",
+      );
+      return false;
+    }
+    if (mapped.has(id)) {
+      log(
+        "an unattributable-client exception names a client that is now mapped",
+        "red",
+      );
+      return false;
+    }
+  }
+
+  log(
+    `all ${PROXY_CLIENT_CONFIGURATORS.length} configured clients are either ` +
+      `attributable or documented as not being so`,
+    "green",
+  );
   return true;
 }
 
@@ -8107,6 +8193,10 @@ const tests: TestFunction[] = [
   {
     name: "Attribution: the request log records the calling CLI",
     fn: testPerClientAttribution,
+  },
+  {
+    name: "Attribution: every configured client is attributable or documented",
+    fn: testEveryConfiguredClientIsAttributable,
     category: "proxy-config",
   },
   {


### PR DESCRIPTION
## What

Two things, both fallout from the attribution work in c4aea05b.

### 1. A measurement I wrote down as fact was wrong

That commit's note says the spoofed `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` User-Agent "was captured from **both** Copilot CLI and Gemini CLI". It was captured from neither.

It is what `curl` sends on a host whose `~/.curlrc` sets `user-agent` — this machine's has, since 2021:

```
# Disguise as IE 9 on Windows 7.
user-agent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
```

The string reached two capture servers during a Copilot run and a Gemini run because each server was probed with `curl` for aliveness moments before the CLI was pointed at it. **The paths said so plainly on review** — the Gemini-side hit was a bare `GET /v1beta/models`, the probe's own URL, not one the CLI requests.

Proven with controls on this host:

| request | User-Agent seen |
|---|---|
| `curl -X POST .../plain` | `Mozilla/5.0 (compatible; MSIE 9.0; ...)` |
| `curl -X POST -A "control-ua/1.0" .../override` | `control-ua/1.0` |

The second row matters: it proves the capture reads the real header, so the first row is the curlrc and not an artefact.

**The conclusion is unchanged and better founded.** A string shared by every curl-driven caller on a host is precisely what must not be mapped to a client. Only the stated evidence was wrong — and a wrong measurement recorded as fact is worse than no note, because the next reader has no reason to doubt it. Two unrelated CLIs appearing to send an identical unusual string should have read as shared tooling, not as a property of either.

This also identifies the largest block of `unknown` rows in the request log: 910 in one five-minute burst, all `claude-haiku-4-5`, all one account — curl-driven traffic, not a coding CLI.

### 2. The check that would have caught the original gap

`CLIENT_PREFIXES` and `PROXY_CLIENT_CONFIGURATORS` live in different files and are updated by different reflexes: you add a configurator to onboard a CLI, and a prefix only once you have watched that CLI's traffic. They drifted apart in exactly that gap — five configurators shipped while the table still knew only Claude Code, so five of six CLIs were filed as `unknown` while the per-client usage feature looked entirely healthy. Nothing failed, because **an unattributed client is indistinguishable from a quiet one**.

The new test asserts:
- every configured client is either mapped to a prefix, or carries a written reason it cannot be;
- the exception list does not outlive its exceptions — an entry naming a client since mapped, or since removed, is stale documentation a real regression could hide behind;
- the roster length is sane first, so a truncated import cannot make the whole check vacuous.

Copilot CLI is the sole current exception: it sends the stock `OpenAI/JS <version>` SDK User-Agent that every caller of that SDK sends.

## Verification

- `pnpm run check` — 0 errors
- `pnpm run lint` — 0 errors
- `pnpm run check:tools-tests` — clean
- `pnpm run build` — clean
- Proxy suite: **94 passed, 0 failed**

Non-vacuity: removing the `qwen-code` prefix makes the suite exit 1 naming the unmapped client, rather than passing quietly. The guard reads `src/` directly, so that check isolates it from the live attribution test, which reads `dist/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attribution handling for common `curl` and OpenAI SDK User-Agent strings, keeping them classified as unknown where appropriate.

* **Tests**
  * Added validation to ensure every configured client is either attributable or explicitly documented as an exception.
  * Updated attribution tests and documentation for more accurate client identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->