### PR TITLE
fix(core): honor turnTimeoutMs and surface real timeout identity

### DIFF
--- a/docs/api/classes/ConversationMemoryError.md
+++ b/docs/api/classes/ConversationMemoryError.md
@@ -6,7 +6,7 @@
 
 # Class: ConversationMemoryError
 
-Defined in: [types/conversation.ts:441](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L441)
+Defined in: [types/conversation.ts:449](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L449)
 
 Error types specific to conversation memory
 
@@ -20,7 +20,7 @@ Error types specific to conversation memory
 
 > **new ConversationMemoryError**(`message`, `code`, `details?`): `ConversationMemoryError`
 
-Defined in: [types/conversation.ts:442](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L442)
+Defined in: [types/conversation.ts:450](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L450)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [types/conversation.ts:442](https://github.com/juspay/neurolink/blob
 
 > **code**: `"STORAGE_ERROR"` \| `"CONFIG_ERROR"` \| `"SESSION_NOT_FOUND"` \| `"CLEANUP_ERROR"`
 
-Defined in: [types/conversation.ts:444](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L444)
+Defined in: [types/conversation.ts:452](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L452)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/conversation.ts:444](https://github.com/juspay/neurolink/blob
 
 > `optional` **details?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/conversation.ts:449](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L449)
+Defined in: [types/conversation.ts:457](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L457)

--- a/docs/api/type-aliases/AdditionalMemoryUser.md
+++ b/docs/api/type-aliases/AdditionalMemoryUser.md
@@ -8,7 +8,7 @@
 
 > **AdditionalMemoryUser** = `object`
 
-Defined in: [types/generate.ts:814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L814)
+Defined in: [types/generate.ts:823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L823)
 
 Represents an additional user whose memory should be included in a generate/stream call.
 Allows per-user prompt overrides for different memory condensation strategies
@@ -20,7 +20,7 @@ Allows per-user prompt overrides for different memory condensation strategies
 
 > **userId**: `string`
 
-Defined in: [types/generate.ts:816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L816)
+Defined in: [types/generate.ts:825](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L825)
 
 The user/owner ID to retrieve or store memory for.
 
@@ -30,7 +30,7 @@ The user/owner ID to retrieve or store memory for.
 
 > `optional` **label?**: `string`
 
-Defined in: [types/generate.ts:822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L822)
+Defined in: [types/generate.ts:831](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L831)
 
 Human-readable label used in the formatted memory context.
 E.g. "Organization Policy", "Team Context", "User Preferences".
@@ -42,7 +42,7 @@ If not provided, defaults to userId.
 
 > `optional` **read?**: `boolean`
 
-Defined in: [types/generate.ts:824](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L824)
+Defined in: [types/generate.ts:833](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L833)
 
 Whether to read this user's memory and include in context. Defaults to true.
 
@@ -52,7 +52,7 @@ Whether to read this user's memory and include in context. Defaults to true.
 
 > `optional` **write?**: `boolean`
 
-Defined in: [types/generate.ts:826](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L826)
+Defined in: [types/generate.ts:835](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L835)
 
 Whether to write conversation into this user's memory. Defaults to true.
 
@@ -62,7 +62,7 @@ Whether to write conversation into this user's memory. Defaults to true.
 
 > `optional` **prompt?**: `string`
 
-Defined in: [types/generate.ts:828](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L828)
+Defined in: [types/generate.ts:837](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L837)
 
 Custom condensation prompt for this user. Overrides the default Hippocampus prompt.
 
@@ -72,6 +72,6 @@ Custom condensation prompt for this user. Overrides the default Hippocampus prom
 
 > `optional` **maxWords?**: `number`
 
-Defined in: [types/generate.ts:830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L830)
+Defined in: [types/generate.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L839)
 
 Max words for this user's condensed memory. Overrides the default maxWords.

--- a/docs/api/type-aliases/AgenticLoopReportMetadata.md
+++ b/docs/api/type-aliases/AgenticLoopReportMetadata.md
@@ -8,7 +8,7 @@
 
 > **AgenticLoopReportMetadata** = `object`
 
-Defined in: [types/conversation.ts:558](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L558)
+Defined in: [types/conversation.ts:566](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L566)
 
 Metadata for an individual agentic loop report
 A conversation session can have multiple reports tracked via this type
@@ -19,7 +19,7 @@ A conversation session can have multiple reports tracked via this type
 
 > **reportId**: `string`
 
-Defined in: [types/conversation.ts:560](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L560)
+Defined in: [types/conversation.ts:568](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L568)
 
 Unique identifier for this report
 
@@ -29,7 +29,7 @@ Unique identifier for this report
 
 > **reportType**: [`AgenticLoopReportType`](AgenticLoopReportType.md)
 
-Defined in: [types/conversation.ts:562](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L562)
+Defined in: [types/conversation.ts:570](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L570)
 
 Platform/category of the report
 
@@ -39,7 +39,7 @@ Platform/category of the report
 
 > **reportStatus**: [`AgenticLoopReportStatus`](AgenticLoopReportStatus.md)
 
-Defined in: [types/conversation.ts:564](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L564)
+Defined in: [types/conversation.ts:572](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L572)
 
 Current status of the report
 
@@ -49,7 +49,7 @@ Current status of the report
 
 > `optional` **auditPeriod?**: `object`
 
-Defined in: [types/conversation.ts:566](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L566)
+Defined in: [types/conversation.ts:574](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L574)
 
 Optional audit period date range for the report
 

--- a/docs/api/type-aliases/AgenticLoopReportStatus.md
+++ b/docs/api/type-aliases/AgenticLoopReportStatus.md
@@ -8,6 +8,6 @@
 
 > **AgenticLoopReportStatus** = `"INPROGRESS"` \| `"COMPLETED"` \| `"CANCELLED"` \| `"FAILED"`
 
-Defined in: [types/conversation.ts:548](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L548)
+Defined in: [types/conversation.ts:556](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L556)
 
 Status of an agentic loop report

--- a/docs/api/type-aliases/AgenticLoopReportType.md
+++ b/docs/api/type-aliases/AgenticLoopReportType.md
@@ -8,7 +8,7 @@
 
 > **AgenticLoopReportType** = `"META"` \| `"GOOGLEADS"` \| `"GOOGLEGA4"` \| `"SHOPIFY"` \| `"BREEZE"` \| `"OTHER"`
 
-Defined in: [types/conversation.ts:537](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L537)
+Defined in: [types/conversation.ts:545](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L545)
 
 Report type for agentic loop reports
 Identifies the platform or category of the report

--- a/docs/api/type-aliases/ChatMessage.md
+++ b/docs/api/type-aliases/ChatMessage.md
@@ -8,7 +8,7 @@
 
 > **ChatMessage** = `object`
 
-Defined in: [types/conversation.ts:333](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L333)
+Defined in: [types/conversation.ts:341](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L341)
 
 Chat message format for conversation history
 
@@ -18,7 +18,7 @@ Chat message format for conversation history
 
 > **id**: `string`
 
-Defined in: [types/conversation.ts:335](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L335)
+Defined in: [types/conversation.ts:343](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L343)
 
 Unique message identifier (required for token-based memory)
 
@@ -28,7 +28,7 @@ Unique message identifier (required for token-based memory)
 
 > **role**: `"user"` \| `"assistant"` \| `"system"` \| `"tool_call"` \| `"tool_result"`
 
-Defined in: [types/conversation.ts:338](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L338)
+Defined in: [types/conversation.ts:346](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L346)
 
 Role/type of the message
 
@@ -38,7 +38,7 @@ Role/type of the message
 
 > **content**: `string`
 
-Defined in: [types/conversation.ts:341](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L341)
+Defined in: [types/conversation.ts:349](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L349)
 
 Content of the message
 
@@ -48,7 +48,7 @@ Content of the message
 
 > `optional` **timestamp?**: `string`
 
-Defined in: [types/conversation.ts:349](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L349)
+Defined in: [types/conversation.ts:357](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L357)
 
 Message timestamp.
 Format: ISO 8601 string (e.g., "2025-01-01T12:30:00.000Z").
@@ -61,7 +61,7 @@ Use `metadata.timestamp` for numeric Unix ms representation.
 
 > `optional` **tool?**: `string`
 
-Defined in: [types/conversation.ts:352](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L352)
+Defined in: [types/conversation.ts:360](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L360)
 
 Tool name (optional) - for tool_call/tool_result messages
 
@@ -71,7 +71,7 @@ Tool name (optional) - for tool_call/tool_result messages
 
 > `optional` **toolCallId?**: `string`
 
-Defined in: [types/conversation.ts:364](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L364)
+Defined in: [types/conversation.ts:372](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L372)
 
 Provider tool-call correlation ID, carried on BOTH the `tool_call` and its
 matching `tool_result`. This is the only reliable way to pair the two:
@@ -88,7 +88,7 @@ existed pair positionally within a batch (see repairToolPairs legacy mode).
 
 > `optional` **args?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/conversation.ts:367](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L367)
+Defined in: [types/conversation.ts:375](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L375)
 
 Tool arguments (optional) - for tool_call messages
 
@@ -98,7 +98,7 @@ Tool arguments (optional) - for tool_call messages
 
 > `optional` **result?**: [`ToolResultData`](ToolResultData.md)
 
-Defined in: [types/conversation.ts:370](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L370)
+Defined in: [types/conversation.ts:378](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L378)
 
 Tool result metadata (optional) - for tool_result messages
 
@@ -108,7 +108,7 @@ Tool result metadata (optional) - for tool_result messages
 
 > `optional` **events?**: [`StreamEventSequence`](StreamEventSequence.md)[]
 
-Defined in: [types/conversation.ts:378](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L378)
+Defined in: [types/conversation.ts:386](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L386)
 
 Event sequence for rich history reconstruction
 Stores ordered events (text-chunk, ui-component, tool calls, HITL, etc.)
@@ -124,7 +124,7 @@ Enables proper ordering and complete context restoration
 
 > `optional` **metadata?**: [`ChatMessageMetadata`](ChatMessageMetadata.md)
 
-Defined in: [types/conversation.ts:381](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L381)
+Defined in: [types/conversation.ts:389](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L389)
 
 Message metadata
 
@@ -134,7 +134,7 @@ Message metadata
 
 > `optional` **condenseId?**: `string`
 
-Defined in: [types/conversation.ts:384](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L384)
+Defined in: [types/conversation.ts:392](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L392)
 
 UUID identifying this condensation group
 
@@ -144,7 +144,7 @@ UUID identifying this condensation group
 
 > `optional` **condenseParent?**: `string`
 
-Defined in: [types/conversation.ts:386](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L386)
+Defined in: [types/conversation.ts:394](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L394)
 
 Points to summary that replaces this message
 
@@ -154,7 +154,7 @@ Points to summary that replaces this message
 
 > `optional` **truncationId?**: `string`
 
-Defined in: [types/conversation.ts:388](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L388)
+Defined in: [types/conversation.ts:396](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L396)
 
 UUID identifying this truncation group
 
@@ -164,7 +164,7 @@ UUID identifying this truncation group
 
 > `optional` **truncationParent?**: `string`
 
-Defined in: [types/conversation.ts:390](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L390)
+Defined in: [types/conversation.ts:398](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L398)
 
 Points to truncation marker that hides this message
 
@@ -174,6 +174,6 @@ Points to truncation marker that hides this message
 
 > `optional` **isTruncationMarker?**: `boolean`
 
-Defined in: [types/conversation.ts:392](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L392)
+Defined in: [types/conversation.ts:400](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L400)
 
 Marks this message as a truncation boundary marker

--- a/docs/api/type-aliases/ChatMessageMetadata.md
+++ b/docs/api/type-aliases/ChatMessageMetadata.md
@@ -8,7 +8,7 @@
 
 > **ChatMessageMetadata** = `object`
 
-Defined in: [types/conversation.ts:260](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L260)
+Defined in: [types/conversation.ts:268](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L268)
 
 Metadata associated with a ChatMessage.
 
@@ -18,7 +18,7 @@ Metadata associated with a ChatMessage.
 
 > `optional` **isSummary?**: `boolean`
 
-Defined in: [types/conversation.ts:262](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L262)
+Defined in: [types/conversation.ts:270](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L270)
 
 Is this a summary message?
 
@@ -28,7 +28,7 @@ Is this a summary message?
 
 > `optional` **summarizesFrom?**: `string`
 
-Defined in: [types/conversation.ts:264](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L264)
+Defined in: [types/conversation.ts:272](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L272)
 
 First message ID that this summary covers
 
@@ -38,7 +38,7 @@ First message ID that this summary covers
 
 > `optional` **summarizesTo?**: `string`
 
-Defined in: [types/conversation.ts:266](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L266)
+Defined in: [types/conversation.ts:274](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L274)
 
 Last message ID that this summary covers
 
@@ -48,7 +48,7 @@ Last message ID that this summary covers
 
 > `optional` **truncated?**: `boolean`
 
-Defined in: [types/conversation.ts:268](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L268)
+Defined in: [types/conversation.ts:276](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L276)
 
 Was this message truncated due to token limits?
 
@@ -58,7 +58,7 @@ Was this message truncated due to token limits?
 
 > `optional` **source?**: `string`
 
-Defined in: [types/conversation.ts:270](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L270)
+Defined in: [types/conversation.ts:278](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L278)
 
 Source of the message (e.g., provider name, user input)
 
@@ -68,7 +68,7 @@ Source of the message (e.g., provider name, user input)
 
 > `optional` **language?**: `string`
 
-Defined in: [types/conversation.ts:272](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L272)
+Defined in: [types/conversation.ts:280](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L280)
 
 Language of the message content
 
@@ -78,7 +78,7 @@ Language of the message content
 
 > `optional` **confidence?**: `number`
 
-Defined in: [types/conversation.ts:274](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L274)
+Defined in: [types/conversation.ts:282](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L282)
 
 Confidence score for AI-generated content
 
@@ -88,7 +88,7 @@ Confidence score for AI-generated content
 
 > `optional` **timestamp?**: `number`
 
-Defined in: [types/conversation.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L281)
+Defined in: [types/conversation.ts:289](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L289)
 
 Numeric timestamp for internal tracking and efficient comparisons.
 Format: Unix epoch milliseconds (number).
@@ -101,7 +101,7 @@ Use this for sorting, filtering, and performance-critical operations.
 
 > `optional` **modelUsed?**: `string`
 
-Defined in: [types/conversation.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L283)
+Defined in: [types/conversation.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L291)
 
 Model used to generate this message
 
@@ -111,7 +111,7 @@ Model used to generate this message
 
 > `optional` **thoughtSignature?**: `string`
 
-Defined in: [types/conversation.ts:285](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L285)
+Defined in: [types/conversation.ts:293](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L293)
 
 Unique signature identifying thought/reasoning patterns
 
@@ -121,7 +121,7 @@ Unique signature identifying thought/reasoning patterns
 
 > `optional` **thoughtHash?**: `string`
 
-Defined in: [types/conversation.ts:287](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L287)
+Defined in: [types/conversation.ts:295](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L295)
 
 Hash of the thinking/reasoning content for deduplication
 
@@ -131,7 +131,7 @@ Hash of the thinking/reasoning content for deduplication
 
 > `optional` **thinkingExpanded?**: `boolean`
 
-Defined in: [types/conversation.ts:289](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L289)
+Defined in: [types/conversation.ts:297](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L297)
 
 Whether extended thinking was used for this message
 
@@ -141,7 +141,7 @@ Whether extended thinking was used for this message
 
 > `optional` **stepIndex?**: `number`
 
-Defined in: [types/conversation.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L291)
+Defined in: [types/conversation.ts:299](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L299)
 
 Step index for reconstructing parallel vs sequential tool calls
 
@@ -151,7 +151,7 @@ Step index for reconstructing parallel vs sequential tool calls
 
 > `optional` **toolOutputPreview?**: `string`
 
-Defined in: [types/conversation.ts:301](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L301)
+Defined in: [types/conversation.ts:309](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L309)
 
 Head/tail preview of a large tool output.
 Only present on tool_result messages where the output exceeded truncation limits.
@@ -164,7 +164,7 @@ this value as the message content instead of the full output.
 
 > `optional` **originalSize?**: `number`
 
-Defined in: [types/conversation.ts:303](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L303)
+Defined in: [types/conversation.ts:311](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L311)
 
 Original byte size of the full tool output before any truncation
 
@@ -174,7 +174,7 @@ Original byte size of the full tool output before any truncation
 
 > `optional` **artifactId?**: `string`
 
-Defined in: [types/conversation.ts:310](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L310)
+Defined in: [types/conversation.ts:318](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L318)
 
 Artifact store ID for an externalized MCP tool output.
 Set when `mcp.outputLimits.strategy = "externalize"` and the tool output
@@ -187,7 +187,7 @@ payload from the local artifact store.
 
 > `optional` **isSkill?**: `boolean`
 
-Defined in: [types/conversation.ts:321](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L321)
+Defined in: [types/conversation.ts:329](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L329)
 
 Marks a pinned skill-activation message: the full instructions of a
 skill loaded via use_skill, persisted into session history so later
@@ -201,7 +201,7 @@ re-included after memory summarization.
 
 > `optional` **skillId?**: `string`
 
-Defined in: [types/conversation.ts:323](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L323)
+Defined in: [types/conversation.ts:331](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L331)
 
 Skill id of a pinned skill-activation message.
 
@@ -211,7 +211,7 @@ Skill id of a pinned skill-activation message.
 
 > `optional` **skillName?**: `string`
 
-Defined in: [types/conversation.ts:325](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L325)
+Defined in: [types/conversation.ts:333](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L333)
 
 Skill name of a pinned skill-activation message.
 
@@ -221,6 +221,6 @@ Skill name of a pinned skill-activation message.
 
 > `optional` **skillVersion?**: `number`
 
-Defined in: [types/conversation.ts:327](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L327)
+Defined in: [types/conversation.ts:335](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L335)
 
 Skill version captured at activation (sessions pin the activated version).

--- a/docs/api/type-aliases/ConversationBase.md
+++ b/docs/api/type-aliases/ConversationBase.md
@@ -8,7 +8,7 @@
 
 > **ConversationBase** = `object`
 
-Defined in: [types/conversation.ts:614](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L614)
+Defined in: [types/conversation.ts:622](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L622)
 
 Base conversation metadata (shared fields across all conversation types)
 Contains essential conversation information without heavy data arrays
@@ -19,7 +19,7 @@ Contains essential conversation information without heavy data arrays
 
 > **id**: `string`
 
-Defined in: [types/conversation.ts:616](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L616)
+Defined in: [types/conversation.ts:624](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L624)
 
 Unique conversation identifier (UUID v4)
 
@@ -29,7 +29,7 @@ Unique conversation identifier (UUID v4)
 
 > **title**: `string`
 
-Defined in: [types/conversation.ts:619](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L619)
+Defined in: [types/conversation.ts:627](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L627)
 
 Auto-generated conversation title
 
@@ -39,7 +39,7 @@ Auto-generated conversation title
 
 > **sessionId**: `string`
 
-Defined in: [types/conversation.ts:622](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L622)
+Defined in: [types/conversation.ts:630](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L630)
 
 Session identifier
 
@@ -49,7 +49,7 @@ Session identifier
 
 > **userId**: `string`
 
-Defined in: [types/conversation.ts:625](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L625)
+Defined in: [types/conversation.ts:633](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L633)
 
 User identifier
 
@@ -59,7 +59,7 @@ User identifier
 
 > **createdAt**: `string`
 
-Defined in: [types/conversation.ts:628](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L628)
+Defined in: [types/conversation.ts:636](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L636)
 
 When this conversation was first created
 
@@ -69,7 +69,7 @@ When this conversation was first created
 
 > **updatedAt**: `string`
 
-Defined in: [types/conversation.ts:631](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L631)
+Defined in: [types/conversation.ts:639](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L639)
 
 When this conversation was last updated
 
@@ -79,7 +79,7 @@ When this conversation was last updated
 
 > `optional` **summarizedUpToMessageId?**: `string`
 
-Defined in: [types/conversation.ts:634](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L634)
+Defined in: [types/conversation.ts:642](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L642)
 
 Pointer to last summarized message (token-based memory)
 
@@ -89,7 +89,7 @@ Pointer to last summarized message (token-based memory)
 
 > `optional` **summarizedMessage?**: `string`
 
-Defined in: [types/conversation.ts:637](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L637)
+Defined in: [types/conversation.ts:645](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L645)
 
 Stored summary message that condenses conversation history up to summarizedUpToMessageId
 
@@ -99,7 +99,7 @@ Stored summary message that condenses conversation history up to summarizedUpToM
 
 > `optional` **tokenThreshold?**: `number`
 
-Defined in: [types/conversation.ts:640](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L640)
+Defined in: [types/conversation.ts:648](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L648)
 
 Per-session token threshold override
 
@@ -109,7 +109,7 @@ Per-session token threshold override
 
 > `optional` **lastTokenCount?**: `number`
 
-Defined in: [types/conversation.ts:643](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L643)
+Defined in: [types/conversation.ts:651](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L651)
 
 Cached token count for efficiency
 
@@ -119,7 +119,7 @@ Cached token count for efficiency
 
 > `optional` **lastCountedAt?**: `number`
 
-Defined in: [types/conversation.ts:646](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L646)
+Defined in: [types/conversation.ts:654](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L654)
 
 Timestamp of last token count
 
@@ -129,7 +129,7 @@ Timestamp of last token count
 
 > `optional` **lastApiTokenCount?**: `object`
 
-Defined in: [types/conversation.ts:649](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L649)
+Defined in: [types/conversation.ts:657](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L657)
 
 API-reported token count from last request
 
@@ -159,7 +159,7 @@ API-reported token count from last request
 
 > `optional` **additionalMetadata?**: `object`
 
-Defined in: [types/conversation.ts:658](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L658)
+Defined in: [types/conversation.ts:666](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L666)
 
 Additional metadata for extensible conversation-level data
 

--- a/docs/api/type-aliases/ConversationData.md
+++ b/docs/api/type-aliases/ConversationData.md
@@ -8,7 +8,7 @@
 
 > **ConversationData** = [`RedisConversationObject`](RedisConversationObject.md) & `object`
 
-Defined in: [types/conversation.ts:679](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L679)
+Defined in: [types/conversation.ts:687](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L687)
 
 Full conversation data for session restoration and manipulation
 Extends Redis storage object with additional loop mode metadata

--- a/docs/api/type-aliases/ConversationMemoryConfig.md
+++ b/docs/api/type-aliases/ConversationMemoryConfig.md
@@ -74,11 +74,24 @@ Model to use for summarization
 
 ---
 
+### summarizationTimeoutMs?
+
+> `optional` **summarizationTimeoutMs?**: `number`
+
+Defined in: [types/conversation.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L97)
+
+Wall-clock cap for one summarization generate call, in milliseconds
+(default: 60000). A summary that overruns is dropped, not fatal — the
+turn continues without it — so size this for the slowest summary a real
+conversation produces rather than losing compaction summaries silently.
+
+---
+
 ### memory?
 
 > `optional` **memory?**: [`HippocampusMemory`](HippocampusMemory.md)
 
-Defined in: [types/conversation.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L92)
+Defined in: [types/conversation.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L100)
 
 Memory SDK config (condensed key-value memory per user). Set enabled: true to activate.
 
@@ -88,7 +101,7 @@ Memory SDK config (condensed key-value memory per user). Set enabled: true to ac
 
 > `optional` **redisConfig?**: [`RedisStorageConfig`](RedisStorageConfig.md)
 
-Defined in: [types/conversation.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L95)
+Defined in: [types/conversation.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L103)
 
 Redis configuration (optional) - overrides environment variables
 
@@ -98,7 +111,7 @@ Redis configuration (optional) - overrides environment variables
 
 > `optional` **contextCompaction?**: `object`
 
-Defined in: [types/conversation.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L98)
+Defined in: [types/conversation.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L106)
 
 Context compaction configuration
 
@@ -166,7 +179,7 @@ File read budget as fraction of remaining context (default: 0.60)
 
 > `optional` **fileSummarization?**: `object`
 
-Defined in: [types/conversation.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L128)
+Defined in: [types/conversation.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L136)
 
 Configuration for automatic file content summarization when files exceed context budget
 
@@ -200,7 +213,7 @@ Configuration for automatic file content summarization when files exceed context
 
 > `optional` **maxTurnsPerSession?**: `number`
 
-Defined in: [types/conversation.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L138)
+Defined in: [types/conversation.ts:146](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L146)
 
 #### Deprecated
 
@@ -212,7 +225,7 @@ Use tokenThreshold instead - Maximum number of conversation turns to keep per se
 
 > `optional` **summarizationThresholdTurns?**: `number`
 
-Defined in: [types/conversation.ts:141](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L141)
+Defined in: [types/conversation.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L149)
 
 #### Deprecated
 
@@ -224,7 +237,7 @@ Use tokenThreshold instead - Turn count to trigger summarization
 
 > `optional` **summarizationTargetTurns?**: `number`
 
-Defined in: [types/conversation.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L144)
+Defined in: [types/conversation.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L152)
 
 #### Deprecated
 

--- a/docs/api/type-aliases/ConversationMemoryEvents.md
+++ b/docs/api/type-aliases/ConversationMemoryEvents.md
@@ -8,7 +8,7 @@
 
 > **ConversationMemoryEvents** = `object`
 
-Defined in: [types/conversation.ts:404](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L404)
+Defined in: [types/conversation.ts:412](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L412)
 
 Events emitted by conversation memory system
 
@@ -18,7 +18,7 @@ Events emitted by conversation memory system
 
 > **session:created**: `object`
 
-Defined in: [types/conversation.ts:409](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L409)
+Defined in: [types/conversation.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L417)
 
 Emitted when a new session is created.
 The timestamp field is Unix epoch milliseconds.
@@ -43,7 +43,7 @@ Event timestamp as Unix epoch milliseconds
 
 > **turn:stored**: `object`
 
-Defined in: [types/conversation.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L417)
+Defined in: [types/conversation.ts:425](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L425)
 
 Emitted when a conversation turn is stored
 
@@ -65,7 +65,7 @@ Emitted when a conversation turn is stored
 
 > **session:cleanup**: `object`
 
-Defined in: [types/conversation.ts:424](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L424)
+Defined in: [types/conversation.ts:432](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L432)
 
 Emitted when a session is cleaned up
 
@@ -87,7 +87,7 @@ Emitted when a session is cleaned up
 
 > **context:injected**: `object`
 
-Defined in: [types/conversation.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L431)
+Defined in: [types/conversation.ts:439](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L439)
 
 Emitted when context is injected
 

--- a/docs/api/type-aliases/ConversationMemoryStats.md
+++ b/docs/api/type-aliases/ConversationMemoryStats.md
@@ -8,7 +8,7 @@
 
 > **ConversationMemoryStats** = `object`
 
-Defined in: [types/conversation.ts:217](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L217)
+Defined in: [types/conversation.ts:225](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L225)
 
 Statistics about conversation memory usage (simplified for pure in-memory storage)
 
@@ -18,7 +18,7 @@ Statistics about conversation memory usage (simplified for pure in-memory storag
 
 > **totalSessions**: `number`
 
-Defined in: [types/conversation.ts:219](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L219)
+Defined in: [types/conversation.ts:227](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L227)
 
 Total number of active sessions
 
@@ -28,6 +28,6 @@ Total number of active sessions
 
 > **totalTurns**: `number`
 
-Defined in: [types/conversation.ts:222](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L222)
+Defined in: [types/conversation.ts:230](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L230)
 
 Total number of conversation turns across all sessions

--- a/docs/api/type-aliases/ConversationSummary.md
+++ b/docs/api/type-aliases/ConversationSummary.md
@@ -8,7 +8,7 @@
 
 > **ConversationSummary** = [`ConversationBase`](ConversationBase.md) & `object`
 
-Defined in: [types/conversation.ts:695](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L695)
+Defined in: [types/conversation.ts:703](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L703)
 
 Conversation summary for listing and selection
 Contains conversation preview information without heavy message arrays

--- a/docs/api/type-aliases/EnhancedGenerateResult.md
+++ b/docs/api/type-aliases/EnhancedGenerateResult.md
@@ -8,7 +8,7 @@
 
 > **EnhancedGenerateResult** = [`GenerateResult`](GenerateResult.md) & `object`
 
-Defined in: [types/generate.ts:1696](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1696)
+Defined in: [types/generate.ts:1705](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1705)
 
 ## Type Declaration
 

--- a/docs/api/type-aliases/EnhancedProvider.md
+++ b/docs/api/type-aliases/EnhancedProvider.md
@@ -8,7 +8,7 @@
 
 > **EnhancedProvider** = `object`
 
-Defined in: [types/generate.ts:1181](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1181)
+Defined in: [types/generate.ts:1190](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1190)
 
 Enhanced provider type with generate method
 
@@ -18,7 +18,7 @@ Enhanced provider type with generate method
 
 > **generate**(`options`): `Promise`\<[`GenerateResult`](GenerateResult.md)\>
 
-Defined in: [types/generate.ts:1182](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1182)
+Defined in: [types/generate.ts:1191](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1191)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/generate.ts:1182](https://github.com/juspay/neurolink/blob/re
 
 > **getName**(): `string`
 
-Defined in: [types/generate.ts:1183](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1183)
+Defined in: [types/generate.ts:1192](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1192)
 
 #### Returns
 
@@ -48,7 +48,7 @@ Defined in: [types/generate.ts:1183](https://github.com/juspay/neurolink/blob/re
 
 > **isAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [types/generate.ts:1184](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1184)
+Defined in: [types/generate.ts:1193](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1193)
 
 #### Returns
 

--- a/docs/api/type-aliases/FactoryEnhancedProvider.md
+++ b/docs/api/type-aliases/FactoryEnhancedProvider.md
@@ -8,7 +8,7 @@
 
 > **FactoryEnhancedProvider** = [`EnhancedProvider`](EnhancedProvider.md) & `object`
 
-Defined in: [types/generate.ts:1191](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1191)
+Defined in: [types/generate.ts:1200](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1200)
 
 Factory-enhanced provider type
 Supports domain configuration and streaming optimizations

--- a/docs/api/type-aliases/GenerateOptions.md
+++ b/docs/api/type-aliases/GenerateOptions.md
@@ -574,7 +574,7 @@ await neurolink.generate({
 
 > `optional` **timeout?**: `number` \| `string`
 
-Defined in: [types/generate.ts:387](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L387)
+Defined in: [types/generate.ts:394](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L394)
 
 Request timeout (e.g. 30000, '30s', '2m').
 
@@ -582,7 +582,14 @@ PER-STEP semantics in agentic loops: on providers that run a native
 multi-step tool loop (Vertex Gemini / Vertex Claude), this bounds EACH
 model call in the loop, not the whole turn — a tool-heavy turn may run
 far longer than this value in total. Size it for the slowest single
-step (default 300s), and use `abortSignal` for a total-turn deadline.
+step (default 300s), and use `turnTimeoutMs` (or `abortSignal`) for a
+total-turn deadline.
+
+On the AI-SDK loop path (direct Anthropic, litellm, OpenAI-compatible)
+the same split holds only when `turnTimeoutMs` is ALSO set: then this
+value bounds each model call and `turnTimeoutMs` bounds the turn. With
+`turnTimeoutMs` unset, this value bounds the WHOLE turn there (the
+pre-existing defensive behavior, kept for backward compatibility).
 
 When set explicitly, a step timeout is surfaced immediately instead of
 burning internal retries/fallbacks that would re-run the same
@@ -594,7 +601,7 @@ provider+model with the same doomed budget.
 
 > `optional` **turnTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L405)
+Defined in: [types/generate.ts:414](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L414)
 
 Hard wall-clock cap for the WHOLE agentic turn (all model calls + tool
 executions), in milliseconds. When the deadline passes the turn ends
@@ -603,9 +610,11 @@ never the step-cap text. Unset = no turn-level deadline (the library
 imposes no product policy).
 
 Enforced by the native Vertex loops (Gemini + Claude) AND the AI-SDK
-loop path (litellm and other OpenAI-compatible providers). On the AI-SDK
-path, an explicit `timeout` also engages the same wrap-up when
-`turnTimeoutMs` is unset. Once the wrap-up window begins (see
+loop path (direct Anthropic, litellm and other OpenAI-compatible
+providers). On the AI-SDK path this value also owns the whole-turn hard
+abort: when set, `timeout` keeps its per-model-call meaning instead of
+bounding the entire loop. An explicit `timeout` also engages the same
+wrap-up when `turnTimeoutMs` is unset. Once the wrap-up window begins (see
 `wrapupTimeLeadMs`), the loop forcibly sets `toolChoice: "none"` for the
 remaining steps — overriding any caller-supplied `toolChoice` or
 `prepareStep` tool selection — and appends an honest time message that a
@@ -618,7 +627,7 @@ wrap-up nudge is applied). An honest partial beats a discarded turn.
 
 > `optional` **stallTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:420](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L420)
+Defined in: [types/generate.ts:429](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L429)
 
 Maximum time with NO progress — no stream chunk received, no tool
 execution started or finished, no step started — before the turn ends
@@ -639,7 +648,7 @@ without this note a caller would reasonably read silence as coverage.
 
 > `optional` **wrapupTimeLeadMs?**: `number`
 
-Defined in: [types/generate.ts:432](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L432)
+Defined in: [types/generate.ts:441](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L441)
 
 When the remaining turn time drops below this, a wrap-up nudge rides the
 next tool-result turn telling the model to consolidate what it has and
@@ -657,7 +666,7 @@ exact override semantics.
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:438](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L438)
+Defined in: [types/generate.ts:447](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L447)
 
 Per-tool-execution timeout in milliseconds (default 300_000). A tool
 that exceeds it fails with an error tool_result and costs one step —
@@ -669,7 +678,7 @@ the turn continues instead of hanging on a wedged tool.
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:440](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L440)
+Defined in: [types/generate.ts:449](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L449)
 
 AbortSignal for external cancellation of the AI call
 
@@ -679,7 +688,7 @@ AbortSignal for external cancellation of the AI call
 
 > `optional` **toolExecutionCapture?**: [`ToolExecutionCaptureOptions`](ToolExecutionCaptureOptions.md)
 
-Defined in: [types/generate.ts:447](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L447)
+Defined in: [types/generate.ts:456](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L456)
 
 Bounds for the per-call tool execution records surfaced on
 `GenerateResult.toolExecutions`. Capture is on by default
@@ -692,7 +701,7 @@ needs full result texts.
 
 > `optional` **disableToolCallRepair?**: `boolean`
 
-Defined in: [types/generate.ts:449](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L449)
+Defined in: [types/generate.ts:458](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L458)
 
 Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled).
 
@@ -702,7 +711,7 @@ Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (r
 
 > `optional` **disableTools?**: `boolean`
 
-Defined in: [types/generate.ts:469](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L469)
+Defined in: [types/generate.ts:478](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L478)
 
 Disable tool execution (including built-in tools)
 
@@ -729,7 +738,7 @@ await neurolink.generate({
 
 > `optional` **toolFilter?**: `string`[]
 
-Defined in: [types/generate.ts:472](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L472)
+Defined in: [types/generate.ts:481](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L481)
 
 Include only these tools by name (whitelist). If set, only matching tools are available.
 
@@ -739,7 +748,7 @@ Include only these tools by name (whitelist). If set, only matching tools are av
 
 > `optional` **excludeTools?**: `string`[]
 
-Defined in: [types/generate.ts:475](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L475)
+Defined in: [types/generate.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L484)
 
 Exclude these tools by name (blacklist). Applied after toolFilter.
 
@@ -749,7 +758,7 @@ Exclude these tools by name (blacklist). Applied after toolFilter.
 
 > `optional` **skipToolPromptInjection?**: `boolean`
 
-Defined in: [types/generate.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L483)
+Defined in: [types/generate.ts:492](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L492)
 
 Skip injecting tool schemas into the system prompt.
 When true, tools are ONLY passed natively via the provider's `tools` parameter,
@@ -762,7 +771,7 @@ Default: false (backward compatible — tool schemas are injected into system pr
 
 > `optional` **disableToolCache?**: `boolean`
 
-Defined in: [types/generate.ts:486](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L486)
+Defined in: [types/generate.ts:495](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L495)
 
 Disable tool result caching for this request (overrides global mcp.cache.enabled)
 
@@ -772,7 +781,7 @@ Disable tool result caching for this request (overrides global mcp.cache.enabled
 
 > `optional` **maxSteps?**: `number`
 
-Defined in: [types/generate.ts:489](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L489)
+Defined in: [types/generate.ts:498](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L498)
 
 Maximum number of tool execution steps (default: 200)
 
@@ -782,7 +791,7 @@ Maximum number of tool execution steps (default: 200)
 
 > `optional` **toolChoice?**: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>
 
-Defined in: [types/generate.ts:504](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L504)
+Defined in: [types/generate.ts:513](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L513)
 
 Tool choice configuration for the generation.
 Controls whether and which tools the model must call.
@@ -802,7 +811,7 @@ will cause infinite tool calls until `maxSteps` is exhausted.
 
 > `optional` **prepareStep?**: (`options`) => `PromiseLike`\<\{ `model?`: `LanguageModel`; `toolChoice?`: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>; `experimental_activeTools?`: `string`[]; \} \| `undefined`\>
 
-Defined in: [types/generate.ts:529](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L529)
+Defined in: [types/generate.ts:538](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L538)
 
 Optional callback that runs before each step in a multi-step generation.
 Allows dynamically changing `toolChoice` and available tools per step.
@@ -859,7 +868,7 @@ https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#parameters
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/generate.ts:544](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L544)
+Defined in: [types/generate.ts:553](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L553)
 
 ---
 
@@ -867,7 +876,7 @@ Defined in: [types/generate.ts:544](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/generate.ts:545](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L545)
+Defined in: [types/generate.ts:554](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L554)
 
 ---
 
@@ -875,7 +884,7 @@ Defined in: [types/generate.ts:545](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **context?**: [`StandardRecord`](StandardRecord.md)
 
-Defined in: [types/generate.ts:546](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L546)
+Defined in: [types/generate.ts:555](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L555)
 
 ---
 
@@ -883,7 +892,7 @@ Defined in: [types/generate.ts:546](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/generate.ts:549](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L549)
+Defined in: [types/generate.ts:558](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L558)
 
 ---
 
@@ -891,7 +900,7 @@ Defined in: [types/generate.ts:549](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/generate.ts:550](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L550)
+Defined in: [types/generate.ts:559](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L559)
 
 ---
 
@@ -899,7 +908,7 @@ Defined in: [types/generate.ts:550](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/generate.ts:557](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L557)
+Defined in: [types/generate.ts:566](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L566)
 
 #### ~~role~~
 
@@ -922,7 +931,7 @@ correctly wired through the entire generate pipeline.
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/generate.ts:565](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L565)
+Defined in: [types/generate.ts:574](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L574)
 
 Previous conversation as a ChatMessage array.
 Messages are injected as proper multi-turn conversation history before the current prompt,
@@ -935,7 +944,7 @@ Used by task continuation mode and available to external callers.
 
 > `optional` **factoryConfig?**: `object`
 
-Defined in: [types/generate.ts:568](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L568)
+Defined in: [types/generate.ts:577](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L577)
 
 #### domainType?
 
@@ -963,7 +972,7 @@ Defined in: [types/generate.ts:568](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **streaming?**: `object`
 
-Defined in: [types/generate.ts:582](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L582)
+Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L591)
 
 #### enabled?
 
@@ -991,7 +1000,7 @@ Defined in: [types/generate.ts:582](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **workflow?**: `string`
 
-Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L591)
+Defined in: [types/generate.ts:600](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L600)
 
 ---
 
@@ -999,7 +1008,7 @@ Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **workflowConfig?**: [`WorkflowConfig`](WorkflowConfig.md)
 
-Defined in: [types/generate.ts:592](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L592)
+Defined in: [types/generate.ts:601](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L601)
 
 ---
 
@@ -1007,7 +1016,7 @@ Defined in: [types/generate.ts:592](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **rag?**: [`RAGConfig`](RAGConfig.md)
 
-Defined in: [types/generate.ts:626](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L626)
+Defined in: [types/generate.ts:635](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L635)
 
 RAG (Retrieval-Augmented Generation) configuration.
 
@@ -1046,7 +1055,7 @@ const result = await neurolink.generate({
 
 > `optional` **maxBudgetUsd?**: `number`
 
-Defined in: [types/generate.ts:641](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L641)
+Defined in: [types/generate.ts:650](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L650)
 
 Maximum budget in USD for this session. When the accumulated cost of all
 generate() calls on this NeuroLink instance exceeds this value, subsequent
@@ -1067,7 +1076,7 @@ const result = await neurolink.generate({
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/generate.ts:648](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L648)
+Defined in: [types/generate.ts:657](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L657)
 
 Optional request identifier for observability and log correlation.
 When provided, this ID is forwarded to spans, logs, and telemetry so
@@ -1079,7 +1088,7 @@ callers can correlate generation traces back to their own request lifecycle.
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/generate.ts:663](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L663)
+Defined in: [types/generate.ts:672](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L672)
 
 Per-call middleware configuration.
 
@@ -1089,7 +1098,7 @@ Per-call middleware configuration.
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/generate.ts:666](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L666)
+Defined in: [types/generate.ts:675](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L675)
 
 Callback invoked when generation completes successfully.
 
@@ -1099,7 +1108,7 @@ Callback invoked when generation completes successfully.
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/generate.ts:669](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L669)
+Defined in: [types/generate.ts:678](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L678)
 
 Callback invoked when generation encounters an error.
 
@@ -1109,7 +1118,7 @@ Callback invoked when generation encounters an error.
 
 > `optional` **requestContext?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:672](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L672)
+Defined in: [types/generate.ts:681](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L681)
 
 Pre-validated user context for the request
 
@@ -1119,7 +1128,7 @@ Pre-validated user context for the request
 
 > `optional` **useKnowledgeGrounding?**: `boolean`
 
-Defined in: [types/generate.ts:678](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L678)
+Defined in: [types/generate.ts:687](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L687)
 
 Opt this generation call into the knowledge grounding configured on the
 NeuroLink instance. Defaults to `false` when omitted.
@@ -1130,7 +1139,7 @@ NeuroLink instance. Defaults to `false` when omitted.
 
 > `optional` **knowledgeContext?**: [`KnowledgeRequestScope`](KnowledgeRequestScope.md)
 
-Defined in: [types/generate.ts:685](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L685)
+Defined in: [types/generate.ts:694](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L694)
 
 Enabled integrations used to scope knowledge retrieval for this turn.
 Used only when `useKnowledgeGrounding` is true and knowledge grounding is
@@ -1142,7 +1151,7 @@ enabled on the NeuroLink instance.
 
 > `optional` **auth?**: `object`
 
-Defined in: [types/generate.ts:688](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L688)
+Defined in: [types/generate.ts:697](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L697)
 
 Raw auth token — validated by configured auth provider
 
@@ -1156,7 +1165,7 @@ Raw auth token — validated by configured auth provider
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/generate.ts:695](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L695)
+Defined in: [types/generate.ts:704](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L704)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -1168,7 +1177,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **providerFallback?**: (`error`) => `Promise`\<\{ `provider?`: `string`; `model?`: `string`; \} \| `null`\>
 
-Defined in: [types/generate.ts:706](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L706)
+Defined in: [types/generate.ts:715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L715)
 
 Curator P2-3: per-call fallback callback. Overrides any
 instance-level `providerFallback` set on `new NeuroLink({...})`.
@@ -1194,7 +1203,7 @@ retry, `null` to bubble.
 
 > `optional` **modelChain?**: `string`[]
 
-Defined in: [types/generate.ts:716](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L716)
+Defined in: [types/generate.ts:725](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L725)
 
 Curator P2-3: per-call ordered model chain. Overrides any
 instance-level `modelChain`. Without an explicit `providerFallback`
@@ -1207,7 +1216,7 @@ other failures (network, 5xx, timeouts) bubble immediately.
 
 > `optional` **memory?**: `object`
 
-Defined in: [types/generate.ts:726](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L726)
+Defined in: [types/generate.ts:735](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L735)
 
 Per-call memory control.
 
@@ -1247,7 +1256,7 @@ Primary user is still determined by context.userId.
 
 > `optional` **piiDetection?**: `object`
 
-Defined in: [types/generate.ts:745](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L745)
+Defined in: [types/generate.ts:754](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L754)
 
 PII detection — scans and optionally redacts PII from input before the LLM call.
 
@@ -1287,7 +1296,7 @@ PII detection — scans and optionally redacts PII from input before the LLM cal
 
 > `optional` **responseValidation?**: `object`
 
-Defined in: [types/generate.ts:770](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L770)
+Defined in: [types/generate.ts:779](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L779)
 
 Response validation — validates and optionally transforms the LLM response.
 Supports retry-with-feedback when `retryOnFailure: true`.
@@ -1354,7 +1363,7 @@ Supports retry-with-feedback when `retryOnFailure: true`.
 
 > `optional` **inputValidation?**: `object`
 
-Defined in: [types/generate.ts:788](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L788)
+Defined in: [types/generate.ts:797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L797)
 
 Input validation — validates input text before any processing.
 
@@ -1380,7 +1389,7 @@ Input validation — validates input text before any processing.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/generate.ts:798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L798)
+Defined in: [types/generate.ts:807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L807)
 
 #### Deprecated
 
@@ -1392,7 +1401,7 @@ Use `piiDetection`, `responseValidation`, and `inputValidation` instead.
 
 > `optional` **skills?**: [`SkillsCallOptions`](SkillsCallOptions.md)
 
-Defined in: [types/generate.ts:806](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L806)
+Defined in: [types/generate.ts:815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L815)
 
 Per-call skills control. Only effective when the instance was
 constructed with `skills.enabled: true`. Lets a call disable the

--- a/docs/api/type-aliases/GenerateOptionsNormalized.md
+++ b/docs/api/type-aliases/GenerateOptionsNormalized.md
@@ -8,7 +8,7 @@
 
 > **GenerateOptionsNormalized** = [`GenerateOptions`](GenerateOptions.md) & `object`
 
-Defined in: [types/generate.ts:1723](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1723)
+Defined in: [types/generate.ts:1732](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1732)
 
 Internal alias used by messageBuilder helpers after the entry-point
 (`buildMultimodalMessagesArray`) has guaranteed that `input` is non-null.

--- a/docs/api/type-aliases/GenerateResult.md
+++ b/docs/api/type-aliases/GenerateResult.md
@@ -8,7 +8,7 @@
 
 > **GenerateResult** = `object` & [`MediaGenerationOutputs`](MediaGenerationOutputs.md)
 
-Defined in: [types/generate.ts:1018](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1018)
+Defined in: [types/generate.ts:1027](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1027)
 
 Generate function result type - Primary output format
 Future-ready for multi-modal outputs while maintaining text focus

--- a/docs/api/type-aliases/GenerateStopReason.md
+++ b/docs/api/type-aliases/GenerateStopReason.md
@@ -8,7 +8,7 @@
 
 > **GenerateStopReason** = `"completed"` \| `"step-cap"` \| `"context-cap"` \| `"time-limit"` \| `"stalled"` \| `"aborted"` \| `"provider-error"`
 
-Defined in: [types/generate.ts:899](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L899)
+Defined in: [types/generate.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L908)
 
 Why an agentic turn ended — the discriminator consumers should branch on
 instead of sniffing the provider-shaped `finishReason` (whose values are

--- a/docs/api/type-aliases/MediaGenerationOutputs.md
+++ b/docs/api/type-aliases/MediaGenerationOutputs.md
@@ -8,7 +8,7 @@
 
 > **MediaGenerationOutputs** = `object`
 
-Defined in: [types/generate.ts:914](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L914)
+Defined in: [types/generate.ts:923](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L923)
 
 Media generation/processing outputs shared by GenerateResult and
 TextGenerationResult. Extracted so both result types intersect (&) this
@@ -21,7 +21,7 @@ same audio/video/avatar/music/ppt/image/transcription fields.
 
 > `optional` **audio?**: [`TTSResult`](TTSResult.md)
 
-Defined in: [types/generate.ts:943](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L943)
+Defined in: [types/generate.ts:952](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L952)
 
 Text-to-Speech audio result
 
@@ -57,7 +57,7 @@ if (result.audio) {
 
 > `optional` **ttsMetadata?**: [`TTSMetadata`](TTSMetadata.md)
 
-Defined in: [types/generate.ts:957](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L957)
+Defined in: [types/generate.ts:966](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L966)
 
 What happened during TTS synthesis, including why it failed.
 
@@ -77,7 +77,7 @@ neurolink.ts describes, on a different field.
 
 > `optional` **video?**: [`VideoGenerationResult`](VideoGenerationResult.md)
 
-Defined in: [types/generate.ts:981](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L981)
+Defined in: [types/generate.ts:990](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L990)
 
 Video generation result
 
@@ -109,7 +109,7 @@ if (result.video) {
 
 > `optional` **avatar?**: [`AvatarResult`](AvatarResult.md)
 
-Defined in: [types/generate.ts:985](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L985)
+Defined in: [types/generate.ts:994](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L994)
 
 Avatar (talking-head) generation result (present when output.mode is "avatar")
 
@@ -119,7 +119,7 @@ Avatar (talking-head) generation result (present when output.mode is "avatar")
 
 > `optional` **music?**: [`MusicResult`](MusicResult.md)
 
-Defined in: [types/generate.ts:989](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L989)
+Defined in: [types/generate.ts:998](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L998)
 
 Music generation result (present when output.mode is "music")
 
@@ -129,7 +129,7 @@ Music generation result (present when output.mode is "music")
 
 > `optional` **ppt?**: [`PPTGenerationResult`](PPTGenerationResult.md)
 
-Defined in: [types/generate.ts:1007](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1007)
+Defined in: [types/generate.ts:1016](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1016)
 
 PowerPoint generation result (present when output.mode is "ppt")
 
@@ -154,7 +154,7 @@ if (result.ppt) {
 
 > `optional` **imageOutput?**: \{ `base64`: `string`; \} \| `null`
 
-Defined in: [types/generate.ts:1009](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1009)
+Defined in: [types/generate.ts:1018](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1018)
 
 Standard format for image generation
 
@@ -164,6 +164,6 @@ Standard format for image generation
 
 > `optional` **transcription?**: [`STTResult`](STTResult.md)
 
-Defined in: [types/generate.ts:1011](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1011)
+Defined in: [types/generate.ts:1020](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1020)
 
 STT transcription result (present when stt.enabled is true and audio input was provided)

--- a/docs/api/type-aliases/MinimalChatMessage.md
+++ b/docs/api/type-aliases/MinimalChatMessage.md
@@ -8,7 +8,7 @@
 
 > **MinimalChatMessage** = `object`
 
-Defined in: [types/conversation.ts:767](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L767)
+Defined in: [types/conversation.ts:775](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L775)
 
 Reduced ChatMessage shape used by callers (typically tests and history
 reconstructors) that pass synthetic entries into the Gemini history
@@ -21,7 +21,7 @@ fields actually read by `prependConversationMessages`.
 
 > **role**: [`ChatMessage`](ChatMessage.md)\[`"role"`\]
 
-Defined in: [types/conversation.ts:768](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L768)
+Defined in: [types/conversation.ts:776](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L776)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [types/conversation.ts:768](https://github.com/juspay/neurolink/blob
 
 > **content**: `string`
 
-Defined in: [types/conversation.ts:769](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L769)
+Defined in: [types/conversation.ts:777](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L777)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [types/conversation.ts:769](https://github.com/juspay/neurolink/blob
 
 > `optional` **tool?**: `string`
 
-Defined in: [types/conversation.ts:770](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L770)
+Defined in: [types/conversation.ts:778](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L778)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [types/conversation.ts:770](https://github.com/juspay/neurolink/blob
 
 > `optional` **args?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/conversation.ts:771](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L771)
+Defined in: [types/conversation.ts:779](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L779)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [types/conversation.ts:771](https://github.com/juspay/neurolink/blob
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/conversation.ts:772](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L772)
+Defined in: [types/conversation.ts:780](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L780)
 
 #### stepIndex?
 

--- a/docs/api/type-aliases/ModelAliasConfig.md
+++ b/docs/api/type-aliases/ModelAliasConfig.md
@@ -8,7 +8,7 @@
 
 > **ModelAliasConfig** = `object`
 
-Defined in: [types/generate.ts:1706](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1706)
+Defined in: [types/generate.ts:1715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1715)
 
 NL-004: Model alias/deprecation configuration.
 Allows mapping deprecated model names to their replacements.
@@ -19,4 +19,4 @@ Allows mapping deprecated model names to their replacements.
 
 > **aliases**: `Record`\<`string`, \{ `target`: `string`; `action`: `"warn"` \| `"redirect"` \| `"block"`; `reason?`: `string`; \}\>
 
-Defined in: [types/generate.ts:1707](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1707)
+Defined in: [types/generate.ts:1716](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1716)

--- a/docs/api/type-aliases/NeurolinkOptions.md
+++ b/docs/api/type-aliases/NeurolinkOptions.md
@@ -8,7 +8,7 @@
 
 > **NeurolinkOptions** = `object`
 
-Defined in: [types/conversation.ts:460](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L460)
+Defined in: [types/conversation.ts:468](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L468)
 
 NeuroLink initialization options
 Configuration for creating NeuroLink instances with conversation memory
@@ -19,7 +19,7 @@ Configuration for creating NeuroLink instances with conversation memory
 
 > `optional` **conversationMemory?**: [`ConversationMemoryConfig`](ConversationMemoryConfig.md)
 
-Defined in: [types/conversation.ts:462](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L462)
+Defined in: [types/conversation.ts:470](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L470)
 
 Conversation memory configuration
 
@@ -29,7 +29,7 @@ Conversation memory configuration
 
 > `optional` **sessionId?**: `string`
 
-Defined in: [types/conversation.ts:465](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L465)
+Defined in: [types/conversation.ts:473](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L473)
 
 Session identifier for conversation context
 
@@ -39,6 +39,6 @@ Session identifier for conversation context
 
 > `optional` **observability?**: [`ObservabilityConfig`](ObservabilityConfig.md)
 
-Defined in: [types/conversation.ts:468](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L468)
+Defined in: [types/conversation.ts:476](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L476)
 
 Observability configuration

--- a/docs/api/type-aliases/ProviderDetails.md
+++ b/docs/api/type-aliases/ProviderDetails.md
@@ -8,7 +8,7 @@
 
 > **ProviderDetails** = `object`
 
-Defined in: [types/conversation.ts:756](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L756)
+Defined in: [types/conversation.ts:764](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L764)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/conversation.ts:756](https://github.com/juspay/neurolink/blob
 
 > **provider**: `string`
 
-Defined in: [types/conversation.ts:757](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L757)
+Defined in: [types/conversation.ts:765](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L765)
 
 ---
 
@@ -24,4 +24,4 @@ Defined in: [types/conversation.ts:757](https://github.com/juspay/neurolink/blob
 
 > **model**: `string`
 
-Defined in: [types/conversation.ts:758](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L758)
+Defined in: [types/conversation.ts:766](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L766)

--- a/docs/api/type-aliases/RedisConversationObject.md
+++ b/docs/api/type-aliases/RedisConversationObject.md
@@ -8,7 +8,7 @@
 
 > **RedisConversationObject** = [`ConversationBase`](ConversationBase.md) & `object`
 
-Defined in: [types/conversation.ts:670](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L670)
+Defined in: [types/conversation.ts:678](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L678)
 
 Redis conversation storage object format
 Contains conversation metadata and full message history

--- a/docs/api/type-aliases/RedisStorageConfig.md
+++ b/docs/api/type-aliases/RedisStorageConfig.md
@@ -8,7 +8,7 @@
 
 > **RedisStorageConfig** = `object`
 
-Defined in: [types/conversation.ts:718](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L718)
+Defined in: [types/conversation.ts:726](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L726)
 
 Redis storage configuration
 
@@ -18,7 +18,7 @@ Redis storage configuration
 
 > `optional` **url?**: `string`
 
-Defined in: [types/conversation.ts:720](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L720)
+Defined in: [types/conversation.ts:728](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L728)
 
 Redis connection URL (e.g., 'rediss://host:6379' for TLS)
 
@@ -28,7 +28,7 @@ Redis connection URL (e.g., 'rediss://host:6379' for TLS)
 
 > `optional` **username?**: `string`
 
-Defined in: [types/conversation.ts:723](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L723)
+Defined in: [types/conversation.ts:731](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L731)
 
 Redis username for ACL authentication (optional)
 
@@ -38,7 +38,7 @@ Redis username for ACL authentication (optional)
 
 > `optional` **host?**: `string`
 
-Defined in: [types/conversation.ts:726](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L726)
+Defined in: [types/conversation.ts:734](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L734)
 
 Redis host (default: 'localhost')
 
@@ -48,7 +48,7 @@ Redis host (default: 'localhost')
 
 > `optional` **port?**: `number`
 
-Defined in: [types/conversation.ts:729](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L729)
+Defined in: [types/conversation.ts:737](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L737)
 
 Redis port (default: 6379)
 
@@ -58,7 +58,7 @@ Redis port (default: 6379)
 
 > `optional` **password?**: `string`
 
-Defined in: [types/conversation.ts:732](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L732)
+Defined in: [types/conversation.ts:740](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L740)
 
 Redis password (optional)
 
@@ -68,7 +68,7 @@ Redis password (optional)
 
 > `optional` **db?**: `number`
 
-Defined in: [types/conversation.ts:735](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L735)
+Defined in: [types/conversation.ts:743](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L743)
 
 Redis database number (default: 0)
 
@@ -78,7 +78,7 @@ Redis database number (default: 0)
 
 > `optional` **keyPrefix?**: `string`
 
-Defined in: [types/conversation.ts:738](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L738)
+Defined in: [types/conversation.ts:746](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L746)
 
 Key prefix for Redis keys (default: 'neurolink:conversation:')
 
@@ -88,7 +88,7 @@ Key prefix for Redis keys (default: 'neurolink:conversation:')
 
 > `optional` **userSessionsKeyPrefix?**: `string`
 
-Defined in: [types/conversation.ts:741](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L741)
+Defined in: [types/conversation.ts:749](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L749)
 
 Key prefix for user sessions mapping (default: derived from keyPrefix)
 
@@ -98,7 +98,7 @@ Key prefix for user sessions mapping (default: derived from keyPrefix)
 
 > `optional` **ttl?**: `number`
 
-Defined in: [types/conversation.ts:744](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L744)
+Defined in: [types/conversation.ts:752](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L752)
 
 Time-to-live in seconds (default: 86400, 24 hours)
 
@@ -108,7 +108,7 @@ Time-to-live in seconds (default: 86400, 24 hours)
 
 > `optional` **connectionOptions?**: `object`
 
-Defined in: [types/conversation.ts:747](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L747)
+Defined in: [types/conversation.ts:755](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L755)
 
 Additional Redis connection options
 

--- a/docs/api/type-aliases/SessionExport.md
+++ b/docs/api/type-aliases/SessionExport.md
@@ -8,7 +8,7 @@
 
 > **SessionExport** = `object`
 
-Defined in: [types/conversation.ts:589](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L589)
+Defined in: [types/conversation.ts:597](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L597)
 
 Complete session export format for backup/analytics
 Contains full session data including all messages
@@ -19,7 +19,7 @@ Contains full session data including all messages
 
 > **sessionId**: `string`
 
-Defined in: [types/conversation.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L591)
+Defined in: [types/conversation.ts:599](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L599)
 
 Session identifier
 
@@ -29,7 +29,7 @@ Session identifier
 
 > `optional` **title?**: `string`
 
-Defined in: [types/conversation.ts:593](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L593)
+Defined in: [types/conversation.ts:601](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L601)
 
 Session title/description
 
@@ -39,7 +39,7 @@ Session title/description
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/conversation.ts:595](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L595)
+Defined in: [types/conversation.ts:603](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L603)
 
 User identifier
 
@@ -49,7 +49,7 @@ User identifier
 
 > **createdAt**: `string`
 
-Defined in: [types/conversation.ts:597](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L597)
+Defined in: [types/conversation.ts:605](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L605)
 
 When session was created (ISO 8601)
 
@@ -59,7 +59,7 @@ When session was created (ISO 8601)
 
 > **updatedAt**: `string`
 
-Defined in: [types/conversation.ts:599](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L599)
+Defined in: [types/conversation.ts:607](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L607)
 
 When session was last updated (ISO 8601)
 
@@ -69,7 +69,7 @@ When session was last updated (ISO 8601)
 
 > **messages**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/conversation.ts:601](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L601)
+Defined in: [types/conversation.ts:609](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L609)
 
 Complete message history
 
@@ -79,7 +79,7 @@ Complete message history
 
 > `optional` **exportMetadata?**: `object`
 
-Defined in: [types/conversation.ts:603](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L603)
+Defined in: [types/conversation.ts:611](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L611)
 
 Export metadata
 

--- a/docs/api/type-aliases/SessionIdentifier.md
+++ b/docs/api/type-aliases/SessionIdentifier.md
@@ -8,7 +8,7 @@
 
 > **SessionIdentifier** = `object`
 
-Defined in: [types/conversation.ts:474](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L474)
+Defined in: [types/conversation.ts:482](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L482)
 
 Session identifier for Redis storage operations
 
@@ -18,7 +18,7 @@ Session identifier for Redis storage operations
 
 > **sessionId**: `string`
 
-Defined in: [types/conversation.ts:475](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L475)
+Defined in: [types/conversation.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L483)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/conversation.ts:475](https://github.com/juspay/neurolink/blob
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/conversation.ts:476](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L476)
+Defined in: [types/conversation.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L484)

--- a/docs/api/type-aliases/SessionListItem.md
+++ b/docs/api/type-aliases/SessionListItem.md
@@ -8,7 +8,7 @@
 
 > **SessionListItem** = [`SessionMetadata`](SessionMetadata.md) & `object`
 
-Defined in: [types/conversation.ts:576](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L576)
+Defined in: [types/conversation.ts:584](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L584)
 
 Session list item for CLI/API listing
 Extends SessionMetadata with additional display information

--- a/docs/api/type-aliases/SessionMemory.md
+++ b/docs/api/type-aliases/SessionMemory.md
@@ -8,7 +8,7 @@
 
 > **SessionMemory** = `object`
 
-Defined in: [types/conversation.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L150)
+Defined in: [types/conversation.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L158)
 
 Complete memory for a conversation session
 ULTRA-OPTIMIZED: Direct ChatMessage[] storage - zero conversion overhead
@@ -19,7 +19,7 @@ ULTRA-OPTIMIZED: Direct ChatMessage[] storage - zero conversion overhead
 
 > **sessionId**: `string`
 
-Defined in: [types/conversation.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L152)
+Defined in: [types/conversation.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L160)
 
 Unique session identifier
 
@@ -29,7 +29,7 @@ Unique session identifier
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/conversation.ts:155](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L155)
+Defined in: [types/conversation.ts:163](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L163)
 
 User identifier (optional)
 
@@ -39,7 +39,7 @@ User identifier (optional)
 
 > `optional` **title?**: `string`
 
-Defined in: [types/conversation.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L158)
+Defined in: [types/conversation.ts:166](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L166)
 
 Auto-generated conversation title (created on first user message)
 
@@ -49,7 +49,7 @@ Auto-generated conversation title (created on first user message)
 
 > **messages**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/conversation.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L161)
+Defined in: [types/conversation.ts:169](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L169)
 
 Direct message storage - ready for immediate AI consumption
 
@@ -59,7 +59,7 @@ Direct message storage - ready for immediate AI consumption
 
 > **createdAt**: `number`
 
-Defined in: [types/conversation.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L168)
+Defined in: [types/conversation.ts:176](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L176)
 
 When this session was created.
 Format: Unix epoch milliseconds (number).
@@ -71,7 +71,7 @@ Example: 1735689600000 for January 1, 2025, 00:00:00 UTC.
 
 > **lastActivity**: `number`
 
-Defined in: [types/conversation.ts:175](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L175)
+Defined in: [types/conversation.ts:183](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L183)
 
 When this session was last active.
 Format: Unix epoch milliseconds (number).
@@ -83,7 +83,7 @@ Updated on every message addition or session interaction.
 
 > `optional` **summarizedUpToMessageId?**: `string`
 
-Defined in: [types/conversation.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L178)
+Defined in: [types/conversation.ts:186](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L186)
 
 Pointer to last summarized message ID (NEW - for token-based memory)
 
@@ -93,7 +93,7 @@ Pointer to last summarized message ID (NEW - for token-based memory)
 
 > `optional` **summarizedMessage?**: `string`
 
-Defined in: [types/conversation.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L181)
+Defined in: [types/conversation.ts:189](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L189)
 
 Stored summary message that condenses conversation history up to summarizedUpToMessageId
 
@@ -103,7 +103,7 @@ Stored summary message that condenses conversation history up to summarizedUpToM
 
 > `optional` **tokenThreshold?**: `number`
 
-Defined in: [types/conversation.ts:184](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L184)
+Defined in: [types/conversation.ts:192](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L192)
 
 Per-session token threshold override (NEW - for token-based memory)
 
@@ -113,7 +113,7 @@ Per-session token threshold override (NEW - for token-based memory)
 
 > `optional` **lastTokenCount?**: `number`
 
-Defined in: [types/conversation.ts:187](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L187)
+Defined in: [types/conversation.ts:195](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L195)
 
 Cached token count for performance (NEW - for token-based memory)
 
@@ -123,7 +123,7 @@ Cached token count for performance (NEW - for token-based memory)
 
 > `optional` **lastCountedAt?**: `number`
 
-Defined in: [types/conversation.ts:190](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L190)
+Defined in: [types/conversation.ts:198](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L198)
 
 When token count was last calculated (NEW - for token-based memory)
 
@@ -133,7 +133,7 @@ When token count was last calculated (NEW - for token-based memory)
 
 > `optional` **lastApiTokenCount?**: `object`
 
-Defined in: [types/conversation.ts:193](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L193)
+Defined in: [types/conversation.ts:201](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L201)
 
 API-reported token count from last request (most accurate)
 
@@ -163,7 +163,7 @@ API-reported token count from last request (most accurate)
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/conversation.ts:202](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L202)
+Defined in: [types/conversation.ts:210](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L210)
 
 Optional session metadata
 

--- a/docs/api/type-aliases/SessionMetadata.md
+++ b/docs/api/type-aliases/SessionMetadata.md
@@ -8,7 +8,7 @@
 
 > **SessionMetadata** = `object`
 
-Defined in: [types/conversation.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L522)
+Defined in: [types/conversation.ts:530](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L530)
 
 Lightweight session metadata for efficient session listing
 Contains only essential information without heavy message arrays
@@ -19,7 +19,7 @@ Contains only essential information without heavy message arrays
 
 > **id**: `string`
 
-Defined in: [types/conversation.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L523)
+Defined in: [types/conversation.ts:531](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L531)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/conversation.ts:523](https://github.com/juspay/neurolink/blob
 
 > **title**: `string`
 
-Defined in: [types/conversation.ts:524](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L524)
+Defined in: [types/conversation.ts:532](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L532)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/conversation.ts:524](https://github.com/juspay/neurolink/blob
 
 > **createdAt**: `string`
 
-Defined in: [types/conversation.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L525)
+Defined in: [types/conversation.ts:533](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L533)
 
 ---
 
@@ -43,7 +43,7 @@ Defined in: [types/conversation.ts:525](https://github.com/juspay/neurolink/blob
 
 > **updatedAt**: `string`
 
-Defined in: [types/conversation.ts:526](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L526)
+Defined in: [types/conversation.ts:534](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L534)
 
 ---
 
@@ -51,7 +51,7 @@ Defined in: [types/conversation.ts:526](https://github.com/juspay/neurolink/blob
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/conversation.ts:528](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L528)
+Defined in: [types/conversation.ts:536](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L536)
 
 Additional metadata including agentic loop reports
 

--- a/docs/api/type-aliases/StoreConversationTurnOptions.md
+++ b/docs/api/type-aliases/StoreConversationTurnOptions.md
@@ -8,7 +8,7 @@
 
 > **StoreConversationTurnOptions** = `object`
 
-Defined in: [types/conversation.ts:482](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L482)
+Defined in: [types/conversation.ts:490](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L490)
 
 Options for storing a conversation turn
 
@@ -18,7 +18,7 @@ Options for storing a conversation turn
 
 > **sessionId**: `string`
 
-Defined in: [types/conversation.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L483)
+Defined in: [types/conversation.ts:491](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L491)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/conversation.ts:483](https://github.com/juspay/neurolink/blob
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/conversation.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L484)
+Defined in: [types/conversation.ts:492](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L492)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/conversation.ts:484](https://github.com/juspay/neurolink/blob
 
 > **userMessage**: `string`
 
-Defined in: [types/conversation.ts:485](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L485)
+Defined in: [types/conversation.ts:493](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L493)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/conversation.ts:485](https://github.com/juspay/neurolink/blob
 
 > **aiResponse**: `string`
 
-Defined in: [types/conversation.ts:486](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L486)
+Defined in: [types/conversation.ts:494](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L494)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/conversation.ts:486](https://github.com/juspay/neurolink/blob
 
 > `optional` **startTimeStamp?**: `Date`
 
-Defined in: [types/conversation.ts:487](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L487)
+Defined in: [types/conversation.ts:495](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L495)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/conversation.ts:487](https://github.com/juspay/neurolink/blob
 
 > `optional` **providerDetails?**: [`ProviderDetails`](ProviderDetails.md)
 
-Defined in: [types/conversation.ts:488](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L488)
+Defined in: [types/conversation.ts:496](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L496)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/conversation.ts:488](https://github.com/juspay/neurolink/blob
 
 > `optional` **enableSummarization?**: `boolean`
 
-Defined in: [types/conversation.ts:489](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L489)
+Defined in: [types/conversation.ts:497](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L497)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/conversation.ts:489](https://github.com/juspay/neurolink/blob
 
 > `optional` **events?**: [`StreamEventSequence`](StreamEventSequence.md)[]
 
-Defined in: [types/conversation.ts:490](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L490)
+Defined in: [types/conversation.ts:498](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L498)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/conversation.ts:490](https://github.com/juspay/neurolink/blob
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/conversation.ts:492](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L492)
+Defined in: [types/conversation.ts:500](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L500)
 
 Observability request identifier for log correlation
 
@@ -92,7 +92,7 @@ Observability request identifier for log correlation
 
 > `optional` **tokenUsage?**: `object`
 
-Defined in: [types/conversation.ts:494](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L494)
+Defined in: [types/conversation.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L502)
 
 API-reported token usage from provider response
 
@@ -122,7 +122,7 @@ API-reported token usage from provider response
 
 > `optional` **thoughtSignature?**: `string`
 
-Defined in: [types/conversation.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L502)
+Defined in: [types/conversation.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L510)
 
 Gemini 3 thought signature for reasoning continuity across turns
 
@@ -132,7 +132,7 @@ Gemini 3 thought signature for reasoning continuity across turns
 
 > `optional` **skillMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/conversation.ts:515](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L515)
+Defined in: [types/conversation.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L523)
 
 Pinned skill-activation messages (skills v2) recorded during this turn.
 Inserted between the user and assistant messages so replayed history

--- a/docs/api/type-aliases/StreamEventSequence.md
+++ b/docs/api/type-aliases/StreamEventSequence.md
@@ -8,7 +8,7 @@
 
 > **StreamEventSequence** = `object`
 
-Defined in: [types/conversation.ts:230](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L230)
+Defined in: [types/conversation.ts:238](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L238)
 
 Stream event for event sequence tracking
 Used to reconstruct exact flow of streaming responses with proper ordering
@@ -29,7 +29,7 @@ Event-specific data
 
 > **type**: `string`
 
-Defined in: [types/conversation.ts:232](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L232)
+Defined in: [types/conversation.ts:240](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L240)
 
 Event type (text-chunk, ui-component, tool:start, tool:end, hitl:confirmation-request, etc.)
 
@@ -39,7 +39,7 @@ Event type (text-chunk, ui-component, tool:start, tool:end, hitl:confirmation-re
 
 > **seq**: `number`
 
-Defined in: [types/conversation.ts:234](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L234)
+Defined in: [types/conversation.ts:242](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L242)
 
 Sequence number for ordering events
 
@@ -49,6 +49,6 @@ Sequence number for ordering events
 
 > **timestamp**: `number`
 
-Defined in: [types/conversation.ts:236](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L236)
+Defined in: [types/conversation.ts:244](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L244)
 
 Timestamp when event occurred

--- a/docs/api/type-aliases/TTSMetadata.md
+++ b/docs/api/type-aliases/TTSMetadata.md
@@ -8,7 +8,7 @@
 
 > **TTSMetadata** = `object`
 
-Defined in: [types/generate.ts:1681](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1681)
+Defined in: [types/generate.ts:1690](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1690)
 
 Enhanced result type with optional analytics/evaluation
 
@@ -18,7 +18,7 @@ Enhanced result type with optional analytics/evaluation
 
 > **attempted**: `boolean`
 
-Defined in: [types/generate.ts:1683](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1683)
+Defined in: [types/generate.ts:1692](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1692)
 
 Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
@@ -28,7 +28,7 @@ Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
 > **success**: `boolean`
 
-Defined in: [types/generate.ts:1685](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1685)
+Defined in: [types/generate.ts:1694](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1694)
 
 Whether TTS synthesis completed successfully.
 
@@ -38,7 +38,7 @@ Whether TTS synthesis completed successfully.
 
 > `optional` **error?**: `object`
 
-Defined in: [types/generate.ts:1687](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1687)
+Defined in: [types/generate.ts:1696](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1696)
 
 Structured synthesis error details, present only when synthesis failed.
 
@@ -60,6 +60,6 @@ Structured synthesis error details, present only when synthesis failed.
 
 > `optional` **latency?**: `number`
 
-Defined in: [types/generate.ts:1693](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1693)
+Defined in: [types/generate.ts:1702](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1702)
 
 TTS synthesis time in milliseconds.

--- a/docs/api/type-aliases/TextGenerationOptions.md
+++ b/docs/api/type-aliases/TextGenerationOptions.md
@@ -8,7 +8,7 @@
 
 > **TextGenerationOptions** = `object`
 
-Defined in: [types/generate.ts:1207](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1207)
+Defined in: [types/generate.ts:1216](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1216)
 
 Text generation options type (consolidated from core types)
 Extended to support video generation mode
@@ -19,7 +19,7 @@ Extended to support video generation mode
 
 > `optional` **prompt?**: `string`
 
-Defined in: [types/generate.ts:1208](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1208)
+Defined in: [types/generate.ts:1217](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1217)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/generate.ts:1208](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **input?**: `object`
 
-Defined in: [types/generate.ts:1218](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1218)
+Defined in: [types/generate.ts:1227](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1227)
 
 Alternative input format for multimodal SDK operations.
 
@@ -70,7 +70,7 @@ Director Mode segments (2-10). When provided, Director Mode is activated.
 
 > `optional` **provider?**: [`AIProviderName`](../enumerations/AIProviderName.md)
 
-Defined in: [types/generate.ts:1231](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1231)
+Defined in: [types/generate.ts:1240](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1240)
 
 ---
 
@@ -78,7 +78,7 @@ Defined in: [types/generate.ts:1231](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **model?**: `string`
 
-Defined in: [types/generate.ts:1232](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1232)
+Defined in: [types/generate.ts:1241](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1241)
 
 ---
 
@@ -86,7 +86,7 @@ Defined in: [types/generate.ts:1232](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **region?**: `string`
 
-Defined in: [types/generate.ts:1233](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1233)
+Defined in: [types/generate.ts:1242](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1242)
 
 ---
 
@@ -94,7 +94,7 @@ Defined in: [types/generate.ts:1233](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1234](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1234)
+Defined in: [types/generate.ts:1243](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1243)
 
 ---
 
@@ -102,7 +102,7 @@ Defined in: [types/generate.ts:1234](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/generate.ts:1235](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1235)
+Defined in: [types/generate.ts:1244](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1244)
 
 ---
 
@@ -110,7 +110,7 @@ Defined in: [types/generate.ts:1235](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **topP?**: `number`
 
-Defined in: [types/generate.ts:1237](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1237)
+Defined in: [types/generate.ts:1246](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1246)
 
 Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
@@ -120,7 +120,7 @@ Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
 > `optional` **topK?**: `number`
 
-Defined in: [types/generate.ts:1239](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1239)
+Defined in: [types/generate.ts:1248](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1248)
 
 Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini models only)
 
@@ -130,7 +130,7 @@ Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini
 
 > `optional` **stopSequences?**: `string`[]
 
-Defined in: [types/generate.ts:1241](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1241)
+Defined in: [types/generate.ts:1250](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1250)
 
 Stop sequences that will halt generation when encountered.
 
@@ -140,7 +140,7 @@ Stop sequences that will halt generation when encountered.
 
 > `optional` **systemPrompt?**: `string`
 
-Defined in: [types/generate.ts:1242](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1242)
+Defined in: [types/generate.ts:1251](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1251)
 
 ---
 
@@ -148,7 +148,7 @@ Defined in: [types/generate.ts:1242](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **schema?**: [`ZodUnknownSchema`](ZodUnknownSchema.md) \| `Schema`\<`unknown`\>
 
-Defined in: [types/generate.ts:1243](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1243)
+Defined in: [types/generate.ts:1252](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1252)
 
 ---
 
@@ -156,7 +156,7 @@ Defined in: [types/generate.ts:1243](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **output?**: `object`
 
-Defined in: [types/generate.ts:1255](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1255)
+Defined in: [types/generate.ts:1264](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1264)
 
 Output configuration options
 
@@ -221,7 +221,7 @@ output: {
 
 > `optional` **tools?**: `Record`\<`string`, `Tool`\>
 
-Defined in: [types/generate.ts:1287](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1287)
+Defined in: [types/generate.ts:1296](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1296)
 
 ---
 
@@ -229,7 +229,7 @@ Defined in: [types/generate.ts:1287](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **enabledToolNames?**: `string`[]
 
-Defined in: [types/generate.ts:1302](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1302)
+Defined in: [types/generate.ts:1311](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1311)
 
 Filter available tools by name.
 Only tools with names in this array will be made available.
@@ -251,7 +251,7 @@ await neurolink.generate({
 
 > `optional` **timeout?**: `number` \| `string`
 
-Defined in: [types/generate.ts:1303](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1303)
+Defined in: [types/generate.ts:1312](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1312)
 
 ---
 
@@ -259,7 +259,7 @@ Defined in: [types/generate.ts:1303](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **turnTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1305](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1305)
+Defined in: [types/generate.ts:1314](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1314)
 
 Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs.
 
@@ -269,7 +269,7 @@ Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutM
 
 > `optional` **stallTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1307](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1307)
+Defined in: [types/generate.ts:1316](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1316)
 
 Max time with no progress before the turn ends as "stalled" (ms). See GenerateOptions.stallTimeoutMs.
 
@@ -279,7 +279,7 @@ Max time with no progress before the turn ends as "stalled" (ms). See GenerateOp
 
 > `optional` **wrapupTimeLeadMs?**: `number`
 
-Defined in: [types/generate.ts:1309](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1309)
+Defined in: [types/generate.ts:1318](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1318)
 
 Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs.
 
@@ -289,7 +289,7 @@ Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptio
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1311](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1311)
+Defined in: [types/generate.ts:1320](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1320)
 
 Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeoutMs.
 
@@ -299,7 +299,7 @@ Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeou
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1313](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1313)
+Defined in: [types/generate.ts:1322](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1322)
 
 AbortSignal for external cancellation of the AI call
 
@@ -309,7 +309,7 @@ AbortSignal for external cancellation of the AI call
 
 > `optional` **toolExecutionCapture?**: [`ToolExecutionCaptureOptions`](ToolExecutionCaptureOptions.md)
 
-Defined in: [types/generate.ts:1315](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1315)
+Defined in: [types/generate.ts:1324](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1324)
 
 Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
@@ -319,7 +319,7 @@ Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
 > `optional` **disableTools?**: `boolean`
 
-Defined in: [types/generate.ts:1323](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1323)
+Defined in: [types/generate.ts:1332](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1332)
 
 ---
 
@@ -327,7 +327,7 @@ Defined in: [types/generate.ts:1323](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **disableToolCallRepair?**: `boolean`
 
-Defined in: [types/generate.ts:1325](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1325)
+Defined in: [types/generate.ts:1334](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1334)
 
 Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled).
 
@@ -337,7 +337,7 @@ Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (r
 
 > `optional` **maxSteps?**: `number`
 
-Defined in: [types/generate.ts:1326](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1326)
+Defined in: [types/generate.ts:1335](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1335)
 
 ---
 
@@ -345,7 +345,7 @@ Defined in: [types/generate.ts:1326](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolFilter?**: `string`[]
 
-Defined in: [types/generate.ts:1329](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1329)
+Defined in: [types/generate.ts:1338](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1338)
 
 Include only these tools by name (whitelist). If set, only matching tools are available.
 
@@ -355,7 +355,7 @@ Include only these tools by name (whitelist). If set, only matching tools are av
 
 > `optional` **excludeTools?**: `string`[]
 
-Defined in: [types/generate.ts:1332](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1332)
+Defined in: [types/generate.ts:1341](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1341)
 
 Exclude these tools by name (blacklist). Applied after toolFilter.
 
@@ -365,7 +365,7 @@ Exclude these tools by name (blacklist). Applied after toolFilter.
 
 > `optional` **disableToolCache?**: `boolean`
 
-Defined in: [types/generate.ts:1335](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1335)
+Defined in: [types/generate.ts:1344](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1344)
 
 Disable tool result caching for this request (overrides global mcp.cache.enabled)
 
@@ -375,7 +375,7 @@ Disable tool result caching for this request (overrides global mcp.cache.enabled
 
 > `optional` **toolChoice?**: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>
 
-Defined in: [types/generate.ts:1350](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1350)
+Defined in: [types/generate.ts:1359](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1359)
 
 Tool choice configuration for the generation.
 Controls whether and which tools the model must call.
@@ -395,7 +395,7 @@ will cause infinite tool calls until `maxSteps` is exhausted.
 
 > `optional` **prepareStep?**: (`options`) => `PromiseLike`\<\{ `model?`: `LanguageModel`; `toolChoice?`: `ToolChoice`\<`Record`\<`string`, `Tool`\>\>; `experimental_activeTools?`: `string`[]; \} \| `undefined`\>
 
-Defined in: [types/generate.ts:1375](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1375)
+Defined in: [types/generate.ts:1384](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1384)
 
 Optional callback that runs before each step in a multi-step generation.
 Allows dynamically changing `toolChoice` and available tools per step.
@@ -452,7 +452,7 @@ https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#parameters
 
 > `optional` **tts?**: [`TTSOptions`](TTSOptions.md)
 
-Defined in: [types/generate.ts:1418](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1418)
+Defined in: [types/generate.ts:1427](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1427)
 
 Text-to-Speech (TTS) configuration
 
@@ -489,7 +489,7 @@ const result = await neurolink.generate({
 
 > `optional` **stt?**: [`STTOptions`](STTOptions.md) & `object`
 
-Defined in: [types/generate.ts:1437](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1437)
+Defined in: [types/generate.ts:1446](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1446)
 
 Speech-to-Text (STT) configuration
 
@@ -529,7 +529,7 @@ const result = await neurolink.generate({
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/generate.ts:1440](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1440)
+Defined in: [types/generate.ts:1449](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1449)
 
 ---
 
@@ -537,7 +537,7 @@ Defined in: [types/generate.ts:1440](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/generate.ts:1441](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1441)
+Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1450)
 
 ---
 
@@ -545,7 +545,7 @@ Defined in: [types/generate.ts:1441](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **context?**: `Record`\<`string`, [`JsonValue`](JsonValue.md)\>
 
-Defined in: [types/generate.ts:1442](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1442)
+Defined in: [types/generate.ts:1451](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1451)
 
 ---
 
@@ -553,7 +553,7 @@ Defined in: [types/generate.ts:1442](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/generate.ts:1445](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1445)
+Defined in: [types/generate.ts:1454](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1454)
 
 ---
 
@@ -561,7 +561,7 @@ Defined in: [types/generate.ts:1445](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/generate.ts:1446](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1446)
+Defined in: [types/generate.ts:1455](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1455)
 
 ---
 
@@ -569,7 +569,7 @@ Defined in: [types/generate.ts:1446](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/generate.ts:1447](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1447)
+Defined in: [types/generate.ts:1456](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1456)
 
 #### role
 
@@ -585,7 +585,7 @@ Defined in: [types/generate.ts:1447](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1450)
+Defined in: [types/generate.ts:1459](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1459)
 
 ---
 
@@ -593,7 +593,7 @@ Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationMemoryConfig?**: `Partial`\<[`ConversationMemoryConfig`](ConversationMemoryConfig.md)\>
 
-Defined in: [types/generate.ts:1453](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1453)
+Defined in: [types/generate.ts:1462](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1462)
 
 ---
 
@@ -601,7 +601,7 @@ Defined in: [types/generate.ts:1453](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **originalPrompt?**: `string`
 
-Defined in: [types/generate.ts:1454](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1454)
+Defined in: [types/generate.ts:1463](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1463)
 
 ---
 
@@ -609,7 +609,7 @@ Defined in: [types/generate.ts:1454](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/generate.ts:1457](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1457)
+Defined in: [types/generate.ts:1466](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1466)
 
 ---
 
@@ -617,7 +617,7 @@ Defined in: [types/generate.ts:1457](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/generate.ts:1465](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1465)
+Defined in: [types/generate.ts:1474](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1474)
 
 ---
 
@@ -625,7 +625,7 @@ Defined in: [types/generate.ts:1465](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/generate.ts:1466](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1466)
+Defined in: [types/generate.ts:1475](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1475)
 
 ---
 
@@ -633,7 +633,7 @@ Defined in: [types/generate.ts:1466](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **expectedOutcome?**: `string`
 
-Defined in: [types/generate.ts:1469](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1469)
+Defined in: [types/generate.ts:1478](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1478)
 
 ---
 
@@ -641,7 +641,7 @@ Defined in: [types/generate.ts:1469](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **evaluationCriteria?**: `string`[]
 
-Defined in: [types/generate.ts:1470](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1470)
+Defined in: [types/generate.ts:1479](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1479)
 
 ---
 
@@ -649,7 +649,7 @@ Defined in: [types/generate.ts:1470](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **csvOptions?**: [`CSVProcessorOptions`](CSVProcessorOptions.md)
 
-Defined in: [types/generate.ts:1473](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1473)
+Defined in: [types/generate.ts:1482](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1482)
 
 ---
 
@@ -657,7 +657,7 @@ Defined in: [types/generate.ts:1473](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **pdfOptions?**: `object`
 
-Defined in: [types/generate.ts:1476](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1476)
+Defined in: [types/generate.ts:1485](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1485)
 
 PDF processing options (#258).
 
@@ -691,7 +691,7 @@ Max pages converted by the image fallback (#297); defaults to PDF_LIMITS.DEFAULT
 
 > `optional` **enableSummarization?**: `boolean`
 
-Defined in: [types/generate.ts:1487](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1487)
+Defined in: [types/generate.ts:1496](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1496)
 
 ---
 
@@ -699,7 +699,7 @@ Defined in: [types/generate.ts:1487](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **skipToolPromptInjection?**: `boolean`
 
-Defined in: [types/generate.ts:1505](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1505)
+Defined in: [types/generate.ts:1514](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1514)
 
 Skip injecting tool schemas into the system prompt.
 When true, tools are ONLY passed natively via the provider's `tools` parameter,
@@ -712,7 +712,7 @@ Default: false (backward compatible — tool schemas are injected into system pr
 
 > `optional` **thinking?**: `boolean`
 
-Defined in: [types/generate.ts:1562](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1562)
+Defined in: [types/generate.ts:1571](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1571)
 
 Enable extended thinking capability (simplified option).
 Equivalent to `thinkingConfig.enabled = true`.
@@ -724,7 +724,7 @@ Works with both Anthropic and Gemini 3 models.
 
 > `optional` **thinkingBudget?**: `number`
 
-Defined in: [types/generate.ts:1569](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1569)
+Defined in: [types/generate.ts:1578](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1578)
 
 Token budget for thinking (Anthropic models only).
 Equivalent to `thinkingConfig.budgetTokens`.
@@ -736,7 +736,7 @@ Range: 5000-100000 tokens. Ignored for Gemini models.
 
 > `optional` **thinkingLevel?**: `"minimal"` \| `"low"` \| `"medium"` \| `"high"`
 
-Defined in: [types/generate.ts:1580](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1580)
+Defined in: [types/generate.ts:1589](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1589)
 
 Thinking level for Gemini 3 models only.
 Equivalent to `thinkingConfig.thinkingLevel`.
@@ -753,7 +753,7 @@ Equivalent to `thinkingConfig.thinkingLevel`.
 
 > `optional` **thinkingConfig?**: `object`
 
-Defined in: [types/generate.ts:1588](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1588)
+Defined in: [types/generate.ts:1597](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1597)
 
 Full thinking/reasoning configuration (recommended for SDK usage).
 Takes precedence over simplified options (thinking, thinkingBudget, thinkingLevel).
@@ -792,7 +792,7 @@ Above documentation for provider-specific behavior and option compatibility.
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/generate.ts:1604](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1604)
+Defined in: [types/generate.ts:1613](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1613)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -804,7 +804,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/generate.ts:1611](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1611)
+Defined in: [types/generate.ts:1620](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1620)
 
 Optional request identifier for observability and log correlation.
 When provided, this ID is forwarded to spans, logs, and telemetry so
@@ -816,7 +816,7 @@ callers can correlate generation traces back to their own request lifecycle.
 
 > `optional` **piiDetection?**: [`GenerateOptions`](GenerateOptions.md)\[`"piiDetection"`\]
 
-Defined in: [types/generate.ts:1614](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1614)
+Defined in: [types/generate.ts:1623](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1623)
 
 PII detection config — forwarded from GenerateOptions/StreamOptions.
 
@@ -826,7 +826,7 @@ PII detection config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **responseValidation?**: [`GenerateOptions`](GenerateOptions.md)\[`"responseValidation"`\]
 
-Defined in: [types/generate.ts:1617](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1617)
+Defined in: [types/generate.ts:1626](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1626)
 
 Response validation config — forwarded from GenerateOptions/StreamOptions.
 
@@ -836,7 +836,7 @@ Response validation config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **inputValidation?**: [`GenerateOptions`](GenerateOptions.md)\[`"inputValidation"`\]
 
-Defined in: [types/generate.ts:1620](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1620)
+Defined in: [types/generate.ts:1629](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1629)
 
 Input validation config — forwarded from GenerateOptions/StreamOptions.
 
@@ -846,7 +846,7 @@ Input validation config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/generate.ts:1623](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1623)
+Defined in: [types/generate.ts:1632](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1632)
 
 #### Deprecated
 

--- a/docs/api/type-aliases/TextGenerationResult.md
+++ b/docs/api/type-aliases/TextGenerationResult.md
@@ -8,7 +8,7 @@
 
 > **TextGenerationResult** = `object` & [`MediaGenerationOutputs`](MediaGenerationOutputs.md)
 
-Defined in: [types/generate.ts:1629](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1629)
+Defined in: [types/generate.ts:1638](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1638)
 
 Text generation result (consolidated from core types)
 

--- a/docs/api/type-aliases/ToolExecutionCaptureOptions.md
+++ b/docs/api/type-aliases/ToolExecutionCaptureOptions.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionCaptureOptions** = `object`
 
-Defined in: [types/generate.ts:866](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L866)
+Defined in: [types/generate.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L875)
 
 Bounds for per-call tool execution capture (see `ToolExecutionRecord`).
 Capture is ON by default with these caps; raise them when a caller needs
@@ -20,7 +20,7 @@ full result texts (e.g. caller-side evidence verification).
 
 > `optional` **maxResultChars?**: `number`
 
-Defined in: [types/generate.ts:868](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L868)
+Defined in: [types/generate.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L877)
 
 Max serialized result characters kept per record (default 8192).
 
@@ -30,7 +30,7 @@ Max serialized result characters kept per record (default 8192).
 
 > `optional` **maxRecords?**: `number`
 
-Defined in: [types/generate.ts:870](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L870)
+Defined in: [types/generate.ts:879](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L879)
 
 Max records kept per turn; oldest are dropped first (default 500).
 
@@ -40,7 +40,7 @@ Max records kept per turn; oldest are dropped first (default 500).
 
 > `optional` **onRecord?**: (`record`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/generate.ts:878](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L878)
+Defined in: [types/generate.ts:887](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L887)
 
 Fire-and-forget per-record callback, invoked as each tool execution
 completes. Listener errors — synchronous throws AND async rejections —

--- a/docs/api/type-aliases/ToolExecutionRecord.md
+++ b/docs/api/type-aliases/ToolExecutionRecord.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionRecord** = `object`
 
-Defined in: [types/generate.ts:842](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L842)
+Defined in: [types/generate.ts:851](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L851)
 
 One real tool invocation captured during an agentic turn.
 
@@ -24,7 +24,7 @@ to observe their own tool traffic.
 
 > **toolName**: `string`
 
-Defined in: [types/generate.ts:844](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L844)
+Defined in: [types/generate.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L853)
 
 Tool name as the model called it.
 
@@ -34,7 +34,7 @@ Tool name as the model called it.
 
 > **params**: `unknown`
 
-Defined in: [types/generate.ts:846](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L846)
+Defined in: [types/generate.ts:855](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L855)
 
 Parameters the tool was invoked with, as parsed by the loop.
 
@@ -44,7 +44,7 @@ Parameters the tool was invoked with, as parsed by the loop.
 
 > **resultText**: `string`
 
-Defined in: [types/generate.ts:852](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L852)
+Defined in: [types/generate.ts:861](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L861)
 
 Serialized tool result (JSON when serializable, else String()), bounded
 by `toolExecutionCapture.maxResultChars` (default ~8KB). Truncated text
@@ -56,7 +56,7 @@ ends with a `…[truncated N chars]` marker.
 
 > **isError**: `boolean`
 
-Defined in: [types/generate.ts:854](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L854)
+Defined in: [types/generate.ts:863](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L863)
 
 True when the execution threw or returned an error-shaped result.
 
@@ -66,7 +66,7 @@ True when the execution threw or returned an error-shaped result.
 
 > **startedAt**: `number`
 
-Defined in: [types/generate.ts:856](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L856)
+Defined in: [types/generate.ts:865](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L865)
 
 Epoch milliseconds when the execution started.
 
@@ -76,6 +76,6 @@ Epoch milliseconds when the execution started.
 
 > **durationMs**: `number`
 
-Defined in: [types/generate.ts:858](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L858)
+Defined in: [types/generate.ts:867](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L867)
 
 Wall-clock duration of the execution in milliseconds.

--- a/docs/api/type-aliases/ToolResultData.md
+++ b/docs/api/type-aliases/ToolResultData.md
@@ -8,7 +8,7 @@
 
 > **ToolResultData** = `object`
 
-Defined in: [types/conversation.ts:242](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L242)
+Defined in: [types/conversation.ts:250](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L250)
 
 Structured metadata for tool_result messages.
 
@@ -18,7 +18,7 @@ Structured metadata for tool_result messages.
 
 > `optional` **success?**: `boolean`
 
-Defined in: [types/conversation.ts:244](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L244)
+Defined in: [types/conversation.ts:252](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L252)
 
 Whether the tool execution succeeded
 
@@ -28,7 +28,7 @@ Whether the tool execution succeeded
 
 > `optional` **expression?**: `string`
 
-Defined in: [types/conversation.ts:246](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L246)
+Defined in: [types/conversation.ts:254](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L254)
 
 Expression that was evaluated (for calculation tools)
 
@@ -38,7 +38,7 @@ Expression that was evaluated (for calculation tools)
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/conversation.ts:252](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L252)
+Defined in: [types/conversation.ts:260](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L260)
 
 The tool execution result.
 
@@ -53,7 +53,7 @@ populated from content for backward compatibility and will be removed in a futur
 
 > `optional` **type?**: `string`
 
-Defined in: [types/conversation.ts:254](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L254)
+Defined in: [types/conversation.ts:262](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L262)
 
 Result type hint
 
@@ -63,6 +63,6 @@ Result type hint
 
 > `optional` **error?**: `string`
 
-Defined in: [types/conversation.ts:256](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L256)
+Defined in: [types/conversation.ts:264](https://github.com/juspay/neurolink/blob/release/src/lib/types/conversation.ts#L264)
 
 Error message if execution failed

--- a/docs/api/type-aliases/UnifiedGenerationOptions.md
+++ b/docs/api/type-aliases/UnifiedGenerationOptions.md
@@ -8,7 +8,7 @@
 
 > **UnifiedGenerationOptions** = [`GenerateOptions`](GenerateOptions.md) & `object`
 
-Defined in: [types/generate.ts:1172](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1172)
+Defined in: [types/generate.ts:1181](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1181)
 
 Unified options for both generation and streaming
 Supports factory patterns and domain configuration

--- a/docs/context-summarization.md
+++ b/docs/context-summarization.md
@@ -52,6 +52,9 @@ const neurolink = new NeuroLink({
     // Use a specific provider and model for the summarization task
     summarizationProvider: "openai",
     summarizationModel: "gpt-4o-mini",
+    // Cap one summarization call (ms). Default 60000; an overrun drops
+    // that summary (non-fatal) instead of failing the turn.
+    summarizationTimeoutMs: 120000,
   },
 });
 ```
@@ -85,6 +88,10 @@ The `conversationMemory` configuration object accepts the following properties r
 - `summarizationProvider: string`
   - **Description**: The AI provider to use for the summarization task.
   - **Default**: `"vertex"`
+
+- `summarizationTimeoutMs: number`
+  - **Description**: Wall-clock cap for one summarization generate call, in milliseconds. An overrun drops that summary (non-fatal — the turn continues without it), so size it for the slowest summary a real conversation produces.
+  - **Default**: `60000`
 
 ## Order of Operations
 

--- a/docs/features/turn-time-budget.md
+++ b/docs/features/turn-time-budget.md
@@ -30,6 +30,17 @@ const result = await neurolink.generate({
 });
 ```
 
+### `turnTimeoutMs` vs `timeout` on the AI-SDK loop path
+
+On the AI-SDK loop path (direct Anthropic, litellm, OpenAI-compatible), an
+explicit `turnTimeoutMs` owns the whole-turn hard abort, and `timeout` keeps
+its per-model-call meaning. Historically `timeout` alone bounded the ENTIRE
+multi-step loop there, so `{ timeout: 300_000, turnTimeoutMs: 2_400_000 }`
+killed a 40-minute turn at 5 minutes flat — surfacing as the provider SDK's
+generic cancel (`Request was aborted.`) mid-loop. When the hard cap does
+fire, the error now carries the timer's own identity (`… timed out after …`)
+instead of that generic cancel shape.
+
 ### Defensive defaults
 
 When `turnTimeoutMs` is **unset**, each loop keeps its pre-existing behavior:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -550,6 +550,7 @@ const neurolink = new NeuroLink({
     // These are top-level conversationMemory fields, not inside contextCompaction.
     summarizationProvider: "vertex",
     summarizationModel: "gemini-2.5-flash",
+    summarizationTimeoutMs: 120000, // cap one summary call; default 60000
   },
 });
 ```

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1763,8 +1763,19 @@ export abstract class BaseProvider implements AIProvider {
     const descriptorGenerateMs = PROVIDER_DESCRIPTORS_BY_NAME.get(
       this.providerName,
     )?.timeouts?.generateMs;
-    const effectiveTimeout =
-      options.timeout ?? Math.max(descriptorGenerateMs ?? 0, 180_000);
+    // An explicit, valid turnTimeoutMs is the caller's whole-turn contract
+    // and owns this hard abort; `timeout` then keeps its per-model-call
+    // meaning (it reaches the model layer via providerOptions.neurolink).
+    // Before this, `timeout` alone bounded the ENTIRE multi-step loop, so a
+    // caller asking for a 40-minute turn of 5-minute calls was killed at 5
+    // minutes flat — mid-loop, dressed as "Request was aborted.".
+    const hasValidTurnTimeout =
+      typeof options.turnTimeoutMs === "number" &&
+      Number.isFinite(options.turnTimeoutMs) &&
+      options.turnTimeoutMs > 0;
+    const effectiveTimeout = hasValidTurnTimeout
+      ? options.turnTimeoutMs
+      : (options.timeout ?? Math.max(descriptorGenerateMs ?? 0, 180_000));
     const timeoutController = createTimeoutController(
       effectiveTimeout,
       this.providerName,
@@ -1786,6 +1797,25 @@ export abstract class BaseProvider implements AIProvider {
         tools,
         composedOptions,
       );
+    } catch (error) {
+      // When OUR timer fired, provider SDKs typically normalize the abort
+      // into their own generic cancel shape (e.g. Anthropic's
+      // APIUserAbortError, "Request was aborted.") and discard the signal's
+      // reason. The TimeoutError on the signal is the honest identity —
+      // rethrow it so logs and abort classification see a timeout, not a
+      // caller cancel. A genuine caller abort (their signal fired) keeps its
+      // original shape even if our timer also expired in the race window.
+      const reason = timeoutController?.controller.signal.aborted
+        ? timeoutController.controller.signal.reason
+        : undefined;
+      if (
+        reason instanceof TimeoutError &&
+        isAbortError(error) &&
+        options.abortSignal?.aborted !== true
+      ) {
+        throw reason;
+      }
+      throw error;
     } finally {
       timeoutController?.cleanup();
     }

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -97,6 +97,7 @@ import {
   composeAbortSignals,
   createTimeoutController,
   mergeAbortSignals,
+  TimeoutError,
 } from "../../utils/timeout.js";
 import { resolveToolChoice } from "../../utils/toolChoice.js";
 import { emitToolEndFromStepFinish } from "../../utils/toolEndEmitter.js";
@@ -1460,36 +1461,54 @@ export class AnthropicProvider extends BaseProvider {
           ...(thinking ? { thinking } : {}),
         };
 
-        // The 60s anthropic generate default was tuned for the old ~4096
-        // max_tokens. Now that the default ceiling is the model's real max,
-        // a large structured response needs more wall-clock to be produced —
-        // otherwise the inner controller aborts mid-generation (the AI-SDK
-        // doGenerate layer doesn't see the caller's `timeout`). Raise the
-        // floor to 5 min when a large output budget is in play — but only
-        // when the caller did NOT set an explicit timeout: an explicit value
-        // is a contract and must never be silently extended. The abort
-        // signal stays the real bound.
-        const callerTimeout = (options as { timeout?: number | string })
-          .timeout;
-        const callerSpecifiedTimeout =
-          callerTimeout !== undefined && callerTimeout !== null;
+        // The caller's resolved `timeout` reaches this layer only through
+        // providerOptions.neurolink.timeoutMs (AI-SDK call options carry no
+        // `timeout`; the old `options.timeout` read here never fired on V3).
+        // An explicit value is a per-call contract: never floored, never
+        // extended. Without one, the 60s anthropic default was tuned for the
+        // old ~4096 max_tokens — now that the default ceiling is the model's
+        // real max, raise the floor to 5 min when a large output budget is
+        // in play. The abort signal stays the real bound.
+        const neurolinkNs = options.providerOptions?.neurolink;
+        const forwardedTimeoutMs =
+          typeof neurolinkNs?.timeoutMs === "number" &&
+          Number.isFinite(neurolinkNs.timeoutMs) &&
+          neurolinkNs.timeoutMs > 0
+            ? neurolinkNs.timeoutMs
+            : undefined;
         const generateTimeoutMs =
-          params.max_tokens > 8192 && !callerSpecifiedTimeout
-            ? Math.max(getTimeoutForOptions(options), 300_000)
-            : getTimeoutForOptions(options);
+          forwardedTimeoutMs !== undefined
+            ? forwardedTimeoutMs
+            : params.max_tokens > 8192
+              ? Math.max(getTimeoutForOptions(options), 300_000)
+              : getTimeoutForOptions(options);
         const timeoutController = createTimeoutController(
           generateTimeoutMs,
           providerName,
           "generate",
         );
+        const requestSignal = composeAbortSignals(
+          options.abortSignal,
+          timeoutController?.controller.signal,
+        );
         let response: Anthropic.Messages.Message;
         try {
           response = await client.messages.create(params, {
-            signal: composeAbortSignals(
-              options.abortSignal,
-              timeoutController?.controller.signal,
-            ),
+            signal: requestSignal,
           });
+        } catch (error) {
+          // The Anthropic SDK collapses ANY fired signal into its generic
+          // APIUserAbortError ("Request was aborted."), discarding the
+          // signal's reason. When the abort came from one of NeuroLink's own
+          // timers (this per-call timer, or the turn-level one upstream),
+          // the TimeoutError reason is the honest identity — surface it.
+          const reason = requestSignal?.aborted
+            ? requestSignal.reason
+            : undefined;
+          if (reason instanceof TimeoutError) {
+            throw reason;
+          }
+          throw error;
         } finally {
           timeoutController?.cleanup();
         }

--- a/src/lib/types/conversation.ts
+++ b/src/lib/types/conversation.ts
@@ -88,6 +88,14 @@ export type ConversationMemoryConfig = {
   /** Model to use for summarization */
   summarizationModel?: string;
 
+  /**
+   * Wall-clock cap for one summarization generate call, in milliseconds
+   * (default: 60000). A summary that overruns is dropped, not fatal — the
+   * turn continues without it — so size this for the slowest summary a real
+   * conversation produces rather than losing compaction summaries silently.
+   */
+  summarizationTimeoutMs?: number;
+
   /** Memory SDK config (condensed key-value memory per user). Set enabled: true to activate. */
   memory?: HippocampusMemory;
 

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -378,7 +378,14 @@ export type GenerateOptions = {
    * multi-step tool loop (Vertex Gemini / Vertex Claude), this bounds EACH
    * model call in the loop, not the whole turn — a tool-heavy turn may run
    * far longer than this value in total. Size it for the slowest single
-   * step (default 300s), and use `abortSignal` for a total-turn deadline.
+   * step (default 300s), and use `turnTimeoutMs` (or `abortSignal`) for a
+   * total-turn deadline.
+   *
+   * On the AI-SDK loop path (direct Anthropic, litellm, OpenAI-compatible)
+   * the same split holds only when `turnTimeoutMs` is ALSO set: then this
+   * value bounds each model call and `turnTimeoutMs` bounds the turn. With
+   * `turnTimeoutMs` unset, this value bounds the WHOLE turn there (the
+   * pre-existing defensive behavior, kept for backward compatibility).
    *
    * When set explicitly, a step timeout is surfaced immediately instead of
    * burning internal retries/fallbacks that would re-run the same
@@ -393,9 +400,11 @@ export type GenerateOptions = {
    * imposes no product policy).
    *
    * Enforced by the native Vertex loops (Gemini + Claude) AND the AI-SDK
-   * loop path (litellm and other OpenAI-compatible providers). On the AI-SDK
-   * path, an explicit `timeout` also engages the same wrap-up when
-   * `turnTimeoutMs` is unset. Once the wrap-up window begins (see
+   * loop path (direct Anthropic, litellm and other OpenAI-compatible
+   * providers). On the AI-SDK path this value also owns the whole-turn hard
+   * abort: when set, `timeout` keeps its per-model-call meaning instead of
+   * bounding the entire loop. An explicit `timeout` also engages the same
+   * wrap-up when `turnTimeoutMs` is unset. Once the wrap-up window begins (see
    * `wrapupTimeLeadMs`), the loop forcibly sets `toolChoice: "none"` for the
    * remaining steps — overriding any caller-supplied `toolChoice` or
    * `prepareStep` tool selection — and appends an honest time message that a

--- a/src/lib/utils/conversationMemory.ts
+++ b/src/lib/utils/conversationMemory.ts
@@ -783,7 +783,16 @@ export async function generateSummary(
   );
 
   const SUMMARIZER_INIT_TIMEOUT = 15_000;
-  const SUMMARIZER_GENERATE_TIMEOUT = 60_000;
+  // Config-driven: a compaction summary of a large conversation routinely
+  // needs more than the old hard-coded 60s, and each overrun silently loses
+  // one summary (non-fatal — the turn continues) with no knob to raise it.
+  const configuredTimeoutMs = config.summarizationTimeoutMs;
+  const SUMMARIZER_GENERATE_TIMEOUT =
+    typeof configuredTimeoutMs === "number" &&
+    Number.isFinite(configuredTimeoutMs) &&
+    configuredTimeoutMs > 0
+      ? configuredTimeoutMs
+      : 60_000;
 
   try {
     if (!cachedSummarizer) {

--- a/src/lib/utils/errorHandling.ts
+++ b/src/lib/utils/errorHandling.ts
@@ -1407,7 +1407,11 @@ export function isAbortError(error: unknown): boolean {
     error instanceof Error &&
     (error.message?.includes("This operation was aborted") ||
       error.message?.includes("The operation was aborted") ||
-      error.message?.includes("The user aborted a request"))
+      error.message?.includes("The user aborted a request") ||
+      // Anthropic SDK's APIUserAbortError — name is plain "Error", so only
+      // the message identifies it. Missing this classified real aborts as
+      // provider failures (ERROR log + fallback consulted on a user cancel).
+      error.message?.includes("Request was aborted"))
   ) {
     return true;
   }

--- a/test/continuous-test-suite-anthropic-loop-characterization.ts
+++ b/test/continuous-test-suite-anthropic-loop-characterization.ts
@@ -687,4 +687,207 @@ await test("fallbackOnMaxSteps: false surfaces a capped turn instead of retrying
   );
 });
 
+// ---------------------------------------------------------------------------
+// generate-path turn-budget semantics (non-streaming doGenerate)
+//
+// Pins the 2026-09-01 curator/yama incident class: `timeout` alone used to
+// bound the ENTIRE multi-step generate loop, so a caller passing
+// `{ timeout: 300s, turnTimeoutMs: 40min }` was killed at 300s flat, and the
+// kill surfaced as the SDK's generic cancel ("Request was aborted.") logged
+// as a provider failure. The three cases below pin the repaired contract:
+// turnTimeoutMs owns the whole-turn cap, `timeout` bounds each model call,
+// an internal timer's kill carries the timer's own identity, and a genuine
+// caller cancel never consults the fallback callback.
+// ---------------------------------------------------------------------------
+
+type JsonTurn = {
+  delayMs: number;
+  message: Record<string, unknown>;
+};
+
+/** Non-streaming Messages response that asks for one tool call. */
+function jsonToolTurn(name: string, id: string): Record<string, unknown> {
+  return {
+    id,
+    type: "message",
+    role: "assistant",
+    model: MODEL,
+    content: [{ type: "tool_use", id: `${id}_use`, name, input: {} }],
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: { input_tokens: 5, output_tokens: 6 },
+  };
+}
+
+/** Non-streaming Messages response that answers with text and stops. */
+function jsonTextTurn(text: string): Record<string, unknown> {
+  return {
+    id: "msg_final",
+    type: "message",
+    role: "assistant",
+    model: MODEL,
+    content: [{ type: "text", text }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 5, output_tokens: 4 },
+  };
+}
+
+/** JSON stand-in for the non-streaming generate path, with per-call delay. */
+async function startJsonStandIn(
+  reply: (callIndex: number) => JsonTurn,
+): Promise<StandIn> {
+  const calls: StandInCall[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const parseBody = (): Record<string, unknown> => {
+        try {
+          return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+        } catch {
+          return {};
+        }
+      };
+      calls.push({ body: parseBody() });
+      const turn = reply(calls.length - 1);
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(turn.message));
+      }, turn.delayMs);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    calls,
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+section("generate-path turn budget semantics");
+
+await test("an explicit turnTimeoutMs owns the whole-turn cap; timeout stays per-call", async () => {
+  // Three model calls of ~1s each under a per-call `timeout` of 2.5s and a
+  // turn cap of 30s. The pre-fix behavior armed the 2.5s value over the
+  // WHOLE loop and killed the turn mid-call 3.
+  const server = await startJsonStandIn((i) =>
+    i === 0
+      ? { delayMs: 1_000, message: jsonToolTurn("lookup", "msg_1") }
+      : i === 1
+        ? { delayMs: 1_000, message: jsonToolTurn("lookup", "msg_2") }
+        : { delayMs: 1_000, message: jsonTextTurn("budget respected") },
+  );
+  const restore = withAnthropicEnv(server.port);
+  const counter = { calls: 0 };
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "do the slow thing" },
+      provider: "anthropic",
+      model: MODEL,
+      maxTokens: 32,
+      maxSteps: 5,
+      disableTools: false,
+      tools: customTool(counter),
+      timeout: 2_500,
+      turnTimeoutMs: 30_000,
+    });
+    assert(
+      (result.content ?? "").includes("budget respected"),
+      "the turn did not run to completion under an explicit turn cap",
+    );
+    assert(
+      server.calls.length === 3,
+      `the tool loop should take exactly three calls, took ${server.calls.length}`,
+    );
+    assert(counter.calls === 2, "the tool did not execute exactly twice");
+  } finally {
+    restore();
+    await server.close();
+  }
+});
+
+await test("a per-call timeout kill carries the timer's identity, not the SDK cancel shape", async () => {
+  // One call that outlives `timeout`. The surfaced error must say what
+  // actually happened (the timer fired) — the pre-fix behavior surfaced the
+  // Anthropic SDK's generic cancel wording, which reads as a caller abort.
+  const server = await startJsonStandIn(() => ({
+    delayMs: 3_000,
+    message: jsonTextTurn("too late"),
+  }));
+  const restore = withAnthropicEnv(server.port);
+  let thrown: Error | undefined;
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "hang" },
+      provider: "anthropic",
+      model: MODEL,
+      maxTokens: 32,
+      timeout: 1_000,
+    });
+  } catch (error) {
+    thrown = error instanceof Error ? error : new Error("non-error thrown");
+  } finally {
+    restore();
+    await server.close();
+  }
+  assert(thrown !== undefined, "the timer did not end the call at all");
+  const text = thrown?.message ?? "";
+  assert(
+    text.includes("timed out"),
+    "the timer's own identity did not surface on the thrown error",
+  );
+  assert(
+    !text.includes("Request was aborted"),
+    "the SDK's generic cancel shape leaked through instead of the timer identity",
+  );
+});
+
+await test("a caller abort never consults the providerFallback callback", async () => {
+  // A genuine cancel (the caller's own signal) must bubble as an abort —
+  // pre-fix, the SDK's cancel wording was not classified as an abort, so
+  // the fallback callback was consulted and the turn re-ran elsewhere.
+  const server = await startJsonStandIn(() => ({
+    delayMs: 2_500,
+    message: jsonTextTurn("should never arrive"),
+  }));
+  const restore = withAnthropicEnv(server.port);
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), 250);
+  let fallbackConsulted = 0;
+  let thrown = false;
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "cancel me" },
+      provider: "anthropic",
+      model: MODEL,
+      maxTokens: 32,
+      timeout: 10_000,
+      abortSignal: controller.signal,
+      providerFallback: async () => {
+        fallbackConsulted++;
+        return null;
+      },
+    });
+  } catch {
+    thrown = true;
+  } finally {
+    clearTimeout(abortTimer);
+    restore();
+    await server.close();
+  }
+  assert(thrown, "the caller's cancel did not end the turn");
+  assert(
+    fallbackConsulted === 0,
+    `a caller cancel must not consult the fallback callback, consulted ${fallbackConsulted} time(s)`,
+  );
+});
+
 await runSuite();


### PR DESCRIPTION
## Summary

RCA of the 2026-09-01 curator/yama incident: a caller passing `{ timeout: 300000, turnTimeoutMs: 2400000 }` had its 40-minute review turn hard-aborted at exactly 300.000s — twice — because the generate path's defensive timer armed `timeout` over the ENTIRE multi-step loop and never consulted `turnTimeoutMs`. The kill then surfaced as the Anthropic SDK's generic `Request was aborted.` (the abort reason is discarded by the SDK), which `isAbortError` does not match, so an internal, scheduled timeout was logged as an ERROR provider failure and misdiagnosed as a proxy/network problem.

Four repairs, one behavioral contract:

- **`executeStandardGenerateFlow`**: an explicit valid `turnTimeoutMs` now owns the whole-turn hard abort; `timeout` keeps its documented per-model-call meaning. With `turnTimeoutMs` unset, behavior is unchanged (`timeout ?? max(descriptor, 180s)` whole-turn bound — backward compatible).
- **Timeout identity**: when a NeuroLink timer fired, the `TimeoutError` reason on the signal is rethrown instead of the SDK's generic cancel shape — logs now say `… timed out after …` instead of `Request was aborted.` (both the per-call timer in the anthropic client and the turn-level timer in baseProvider).
- **`isAbortError`**: matches Anthropic's `APIUserAbortError` message, so a genuine caller cancel is classified as an abort (INFO log, no fallback consult) — its `name` is plain `Error`, only the message identifies it.
- **Anthropic doGenerate**: reads the caller's resolved timeout from `providerOptions.neurolink.timeoutMs` (the AI-SDK call options carry no `timeout`; the old read was dead on V3), so an explicit per-call timeout is honored as a contract instead of the 60s/300s-floor defaults.
- **Config-driven summarizer timeout**: `conversationMemory.summarizationTimeoutMs` replaces the hard-coded 60s `SUMMARIZER_GENERATE_TIMEOUT` (default unchanged; an overrun still drops only that summary).

Since when: the whole-loop `timeout` bound shipped in v9.65.0 (2026-05-16); the conflict with `turnTimeoutMs` has existed since `turnTimeoutMs` shipped in v9.81.0 (2026-07-03); the `isAbortError` gap since v9.7.0 (2026-02-16); the summarizer constant since v9.16.0 (2026-03-01).

## Testing

- Three new regression cases in `test/continuous-test-suite-anthropic-loop-characterization.ts` (CI-gated via provider-safety-net), driving `dist` against a local non-streaming JSON stand-in: turn cap owned by `turnTimeoutMs` with per-call `timeout`; a timer kill carries `timed out` and not the SDK cancel wording; a caller abort never consults `providerFallback`.
- Suite 10/10 locally; `pnpm run check`, `pnpm run lint`, `pnpm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable time limits for conversation summarization, with a 60-second default.
  * Clarified whole-turn and per-call timeout behavior for AI generation.
  * Improved timeout messages to identify the specific timer involved.

* **Bug Fixes**
  * Preserved timeout details instead of reporting generic request-abort errors.
  * Improved recognition of user-cancelled requests and prevented unnecessary fallback handling.

* **Documentation**
  * Updated configuration, timeout, and API reference documentation to reflect current options and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->