### PR TITLE
fix(localUsage): pin window monotonicity, and stop two tests lying about failure

### DIFF
--- a/src/lib/localUsage/scanWindow.ts
+++ b/src/lib/localUsage/scanWindow.ts
@@ -16,10 +16,33 @@
  * Three fixes in three files each closed one door and left the others open.
  * The logic lives here once now, so the next door closes everywhere at once.
  *
- * Contract: `Infinity` is the ONLY value meaning all-history. Anything that is
- * not a usable finite window — NaN, negative, or so large the arithmetic stops
- * being finite — collapses to a zero-length window, which is what a
- * nonsensical request should read as.
+ * Contract, stated as the two directions rather than as one rule, because the
+ * single-sentence version of it was wrong here for weeks:
+ *
+ *   - `0`, negatives, `-Infinity` and `NaN` are NOT windows. They collapse to
+ *     a zero-length one and read nothing. Two of the three historical defects
+ *     above are here (`0` and `NaN`); `-Infinity` and negatives are the same
+ *     class and were fixed with them.
+ *   - `Infinity`, and any finite value whose window is longer than any
+ *     history, mean ALL HISTORY. The THIRD historical defect — `MAX_VALUE` —
+ *     lives in this bucket, not the one above: what was wrong about it was the
+ *     mechanism (a `-Infinity` cutoff), never the outcome. A window of 1e308 days covers every
+ *     transcript that could exist, so "everything" is the right answer to it
+ *     and "nothing" is a wrong one.
+ *
+ * The prose here used to say the opposite of that second point — that a span
+ * too large to stay finite "collapses to a zero-length window". The code never
+ * did that, and the code was right. Anyone reconciling the two by changing the
+ * code re-creates a defect this suite has already seen once: asserting
+ * absurd-means-nothing produces a NON-MONOTONIC CLIFF, where 2.07e300 read
+ * everything, 2.09e300 read nothing, and `Infinity` read everything again.
+ * That was found by running the CLI — `usage local --since 999999999999`
+ * reported 518,576 turns while `--since 1e308` reported 39 — not by reading
+ * either the code or this comment.
+ *
+ * The invariant that actually holds, and the one worth testing, is
+ * MONOTONICITY: a wider window never reads less than a narrower one, across
+ * the whole range including the absurd end.
  */
 export const DEFAULT_SINCE_DAYS = 30;
 
@@ -27,7 +50,13 @@ const MS_PER_DAY = 86_400_000;
 
 /**
  * @returns the epoch-ms cutoff a scan must not read past, or `undefined` for an
- * unbounded (all-history) scan — which only `Infinity` produces.
+ * unbounded (all-history) scan.
+ *
+ * `undefined` has TWO sources, not one, and this line used to name only the
+ * first: an explicit `Infinity`, and any finite request whose span overflows
+ * (`Number.MAX_VALUE`). They mean the same thing on purpose — see the contract
+ * above — but a reader who believes only `Infinity` reaches this branch will
+ * mis-handle the second.
  */
 export function resolveScanCutoffMs(
   sinceDays: number | undefined,

--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -660,6 +660,88 @@ async function runAllTests(): Promise<void> {
     log("an absent store reports as notInstalled rather than as an error");
   });
 
+  await test("widening the window never reads less, across the whole range", async () => {
+    // A fixture, not this machine's store. The absurd rungs are full sweeps,
+    // and on a real 17k-file store nine of them take longer than the whole
+    // rest of this suite — the first version of this case timed out at ten
+    // minutes. Controlled mtimes also make the ladder actually vary, which a
+    // single-age store never would.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nl-monotonic-"));
+    const project = path.join(home, ".claude", "projects", "-tmp-ladder");
+    fs.mkdirSync(project, { recursive: true });
+    const ages = [2, 60, 900]; // days old
+    ages.forEach((ageDays, i) => {
+      const f = path.join(project, `session-${i}.jsonl`);
+      fs.writeFileSync(
+        f,
+        assistantLine(`msg_L${i}`, "claude-sonnet-4-5", {
+          input_tokens: 3,
+          output_tokens: 4,
+        }) + "\n",
+      );
+      const when = new Date(Date.now() - ageDays * 86_400_000);
+      fs.utimesSync(f, when, when);
+    });
+
+    // Rungs chosen to cross each fixture age and then run off the end of any
+    // possible history: 1e15 and 1e300 stay finite, MAX_VALUE overflows its
+    // span. All three mean all-history, and the cliff this guards against
+    // appeared precisely between two neighbouring absurd values.
+    const ladder = [1, 30, 100, 365, 36_500, 1e15, 1e300, Number.MAX_VALUE];
+    // The per-reader surface, not readAllLocalUsage: the aggregate reports
+    // totals keyed by CLI and carries no filesScanned of its own, so the
+    // file-count half of monotonicity is only observable here.
+    const { scans, all } = await withHome(home, async () => {
+      const reader = await createLocalUsageReader("claude-code");
+      const out: Array<{ days: number; files: number; requests: number }> = [];
+      for (const days of ladder) {
+        const r = await reader.scan({ sinceDays: days });
+        out.push({
+          days,
+          files: r.filesScanned,
+          requests: r.totals.requests,
+        });
+      }
+      return {
+        scans: out,
+        all: await reader.scan({ sinceDays: Infinity }),
+      };
+    });
+
+    // Precondition: the ladder must actually climb, or every comparison
+    // below is 0 >= 0 and this proves nothing.
+    assert(
+      all.filesScanned === ages.length,
+      "the fixture store did not scan as authored",
+    );
+    assert(
+      scans[0].files < all.filesScanned,
+      "the narrowest rung already read the whole fixture; the ladder cannot climb",
+    );
+
+    for (let i = 1; i < scans.length; i++) {
+      assert(
+        scans[i].files >= scans[i - 1].files,
+        `widening the window scanned fewer files at rung ${i}`,
+      );
+      assert(
+        scans[i].requests >= scans[i - 1].requests,
+        `widening the window counted fewer requests at rung ${i}`,
+      );
+    }
+    // Monotonicity alone still permits a ladder that plateaus below
+    // all-history. The top rung must reach it.
+    assert(
+      scans[scans.length - 1].files === all.filesScanned,
+      "the widest finite window disagreed with Infinity",
+    );
+
+    fs.rmSync(home, { recursive: true, force: true });
+    log(
+      `monotonic across ${ladder.length} rungs, ${scans[0].files} to ${all.filesScanned} files, top rung agrees with Infinity`,
+    );
+  });
+
   await test("this machine's real transcripts scan coherently", async () => {
     const realProjects = path.join(os.homedir(), ".claude", "projects");
     if (!fs.existsSync(realProjects)) {

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -659,11 +659,44 @@ async function testCodexModelsDiscovery(): Promise<boolean | null> {
     log(`Codex /models answered with status ${resp.status}`, "green");
     return true;
   } catch (err) {
+    // A transport failure here has two very different causes, and reporting
+    // both the same way is what was wrong before. This used to return false
+    // unconditionally, so a dropped connection to the throwaway proxy THIS
+    // SUITE spawned was reported as "Codex model discovery is unroutable". It
+    // did exactly that twice while `codex exec` was answering correctly
+    // through the same proxy and the route itself returned 200.
+    //
+    // But turning it into an unconditional skip is the opposite error: a route
+    // that deadlocks or resets the connection is a real defect, and it
+    // presents as a transport failure too. So distinguish them with a
+    // precondition rather than a guess — ask whether the proxy is answering at
+    // all. If /status responds, the process is healthy and this route
+    // specifically failed: that is a genuine finding and must FAIL. If /status
+    // is also unreachable, the harness lost its server and this case observed
+    // nothing, which is a SKIP.
+    //
+    // (Most catch blocks in this file return false. That is right for them —
+    // they assert on a response they did receive. This one is bounded by
+    // whether a request could be made at all.)
+    let proxyAlive: boolean;
+    try {
+      const health = await fetchProxy("/status");
+      proxyAlive = health.ok;
+    } catch {
+      proxyAlive = false;
+    }
+    if (proxyAlive) {
+      log(
+        "Codex model discovery threw while the proxy was still answering /status — the route itself failed",
+        "red",
+      );
+      return false;
+    }
     log(
-      `Codex models endpoint error: ${err instanceof Error ? err.message : String(err)}`,
-      "red",
+      "the spawned proxy stopped answering entirely, so Codex model discovery was never observed",
+      "yellow",
     );
-    return false;
+    return null;
   }
 }
 


### PR DESCRIPTION
Three defects, all the same shape: something stating a result it had not established. Found while auditing the whole CLI-support session against the repo rather than against memory.

## 1. `scanWindow.ts` documented a contract its code does not implement

The header said a span too large to stay finite *"collapses to a zero-length window"*. The code returns `undefined` — all-history — and always has. **The code is right**: a window of 1e308 days is longer than any transcript store, so "everything" is the correct answer and "nothing" is a wrong one.

**Only the prose changed.** That is deliberate, and the header now says why: reconciling the two by changing the code re-creates a defect this suite has already seen, where absurd-means-nothing produced a **non-monotonic cliff** — 2.07e300 read everything, 2.09e300 read nothing, `Infinity` read everything again. That was found by running the CLI (`usage local --since 999999999999` → 518,576 turns, `--since 1e308` → 39), not by reading code.

I attempted that same wrong fix while writing this commit. The existing case caught it, which is the only reason the code is intact.

## 2. The property that failure actually violates was never pinned

Every existing case pins one value's meaning, so a defect that gets each value right and the **order** between them wrong passes all of them — which is exactly what the cliff was.

The new case walks a ladder from 1 day to `Number.MAX_VALUE` over a fixture aged 2/60/900 days, asserts a wider window never reads less, then that the widest finite rung agrees with `Infinity` (monotonicity alone still permits a ladder that plateaus below all-history).

Non-vacuity: re-applying the cliff fails it at rung 4, naming the rung.

It uses a fixture, not this machine's store, on purpose — the first version walked the real 17k-file store, whose absurd rungs are full sweeps; nine of them ran longer than the rest of the suite and timed out at ten minutes.

## 3. The Codex model-discovery case reported a product defect for a transport failure

It returned `false` — a hard FAIL — when its fetch to the proxy **the suite itself spawned** threw. It did that twice while `codex exec` was answering correctly through the same proxy and `GET /backend-api/codex/models` returned 200.

## Adversarial review — 19 agents, 5 lenses, 2 skeptics per finding

Seven findings raised, 14 refutation votes, 9 stood. Four were fixed before this landed:

| Finding | What it caught |
| --- | --- |
| `@returns` still wrong | The rewrite fixed the file header and left the identical claim on the function signature — *"which only `Infinity` produces"* — which is what an IDE shows on hover. An overflowing span returns `undefined` too, for any value above ~2.08e300, **including the 1e308 the new contract uses as its own example**. |
| Backreference miscounted | Called a four-item list "the three defects above", and put `MAX_VALUE` in the read-nothing half — the opposite bucket to where the code puts it — inside the paragraph whose whole job is making that split exact. |
| Codex comment was false | It asserted *"every other live case in this file returns null here."* Of 20 bound catch blocks, **13 return `false` and 5 return `null`.** The change may have been right; the reason given was not, and I had not checked it. |
| Skip was too broad | A route that deadlocks or resets presents as a transport failure too, so an unconditional skip would hide the defect the case exists to find. |

The last one is now fixed properly, with a precondition instead of a guess: if `/status` still answers, the process is healthy and this route specifically failed → **FAIL**; if the proxy has stopped answering at all, nothing was observed → **SKIP**.

## Verification

- `pnpm run check` · `lint` · `check:tools-tests` · `build` — all clean
- Proxy suite: **94 passed, 0 failed**
- Local-usage suite: **44 passed, 0 failed**

Note for the next person: `check:tools-tests` type-checks tests that import `../dist/index.js`, so running it against a stale `dist` reports confident errors in unrelated suites. Build first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how scan time windows handle zero, negative, invalid, infinite, and extremely large values.
  * Documented that wider scan windows consistently include at least as much history as narrower windows.

* **Tests**
  * Added coverage confirming scan results grow monotonically as the scan window expands.
  * Improved proxy test reporting by distinguishing route failures from unavailable test servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->