### PR TITLE
fix(proxy): reconcile recovered quota cooldowns

### DIFF
--- a/src/lib/server/routes/claudeProxyRoutes.ts
+++ b/src/lib/server/routes/claudeProxyRoutes.ts
@@ -974,11 +974,10 @@ function minutesUntil(untilMs: number, now: number): number {
 }
 
 /**
- * Proactively cool an account when a SUCCESS response reveals a window has just
- * flipped to "rejected" (the boundary request that spends the last of the quota
- * still returns 200 but reports rejected/next-reset). Parks the account until
- * its reset so the next request skips it instead of discovering the limit via a
- * 429, except when the provider explicitly enables paid overage.
+ * Reconcile quota-backed cooldowns against a fresh provider observation. A
+ * rejected window parks the account until its reset; an allowed observation for
+ * that same window releases an earlier cooldown whose reset timestamp was
+ * stale. Transient and authentication cooldowns are intentionally untouched.
  */
 function reconcileCooldownFromQuota(
   state: RuntimeAccountState,
@@ -1023,6 +1022,23 @@ function reconcileCooldownFromQuota(
     reason = "unified";
   }
   if (until === undefined) {
+    const recoveredQuotaCooldown =
+      !!state.coolingUntil &&
+      ((state.coolingReason === "weekly" && quota.weeklyStatus === "allowed") ||
+        (state.coolingReason === "session" &&
+          quota.sessionStatus === "allowed") ||
+        (state.coolingReason === "unified" &&
+          quota.unifiedStatus === "allowed"));
+    if (recoveredQuotaCooldown && state.coolingUntil) {
+      const previousCoolingUntil = state.coolingUntil;
+      const previousCoolingReason = state.coolingReason;
+      state.coolingUntil = undefined;
+      state.coolingReason = undefined;
+      logger.always(
+        `[proxy] clearing ${previousCoolingReason} cooldown from fresh provider quota`,
+      );
+      return { kind: "cleared", coolingUntil: previousCoolingUntil };
+    }
     return null;
   }
   const clamped = clampCooldownUntil(until, now, reason);

--- a/test/continuous-test-suite-proxy.ts
+++ b/test/continuous-test-suite-proxy.ts
@@ -6615,6 +6615,82 @@ async function testCooldownReasonCeilings(): Promise<boolean | null> {
   return true;
 }
 
+async function testQuotaRefreshReleasesRecoveredCooldown(): Promise<
+  boolean | null
+> {
+  const { __testHooks } =
+    await import("../src/lib/server/routes/claudeProxyRoutes.js");
+  const now = TEST_NOW;
+  const nowSec = Math.floor(now / 1000);
+  const state = {
+    coolingUntil: now + 6 * 24 * 3600 * 1000,
+    coolingReason: "weekly",
+  } as never;
+
+  const stillExhausted = __testHooks.reconcileCooldownFromQuota(
+    state,
+    makeQuota({
+      weeklyStatus: "rejected",
+      weeklyResetAt: nowSec + 6 * 24 * 3600,
+      lastUpdated: now,
+    }) as never,
+    now,
+  );
+  if (
+    stillExhausted !== null ||
+    !(state as { coolingUntil?: number }).coolingUntil
+  ) {
+    log("quota refresh: rejected weekly window must remain cooling", "red");
+    return false;
+  }
+
+  const recovered = __testHooks.reconcileCooldownFromQuota(
+    state,
+    makeQuota({
+      weeklyStatus: "allowed",
+      weeklyUsed: 0.05,
+      weeklyResetAt: nowSec + 7 * 24 * 3600,
+      lastUpdated: now + 1,
+    }) as never,
+    now + 1,
+  );
+  if (
+    recovered?.kind !== "cleared" ||
+    (state as { coolingUntil?: number }).coolingUntil !== undefined ||
+    (state as { coolingReason?: string }).coolingReason !== undefined
+  ) {
+    log("quota refresh: allowed weekly window did not release cooldown", "red");
+    return false;
+  }
+
+  const transientState = {
+    coolingUntil: now + 30_000,
+    coolingReason: "transient",
+  } as never;
+  const transientUpdate = __testHooks.reconcileCooldownFromQuota(
+    transientState,
+    makeQuota({
+      weeklyStatus: "allowed",
+      weeklyUsed: 0.05,
+      lastUpdated: now + 2,
+    }) as never,
+    now + 2,
+  );
+  if (
+    transientUpdate !== null ||
+    (transientState as { coolingUntil?: number }).coolingUntil === undefined
+  ) {
+    log("quota refresh: must not clear an unrelated transient cooldown", "red");
+    return false;
+  }
+
+  log(
+    "quota refresh: fresh weekly recovery releases only its cooldown",
+    "green",
+  );
+  return true;
+}
+
 async function testPersistedCooldownClamp(): Promise<boolean | null> {
   const { initAccountCooldown, loadAccountCooldowns } =
     await import("../src/lib/proxy/accountCooldown.js");
@@ -8295,6 +8371,11 @@ const tests: TestFunction[] = [
   {
     name: "Cooldown: per-reason ceilings",
     fn: testCooldownReasonCeilings,
+    category: "proxy-primary",
+  },
+  {
+    name: "Cooldown: fresh quota recovery releases stale weekly state",
+    fn: testQuotaRefreshReleasesRecoveredCooldown,
     category: "proxy-primary",
   },
   {


### PR DESCRIPTION
## Summary
- clear a quota-backed runtime cooldown only when fresh provider usage reports its matching window as allowed
- keep still-rejected, transient, and authentication cooldowns intact
- cover stale weekly recovery through the proxy quota-reconciliation path

## Verification
- pnpm run build:cli
- pnpm run test:proxy (94 passed, 7 credential-dependent skips)
- pnpm run typecheck
- focused Prettier and ESLint checks
- pre-push: dependency guard, package build, provider structure, and model manifests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts no longer remain paused after a fresh provider quota update confirms that a weekly, session, or unified limit has recovered.
  * Unrelated temporary cooldowns remain unchanged.

* **Tests**
  * Added coverage for preserving active cooldowns, clearing recovered quota cooldowns, and leaving unrelated cooldown states untouched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->