### PR TITLE
fix(proxy): repair the comment #1601 landed malformed, and the claim it left standing

### DIFF
--- a/src/lib/core/evaluationProviders.ts
+++ b/src/lib/core/evaluationProviders.ts
@@ -149,7 +149,7 @@ export function getBestAvailableProvider(
 }
 
 /**
- Record actual provider performance for optimization
+ * Record actual provider performance for optimization
  */
 
 export function recordProviderPerformanceFromMetrics(

--- a/src/lib/proxy/clientAttribution.ts
+++ b/src/lib/proxy/clientAttribution.ts
@@ -43,34 +43,37 @@ const CLIENT_PREFIXES: ReadonlyArray<readonly [string, string]> = [
 ];
 
 /**
- * Deliberately NOT mapped, with the measurement that ruled each one out.
+ * Deliberately NOT mapped, and why each was ruled out.
  *
- * Copilot CLI is the one client here that cannot be identified from its
- * User-Agent, and both of the strings it sends are actively unsafe to key on:
+ * These two strings are unrelated to each other. They are grouped only because
+ * both were candidates for a Copilot mapping at some point, and neither can
+ * carry one.
  *
- * - `OpenAI/JS 5.20.1` — the stock OpenAI JS SDK UA, sent by every caller of
- *   that SDK. Mapping it to Copilot would file unrelated OpenAI-SDK traffic
- *   under Copilot's name, which is worse than leaving it unattributed.
- - `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` — not a
- *   CLI's User-Agent at all. This is what `curl` sends on a machine whose
- *   `~/.curlrc` sets `user-agent`, so every curl-driven caller on such a host
- *   shares it: scripts, agents, health probes. It accounted for the largest
- *   single block of `unknown` rows in the log this table was measured against,
- *   which is exactly what made it tempting.
+ * - `OpenAI/JS 5.20.1` — Copilot CLI's actual User-Agent, and the problem is
+ *   that it is not Copilot's alone: it is the stock OpenAI JS SDK string, sent
+ *   by every caller of that SDK. Mapping it would file unrelated OpenAI-SDK
+ *   traffic under Copilot's name, which is worse than leaving it unattributed.
+ *   Copilot also sends `x-initiator` and `x-interaction-type`, but neither is
+ *   exclusive to it either, so it stays `unknown` and remains traceable
+ *   through the stored raw header.
+ *
+ * - `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` — not a
+ *   CLI's User-Agent at all, and in particular NOT Copilot's. It is what
+ *   `curl` sends on a machine whose `~/.curlrc` sets `user-agent`, so every
+ *   curl-driven caller on such a host shares it: scripts, agents, health
+ *   probes. It accounted for the largest single block of `unknown` rows in the
+ *   log this table was measured against, which is exactly what made it
+ *   tempting.
  *
  *   Recorded because the first pass got this wrong in a way worth naming. The
- *   string was seen arriving at two capture servers during Copilot CLI and
- *   Gemini CLI runs and was written up as "sent by both CLIs". It was neither:
- *   it was the aliveness `curl` fired at each capture server moments before
- *   the CLI, picking up that host's curlrc. The paths gave it away on review —
- *   the Gemini-side hit was a bare `GET /v1beta/models`, which is the probe's
- *   URL and not one the CLI requests. A shared string across two unrelated
- *   clients should have read as "shared dependency or shared tooling", not as
- *   a property of either client.
- *
- * Copilot does send `x-initiator` and `x-interaction-type`, but neither is
- * exclusive to it either. Attributing it needs a signal nobody has found yet,
- * so it stays `unknown` and remains traceable through the stored raw header.
+ *   string was seen arriving at two capture servers during a Copilot CLI run
+ *   and a Gemini CLI run, and was written up as "sent by both CLIs". It was
+ *   sent by neither: it was the aliveness `curl` fired at each capture server
+ *   moments before the CLI was pointed at it, picking up that host's curlrc.
+ *   The request paths gave it away on review — the Gemini-side hit was a bare
+ *   `GET /v1beta/models`, which is the probe's URL and not one the CLI
+ *   requests. An identical unusual string arriving from two unrelated clients
+ *   is evidence of shared tooling, never a property of either client.
  */
 
 /**


### PR DESCRIPTION
Follow-up to #1601 (4e909f91). Two defects in the block it landed — one cosmetic, one not.

## 1. The comment no longer parses as one

`src/lib/proxy/clientAttribution.ts` — the MSIE bullet opens with `space-hyphen` instead of `space-asterisk-space-hyphen`, so that bullet and everything indented under it sits outside the block comment:

```
 *   under Copilot's name, which is worse than leaving it unattributed.
 - `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)` — not a
 *   CLI's User-Agent at all. ...
```

Caught in review by a second session. Nothing breaks — tsc is happy, and **prettier does not normalise the asterisk prefix inside a block comment**, so `format:check` passes and all five required checks stayed green over it. Our format gate cannot see this class of defect.

## 2. The claim #1601 existed to retract is still there

The paragraph that *introduces* the corrected bullet still reads:

> Copilot CLI is the one client here that cannot be identified from its User-Agent, and **both of the strings it sends** are actively unsafe to key on

The bullet below it says the MSIE string is curl's and not any CLI's. The sentence above says Copilot sends it. Both are on `release` right now, and a reader has no way to tell which is current — with the retraction looking like the afterthought.

This is the more serious of the two, and it happened because the correction was made by editing the bullet in place, so the framing sentence was never re-read. That is the same failure the commit was about, one paragraph higher up. **Fixing a wrong claim means re-reading everything that claim supports, not just the line it was written on.**

The block is now restructured so the two strings are not presented as a pair. They were only ever grouped because both had been Copilot-mapping candidates; they have nothing else in common, and grouping them under "both of the strings it sends" is what made the false framing easy to write and hard to notice.

## 3. One other instance of the same defect

Swept `src/` for block-comment lines missing their leading asterisk, on the grounds that neither tsc nor prettier reports it and there was no reason to assume this instance was unique. Found exactly one more, in `evaluationProviders.ts`, and fixed it. Sweep now reports zero.

## Verification

- `pnpm run check` — 0 errors
- `pnpm run lint` — 0 errors
- `pnpm run check:tools-tests` — clean
- `pnpm run build` — clean
- Proxy suite: **94 passed, 0 failed**

One note for whoever runs these next: `check:tools-tests` type-checks test files that import `../dist/index.js`, so running it against a stale `dist` produces confident errors in unrelated suites. It reported four TTS type errors here until `build` was re-run, and they had nothing to do with this change. Run `build` first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified provider performance recording documentation.
  * Updated client attribution notes to accurately describe unmapped client identifiers and header behavior.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->