### PR TITLE
ci(yama): bump to 6.1.1

### DIFF
--- a/.github/workflows/yama-learn.yml
+++ b/.github/workflows/yama-learn.yml
@@ -134,6 +134,9 @@ jobs:
         # exactly that file, reads the staged set back, and commits + pushes
         # with [skip ci] — never a force push. A refused or failed write exits
         # non-zero, so a silent no-op cannot pass for a successful learn.
+        #
+        # Same floor as yama-review.yml: 6.1.1 pulls the NeuroLink that observes
+        # stdio MCP server death (juspay/neurolink #1610).
         env:
           YAMA_GITHUB_TOKEN: ${{ secrets.YAMA_GITHUB_TOKEN }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
@@ -141,7 +144,7 @@ jobs:
           PR_NUMBER: ${{ steps.target.outputs.pr }}
         working-directory: .yama
         run: |
-          npx --yes @juspay/yama@^6.1.0 learn "pr=$PR_NUMBER" 2>&1 | tee learn-run.log
+          npx --yes @juspay/yama@^6.1.1 learn "pr=$PR_NUMBER" 2>&1 | tee learn-run.log
           exit "${PIPESTATUS[0]}"
 
       - name: Archive the run log

--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -97,6 +97,11 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         # Pinned to the 6.x major: this wiring is the v6 config layout, and the
         # learn command this repository chains on post-merge needs >= 6.1.0.
+        #
+        # Floor raised to 6.1.1: its NeuroLink dependency (>= 12.7.8) observes a
+        # stdio MCP server dying mid-review and restarts it (juspay/neurolink
+        # #1610). On the previous floor the code-review-graph server could die
+        # silently and every later call failed with "Not connected".
         env:
           YAMA_GITHUB_TOKEN: ${{ secrets.YAMA_GITHUB_TOKEN }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
@@ -107,7 +112,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         working-directory: .yama
         run: |
-          npx --yes @juspay/yama@^6.1.0 run "pr=$PR_NUMBER" "branch=$HEAD_REF" 2>&1 | tee review-run.log
+          npx --yes @juspay/yama@^6.1.1 run "pr=$PR_NUMBER" "branch=$HEAD_REF" 2>&1 | tee review-run.log
           exit "${PIPESTATUS[0]}"
 
       - name: Archive the run log


### PR DESCRIPTION
## Description

**What does this PR do?**

Bumps the Yama floor in both workflows from `@juspay/yama@^6.1.0` to `^6.1.1`.

Yama 6.1.1 depends on `@juspay/neurolink ^12.7.8`. NeuroLink 12.7.8 is the release cut from #1610 (`gitHead` `8d774c4a`), which makes the stdio MCP layer observe a server process dying mid-run and restart it, and surfaces the server's stderr when it does. On the previous floor, the `code-review-graph` stdio server used by the review could die silently: every later call failed with `Not connected` for the rest of the run while NeuroLink still reported it connected (runs 33542846056 and 33544249626).

## Type of Change

- [x] Build/CI configuration

## Changes Made

- `.github/workflows/yama-review.yml` — `npx --yes @juspay/yama@^6.1.1 run …`, pin comment records why the floor moved.
- `.github/workflows/yama-learn.yml` — `npx --yes @juspay/yama@^6.1.1 learn …`, same note.

No source, config or dependency changes. The `.yama/` config layout is unchanged between 6.1.0 and 6.1.1.

## Breaking Changes

- [x] No breaking changes

## New Provider Onboarding

- [x] N/A — no provider/model change

## Testing

The `Yama PR Review` check on this PR is the live test: it is the first run on 6.1.1 / NeuroLink 12.7.8. What to look for in its log:

- no `Not connected` storm after a `Connection closed`;
- if `code-review-graph` still dies, a restart follows and the review keeps its graph tools instead of losing them for the remainder of the run.

Note that the workflow currently shows only `NEUROLINK:ERROR` lines, so the `Connection lost … last stderr` (WARN) and `Scheduling restart` (INFO) lines from the new lifecycle code are not visible at Yama's log level. Raising it (`NEUROLINK_LOG_LEVEL=warn`) is a follow-up if the crash reason is wanted in CI output.

## Dependencies

- [x] No dependency changes (the pin lives in the workflow `npx` invocation, not in `package.json`)

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated learning and review workflows by updating the Yama tooling.
  * Added handling to restart stdio MCP servers that stop unexpectedly, preventing failures caused by lost connections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->