### PR TITLE
fix(proxy): use Codex WHAM usage endpoint

### DIFF
--- a/docs/api/type-aliases/CodexContentPart.md
+++ b/docs/api/type-aliases/CodexContentPart.md
@@ -8,6 +8,6 @@
 
 > **CodexContentPart** = \{ `type`: `"input_text"`; `text`: `string`; \} \| \{ `type`: `"output_text"`; `text`: `string`; \} \| \{ `type`: `"input_image"`; `image_url`: `string`; \}
 
-Defined in: [types/codex.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L114)
+Defined in: [types/codex.ts:132](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L132)
 
 A text or image content part accepted by the Codex Responses backend.

--- a/docs/api/type-aliases/CodexFallbackResult.md
+++ b/docs/api/type-aliases/CodexFallbackResult.md
@@ -8,7 +8,7 @@
 
 > **CodexFallbackResult** = `object`
 
-Defined in: [types/codex.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L158)
+Defined in: [types/codex.ts:176](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L176)
 
 Fully buffered Codex result rendered back as an Anthropic response.
 
@@ -18,7 +18,7 @@ Fully buffered Codex result rendered back as an Anthropic response.
 
 > **text**: `string`
 
-Defined in: [types/codex.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L159)
+Defined in: [types/codex.ts:177](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L177)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/codex.ts:159](https://github.com/juspay/neurolink/blob/releas
 
 > **toolCalls**: `NonNullable`\<[`InternalResult`](InternalResult.md)\[`"toolCalls"`\]\>
 
-Defined in: [types/codex.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L160)
+Defined in: [types/codex.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L178)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/codex.ts:160](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **usage?**: `NonNullable`\<[`InternalResult`](InternalResult.md)\[`"usage"`\]\>
 
-Defined in: [types/codex.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L161)
+Defined in: [types/codex.ts:179](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L179)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/codex.ts:161](https://github.com/juspay/neurolink/blob/releas
 
 > **finishReason**: `"end_turn"` \| `"tool_use"`
 
-Defined in: [types/codex.ts:162](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L162)
+Defined in: [types/codex.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L180)

--- a/docs/api/type-aliases/CodexProxyStatusAccountIdentity.md
+++ b/docs/api/type-aliases/CodexProxyStatusAccountIdentity.md
@@ -8,6 +8,6 @@
 
 > **CodexProxyStatusAccountIdentity** = \{ `provider`: `"anthropic"`; `key`: `string`; \} \| \{ `provider`: `"codex"`; `key`: `string`; \} \| \{ `provider`: `"other"`; `key`: `null`; \}
 
-Defined in: [types/codex.ts:108](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L108)
+Defined in: [types/codex.ts:126](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L126)
 
 Provider-qualified account identity used by proxy status rendering.

--- a/docs/api/type-aliases/CodexRateLimitWindow.md
+++ b/docs/api/type-aliases/CodexRateLimitWindow.md
@@ -55,3 +55,21 @@ instead of degrading to the transient ceiling.
 > `optional` **resets_at?**: `number` \| `null`
 
 Defined in: [types/codex.ts:70](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L70)
+
+---
+
+### reset_after_seconds?
+
+> `optional` **reset_after_seconds?**: `number` \| `null`
+
+Defined in: [types/codex.ts:72](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L72)
+
+Current WHAM usage fields.
+
+---
+
+### reset_at?
+
+> `optional` **reset_at?**: `number` \| `null`
+
+Defined in: [types/codex.ts:73](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L73)

--- a/docs/api/type-aliases/CodexRateLimits.md
+++ b/docs/api/type-aliases/CodexRateLimits.md
@@ -8,7 +8,7 @@
 
 > **CodexRateLimits** = `object`
 
-Defined in: [types/codex.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L74)
+Defined in: [types/codex.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L77)
 
 Codex rate-limit block: a primary (short) and secondary (long) window.
 
@@ -18,7 +18,7 @@ Codex rate-limit block: a primary (short) and secondary (long) window.
 
 > `optional` **primary?**: [`CodexRateLimitWindow`](CodexRateLimitWindow.md) \| `null`
 
-Defined in: [types/codex.ts:75](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L75)
+Defined in: [types/codex.ts:78](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L78)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/codex.ts:75](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **secondary?**: [`CodexRateLimitWindow`](CodexRateLimitWindow.md) \| `null`
 
-Defined in: [types/codex.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L76)
+Defined in: [types/codex.ts:79](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L79)

--- a/docs/api/type-aliases/CodexResponsesInputItem.md
+++ b/docs/api/type-aliases/CodexResponsesInputItem.md
@@ -8,6 +8,6 @@
 
 > **CodexResponsesInputItem** = \{ `role`: `"user"` \| `"assistant"`; `content`: [`CodexContentPart`](CodexContentPart.md)[]; \} \| \{ `type`: `"function_call"`; `call_id`: `string`; `name`: `string`; `arguments`: `string`; \} \| \{ `type`: `"function_call_output"`; `call_id`: `string`; `output`: `string`; \}
 
-Defined in: [types/codex.ts:120](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L120)
+Defined in: [types/codex.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L138)
 
 A single item in a Codex Responses request.

--- a/docs/api/type-aliases/CodexResponsesRequest.md
+++ b/docs/api/type-aliases/CodexResponsesRequest.md
@@ -8,7 +8,7 @@
 
 > **CodexResponsesRequest** = `object`
 
-Defined in: [types/codex.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L138)
+Defined in: [types/codex.ts:156](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L156)
 
 Request shape used to bridge Anthropic Messages traffic to Codex Responses.
 
@@ -18,7 +18,7 @@ Request shape used to bridge Anthropic Messages traffic to Codex Responses.
 
 > **model**: `string`
 
-Defined in: [types/codex.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L139)
+Defined in: [types/codex.ts:157](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L157)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/codex.ts:139](https://github.com/juspay/neurolink/blob/releas
 
 > **input**: [`CodexResponsesInputItem`](CodexResponsesInputItem.md)[]
 
-Defined in: [types/codex.ts:140](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L140)
+Defined in: [types/codex.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L158)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/codex.ts:140](https://github.com/juspay/neurolink/blob/releas
 
 > **stream**: `true`
 
-Defined in: [types/codex.ts:141](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L141)
+Defined in: [types/codex.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L159)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/codex.ts:141](https://github.com/juspay/neurolink/blob/releas
 
 > **store**: `false`
 
-Defined in: [types/codex.ts:142](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L142)
+Defined in: [types/codex.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L160)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/codex.ts:142](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **instructions?**: `string`
 
-Defined in: [types/codex.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L143)
+Defined in: [types/codex.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L161)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/codex.ts:143](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **tools?**: `object`[]
 
-Defined in: [types/codex.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L144)
+Defined in: [types/codex.ts:162](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L162)
 
 #### type
 
@@ -82,4 +82,4 @@ Defined in: [types/codex.ts:144](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **tool_choice?**: `"auto"` \| `"required"` \| `"none"` \| \{ `type`: `"function"`; `name`: `string`; \}
 
-Defined in: [types/codex.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L150)
+Defined in: [types/codex.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L168)

--- a/docs/api/type-aliases/CodexRuntimeAccount.md
+++ b/docs/api/type-aliases/CodexRuntimeAccount.md
@@ -8,7 +8,7 @@
 
 > **CodexRuntimeAccount** = `object`
 
-Defined in: [types/codex.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L91)
+Defined in: [types/codex.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L109)
 
 A Codex account with its runtime cooldown/quota state hydrated from disk.
 
@@ -18,7 +18,7 @@ A Codex account with its runtime cooldown/quota state hydrated from disk.
 
 > **key**: `string`
 
-Defined in: [types/codex.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L92)
+Defined in: [types/codex.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L110)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/codex.ts:92](https://github.com/juspay/neurolink/blob/release
 
 > **label**: `string`
 
-Defined in: [types/codex.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L93)
+Defined in: [types/codex.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L111)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/codex.ts:93](https://github.com/juspay/neurolink/blob/release
 
 > **token**: `string`
 
-Defined in: [types/codex.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L94)
+Defined in: [types/codex.ts:112](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L112)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/codex.ts:94](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **refreshToken?**: `string`
 
-Defined in: [types/codex.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L95)
+Defined in: [types/codex.ts:113](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L113)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/codex.ts:95](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **expiresAt?**: `number`
 
-Defined in: [types/codex.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L96)
+Defined in: [types/codex.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L114)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/codex.ts:96](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **accountId?**: `string`
 
-Defined in: [types/codex.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L97)
+Defined in: [types/codex.ts:115](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L115)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/codex.ts:97](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **quota?**: [`AccountQuota`](AccountQuota.md)
 
-Defined in: [types/codex.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L98)
+Defined in: [types/codex.ts:116](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L116)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/codex.ts:98](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **coolingUntil?**: `number`
 
-Defined in: [types/codex.ts:99](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L99)
+Defined in: [types/codex.ts:117](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L117)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/codex.ts:99](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **coolingReason?**: [`AccountCoolingReason`](AccountCoolingReason.md)
 
-Defined in: [types/codex.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L100)
+Defined in: [types/codex.ts:118](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L118)
 
 ---
 
@@ -90,7 +90,7 @@ Defined in: [types/codex.ts:100](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **expiredCooldownUntil?**: `number`
 
-Defined in: [types/codex.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L104)
+Defined in: [types/codex.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L122)
 
 A persisted cooldown whose window has already passed. Present only when the
 account is therefore eligible again, so the success path can delete the

--- a/docs/api/type-aliases/CodexUsageFetchResult.md
+++ b/docs/api/type-aliases/CodexUsageFetchResult.md
@@ -6,8 +6,8 @@
 
 # Type Alias: CodexUsageFetchResult
 
-> **CodexUsageFetchResult** = \{ `ok`: `true`; `quota`: [`AccountQuota`](AccountQuota.md); \} \| \{ `ok`: `false`; `reason`: `"not_oauth"` \| `"auth"` \| `"http"` \| `"network"` \| `"parse"`; \}
+> **CodexUsageFetchResult** = \{ `ok`: `true`; `quota`: [`AccountQuota`](AccountQuota.md); \} \| \{ `ok`: `false`; `reason`: `"not_oauth"` \| `"auth"` \| `"rate_limited"` \| `"http"` \| `"network"` \| `"parse"`; \}
 
-Defined in: [types/codex.ts:86](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L86)
+Defined in: [types/codex.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L95)
 
 Result of a single Codex usage fetch.

--- a/docs/api/type-aliases/CodexUsageResponse.md
+++ b/docs/api/type-aliases/CodexUsageResponse.md
@@ -8,7 +8,7 @@
 
 > **CodexUsageResponse** = `object`
 
-Defined in: [types/codex.ts:80](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L80)
+Defined in: [types/codex.ts:83](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L83)
 
 Loose shape of the Codex usage endpoint response.
 
@@ -18,7 +18,19 @@ Loose shape of the Codex usage endpoint response.
 
 > `optional` **rate_limits?**: [`CodexRateLimits`](CodexRateLimits.md) \| `null`
 
-Defined in: [types/codex.ts:81](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L81)
+Defined in: [types/codex.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L85)
+
+Legacy Codex usage payload.
+
+---
+
+### rate_limit?
+
+> `optional` **rate_limit?**: \{ `primary_window?`: [`CodexRateLimitWindow`](CodexRateLimitWindow.md) \| `null`; `secondary_window?`: [`CodexRateLimitWindow`](CodexRateLimitWindow.md) \| `null`; \} \| `null`
+
+Defined in: [types/codex.ts:87](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L87)
+
+Current ChatGPT WHAM account-usage payload.
 
 ---
 
@@ -26,4 +38,4 @@ Defined in: [types/codex.ts:81](https://github.com/juspay/neurolink/blob/release
 
 > `optional` **plan_type?**: `string` \| `null`
 
-Defined in: [types/codex.ts:82](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L82)
+Defined in: [types/codex.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/codex.ts#L91)

--- a/src/lib/auth/codexOAuth.ts
+++ b/src/lib/auth/codexOAuth.ts
@@ -36,7 +36,9 @@ export const CODEX_DEFAULT_SCOPES = [
 // Upstream backend (ChatGPT subscription path).
 export const CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex";
 export const CODEX_RESPONSES_URL = `${CODEX_BACKEND_BASE_URL}/responses`;
-export const CODEX_USAGE_URL = `${CODEX_BACKEND_BASE_URL}/usage`;
+// Codex completions use the /codex namespace, but account quota is exposed by
+// the ChatGPT backend's WHAM account service.
+export const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 export const CODEX_MODELS_URL = `${CODEX_BACKEND_BASE_URL}/models`;
 
 // Client fingerprint. The real Codex CLI sends these; the proxy defaults them

--- a/src/lib/proxy/codexAccountUsage.ts
+++ b/src/lib/proxy/codexAccountUsage.ts
@@ -11,7 +11,6 @@ import { tokenStore } from "../auth/tokenStore.js";
 import type { CodexProxyStatusAccountIdentity } from "../types/index.js";
 import { normalizeAnthropicAccountKey } from "./accountSelection.js";
 import {
-  CODEX_ORIGINATOR,
   CODEX_USAGE_URL,
   CODEX_USER_AGENT,
   decodeCodexAccessToken,
@@ -100,6 +99,7 @@ function toFraction(percent: number | null | undefined): number {
   return Math.min(1, Math.max(0, percent / 100));
 }
 
+/** Convert absolute or relative Codex window resets into epoch seconds. */
 function windowResetEpochSeconds(
   window: CodexRateLimitWindow | null | undefined,
   nowSeconds: number,
@@ -117,10 +117,21 @@ function windowResetEpochSeconds(
       ? Math.floor(window.resets_at / 1000)
       : window.resets_at;
   }
+  if (
+    typeof window.reset_at === "number" &&
+    Number.isFinite(window.reset_at) &&
+    window.reset_at > 0
+  ) {
+    return window.reset_at > 4_102_444_800
+      ? Math.floor(window.reset_at / 1000)
+      : window.reset_at;
+  }
   const relative =
     typeof window.resets_in_seconds === "number"
       ? window.resets_in_seconds
-      : window.reset_after;
+      : typeof window.reset_after_seconds === "number"
+        ? window.reset_after_seconds
+        : window.reset_after;
   if (
     typeof relative === "number" &&
     Number.isFinite(relative) &&
@@ -244,7 +255,6 @@ export async function fetchCodexAccountUsage(
       headers: {
         Authorization: `Bearer ${account.token}`,
         ...(accountId ? { "chatgpt-account-id": accountId } : {}),
-        originator: CODEX_ORIGINATOR,
         "User-Agent": CODEX_USER_AGENT,
         Accept: "application/json",
       },
@@ -253,11 +263,20 @@ export async function fetchCodexAccountUsage(
     if (response.status === 401 || response.status === 403) {
       return { ok: false, reason: "auth" };
     }
+    if (response.status === 429) {
+      return { ok: false, reason: "rate_limited" };
+    }
     if (!response.ok) {
       return { ok: false, reason: "http" };
     }
     const usage = (await response.json()) as CodexUsageResponse;
-    return { ok: true, quota: codexRateLimitsToQuota(usage.rate_limits) };
+    const rateLimits = usage.rate_limit
+      ? {
+          primary: usage.rate_limit.primary_window,
+          secondary: usage.rate_limit.secondary_window,
+        }
+      : usage.rate_limits;
+    return { ok: true, quota: codexRateLimitsToQuota(rateLimits) };
   } catch (error) {
     logger.debug(
       `Codex usage fetch failed for ${account.label}: ${

--- a/src/lib/types/codex.ts
+++ b/src/lib/types/codex.ts
@@ -68,6 +68,9 @@ export type CodexRateLimitWindow = {
    *  instead of degrading to the transient ceiling. */
   reset_after?: number | null;
   resets_at?: number | null;
+  /** Current WHAM usage fields. */
+  reset_after_seconds?: number | null;
+  reset_at?: number | null;
 };
 
 /** Codex rate-limit block: a primary (short) and secondary (long) window. */
@@ -78,14 +81,29 @@ export type CodexRateLimits = {
 
 /** Loose shape of the Codex usage endpoint response. */
 export type CodexUsageResponse = {
+  /** Legacy Codex usage payload. */
   rate_limits?: CodexRateLimits | null;
+  /** Current ChatGPT WHAM account-usage payload. */
+  rate_limit?: {
+    primary_window?: CodexRateLimitWindow | null;
+    secondary_window?: CodexRateLimitWindow | null;
+  } | null;
   plan_type?: string | null;
 };
 
 /** Result of a single Codex usage fetch. */
 export type CodexUsageFetchResult =
   | { ok: true; quota: AccountQuota }
-  | { ok: false; reason: "not_oauth" | "auth" | "http" | "network" | "parse" };
+  | {
+      ok: false;
+      reason:
+        | "not_oauth"
+        | "auth"
+        | "rate_limited"
+        | "http"
+        | "network"
+        | "parse";
+    };
 
 /** A Codex account with its runtime cooldown/quota state hydrated from disk. */
 export type CodexRuntimeAccount = {

--- a/test/continuous-test-suite-codex.ts
+++ b/test/continuous-test-suite-codex.ts
@@ -50,6 +50,7 @@ import {
 } from "../src/lib/auth/codexOAuth.js";
 import {
   codexRateLimitsToQuota,
+  fetchCodexAccountUsage,
   parseCodexRateLimitHeaders,
   resolveProxyStatusAccountIdentity,
 } from "../src/lib/proxy/codexAccountUsage.js";
@@ -401,6 +402,70 @@ await test("codexRateLimitsToQuota accepts reset_after as a relative reset", () 
     NOW_SECONDS + 1800,
     "reset_after must resolve to an absolute reset",
   );
+});
+
+await test("Codex usage refresh follows the WHAM account protocol", async () => {
+  const token = fakeCodexJwt({ chatgpt_account_id: "acct-usage" });
+  const originalFetch = globalThis.fetch;
+  const beforeFetch = Math.floor(Date.now() / 1000);
+  let request: { url: string; init?: RequestInit } | undefined;
+  globalThis.fetch = (async (input, init) => {
+    request = { url: input.toString(), init };
+    return new Response(
+      JSON.stringify({
+        plan_type: "pro",
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: { used_percent: 40, reset_after_seconds: 3600 },
+          secondary_window: { used_percent: 80, reset_at: NOW_SECONDS + 86400 },
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof globalThis.fetch;
+  try {
+    const result = await fetchCodexAccountUsage({
+      key: "codex:usage@example.com",
+      label: "usage@example.com",
+      token,
+      type: "oauth",
+    });
+    assert(result.ok, "WHAM usage response was not accepted");
+    if (!result.ok) {
+      return;
+    }
+    assertEqual(result.quota.sessionUsed, 0.4, "primary usage was not parsed");
+    assert(
+      result.quota.sessionResetAt >= beforeFetch + 3599 &&
+        result.quota.sessionResetAt <= beforeFetch + 3601,
+      "reset_after_seconds was not resolved",
+    );
+    assertEqual(result.quota.weeklyUsed, 0.8, "secondary usage was not parsed");
+    assertEqual(
+      result.quota.weeklyResetAt,
+      NOW_SECONDS + 86400,
+      "reset_at was not preserved",
+    );
+    assertEqual(
+      request?.url,
+      "https://chatgpt.com/backend-api/wham/usage",
+      "usage refresh did not call the WHAM account endpoint",
+    );
+    const headers = new Headers(request?.init?.headers);
+    assertEqual(
+      headers.get("chatgpt-account-id"),
+      "acct-usage",
+      "account identity was omitted",
+    );
+    assertEqual(
+      headers.get("authorization"),
+      `Bearer ${token}`,
+      "usage refresh did not send its account bearer",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 await test("parseCodexRateLimitHeaders tolerates absent and malformed headers", () => {


### PR DESCRIPTION
## Summary
- query Codex account quota through the current ChatGPT WHAM usage endpoint
- normalize WHAM window fields and report a true upstream 429 as `usage rate_limited`
- cover the endpoint, account identity, and quota mapping with an offline contract test

## Verification
- `pnpm run build:cli`
- `pnpm run test:codex` (47 passed)
- read-only live Codex usage probe succeeded: session 9%, allowed

The running proxy and installed package were not changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account usage retrieval using the current ChatGPT quota service.
  * Added support for updated quota response formats and reset-time values.
  * Account rate limiting is now reported clearly when usage requests receive a 429 response.
  * Maintained compatibility with legacy usage data formats.

* **Tests**
  * Added coverage verifying quota retrieval, request details, and parsed usage information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->