### PR TITLE
fix(proxy): relay Codex streams through one tracker

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -65,6 +65,7 @@ import type {
   ProxyRuntimeActivity,
   ProxyRuntimeConfigSnapshot,
   ProxyReadinessState,
+  ProxyResponseTrackingObserver,
   RuntimeRequestMetadata,
   StatusStats,
 } from "../../lib/types/index.js";
@@ -84,6 +85,7 @@ import { resolveProxyStatusAccountIdentity } from "../../lib/proxy/codexAccountU
 import {
   beginProxyRequest,
   getProxyActivitySnapshot,
+  takeProxyResponseObservers,
   trackProxyResponse,
 } from "../../lib/proxy/proxyActivity.js";
 import {
@@ -1462,6 +1464,33 @@ function registerProxyRequestTracking(
         responseStatus,
         elapsedMs: performance.now() - startedMonotonicMs,
       });
+      const routeResponseObservers = takeProxyResponseObservers(metadata);
+      const notifyRouteFirstChunk = (
+        details: Parameters<
+          NonNullable<ProxyResponseTrackingObserver["onFirstChunk"]>
+        >[0],
+      ): void => {
+        for (const observer of routeResponseObservers) {
+          try {
+            observer.onFirstChunk?.(details);
+          } catch {
+            // Route-level accounting must never interfere with the relay.
+          }
+        }
+      };
+      const notifyRouteTerminal = (
+        details: Parameters<
+          NonNullable<ProxyResponseTrackingObserver["onTerminal"]>
+        >[0],
+      ): void => {
+        for (const observer of routeResponseObservers) {
+          try {
+            observer.onTerminal?.(details);
+          } catch {
+            // Route-level accounting must never interfere with the relay.
+          }
+        }
+      };
       c.res = trackProxyResponse(c.res, finish, {
         onFirstChunk: ({ observedBodyBytes, responseChunks }) => {
           logProxyLifecycleEvent({
@@ -1478,6 +1507,10 @@ function registerProxyRequestTracking(
             observedBodyBytes,
             responseChunks,
             elapsedMs: performance.now() - startedMonotonicMs,
+          });
+          notifyRouteFirstChunk({
+            observedBodyBytes,
+            responseChunks,
           });
         },
         onTerminal: ({ outcome, observedBodyBytes, responseChunks }) => {
@@ -1498,6 +1531,11 @@ function registerProxyRequestTracking(
             terminalOutcome: outcome,
             errorType: metadata.terminalErrorType,
             errorCode: metadata.terminalErrorCode,
+          });
+          notifyRouteTerminal({
+            outcome,
+            observedBodyBytes,
+            responseChunks,
           });
         },
       });
@@ -1919,7 +1957,10 @@ export async function createProxyStartApp(params: {
         neurolink: params.neurolink as NeuroLink,
         toolRegistry: params.neurolink.getToolRegistry(),
         timestamp: Date.now(),
-        metadata: {},
+        // Keep route terminal observers on the runtime request metadata so the
+        // outer response tracker can notify them without adding a second body
+        // wrapper to streaming routes.
+        metadata: (metadata ?? {}) as Record<string, unknown>,
         // Route handlers publish limit/quota headers here. Only the streaming
         // paths build their own Response (and set headers directly); every
         // JSON and error path returns a plain object, so without this the

--- a/src/lib/proxy/proxyActivity.ts
+++ b/src/lib/proxy/proxyActivity.ts
@@ -11,6 +11,35 @@ const PROXY_RESPONSE_CANCEL_TIMEOUT_MS = 1_000;
 let activeRequests = 0;
 let lastActivityAtMs: number | null = null;
 
+// Route handlers can attach terminal observers to their request context without
+// wrapping the response body a second time. The HTTP runtime drains every
+// response through one tracker, which fans these observers out at the point
+// where bytes actually leave the proxy.
+const responseObserversByMetadata = new WeakMap<
+  object,
+  ProxyResponseTrackingObserver[]
+>();
+
+export function registerProxyResponseObserver(
+  metadata: object,
+  observer: ProxyResponseTrackingObserver,
+): void {
+  const existing = responseObserversByMetadata.get(metadata);
+  if (existing) {
+    existing.push(observer);
+    return;
+  }
+  responseObserversByMetadata.set(metadata, [observer]);
+}
+
+export function takeProxyResponseObservers(
+  metadata: object,
+): ProxyResponseTrackingObserver[] {
+  const observers = responseObserversByMetadata.get(metadata) ?? [];
+  responseObserversByMetadata.delete(metadata);
+  return observers;
+}
+
 function touchActivity(): void {
   lastActivityAtMs = Date.now();
 }

--- a/src/lib/server/routes/codexProxyRoutes.ts
+++ b/src/lib/server/routes/codexProxyRoutes.ts
@@ -44,7 +44,7 @@ import {
   parseCodexRateLimitHeaders,
 } from "../../proxy/codexAccountUsage.js";
 import { buildClientAttribution } from "../../proxy/clientAttribution.js";
-import { trackProxyResponse } from "../../proxy/proxyActivity.js";
+import { registerProxyResponseObserver } from "../../proxy/proxyActivity.js";
 import { logRequest, logRequestAttempt } from "../../proxy/requestLogger.js";
 import { parseRetryAfterMs } from "../../proxy/routingPolicy.js";
 import {
@@ -620,7 +620,7 @@ export async function handleCodexResponsesRequest(
           status: upstream.status,
           headers,
         });
-        return trackProxyResponse(relay, () => undefined, {
+        registerProxyResponseObserver(ctx.metadata, {
           onTerminal: ({ outcome }) => {
             void usageSeen
               .then((usage) => {
@@ -658,6 +658,7 @@ export async function handleCodexResponsesRequest(
               .catch(() => undefined);
           },
         });
+        return relay;
       }
 
       const errText = await upstream.text().catch(() => "");

--- a/test/codex-quota-observability.test.ts
+++ b/test/codex-quota-observability.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/lib/proxy/accountCooldown.js";
 import {
   resetProxyActivityForTests,
+  takeProxyResponseObservers,
   trackProxyResponse,
 } from "../src/lib/proxy/proxyActivity.js";
 import { resolveProxyStatusAccountIdentity } from "../src/lib/proxy/codexAccountUsage.js";
@@ -435,11 +436,19 @@ describe.sequential("Codex quota observability", () => {
         headers: { "content-type": "text/event-stream" },
       })) as typeof globalThis.fetch;
 
-    const response = await handleCodexResponsesRequest(
-      requestContext("codex-stream-success"),
-    );
+    const ctx = requestContext("codex-stream-success");
+    const response = await handleCodexResponsesRequest(ctx);
     expect(getStats().totalRequests).toBe(0);
-    expect(await response.text()).toContain("response.completed");
+    const observers = takeProxyResponseObservers(ctx.metadata);
+    expect(observers).toHaveLength(1);
+    const trackedResponse = trackProxyResponse(response, () => undefined, {
+      onTerminal: (details) => {
+        for (const observer of observers) {
+          observer.onTerminal?.(details);
+        }
+      },
+    });
+    expect(await trackedResponse.text()).toContain("response.completed");
     await settleTerminalObservers();
 
     expect(getStats().accounts[account.key]).toMatchObject({


### PR DESCRIPTION
## Summary
- remove the redundant inner response tracker from the Codex streaming route
- deliver route terminal observers through the proxy runtime tracker instead
- retain Codex usage and terminal-outcome accounting without a second cancellation boundary

## Verification
- `pnpm exec vitest run test/codex-quota-observability.test.ts`
- `pnpm run test:codex`
- `pnpm run typecheck`
- `pnpm run lint`
- pre-push: dependency guard, production build, provider-structure, and model-manifest checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy response tracking for streamed responses, including first-chunk and completion events.
  * Ensured usage and quota accounting remains accurate when streaming requests finish successfully or encounter errors.
  * Prevented response-tracking failures from interrupting proxy request delivery.
* **Reliability**
  * Improved handling of terminal outcomes for Codex proxy requests without adding unnecessary processing to streamed response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->