### PR TITLE
fix(providers): repair Cloudflare tool calling, refresh model data, survive rot

### DIFF
--- a/.github/workflows/live-matrix.yml
+++ b/.github/workflows/live-matrix.yml
@@ -65,8 +65,13 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           NVIDIA_NIM_API_KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # The catalog derives <ID>_API_KEY, so Cloudflare is read as
+          # CLOUDFLARE_API_KEY. This passed CLOUDFLARE_API_TOKEN, which
+          # nothing reads — Cloudflare was silently skipped every night.
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SAMBANOVA_API_KEY: ${{ secrets.SAMBANOVA_API_KEY }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
           JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
           STABILITY_API_KEY: ${{ secrets.STABILITY_API_KEY }}

--- a/.github/workflows/model-liveness.yml
+++ b/.github/workflows/model-liveness.yml
@@ -1,0 +1,110 @@
+name: Catalog Model Liveness (Nightly)
+
+on:
+  schedule:
+    # 04:00 UTC daily — an hour after live-matrix, so the two sweeps don't
+    # hammer the same provider accounts concurrently and trip rate limits.
+    - cron: "0 4 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  model-liveness:
+    name: 🩺 Catalog Model Liveness
+    runs-on: ubuntu-latest
+    # Not a required check: it calls real vendor APIs and must not block
+    # merges on an upstream outage. It is not allowed to fail *silently*
+    # either — that is the whole point of the issue-filing step below.
+    # Groq retired its entire llama/gemma/mixtral lineup and every id in its
+    # catalog entry went dead while nightly CI stayed green, because the
+    # matrix sweep skips providers whose keys are absent and silence read as
+    # success.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # check:models is source-only and buildless by design, so there is no
+      # build step here: it reads the catalog JSON and talks to vendors over
+      # HTTP. A broken build must not be able to hide model rot.
+      - name: Check catalog model liveness
+        id: liveness
+        run: |
+          set +e
+          pnpm run check:models 2>&1 | tee liveness.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        env:
+          # NOTE: these must match the names the catalog derives
+          # (<ID>_API_KEY), not whatever the vendor's own docs call them.
+          # live-matrix.yml passes CLOUDFLARE_API_TOKEN, which nothing reads,
+          # so Cloudflare has been silently skipped in that workflow.
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          SAMBANOVA_API_KEY: ${{ secrets.SAMBANOVA_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+
+      - name: Open or update the rot-tracking issue
+        if: steps.liveness.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Catalog model rot: a provider default is retired upstream"
+          BODY_FILE=$(mktemp)
+          {
+            echo "\`check:models\` found at least one provider whose **default model** the vendor no longer serves."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo '```'
+            cat liveness.txt
+            echo '```'
+            echo
+            echo "Fix by updating the provider's \`src/lib/providers/catalog/<id>.json\`:"
+            echo "set \`models.default\` to a live id, mark the retired ids \`\"status\": \"retired\"\`"
+            echo "(do not delete them — the frozen public-surface snapshot pins their enum members),"
+            echo "and refresh \`evidence.rosterVerified\`."
+            echo
+            echo "_Filed automatically by \`.github/workflows/model-liveness.yml\`._"
+          } > "$BODY_FILE"
+
+          # One rolling issue, not one per night: reopen and comment on the
+          # existing one so this cannot spam the tracker into being muted.
+          EXISTING=$(gh issue list --state open --label model-rot \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+            echo "commented on #$EXISTING"
+          else
+            gh label create model-rot \
+              --description "A catalog provider's default model is retired upstream" \
+              --color B60205 2>/dev/null || true
+            gh issue create --title "$TITLE" --label model-rot --body-file "$BODY_FILE"
+          fi
+
+      - name: Fail the run when a default model is dead
+        if: steps.liveness.outputs.exit_code != '0'
+        run: exit 1

--- a/docs/api/NeuroLink-API-Reference/namespaces/BedrockTypes/type-aliases/BedrockClient.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/BedrockTypes/type-aliases/BedrockClient.md
@@ -8,7 +8,7 @@
 
 > **BedrockClient** = `object`
 
-Defined in: [types/providers.ts:1918](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1918)
+Defined in: [types/providers.ts:1921](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1921)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1918](https://github.com/juspay/neurolink/blob/r
 
 > **config**: `object`
 
-Defined in: [types/providers.ts:1920](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1920)
+Defined in: [types/providers.ts:1923](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1923)
 
 #### region?
 
@@ -32,7 +32,7 @@ Defined in: [types/providers.ts:1920](https://github.com/juspay/neurolink/blob/r
 
 > **send**(`command`): `Promise`\<`unknown`\>
 
-Defined in: [types/providers.ts:1919](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1919)
+Defined in: [types/providers.ts:1922](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1922)
 
 #### Parameters
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/BedrockTypes/type-aliases/InvokeModelCommand.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/BedrockTypes/type-aliases/InvokeModelCommand.md
@@ -8,7 +8,7 @@
 
 > **InvokeModelCommand** = `object`
 
-Defined in: [types/providers.ts:1927](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1927)
+Defined in: [types/providers.ts:1930](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1930)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1927](https://github.com/juspay/neurolink/blob/r
 
 > **input**: `object`
 
-Defined in: [types/providers.ts:1928](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1928)
+Defined in: [types/providers.ts:1931](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1931)
 
 #### modelId
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/MistralTypes/type-aliases/MistralClient.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/MistralTypes/type-aliases/MistralClient.md
@@ -8,7 +8,7 @@
 
 > **MistralClient** = `object`
 
-Defined in: [types/providers.ts:1941](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1941)
+Defined in: [types/providers.ts:1944](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1944)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1941](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **chat?**: `object`
 
-Defined in: [types/providers.ts:1942](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1942)
+Defined in: [types/providers.ts:1945](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1945)
 
 #### complete?
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Counter.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Counter.md
@@ -8,7 +8,7 @@
 
 > **Counter** = `object`
 
-Defined in: [types/providers.ts:1962](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1962)
+Defined in: [types/providers.ts:1965](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1965)
 
 ## Methods
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1962](https://github.com/juspay/neurolink/blob/r
 
 > **add**(`value`, `attributes?`): `void`
 
-Defined in: [types/providers.ts:1963](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1963)
+Defined in: [types/providers.ts:1966](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1966)
 
 #### Parameters
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Histogram.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Histogram.md
@@ -8,7 +8,7 @@
 
 > **Histogram** = `object`
 
-Defined in: [types/providers.ts:1966](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1966)
+Defined in: [types/providers.ts:1969](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1969)
 
 ## Methods
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1966](https://github.com/juspay/neurolink/blob/r
 
 > **record**(`value`, `attributes?`): `void`
 
-Defined in: [types/providers.ts:1967](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1967)
+Defined in: [types/providers.ts:1970](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1970)
 
 #### Parameters
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Meter.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Meter.md
@@ -8,7 +8,7 @@
 
 > **Meter** = `object`
 
-Defined in: [types/providers.ts:1953](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1953)
+Defined in: [types/providers.ts:1956](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1956)
 
 ## Methods
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1953](https://github.com/juspay/neurolink/blob/r
 
 > **createCounter**(`name`, `options?`): [`Counter`](Counter.md)
 
-Defined in: [types/providers.ts:1954](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1954)
+Defined in: [types/providers.ts:1957](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1957)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [types/providers.ts:1954](https://github.com/juspay/neurolink/blob/r
 
 > **createHistogram**(`name`, `options?`): [`Histogram`](Histogram.md)
 
-Defined in: [types/providers.ts:1955](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1955)
+Defined in: [types/providers.ts:1958](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1958)
 
 #### Parameters
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Span.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Span.md
@@ -8,7 +8,7 @@
 
 > **Span** = `object`
 
-Defined in: [types/providers.ts:1970](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1970)
+Defined in: [types/providers.ts:1973](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1973)
 
 ## Methods
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1970](https://github.com/juspay/neurolink/blob/r
 
 > **end**(): `void`
 
-Defined in: [types/providers.ts:1971](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1971)
+Defined in: [types/providers.ts:1974](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1974)
 
 #### Returns
 
@@ -28,7 +28,7 @@ Defined in: [types/providers.ts:1971](https://github.com/juspay/neurolink/blob/r
 
 > **setStatus**(`status`): `void`
 
-Defined in: [types/providers.ts:1972](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1972)
+Defined in: [types/providers.ts:1975](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1975)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:1972](https://github.com/juspay/neurolink/blob/r
 
 > **recordException**(`exception`): `void`
 
-Defined in: [types/providers.ts:1973](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1973)
+Defined in: [types/providers.ts:1976](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1976)
 
 #### Parameters
 

--- a/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Tracer.md
+++ b/docs/api/NeuroLink-API-Reference/namespaces/TelemetryTypes/type-aliases/Tracer.md
@@ -8,7 +8,7 @@
 
 > **Tracer** = `object`
 
-Defined in: [types/providers.ts:1958](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1958)
+Defined in: [types/providers.ts:1961](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1961)
 
 ## Methods
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1958](https://github.com/juspay/neurolink/blob/r
 
 > **startSpan**(`name`, `options?`): [`Span`](Span.md)
 
-Defined in: [types/providers.ts:1959](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1959)
+Defined in: [types/providers.ts:1962](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1962)
 
 #### Parameters
 

--- a/docs/api/type-aliases/AIProvider.md
+++ b/docs/api/type-aliases/AIProvider.md
@@ -8,7 +8,7 @@
 
 > **AIProvider** = `object`
 
-Defined in: [types/providers.ts:834](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L834)
+Defined in: [types/providers.ts:837](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L837)
 
 AI Provider type with flexible parameter support
 
@@ -18,7 +18,7 @@ AI Provider type with flexible parameter support
 
 > **stream**(`optionsOrPrompt`, `analysisSchema?`): `Promise`\<[`StreamResult`](StreamResult.md)\>
 
-Defined in: [types/providers.ts:836](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L836)
+Defined in: [types/providers.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L839)
 
 #### Parameters
 
@@ -40,7 +40,7 @@ Defined in: [types/providers.ts:836](https://github.com/juspay/neurolink/blob/re
 
 > **generate**(`optionsOrPrompt`, `analysisSchema?`): `Promise`\<[`EnhancedGenerateResult`](EnhancedGenerateResult.md) \| `null`\>
 
-Defined in: [types/providers.ts:841](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L841)
+Defined in: [types/providers.ts:844](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L844)
 
 #### Parameters
 
@@ -62,7 +62,7 @@ Defined in: [types/providers.ts:841](https://github.com/juspay/neurolink/blob/re
 
 > **gen**(`optionsOrPrompt`, `analysisSchema?`): `Promise`\<[`EnhancedGenerateResult`](EnhancedGenerateResult.md) \| `null`\>
 
-Defined in: [types/providers.ts:846](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L846)
+Defined in: [types/providers.ts:849](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L849)
 
 #### Parameters
 
@@ -84,7 +84,7 @@ Defined in: [types/providers.ts:846](https://github.com/juspay/neurolink/blob/re
 
 > **embed**(`text`, `modelName?`): `Promise`\<`number`[]\>
 
-Defined in: [types/providers.ts:851](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L851)
+Defined in: [types/providers.ts:854](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L854)
 
 #### Parameters
 
@@ -106,7 +106,7 @@ Defined in: [types/providers.ts:851](https://github.com/juspay/neurolink/blob/re
 
 > **embedMany**(`texts`, `modelName?`): `Promise`\<`number`[][]\>
 
-Defined in: [types/providers.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L853)
+Defined in: [types/providers.ts:856](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L856)
 
 #### Parameters
 
@@ -128,7 +128,7 @@ Defined in: [types/providers.ts:853](https://github.com/juspay/neurolink/blob/re
 
 > **setupToolExecutor**(`sdk`, `functionTag`): `void`
 
-Defined in: [types/providers.ts:856](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L856)
+Defined in: [types/providers.ts:859](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L859)
 
 #### Parameters
 
@@ -156,7 +156,7 @@ Defined in: [types/providers.ts:856](https://github.com/juspay/neurolink/blob/re
 
 > **setTraceContext**(`ctx`): `void`
 
-Defined in: [types/providers.ts:868](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L868)
+Defined in: [types/providers.ts:871](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L871)
 
 Propagate trace context from NeuroLink SDK for parent-child span hierarchy.
 Use this method instead of accessing `_traceContext` directly.
@@ -177,7 +177,7 @@ Use this method instead of accessing `_traceContext` directly.
 
 > `optional` **supportsTools**(): `boolean`
 
-Defined in: [types/providers.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L877)
+Defined in: [types/providers.ts:880](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L880)
 
 Whether this provider supports native tool/function calling for the
 current model. Implemented by BaseProvider (default true); overridden by
@@ -195,7 +195,7 @@ external AIProvider implementations — callers treat absence as `true`.
 
 > `optional` **ensureModelLimits**(): `Promise`\<`void`\>
 
-Defined in: [types/providers.ts:887](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L887)
+Defined in: [types/providers.ts:890](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L890)
 
 Ensure runtime-discovered model limits (context window, output-token
 ceiling) are registered before budget math runs. Implemented by

--- a/docs/api/type-aliases/AISDKGenerateResult.md
+++ b/docs/api/type-aliases/AISDKGenerateResult.md
@@ -8,7 +8,7 @@
 
 > **AISDKGenerateResult** = [`GenerateResult`](GenerateResult.md) & `object`
 
-Defined in: [types/providers.ts:960](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L960)
+Defined in: [types/providers.ts:963](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L963)
 
 AI SDK generate result with steps support (extends GenerateResult)
 

--- a/docs/api/type-aliases/AdaptiveSemaphoreConfig.md
+++ b/docs/api/type-aliases/AdaptiveSemaphoreConfig.md
@@ -8,7 +8,7 @@
 
 > **AdaptiveSemaphoreConfig** = `object`
 
-Defined in: [types/providers.ts:1356](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1356)
+Defined in: [types/providers.ts:1359](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1359)
 
 Adaptive semaphore configuration for concurrency management
 
@@ -18,7 +18,7 @@ Adaptive semaphore configuration for concurrency management
 
 > **initialConcurrency**: `number`
 
-Defined in: [types/providers.ts:1357](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1357)
+Defined in: [types/providers.ts:1360](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1360)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1357](https://github.com/juspay/neurolink/blob/r
 
 > **maxConcurrency**: `number`
 
-Defined in: [types/providers.ts:1358](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1358)
+Defined in: [types/providers.ts:1361](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1361)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:1358](https://github.com/juspay/neurolink/blob/r
 
 > **minConcurrency**: `number`
 
-Defined in: [types/providers.ts:1359](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1359)
+Defined in: [types/providers.ts:1362](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1362)

--- a/docs/api/type-aliases/AdaptiveSemaphoreMetrics.md
+++ b/docs/api/type-aliases/AdaptiveSemaphoreMetrics.md
@@ -8,7 +8,7 @@
 
 > **AdaptiveSemaphoreMetrics** = `object`
 
-Defined in: [types/providers.ts:1365](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1365)
+Defined in: [types/providers.ts:1368](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1368)
 
 Metrics for adaptive semaphore performance tracking
 
@@ -18,7 +18,7 @@ Metrics for adaptive semaphore performance tracking
 
 > **activeRequests**: `number`
 
-Defined in: [types/providers.ts:1366](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1366)
+Defined in: [types/providers.ts:1369](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1369)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1366](https://github.com/juspay/neurolink/blob/r
 
 > **currentConcurrency**: `number`
 
-Defined in: [types/providers.ts:1367](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1367)
+Defined in: [types/providers.ts:1370](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1370)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:1367](https://github.com/juspay/neurolink/blob/r
 
 > **completedCount**: `number`
 
-Defined in: [types/providers.ts:1368](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1368)
+Defined in: [types/providers.ts:1371](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1371)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:1368](https://github.com/juspay/neurolink/blob/r
 
 > **errorCount**: `number`
 
-Defined in: [types/providers.ts:1369](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1369)
+Defined in: [types/providers.ts:1372](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1372)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/providers.ts:1369](https://github.com/juspay/neurolink/blob/r
 
 > **averageResponseTime**: `number`
 
-Defined in: [types/providers.ts:1370](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1370)
+Defined in: [types/providers.ts:1373](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1373)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/providers.ts:1370](https://github.com/juspay/neurolink/blob/r
 
 > **waitingCount**: `number`
 
-Defined in: [types/providers.ts:1371](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1371)
+Defined in: [types/providers.ts:1374](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1374)

--- a/docs/api/type-aliases/AnthropicPendingToolUse.md
+++ b/docs/api/type-aliases/AnthropicPendingToolUse.md
@@ -8,7 +8,7 @@
 
 > **AnthropicPendingToolUse** = `object`
 
-Defined in: [types/providers.ts:1040](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1040)
+Defined in: [types/providers.ts:1043](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1043)
 
 A tool_use block being assembled across Anthropic `input_json_delta` events.
 
@@ -18,7 +18,7 @@ A tool_use block being assembled across Anthropic `input_json_delta` events.
 
 > **id**: `string`
 
-Defined in: [types/providers.ts:1041](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1041)
+Defined in: [types/providers.ts:1044](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1044)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1041](https://github.com/juspay/neurolink/blob/r
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:1042](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1042)
+Defined in: [types/providers.ts:1045](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1045)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:1042](https://github.com/juspay/neurolink/blob/r
 
 > **inputJson**: `string`
 
-Defined in: [types/providers.ts:1043](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1043)
+Defined in: [types/providers.ts:1046](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1046)

--- a/docs/api/type-aliases/AnthropicVertexSettings.md
+++ b/docs/api/type-aliases/AnthropicVertexSettings.md
@@ -8,7 +8,7 @@
 
 > **AnthropicVertexSettings** = `object`
 
-Defined in: [types/providers.ts:1264](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1264)
+Defined in: [types/providers.ts:1267](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1267)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1264](https://github.com/juspay/neurolink/blob/r
 
 > **projectId**: `string`
 
-Defined in: [types/providers.ts:1266](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1266)
+Defined in: [types/providers.ts:1269](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1269)
 
 Google Cloud project ID
 
@@ -26,7 +26,7 @@ Google Cloud project ID
 
 > **region**: `string`
 
-Defined in: [types/providers.ts:1268](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1268)
+Defined in: [types/providers.ts:1271](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1271)
 
 Google Cloud region for Anthropic models (e.g., 'us-east5')
 
@@ -36,7 +36,7 @@ Google Cloud region for Anthropic models (e.g., 'us-east5')
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/providers.ts:1270](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1270)
+Defined in: [types/providers.ts:1273](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1273)
 
 SDK request timeout in milliseconds
 
@@ -46,7 +46,7 @@ SDK request timeout in milliseconds
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/providers.ts:1272](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1272)
+Defined in: [types/providers.ts:1275](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1275)
 
 SDK-internal retry budget (transport retries are the orchestrator's job)
 
@@ -56,7 +56,7 @@ SDK-internal retry budget (transport retries are the orchestrator's job)
 
 > `optional` **baseURL?**: `string`
 
-Defined in: [types/providers.ts:1278](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1278)
+Defined in: [types/providers.ts:1281](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1281)
 
 Endpoint override. The SDK derives
 `https://${region}-aiplatform.googleapis.com/v1` by default; a gateway or
@@ -68,7 +68,7 @@ a compatible endpoint is reached by setting this instead.
 
 > `optional` **authClient?**: [`VertexAnthropicAuthClient`](VertexAnthropicAuthClient.md)
 
-Defined in: [types/providers.ts:1288](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1288)
+Defined in: [types/providers.ts:1291](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1291)
 
 Supply the request credentials directly, bypassing Application Default
 Credentials.

--- a/docs/api/type-aliases/BatchInferenceConfig.md
+++ b/docs/api/type-aliases/BatchInferenceConfig.md
@@ -8,7 +8,7 @@
 
 > **BatchInferenceConfig** = `object`
 
-Defined in: [types/providers.ts:1737](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1737)
+Defined in: [types/providers.ts:1740](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1740)
 
 Batch inference job configuration
 
@@ -18,7 +18,7 @@ Batch inference job configuration
 
 > **inputS3Uri**: `string`
 
-Defined in: [types/providers.ts:1739](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1739)
+Defined in: [types/providers.ts:1742](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1742)
 
 Input S3 location
 
@@ -28,7 +28,7 @@ Input S3 location
 
 > **outputS3Uri**: `string`
 
-Defined in: [types/providers.ts:1741](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1741)
+Defined in: [types/providers.ts:1744](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1744)
 
 Output S3 location
 
@@ -38,7 +38,7 @@ Output S3 location
 
 > **modelName**: `string`
 
-Defined in: [types/providers.ts:1743](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1743)
+Defined in: [types/providers.ts:1746](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1746)
 
 SageMaker model name
 
@@ -48,7 +48,7 @@ SageMaker model name
 
 > **instanceType**: `string`
 
-Defined in: [types/providers.ts:1745](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1745)
+Defined in: [types/providers.ts:1748](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1748)
 
 Instance type for batch job
 
@@ -58,7 +58,7 @@ Instance type for batch job
 
 > **instanceCount**: `number`
 
-Defined in: [types/providers.ts:1747](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1747)
+Defined in: [types/providers.ts:1750](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1750)
 
 Instance count for batch job
 
@@ -68,7 +68,7 @@ Instance count for batch job
 
 > `optional` **maxPayloadInMB?**: `number`
 
-Defined in: [types/providers.ts:1749](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1749)
+Defined in: [types/providers.ts:1752](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1752)
 
 Maximum payload size in MB
 
@@ -78,6 +78,6 @@ Maximum payload size in MB
 
 > `optional` **batchStrategy?**: `"MultiRecord"` \| `"SingleRecord"`
 
-Defined in: [types/providers.ts:1751](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1751)
+Defined in: [types/providers.ts:1754](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1754)
 
 Batch strategy

--- a/docs/api/type-aliases/BedrockContentBlock.md
+++ b/docs/api/type-aliases/BedrockContentBlock.md
@@ -8,7 +8,7 @@
 
 > **BedrockContentBlock** = `object`
 
-Defined in: [types/providers.ts:1001](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1001)
+Defined in: [types/providers.ts:1004](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1004)
 
 Bedrock content block structure
 
@@ -18,7 +18,7 @@ Bedrock content block structure
 
 > `optional` **text?**: `string`
 
-Defined in: [types/providers.ts:1002](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1002)
+Defined in: [types/providers.ts:1005](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1005)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1002](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **image?**: `object`
 
-Defined in: [types/providers.ts:1003](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1003)
+Defined in: [types/providers.ts:1006](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1006)
 
 #### format
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:1003](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **document?**: `object`
 
-Defined in: [types/providers.ts:1009](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1009)
+Defined in: [types/providers.ts:1012](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1012)
 
 #### format
 
@@ -70,7 +70,7 @@ Defined in: [types/providers.ts:1009](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **toolUse?**: [`BedrockToolUse`](BedrockToolUse.md)
 
-Defined in: [types/providers.ts:1025](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1025)
+Defined in: [types/providers.ts:1028](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1028)
 
 ---
 
@@ -78,4 +78,4 @@ Defined in: [types/providers.ts:1025](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **toolResult?**: [`BedrockToolResult`](BedrockToolResult.md)
 
-Defined in: [types/providers.ts:1026](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1026)
+Defined in: [types/providers.ts:1029](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1029)

--- a/docs/api/type-aliases/BedrockMessage.md
+++ b/docs/api/type-aliases/BedrockMessage.md
@@ -8,7 +8,7 @@
 
 > **BedrockMessage** = `object`
 
-Defined in: [types/providers.ts:1049](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1049)
+Defined in: [types/providers.ts:1052](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1052)
 
 Bedrock message structure
 
@@ -18,7 +18,7 @@ Bedrock message structure
 
 > **role**: `"user"` \| `"assistant"`
 
-Defined in: [types/providers.ts:1050](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1050)
+Defined in: [types/providers.ts:1053](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1053)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/providers.ts:1050](https://github.com/juspay/neurolink/blob/r
 
 > **content**: [`BedrockContentBlock`](BedrockContentBlock.md)[]
 
-Defined in: [types/providers.ts:1051](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1051)
+Defined in: [types/providers.ts:1054](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1054)

--- a/docs/api/type-aliases/BedrockPendingContentBlock.md
+++ b/docs/api/type-aliases/BedrockPendingContentBlock.md
@@ -8,7 +8,7 @@
 
 > **BedrockPendingContentBlock** = [`BedrockContentBlock`](BedrockContentBlock.md) & `object`
 
-Defined in: [types/providers.ts:1035](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1035)
+Defined in: [types/providers.ts:1038](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1038)
 
 A Bedrock content block still being assembled from a ConverseStream event
 sequence. `_inputBuffer` holds the partial tool-call JSON that arrives

--- a/docs/api/type-aliases/BedrockToolResult.md
+++ b/docs/api/type-aliases/BedrockToolResult.md
@@ -8,7 +8,7 @@
 
 > **BedrockToolResult** = `object`
 
-Defined in: [types/providers.ts:992](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L992)
+Defined in: [types/providers.ts:995](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L995)
 
 Bedrock tool result structure
 
@@ -18,7 +18,7 @@ Bedrock tool result structure
 
 > **toolUseId**: `string`
 
-Defined in: [types/providers.ts:993](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L993)
+Defined in: [types/providers.ts:996](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L996)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:993](https://github.com/juspay/neurolink/blob/re
 
 > **content**: `object`[]
 
-Defined in: [types/providers.ts:994](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L994)
+Defined in: [types/providers.ts:997](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L997)
 
 #### text
 
@@ -38,4 +38,4 @@ Defined in: [types/providers.ts:994](https://github.com/juspay/neurolink/blob/re
 
 > **status**: `string`
 
-Defined in: [types/providers.ts:995](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L995)
+Defined in: [types/providers.ts:998](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L998)

--- a/docs/api/type-aliases/BedrockToolUse.md
+++ b/docs/api/type-aliases/BedrockToolUse.md
@@ -8,7 +8,7 @@
 
 > **BedrockToolUse** = `object`
 
-Defined in: [types/providers.ts:983](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L983)
+Defined in: [types/providers.ts:986](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L986)
 
 Bedrock tool usage structure
 
@@ -18,7 +18,7 @@ Bedrock tool usage structure
 
 > **toolUseId**: `string`
 
-Defined in: [types/providers.ts:984](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L984)
+Defined in: [types/providers.ts:987](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L987)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:984](https://github.com/juspay/neurolink/blob/re
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:985](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L985)
+Defined in: [types/providers.ts:988](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L988)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:985](https://github.com/juspay/neurolink/blob/re
 
 > **input**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:986](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L986)
+Defined in: [types/providers.ts:989](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L989)

--- a/docs/api/type-aliases/CatalogBillingPolicy.md
+++ b/docs/api/type-aliases/CatalogBillingPolicy.md
@@ -8,4 +8,4 @@
 
 > **CatalogBillingPolicy** = `"free-tier"` \| `"free-with-card"` \| `"no-free-tier"`
 
-Defined in: [types/providerCatalog.ts:58](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L58)
+Defined in: [types/providerCatalog.ts:64](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L64)

--- a/docs/api/type-aliases/CatalogCapabilities.md
+++ b/docs/api/type-aliases/CatalogCapabilities.md
@@ -8,7 +8,7 @@
 
 > **CatalogCapabilities** = `object`
 
-Defined in: [types/providerCatalog.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L92)
+Defined in: [types/providerCatalog.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L98)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providerCatalog.ts:92](https://github.com/juspay/neurolink/bl
 
 > **text**: `boolean`
 
-Defined in: [types/providerCatalog.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L93)
+Defined in: [types/providerCatalog.ts:99](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L99)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providerCatalog.ts:93](https://github.com/juspay/neurolink/bl
 
 > **streaming**: `boolean`
 
-Defined in: [types/providerCatalog.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L94)
+Defined in: [types/providerCatalog.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L100)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providerCatalog.ts:94](https://github.com/juspay/neurolink/bl
 
 > **tools**: `boolean`
 
-Defined in: [types/providerCatalog.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L95)
+Defined in: [types/providerCatalog.ts:101](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L101)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/providerCatalog.ts:95](https://github.com/juspay/neurolink/bl
 
 > **toolsWithStreaming**: `boolean`
 
-Defined in: [types/providerCatalog.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L96)
+Defined in: [types/providerCatalog.ts:102](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L102)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/providerCatalog.ts:96](https://github.com/juspay/neurolink/bl
 
 > **structuredOutput**: `boolean`
 
-Defined in: [types/providerCatalog.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L97)
+Defined in: [types/providerCatalog.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L103)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/providerCatalog.ts:97](https://github.com/juspay/neurolink/bl
 
 > **structuredOutputWithTools**: `boolean`
 
-Defined in: [types/providerCatalog.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L98)
+Defined in: [types/providerCatalog.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L104)
 
 ---
 
@@ -64,7 +64,7 @@ Defined in: [types/providerCatalog.ts:98](https://github.com/juspay/neurolink/bl
 
 > **embeddings**: `boolean`
 
-Defined in: [types/providerCatalog.ts:99](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L99)
+Defined in: [types/providerCatalog.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L105)
 
 ---
 
@@ -72,4 +72,4 @@ Defined in: [types/providerCatalog.ts:99](https://github.com/juspay/neurolink/bl
 
 > **thinking**: `boolean`
 
-Defined in: [types/providerCatalog.ts:100](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L100)
+Defined in: [types/providerCatalog.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L106)

--- a/docs/api/type-aliases/CatalogEvidence.md
+++ b/docs/api/type-aliases/CatalogEvidence.md
@@ -8,7 +8,7 @@
 
 > **CatalogEvidence** = `object`
 
-Defined in: [types/providerCatalog.ts:84](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L84)
+Defined in: [types/providerCatalog.ts:90](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L90)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providerCatalog.ts:84](https://github.com/juspay/neurolink/bl
 
 > **rosterVerified**: [`CatalogProbeEvidence`](CatalogProbeEvidence.md)
 
-Defined in: [types/providerCatalog.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L85)
+Defined in: [types/providerCatalog.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L91)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providerCatalog.ts:85](https://github.com/juspay/neurolink/bl
 
 > `optional` **authProbe?**: [`CatalogProbeEvidence`](CatalogProbeEvidence.md)
 
-Defined in: [types/providerCatalog.ts:86](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L86)
+Defined in: [types/providerCatalog.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L92)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providerCatalog.ts:86](https://github.com/juspay/neurolink/bl
 
 > `optional` **billingProbe?**: [`CatalogProbeEvidence`](CatalogProbeEvidence.md)
 
-Defined in: [types/providerCatalog.ts:87](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L87)
+Defined in: [types/providerCatalog.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L93)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/providerCatalog.ts:87](https://github.com/juspay/neurolink/bl
 
 > **liveMatrix**: \{ `date`: `string`; `result`: `string`; \} \| `null`
 
-Defined in: [types/providerCatalog.ts:88](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L88)
+Defined in: [types/providerCatalog.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L94)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/providerCatalog.ts:88](https://github.com/juspay/neurolink/bl
 
 > **addedInPR**: `string`
 
-Defined in: [types/providerCatalog.ts:89](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L89)
+Defined in: [types/providerCatalog.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L95)

--- a/docs/api/type-aliases/CatalogProbeEvidence.md
+++ b/docs/api/type-aliases/CatalogProbeEvidence.md
@@ -8,7 +8,7 @@
 
 > **CatalogProbeEvidence** = `object`
 
-Defined in: [types/providerCatalog.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L77)
+Defined in: [types/providerCatalog.ts:83](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L83)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providerCatalog.ts:77](https://github.com/juspay/neurolink/bl
 
 > **date**: `string`
 
-Defined in: [types/providerCatalog.ts:78](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L78)
+Defined in: [types/providerCatalog.ts:84](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L84)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providerCatalog.ts:78](https://github.com/juspay/neurolink/bl
 
 > `optional` **status?**: `number`
 
-Defined in: [types/providerCatalog.ts:79](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L79)
+Defined in: [types/providerCatalog.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L85)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providerCatalog.ts:79](https://github.com/juspay/neurolink/bl
 
 > `optional` **code?**: `string`
 
-Defined in: [types/providerCatalog.ts:80](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L80)
+Defined in: [types/providerCatalog.ts:86](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L86)
 
 ---
 
@@ -40,4 +40,4 @@ Defined in: [types/providerCatalog.ts:80](https://github.com/juspay/neurolink/bl
 
 > `optional` **method?**: `string`
 
-Defined in: [types/providerCatalog.ts:81](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L81)
+Defined in: [types/providerCatalog.ts:87](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L87)

--- a/docs/api/type-aliases/CatalogQuirks.md
+++ b/docs/api/type-aliases/CatalogQuirks.md
@@ -20,8 +20,22 @@ Defined in: [types/providerCatalog.ts:54](https://github.com/juspay/neurolink/bl
 
 ---
 
+### messageContentFormat?
+
+> `optional` **messageContentFormat?**: `"string"`
+
+Defined in: [types/providerCatalog.ts:60](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L60)
+
+Vendor speaks OpenAI for chat but restricts how message content is
+encoded. "string": `messages[].content` must be a plain string —
+the content-parts array and the `null` OpenAI uses on an assistant
+message with tool_calls are both rejected with HTTP 400. Normalized by
+ConfiguredOpenAICompatProvider so tool round-trips work.
+
+---
+
 ### registryDefaultIgnoresModelEnvVar?
 
 > `optional` **registryDefaultIgnoresModelEnvVar?**: `boolean`
 
-Defined in: [types/providerCatalog.ts:55](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L55)
+Defined in: [types/providerCatalog.ts:61](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L61)

--- a/docs/api/type-aliases/CatalogSetup.md
+++ b/docs/api/type-aliases/CatalogSetup.md
@@ -8,7 +8,7 @@
 
 > **CatalogSetup** = `object`
 
-Defined in: [types/providerCatalog.ts:63](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L63)
+Defined in: [types/providerCatalog.ts:69](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L69)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providerCatalog.ts:63](https://github.com/juspay/neurolink/bl
 
 > **url**: `string`
 
-Defined in: [types/providerCatalog.ts:64](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L64)
+Defined in: [types/providerCatalog.ts:70](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L70)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providerCatalog.ts:64](https://github.com/juspay/neurolink/bl
 
 > **apiKeyFormat**: `string` \| `null`
 
-Defined in: [types/providerCatalog.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L65)
+Defined in: [types/providerCatalog.ts:71](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L71)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providerCatalog.ts:65](https://github.com/juspay/neurolink/bl
 
 > **billingPolicy**: [`CatalogBillingPolicy`](CatalogBillingPolicy.md)
 
-Defined in: [types/providerCatalog.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L66)
+Defined in: [types/providerCatalog.ts:72](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L72)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/providerCatalog.ts:66](https://github.com/juspay/neurolink/bl
 
 > **instructions**: `string`[]
 
-Defined in: [types/providerCatalog.ts:67](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L67)
+Defined in: [types/providerCatalog.ts:73](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L73)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/providerCatalog.ts:67](https://github.com/juspay/neurolink/bl
 
 > `optional` **description?**: `string`
 
-Defined in: [types/providerCatalog.ts:74](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L74)
+Defined in: [types/providerCatalog.ts:80](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L80)
 
 Config-options description shown to callers for this credential.
 Default: "API key". Set explicitly where the legacy entry's

--- a/docs/api/type-aliases/CollectedChunkResult.md
+++ b/docs/api/type-aliases/CollectedChunkResult.md
@@ -8,7 +8,7 @@
 
 > **CollectedChunkResult** = `object`
 
-Defined in: [types/providers.ts:2070](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2070)
+Defined in: [types/providers.ts:2073](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2073)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:2070](https://github.com/juspay/neurolink/blob/r
 
 > **rawResponseParts**: `unknown`[]
 
-Defined in: [types/providers.ts:2071](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2071)
+Defined in: [types/providers.ts:2074](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2074)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providers.ts:2071](https://github.com/juspay/neurolink/blob/r
 
 > **stepFunctionCalls**: [`NativeFunctionCall`](NativeFunctionCall.md)[]
 
-Defined in: [types/providers.ts:2072](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2072)
+Defined in: [types/providers.ts:2075](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2075)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providers.ts:2072](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/providers.ts:2074](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2074)
+Defined in: [types/providers.ts:2077](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2077)
 
 Raw `Candidate.finishReason` from the last chunk that carried one.
 
@@ -42,7 +42,7 @@ Raw `Candidate.finishReason` from the last chunk that carried one.
 
 > **inputTokens**: `number`
 
-Defined in: [types/providers.ts:2075](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2075)
+Defined in: [types/providers.ts:2078](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2078)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/providers.ts:2075](https://github.com/juspay/neurolink/blob/r
 
 > **outputTokens**: `number`
 
-Defined in: [types/providers.ts:2076](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2076)
+Defined in: [types/providers.ts:2079](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2079)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/providers.ts:2076](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **cacheReadTokens?**: `number`
 
-Defined in: [types/providers.ts:2082](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2082)
+Defined in: [types/providers.ts:2085](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2085)
 
 Gemini cached-content tokens (overlapping: included in promptTokenCount).
 Surfaced so the call site can subtract from input and bill at cacheRead
@@ -70,7 +70,7 @@ rate. Subtraction happens at the call site, not in the collector.
 
 > `optional` **cacheCreationTokens?**: `number`
 
-Defined in: [types/providers.ts:2084](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2084)
+Defined in: [types/providers.ts:2087](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2087)
 
 Cache creation tokens (symmetry; Gemini does not emit this).
 
@@ -80,7 +80,7 @@ Cache creation tokens (symmetry; Gemini does not emit this).
 
 > `optional` **reasoningTokens?**: `number`
 
-Defined in: [types/providers.ts:2090](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2090)
+Defined in: [types/providers.ts:2093](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2093)
 
 Gemini thinking tokens (usageMetadata.thoughtsTokenCount). Billed at the
 output rate but NOT included in candidatesTokenCount — Gemini reports

--- a/docs/api/type-aliases/CostEstimate.md
+++ b/docs/api/type-aliases/CostEstimate.md
@@ -8,7 +8,7 @@
 
 > **CostEstimate** = `object`
 
-Defined in: [types/providers.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1809)
+Defined in: [types/providers.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1812)
 
 Cost estimation data
 
@@ -18,7 +18,7 @@ Cost estimation data
 
 > **estimatedCost**: `number`
 
-Defined in: [types/providers.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1811)
+Defined in: [types/providers.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1814)
 
 Estimated cost in USD
 
@@ -28,7 +28,7 @@ Estimated cost in USD
 
 > **currency**: `string`
 
-Defined in: [types/providers.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1813)
+Defined in: [types/providers.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1816)
 
 Currency code
 
@@ -38,7 +38,7 @@ Currency code
 
 > **breakdown**: `object`
 
-Defined in: [types/providers.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1815)
+Defined in: [types/providers.ts:1818](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1818)
 
 Cost breakdown
 
@@ -66,7 +66,7 @@ Total processing hours
 
 > `optional` **period?**: `object`
 
-Defined in: [types/providers.ts:1824](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1824)
+Defined in: [types/providers.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1827)
 
 Time period for estimate
 

--- a/docs/api/type-aliases/DetectionTestConfig.md
+++ b/docs/api/type-aliases/DetectionTestConfig.md
@@ -8,7 +8,7 @@
 
 > **DetectionTestConfig** = `object`
 
-Defined in: [types/providers.ts:2285](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2285)
+Defined in: [types/providers.ts:2288](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2288)
 
 Configuration object for a detection test wrapper.
 
@@ -18,7 +18,7 @@ Configuration object for a detection test wrapper.
 
 > **test**: () => `Promise`\<`void`\>
 
-Defined in: [types/providers.ts:2286](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2286)
+Defined in: [types/providers.ts:2289](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2289)
 
 #### Returns
 
@@ -30,7 +30,7 @@ Defined in: [types/providers.ts:2286](https://github.com/juspay/neurolink/blob/r
 
 > **index**: `number`
 
-Defined in: [types/providers.ts:2287](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2287)
+Defined in: [types/providers.ts:2290](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2290)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/providers.ts:2287](https://github.com/juspay/neurolink/blob/r
 
 > **testName**: `string`
 
-Defined in: [types/providers.ts:2288](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2288)
+Defined in: [types/providers.ts:2291](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2291)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:2288](https://github.com/juspay/neurolink/blob/r
 
 > **endpointName**: `string`
 
-Defined in: [types/providers.ts:2289](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2289)
+Defined in: [types/providers.ts:2292](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2292)
 
 ---
 
@@ -54,7 +54,7 @@ Defined in: [types/providers.ts:2289](https://github.com/juspay/neurolink/blob/r
 
 > **semaphore**: `object`
 
-Defined in: [types/providers.ts:2290](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2290)
+Defined in: [types/providers.ts:2293](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2293)
 
 #### acquire()
 
@@ -78,7 +78,7 @@ Defined in: [types/providers.ts:2290](https://github.com/juspay/neurolink/blob/r
 
 > **incrementRateLimit**: () => `void`
 
-Defined in: [types/providers.ts:2294](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2294)
+Defined in: [types/providers.ts:2297](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2297)
 
 #### Returns
 
@@ -90,7 +90,7 @@ Defined in: [types/providers.ts:2294](https://github.com/juspay/neurolink/blob/r
 
 > **maxRateLimitRetries**: `number`
 
-Defined in: [types/providers.ts:2295](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2295)
+Defined in: [types/providers.ts:2298](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2298)
 
 ---
 
@@ -98,7 +98,7 @@ Defined in: [types/providers.ts:2295](https://github.com/juspay/neurolink/blob/r
 
 > **rateLimitState**: `object`
 
-Defined in: [types/providers.ts:2296](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2296)
+Defined in: [types/providers.ts:2299](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2299)
 
 #### count
 

--- a/docs/api/type-aliases/DiagnosticReport.md
+++ b/docs/api/type-aliases/DiagnosticReport.md
@@ -8,7 +8,7 @@
 
 > **DiagnosticReport** = `object`
 
-Defined in: [types/providers.ts:2321](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2321)
+Defined in: [types/providers.ts:2324](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2324)
 
 Aggregated SageMaker diagnostic report.
 
@@ -18,7 +18,7 @@ Aggregated SageMaker diagnostic report.
 
 > **overallStatus**: `"healthy"` \| `"issues"` \| `"critical"`
 
-Defined in: [types/providers.ts:2322](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2322)
+Defined in: [types/providers.ts:2325](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2325)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2322](https://github.com/juspay/neurolink/blob/r
 
 > **results**: [`DiagnosticResult`](DiagnosticResult.md)[]
 
-Defined in: [types/providers.ts:2323](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2323)
+Defined in: [types/providers.ts:2326](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2326)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2323](https://github.com/juspay/neurolink/blob/r
 
 > **summary**: `object`
 
-Defined in: [types/providers.ts:2324](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2324)
+Defined in: [types/providers.ts:2327](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2327)
 
 #### total
 

--- a/docs/api/type-aliases/DiagnosticResult.md
+++ b/docs/api/type-aliases/DiagnosticResult.md
@@ -8,7 +8,7 @@
 
 > **DiagnosticResult** = `object`
 
-Defined in: [types/providers.ts:2311](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2311)
+Defined in: [types/providers.ts:2314](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2314)
 
 Individual SageMaker diagnostic result.
 
@@ -18,7 +18,7 @@ Individual SageMaker diagnostic result.
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:2312](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2312)
+Defined in: [types/providers.ts:2315](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2315)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2312](https://github.com/juspay/neurolink/blob/r
 
 > **category**: `"configuration"` \| `"connectivity"` \| `"streaming"`
 
-Defined in: [types/providers.ts:2313](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2313)
+Defined in: [types/providers.ts:2316](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2316)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2313](https://github.com/juspay/neurolink/blob/r
 
 > **status**: `"pass"` \| `"fail"` \| `"warning"`
 
-Defined in: [types/providers.ts:2314](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2314)
+Defined in: [types/providers.ts:2317](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2317)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:2314](https://github.com/juspay/neurolink/blob/r
 
 > **message**: `string`
 
-Defined in: [types/providers.ts:2315](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2315)
+Defined in: [types/providers.ts:2318](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2318)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/providers.ts:2315](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **details?**: `string`
 
-Defined in: [types/providers.ts:2316](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2316)
+Defined in: [types/providers.ts:2319](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2319)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/providers.ts:2316](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **recommendation?**: `string`
 
-Defined in: [types/providers.ts:2317](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2317)
+Defined in: [types/providers.ts:2320](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2320)

--- a/docs/api/type-aliases/EndpointHealth.md
+++ b/docs/api/type-aliases/EndpointHealth.md
@@ -8,7 +8,7 @@
 
 > **EndpointHealth** = `object`
 
-Defined in: [types/providers.ts:2272](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2272)
+Defined in: [types/providers.ts:2275](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2275)
 
 Endpoint health and metadata information.
 
@@ -18,7 +18,7 @@ Endpoint health and metadata information.
 
 > **status**: `"healthy"` \| `"unhealthy"` \| `"unknown"`
 
-Defined in: [types/providers.ts:2273](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2273)
+Defined in: [types/providers.ts:2276](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2276)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2273](https://github.com/juspay/neurolink/blob/r
 
 > **responseTime**: `number`
 
-Defined in: [types/providers.ts:2274](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2274)
+Defined in: [types/providers.ts:2277](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2277)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2274](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **metadata?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:2275](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2275)
+Defined in: [types/providers.ts:2278](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2278)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:2275](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **modelInfo?**: `object`
 
-Defined in: [types/providers.ts:2276](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2276)
+Defined in: [types/providers.ts:2279](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2279)
 
 #### name?
 

--- a/docs/api/type-aliases/EndpointMetrics.md
+++ b/docs/api/type-aliases/EndpointMetrics.md
@@ -8,7 +8,7 @@
 
 > **EndpointMetrics** = `object`
 
-Defined in: [types/providers.ts:1787](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1787)
+Defined in: [types/providers.ts:1790](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1790)
 
 Endpoint metrics and monitoring data
 
@@ -18,7 +18,7 @@ Endpoint metrics and monitoring data
 
 > **endpointName**: `string`
 
-Defined in: [types/providers.ts:1789](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1789)
+Defined in: [types/providers.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1792)
 
 Endpoint name
 
@@ -28,7 +28,7 @@ Endpoint name
 
 > **invocations**: `number`
 
-Defined in: [types/providers.ts:1791](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1791)
+Defined in: [types/providers.ts:1794](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1794)
 
 Total invocations
 
@@ -38,7 +38,7 @@ Total invocations
 
 > **averageLatency**: `number`
 
-Defined in: [types/providers.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1793)
+Defined in: [types/providers.ts:1796](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1796)
 
 Average latency in milliseconds
 
@@ -48,7 +48,7 @@ Average latency in milliseconds
 
 > **errorRate**: `number`
 
-Defined in: [types/providers.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1795)
+Defined in: [types/providers.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1798)
 
 Error rate percentage
 
@@ -58,7 +58,7 @@ Error rate percentage
 
 > `optional` **cpuUtilization?**: `number`
 
-Defined in: [types/providers.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1797)
+Defined in: [types/providers.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1800)
 
 CPU utilization percentage
 
@@ -68,7 +68,7 @@ CPU utilization percentage
 
 > `optional` **memoryUtilization?**: `number`
 
-Defined in: [types/providers.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1799)
+Defined in: [types/providers.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1802)
 
 Memory utilization percentage
 
@@ -78,7 +78,7 @@ Memory utilization percentage
 
 > **instanceCount**: `number`
 
-Defined in: [types/providers.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1801)
+Defined in: [types/providers.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1804)
 
 Instance count
 
@@ -88,6 +88,6 @@ Instance count
 
 > **timestamp**: `string`
 
-Defined in: [types/providers.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1803)
+Defined in: [types/providers.ts:1806](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1806)
 
 Timestamp of metrics as ISO 8601 date string

--- a/docs/api/type-aliases/ExtendedTool.md
+++ b/docs/api/type-aliases/ExtendedTool.md
@@ -8,6 +8,6 @@
 
 > **ExtendedTool** = `Tool` & `Partial`\<[`ExternalMCPToolInfo`](ExternalMCPToolInfo.md)\>
 
-Defined in: [types/providers.ts:955](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L955)
+Defined in: [types/providers.ts:958](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L958)
 
 Extended tool type that combines AI SDK tools with external MCP tool info

--- a/docs/api/type-aliases/GeminiMultimodalInput.md
+++ b/docs/api/type-aliases/GeminiMultimodalInput.md
@@ -8,7 +8,7 @@
 
 > **GeminiMultimodalInput** = `object`
 
-Defined in: [types/providers.ts:2394](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2394)
+Defined in: [types/providers.ts:2397](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2397)
 
 Subset of `GenerateOptions["input"]` consumed by the shared Gemini-native
 multimodal-parts builder. Kept narrow so the helper doesn't depend on the
@@ -22,7 +22,7 @@ value SDK callers pass in (plain Buffer/string or `ImageWithAltText`).
 
 > `optional` **text?**: `string`
 
-Defined in: [types/providers.ts:2395](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2395)
+Defined in: [types/providers.ts:2398](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2398)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/providers.ts:2395](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **pdfFiles?**: (`Buffer` \| `string`)[]
 
-Defined in: [types/providers.ts:2396](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2396)
+Defined in: [types/providers.ts:2399](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2399)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/providers.ts:2396](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **images?**: (`Buffer` \| `string` \| \{ `data`: `Buffer` \| `string`; `altText?`: `string`; \})[]
 
-Defined in: [types/providers.ts:2397](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2397)
+Defined in: [types/providers.ts:2400](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2400)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:2397](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **nativeAudioFiles?**: [`MultimodalAudioEntry`](MultimodalAudioEntry.md)[]
 
-Defined in: [types/providers.ts:2403](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2403)
+Defined in: [types/providers.ts:2406](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2406)
 
 Audio collected during file detection, carried through to the native
 request as `inlineData`. Distinct from the user-facing `audioFiles`: these

--- a/docs/api/type-aliases/GenAIClient.md
+++ b/docs/api/type-aliases/GenAIClient.md
@@ -8,7 +8,7 @@
 
 > **GenAIClient** = `object`
 
-Defined in: [types/providers.ts:1196](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1196)
+Defined in: [types/providers.ts:1199](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1199)
 
 Google AI client interface
 
@@ -18,7 +18,7 @@ Google AI client interface
 
 > **live**: `object`
 
-Defined in: [types/providers.ts:1197](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1197)
+Defined in: [types/providers.ts:1200](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1200)
 
 #### connect
 
@@ -40,4 +40,4 @@ Defined in: [types/providers.ts:1197](https://github.com/juspay/neurolink/blob/r
 
 > **models**: [`GenAIModelsAPI`](GenAIModelsAPI.md)
 
-Defined in: [types/providers.ts:1198](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1198)
+Defined in: [types/providers.ts:1201](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1201)

--- a/docs/api/type-aliases/GenAIGenerateContentResponse.md
+++ b/docs/api/type-aliases/GenAIGenerateContentResponse.md
@@ -8,7 +8,7 @@
 
 > **GenAIGenerateContentResponse** = `object`
 
-Defined in: [types/providers.ts:1156](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1156)
+Defined in: [types/providers.ts:1159](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1159)
 
 Google AI generate content response
 
@@ -18,7 +18,7 @@ Google AI generate content response
 
 > `optional` **candidates?**: `object`[]
 
-Defined in: [types/providers.ts:1157](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1157)
+Defined in: [types/providers.ts:1160](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1160)
 
 #### content?
 

--- a/docs/api/type-aliases/GenAILiveMedia.md
+++ b/docs/api/type-aliases/GenAILiveMedia.md
@@ -8,7 +8,7 @@
 
 > **GenAILiveMedia** = `object`
 
-Defined in: [types/providers.ts:1061](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1061)
+Defined in: [types/providers.ts:1064](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1064)
 
 Google AI Live media configuration
 
@@ -18,7 +18,7 @@ Google AI Live media configuration
 
 > **data**: `string`
 
-Defined in: [types/providers.ts:1062](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1062)
+Defined in: [types/providers.ts:1065](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1065)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/providers.ts:1062](https://github.com/juspay/neurolink/blob/r
 
 > **mimeType**: `string`
 
-Defined in: [types/providers.ts:1063](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1063)
+Defined in: [types/providers.ts:1066](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1066)

--- a/docs/api/type-aliases/GenAILiveSession.md
+++ b/docs/api/type-aliases/GenAILiveSession.md
@@ -8,7 +8,7 @@
 
 > **GenAILiveSession** = `object`
 
-Defined in: [types/providers.ts:1122](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1122)
+Defined in: [types/providers.ts:1125](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1125)
 
 Google AI Live session interface
 
@@ -18,7 +18,7 @@ Google AI Live session interface
 
 > `optional` **sendRealtimeInput?**: (`payload`) => `Promise`\<`void`\> \| `void`
 
-Defined in: [types/providers.ts:1123](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1123)
+Defined in: [types/providers.ts:1126](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1126)
 
 #### Parameters
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:1123](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **sendInput?**: (`payload`) => `Promise`\<`void`\> \| `void`
 
-Defined in: [types/providers.ts:1127](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1127)
+Defined in: [types/providers.ts:1130](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1130)
 
 #### Parameters
 
@@ -66,7 +66,7 @@ Defined in: [types/providers.ts:1127](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **close?**: (`code?`, `reason?`) => `Promise`\<`void`\> \| `void`
 
-Defined in: [types/providers.ts:1131](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1131)
+Defined in: [types/providers.ts:1134](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1134)
 
 #### Parameters
 

--- a/docs/api/type-aliases/GenAIModelsAPI.md
+++ b/docs/api/type-aliases/GenAIModelsAPI.md
@@ -8,7 +8,7 @@
 
 > **GenAIModelsAPI** = `object`
 
-Defined in: [types/providers.ts:1173](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1173)
+Defined in: [types/providers.ts:1176](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1176)
 
 Google AI models API interface
 
@@ -18,7 +18,7 @@ Google AI models API interface
 
 > **generateContentStream**: (`params`) => `Promise`\<`AsyncIterable`\<[`GenAIStreamChunk`](GenAIStreamChunk.md)\>\>
 
-Defined in: [types/providers.ts:1174](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1174)
+Defined in: [types/providers.ts:1177](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1177)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:1174](https://github.com/juspay/neurolink/blob/r
 
 > **generateContent**: (`params`) => `Promise`\<[`GenAIGenerateContentResponse`](GenAIGenerateContentResponse.md)\>
 
-Defined in: [types/providers.ts:1179](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1179)
+Defined in: [types/providers.ts:1182](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1182)
 
 #### Parameters
 
@@ -74,7 +74,7 @@ Defined in: [types/providers.ts:1179](https://github.com/juspay/neurolink/blob/r
 
 > **embedContent**: (`params`) => `Promise`\<\{ `embeddings?`: `object`[]; \}\>
 
-Defined in: [types/providers.ts:1184](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1184)
+Defined in: [types/providers.ts:1187](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1187)
 
 #### Parameters
 

--- a/docs/api/type-aliases/GenAIStreamChunk.md
+++ b/docs/api/type-aliases/GenAIStreamChunk.md
@@ -8,7 +8,7 @@
 
 > **GenAIStreamChunk** = `object`
 
-Defined in: [types/providers.ts:1137](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1137)
+Defined in: [types/providers.ts:1140](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1140)
 
 Google AI generateContentStream response chunk
 
@@ -18,7 +18,7 @@ Google AI generateContentStream response chunk
 
 > `optional` **text?**: `string`
 
-Defined in: [types/providers.ts:1138](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1138)
+Defined in: [types/providers.ts:1141](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1141)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1138](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **functionCalls?**: `object`[]
 
-Defined in: [types/providers.ts:1139](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1139)
+Defined in: [types/providers.ts:1142](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1142)
 
 #### name
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:1139](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **candidates?**: `object`[]
 
-Defined in: [types/providers.ts:1140](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1140)
+Defined in: [types/providers.ts:1143](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1143)
 
 #### content?
 

--- a/docs/api/type-aliases/GoogleGenAIClass.md
+++ b/docs/api/type-aliases/GoogleGenAIClass.md
@@ -8,7 +8,7 @@
 
 > **GoogleGenAIClass** = (`cfg`) => [`GenAIClient`](GenAIClient.md)
 
-Defined in: [types/providers.ts:1216](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1216)
+Defined in: [types/providers.ts:1219](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1219)
 
 Google GenAI constructor type
 Supports both API key (Google AI Studio) and Vertex AI configurations

--- a/docs/api/type-aliases/GoogleGenAIHttpOptions.md
+++ b/docs/api/type-aliases/GoogleGenAIHttpOptions.md
@@ -8,7 +8,7 @@
 
 > **GoogleGenAIHttpOptions** = `object`
 
-Defined in: [types/providers.ts:1205](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1205)
+Defined in: [types/providers.ts:1208](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1208)
 
 HTTP options for Google GenAI SDK
 Allows custom fetch implementation for proxy support
@@ -19,7 +19,7 @@ Allows custom fetch implementation for proxy support
 
 > `optional` **fetch?**: _typeof_ `fetch`
 
-Defined in: [types/providers.ts:1207](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1207)
+Defined in: [types/providers.ts:1210](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1210)
 
 Custom fetch implementation for proxy support
 
@@ -29,6 +29,6 @@ Custom fetch implementation for proxy support
 
 > `optional` **baseUrl?**: `string`
 
-Defined in: [types/providers.ts:1209](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1209)
+Defined in: [types/providers.ts:1212](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1212)
 
 Override the API base URL (e.g. a corporate proxy or mock endpoint)

--- a/docs/api/type-aliases/GoogleLiveAudioQueueItem.md
+++ b/docs/api/type-aliases/GoogleLiveAudioQueueItem.md
@@ -8,7 +8,7 @@
 
 > **GoogleLiveAudioQueueItem** = \{ `type`: `"audio"`; `audio`: [`AudioChunk`](AudioChunk.md); \} \| \{ `type`: `"end"`; \} \| \{ `type`: `"error"`; `error`: `unknown`; \}
 
-Defined in: [types/providers.ts:2354](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2354)
+Defined in: [types/providers.ts:2357](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2357)
 
 Event pushed through the Google AI Studio voice session's internal queue
 while audio chunks stream back from the Gemini Live API.

--- a/docs/api/type-aliases/GoogleVertexProviderSettings.md
+++ b/docs/api/type-aliases/GoogleVertexProviderSettings.md
@@ -8,7 +8,7 @@
 
 > **GoogleVertexProviderSettings** = `object`
 
-Defined in: [types/providers.ts:1238](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1238)
+Defined in: [types/providers.ts:1241](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1241)
 
 Google Vertex AI provider settings for native SDK configuration
 Used with @google/genai SDK in vertexai mode
@@ -22,7 +22,7 @@ or the temporary credentials file approach, not through these settings fields.
 
 > **project**: `string`
 
-Defined in: [types/providers.ts:1240](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1240)
+Defined in: [types/providers.ts:1243](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1243)
 
 Google Cloud project ID
 
@@ -32,7 +32,7 @@ Google Cloud project ID
 
 > **location**: `string`
 
-Defined in: [types/providers.ts:1242](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1242)
+Defined in: [types/providers.ts:1245](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1245)
 
 Google Cloud region/location (e.g., 'us-central1')
 
@@ -42,6 +42,6 @@ Google Cloud region/location (e.g., 'us-central1')
 
 > `optional` **fetch?**: _typeof_ `fetch`
 
-Defined in: [types/providers.ts:1244](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1244)
+Defined in: [types/providers.ts:1247](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1247)
 
 Optional custom fetch implementation

--- a/docs/api/type-aliases/InvokeEndpointParams.md
+++ b/docs/api/type-aliases/InvokeEndpointParams.md
@@ -8,7 +8,7 @@
 
 > **InvokeEndpointParams** = `object`
 
-Defined in: [types/providers.ts:1494](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1494)
+Defined in: [types/providers.ts:1497](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1497)
 
 Parameters for SageMaker endpoint invocation
 
@@ -18,7 +18,7 @@ Parameters for SageMaker endpoint invocation
 
 > **EndpointName**: `string`
 
-Defined in: [types/providers.ts:1496](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1496)
+Defined in: [types/providers.ts:1499](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1499)
 
 Endpoint name to invoke
 
@@ -28,7 +28,7 @@ Endpoint name to invoke
 
 > **Body**: `string` \| `Uint8Array`
 
-Defined in: [types/providers.ts:1498](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1498)
+Defined in: [types/providers.ts:1501](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1501)
 
 Request body as string or Uint8Array
 
@@ -38,7 +38,7 @@ Request body as string or Uint8Array
 
 > `optional` **ContentType?**: `string`
 
-Defined in: [types/providers.ts:1500](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1500)
+Defined in: [types/providers.ts:1503](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1503)
 
 Content type of the request
 
@@ -48,7 +48,7 @@ Content type of the request
 
 > `optional` **Accept?**: `string`
 
-Defined in: [types/providers.ts:1502](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1502)
+Defined in: [types/providers.ts:1505](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1505)
 
 Accept header for response format
 
@@ -58,7 +58,7 @@ Accept header for response format
 
 > `optional` **CustomAttributes?**: `string`
 
-Defined in: [types/providers.ts:1504](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1504)
+Defined in: [types/providers.ts:1507](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1507)
 
 Custom attributes for the request
 
@@ -68,7 +68,7 @@ Custom attributes for the request
 
 > `optional` **TargetModel?**: `string`
 
-Defined in: [types/providers.ts:1506](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1506)
+Defined in: [types/providers.ts:1509](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1509)
 
 Target model for multi-model endpoints
 
@@ -78,7 +78,7 @@ Target model for multi-model endpoints
 
 > `optional` **TargetVariant?**: `string`
 
-Defined in: [types/providers.ts:1508](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1508)
+Defined in: [types/providers.ts:1511](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1511)
 
 Target variant for A/B testing
 
@@ -88,7 +88,7 @@ Target variant for A/B testing
 
 > `optional` **InferenceId?**: `string`
 
-Defined in: [types/providers.ts:1510](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1510)
+Defined in: [types/providers.ts:1513](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1513)
 
 Inference ID for request tracking
 
@@ -98,7 +98,7 @@ Inference ID for request tracking
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/providers.ts:1520](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1520)
+Defined in: [types/providers.ts:1523](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1523)
 
 Cancels the in-flight HTTP request, not just the loop around it.
 

--- a/docs/api/type-aliases/InvokeEndpointResponse.md
+++ b/docs/api/type-aliases/InvokeEndpointResponse.md
@@ -8,7 +8,7 @@
 
 > **InvokeEndpointResponse** = `object`
 
-Defined in: [types/providers.ts:1526](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1526)
+Defined in: [types/providers.ts:1529](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1529)
 
 Response from SageMaker endpoint invocation
 
@@ -18,7 +18,7 @@ Response from SageMaker endpoint invocation
 
 > `optional` **Body?**: `Uint8Array`
 
-Defined in: [types/providers.ts:1528](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1528)
+Defined in: [types/providers.ts:1531](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1531)
 
 Response body
 
@@ -28,7 +28,7 @@ Response body
 
 > `optional` **ContentType?**: `string`
 
-Defined in: [types/providers.ts:1530](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1530)
+Defined in: [types/providers.ts:1533](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1533)
 
 Content type of the response
 
@@ -38,7 +38,7 @@ Content type of the response
 
 > `optional` **InvokedProductionVariant?**: `string`
 
-Defined in: [types/providers.ts:1532](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1532)
+Defined in: [types/providers.ts:1535](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1535)
 
 Invoked production variant
 
@@ -48,6 +48,6 @@ Invoked production variant
 
 > `optional` **CustomAttributes?**: `string`
 
-Defined in: [types/providers.ts:1534](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1534)
+Defined in: [types/providers.ts:1537](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1537)
 
 Custom attributes in the response

--- a/docs/api/type-aliases/LanguageModelObject.md
+++ b/docs/api/type-aliases/LanguageModelObject.md
@@ -8,7 +8,7 @@
 
 > **LanguageModelObject** = `object`
 
-Defined in: [types/providers.ts:2098](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2098)
+Defined in: [types/providers.ts:2101](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2101)
 
 Language model object shape (LanguageModelV2/V3).
 
@@ -18,7 +18,7 @@ Language model object shape (LanguageModelV2/V3).
 
 > `readonly` **modelId**: `string`
 
-Defined in: [types/providers.ts:2099](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2099)
+Defined in: [types/providers.ts:2102](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2102)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/providers.ts:2099](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **provider**: `string`
 
-Defined in: [types/providers.ts:2100](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2100)
+Defined in: [types/providers.ts:2103](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2103)

--- a/docs/api/type-aliases/LiveConnectCallbacks.md
+++ b/docs/api/type-aliases/LiveConnectCallbacks.md
@@ -8,7 +8,7 @@
 
 > **LiveConnectCallbacks** = `object`
 
-Defined in: [types/providers.ts:1098](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1098)
+Defined in: [types/providers.ts:1101](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1101)
 
 Live connection callbacks
 
@@ -18,7 +18,7 @@ Live connection callbacks
 
 > `optional` **onopen?**: () => `void`
 
-Defined in: [types/providers.ts:1099](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1099)
+Defined in: [types/providers.ts:1102](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1102)
 
 #### Returns
 
@@ -30,7 +30,7 @@ Defined in: [types/providers.ts:1099](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onmessage?**: (`message`) => `void`
 
-Defined in: [types/providers.ts:1100](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1100)
+Defined in: [types/providers.ts:1103](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1103)
 
 #### Parameters
 
@@ -48,7 +48,7 @@ Defined in: [types/providers.ts:1100](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onerror?**: (`e`) => `void`
 
-Defined in: [types/providers.ts:1101](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1101)
+Defined in: [types/providers.ts:1104](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1104)
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: [types/providers.ts:1101](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onclose?**: (`e`) => `void`
 
-Defined in: [types/providers.ts:1102](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1102)
+Defined in: [types/providers.ts:1105](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1105)
 
 #### Parameters
 

--- a/docs/api/type-aliases/LiveConnectConfig.md
+++ b/docs/api/type-aliases/LiveConnectConfig.md
@@ -8,7 +8,7 @@
 
 > **LiveConnectConfig** = `object`
 
-Defined in: [types/providers.ts:1108](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1108)
+Defined in: [types/providers.ts:1111](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1111)
 
 Live connection configuration
 
@@ -18,7 +18,7 @@ Live connection configuration
 
 > **model**: `string`
 
-Defined in: [types/providers.ts:1109](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1109)
+Defined in: [types/providers.ts:1112](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1112)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1109](https://github.com/juspay/neurolink/blob/r
 
 > **callbacks**: [`LiveConnectCallbacks`](LiveConnectCallbacks.md)
 
-Defined in: [types/providers.ts:1110](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1110)
+Defined in: [types/providers.ts:1113](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1113)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:1110](https://github.com/juspay/neurolink/blob/r
 
 > **config**: `object`
 
-Defined in: [types/providers.ts:1111](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1111)
+Defined in: [types/providers.ts:1114](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1114)
 
 #### responseModalities
 

--- a/docs/api/type-aliases/LiveServerContent.md
+++ b/docs/api/type-aliases/LiveServerContent.md
@@ -8,7 +8,7 @@
 
 > **LiveServerContent** = `object`
 
-Defined in: [types/providers.ts:1083](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1083)
+Defined in: [types/providers.ts:1086](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1086)
 
 Live server content structure
 
@@ -18,7 +18,7 @@ Live server content structure
 
 > `optional` **modelTurn?**: [`LiveServerMessageModelTurn`](LiveServerMessageModelTurn.md)
 
-Defined in: [types/providers.ts:1084](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1084)
+Defined in: [types/providers.ts:1087](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1087)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/providers.ts:1084](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **interrupted?**: `boolean`
 
-Defined in: [types/providers.ts:1085](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1085)
+Defined in: [types/providers.ts:1088](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1088)

--- a/docs/api/type-aliases/LiveServerMessage.md
+++ b/docs/api/type-aliases/LiveServerMessage.md
@@ -8,7 +8,7 @@
 
 > **LiveServerMessage** = `object`
 
-Defined in: [types/providers.ts:1091](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1091)
+Defined in: [types/providers.ts:1094](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1094)
 
 Live server message structure
 
@@ -18,4 +18,4 @@ Live server message structure
 
 > `optional` **serverContent?**: [`LiveServerContent`](LiveServerContent.md)
 
-Defined in: [types/providers.ts:1092](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1092)
+Defined in: [types/providers.ts:1095](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1095)

--- a/docs/api/type-aliases/LiveServerMessageModelTurn.md
+++ b/docs/api/type-aliases/LiveServerMessageModelTurn.md
@@ -8,7 +8,7 @@
 
 > **LiveServerMessageModelTurn** = `object`
 
-Defined in: [types/providers.ts:1076](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1076)
+Defined in: [types/providers.ts:1079](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1079)
 
 Live server message model turn
 
@@ -18,7 +18,7 @@ Live server message model turn
 
 > `optional` **parts?**: `object`[]
 
-Defined in: [types/providers.ts:1077](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1077)
+Defined in: [types/providers.ts:1080](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1080)
 
 #### inlineData?
 

--- a/docs/api/type-aliases/LiveServerMessagePartInlineData.md
+++ b/docs/api/type-aliases/LiveServerMessagePartInlineData.md
@@ -8,7 +8,7 @@
 
 > **LiveServerMessagePartInlineData** = `object`
 
-Defined in: [types/providers.ts:1069](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1069)
+Defined in: [types/providers.ts:1072](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1072)
 
 Live server message inline data
 
@@ -18,4 +18,4 @@ Live server message inline data
 
 > `optional` **data?**: `string`
 
-Defined in: [types/providers.ts:1070](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1070)
+Defined in: [types/providers.ts:1073](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1073)

--- a/docs/api/type-aliases/ModelDeploymentConfig.md
+++ b/docs/api/type-aliases/ModelDeploymentConfig.md
@@ -8,7 +8,7 @@
 
 > **ModelDeploymentConfig** = `object`
 
-Defined in: [types/providers.ts:1757](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1757)
+Defined in: [types/providers.ts:1760](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1760)
 
 Model deployment configuration
 
@@ -18,7 +18,7 @@ Model deployment configuration
 
 > **modelName**: `string`
 
-Defined in: [types/providers.ts:1759](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1759)
+Defined in: [types/providers.ts:1762](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1762)
 
 Model name
 
@@ -28,7 +28,7 @@ Model name
 
 > **endpointName**: `string`
 
-Defined in: [types/providers.ts:1761](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1761)
+Defined in: [types/providers.ts:1764](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1764)
 
 Endpoint name
 
@@ -38,7 +38,7 @@ Endpoint name
 
 > **instanceType**: `string`
 
-Defined in: [types/providers.ts:1763](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1763)
+Defined in: [types/providers.ts:1766](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1766)
 
 EC2 instance type
 
@@ -48,7 +48,7 @@ EC2 instance type
 
 > **initialInstanceCount**: `number`
 
-Defined in: [types/providers.ts:1765](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1765)
+Defined in: [types/providers.ts:1768](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1768)
 
 Initial instance count
 
@@ -58,7 +58,7 @@ Initial instance count
 
 > **modelDataUrl**: `string`
 
-Defined in: [types/providers.ts:1767](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1767)
+Defined in: [types/providers.ts:1770](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1770)
 
 Model data S3 location
 
@@ -68,7 +68,7 @@ Model data S3 location
 
 > **image**: `string`
 
-Defined in: [types/providers.ts:1769](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1769)
+Defined in: [types/providers.ts:1772](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1772)
 
 Container image URI
 
@@ -78,7 +78,7 @@ Container image URI
 
 > **executionRoleArn**: `string`
 
-Defined in: [types/providers.ts:1771](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1771)
+Defined in: [types/providers.ts:1774](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1774)
 
 IAM execution role ARN
 
@@ -88,7 +88,7 @@ IAM execution role ARN
 
 > `optional` **tags?**: `Record`\<`string`, `string`\>
 
-Defined in: [types/providers.ts:1773](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1773)
+Defined in: [types/providers.ts:1776](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1776)
 
 Resource tags
 
@@ -98,7 +98,7 @@ Resource tags
 
 > `optional` **autoScaling?**: `object`
 
-Defined in: [types/providers.ts:1775](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1775)
+Defined in: [types/providers.ts:1778](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1778)
 
 Auto scaling configuration
 

--- a/docs/api/type-aliases/ModelDetectionResult.md
+++ b/docs/api/type-aliases/ModelDetectionResult.md
@@ -8,7 +8,7 @@
 
 > **ModelDetectionResult** = `object`
 
-Defined in: [types/providers.ts:2264](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2264)
+Defined in: [types/providers.ts:2267](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2267)
 
 Model type detection result.
 
@@ -18,7 +18,7 @@ Model type detection result.
 
 > **type**: [`StreamingCapability`](StreamingCapability.md)\[`"modelType"`\]
 
-Defined in: [types/providers.ts:2265](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2265)
+Defined in: [types/providers.ts:2268](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2268)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2265](https://github.com/juspay/neurolink/blob/r
 
 > **confidence**: `number`
 
-Defined in: [types/providers.ts:2266](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2266)
+Defined in: [types/providers.ts:2269](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2269)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2266](https://github.com/juspay/neurolink/blob/r
 
 > **evidence**: `string`[]
 
-Defined in: [types/providers.ts:2267](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2267)
+Defined in: [types/providers.ts:2270](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2270)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/providers.ts:2267](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **suggestedConfig?**: `Partial`\<[`SageMakerModelConfig`](SageMakerModelConfig.md)\>
 
-Defined in: [types/providers.ts:2268](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2268)
+Defined in: [types/providers.ts:2271](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2271)

--- a/docs/api/type-aliases/ModelsResponse.md
+++ b/docs/api/type-aliases/ModelsResponse.md
@@ -8,7 +8,7 @@
 
 > **ModelsResponse** = `object`
 
-Defined in: [types/providers.ts:1298](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1298)
+Defined in: [types/providers.ts:1301](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1301)
 
 OpenAI-compatible models endpoint response structure
 
@@ -18,7 +18,7 @@ OpenAI-compatible models endpoint response structure
 
 > **data**: `object`[]
 
-Defined in: [types/providers.ts:1299](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1299)
+Defined in: [types/providers.ts:1302](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1302)
 
 #### id
 

--- a/docs/api/type-aliases/NativeFunctionCall.md
+++ b/docs/api/type-aliases/NativeFunctionCall.md
@@ -8,7 +8,7 @@
 
 > **NativeFunctionCall** = `object`
 
-Defined in: [types/providers.ts:2050](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2050)
+Defined in: [types/providers.ts:2053](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2053)
 
 A single function call returned by the Gemini model.
 
@@ -18,7 +18,7 @@ A single function call returned by the Gemini model.
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:2051](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2051)
+Defined in: [types/providers.ts:2054](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2054)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/providers.ts:2051](https://github.com/juspay/neurolink/blob/r
 
 > **args**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:2052](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2052)
+Defined in: [types/providers.ts:2055](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2055)

--- a/docs/api/type-aliases/NativeFunctionDeclaration.md
+++ b/docs/api/type-aliases/NativeFunctionDeclaration.md
@@ -8,7 +8,7 @@
 
 > **NativeFunctionDeclaration** = `object`
 
-Defined in: [types/providers.ts:2024](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2024)
+Defined in: [types/providers.ts:2027](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2027)
 
 A single function declaration for the Gemini native SDK.
 
@@ -18,7 +18,7 @@ A single function declaration for the Gemini native SDK.
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:2025](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2025)
+Defined in: [types/providers.ts:2028](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2028)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2025](https://github.com/juspay/neurolink/blob/r
 
 > **description**: `string`
 
-Defined in: [types/providers.ts:2026](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2026)
+Defined in: [types/providers.ts:2029](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2029)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:2026](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **parametersJsonSchema?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:2027](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2027)
+Defined in: [types/providers.ts:2030](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2030)

--- a/docs/api/type-aliases/NativeFunctionResponse.md
+++ b/docs/api/type-aliases/NativeFunctionResponse.md
@@ -8,7 +8,7 @@
 
 > **NativeFunctionResponse** = `object`
 
-Defined in: [types/providers.ts:2056](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2056)
+Defined in: [types/providers.ts:2059](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2059)
 
 A single function response to feed back into the conversation.
 
@@ -18,7 +18,7 @@ A single function response to feed back into the conversation.
 
 > **functionResponse**: `object`
 
-Defined in: [types/providers.ts:2057](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2057)
+Defined in: [types/providers.ts:2060](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2060)
 
 #### name
 

--- a/docs/api/type-aliases/NativeToolDeclarationsResult.md
+++ b/docs/api/type-aliases/NativeToolDeclarationsResult.md
@@ -8,7 +8,7 @@
 
 > **NativeToolDeclarationsResult** = `object`
 
-Defined in: [types/providers.ts:2043](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2043)
+Defined in: [types/providers.ts:2046](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2046)
 
 Return value of buildNativeToolDeclarations.
 
@@ -23,7 +23,7 @@ MUST be hidden from tool-call metadata exposed to consumers.
 
 > **toolsConfig**: [`NativeToolsConfig`](NativeToolsConfig.md)
 
-Defined in: [types/providers.ts:2044](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2044)
+Defined in: [types/providers.ts:2047](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2047)
 
 ---
 
@@ -31,7 +31,7 @@ Defined in: [types/providers.ts:2044](https://github.com/juspay/neurolink/blob/r
 
 > **executeMap**: `Map`\<`string`, `Tool`\[`"execute"`\]\>
 
-Defined in: [types/providers.ts:2045](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2045)
+Defined in: [types/providers.ts:2048](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2048)
 
 ---
 
@@ -39,4 +39,4 @@ Defined in: [types/providers.ts:2045](https://github.com/juspay/neurolink/blob/r
 
 > **originalNameMap**: `Map`\<`string`, `string`\>
 
-Defined in: [types/providers.ts:2046](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2046)
+Defined in: [types/providers.ts:2049](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2049)

--- a/docs/api/type-aliases/NativeToolsConfig.md
+++ b/docs/api/type-aliases/NativeToolsConfig.md
@@ -8,7 +8,7 @@
 
 > **NativeToolsConfig** = `object`[]
 
-Defined in: [types/providers.ts:2031](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2031)
+Defined in: [types/providers.ts:2034](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2034)
 
 The tools config array expected by the @google/genai SDK.
 

--- a/docs/api/type-aliases/NeuroLinkInstance.md
+++ b/docs/api/type-aliases/NeuroLinkInstance.md
@@ -8,7 +8,7 @@
 
 > **NeuroLinkInstance** = `object`
 
-Defined in: [types/providers.ts:2255](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2255)
+Defined in: [types/providers.ts:2258](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2258)
 
 Minimal NeuroLink-like instance accepted by the image generation service.
 
@@ -18,7 +18,7 @@ Minimal NeuroLink-like instance accepted by the image generation service.
 
 > **generate**: (`options`) => `Promise`\<`unknown`\>
 
-Defined in: [types/providers.ts:2256](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2256)
+Defined in: [types/providers.ts:2259](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2259)
 
 #### Parameters
 

--- a/docs/api/type-aliases/OpenAICompatCatalogEntry.md
+++ b/docs/api/type-aliases/OpenAICompatCatalogEntry.md
@@ -242,3 +242,14 @@ the classifier's default (six of the seven catalog entries).
 #### Returns
 
 [`ProviderError`](../classes/ProviderError.md)
+
+---
+
+### messageContentFormat?
+
+> `optional` **messageContentFormat?**: `"string"`
+
+Defined in: [types/providers.ts:814](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L814)
+
+See CatalogQuirks.messageContentFormat — a vendor that accepts
+`messages[].content` only as a plain string.

--- a/docs/api/type-aliases/OpenAICompatConfigInput.md
+++ b/docs/api/type-aliases/OpenAICompatConfigInput.md
@@ -8,7 +8,7 @@
 
 > **OpenAICompatConfigInput** = `Pick`\<[`OpenAICompatCatalogEntry`](OpenAICompatCatalogEntry.md), `"providerName"` \| `"apiKeyEnvVar"` \| `"baseURLEnvVar"` \| `"defaultBaseURL"` \| `"computedBaseURL"` \| `"configOptions"`\>
 
-Defined in: [types/providers.ts:817](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L817)
+Defined in: [types/providers.ts:820](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L820)
 
 The subset of OpenAICompatCatalogEntry that resolveOpenAICompatConfig()
 needs — lets call sites pass a minimal object without the full catalog

--- a/docs/api/type-aliases/OpenRouterModelInfo.md
+++ b/docs/api/type-aliases/OpenRouterModelInfo.md
@@ -8,7 +8,7 @@
 
 > **OpenRouterModelInfo** = `object`
 
-Defined in: [types/providers.ts:1984](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1984)
+Defined in: [types/providers.ts:1987](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1987)
 
 OpenRouter model information from /api/v1/models endpoint
 
@@ -18,7 +18,7 @@ OpenRouter model information from /api/v1/models endpoint
 
 > **id**: `string`
 
-Defined in: [types/providers.ts:1986](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1986)
+Defined in: [types/providers.ts:1989](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1989)
 
 Model ID in format 'provider/model-name'
 
@@ -28,7 +28,7 @@ Model ID in format 'provider/model-name'
 
 > `optional` **supported_parameters?**: `string`[]
 
-Defined in: [types/providers.ts:1988](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1988)
+Defined in: [types/providers.ts:1991](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1991)
 
 Supported parameters (e.g., 'tools', 'temperature')
 
@@ -38,7 +38,7 @@ Supported parameters (e.g., 'tools', 'temperature')
 
 > `optional` **name?**: `string`
 
-Defined in: [types/providers.ts:1990](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1990)
+Defined in: [types/providers.ts:1993](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1993)
 
 Model name
 
@@ -48,7 +48,7 @@ Model name
 
 > `optional` **description?**: `string`
 
-Defined in: [types/providers.ts:1992](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1992)
+Defined in: [types/providers.ts:1995](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1995)
 
 Model description
 
@@ -58,7 +58,7 @@ Model description
 
 > `optional` **pricing?**: `object`
 
-Defined in: [types/providers.ts:1994](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1994)
+Defined in: [types/providers.ts:1997](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1997)
 
 Pricing information
 
@@ -76,6 +76,6 @@ Pricing information
 
 > `optional` **context_length?**: `number`
 
-Defined in: [types/providers.ts:1999](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1999)
+Defined in: [types/providers.ts:2002](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2002)
 
 Context length

--- a/docs/api/type-aliases/OpenRouterModelsResponse.md
+++ b/docs/api/type-aliases/OpenRouterModelsResponse.md
@@ -8,7 +8,7 @@
 
 > **OpenRouterModelsResponse** = `object`
 
-Defined in: [types/providers.ts:2005](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2005)
+Defined in: [types/providers.ts:2008](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2008)
 
 OpenRouter models API response
 
@@ -18,4 +18,4 @@ OpenRouter models API response
 
 > **data**: [`OpenRouterModelInfo`](OpenRouterModelInfo.md)[]
 
-Defined in: [types/providers.ts:2006](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2006)
+Defined in: [types/providers.ts:2009](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2009)

--- a/docs/api/type-aliases/OpenRouterProviderCache.md
+++ b/docs/api/type-aliases/OpenRouterProviderCache.md
@@ -8,7 +8,7 @@
 
 > **OpenRouterProviderCache** = `object`
 
-Defined in: [types/providers.ts:2012](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2012)
+Defined in: [types/providers.ts:2015](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2015)
 
 OpenRouter provider static cache properties (for testing/internal use)
 
@@ -18,7 +18,7 @@ OpenRouter provider static cache properties (for testing/internal use)
 
 > **modelsCache**: `string`[]
 
-Defined in: [types/providers.ts:2013](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2013)
+Defined in: [types/providers.ts:2016](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2016)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2013](https://github.com/juspay/neurolink/blob/r
 
 > **modelsCacheTime**: `number`
 
-Defined in: [types/providers.ts:2014](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2014)
+Defined in: [types/providers.ts:2017](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2017)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2014](https://github.com/juspay/neurolink/blob/r
 
 > **toolCapableModels**: `Set`\<`string`\>
 
-Defined in: [types/providers.ts:2015](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2015)
+Defined in: [types/providers.ts:2018](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2018)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/providers.ts:2015](https://github.com/juspay/neurolink/blob/r
 
 > **capabilitiesCached**: `boolean`
 
-Defined in: [types/providers.ts:2016](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2016)
+Defined in: [types/providers.ts:2019](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2019)

--- a/docs/api/type-aliases/ParallelDetectionConfig.md
+++ b/docs/api/type-aliases/ParallelDetectionConfig.md
@@ -8,7 +8,7 @@
 
 > **ParallelDetectionConfig** = `object`
 
-Defined in: [types/providers.ts:2300](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2300)
+Defined in: [types/providers.ts:2303](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2303)
 
 Configuration object for parallel detection test execution.
 
@@ -18,7 +18,7 @@ Configuration object for parallel detection test execution.
 
 > **maxConcurrentTests**: `number`
 
-Defined in: [types/providers.ts:2301](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2301)
+Defined in: [types/providers.ts:2304](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2304)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2301](https://github.com/juspay/neurolink/blob/r
 
 > **maxRateLimitRetries**: `number`
 
-Defined in: [types/providers.ts:2302](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2302)
+Defined in: [types/providers.ts:2305](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2305)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:2302](https://github.com/juspay/neurolink/blob/r
 
 > **initialRateLimitCount**: `number`
 
-Defined in: [types/providers.ts:2303](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2303)
+Defined in: [types/providers.ts:2306](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2306)

--- a/docs/api/type-aliases/ProviderAttempt.md
+++ b/docs/api/type-aliases/ProviderAttempt.md
@@ -8,7 +8,7 @@
 
 > **ProviderAttempt** = `object`
 
-Defined in: [types/providers.ts:893](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L893)
+Defined in: [types/providers.ts:896](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L896)
 
 Provider attempt result for iteration tracking (converted from interface)
 
@@ -18,7 +18,7 @@ Provider attempt result for iteration tracking (converted from interface)
 
 > **provider**: [`AIProviderName`](../enumerations/AIProviderName.md)
 
-Defined in: [types/providers.ts:894](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L894)
+Defined in: [types/providers.ts:897](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L897)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:894](https://github.com/juspay/neurolink/blob/re
 
 > **model**: [`SupportedModelName`](SupportedModelName.md)
 
-Defined in: [types/providers.ts:895](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L895)
+Defined in: [types/providers.ts:898](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L898)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:895](https://github.com/juspay/neurolink/blob/re
 
 > **success**: `boolean`
 
-Defined in: [types/providers.ts:896](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L896)
+Defined in: [types/providers.ts:899](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L899)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:896](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **error?**: `string`
 
-Defined in: [types/providers.ts:897](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L897)
+Defined in: [types/providers.ts:900](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L900)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/providers.ts:897](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **stack?**: `string`
 
-Defined in: [types/providers.ts:898](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L898)
+Defined in: [types/providers.ts:901](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L901)

--- a/docs/api/type-aliases/ProviderCapability.md
+++ b/docs/api/type-aliases/ProviderCapability.md
@@ -8,6 +8,6 @@
 
 > **ProviderCapability** = `"text-generation"` \| `"streaming"` \| `"tool-calling"` \| `"image-generation"` \| `"embeddings"`
 
-Defined in: [types/providers.ts:945](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L945)
+Defined in: [types/providers.ts:948](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L948)
 
 Provider capability type

--- a/docs/api/type-aliases/ProviderCatalogJson.md
+++ b/docs/api/type-aliases/ProviderCatalogJson.md
@@ -8,7 +8,7 @@
 
 > **ProviderCatalogJson** = `object`
 
-Defined in: [types/providerCatalog.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L103)
+Defined in: [types/providerCatalog.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L109)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providerCatalog.ts:103](https://github.com/juspay/neurolink/b
 
 > `optional` **$schema?**: `string`
 
-Defined in: [types/providerCatalog.ts:105](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L105)
+Defined in: [types/providerCatalog.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L111)
 
 Editor-only pointer to provider-catalog.schema.json — accepted and ignored.
 
@@ -26,7 +26,7 @@ Editor-only pointer to provider-catalog.schema.json — accepted and ignored.
 
 > **id**: `string`
 
-Defined in: [types/providerCatalog.ts:106](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L106)
+Defined in: [types/providerCatalog.ts:112](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L112)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providerCatalog.ts:106](https://github.com/juspay/neurolink/b
 
 > **displayName**: `string`
 
-Defined in: [types/providerCatalog.ts:107](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L107)
+Defined in: [types/providerCatalog.ts:113](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L113)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providerCatalog.ts:107](https://github.com/juspay/neurolink/b
 
 > `optional` **enumTypeName?**: `string`
 
-Defined in: [types/providerCatalog.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L114)
+Defined in: [types/providerCatalog.ts:120](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L120)
 
 Exported <Name>Models enum name override. Default: PascalCase(id) +
 "Models". REQUIRED where the derived name differs from a pre-existing
@@ -55,7 +55,7 @@ export ("together-ai" derives "TogetherAiModels"; the legacy export is
 
 > `optional` **credentialsKey?**: `string`
 
-Defined in: [types/providerCatalog.ts:123](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L123)
+Defined in: [types/providerCatalog.ts:129](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L129)
 
 NeurolinkCredentials key override. Default: toCamelCase(id). REQUIRED
 where the derived key differs from a pre-existing public credential
@@ -70,7 +70,7 @@ forbids).
 
 > **aliases**: `string`[]
 
-Defined in: [types/providerCatalog.ts:124](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L124)
+Defined in: [types/providerCatalog.ts:130](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L130)
 
 ---
 
@@ -78,7 +78,7 @@ Defined in: [types/providerCatalog.ts:124](https://github.com/juspay/neurolink/b
 
 > **tier**: `2`
 
-Defined in: [types/providerCatalog.ts:125](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L125)
+Defined in: [types/providerCatalog.ts:131](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L131)
 
 ---
 
@@ -86,7 +86,7 @@ Defined in: [types/providerCatalog.ts:125](https://github.com/juspay/neurolink/b
 
 > **wire**: [`CatalogWire`](CatalogWire.md)
 
-Defined in: [types/providerCatalog.ts:126](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L126)
+Defined in: [types/providerCatalog.ts:132](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L132)
 
 ---
 
@@ -94,7 +94,7 @@ Defined in: [types/providerCatalog.ts:126](https://github.com/juspay/neurolink/b
 
 > **models**: `object`
 
-Defined in: [types/providerCatalog.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L127)
+Defined in: [types/providerCatalog.ts:133](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L133)
 
 #### default
 
@@ -166,7 +166,7 @@ runtime default.
 
 > **capabilities**: [`CatalogCapabilities`](CatalogCapabilities.md)
 
-Defined in: [types/providerCatalog.ts:158](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L158)
+Defined in: [types/providerCatalog.ts:164](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L164)
 
 ---
 
@@ -174,7 +174,7 @@ Defined in: [types/providerCatalog.ts:158](https://github.com/juspay/neurolink/b
 
 > **errorRules**: [`CatalogErrorRuleJson`](CatalogErrorRuleJson.md)[]
 
-Defined in: [types/providerCatalog.ts:159](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L159)
+Defined in: [types/providerCatalog.ts:165](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L165)
 
 ---
 
@@ -182,7 +182,7 @@ Defined in: [types/providerCatalog.ts:159](https://github.com/juspay/neurolink/b
 
 > `optional` **quirks?**: [`CatalogQuirks`](CatalogQuirks.md)
 
-Defined in: [types/providerCatalog.ts:160](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L160)
+Defined in: [types/providerCatalog.ts:166](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L166)
 
 ---
 
@@ -190,7 +190,7 @@ Defined in: [types/providerCatalog.ts:160](https://github.com/juspay/neurolink/b
 
 > **setup**: [`CatalogSetup`](CatalogSetup.md)
 
-Defined in: [types/providerCatalog.ts:161](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L161)
+Defined in: [types/providerCatalog.ts:167](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L167)
 
 ---
 
@@ -198,4 +198,4 @@ Defined in: [types/providerCatalog.ts:161](https://github.com/juspay/neurolink/b
 
 > **evidence**: [`CatalogEvidence`](CatalogEvidence.md)
 
-Defined in: [types/providerCatalog.ts:162](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L162)
+Defined in: [types/providerCatalog.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/types/providerCatalog.ts#L168)

--- a/docs/api/type-aliases/ProviderConstructor.md
+++ b/docs/api/type-aliases/ProviderConstructor.md
@@ -8,7 +8,7 @@
 
 > **ProviderConstructor** = ((`modelName?`, `providerName?`, `sdk?`, `region?`, `credentials?`) => [`AIProvider`](AIProvider.md)) \| ((`modelName?`, `providerName?`, `sdk?`, `region?`, `credentials?`) => `Promise`\<[`AIProvider`](AIProvider.md)\>)
 
-Defined in: [types/providers.ts:2133](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2133)
+Defined in: [types/providers.ts:2136](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2136)
 
 Provider constructor interface - supports both sync constructors and async
 factory functions.

--- a/docs/api/type-aliases/ProviderCreationError.md
+++ b/docs/api/type-aliases/ProviderCreationError.md
@@ -8,7 +8,7 @@
 
 > **ProviderCreationError** = `object`
 
-Defined in: [types/providers.ts:904](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L904)
+Defined in: [types/providers.ts:907](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L907)
 
 Error types for provider creation
 
@@ -18,7 +18,7 @@ Error types for provider creation
 
 > **code**: `"INVALID_PROVIDER"` \| `"CONFIGURATION_ERROR"` \| `"INSTANTIATION_ERROR"`
 
-Defined in: [types/providers.ts:905](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L905)
+Defined in: [types/providers.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L908)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:905](https://github.com/juspay/neurolink/blob/re
 
 > **message**: `string`
 
-Defined in: [types/providers.ts:906](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L906)
+Defined in: [types/providers.ts:909](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L909)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:906](https://github.com/juspay/neurolink/blob/re
 
 > **provider**: `string`
 
-Defined in: [types/providers.ts:907](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L907)
+Defined in: [types/providers.ts:910](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L910)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/providers.ts:907](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **details?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L908)
+Defined in: [types/providers.ts:911](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L911)

--- a/docs/api/type-aliases/ProviderDescriptor.md
+++ b/docs/api/type-aliases/ProviderDescriptor.md
@@ -8,7 +8,7 @@
 
 > **ProviderDescriptor** = `object`
 
-Defined in: [types/providers.ts:2169](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2169)
+Defined in: [types/providers.ts:2172](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2172)
 
 Single source of truth for one AI provider's static identity: how it's
 addressed (name/aliases), how it's authenticated (credentialsKey/envVars),
@@ -25,7 +25,7 @@ instead. See src/lib/factories/providerDescriptors.ts for the data.
 
 > **name**: [`AIProviderName`](../enumerations/AIProviderName.md)
 
-Defined in: [types/providers.ts:2171](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2171)
+Defined in: [types/providers.ts:2174](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2174)
 
 Canonical identity — matches an AIProviderName enum member (never AUTO).
 
@@ -35,7 +35,7 @@ Canonical identity — matches an AIProviderName enum member (never AUTO).
 
 > **aliases**: readonly `string`[]
 
-Defined in: [types/providers.ts:2173](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2173)
+Defined in: [types/providers.ts:2176](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2176)
 
 Alternate spellings accepted by the CLI and the alias index (kebab-case, shorthand, legacy names). Does not include `name` itself.
 
@@ -45,7 +45,7 @@ Alternate spellings accepted by the CLI and the alias index (kebab-case, shortha
 
 > **credentialsKey**: keyof [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/providers.ts:2175](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2175)
+Defined in: [types/providers.ts:2178](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2178)
 
 Key into NeurolinkCredentials for per-call/per-instance credential overrides.
 
@@ -55,7 +55,7 @@ Key into NeurolinkCredentials for per-call/per-instance credential overrides.
 
 > **envVars**: `object`
 
-Defined in: [types/providers.ts:2177](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2177)
+Defined in: [types/providers.ts:2180](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2180)
 
 Environment variables this provider reads at runtime.
 
@@ -117,7 +117,7 @@ True when the provider is usable with zero configuration (local runtime with a d
 
 > **defaultModel**: `string`
 
-Defined in: [types/providers.ts:2203](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2203)
+Defined in: [types/providers.ts:2206](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2206)
 
 Static fallback model. The empty string "" is a documented sentinel
 meaning "no static default — resolved at runtime via envVars.model or
@@ -131,7 +131,7 @@ LM Studio, llama.cpp, matching how providerRegistry.ts already passes
 
 > **toolSupport**: `"native"` \| `"prompt-only"` \| `"none"` \| `"model-dependent"`
 
-Defined in: [types/providers.ts:2204](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2204)
+Defined in: [types/providers.ts:2207](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2207)
 
 ---
 
@@ -139,7 +139,7 @@ Defined in: [types/providers.ts:2204](https://github.com/juspay/neurolink/blob/r
 
 > **localRuntime**: `boolean`
 
-Defined in: [types/providers.ts:2206](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2206)
+Defined in: [types/providers.ts:2209](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2209)
 
 True only for providers that run entirely on the caller's machine with no cloud account (Ollama, LM Studio, llama.cpp). LiteLLM is a local proxy but commonly points at cloud models, so it is deliberately false.
 
@@ -149,7 +149,7 @@ True only for providers that run entirely on the caller's machine with no cloud 
 
 > **healthCheck**: `"env-only"` \| `"models-probe"` \| `"live-generate"`
 
-Defined in: [types/providers.ts:2208](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2208)
+Defined in: [types/providers.ts:2211](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2211)
 
 How ProviderHealthChecker should verify this provider is reachable.
 
@@ -159,7 +159,7 @@ How ProviderHealthChecker should verify this provider is reachable.
 
 > `optional` **defaultHealthSweepPriority?**: `number`
 
-Defined in: [types/providers.ts:2217](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2217)
+Defined in: [types/providers.ts:2220](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2220)
 
 Membership + order in the default health sweep
 (`ProviderHealthChecker.checkAllProvidersHealth` with no explicit
@@ -174,7 +174,7 @@ array that lived in providerHealth.ts.
 
 > `optional` **autoSelectPreference?**: `number`
 
-Defined in: [types/providers.ts:2226](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2226)
+Defined in: [types/providers.ts:2229](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2229)
 
 Preference rank for `getBestHealthyProvider`'s default auto-selection
 (lower = tried first). Deliberately a SEPARATE ordering from the sweep:
@@ -189,7 +189,7 @@ that lived inline as getBestHealthyProvider's default parameter.
 
 > `optional` **setupUrl?**: `string`
 
-Defined in: [types/providers.ts:2227](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2227)
+Defined in: [types/providers.ts:2230](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2230)
 
 ---
 
@@ -197,7 +197,7 @@ Defined in: [types/providers.ts:2227](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **timeouts?**: `object`
 
-Defined in: [types/providers.ts:2228](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2228)
+Defined in: [types/providers.ts:2231](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2231)
 
 #### generateMs?
 
@@ -213,7 +213,7 @@ Defined in: [types/providers.ts:2228](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **autoSelectPriority?**: `number`
 
-Defined in: [types/providers.ts:2230](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2230)
+Defined in: [types/providers.ts:2233](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2233)
 
 Ascending priority (1 = tried first) in the auto-select fallback chain used by getBestProvider(). Undefined = not part of the auto-select chain.
 
@@ -223,7 +223,7 @@ Ascending priority (1 = tried first) in the auto-select fallback chain used by g
 
 > `optional` **apiKeyFormatPattern?**: `RegExp`
 
-Defined in: [types/providers.ts:2232](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2232)
+Defined in: [types/providers.ts:2235](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2235)
 
 Format-validation regex sourced from providerConfig.ts's API_KEY_FORMATS, when one exists for this provider.
 
@@ -233,7 +233,7 @@ Format-validation regex sourced from providerConfig.ts's API_KEY_FORMATS, when o
 
 > `optional` **credentialsResolvedExternally?**: `boolean`
 
-Defined in: [types/providers.ts:2247](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2247)
+Defined in: [types/providers.ts:2250](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2250)
 
 True when this provider's credentials are resolved by an external chain
 or its own config validator rather than by plain env-var presence, so

--- a/docs/api/type-aliases/ProviderHealthCheckOptions.md
+++ b/docs/api/type-aliases/ProviderHealthCheckOptions.md
@@ -8,7 +8,7 @@
 
 > **ProviderHealthCheckOptions** = `object`
 
-Defined in: [types/providers.ts:1901](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1901)
+Defined in: [types/providers.ts:1904](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1904)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1901](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/providers.ts:1902](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1902)
+Defined in: [types/providers.ts:1905](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1905)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providers.ts:1902](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **includeConnectivityTest?**: `boolean`
 
-Defined in: [types/providers.ts:1903](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1903)
+Defined in: [types/providers.ts:1906](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1906)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providers.ts:1903](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **includeModelValidation?**: `boolean`
 
-Defined in: [types/providers.ts:1904](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1904)
+Defined in: [types/providers.ts:1907](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1907)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/providers.ts:1904](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **cacheResults?**: `boolean`
 
-Defined in: [types/providers.ts:1905](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1905)
+Defined in: [types/providers.ts:1908](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1908)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/providers.ts:1905](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **maxCacheAge?**: `number`
 
-Defined in: [types/providers.ts:1906](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1906)
+Defined in: [types/providers.ts:1909](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1909)

--- a/docs/api/type-aliases/ProviderHealthStatusOptions.md
+++ b/docs/api/type-aliases/ProviderHealthStatusOptions.md
@@ -8,7 +8,7 @@
 
 > **ProviderHealthStatusOptions** = `object`
 
-Defined in: [types/providers.ts:1867](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1867)
+Defined in: [types/providers.ts:1870](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1870)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:1867](https://github.com/juspay/neurolink/blob/r
 
 > **provider**: [`AIProviderName`](../enumerations/AIProviderName.md)
 
-Defined in: [types/providers.ts:1868](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1868)
+Defined in: [types/providers.ts:1871](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1871)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providers.ts:1868](https://github.com/juspay/neurolink/blob/r
 
 > **isHealthy**: `boolean`
 
-Defined in: [types/providers.ts:1869](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1869)
+Defined in: [types/providers.ts:1872](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1872)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/providers.ts:1869](https://github.com/juspay/neurolink/blob/r
 
 > **isConfigured**: `boolean`
 
-Defined in: [types/providers.ts:1870](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1870)
+Defined in: [types/providers.ts:1873](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1873)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/providers.ts:1870](https://github.com/juspay/neurolink/blob/r
 
 > **hasApiKey**: `boolean`
 
-Defined in: [types/providers.ts:1871](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1871)
+Defined in: [types/providers.ts:1874](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1874)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/providers.ts:1871](https://github.com/juspay/neurolink/blob/r
 
 > **lastChecked**: `Date`
 
-Defined in: [types/providers.ts:1872](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1872)
+Defined in: [types/providers.ts:1875](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1875)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/providers.ts:1872](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **error?**: `string`
 
-Defined in: [types/providers.ts:1873](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1873)
+Defined in: [types/providers.ts:1876](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1876)
 
 ---
 
@@ -64,7 +64,7 @@ Defined in: [types/providers.ts:1873](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **warning?**: `string`
 
-Defined in: [types/providers.ts:1874](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1874)
+Defined in: [types/providers.ts:1877](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1877)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [types/providers.ts:1874](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **responseTime?**: `number`
 
-Defined in: [types/providers.ts:1875](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1875)
+Defined in: [types/providers.ts:1878](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1878)
 
 ---
 
@@ -80,7 +80,7 @@ Defined in: [types/providers.ts:1875](https://github.com/juspay/neurolink/blob/r
 
 > **configurationIssues**: `string`[]
 
-Defined in: [types/providers.ts:1876](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1876)
+Defined in: [types/providers.ts:1879](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1879)
 
 ---
 
@@ -88,4 +88,4 @@ Defined in: [types/providers.ts:1876](https://github.com/juspay/neurolink/blob/r
 
 > **recommendations**: `string`[]
 
-Defined in: [types/providers.ts:1877](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1877)
+Defined in: [types/providers.ts:1880](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1880)

--- a/docs/api/type-aliases/ProviderMetadata.md
+++ b/docs/api/type-aliases/ProviderMetadata.md
@@ -8,7 +8,7 @@
 
 > **ProviderMetadata** = `object`
 
-Defined in: [types/providers.ts:934](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L934)
+Defined in: [types/providers.ts:937](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L937)
 
 Provider metadata type
 
@@ -18,7 +18,7 @@ Provider metadata type
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:935](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L935)
+Defined in: [types/providers.ts:938](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L938)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:935](https://github.com/juspay/neurolink/blob/re
 
 > **version**: `string`
 
-Defined in: [types/providers.ts:936](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L936)
+Defined in: [types/providers.ts:939](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L939)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:936](https://github.com/juspay/neurolink/blob/re
 
 > **capabilities**: [`ProviderCapability`](ProviderCapability.md)[]
 
-Defined in: [types/providers.ts:937](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L937)
+Defined in: [types/providers.ts:940](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L940)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:937](https://github.com/juspay/neurolink/blob/re
 
 > **models**: `string`[]
 
-Defined in: [types/providers.ts:938](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L938)
+Defined in: [types/providers.ts:941](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L941)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/providers.ts:938](https://github.com/juspay/neurolink/blob/re
 
 > **healthStatus**: [`ProviderHealthStatus`](ProviderHealthStatus.md)
 
-Defined in: [types/providers.ts:939](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L939)
+Defined in: [types/providers.ts:942](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L942)

--- a/docs/api/type-aliases/ProviderRegistration.md
+++ b/docs/api/type-aliases/ProviderRegistration.md
@@ -8,7 +8,7 @@
 
 > **ProviderRegistration** = `object`
 
-Defined in: [types/providers.ts:2152](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2152)
+Defined in: [types/providers.ts:2155](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2155)
 
 Provider registration entry held by ProviderFactory.
 
@@ -18,7 +18,7 @@ Provider registration entry held by ProviderFactory.
 
 > **constructor**: [`ProviderConstructor`](ProviderConstructor.md)
 
-Defined in: [types/providers.ts:2153](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2153)
+Defined in: [types/providers.ts:2156](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2156)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2153](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **defaultModel?**: `string`
 
-Defined in: [types/providers.ts:2154](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2154)
+Defined in: [types/providers.ts:2157](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2157)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2154](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **aliases?**: `string`[]
 
-Defined in: [types/providers.ts:2155](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2155)
+Defined in: [types/providers.ts:2158](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2158)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/providers.ts:2155](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **descriptor?**: [`ProviderDescriptor`](ProviderDescriptor.md)
 
-Defined in: [types/providers.ts:2156](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2156)
+Defined in: [types/providers.ts:2159](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2159)

--- a/docs/api/type-aliases/ProviderRegistryOptions.md
+++ b/docs/api/type-aliases/ProviderRegistryOptions.md
@@ -8,7 +8,7 @@
 
 > **ProviderRegistryOptions** = `object`
 
-Defined in: [types/providers.ts:923](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L923)
+Defined in: [types/providers.ts:926](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L926)
 
 Configuration options for the provider registry
 
@@ -18,7 +18,7 @@ Configuration options for the provider registry
 
 > `optional` **enableManualMCP?**: `boolean`
 
-Defined in: [types/providers.ts:928](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L928)
+Defined in: [types/providers.ts:931](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L931)
 
 Enable loading of manual MCP configurations from .mcp-config.json
 Should only be true for CLI mode, false for SDK mode

--- a/docs/api/type-aliases/SageMakerAsLanguageModel.md
+++ b/docs/api/type-aliases/SageMakerAsLanguageModel.md
@@ -8,7 +8,7 @@
 
 > **SageMakerAsLanguageModel** = `object`
 
-Defined in: [types/providers.ts:1892](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1892)
+Defined in: [types/providers.ts:1895](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1895)
 
 Structural type that captures what AI SDK's `streamText` / `generateText`
 actually invoke at runtime on a model object.
@@ -23,7 +23,7 @@ intermediate type, avoiding `as unknown as LanguageModel`.
 
 > `readonly` **specificationVersion**: `string`
 
-Defined in: [types/providers.ts:1893](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1893)
+Defined in: [types/providers.ts:1896](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1896)
 
 ---
 
@@ -31,7 +31,7 @@ Defined in: [types/providers.ts:1893](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **provider**: `string`
 
-Defined in: [types/providers.ts:1894](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1894)
+Defined in: [types/providers.ts:1897](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1897)
 
 ---
 
@@ -39,7 +39,7 @@ Defined in: [types/providers.ts:1894](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **modelId**: `string`
 
-Defined in: [types/providers.ts:1895](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1895)
+Defined in: [types/providers.ts:1898](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1898)
 
 ---
 
@@ -47,7 +47,7 @@ Defined in: [types/providers.ts:1895](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **supportedUrls**: `Record`\<`string`, `RegExp`[]\>
 
-Defined in: [types/providers.ts:1896](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1896)
+Defined in: [types/providers.ts:1899](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1899)
 
 ## Methods
 
@@ -55,7 +55,7 @@ Defined in: [types/providers.ts:1896](https://github.com/juspay/neurolink/blob/r
 
 > **doGenerate**(`options`): `Promise`\<`unknown`\>
 
-Defined in: [types/providers.ts:1897](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1897)
+Defined in: [types/providers.ts:1900](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1900)
 
 #### Parameters
 
@@ -73,7 +73,7 @@ Defined in: [types/providers.ts:1897](https://github.com/juspay/neurolink/blob/r
 
 > **doStream**(`options`): `Promise`\<`unknown`\>
 
-Defined in: [types/providers.ts:1898](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1898)
+Defined in: [types/providers.ts:1901](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1901)
 
 #### Parameters
 

--- a/docs/api/type-aliases/SageMakerConfig.md
+++ b/docs/api/type-aliases/SageMakerConfig.md
@@ -8,7 +8,7 @@
 
 > **SageMakerConfig** = `object`
 
-Defined in: [types/providers.ts:1377](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1377)
+Defined in: [types/providers.ts:1380](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1380)
 
 AWS configuration options for SageMaker client
 
@@ -18,7 +18,7 @@ AWS configuration options for SageMaker client
 
 > **region**: `string`
 
-Defined in: [types/providers.ts:1379](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1379)
+Defined in: [types/providers.ts:1382](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1382)
 
 AWS region for SageMaker service
 
@@ -28,7 +28,7 @@ AWS region for SageMaker service
 
 > **accessKeyId**: `string`
 
-Defined in: [types/providers.ts:1381](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1381)
+Defined in: [types/providers.ts:1384](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1384)
 
 AWS access key ID
 
@@ -38,7 +38,7 @@ AWS access key ID
 
 > **secretAccessKey**: `string`
 
-Defined in: [types/providers.ts:1383](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1383)
+Defined in: [types/providers.ts:1386](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1386)
 
 AWS secret access key
 
@@ -48,7 +48,7 @@ AWS secret access key
 
 > `optional` **sessionToken?**: `string`
 
-Defined in: [types/providers.ts:1385](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1385)
+Defined in: [types/providers.ts:1388](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1388)
 
 AWS session token (optional, for temporary credentials)
 
@@ -58,7 +58,7 @@ AWS session token (optional, for temporary credentials)
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/providers.ts:1387](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1387)
+Defined in: [types/providers.ts:1390](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1390)
 
 Request timeout in milliseconds
 
@@ -68,7 +68,7 @@ Request timeout in milliseconds
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/providers.ts:1389](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1389)
+Defined in: [types/providers.ts:1392](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1392)
 
 Maximum number of retry attempts
 
@@ -78,6 +78,6 @@ Maximum number of retry attempts
 
 > `optional` **endpoint?**: `string`
 
-Defined in: [types/providers.ts:1391](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1391)
+Defined in: [types/providers.ts:1394](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1394)
 
 Custom SageMaker endpoint URL (optional)

--- a/docs/api/type-aliases/SageMakerEndpointInfo.md
+++ b/docs/api/type-aliases/SageMakerEndpointInfo.md
@@ -8,7 +8,7 @@
 
 > **SageMakerEndpointInfo** = `object`
 
-Defined in: [types/providers.ts:1439](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1439)
+Defined in: [types/providers.ts:1442](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1442)
 
 SageMaker endpoint information and metadata
 
@@ -18,7 +18,7 @@ SageMaker endpoint information and metadata
 
 > **endpointName**: `string`
 
-Defined in: [types/providers.ts:1441](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1441)
+Defined in: [types/providers.ts:1444](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1444)
 
 Endpoint name
 
@@ -28,7 +28,7 @@ Endpoint name
 
 > **endpointArn**: `string`
 
-Defined in: [types/providers.ts:1443](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1443)
+Defined in: [types/providers.ts:1446](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1446)
 
 Endpoint ARN
 
@@ -38,7 +38,7 @@ Endpoint ARN
 
 > **modelName**: `string`
 
-Defined in: [types/providers.ts:1445](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1445)
+Defined in: [types/providers.ts:1448](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1448)
 
 Associated model name
 
@@ -48,7 +48,7 @@ Associated model name
 
 > **instanceType**: `string`
 
-Defined in: [types/providers.ts:1447](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1447)
+Defined in: [types/providers.ts:1450](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1450)
 
 EC2 instance type
 
@@ -58,7 +58,7 @@ EC2 instance type
 
 > **creationTime**: `string`
 
-Defined in: [types/providers.ts:1449](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1449)
+Defined in: [types/providers.ts:1452](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1452)
 
 Endpoint creation timestamp
 
@@ -68,7 +68,7 @@ Endpoint creation timestamp
 
 > **lastModifiedTime**: `string`
 
-Defined in: [types/providers.ts:1451](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1451)
+Defined in: [types/providers.ts:1454](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1454)
 
 Last modification timestamp
 
@@ -78,7 +78,7 @@ Last modification timestamp
 
 > **endpointStatus**: `"InService"` \| `"Creating"` \| `"Updating"` \| `"SystemUpdating"` \| `"RollingBack"` \| `"Deleting"` \| `"Failed"`
 
-Defined in: [types/providers.ts:1453](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1453)
+Defined in: [types/providers.ts:1456](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1456)
 
 Current endpoint status
 
@@ -88,7 +88,7 @@ Current endpoint status
 
 > `optional` **currentInstanceCount?**: `number`
 
-Defined in: [types/providers.ts:1462](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1462)
+Defined in: [types/providers.ts:1465](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1465)
 
 Current instance count
 
@@ -98,7 +98,7 @@ Current instance count
 
 > `optional` **productionVariants?**: `object`[]
 
-Defined in: [types/providers.ts:1464](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1464)
+Defined in: [types/providers.ts:1467](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1467)
 
 Variant weights for A/B testing
 

--- a/docs/api/type-aliases/SageMakerErrorCode.md
+++ b/docs/api/type-aliases/SageMakerErrorCode.md
@@ -8,6 +8,6 @@
 
 > **SageMakerErrorCode** = `"VALIDATION_ERROR"` \| `"MODEL_ERROR"` \| `"INTERNAL_ERROR"` \| `"SERVICE_UNAVAILABLE"` \| `"CREDENTIALS_ERROR"` \| `"NETWORK_ERROR"` \| `"ENDPOINT_NOT_FOUND"` \| `"THROTTLING_ERROR"` \| `"UNKNOWN_ERROR"`
 
-Defined in: [types/providers.ts:1703](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1703)
+Defined in: [types/providers.ts:1706](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1706)
 
 Error codes specific to SageMaker operations

--- a/docs/api/type-aliases/SageMakerErrorInfo.md
+++ b/docs/api/type-aliases/SageMakerErrorInfo.md
@@ -8,7 +8,7 @@
 
 > **SageMakerErrorInfo** = `object`
 
-Defined in: [types/providers.ts:1717](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1717)
+Defined in: [types/providers.ts:1720](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1720)
 
 SageMaker-specific error information
 
@@ -18,7 +18,7 @@ SageMaker-specific error information
 
 > **code**: [`SageMakerErrorCode`](SageMakerErrorCode.md)
 
-Defined in: [types/providers.ts:1719](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1719)
+Defined in: [types/providers.ts:1722](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1722)
 
 Error code
 
@@ -28,7 +28,7 @@ Error code
 
 > **message**: `string`
 
-Defined in: [types/providers.ts:1721](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1721)
+Defined in: [types/providers.ts:1724](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1724)
 
 Human-readable error message
 
@@ -38,7 +38,7 @@ Human-readable error message
 
 > `optional` **statusCode?**: `number`
 
-Defined in: [types/providers.ts:1723](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1723)
+Defined in: [types/providers.ts:1726](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1726)
 
 HTTP status code if applicable
 
@@ -48,7 +48,7 @@ HTTP status code if applicable
 
 > `optional` **cause?**: `Error`
 
-Defined in: [types/providers.ts:1725](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1725)
+Defined in: [types/providers.ts:1728](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1728)
 
 Original error from AWS SDK
 
@@ -58,7 +58,7 @@ Original error from AWS SDK
 
 > `optional` **endpoint?**: `string`
 
-Defined in: [types/providers.ts:1727](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1727)
+Defined in: [types/providers.ts:1730](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1730)
 
 Endpoint name where error occurred
 
@@ -68,7 +68,7 @@ Endpoint name where error occurred
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/providers.ts:1729](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1729)
+Defined in: [types/providers.ts:1732](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1732)
 
 Request ID for debugging
 
@@ -78,6 +78,6 @@ Request ID for debugging
 
 > `optional` **retryable?**: `boolean`
 
-Defined in: [types/providers.ts:1731](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1731)
+Defined in: [types/providers.ts:1734](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1734)
 
 Retry suggestion

--- a/docs/api/type-aliases/SageMakerGenerateResult.md
+++ b/docs/api/type-aliases/SageMakerGenerateResult.md
@@ -8,7 +8,7 @@
 
 > **SageMakerGenerateResult** = `object`
 
-Defined in: [types/providers.ts:1833](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1833)
+Defined in: [types/providers.ts:1836](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1836)
 
 SageMaker generation result type for better type safety
 
@@ -18,7 +18,7 @@ SageMaker generation result type for better type safety
 
 > `optional` **text?**: `string`
 
-Defined in: [types/providers.ts:1834](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1834)
+Defined in: [types/providers.ts:1837](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1837)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:1834](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **reasoning?**: `string` \| (\{ `type`: `"text"`; `text`: `string`; `signature?`: `string`; \} \| \{ `type`: `"redacted"`; `data`: `string`; \})[]
 
-Defined in: [types/providers.ts:1835](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1835)
+Defined in: [types/providers.ts:1838](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1838)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:1835](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **files?**: `object`[]
 
-Defined in: [types/providers.ts:1841](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1841)
+Defined in: [types/providers.ts:1844](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1844)
 
 #### data
 
@@ -50,7 +50,7 @@ Defined in: [types/providers.ts:1841](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **logprobs?**: `object`[]
 
-Defined in: [types/providers.ts:1842](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1842)
+Defined in: [types/providers.ts:1845](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1845)
 
 #### token
 
@@ -70,7 +70,7 @@ Defined in: [types/providers.ts:1842](https://github.com/juspay/neurolink/blob/r
 
 > **usage**: `object`
 
-Defined in: [types/providers.ts:1847](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1847)
+Defined in: [types/providers.ts:1850](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1850)
 
 #### promptTokens
 
@@ -90,7 +90,7 @@ Defined in: [types/providers.ts:1847](https://github.com/juspay/neurolink/blob/r
 
 > **finishReason**: `"stop"` \| `"length"` \| `"content-filter"` \| `"tool-calls"` \| `"error"` \| `"unknown"`
 
-Defined in: [types/providers.ts:1852](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1852)
+Defined in: [types/providers.ts:1855](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1855)
 
 ---
 
@@ -98,7 +98,7 @@ Defined in: [types/providers.ts:1852](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **warnings?**: `object`[]
 
-Defined in: [types/providers.ts:1859](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1859)
+Defined in: [types/providers.ts:1862](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1862)
 
 #### type
 
@@ -114,7 +114,7 @@ Defined in: [types/providers.ts:1859](https://github.com/juspay/neurolink/blob/r
 
 > **rawCall**: `object`
 
-Defined in: [types/providers.ts:1860](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1860)
+Defined in: [types/providers.ts:1863](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1863)
 
 #### rawPrompt
 
@@ -130,7 +130,7 @@ Defined in: [types/providers.ts:1860](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **rawResponse?**: `object`
 
-Defined in: [types/providers.ts:1861](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1861)
+Defined in: [types/providers.ts:1864](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1864)
 
 #### headers?
 
@@ -142,7 +142,7 @@ Defined in: [types/providers.ts:1861](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **request?**: `object`
 
-Defined in: [types/providers.ts:1862](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1862)
+Defined in: [types/providers.ts:1865](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1865)
 
 #### body?
 
@@ -154,7 +154,7 @@ Defined in: [types/providers.ts:1862](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **toolCalls?**: [`SageMakerToolCall`](SageMakerToolCall.md)[]
 
-Defined in: [types/providers.ts:1863](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1863)
+Defined in: [types/providers.ts:1866](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1866)
 
 ---
 
@@ -162,4 +162,4 @@ Defined in: [types/providers.ts:1863](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **object?**: `unknown`
 
-Defined in: [types/providers.ts:1864](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1864)
+Defined in: [types/providers.ts:1867](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1867)

--- a/docs/api/type-aliases/SageMakerGenerationOptions.md
+++ b/docs/api/type-aliases/SageMakerGenerationOptions.md
@@ -8,7 +8,7 @@
 
 > **SageMakerGenerationOptions** = `object`
 
-Defined in: [types/providers.ts:1653](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1653)
+Defined in: [types/providers.ts:1656](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1656)
 
 Enhanced generation request options
 
@@ -18,7 +18,7 @@ Enhanced generation request options
 
 > **prompt**: `string`
 
-Defined in: [types/providers.ts:1655](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1655)
+Defined in: [types/providers.ts:1658](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1658)
 
 Input prompt text
 
@@ -28,7 +28,7 @@ Input prompt text
 
 > `optional` **systemPrompt?**: `string`
 
-Defined in: [types/providers.ts:1657](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1657)
+Defined in: [types/providers.ts:1660](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1660)
 
 System prompt for context
 
@@ -38,7 +38,7 @@ System prompt for context
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/providers.ts:1659](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1659)
+Defined in: [types/providers.ts:1662](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1662)
 
 Maximum tokens to generate
 
@@ -48,7 +48,7 @@ Maximum tokens to generate
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/providers.ts:1661](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1661)
+Defined in: [types/providers.ts:1664](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1664)
 
 Temperature for randomness (0-1)
 
@@ -58,7 +58,7 @@ Temperature for randomness (0-1)
 
 > `optional` **topP?**: `number`
 
-Defined in: [types/providers.ts:1663](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1663)
+Defined in: [types/providers.ts:1666](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1666)
 
 Top-p nucleus sampling (0-1)
 
@@ -68,7 +68,7 @@ Top-p nucleus sampling (0-1)
 
 > `optional` **topK?**: `number`
 
-Defined in: [types/providers.ts:1665](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1665)
+Defined in: [types/providers.ts:1668](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1668)
 
 Top-k sampling
 
@@ -78,7 +78,7 @@ Top-k sampling
 
 > `optional` **stopSequences?**: `string`[]
 
-Defined in: [types/providers.ts:1667](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1667)
+Defined in: [types/providers.ts:1670](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1670)
 
 Stop sequences to end generation
 
@@ -88,7 +88,7 @@ Stop sequences to end generation
 
 > `optional` **stream?**: `boolean`
 
-Defined in: [types/providers.ts:1669](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1669)
+Defined in: [types/providers.ts:1672](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1672)
 
 Enable streaming response
 
@@ -98,7 +98,7 @@ Enable streaming response
 
 > `optional` **tools?**: `object`[]
 
-Defined in: [types/providers.ts:1671](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1671)
+Defined in: [types/providers.ts:1674](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1674)
 
 Tools available for function calling
 
@@ -120,6 +120,6 @@ Tools available for function calling
 
 > `optional` **toolChoice?**: `"auto"` \| `"none"` \| \{ `type`: `"tool"`; `name`: `string`; \}
 
-Defined in: [types/providers.ts:1677](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1677)
+Defined in: [types/providers.ts:1680](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1680)
 
 Tool choice mode

--- a/docs/api/type-aliases/SageMakerGenerationResponse.md
+++ b/docs/api/type-aliases/SageMakerGenerationResponse.md
@@ -8,7 +8,7 @@
 
 > **SageMakerGenerationResponse** = `object`
 
-Defined in: [types/providers.ts:1683](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1683)
+Defined in: [types/providers.ts:1686](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1686)
 
 Generation response from SageMaker
 
@@ -18,7 +18,7 @@ Generation response from SageMaker
 
 > **text**: `string`
 
-Defined in: [types/providers.ts:1685](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1685)
+Defined in: [types/providers.ts:1688](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1688)
 
 Generated text content
 
@@ -28,7 +28,7 @@ Generated text content
 
 > **usage**: [`SageMakerUsage`](SageMakerUsage.md)
 
-Defined in: [types/providers.ts:1687](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1687)
+Defined in: [types/providers.ts:1690](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1690)
 
 Token usage information
 
@@ -38,7 +38,7 @@ Token usage information
 
 > **finishReason**: `"stop"` \| `"length"` \| `"tool-calls"` \| `"content-filter"` \| `"unknown"`
 
-Defined in: [types/providers.ts:1689](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1689)
+Defined in: [types/providers.ts:1692](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1692)
 
 Finish reason for generation
 
@@ -48,7 +48,7 @@ Finish reason for generation
 
 > `optional` **toolCalls?**: [`SageMakerToolCall`](SageMakerToolCall.md)[]
 
-Defined in: [types/providers.ts:1691](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1691)
+Defined in: [types/providers.ts:1694](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1694)
 
 Tool calls made during generation
 
@@ -58,7 +58,7 @@ Tool calls made during generation
 
 > `optional` **toolResults?**: [`SageMakerToolResult`](SageMakerToolResult.md)[]
 
-Defined in: [types/providers.ts:1693](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1693)
+Defined in: [types/providers.ts:1696](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1696)
 
 Tool results if tools were executed
 
@@ -68,7 +68,7 @@ Tool results if tools were executed
 
 > `optional` **metadata?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:1695](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1695)
+Defined in: [types/providers.ts:1698](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1698)
 
 Additional metadata
 
@@ -78,6 +78,6 @@ Additional metadata
 
 > `optional` **modelVersion?**: `string`
 
-Defined in: [types/providers.ts:1697](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1697)
+Defined in: [types/providers.ts:1700](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1700)
 
 Model version or identifier

--- a/docs/api/type-aliases/SageMakerModelConfig.md
+++ b/docs/api/type-aliases/SageMakerModelConfig.md
@@ -8,7 +8,7 @@
 
 > **SageMakerModelConfig** = `object`
 
-Defined in: [types/providers.ts:1397](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1397)
+Defined in: [types/providers.ts:1400](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1400)
 
 Model-specific configuration for SageMaker endpoints
 
@@ -18,7 +18,7 @@ Model-specific configuration for SageMaker endpoints
 
 > **endpointName**: `string`
 
-Defined in: [types/providers.ts:1399](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1399)
+Defined in: [types/providers.ts:1402](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1402)
 
 SageMaker endpoint name
 
@@ -28,7 +28,7 @@ SageMaker endpoint name
 
 > `optional` **modelType?**: `"llama"` \| `"mistral"` \| `"claude"` \| `"huggingface"` \| `"jumpstart"` \| `"custom"`
 
-Defined in: [types/providers.ts:1401](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1401)
+Defined in: [types/providers.ts:1404](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1404)
 
 Model type for request/response formatting
 
@@ -38,7 +38,7 @@ Model type for request/response formatting
 
 > `optional` **contentType?**: `string`
 
-Defined in: [types/providers.ts:1409](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1409)
+Defined in: [types/providers.ts:1412](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1412)
 
 Content type for requests
 
@@ -48,7 +48,7 @@ Content type for requests
 
 > `optional` **accept?**: `string`
 
-Defined in: [types/providers.ts:1411](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1411)
+Defined in: [types/providers.ts:1414](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1414)
 
 Accept header for responses
 
@@ -58,7 +58,7 @@ Accept header for responses
 
 > `optional` **customAttributes?**: `string`
 
-Defined in: [types/providers.ts:1413](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1413)
+Defined in: [types/providers.ts:1416](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1416)
 
 Custom attributes for the endpoint
 
@@ -68,7 +68,7 @@ Custom attributes for the endpoint
 
 > `optional` **inputFormat?**: `"huggingface"` \| `"jumpstart"` \| `"custom"`
 
-Defined in: [types/providers.ts:1415](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1415)
+Defined in: [types/providers.ts:1418](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1418)
 
 Input format specification
 
@@ -78,7 +78,7 @@ Input format specification
 
 > `optional` **outputFormat?**: `"huggingface"` \| `"jumpstart"` \| `"custom"`
 
-Defined in: [types/providers.ts:1417](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1417)
+Defined in: [types/providers.ts:1420](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1420)
 
 Output format specification
 
@@ -88,7 +88,7 @@ Output format specification
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/providers.ts:1419](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1419)
+Defined in: [types/providers.ts:1422](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1422)
 
 Maximum tokens for generation
 
@@ -98,7 +98,7 @@ Maximum tokens for generation
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/providers.ts:1421](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1421)
+Defined in: [types/providers.ts:1424](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1424)
 
 Temperature parameter
 
@@ -108,7 +108,7 @@ Temperature parameter
 
 > `optional` **topP?**: `number`
 
-Defined in: [types/providers.ts:1423](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1423)
+Defined in: [types/providers.ts:1426](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1426)
 
 Top-p parameter
 
@@ -118,7 +118,7 @@ Top-p parameter
 
 > `optional` **stopSequences?**: `string`[]
 
-Defined in: [types/providers.ts:1425](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1425)
+Defined in: [types/providers.ts:1428](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1428)
 
 Stop sequences
 
@@ -128,7 +128,7 @@ Stop sequences
 
 > `optional` **initialConcurrency?**: `number`
 
-Defined in: [types/providers.ts:1427](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1427)
+Defined in: [types/providers.ts:1430](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1430)
 
 Initial concurrency for batch processing
 
@@ -138,7 +138,7 @@ Initial concurrency for batch processing
 
 > `optional` **maxConcurrency?**: `number`
 
-Defined in: [types/providers.ts:1429](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1429)
+Defined in: [types/providers.ts:1432](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1432)
 
 Maximum concurrency for batch processing
 
@@ -148,7 +148,7 @@ Maximum concurrency for batch processing
 
 > `optional` **minConcurrency?**: `number`
 
-Defined in: [types/providers.ts:1431](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1431)
+Defined in: [types/providers.ts:1434](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1434)
 
 Minimum concurrency for batch processing
 
@@ -158,6 +158,6 @@ Minimum concurrency for batch processing
 
 > `optional` **maxConcurrentDetectionTests?**: `number`
 
-Defined in: [types/providers.ts:1433](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1433)
+Defined in: [types/providers.ts:1436](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1436)
 
 Maximum concurrent detection tests

--- a/docs/api/type-aliases/SageMakerOpenAIToolCall.md
+++ b/docs/api/type-aliases/SageMakerOpenAIToolCall.md
@@ -8,7 +8,7 @@
 
 > **SageMakerOpenAIToolCall** = `object`
 
-Defined in: [types/providers.ts:2337](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2337)
+Defined in: [types/providers.ts:2340](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2340)
 
 SageMaker tool_call item in the OpenAI-compatible payload shape.
 
@@ -18,7 +18,7 @@ SageMaker tool_call item in the OpenAI-compatible payload shape.
 
 > **type**: `"function"`
 
-Defined in: [types/providers.ts:2338](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2338)
+Defined in: [types/providers.ts:2341](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2341)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2338](https://github.com/juspay/neurolink/blob/r
 
 > **id**: `string`
 
-Defined in: [types/providers.ts:2339](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2339)
+Defined in: [types/providers.ts:2342](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2342)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2339](https://github.com/juspay/neurolink/blob/r
 
 > **function**: `object`
 
-Defined in: [types/providers.ts:2340](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2340)
+Defined in: [types/providers.ts:2343](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2343)
 
 #### name
 

--- a/docs/api/type-aliases/SageMakerStreamChunk.md
+++ b/docs/api/type-aliases/SageMakerStreamChunk.md
@@ -8,7 +8,7 @@
 
 > **SageMakerStreamChunk** = `object`
 
-Defined in: [types/providers.ts:1540](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1540)
+Defined in: [types/providers.ts:1543](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1543)
 
 Streaming response chunk from SageMaker
 
@@ -18,7 +18,7 @@ Streaming response chunk from SageMaker
 
 > `optional` **content?**: `string`
 
-Defined in: [types/providers.ts:1542](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1542)
+Defined in: [types/providers.ts:1545](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1545)
 
 Text content in the chunk
 
@@ -28,7 +28,7 @@ Text content in the chunk
 
 > `optional` **done?**: `boolean`
 
-Defined in: [types/providers.ts:1544](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1544)
+Defined in: [types/providers.ts:1547](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1547)
 
 Indicates if this is the final chunk
 
@@ -38,7 +38,7 @@ Indicates if this is the final chunk
 
 > `optional` **usage?**: [`SageMakerUsage`](SageMakerUsage.md)
 
-Defined in: [types/providers.ts:1546](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1546)
+Defined in: [types/providers.ts:1549](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1549)
 
 Usage information (only in final chunk)
 
@@ -48,7 +48,7 @@ Usage information (only in final chunk)
 
 > `optional` **error?**: `string`
 
-Defined in: [types/providers.ts:1548](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1548)
+Defined in: [types/providers.ts:1551](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1551)
 
 Error information if chunk contains error
 
@@ -58,7 +58,7 @@ Error information if chunk contains error
 
 > `optional` **finishReason?**: `"stop"` \| `"length"` \| `"tool-calls"` \| `"content-filter"` \| `"unknown"`
 
-Defined in: [types/providers.ts:1550](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1550)
+Defined in: [types/providers.ts:1553](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1553)
 
 Finish reason for generation
 
@@ -68,7 +68,7 @@ Finish reason for generation
 
 > `optional` **toolCall?**: [`SageMakerStreamingToolCall`](SageMakerStreamingToolCall.md)
 
-Defined in: [types/providers.ts:1557](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1557)
+Defined in: [types/providers.ts:1560](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1560)
 
 Tool call in progress (Phase 2.3)
 
@@ -78,7 +78,7 @@ Tool call in progress (Phase 2.3)
 
 > `optional` **toolResult?**: [`SageMakerStreamingToolResult`](SageMakerStreamingToolResult.md)
 
-Defined in: [types/providers.ts:1559](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1559)
+Defined in: [types/providers.ts:1562](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1562)
 
 Tool result chunk (Phase 2.3)
 
@@ -88,6 +88,6 @@ Tool result chunk (Phase 2.3)
 
 > `optional` **structuredOutput?**: [`SageMakerStructuredOutput`](SageMakerStructuredOutput.md)
 
-Defined in: [types/providers.ts:1561](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1561)
+Defined in: [types/providers.ts:1564](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1564)
 
 Structured output streaming (Phase 2.3)

--- a/docs/api/type-aliases/SageMakerStreamingToolCall.md
+++ b/docs/api/type-aliases/SageMakerStreamingToolCall.md
@@ -8,7 +8,7 @@
 
 > **SageMakerStreamingToolCall** = `object`
 
-Defined in: [types/providers.ts:1597](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1597)
+Defined in: [types/providers.ts:1600](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1600)
 
 Streaming tool call information (Phase 2.3)
 
@@ -18,7 +18,7 @@ Streaming tool call information (Phase 2.3)
 
 > **id**: `string`
 
-Defined in: [types/providers.ts:1599](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1599)
+Defined in: [types/providers.ts:1602](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1602)
 
 Tool call identifier
 
@@ -28,7 +28,7 @@ Tool call identifier
 
 > `optional` **name?**: `string`
 
-Defined in: [types/providers.ts:1601](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1601)
+Defined in: [types/providers.ts:1604](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1604)
 
 Tool/function name
 
@@ -38,7 +38,7 @@ Tool/function name
 
 > `optional` **arguments?**: `string`
 
-Defined in: [types/providers.ts:1603](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1603)
+Defined in: [types/providers.ts:1606](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1606)
 
 Partial or complete arguments as JSON string
 
@@ -48,7 +48,7 @@ Partial or complete arguments as JSON string
 
 > **type**: `"function"`
 
-Defined in: [types/providers.ts:1605](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1605)
+Defined in: [types/providers.ts:1608](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1608)
 
 Tool call type
 
@@ -58,7 +58,7 @@ Tool call type
 
 > `optional` **complete?**: `boolean`
 
-Defined in: [types/providers.ts:1607](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1607)
+Defined in: [types/providers.ts:1610](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1610)
 
 Indicates if this tool call is complete
 
@@ -68,6 +68,6 @@ Indicates if this tool call is complete
 
 > `optional` **argumentsDelta?**: `string`
 
-Defined in: [types/providers.ts:1609](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1609)
+Defined in: [types/providers.ts:1612](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1612)
 
 Delta text for incremental argument building

--- a/docs/api/type-aliases/SageMakerStreamingToolResult.md
+++ b/docs/api/type-aliases/SageMakerStreamingToolResult.md
@@ -8,7 +8,7 @@
 
 > **SageMakerStreamingToolResult** = `object`
 
-Defined in: [types/providers.ts:1615](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1615)
+Defined in: [types/providers.ts:1618](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1618)
 
 Streaming tool result information (Phase 2.3)
 
@@ -18,7 +18,7 @@ Streaming tool result information (Phase 2.3)
 
 > **toolCallId**: `string`
 
-Defined in: [types/providers.ts:1617](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1617)
+Defined in: [types/providers.ts:1620](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1620)
 
 Tool call identifier
 
@@ -28,7 +28,7 @@ Tool call identifier
 
 > **toolName**: `string`
 
-Defined in: [types/providers.ts:1619](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1619)
+Defined in: [types/providers.ts:1622](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1622)
 
 Tool name
 
@@ -38,7 +38,7 @@ Tool name
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/providers.ts:1621](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1621)
+Defined in: [types/providers.ts:1624](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1624)
 
 Partial or complete result data
 
@@ -48,7 +48,7 @@ Partial or complete result data
 
 > `optional` **resultDelta?**: `string`
 
-Defined in: [types/providers.ts:1623](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1623)
+Defined in: [types/providers.ts:1626](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1626)
 
 Result delta for incremental responses
 
@@ -58,7 +58,7 @@ Result delta for incremental responses
 
 > **status**: `"pending"` \| `"running"` \| `"success"` \| `"error"`
 
-Defined in: [types/providers.ts:1625](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1625)
+Defined in: [types/providers.ts:1628](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1628)
 
 Execution status
 
@@ -68,7 +68,7 @@ Execution status
 
 > `optional` **error?**: `string`
 
-Defined in: [types/providers.ts:1627](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1627)
+Defined in: [types/providers.ts:1630](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1630)
 
 Error message if status is error
 
@@ -78,6 +78,6 @@ Error message if status is error
 
 > `optional` **complete?**: `boolean`
 
-Defined in: [types/providers.ts:1629](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1629)
+Defined in: [types/providers.ts:1632](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1632)
 
 Indicates if this result is complete

--- a/docs/api/type-aliases/SageMakerStructuredOutput.md
+++ b/docs/api/type-aliases/SageMakerStructuredOutput.md
@@ -8,7 +8,7 @@
 
 > **SageMakerStructuredOutput** = `object`
 
-Defined in: [types/providers.ts:1635](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1635)
+Defined in: [types/providers.ts:1638](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1638)
 
 Structured output streaming information (Phase 2.3)
 
@@ -18,7 +18,7 @@ Structured output streaming information (Phase 2.3)
 
 > `optional` **partialObject?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:1637](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1637)
+Defined in: [types/providers.ts:1640](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1640)
 
 Partial JSON object being built
 
@@ -28,7 +28,7 @@ Partial JSON object being built
 
 > `optional` **jsonDelta?**: `string`
 
-Defined in: [types/providers.ts:1639](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1639)
+Defined in: [types/providers.ts:1642](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1642)
 
 JSON delta text
 
@@ -38,7 +38,7 @@ JSON delta text
 
 > `optional` **currentPath?**: `string`
 
-Defined in: [types/providers.ts:1641](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1641)
+Defined in: [types/providers.ts:1644](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1644)
 
 Current parsing path (e.g., "user.name")
 
@@ -48,7 +48,7 @@ Current parsing path (e.g., "user.name")
 
 > `optional` **validationErrors?**: `string`[]
 
-Defined in: [types/providers.ts:1643](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1643)
+Defined in: [types/providers.ts:1646](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1646)
 
 Schema validation errors
 
@@ -58,7 +58,7 @@ Schema validation errors
 
 > `optional` **complete?**: `boolean`
 
-Defined in: [types/providers.ts:1645](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1645)
+Defined in: [types/providers.ts:1648](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1648)
 
 Indicates if JSON is complete and valid
 
@@ -68,6 +68,6 @@ Indicates if JSON is complete and valid
 
 > `optional` **schema?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:1647](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1647)
+Defined in: [types/providers.ts:1650](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1650)
 
 JSON schema being validated against

--- a/docs/api/type-aliases/SageMakerToolCall.md
+++ b/docs/api/type-aliases/SageMakerToolCall.md
@@ -8,7 +8,7 @@
 
 > **SageMakerToolCall** = `object`
 
-Defined in: [types/providers.ts:1567](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1567)
+Defined in: [types/providers.ts:1570](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1570)
 
 Tool call information for function calling
 
@@ -18,7 +18,7 @@ Tool call information for function calling
 
 > **id**: `string`
 
-Defined in: [types/providers.ts:1569](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1569)
+Defined in: [types/providers.ts:1572](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1572)
 
 Tool call identifier
 
@@ -28,7 +28,7 @@ Tool call identifier
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:1571](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1571)
+Defined in: [types/providers.ts:1574](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1574)
 
 Tool/function name
 
@@ -38,7 +38,7 @@ Tool/function name
 
 > **arguments**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:1573](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1573)
+Defined in: [types/providers.ts:1576](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1576)
 
 Tool arguments as JSON object
 
@@ -48,6 +48,6 @@ Tool arguments as JSON object
 
 > **type**: `"function"`
 
-Defined in: [types/providers.ts:1575](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1575)
+Defined in: [types/providers.ts:1578](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1578)
 
 Tool call type

--- a/docs/api/type-aliases/SageMakerToolResult.md
+++ b/docs/api/type-aliases/SageMakerToolResult.md
@@ -8,7 +8,7 @@
 
 > **SageMakerToolResult** = `object`
 
-Defined in: [types/providers.ts:1581](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1581)
+Defined in: [types/providers.ts:1584](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1584)
 
 Tool result information
 
@@ -18,7 +18,7 @@ Tool result information
 
 > **toolCallId**: `string`
 
-Defined in: [types/providers.ts:1583](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1583)
+Defined in: [types/providers.ts:1586](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1586)
 
 Tool call identifier
 
@@ -28,7 +28,7 @@ Tool call identifier
 
 > **toolName**: `string`
 
-Defined in: [types/providers.ts:1585](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1585)
+Defined in: [types/providers.ts:1588](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1588)
 
 Tool name
 
@@ -38,7 +38,7 @@ Tool name
 
 > **result**: `unknown`
 
-Defined in: [types/providers.ts:1587](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1587)
+Defined in: [types/providers.ts:1590](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1590)
 
 Tool result data
 
@@ -48,7 +48,7 @@ Tool result data
 
 > **status**: `"success"` \| `"error"`
 
-Defined in: [types/providers.ts:1589](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1589)
+Defined in: [types/providers.ts:1592](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1592)
 
 Execution status
 
@@ -58,6 +58,6 @@ Execution status
 
 > `optional` **error?**: `string`
 
-Defined in: [types/providers.ts:1591](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1591)
+Defined in: [types/providers.ts:1594](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1594)
 
 Error message if status is error

--- a/docs/api/type-aliases/SageMakerUsage.md
+++ b/docs/api/type-aliases/SageMakerUsage.md
@@ -8,7 +8,7 @@
 
 > **SageMakerUsage** = `object`
 
-Defined in: [types/providers.ts:1476](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1476)
+Defined in: [types/providers.ts:1479](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1479)
 
 Token usage and billing information
 
@@ -18,7 +18,7 @@ Token usage and billing information
 
 > **promptTokens**: `number`
 
-Defined in: [types/providers.ts:1478](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1478)
+Defined in: [types/providers.ts:1481](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1481)
 
 Number of prompt tokens
 
@@ -28,7 +28,7 @@ Number of prompt tokens
 
 > **completionTokens**: `number`
 
-Defined in: [types/providers.ts:1480](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1480)
+Defined in: [types/providers.ts:1483](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1483)
 
 Number of completion tokens
 
@@ -38,7 +38,7 @@ Number of completion tokens
 
 > **total**: `number`
 
-Defined in: [types/providers.ts:1482](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1482)
+Defined in: [types/providers.ts:1485](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1485)
 
 Total tokens used
 
@@ -48,7 +48,7 @@ Total tokens used
 
 > `optional` **requestTime?**: `number`
 
-Defined in: [types/providers.ts:1484](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1484)
+Defined in: [types/providers.ts:1487](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1487)
 
 Request processing time in milliseconds
 
@@ -58,7 +58,7 @@ Request processing time in milliseconds
 
 > `optional` **inferenceTime?**: `number`
 
-Defined in: [types/providers.ts:1486](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1486)
+Defined in: [types/providers.ts:1489](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1489)
 
 Model inference time in milliseconds
 
@@ -68,6 +68,6 @@ Model inference time in milliseconds
 
 > `optional` **estimatedCost?**: `number`
 
-Defined in: [types/providers.ts:1488](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1488)
+Defined in: [types/providers.ts:1491](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1491)
 
 Estimated cost in USD

--- a/docs/api/type-aliases/StepFinishEvent.md
+++ b/docs/api/type-aliases/StepFinishEvent.md
@@ -8,7 +8,7 @@
 
 > **StepFinishEvent** = `object`
 
-Defined in: [types/providers.ts:2104](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2104)
+Defined in: [types/providers.ts:2107](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2107)
 
 Step finish event shape for multi-step generation.
 
@@ -22,7 +22,7 @@ Step finish event shape for multi-step generation.
 
 > `readonly` **toolCalls**: `ReadonlyArray`\<`unknown`\>
 
-Defined in: [types/providers.ts:2105](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2105)
+Defined in: [types/providers.ts:2108](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2108)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/providers.ts:2105](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **toolResults**: `ReadonlyArray`\<`unknown`\>
 
-Defined in: [types/providers.ts:2106](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2106)
+Defined in: [types/providers.ts:2109](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2109)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/providers.ts:2106](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **text**: `string`
 
-Defined in: [types/providers.ts:2107](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2107)
+Defined in: [types/providers.ts:2110](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2110)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/providers.ts:2107](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **finishReason**: `string`
 
-Defined in: [types/providers.ts:2108](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2108)
+Defined in: [types/providers.ts:2111](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2111)
 
 ---
 
@@ -54,7 +54,7 @@ Defined in: [types/providers.ts:2108](https://github.com/juspay/neurolink/blob/r
 
 > `readonly` **usage**: `object`
 
-Defined in: [types/providers.ts:2109](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2109)
+Defined in: [types/providers.ts:2112](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2112)
 
 #### inputTokens?
 

--- a/docs/api/type-aliases/ToolWithLegacyParams.md
+++ b/docs/api/type-aliases/ToolWithLegacyParams.md
@@ -8,7 +8,7 @@
 
 > **ToolWithLegacyParams** = `object`
 
-Defined in: [types/providers.ts:2117](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2117)
+Defined in: [types/providers.ts:2120](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2120)
 
 Represents an AI SDK Tool that may carry a legacy `parameters` field
 (from AI SDK v3/v4) in addition to the current `inputSchema`.
@@ -19,7 +19,7 @@ Represents an AI SDK Tool that may carry a legacy `parameters` field
 
 > `optional` **description?**: `string`
 
-Defined in: [types/providers.ts:2118](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2118)
+Defined in: [types/providers.ts:2121](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2121)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/providers.ts:2118](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **inputSchema?**: `unknown`
 
-Defined in: [types/providers.ts:2119](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2119)
+Defined in: [types/providers.ts:2122](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2122)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/providers.ts:2119](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **execute?**: (...`args`) => `unknown`
 
-Defined in: [types/providers.ts:2120](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2120)
+Defined in: [types/providers.ts:2123](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2123)
 
 #### Parameters
 
@@ -53,6 +53,6 @@ Defined in: [types/providers.ts:2120](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **parameters?**: `unknown`
 
-Defined in: [types/providers.ts:2122](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2122)
+Defined in: [types/providers.ts:2125](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2125)
 
 Legacy field from AI SDK v3/v4

--- a/docs/api/type-aliases/VertexAnthropicAuthClient.md
+++ b/docs/api/type-aliases/VertexAnthropicAuthClient.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicAuthClient** = `object`
 
-Defined in: [types/providers.ts:1259](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1259)
+Defined in: [types/providers.ts:1262](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1262)
 
 The two members `@anthropic-ai/vertex-sdk` actually uses off an auth client.
 
@@ -23,7 +23,7 @@ instead of standing up Application Default Credentials.
 
 > **getRequestHeaders**: () => `Promise`\<`Record`\<`string`, `string`\>\>
 
-Defined in: [types/providers.ts:1260](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1260)
+Defined in: [types/providers.ts:1263](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1263)
 
 #### Returns
 
@@ -35,4 +35,4 @@ Defined in: [types/providers.ts:1260](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **projectId?**: `string` \| `null`
 
-Defined in: [types/providers.ts:1261](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1261)
+Defined in: [types/providers.ts:1264](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1264)

--- a/docs/api/type-aliases/VertexAnthropicCacheControl.md
+++ b/docs/api/type-aliases/VertexAnthropicCacheControl.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicCacheControl** = `object`
 
-Defined in: [types/providers.ts:2448](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2448)
+Defined in: [types/providers.ts:2451](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2451)
 
 Anthropic ephemeral prompt-cache breakpoint marker. Placed on a content
 block / tool / system block to make the rendered prefix up to that point a
@@ -21,4 +21,4 @@ are the only way the conversation prefix is cached across turns.
 
 > **type**: `"ephemeral"`
 
-Defined in: [types/providers.ts:2448](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2448)
+Defined in: [types/providers.ts:2451](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2451)

--- a/docs/api/type-aliases/VertexAnthropicCacheInput.md
+++ b/docs/api/type-aliases/VertexAnthropicCacheInput.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicCacheInput** = `object`
 
-Defined in: [types/providers.ts:2520](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2520)
+Defined in: [types/providers.ts:2523](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2523)
 
 Input to `applyVertexAnthropicCacheBreakpoints`.
 
@@ -18,7 +18,7 @@ Input to `applyVertexAnthropicCacheBreakpoints`.
 
 > `optional` **system?**: `string`
 
-Defined in: [types/providers.ts:2521](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2521)
+Defined in: [types/providers.ts:2524](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2524)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2521](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **tools?**: [`VertexAnthropicTool`](VertexAnthropicTool.md)[]
 
-Defined in: [types/providers.ts:2522](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2522)
+Defined in: [types/providers.ts:2525](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2525)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2522](https://github.com/juspay/neurolink/blob/r
 
 > **messages**: [`VertexAnthropicMessage`](VertexAnthropicMessage.md)[]
 
-Defined in: [types/providers.ts:2523](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2523)
+Defined in: [types/providers.ts:2526](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2526)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/providers.ts:2523](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **maxHistoryBreakpoints?**: `number`
 
-Defined in: [types/providers.ts:2530](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2530)
+Defined in: [types/providers.ts:2533](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2533)
 
 Cap on how many of the most-recent messages receive a rolling history
 breakpoint. Defaults to "use the remaining budget". Two or more gives

--- a/docs/api/type-aliases/VertexAnthropicCacheOutput.md
+++ b/docs/api/type-aliases/VertexAnthropicCacheOutput.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicCacheOutput** = `object`
 
-Defined in: [types/providers.ts:2534](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2534)
+Defined in: [types/providers.ts:2537](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2537)
 
 Output of `applyVertexAnthropicCacheBreakpoints` — a cache-annotated request.
 
@@ -18,7 +18,7 @@ Output of `applyVertexAnthropicCacheBreakpoints` — a cache-annotated request.
 
 > `optional` **system?**: `string` \| [`VertexAnthropicSystemBlock`](VertexAnthropicSystemBlock.md)[]
 
-Defined in: [types/providers.ts:2535](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2535)
+Defined in: [types/providers.ts:2538](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2538)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2535](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **tools?**: [`VertexAnthropicTool`](VertexAnthropicTool.md)[]
 
-Defined in: [types/providers.ts:2536](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2536)
+Defined in: [types/providers.ts:2539](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2539)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/providers.ts:2536](https://github.com/juspay/neurolink/blob/r
 
 > **messages**: [`VertexAnthropicMessage`](VertexAnthropicMessage.md)[]
 
-Defined in: [types/providers.ts:2537](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2537)
+Defined in: [types/providers.ts:2540](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2540)

--- a/docs/api/type-aliases/VertexAnthropicContentBlock.md
+++ b/docs/api/type-aliases/VertexAnthropicContentBlock.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicContentBlock** = \{ `type`: `"text"`; `text`: `string`; \} \| \{ `type`: `"tool_use"`; `id`: `string`; `name`: `string`; `input`: `Record`\<`string`, `unknown`\>; \} \| \{ `type`: `"tool_result"`; `tool_use_id`: `string`; `content`: `string`; \}
 
-Defined in: [types/providers.ts:2544](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2544)
+Defined in: [types/providers.ts:2547](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2547)
 
 Content block variants returned by the Anthropic Vertex SDK during streaming
 and generation — used to narrow responses before handing tool calls back.

--- a/docs/api/type-aliases/VertexAnthropicMessage.md
+++ b/docs/api/type-aliases/VertexAnthropicMessage.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicMessage** = `object`
 
-Defined in: [types/providers.ts:2450](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2450)
+Defined in: [types/providers.ts:2453](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2453)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:2450](https://github.com/juspay/neurolink/blob/r
 
 > **role**: `"user"` \| `"assistant"`
 
-Defined in: [types/providers.ts:2451](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2451)
+Defined in: [types/providers.ts:2454](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2454)
 
 ---
 
@@ -24,4 +24,4 @@ Defined in: [types/providers.ts:2451](https://github.com/juspay/neurolink/blob/r
 
 > **content**: `string` \| (\{ `type`: `"text"`; `text`: `string`; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"image"`; `source`: \{ `type`: `"base64"`; `media_type`: `string`; `data`: `string`; \}; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"document"`; `source`: \{ `type`: `"base64"`; `media_type`: `string`; `data`: `string`; \}; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"tool_use"`; `id`: `string`; `name`: `string`; `input`: `unknown`; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"tool_result"`; `tool_use_id`: `string`; `content`: `string`; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"thinking"`; `thinking`: `string`; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \} \| \{ `type`: `"redacted_thinking"`; `data`: `string`; `cache_control?`: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md); \})[]
 
-Defined in: [types/providers.ts:2452](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2452)
+Defined in: [types/providers.ts:2455](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2455)

--- a/docs/api/type-aliases/VertexAnthropicSystemBlock.md
+++ b/docs/api/type-aliases/VertexAnthropicSystemBlock.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicSystemBlock** = `object`
 
-Defined in: [types/providers.ts:2501](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2501)
+Defined in: [types/providers.ts:2504](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2504)
 
 System prompt block form accepted by the Anthropic Vertex SDK. Used instead
 of a bare string when a `cache_control` breakpoint must ride on the system
@@ -20,7 +20,7 @@ prompt (a string `system` cannot carry one).
 
 > **type**: `"text"`
 
-Defined in: [types/providers.ts:2502](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2502)
+Defined in: [types/providers.ts:2505](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2505)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [types/providers.ts:2502](https://github.com/juspay/neurolink/blob/r
 
 > **text**: `string`
 
-Defined in: [types/providers.ts:2503](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2503)
+Defined in: [types/providers.ts:2506](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2506)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [types/providers.ts:2503](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **cache_control?**: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md)
 
-Defined in: [types/providers.ts:2504](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2504)
+Defined in: [types/providers.ts:2507](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2507)

--- a/docs/api/type-aliases/VertexAnthropicTool.md
+++ b/docs/api/type-aliases/VertexAnthropicTool.md
@@ -8,7 +8,7 @@
 
 > **VertexAnthropicTool** = `object`
 
-Defined in: [types/providers.ts:2508](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2508)
+Defined in: [types/providers.ts:2511](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2511)
 
 Tool definition accepted by the Anthropic Vertex SDK.
 
@@ -18,7 +18,7 @@ Tool definition accepted by the Anthropic Vertex SDK.
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:2509](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2509)
+Defined in: [types/providers.ts:2512](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2512)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/providers.ts:2509](https://github.com/juspay/neurolink/blob/r
 
 > **description**: `string`
 
-Defined in: [types/providers.ts:2510](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2510)
+Defined in: [types/providers.ts:2513](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2513)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/providers.ts:2510](https://github.com/juspay/neurolink/blob/r
 
 > **input_schema**: `object`
 
-Defined in: [types/providers.ts:2511](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2511)
+Defined in: [types/providers.ts:2514](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2514)
 
 #### type
 
@@ -54,4 +54,4 @@ Defined in: [types/providers.ts:2511](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **cache_control?**: [`VertexAnthropicCacheControl`](VertexAnthropicCacheControl.md)
 
-Defined in: [types/providers.ts:2516](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2516)
+Defined in: [types/providers.ts:2519](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2519)

--- a/docs/api/type-aliases/VertexGenaiFunctionDeclaration.md
+++ b/docs/api/type-aliases/VertexGenaiFunctionDeclaration.md
@@ -8,7 +8,7 @@
 
 > **VertexGenaiFunctionDeclaration** = `object`
 
-Defined in: [types/providers.ts:2428](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2428)
+Defined in: [types/providers.ts:2431](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2431)
 
 Function declaration shape accepted by the @google/genai SDK when tools are
 attached to a Vertex generateContent call.
@@ -19,7 +19,7 @@ attached to a Vertex generateContent call.
 
 > **name**: `string`
 
-Defined in: [types/providers.ts:2429](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2429)
+Defined in: [types/providers.ts:2432](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2432)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/providers.ts:2429](https://github.com/juspay/neurolink/blob/r
 
 > **description**: `string`
 
-Defined in: [types/providers.ts:2430](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2430)
+Defined in: [types/providers.ts:2433](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2433)
 
 ---
 
@@ -35,4 +35,4 @@ Defined in: [types/providers.ts:2430](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **parametersJsonSchema?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/providers.ts:2431](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2431)
+Defined in: [types/providers.ts:2434](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2434)

--- a/docs/api/type-aliases/VertexNativeLoopPart.md
+++ b/docs/api/type-aliases/VertexNativeLoopPart.md
@@ -8,7 +8,7 @@
 
 > **VertexNativeLoopPart** = [`VertexNativePart`](VertexNativePart.md) \| \{ `functionCall`: \{ `name`: `string`; `args`: `Record`\<`string`, `unknown`\>; \}; \} \| \{ `functionResponse`: \{ `name`: `string`; `response`: `Record`\<`string`, `unknown`\>; \}; \}
 
-Defined in: [types/providers.ts:2382](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2382)
+Defined in: [types/providers.ts:2385](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2385)
 
 Part variants that ride the native Gemini agentic tool loop in addition to
 the plain `VertexNativePart` content shapes: model-issued function calls

--- a/docs/api/type-aliases/VertexNativePart.md
+++ b/docs/api/type-aliases/VertexNativePart.md
@@ -8,7 +8,7 @@
 
 > **VertexNativePart** = \{ `text`: `string`; \} \| \{ `inlineData`: \{ `mimeType`: `string`; `data`: `string`; \}; \}
 
-Defined in: [types/providers.ts:2370](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2370)
+Defined in: [types/providers.ts:2373](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2373)
 
 Single part inside a Google Vertex "native" (non-AI-SDK) generateContent
 payload — either inline text or an inline base64 data blob.

--- a/docs/api/type-aliases/VertexRegularSegment.md
+++ b/docs/api/type-aliases/VertexRegularSegment.md
@@ -8,7 +8,7 @@
 
 > **VertexRegularSegment** = `object`
 
-Defined in: [types/providers.ts:2416](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2416)
+Defined in: [types/providers.ts:2419](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2419)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/providers.ts:2416](https://github.com/juspay/neurolink/blob/r
 
 > **type**: `"regular"`
 
-Defined in: [types/providers.ts:2417](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2417)
+Defined in: [types/providers.ts:2420](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2420)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/providers.ts:2417](https://github.com/juspay/neurolink/blob/r
 
 > **role**: `string`
 
-Defined in: [types/providers.ts:2418](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2418)
+Defined in: [types/providers.ts:2421](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2421)
 
 ---
 
@@ -32,4 +32,4 @@ Defined in: [types/providers.ts:2418](https://github.com/juspay/neurolink/blob/r
 
 > **parts**: `unknown`[]
 
-Defined in: [types/providers.ts:2419](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2419)
+Defined in: [types/providers.ts:2422](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2422)

--- a/docs/api/type-aliases/VertexSegment.md
+++ b/docs/api/type-aliases/VertexSegment.md
@@ -8,4 +8,4 @@
 
 > **VertexSegment** = [`VertexToolStep`](VertexToolStep.md) \| [`VertexRegularSegment`](VertexRegularSegment.md)
 
-Defined in: [types/providers.ts:2422](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2422)
+Defined in: [types/providers.ts:2425](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2425)

--- a/docs/api/type-aliases/VertexToolStep.md
+++ b/docs/api/type-aliases/VertexToolStep.md
@@ -8,7 +8,7 @@
 
 > **VertexToolStep** = `object`
 
-Defined in: [types/providers.ts:2410](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2410)
+Defined in: [types/providers.ts:2413](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2413)
 
 Internal helpers used by the conversation-history builder in
 providers/googleVertex.ts to merge interleaved tool call / result turns.
@@ -19,7 +19,7 @@ providers/googleVertex.ts to merge interleaved tool call / result turns.
 
 > **type**: `"tool_step"`
 
-Defined in: [types/providers.ts:2411](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2411)
+Defined in: [types/providers.ts:2414](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2414)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/providers.ts:2411](https://github.com/juspay/neurolink/blob/r
 
 > **callParts**: `unknown`[]
 
-Defined in: [types/providers.ts:2412](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2412)
+Defined in: [types/providers.ts:2415](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2415)
 
 ---
 
@@ -35,4 +35,4 @@ Defined in: [types/providers.ts:2412](https://github.com/juspay/neurolink/blob/r
 
 > **resultParts**: `unknown`[]
 
-Defined in: [types/providers.ts:2413](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2413)
+Defined in: [types/providers.ts:2416](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2416)

--- a/docs/api/type-aliases/VertexUsageCounter.md
+++ b/docs/api/type-aliases/VertexUsageCounter.md
@@ -8,7 +8,7 @@
 
 > **VertexUsageCounter** = `"input"` \| `"output"` \| `"cacheRead"` \| `"reasoning"`
 
-Defined in: [types/providers.ts:2068](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2068)
+Defined in: [types/providers.ts:2071](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L2071)
 
 Which turn-level counter a per-chunk Vertex usage delta belongs to.
 

--- a/docs/api/variables/DEFAULT_MODEL_ALIASES.md
+++ b/docs/api/variables/DEFAULT_MODEL_ALIASES.md
@@ -8,7 +8,7 @@
 
 > `const` **DEFAULT_MODEL_ALIASES**: `object`
 
-Defined in: [types/providers.ts:1310](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1310)
+Defined in: [types/providers.ts:1313](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1313)
 
 Default model aliases for easy reference
 

--- a/docs/api/variables/DEFAULT_PROVIDER_CONFIGS.md
+++ b/docs/api/variables/DEFAULT_PROVIDER_CONFIGS.md
@@ -8,6 +8,6 @@
 
 > `const` **DEFAULT_PROVIDER_CONFIGS**: [`AIModelProviderConfig`](../type-aliases/AIModelProviderConfig.md)[]
 
-Defined in: [types/providers.ts:1334](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1334)
+Defined in: [types/providers.ts:1337](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1337)
 
 Default provider configurations

--- a/docs/api/variables/ModelAliases.md
+++ b/docs/api/variables/ModelAliases.md
@@ -8,7 +8,7 @@
 
 > `const` **ModelAliases**: `object` = `DEFAULT_MODEL_ALIASES`
 
-Defined in: [types/providers.ts:1329](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1329)
+Defined in: [types/providers.ts:1332](https://github.com/juspay/neurolink/blob/release/src/lib/types/providers.ts#L1332)
 
 ## Type Declaration
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepack": "svelte-kit sync && svelte-package && pnpm run build:react-hooks && pnpm run build:cli && pnpm run build:browser && publint",
     "build:react-hooks": "pnpm exec tsc --jsx react-jsx --module nodenext --moduleResolution nodenext --target esnext --esModuleInterop --skipLibCheck --outDir dist --declaration false src/lib/client/reactHooks.tsx",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc --noEmit --strict",
+    "check:models": "tsx tools/check-model-liveness.ts",
     "check:ci-scripts": "svelte-kit sync && tsc -p tsconfig.ci-scripts.json",
     "check:test-parse": "node scripts/parse-check-tests.mjs",
     "check:tools-tests": "svelte-kit sync && tsc -p tsconfig.tools-tests.json",

--- a/src/lib/constants/enums.ts
+++ b/src/lib/constants/enums.ts
@@ -1232,18 +1232,30 @@ export enum CloudflareModels {
 }
 
 export enum FireworksModels {
+  KIMI_K2P6 = "accounts/fireworks/models/kimi-k2p6",
+  GPT_OSS_120B = "accounts/fireworks/models/gpt-oss-120b",
+  KIMI_K3 = "accounts/fireworks/models/kimi-k3",
+  QWEN3P8_MAX = "accounts/fireworks/models/qwen3p8-max",
+  GLM_5P3 = "accounts/fireworks/models/glm-5p3",
+  MINIMAX_M3 = "accounts/fireworks/models/minimax-m3",
+  DEEPSEEK_V4_FLASH_0731 = "accounts/fireworks/models/deepseek-v4-flash-0731",
   DEEPSEEK_V4_PRO = "accounts/fireworks/models/deepseek-v4-pro",
   GLM_5P1 = "accounts/fireworks/models/glm-5p1",
   GLM_5 = "accounts/fireworks/models/glm-5",
-  KIMI_K2P6 = "accounts/fireworks/models/kimi-k2p6",
   KIMI_K2P5 = "accounts/fireworks/models/kimi-k2p5",
-  GPT_OSS_120B = "accounts/fireworks/models/gpt-oss-120b",
   LLAMA_V3P2_90B_VISION_INSTRUCT = "accounts/fireworks/models/llama-v3p2-90b-vision-instruct",
   LLAMA_V3P2_11B_VISION_INSTRUCT = "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
   PHI_3_VISION_128K_INSTRUCT = "accounts/fireworks/models/phi-3-vision-128k-instruct",
 }
 
 export enum GroqModels {
+  GPT_OSS_120B = "openai/gpt-oss-120b",
+  GPT_OSS_20B = "openai/gpt-oss-20b",
+  QWEN_3_8_27B = "qwen/qwen3.8-27b",
+  QWEN_3_6_27B = "qwen/qwen3.6-27b",
+  COMPOUND = "groq/compound",
+  COMPOUND_MINI = "groq/compound-mini",
+  ALLAM_2_7B = "allam-2-7b",
   LLAMA_3_3_70B_VERSATILE = "llama-3.3-70b-versatile",
   LLAMA_3_1_8B_INSTANT = "llama-3.1-8b-instant",
   GEMMA_2_9B_IT = "gemma2-9b-it",
@@ -1322,6 +1334,9 @@ export enum TogetherAIModels {
 }
 
 export enum XaiModels {
+  GROK_4_6 = "grok-4.6",
+  GROK_4_5 = "grok-4.5",
+  GROK_4_3 = "grok-4.3",
   GROK_3 = "grok-3",
   GROK_3_MINI = "grok-3-mini",
   GROK_2_LATEST = "grok-2-latest",

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -35,7 +35,21 @@ import {
   isAbortError,
   NeuroLinkError,
 } from "../utils/errorHandling.js";
-import { ProviderError } from "../types/index.js";
+import { InvalidModelError, ProviderError } from "../types/index.js";
+
+/**
+ * `instanceof` is not reliable here. The published bundle and the source tree
+ * are separate module graphs, so an InvalidModelError built by the error
+ * classifier can fail an `instanceof` against the class this file imported —
+ * silently, with a clean typecheck. The constructor-name check is the same
+ * approach the OTel error-type mapping below already uses.
+ */
+function isInvalidModelError(error: unknown): boolean {
+  return (
+    error instanceof InvalidModelError ||
+    (error instanceof Error && error.constructor.name === "InvalidModelError")
+  );
+}
 import { sanitizeErrorCause } from "../utils/logSanitize.js";
 import { createAnalytics as buildAnalytics } from "./analytics.js";
 import { ErrorCategory, ErrorSeverity } from "../constants/enums.js";
@@ -475,8 +489,25 @@ export abstract class BaseProvider implements AIProvider {
       // anything that doesn't go through streamText) bypass it. Wrapping
       // here makes the callbacks fire for every provider, regardless of
       // streaming implementation.
-      return this.wrapStreamWithLifecycleCallbacks(realStreamResult, options);
+      return this.wrapStreamWithLifecycleCallbacks(
+        this.withStreamModelFallback(realStreamResult, options, analysisSchema),
+        options,
+      );
     } catch (realStreamError) {
+      // Retired-model fallback runs FIRST, before any lifecycle callback has
+      // fired and before a single chunk has reached the consumer: onChunk and
+      // onFinish are only wired on the success path above, and onError fires
+      // further down this same catch. That ordering is what makes retrying a
+      // stream safe at all — nothing observable has happened yet.
+      const recovered = await this.retryStreamWithFallbackModel(
+        realStreamError,
+        options,
+        analysisSchema,
+      );
+      if (recovered) {
+        return recovered;
+      }
+
       // The fallback is BROAD, not narrow: only the terminal errors listed
       // below (abort, timeout, 401/403, quota, rate limit, authentication)
       // re-throw. Every other failure — including a genuine configuration or
@@ -536,6 +567,225 @@ export abstract class BaseProvider implements AIProvider {
         throw this.handleProviderError(realStreamError);
       }
     }
+  }
+
+  /**
+   * Swap in a fallback model when a stream dies on a retired id before it has
+   * produced anything.
+   *
+   * OpenAI-compatible streaming is lazy: executeStream() returns a
+   * StreamResult without touching the network, and the request only goes out
+   * on the consumer's first pull. A retired model therefore does NOT fail in
+   * stream()'s try/catch — it fails deep inside iteration. This wrapper sits
+   * UNDER wrapStreamWithLifecycleCallbacks precisely so that a failed first
+   * attempt is invisible: onChunk, onFinish and onError all belong to the
+   * layer above and never observe it.
+   *
+   * The `yielded` guards are the safety property. A stream is only retried
+   * while it has emitted nothing; once a single chunk has reached the
+   * consumer the output is committed, and any later failure propagates
+   * untouched rather than replaying a half-delivered response.
+   */
+  private withStreamModelFallback(
+    result: StreamResult,
+    options: StreamOptions,
+    analysisSchema: ValidationSchema | undefined,
+  ): StreamResult {
+    // The caller owns fallback order (the Claude proxy sets this): hand the
+    // stream back untouched so an invalid model surfaces as exactly that.
+    if (options.disableInternalFallback === true) {
+      return result;
+    }
+    const provider = this;
+    const source = result.stream;
+    // Iterate through explicit iterators so a consumer break can be forwarded
+    // to the one that is actually in flight (see the cancel hook below): a
+    // generator's own return() is queued behind a pending next(), and a
+    // source that is waiting on a slow vendor would never see the break.
+    const sourceIterator = source[Symbol.asyncIterator]();
+    let activeStream: unknown = source;
+    let activeIterator: { return?: (value?: unknown) => unknown } =
+      sourceIterator;
+    const iterableOf = <T>(iterator: AsyncIterator<T>): AsyncIterable<T> => ({
+      [Symbol.asyncIterator]: () => iterator,
+    });
+
+    // A failing stream still emits one chunk before it throws: the no-output
+    // sentinel, {content: "", metadata: {noOutput: true, ...}}. That is a
+    // marker, not output, so it must not count as committed — otherwise the
+    // guard below blocks every retry it exists to allow. Only that sentinel
+    // and a bare empty text chunk are withheld; everything else — reasoning
+    // deltas ({content: "", reasoning}), tool-call deltas, audio and image
+    // chunks — IS output, commits the stream, and is yielded immediately so
+    // real-time streaming is untouched. Withheld chunks are released in order
+    // once real output arrives, at end of stream, or before any error that is
+    // not retried; they are dropped only when a fallback model takes over.
+    const isWithheld = (chunk: unknown): boolean => {
+      if (typeof chunk === "string") {
+        return chunk.length === 0;
+      }
+      if (typeof chunk !== "object" || chunk === null) {
+        return false;
+      }
+      const shape = chunk as {
+        content?: unknown;
+        metadata?: { noOutput?: unknown };
+      };
+      if (shape.metadata?.noOutput === true) {
+        return true;
+      }
+      return shape.content === "" && Object.keys(shape).length === 1;
+    };
+
+    async function* withFallback(): AsyncGenerator<unknown, void, unknown> {
+      let committed = false;
+      const held: unknown[] = [];
+      try {
+        for await (const chunk of iterableOf(sourceIterator)) {
+          if (isWithheld(chunk)) {
+            held.push(chunk);
+            continue;
+          }
+          committed = true;
+          while (held.length > 0) {
+            yield held.shift();
+          }
+          yield chunk;
+        }
+        while (held.length > 0) {
+          yield held.shift();
+        }
+        return;
+      } catch (error) {
+        if (
+          committed ||
+          !isInvalidModelError(provider.formatProviderError(error))
+        ) {
+          // Not retrying: release what was withheld — the sentinel included —
+          // so the consumer sees exactly what the unwrapped stream produced
+          // before the error.
+          while (held.length > 0) {
+            yield held.shift();
+          }
+          throw error;
+        }
+        const requestedModel = provider.modelName;
+        const candidates = provider
+          .getModelFallbacks()
+          .filter((model) => model !== requestedModel);
+        for (const candidate of candidates) {
+          logger.warn(
+            `[${provider.providerName}] model "${requestedModel}" was rejected as invalid — retrying stream with fallback "${candidate}". This provider's catalog entry is stale; run "pnpm run check:models".`,
+          );
+          provider.refreshHandlersForModel(candidate);
+          let retryCommitted = false;
+          const retryHeld: unknown[] = [];
+          try {
+            const retry = await provider.executeStream(options, analysisSchema);
+            const retryIterator = retry.stream[Symbol.asyncIterator]();
+            activeStream = retry.stream;
+            activeIterator = retryIterator;
+            for await (const chunk of iterableOf(retryIterator)) {
+              if (isWithheld(chunk)) {
+                retryHeld.push(chunk);
+                continue;
+              }
+              retryCommitted = true;
+              while (retryHeld.length > 0) {
+                yield retryHeld.shift();
+              }
+              yield chunk;
+            }
+            while (retryHeld.length > 0) {
+              yield retryHeld.shift();
+            }
+            return;
+          } catch (retryError) {
+            // Same rule as above: once this candidate has emitted real
+            // content its output is committed, and moving to another model
+            // would splice two different responses together.
+            if (retryCommitted) {
+              throw retryError;
+            }
+          }
+        }
+        provider.refreshHandlersForModel(requestedModel);
+        // Every fallback failed too: release the original attempt's withheld
+        // chunks, then surface the ORIGINAL error — it names the model the
+        // caller asked for.
+        while (held.length > 0) {
+          yield held.shift();
+        }
+        throw error;
+      }
+    }
+
+    const wrapped = withFallback();
+    // Same contract as wrapStreamWithLifecycleCallbacks: a consumer break
+    // (cancelStream on the outer stream) must close the live upstream
+    // iterator directly, not wait for this generator to reach its next
+    // yield. Without this, the TTS early-break path — and any consumer that
+    // stops mid-stream — would leave the vendor request open until the next
+    // chunk arrived.
+    attachStreamCancel(wrapped, () => {
+      cancelStream(activeStream);
+      releaseIterator(activeIterator);
+    });
+    return {
+      ...result,
+      stream: wrapped as StreamResult["stream"],
+    };
+  }
+
+  /**
+   * The eager half of the retired-model stream fallback, for providers whose
+   * executeStream() reaches the network before returning (see
+   * runGenerateWithModelFallback for the generate() half and the reasoning).
+   *
+   * Returns a working StreamResult when a fallback model succeeds, or
+   * undefined to mean "not recoverable — carry on with the original error".
+   * Returning rather than throwing is deliberate: every existing path in the
+   * caller's catch (the broad fake-streaming fallback, the terminal-error
+   * re-throw, the onError firing) is left exactly as it was, so behaviour
+   * changes only when a fallback actually succeeds.
+   */
+  private async retryStreamWithFallbackModel(
+    error: unknown,
+    options: StreamOptions,
+    analysisSchema: ValidationSchema | undefined,
+  ): Promise<StreamResult | undefined> {
+    if (options.disableInternalFallback === true) {
+      return undefined;
+    }
+    // executeStream() surfaces the raw transport error, so classify it the
+    // way this provider would before deciding. formatProviderError is
+    // contractually return-only, never throw.
+    if (!isInvalidModelError(this.formatProviderError(error))) {
+      return undefined;
+    }
+    const requestedModel = this.modelName;
+    const candidates = this.getModelFallbacks().filter(
+      (model) => model !== requestedModel,
+    );
+    for (const candidate of candidates) {
+      logger.warn(
+        `[${this.providerName}] model "${requestedModel}" was rejected as invalid — retrying stream with fallback "${candidate}". This provider's catalog entry is stale; run "pnpm run check:models".`,
+      );
+      this.refreshHandlersForModel(candidate);
+      try {
+        const result = await this.executeStream(options, analysisSchema);
+        return this.wrapStreamWithLifecycleCallbacks(result, options);
+      } catch {
+        // Any failure on a candidate — stale id or otherwise — just moves to
+        // the next one. Nothing is reported from here: if none succeed the
+        // caller still handles the ORIGINAL error, which names the model the
+        // caller actually asked for.
+      }
+    }
+    // Restore the caller's model so a failed request does not leave this
+    // instance silently pointing at the last fallback it tried.
+    this.refreshHandlersForModel(requestedModel);
+    return undefined;
   }
 
   /**
@@ -1474,29 +1724,115 @@ export abstract class BaseProvider implements AIProvider {
     this.validateOptions(options);
     const startTime = Date.now();
 
-    // OTEL span for provider-level generate tracing
-    // Use startActiveSpan pattern via context.with() so child spans become descendants
-    const otelSpan = tracers.provider.startSpan("neurolink.provider.generate", {
-      kind: SpanKind.CLIENT,
-      attributes: {
-        [ATTR.GEN_AI_SYSTEM]: this.providerName || "unknown",
-        [ATTR.GEN_AI_MODEL]: this.modelName || options.model || "unknown",
-        [ATTR.GEN_AI_OPERATION]: "generate",
-        [ATTR.NL_PROVIDER]: this.providerName || "unknown",
-      },
-    });
-    // Set this span as the active context so child spans (GenerationHandler, etc.) become descendants
-    const activeCtx = trace.setSpan(context.active(), otelSpan);
-    const otelSpanState = { ended: false };
+    // One span per attempt. runGenerateInActiveContext ends the span on the
+    // way out (success or failure), so a model-fallback retry must not reuse
+    // it — an ended span would swallow the retry's attributes and report the
+    // model that failed rather than the one that served.
+    const attempt = async (): Promise<EnhancedGenerateResult | null> => {
+      // OTEL span for provider-level generate tracing
+      // Use startActiveSpan pattern via context.with() so child spans become descendants
+      const otelSpan = tracers.provider.startSpan(
+        "neurolink.provider.generate",
+        {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            [ATTR.GEN_AI_SYSTEM]: this.providerName || "unknown",
+            [ATTR.GEN_AI_MODEL]: this.modelName || options.model || "unknown",
+            [ATTR.GEN_AI_OPERATION]: "generate",
+            [ATTR.NL_PROVIDER]: this.providerName || "unknown",
+          },
+        },
+      );
+      // Set this span as the active context so child spans (GenerationHandler, etc.) become descendants
+      const activeCtx = trace.setSpan(context.active(), otelSpan);
+      const otelSpanState = { ended: false };
 
-    return await context.with(activeCtx, async () =>
-      this.runGenerateInActiveContext(
-        options,
-        startTime,
-        otelSpan,
-        otelSpanState,
-      ),
-    );
+      return await context.with(activeCtx, async () =>
+        this.runGenerateInActiveContext(
+          options,
+          startTime,
+          otelSpan,
+          otelSpanState,
+        ),
+      );
+    };
+
+    // TextGenerationOptions does not declare the flag (it lives on
+    // StreamOptions), but callers that own fallback order pass it on both
+    // paths, so honour it here as well.
+    const callerOwnsFallback =
+      "disableInternalFallback" in options &&
+      options.disableInternalFallback === true;
+    return await this.runGenerateWithModelFallback(attempt, callerOwnsFallback);
+  }
+
+  /**
+   * Models the catalog names are the models a vendor served when the entry was
+   * last verified. Vendors retire them without warning, and until this existed
+   * the runtime had no answer for that: an InvalidModelError is classified
+   * non-retryable (correctly — another *provider* cannot fix a bad model id),
+   * so the fallback chain stopped dead and the caller got an error even though
+   * the same provider was still serving four other models listed right there
+   * in the catalog's `fallbacks`.
+   *
+   * So on an invalid-model error only, walk this provider's fallbacks. Every
+   * switch is a loud WARN: the caller asked for one model and is getting
+   * another, which they must be able to see in the logs. Any other error type
+   * propagates untouched on the first attempt.
+   *
+   * stream() gets the same treatment via retryStreamWithFallbackModel, which
+   * is safe for the same reason it is cheap: the retry happens before any
+   * lifecycle callback has fired and before a chunk has reached the consumer,
+   * so there is no observable output to replay.
+   */
+  private async runGenerateWithModelFallback(
+    attempt: () => Promise<EnhancedGenerateResult | null>,
+    callerOwnsFallback: boolean,
+  ): Promise<EnhancedGenerateResult | null> {
+    const requestedModel = this.modelName;
+    try {
+      return await attempt();
+    } catch (error) {
+      if (callerOwnsFallback || !isInvalidModelError(error)) {
+        throw error;
+      }
+      const candidates = this.getModelFallbacks().filter(
+        (model) => model !== requestedModel,
+      );
+      if (candidates.length === 0) {
+        throw error;
+      }
+      for (const candidate of candidates) {
+        logger.warn(
+          `[${this.providerName}] model "${requestedModel}" was rejected as invalid — retrying with fallback "${candidate}". This provider's catalog entry is stale; run "pnpm run check:models".`,
+        );
+        this.refreshHandlersForModel(candidate);
+        try {
+          return await attempt();
+        } catch (retryError) {
+          if (!isInvalidModelError(retryError)) {
+            // Restore the caller's model: this failure is unrelated to the
+            // model id, so the instance must not be left on a fallback.
+            this.refreshHandlersForModel(requestedModel);
+            throw retryError;
+          }
+          // This fallback is stale too — keep walking the list.
+        }
+      }
+      // Every fallback was rejected as well. Restore the caller's model so a
+      // failed request does not leave this instance silently repointed, and
+      // surface the ORIGINAL error: it names the model the caller asked for.
+      this.refreshHandlersForModel(requestedModel);
+      throw error;
+    }
+  }
+
+  /**
+   * Model ids to try when this provider rejects its current model as invalid.
+   * Empty by default; catalog-driven providers return their `fallbacks`.
+   */
+  protected getModelFallbacks(): string[] {
+    return [];
   }
   /**
    * Alias for generate method - implements AIProvider interface

--- a/src/lib/providers/catalog/cerebras.json
+++ b/src/lib/providers/catalog/cerebras.json
@@ -15,19 +15,26 @@
     "catalog": {
       "gpt-oss-120b": {
         "contextWindow": 65536,
-        "pricingPerMTok": { "input": 0.35, "output": 0.75 },
+        "pricingPerMTok": {
+          "input": 0.35,
+          "output": 0.75
+        },
         "vision": false,
         "status": "production",
         "description": "Recommended - OpenAI GPT-OSS 120B (open-weight); wafer-scale speed"
       },
       "gemma-4-31b": {
         "contextWindow": 65536,
-        "pricingPerMTok": { "input": 0.99, "output": 1.49 },
-        "vision": false,
+        "pricingPerMTok": {
+          "input": 0.99,
+          "output": 1.49
+        },
+        "vision": true,
         "status": "production",
-        "description": "Google Gemma 4 31B"
+        "description": "Google Gemma 4 31B — vision-capable"
       }
     },
+    "visionModel": "gemma-4-31b",
     "topModels": ["gpt-oss-120b", "gemma-4-31b"]
   },
   "capabilities": {
@@ -69,7 +76,10 @@
       "status": 401,
       "code": "wrong_api_key"
     },
-    "liveMatrix": { "date": "2026-08-27", "result": "4/4" },
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "Both ids answer. Vision re-tested with a valid 64x64 PNG: gemma-4-31b describes it correctly, so its vision flag is now true (it was false); gpt-oss-120b answers \"Content type 'image_url' is not supported by selected model\"."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1561"
   }
 }

--- a/src/lib/providers/catalog/cloudflare.json
+++ b/src/lib/providers/catalog/cloudflare.json
@@ -16,9 +16,7 @@
       "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
       "@cf/meta/llama-3.1-70b-instruct",
       "@cf/meta/llama-3.1-8b-instruct-fast",
-      "@cf/meta/llama-3.2-11b-vision-instruct",
-      "@cf/mistral/mistral-7b-instruct-v0.2",
-      "@cf/qwen/qwen1.5-14b-chat-awq"
+      "@cf/google/gemma-2b-it-lora"
     ],
     "defaultContextWindow": 8192,
     "defaultMaxOutputTokens": 4096,
@@ -47,23 +45,23 @@
       "@cf/meta/llama-3.2-11b-vision-instruct": {
         "enumMember": "LLAMA_3_2_11B_VISION",
         "contextWindow": 24000,
-        "vision": true,
+        "vision": false,
         "status": "production",
-        "description": "Llama 3.2 11B Vision Instruct"
+        "description": "Llama 3.2 11B Vision Instruct — gated: Cloudflare returns 403 until the model's Community License is accepted once on the account, so it is unusable here and its vision flag is false despite being a vision model"
       },
       "@cf/mistral/mistral-7b-instruct-v0.2": {
         "enumMember": "MISTRAL_7B_INSTRUCT_V0_2",
         "contextWindow": 32768,
         "vision": false,
-        "status": "production",
-        "description": "Mistral 7B Instruct v0.2"
+        "status": "retired",
+        "description": "Retired 2026-08 — Cloudflare answers 'No such model'"
       },
       "@cf/qwen/qwen1.5-14b-chat-awq": {
         "enumMember": "QWEN_1P5_14B_CHAT_AWQ",
         "contextWindow": 7500,
         "vision": false,
-        "status": "production",
-        "description": "Qwen 1.5 14B Chat AWQ"
+        "status": "retired",
+        "description": "Retired 2026-08 — Cloudflare reports it was deprecated on 2025-10-01"
       },
       "@cf/google/gemma-2b-it-lora": {
         "enumMember": "GEMMA_2B_IT_LORA",
@@ -77,7 +75,7 @@
       "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
       "@cf/meta/llama-3.1-70b-instruct",
       "@cf/meta/llama-3.1-8b-instruct-fast",
-      "@cf/meta/llama-3.2-11b-vision-instruct"
+      "@cf/google/gemma-2b-it-lora"
     ]
   },
   "capabilities": {
@@ -112,10 +110,16 @@
   },
   "evidence": {
     "rosterVerified": {
-      "date": "2026-08-28",
-      "method": "transcribed from pre-migration TS catalog"
+      "date": "2026-08-30",
+      "method": "real chat call per id against the live account"
     },
-    "liveMatrix": null,
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "Live tool round-trip verified on @cf/meta/llama-3.1-8b-instruct-fast, both non-streaming and streaming, once messageContentFormat normalization was applied; before it the follow-up turn was rejected with HTTP 400 (content sent as array/null). Of the three ids that failed, only two are actually gone: mistral-7b-instruct-v0.2 ('No such model') and qwen1.5-14b-chat-awq ('deprecated on 2025-10-01'). llama-3.2-11b-vision-instruct is alive but gated behind a one-time Community License acceptance on the account, so it answers 403 and is left production with vision false rather than retired."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
+  },
+  "quirks": {
+    "messageContentFormat": "string"
   }
 }

--- a/src/lib/providers/catalog/fireworks.json
+++ b/src/lib/providers/catalog/fireworks.json
@@ -8,49 +8,23 @@
     "baseURL": "https://api.fireworks.ai/inference/v1"
   },
   "models": {
-    "default": "accounts/fireworks/models/deepseek-v4-pro",
-    "testModel": "accounts/fireworks/models/kimi-k2p6",
-    "fallbackModelName": "accounts/fireworks/models/deepseek-v4-pro",
+    "default": "accounts/fireworks/models/kimi-k2p6",
+    "fallbackModelName": "accounts/fireworks/models/gpt-oss-120b",
     "fallbacks": [
-      "accounts/fireworks/models/deepseek-v4-pro",
-      "accounts/fireworks/models/glm-5p1",
-      "accounts/fireworks/models/glm-5",
       "accounts/fireworks/models/kimi-k2p6",
-      "accounts/fireworks/models/kimi-k2p5",
-      "accounts/fireworks/models/gpt-oss-120b"
+      "accounts/fireworks/models/gpt-oss-120b",
+      "accounts/fireworks/models/kimi-k3",
+      "accounts/fireworks/models/qwen3p8-max",
+      "accounts/fireworks/models/glm-5p3"
     ],
     "defaultContextWindow": 128000,
     "defaultMaxOutputTokens": 4096,
     "catalog": {
-      "accounts/fireworks/models/deepseek-v4-pro": {
-        "enumMember": "DEEPSEEK_V4_PRO",
-        "vision": false,
-        "status": "production",
-        "description": "Recommended - DeepSeek V4 Pro, current general-purpose default"
-      },
-      "accounts/fireworks/models/glm-5p1": {
-        "enumMember": "GLM_5P1",
-        "vision": false,
-        "status": "production",
-        "description": "GLM 5.1 — Zhipu flagship"
-      },
-      "accounts/fireworks/models/glm-5": {
-        "enumMember": "GLM_5",
-        "vision": false,
-        "status": "production",
-        "description": "GLM 5 — broader coverage"
-      },
       "accounts/fireworks/models/kimi-k2p6": {
         "enumMember": "KIMI_K2P6",
-        "vision": false,
+        "vision": true,
         "status": "production",
-        "description": "Kimi K2.6 — Moonshot flagship"
-      },
-      "accounts/fireworks/models/kimi-k2p5": {
-        "enumMember": "KIMI_K2P5",
-        "vision": false,
-        "status": "production",
-        "description": "Kimi K2.5 — preceding Kimi"
+        "description": "Recommended - Kimi K2.6, Moonshot flagship; vision-capable"
       },
       "accounts/fireworks/models/gpt-oss-120b": {
         "enumMember": "GPT_OSS_120B",
@@ -58,30 +32,84 @@
         "status": "production",
         "description": "GPT-OSS 120B — Apache-2.0 OpenAI weights"
       },
-      "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
-        "enumMember": "LLAMA_V3P2_90B_VISION_INSTRUCT",
+      "accounts/fireworks/models/kimi-k3": {
+        "enumMember": "KIMI_K3",
         "vision": true,
         "status": "production",
-        "description": "Llama 3.2 90B Vision Instruct — vision-capable; restored from the pre-migration adapter's vision map (contextWindow/pricing not yet re-verified)"
+        "description": "Kimi K3 — newest Moonshot generation; vision-capable"
+      },
+      "accounts/fireworks/models/qwen3p8-max": {
+        "enumMember": "QWEN3P8_MAX",
+        "vision": true,
+        "status": "production",
+        "description": "Qwen 3.8 Max — vision-capable"
+      },
+      "accounts/fireworks/models/glm-5p3": {
+        "enumMember": "GLM_5P3",
+        "vision": false,
+        "status": "production",
+        "description": "GLM 5.3 — Zhipu flagship"
+      },
+      "accounts/fireworks/models/minimax-m3": {
+        "enumMember": "MINIMAX_M3",
+        "vision": false,
+        "status": "production",
+        "description": "MiniMax M3"
+      },
+      "accounts/fireworks/models/deepseek-v4-flash-0731": {
+        "enumMember": "DEEPSEEK_V4_FLASH_0731",
+        "vision": false,
+        "status": "production",
+        "description": "DeepSeek V4 Flash — low-latency DeepSeek"
+      },
+      "accounts/fireworks/models/deepseek-v4-pro": {
+        "enumMember": "DEEPSEEK_V4_PRO",
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 as a usable id — still on the Fireworks roster but never answers: a real chat call hangs past 120s on this account"
+      },
+      "accounts/fireworks/models/glm-5p1": {
+        "enumMember": "GLM_5P1",
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
+      },
+      "accounts/fireworks/models/glm-5": {
+        "enumMember": "GLM_5",
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
+      },
+      "accounts/fireworks/models/kimi-k2p5": {
+        "enumMember": "KIMI_K2P5",
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
+      },
+      "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
+        "enumMember": "LLAMA_V3P2_90B_VISION_INSTRUCT",
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
       },
       "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
         "enumMember": "LLAMA_V3P2_11B_VISION_INSTRUCT",
-        "vision": true,
-        "status": "production",
-        "description": "Llama 3.2 11B Vision Instruct — vision-capable; restored from the pre-migration adapter's vision map (contextWindow/pricing not yet re-verified)"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
       },
       "accounts/fireworks/models/phi-3-vision-128k-instruct": {
         "enumMember": "PHI_3_VISION_128K_INSTRUCT",
-        "vision": true,
-        "status": "production",
-        "description": "Phi-3 Vision 128K Instruct — vision-capable; restored from the pre-migration adapter's vision map (contextWindow/pricing not yet re-verified)"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Fireworks returns 404 'not deployed'"
       }
     },
     "topModels": [
-      "accounts/fireworks/models/deepseek-v4-pro",
-      "accounts/fireworks/models/glm-5p1",
       "accounts/fireworks/models/kimi-k2p6",
-      "accounts/fireworks/models/gpt-oss-120b"
+      "accounts/fireworks/models/gpt-oss-120b",
+      "accounts/fireworks/models/kimi-k3",
+      "accounts/fireworks/models/qwen3p8-max"
     ]
   },
   "capabilities": {
@@ -115,10 +143,13 @@
   },
   "evidence": {
     "rosterVerified": {
-      "date": "2026-08-28",
-      "method": "transcribed from pre-migration TS catalog"
+      "date": "2026-08-30",
+      "method": "GET /models against the live account, cross-checked with a real chat call per id"
     },
-    "liveMatrix": null,
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "The previous default, deepseek-v4-pro, is the reason a roster listing is never sufficient evidence here: it is still listed but a real chat call hangs past 120s, so the default moved to kimi-k2p6 (200 OK). Six ids return 404 'not deployed', including all three old vision models. Vision did not disappear with them: re-tested with a valid 64x64 PNG, kimi-k2p6, kimi-k3 and qwen3p8-max all describe the image correctly, while glm-5p3 answers 'does not support image inputs'. gpt-oss-20b is listed but 404s and was therefore not added."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
   }
 }

--- a/src/lib/providers/catalog/groq.json
+++ b/src/lib/providers/catalog/groq.json
@@ -8,75 +8,121 @@
     "baseURL": "https://api.groq.com/openai/v1"
   },
   "models": {
-    "default": "llama-3.3-70b-versatile",
-    "testModel": "openai/gpt-oss-120b",
+    "default": "openai/gpt-oss-120b",
     "fallbacks": [
-      "llama-3.3-70b-versatile",
-      "llama-3.1-8b-instant",
-      "gemma2-9b-it",
-      "mixtral-8x7b-32768",
-      "llama-3.2-90b-vision-preview",
-      "llama-3.2-11b-vision-preview"
+      "openai/gpt-oss-120b",
+      "openai/gpt-oss-20b",
+      "qwen/qwen3.8-27b",
+      "groq/compound"
     ],
     "defaultContextWindow": 128000,
     "defaultMaxOutputTokens": 4096,
     "catalog": {
+      "openai/gpt-oss-120b": {
+        "enumMember": "GPT_OSS_120B",
+        "contextWindow": 131072,
+        "vision": false,
+        "status": "production",
+        "description": "Recommended - GPT-OSS 120B, Groq's flagship open model"
+      },
+      "openai/gpt-oss-20b": {
+        "enumMember": "GPT_OSS_20B",
+        "contextWindow": 131072,
+        "vision": false,
+        "status": "production",
+        "description": "GPT-OSS 20B — lower latency, smaller model"
+      },
+      "qwen/qwen3.8-27b": {
+        "enumMember": "QWEN_3_8_27B",
+        "contextWindow": 131072,
+        "vision": true,
+        "status": "production",
+        "description": "Qwen 3.8 27B — Groq's only vision-capable model"
+      },
+      "qwen/qwen3.6-27b": {
+        "enumMember": "QWEN_3_6_27B",
+        "contextWindow": 131072,
+        "vision": false,
+        "status": "production",
+        "description": "Qwen 3.6 27B"
+      },
+      "groq/compound": {
+        "enumMember": "COMPOUND",
+        "contextWindow": 131072,
+        "vision": false,
+        "status": "production",
+        "description": "Groq Compound — agentic system with built-in tool use"
+      },
+      "groq/compound-mini": {
+        "enumMember": "COMPOUND_MINI",
+        "contextWindow": 131072,
+        "vision": false,
+        "status": "production",
+        "description": "Groq Compound Mini — lighter agentic system"
+      },
+      "allam-2-7b": {
+        "enumMember": "ALLAM_2_7B",
+        "contextWindow": 4096,
+        "vision": false,
+        "status": "production",
+        "description": "ALLaM 2 7B — Arabic-focused model"
+      },
       "llama-3.3-70b-versatile": {
         "contextWindow": 131072,
         "pricingPerMTok": { "input": 0.59, "output": 0.79 },
         "vision": false,
-        "status": "production",
-        "description": "Recommended - Production default; sub-100ms"
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq returns 404 'does not exist'"
       },
       "llama-3.1-8b-instant": {
         "contextWindow": 128000,
         "pricingPerMTok": { "input": 0.05, "output": 0.08 },
         "vision": false,
-        "status": "production",
-        "description": "Lowest latency tier"
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq returns 404 'does not exist'"
       },
       "gemma2-9b-it": {
         "enumMember": "GEMMA_2_9B_IT",
         "contextWindow": 8192,
         "pricingPerMTok": { "input": 0.2, "output": 0.2 },
         "vision": false,
-        "status": "production",
-        "description": "Google Gemma 2 9B"
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq reports 'decommissioned'"
       },
       "mixtral-8x7b-32768": {
         "contextWindow": 32768,
         "pricingPerMTok": { "input": 0.24, "output": 0.24 },
         "vision": false,
-        "status": "production",
-        "description": "Mistral 8x7B MoE, 32K context"
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq reports 'decommissioned'"
       },
       "llama-guard-3-8b": {
         "contextWindow": 8192,
         "vision": false,
-        "status": "production",
-        "description": "Llama Guard 3 8B — safety classifier"
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq reports 'decommissioned'"
       },
       "llama-3.2-90b-vision-preview": {
         "contextWindow": 128000,
         "pricingPerMTok": { "input": 0.9, "output": 0.9 },
-        "vision": true,
-        "status": "preview",
-        "description": "Multimodal (vision)"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq reports 'decommissioned'"
       },
       "llama-3.2-11b-vision-preview": {
         "contextWindow": 128000,
         "pricingPerMTok": { "input": 0.18, "output": 0.18 },
-        "vision": true,
-        "status": "preview",
-        "description": "Llama 3.2 11B Vision Preview — smaller multimodal"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — Groq reports 'decommissioned'"
       }
     },
+    "visionModel": "qwen/qwen3.8-27b",
     "topModels": [
-      "llama-3.3-70b-versatile",
-      "llama-3.1-8b-instant",
-      "llama-3.2-90b-vision-preview",
-      "gemma2-9b-it",
-      "mixtral-8x7b-32768"
+      "openai/gpt-oss-120b",
+      "openai/gpt-oss-20b",
+      "qwen/qwen3.8-27b",
+      "groq/compound"
     ]
   },
   "capabilities": {
@@ -118,10 +164,13 @@
   },
   "evidence": {
     "rosterVerified": {
-      "date": "2026-08-28",
-      "method": "transcribed from pre-migration TS catalog"
+      "date": "2026-08-30",
+      "method": "GET /models against the live account, cross-checked with a real chat call per id"
     },
-    "liveMatrix": null,
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "All 7 previously-catalogued ids are gone: Groq answers 404 'does not exist' for the llama ids and 'has been decommissioned' for gemma2/mixtral/llama-guard/llama-3.2-vision. The 7 replacements listed here each returned 200 to a real chat call. Vision was re-tested with a valid 64x64 PNG: qwen/qwen3.8-27b describes the image correctly and is the only vision-capable id; gpt-oss-120b and groq/compound reject an image part with 'messages[0].content must be a string'."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
   }
 }

--- a/src/lib/providers/catalog/loader.ts
+++ b/src/lib/providers/catalog/loader.ts
@@ -149,6 +149,9 @@ export function buildCatalogEntries(): OpenAICompatCatalogEntry[] {
       base.baseURLEnvVar = catalogEnvVar(entry, "baseURL");
       base.defaultBaseURL = entry.wire.baseURL;
     }
+    if (entry.quirks?.messageContentFormat) {
+      base.messageContentFormat = entry.quirks.messageContentFormat;
+    }
     if (entry.quirks?.timeoutErrorClass === "provider") {
       base.timeoutErrorClass = ProviderError;
     }

--- a/src/lib/providers/catalog/mistral.json
+++ b/src/lib/providers/catalog/mistral.json
@@ -106,14 +106,14 @@
         "description": "Devstral Small (Software Development)"
       },
       "pixtral-large": {
-        "vision": true,
+        "vision": false,
         "status": "retired",
-        "description": "Retired 2026-05-31 — use mistral-medium-latest instead"
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "pixtral-12b": {
         "vision": true,
-        "status": "retired",
-        "description": "Retired 2025-12-31 — use ministral-14b-2512 instead"
+        "status": "production",
+        "description": "Pixtral 12B — vision-capable; re-verified live 2026-08-30"
       },
       "voxtral-small-latest": {
         "vision": false,
@@ -136,18 +136,18 @@
         "enumMember": "DEVSTRAL_SMALL_2",
         "contextWindow": 256000,
         "vision": false,
-        "status": "production",
-        "description": "Devstral Small 2 (December 2025)"
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "magistral-medium-2509": {
-        "vision": true,
-        "status": "production",
-        "description": "Magistral Medium 2509"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "magistral-small-2509": {
-        "vision": true,
-        "status": "production",
-        "description": "Magistral Small 2509"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "voxtral-mini-2602": {
         "enumMember": "VOXTRAL_MINI_TRANSCRIBE_2",
@@ -168,8 +168,8 @@
       },
       "mistral-nemo": {
         "vision": false,
-        "status": "production",
-        "description": "Mistral Nemo"
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "mistral-embed": {
         "vision": false,
@@ -178,8 +178,8 @@
       },
       "mistral-moderation-latest": {
         "vision": false,
-        "status": "production",
-        "description": "Mistral Moderation (Latest)"
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       },
       "mistral-small-2603": {
         "enumMember": "MISTRAL_SMALL_4",
@@ -189,17 +189,18 @@
         "description": "Mistral Small 4 (June 2026)"
       },
       "mistral-small-creative": {
-        "vision": true,
-        "status": "production",
-        "description": "Mistral Small Creative"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — absent from Mistral's roster and rejected as an invalid model"
       }
     },
+    "visionModel": "mistral-medium-latest",
     "topModels": [
       "mistral-large-latest",
       "mistral-small-latest",
       "codestral-latest",
       "magistral-medium-latest",
-      "mistral-nemo"
+      "pixtral-12b"
     ]
   },
   "capabilities": {
@@ -235,10 +236,13 @@
   },
   "evidence": {
     "rosterVerified": {
-      "date": "2026-08-28",
-      "method": "transcribed from pre-migration TS catalog"
+      "date": "2026-08-30",
+      "method": "GET /models against the live account, cross-checked with a real chat call per id"
     },
-    "liveMatrix": null,
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "17 ids answer normally. A chat probe alone was not enough to judge the rest, because Mistral rejects every non-chat model with the same generic 'Invalid model' text: cross-referencing the roster shows mistral-embed, codestral-embed, mistral-ocr-latest, mistral-ocr-2512, voxtral-mini-latest and voxtral-mini-2602 are all still listed and alive — they are embedding, OCR and audio models that a chat endpoint is right to refuse — so they keep production status. An id is marked retired only when BOTH signals agree: absent from the roster AND rejected by a live chat call. pixtral-12b is the one id where they disagree — the roster omits it but a real call returns 200, so it was moved back to production, on the rule that a live 200 outranks a roster omission. mistral-large-latest and mistral-large-2512 answer 403 'not available in your subscription tier': a plan limit on this account, not a retirement, so they stay production. visionModel is pinned to mistral-medium-latest because the otherwise-first vision id, mistral-large-latest, is behind that plan gate."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
   }
 }

--- a/src/lib/providers/catalog/provider-catalog.schema.json
+++ b/src/lib/providers/catalog/provider-catalog.schema.json
@@ -262,6 +262,11 @@
         },
         "registryDefaultIgnoresModelEnvVar": {
           "type": "boolean"
+        },
+        "messageContentFormat": {
+          "type": "string",
+          "enum": ["string"],
+          "description": "Vendor accepts messages[].content only as a plain string, rejecting OpenAI's content-parts array and the null used on an assistant message with tool_calls. Normalized by ConfiguredOpenAICompatProvider."
         }
       }
     },

--- a/src/lib/providers/catalog/sambanova.json
+++ b/src/lib/providers/catalog/sambanova.json
@@ -9,55 +9,77 @@
   },
   "models": {
     "default": "Meta-Llama-3.3-70B-Instruct",
-    "visionModel": "gemma-4-31B-it",
+    "visionModel": "Meta-Llama-3.3-70B-Instruct",
     "fallbacks": ["Meta-Llama-3.3-70B-Instruct", "gpt-oss-120b"],
     "defaultContextWindow": 131072,
     "defaultMaxOutputTokens": 8192,
     "catalog": {
       "Meta-Llama-3.3-70B-Instruct": {
         "contextWindow": 131072,
-        "pricingPerMTok": { "input": 0.6, "output": 1.2 },
-        "vision": false,
+        "pricingPerMTok": {
+          "input": 0.6,
+          "output": 1.2
+        },
+        "vision": true,
         "status": "production",
-        "description": "Recommended - Meta Llama 3.3 70B; production, 128K context"
+        "description": "Recommended - Meta Llama 3.3 70B; production, 128K context; vision-capable"
       },
       "gpt-oss-120b": {
         "contextWindow": 131072,
-        "pricingPerMTok": { "input": 0.22, "output": 0.59 },
+        "pricingPerMTok": {
+          "input": 0.22,
+          "output": 0.59
+        },
         "vision": false,
         "status": "production",
         "description": "OpenAI GPT-OSS 120B (open-weight)"
       },
       "DeepSeek-V3.1": {
         "contextWindow": 131072,
-        "pricingPerMTok": { "input": 3, "output": 4.5 },
+        "pricingPerMTok": {
+          "input": 3,
+          "output": 4.5
+        },
         "vision": false,
         "status": "production",
         "description": "DeepSeek V3.1 (reasoning)"
       },
       "DeepSeek-V3.2": {
         "contextWindow": 32768,
-        "pricingPerMTok": { "input": 3, "output": 4.5 },
+        "pricingPerMTok": {
+          "input": 3,
+          "output": 4.5
+        },
         "vision": false,
         "status": "preview",
         "description": "DeepSeek V3.2 (reasoning; vendor preview, 32K context)"
       },
       "MiniMax-M2.7": {
         "contextWindow": 196608,
-        "pricingPerMTok": { "input": 0.6, "output": 2.4, "cachedInput": 0.06 },
+        "pricingPerMTok": {
+          "input": 0.6,
+          "output": 2.4,
+          "cachedInput": 0.06
+        },
         "vision": false,
         "status": "production",
         "description": "MiniMax M2.7, 192K context"
       },
       "MiniMax-M3": {
-        "pricingPerMTok": { "input": 0.6, "output": 2.4 },
+        "pricingPerMTok": {
+          "input": 0.6,
+          "output": 2.4
+        },
         "vision": true,
         "status": "production",
         "description": "MiniMax M3 (vision)"
       },
       "gemma-4-31B-it": {
         "contextWindow": 131072,
-        "pricingPerMTok": { "input": 0.38, "output": 1.15 },
+        "pricingPerMTok": {
+          "input": 0.38,
+          "output": 1.15
+        },
         "vision": true,
         "status": "preview",
         "description": "Google Gemma 4 31B IT (vision; vendor preview)"
@@ -123,7 +145,10 @@
       "status": 402,
       "code": "PAYMENT_METHOD_REQUIRED"
     },
-    "liveMatrix": { "date": "2026-08-28", "result": "5/5" },
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "Six of seven ids answer. Vision re-tested with a valid 64x64 PNG: gemma-4-31B-it and Meta-Llama-3.3-70B-Instruct both describe it correctly, so Meta-Llama's vision flag is now true. MiniMax-M3 returned 429 'currently experiencing high demand' — the model is served and simply busy, so it stays production rather than being retired; its declared vision support is therefore still unverified."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1586"
   }
 }

--- a/src/lib/providers/catalog/schema.ts
+++ b/src/lib/providers/catalog/schema.ts
@@ -151,6 +151,7 @@ const catalogErrorRuleJsonSchema = z
 
 const catalogQuirksSchema = z.strictObject({
   timeoutErrorClass: z.literal("provider").optional(),
+  messageContentFormat: z.literal("string").optional(),
   registryDefaultIgnoresModelEnvVar: z.boolean().optional(),
 });
 

--- a/src/lib/providers/catalog/xai.json
+++ b/src/lib/providers/catalog/xai.json
@@ -8,23 +8,38 @@
     "baseURL": "https://api.x.ai/v1"
   },
   "models": {
-    "default": "grok-3",
-    "fallbacks": [
-      "grok-3",
-      "grok-3-mini",
-      "grok-2-latest",
-      "grok-2-vision-latest",
-      "grok-beta"
-    ],
+    "default": "grok-4.6",
+    "fallbacks": ["grok-4.6", "grok-4.5", "grok-4.3", "grok-3", "grok-3-mini"],
     "defaultContextWindow": 131072,
     "defaultMaxOutputTokens": 4096,
     "catalog": {
+      "grok-4.6": {
+        "enumMember": "GROK_4_6",
+        "contextWindow": 131072,
+        "vision": true,
+        "status": "production",
+        "description": "Recommended - Grok 4.6, current flagship; vision-capable"
+      },
+      "grok-4.5": {
+        "enumMember": "GROK_4_5",
+        "contextWindow": 131072,
+        "vision": true,
+        "status": "production",
+        "description": "Grok 4.5 — vision-capable"
+      },
+      "grok-4.3": {
+        "enumMember": "GROK_4_3",
+        "contextWindow": 131072,
+        "vision": true,
+        "status": "production",
+        "description": "Grok 4.3 — vision-capable"
+      },
       "grok-3": {
         "contextWindow": 131072,
         "pricingPerMTok": { "input": 3.0, "output": 15.0 },
         "vision": false,
         "status": "production",
-        "description": "Recommended - Latest flagship Grok"
+        "description": "Grok 3 — still served, though absent from the /models roster"
       },
       "grok-3-mini": {
         "contextWindow": 131072,
@@ -37,31 +52,26 @@
         "contextWindow": 131072,
         "pricingPerMTok": { "input": 2.0, "output": 10.0 },
         "vision": false,
-        "status": "production",
-        "description": "Previous flagship"
+        "status": "retired",
+        "description": "Retired 2026-08 — xAI rejects it as an invalid model"
       },
       "grok-2-vision-latest": {
         "contextWindow": 32768,
         "pricingPerMTok": { "input": 2.0, "output": 10.0 },
-        "vision": true,
-        "status": "production",
-        "description": "Multimodal (text + images)"
+        "vision": false,
+        "status": "retired",
+        "description": "Retired 2026-08 — xAI rejects it as an invalid model; vision moved to the grok-4.x line"
       },
       "grok-beta": {
         "contextWindow": 131072,
         "pricingPerMTok": { "input": 5.0, "output": 15.0 },
         "vision": false,
-        "status": "preview",
-        "description": "Pre-release / experimental"
+        "status": "retired",
+        "description": "Retired 2026-08 — xAI rejects it as an invalid model"
       }
     },
-    "topModels": [
-      "grok-3",
-      "grok-3-mini",
-      "grok-2-vision-latest",
-      "grok-2-latest",
-      "grok-beta"
-    ]
+    "visionModel": "grok-4.6",
+    "topModels": ["grok-4.6", "grok-4.5", "grok-4.3", "grok-3"]
   },
   "capabilities": {
     "text": true,
@@ -99,10 +109,13 @@
   },
   "evidence": {
     "rosterVerified": {
-      "date": "2026-08-28",
-      "method": "transcribed from pre-migration TS catalog"
+      "date": "2026-08-30",
+      "method": "GET /models against the live account, cross-checked with a real chat call per id"
     },
-    "liveMatrix": null,
+    "liveMatrix": {
+      "date": "2026-08-30",
+      "result": "grok-2-latest, grok-2-vision-latest and grok-beta are rejected as invalid models. The grok-4.x line replaces them: 4.3/4.5/4.6 all answer, and all three read a 64x64 PNG correctly, so vision moved there from the retired grok-2-vision-latest. An earlier probe with an 8x8 PNG reported no vision — that was xAI answering 'Invalid PNG image', a complaint about the file rather than the capability. grok-3 and grok-3-mini are kept because they still serve, even though xAI's /models roster omits them: roster absence is not evidence of death here."
+    },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
   }
 }

--- a/src/lib/providers/configuredOpenAICompat.ts
+++ b/src/lib/providers/configuredOpenAICompat.ts
@@ -1,6 +1,8 @@
 import type { AIProviderName } from "../constants/enums.js";
 import type {
   OpenAICompatCatalogEntry,
+  OpenAICompatChatMessage,
+  OpenAICompatChatRequest,
   OpenAICompatCredentials,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
@@ -14,6 +16,28 @@ import { TimeoutError } from "../utils/timeout.js";
 import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
 
 /**
+ * Collapse OpenAI's `content` union down to the plain string that
+ * string-only vendors accept. Image parts carry no string representation and
+ * are dropped — a provider that cannot accept a content array cannot accept
+ * inline images either.
+ */
+const flattenMessageContent = (
+  content: OpenAICompatChatMessage["content"],
+): string => {
+  if (typeof content === "string") {
+    return content;
+  }
+  // An assistant message with tool_calls legitimately has null content;
+  // the empty string is its string-only equivalent.
+  if (content === null || content === undefined) {
+    return "";
+  }
+  return content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+};
+
+/**
  * Generic OpenAI-compatible provider driven entirely by an
  * OpenAICompatCatalogEntry. Replaces a hand-written subclass for any
  * provider whose only differences from its siblings are credentials, base
@@ -24,6 +48,22 @@ import { OpenAIChatCompletionsProvider } from "./openaiChatCompletionsBase.js";
  * adjustBodyAfter400, getChatCompletionsURL, getAuthHeaders,
  * suppressResponseFormatWithTools, ...) it does NOT belong in the catalog —
  * write a dedicated subclass instead (see deepseek.ts, azureOpenai.ts).
+ *
+ * The exception is a WIRE DIALECT: a vendor that speaks OpenAI for ordinary
+ * chat but encodes one part of the request differently. Expressing that as
+ * data (the catalog's `messageContentFormat`) keeps the provider a
+ * one-JSON-file entry instead of promoting it to a hand-written subclass
+ * over a single incompatibility.
+ *
+ * Today that is Cloudflare Workers AI, whose OpenAI-compatible endpoint
+ * accepts `messages[].content` only as a plain string — never the
+ * content-parts array OpenAI allows, and never the `null` that OpenAI uses
+ * on an assistant message carrying tool_calls. Its schema rejects both with
+ * HTTP 400 ("Type mismatch of '/messages/N/content'"). That bites precisely
+ * on the second turn of a tool call, so single-turn chat looks healthy while
+ * every tool round-trip fails. Normalizing content to a string below is the
+ * whole fix: tools, tool_choice, the `tool` role and `tool_calls` are all
+ * accepted as-is.
  */
 export class ConfiguredOpenAICompatProvider extends OpenAIChatCompletionsProvider {
   private readonly entry: OpenAICompatCatalogEntry;
@@ -70,6 +110,23 @@ export class ConfiguredOpenAICompatProvider extends OpenAIChatCompletionsProvide
 
   protected getFallbackModels(): string[] {
     return this.entry.fallbackModels;
+  }
+
+  protected adjustRequestBody(
+    body: OpenAICompatChatRequest,
+    modelId: string,
+  ): OpenAICompatChatRequest {
+    const adjusted = super.adjustRequestBody(body, modelId);
+    if (this.entry.messageContentFormat !== "string") {
+      return adjusted;
+    }
+    return {
+      ...adjusted,
+      messages: adjusted.messages.map((message) => ({
+        ...message,
+        content: flattenMessageContent(message.content),
+      })),
+    };
   }
 
   protected formatProviderError(error: unknown): Error {

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -149,6 +149,28 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
    * Hardcoded model names returned from `getAvailableModels()` when the
    * remote `/models` endpoint can't be reached. Default empty.
    */
+  /**
+   * Feed the catalog's `fallbacks` to BaseProvider's invalid-model retry, so
+   * a default the vendor has retired degrades to the next live model in the
+   * entry instead of failing the call outright.
+   */
+  protected getModelFallbacks(): string[] {
+    return this.getFallbackModels();
+  }
+
+  /**
+   * `resolvedModel` memoizes the first id this provider resolved, and
+   * getAISDKModel() builds its wire model from that memo rather than from
+   * `modelName`. Leaving it stale here silently defeats the invalid-model
+   * fallback: modelName advances to the next candidate while every request
+   * still carries the retired id, so each retry fails for the same reason
+   * the first attempt did.
+   */
+  protected refreshHandlersForModel(model: string): void {
+    this.resolvedModel = model;
+    super.refreshHandlersForModel(model);
+  }
+
   protected getFallbackModels(): string[] {
     return [];
   }

--- a/src/lib/types/providerCatalog.ts
+++ b/src/lib/types/providerCatalog.ts
@@ -52,6 +52,12 @@ export type CatalogErrorRuleJson = {
 
 export type CatalogQuirks = {
   timeoutErrorClass?: "provider";
+  /** Vendor speaks OpenAI for chat but restricts how message content is
+   *  encoded. "string": `messages[].content` must be a plain string —
+   *  the content-parts array and the `null` OpenAI uses on an assistant
+   *  message with tool_calls are both rejected with HTTP 400. Normalized by
+   *  ConfiguredOpenAICompatProvider so tool round-trips work. */
+  messageContentFormat?: "string";
   registryDefaultIgnoresModelEnvVar?: boolean;
 };
 

--- a/src/lib/types/providers.ts
+++ b/src/lib/types/providers.ts
@@ -809,6 +809,9 @@ export type OpenAICompatCatalogEntry = {
    * the classifier's default (six of the seven catalog entries).
    */
   timeoutErrorClass?: new (message: string, provider?: string) => ProviderError;
+  /** See CatalogQuirks.messageContentFormat — a vendor that accepts
+   *  `messages[].content` only as a plain string. */
+  messageContentFormat?: "string";
 };
 
 /** The subset of OpenAICompatCatalogEntry that resolveOpenAICompatConfig()

--- a/test/continuous-test-suite-providers-mocked.ts
+++ b/test/continuous-test-suite-providers-mocked.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import "dotenv/config";
+import { jsonSchema } from "ai";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -2587,6 +2588,392 @@ async function runAnthropicSection(): Promise<void> {
 }
 
 // ───────────────────────────────────────────────────────────────────────
+// Section: Cloudflare message-content normalization (catalog quirk
+// messageContentFormat: "string").
+//
+// Regression guard. Cloudflare's OpenAI-compatible endpoint accepts
+// `messages[].content` ONLY as a plain string: it rejects both OpenAI's
+// content-parts array and the `null` that OpenAI puts on an assistant
+// message carrying tool_calls, with HTTP 400 "Type mismatch of
+// '/messages/N/content'". The first turn of a conversation has string
+// content already, so plain chat looked healthy while EVERY tool
+// round-trip failed on the follow-up turn — which is why this asserts on
+// the second request, not the first.
+// ───────────────────────────────────────────────────────────────────────
+
+async function runCloudflareContentFormatSection(): Promise<void> {
+  const section = "LLM cloudflare (messageContentFormat)";
+  console.log(`\n=== ${section} ===`);
+
+  setEnv("CLOUDFLARE_API_KEY", "test-fake-cloudflare-credential");
+  setEnv("CLOUDFLARE_ACCOUNT_ID", "test-account-id");
+
+  const model = "@cf/meta/llama-3.1-8b-instruct-fast";
+  const { NeuroLink } = await import("../dist/index.js");
+
+  const toolCallResponse = {
+    id: "chatcmpl-mock",
+    object: "chat.completion",
+    created: 0,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "multiply",
+                arguments: JSON.stringify({ a: 17, b: 4 }),
+              },
+            },
+          ],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+  };
+
+  try {
+    let turn = 0;
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.cloudflare.com",
+          respond: () => {
+            turn += 1;
+            return {
+              status: 200,
+              json:
+                turn === 1 ? toolCallResponse : openAIChatResponse("68", model),
+            };
+          },
+        },
+      ],
+      async ({ calls }) => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        await nl.generate({
+          provider: "cloudflare",
+          model,
+          input: { text: "What is 17 times 4? Use the multiply tool." },
+          tools: {
+            multiply: {
+              description: "Multiply two numbers",
+              inputSchema: jsonSchema<{ a: number; b: number }>({
+                type: "object",
+                properties: { a: { type: "number" }, b: { type: "number" } },
+                required: ["a", "b"],
+              }),
+              execute: async ({ a, b }) => ({ result: a * b }),
+            },
+          },
+        });
+
+        expect(
+          calls.length >= 2,
+          `expected a follow-up turn after the tool call — saw ${calls.length} request(s)`,
+        );
+
+        // Every message of every turn must carry string content. The
+        // follow-up turn is where the assistant tool_calls message (null
+        // content) and the tool-result message appear.
+        for (const [index, call] of calls.entries()) {
+          const body = (call.bodyJson ?? {}) as {
+            messages?: Array<{ role?: string; content?: unknown }>;
+          };
+          expect(
+            Array.isArray(body.messages),
+            `turn ${index + 1}: body.messages is an array`,
+          );
+          for (const [position, message] of (body.messages ?? []).entries()) {
+            expectEq(
+              typeof message.content,
+              "string",
+              `turn ${index + 1} message ${position} (role=${String(message.role)}) content type`,
+            );
+          }
+        }
+
+        // The assistant's tool_calls must survive normalization — only the
+        // content encoding changes, never the tool wiring.
+        const followUp = (calls[1]?.bodyJson ?? {}) as {
+          messages?: Array<{ role?: string; tool_calls?: unknown[] }>;
+        };
+        const assistantWithCalls = (followUp.messages ?? []).find(
+          (m) => m.role === "assistant" && Array.isArray(m.tool_calls),
+        );
+        expect(
+          assistantWithCalls !== undefined,
+          "follow-up turn preserves the assistant message's tool_calls",
+        );
+      },
+    );
+    record(results, `${section}: tool round-trip sends string content`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: tool round-trip sends string content`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Section: invalid-model fallback (anti-rot "survive" layer).
+//
+// Vendors retire models without warning. An InvalidModelError is classified
+// non-retryable — correctly, since switching PROVIDER cannot fix a bad model
+// id — which meant the fallback chain stopped dead and the caller got an
+// error while the same provider was still serving other models named in the
+// catalog's own `fallbacks`. Groq shipped exactly that state: all seven
+// catalogued ids retired upstream, default included.
+// ───────────────────────────────────────────────────────────────────────
+
+async function runInvalidModelFallbackSection(): Promise<void> {
+  const section = "LLM groq (invalid-model fallback)";
+  console.log(`\n=== ${section} ===`);
+
+  setEnv("GROQ_API_KEY", "test-fake-groq-credential");
+  const { NeuroLink } = await import("../dist/index.js");
+
+  const deadModel = "llama-3.3-70b-versatile"; // retired upstream 2026-08
+  try {
+    const requested: string[] = [];
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.groq.com",
+          respond: (req) => {
+            const body = (req.bodyJson ?? {}) as { model?: string };
+            const model = String(body.model ?? "");
+            requested.push(model);
+            if (model === deadModel) {
+              return {
+                status: 404,
+                json: {
+                  error: {
+                    message: `The model \`${model}\` does not exist or you do not have access to it.`,
+                    type: "invalid_request_error",
+                    code: "model_not_found",
+                  },
+                },
+              };
+            }
+            return { status: 200, json: openAIChatResponse("pong", model) };
+          },
+        },
+      ],
+      async () => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const result = await nl.generate({
+          provider: "groq",
+          model: deadModel,
+          input: { text: "ping" },
+          disableTools: true,
+        });
+
+        expect(
+          requested.length >= 2,
+          `expected a retry after the invalid-model rejection — saw ${requested.length} request(s)`,
+        );
+        expectEq(requested[0], deadModel, "first attempt uses the dead model");
+        expect(
+          requested[1] !== deadModel,
+          "second attempt switches to a different model",
+        );
+        expect(
+          (result.content ?? "").toLowerCase().includes("pong"),
+          "caller still receives a completed generation",
+        );
+      },
+    );
+    record(results, `${section}: retired model falls back to a live one`, true);
+  } catch (err) {
+    record(
+      results,
+      `${section}: retired model falls back to a live one`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── Streaming. OpenAI-compatible streams are lazy: the request only goes
+  // out on the consumer's first pull, so a retired model fails deep inside
+  // iteration rather than in stream()'s try/catch. The retry therefore sits
+  // below the lifecycle wrapper, and is only legal while the stream has
+  // emitted no real content.
+  try {
+    const requested: string[] = [];
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.groq.com",
+          respond: (req) => {
+            const body = (req.bodyJson ?? {}) as { model?: string };
+            const model = String(body.model ?? "");
+            requested.push(model);
+            if (model === deadModel) {
+              return {
+                status: 404,
+                json: {
+                  error: {
+                    message: `The model \`${model}\` does not exist or you do not have access to it.`,
+                    type: "invalid_request_error",
+                    code: "model_not_found",
+                  },
+                },
+              };
+            }
+            return {
+              status: 200,
+              contentType: "text/event-stream",
+              text: sseBody([
+                {
+                  id: "chatcmpl-mock",
+                  object: "chat.completion.chunk",
+                  created: 0,
+                  model,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { content: "pong" },
+                      finish_reason: null,
+                    },
+                  ],
+                },
+                {
+                  id: "chatcmpl-mock",
+                  object: "chat.completion.chunk",
+                  created: 0,
+                  model,
+                  choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                },
+              ]),
+            };
+          },
+        },
+      ],
+      async () => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        const res = await nl.stream({
+          provider: "groq",
+          model: deadModel,
+          input: { text: "ping" },
+          disableTools: true,
+        });
+        let text = "";
+        for await (const chunk of res.stream) {
+          text +=
+            typeof chunk === "string"
+              ? chunk
+              : ((chunk as { content?: string })?.content ?? "");
+        }
+
+        expect(
+          requested.length >= 2,
+          `expected a retry after the invalid-model rejection — saw ${requested.length} request(s)`,
+        );
+        expectEq(requested[0], deadModel, "first attempt uses the dead model");
+        expect(
+          requested[1] !== deadModel,
+          "second attempt switches to a different model",
+        );
+        expect(
+          text.includes("pong"),
+          "consumer receives the fallback model's streamed content",
+        );
+      },
+    );
+    record(
+      results,
+      `${section}: retired model falls back when streaming`,
+      true,
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: retired model falls back when streaming`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // ── A caller that owns fallback order (the Claude proxy sets
+  // disableInternalFallback on its stream calls) must get the invalid-model
+  // error as-is: no silent switch to another model.
+  try {
+    const requested: string[] = [];
+    await withMocks(
+      [
+        {
+          method: "POST",
+          url: "api.groq.com",
+          respond: (req) => {
+            const body = (req.bodyJson ?? {}) as { model?: string };
+            requested.push(String(body.model ?? ""));
+            return {
+              status: 404,
+              json: {
+                error: {
+                  message: `The model \`${String(body.model ?? "")}\` does not exist or you do not have access to it.`,
+                  type: "invalid_request_error",
+                  code: "model_not_found",
+                },
+              },
+            };
+          },
+        },
+      ],
+      async () => {
+        const nl = new NeuroLink({ conversationMemory: { enabled: false } });
+        let streamThrew = false;
+        try {
+          const res = await nl.stream({
+            provider: "groq",
+            model: deadModel,
+            input: { text: "ping" },
+            disableTools: true,
+            disableInternalFallback: true,
+          });
+          for await (const _chunk of res.stream) {
+            // drain
+          }
+        } catch {
+          streamThrew = true;
+        }
+        expect(streamThrew, "stream() surfaces the invalid-model error");
+        expect(requested.length >= 1, "stream() reached the provider");
+        expect(
+          requested.every((m) => m === deadModel),
+          "stream() never switched models — every request used the requested model",
+        );
+      },
+    );
+    record(
+      results,
+      `${section}: disableInternalFallback keeps the invalid-model error`,
+      true,
+    );
+  } catch (err) {
+    record(
+      results,
+      `${section}: disableInternalFallback keeps the invalid-model error`,
+      false,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────
 // Section: Vertex (construction + formatProviderError contract only —
 // gaxios routes ADC token exchange through node-fetch, not globalThis.fetch,
 // so installMockFetch() cannot intercept it. This section verifies
@@ -2841,6 +3228,8 @@ async function main(): Promise<void> {
     await runOpenAISection();
     await runAzureSection();
     await runAnthropicSection();
+    await runCloudflareContentFormatSection();
+    await runInvalidModelFallbackSection();
     await runVertexSection();
     await runBedrockSection();
   } finally {

--- a/tools/check-model-liveness.ts
+++ b/tools/check-model-liveness.ts
@@ -1,0 +1,321 @@
+#!/usr/bin/env tsx
+/**
+ * Catalog model liveness gate.
+ *
+ * Vendors retire models without telling us. Until this existed, the only
+ * signal was a user hitting a 404: Groq deleted its entire llama/gemma/mixtral
+ * lineup and every one of the seven ids in its catalog entry went dead, while
+ * the nightly matrix stayed green because it skips providers whose keys are
+ * absent — and silence looked like success.
+ *
+ * For every catalog provider this checks three things:
+ *   1. LIVENESS  — a real 1-token call to the default model. A vendor
+ *      "model not found / decommissioned / not deployed" reply is a hard
+ *      failure; a network blip or auth problem is inconclusive, not a failure.
+ *   2. ROSTER    — catalog ids that the vendor's own /models listing no longer
+ *      returns. A SOFT signal by design: Fireworks lists models it will not
+ *      actually serve to this account, so absence from the roster warns and
+ *      presence never excuses a failed call.
+ *   3. STALENESS — how long since evidence.rosterVerified.date. Old evidence
+ *      is not proof of rot, but it is proof nobody has looked.
+ *
+ * Providers whose API key is absent are reported as SKIPPED and counted. They
+ * are never silently omitted: an unseen provider is the failure mode this file
+ * exists to prevent. A run in which EVERY provider is skipped fails outright —
+ * that is not "nothing wrong", it is "no key reached the job".
+ *
+ * Source-only and buildless (same contract as verify-provider-onboarding.ts):
+ * it reads the catalog JSON and talks to vendors over HTTP, so it never needs
+ * `pnpm run build` and never depends on dist/.
+ *
+ * Run: pnpm run check:models            (human output; what CI runs, and what
+ *                                       it pastes into the rot-tracking issue)
+ *      pnpm run check:models -- --json  (machine output, for scripted callers)
+ */
+
+import "dotenv/config";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseProviderCatalogJson } from "../src/lib/providers/catalog/schema.js";
+import type { ProviderCatalogJson } from "../src/lib/types/index.js";
+
+const CATALOG_DIR = join(process.cwd(), "src/lib/providers/catalog");
+const STALE_AFTER_DAYS = 90;
+const PROBE_TIMEOUT_MS = 30_000;
+const jsonMode = process.argv.includes("--json");
+
+type ModelVerdict = "alive" | "dead" | "inconclusive";
+
+type ProviderReport = {
+  provider: string;
+  skipped?: string;
+  defaultModel?: string;
+  defaultVerdict?: ModelVerdict;
+  defaultError?: string;
+  missingFromRoster?: string[];
+  rosterError?: string;
+  evidenceDate?: string;
+  evidenceAgeDays?: number;
+  stale?: boolean;
+};
+
+// Vendors phrase a retired model differently — Groq says "decommissioned",
+// Fireworks "not deployed", OpenAI-compat "does not exist". Matching the
+// union keeps one dead model from reading as a transient outage.
+const DEAD_MODEL_PATTERNS =
+  /model[_ ]?not[_ ]?found|does not exist|decommissioned|not deployed|inaccessible|no such model|unknown model|invalid[_ ]model/i;
+
+function loadCatalog(): ProviderCatalogJson[] {
+  return readdirSync(CATALOG_DIR)
+    .filter((f) => f.endsWith(".json") && !f.endsWith(".schema.json"))
+    .sort()
+    .map((f) =>
+      parseProviderCatalogJson(
+        JSON.parse(readFileSync(join(CATALOG_DIR, f), "utf8")),
+        f,
+      ),
+    );
+}
+
+// Mirrors the loader's env-var convention. Reimplemented rather than imported
+// so a bug in the loader cannot make this gate look at the wrong variable and
+// report a live provider as unkeyed.
+function apiKeyEnvVar(entry: ProviderCatalogJson): string {
+  return (
+    entry.wire.envOverrides?.apiKey ??
+    `${entry.id.toUpperCase().replace(/-/g, "_")}_API_KEY`
+  );
+}
+
+function extraEnvVar(entry: ProviderCatalogJson): string | undefined {
+  const extra = entry.wire.extraCredentials?.[0];
+  if (!extra) {
+    return undefined;
+  }
+  const snake = extra.replace(/([A-Z])/g, "_$1").toUpperCase();
+  return `${entry.id.toUpperCase().replace(/-/g, "_")}_${snake}`;
+}
+
+function resolveBaseURL(entry: ProviderCatalogJson): string | undefined {
+  if (entry.wire.baseURL) {
+    return entry.wire.baseURL;
+  }
+  const template = entry.wire.baseURLTemplate;
+  const extraKey = entry.wire.extraCredentials?.[0];
+  const varName = extraEnvVar(entry);
+  if (!template || !extraKey || !varName) {
+    return undefined;
+  }
+  const value = process.env[varName];
+  return value ? template.replace(`{${extraKey}}`, value) : undefined;
+}
+
+async function probeModel(
+  baseURL: string,
+  key: string,
+  model: string,
+): Promise<{ verdict: ModelVerdict; error?: string }> {
+  try {
+    const res = await fetch(`${baseURL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+      }),
+      // A vendor can accept the connection and then never answer — Fireworks'
+      // deepseek-v4-pro does exactly that. Without a deadline one such model
+      // stalls every provider after it and the run never reaches its exit(1),
+      // so the gate dies quietly: the precise failure this file exists to
+      // prevent, arriving by a different route.
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (res.ok) {
+      return { verdict: "alive" };
+    }
+    // 401/403/429/5xx say nothing about whether the model exists, and their
+    // bodies can still carry dead-looking wording — a plan limit says
+    // "inaccessible", a rate limit can say "invalid model". Decide on the
+    // status first so the pattern never gets first refusal on those.
+    if (
+      res.status === 401 ||
+      res.status === 403 ||
+      res.status === 429 ||
+      res.status >= 500
+    ) {
+      return { verdict: "inconclusive", error: `HTTP ${res.status}` };
+    }
+    const body = (await res.text()).slice(0, 400);
+    if (DEAD_MODEL_PATTERNS.test(body)) {
+      return { verdict: "dead", error: body.slice(0, 160) };
+    }
+    return { verdict: "inconclusive", error: `HTTP ${res.status}` };
+  } catch (err) {
+    return {
+      verdict: "inconclusive",
+      error: err instanceof Error ? err.message.slice(0, 120) : String(err),
+    };
+  }
+}
+
+async function fetchRoster(
+  baseURL: string,
+  key: string,
+): Promise<{ ids?: Set<string>; error?: string }> {
+  try {
+    const res = await fetch(`${baseURL}/models`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return { error: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as { data?: Array<{ id?: string }> };
+    return {
+      ids: new Set((body.data ?? []).flatMap((m) => (m.id ? [m.id] : []))),
+    };
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err.message.slice(0, 120) : String(err),
+    };
+  }
+}
+
+function daysSince(dateStr: string): number | undefined {
+  const then = Date.parse(dateStr);
+  if (Number.isNaN(then)) {
+    return undefined;
+  }
+  return Math.floor((Date.now() - then) / 86_400_000);
+}
+
+async function main(): Promise<void> {
+  const entries = loadCatalog();
+  const reports: ProviderReport[] = [];
+
+  for (const entry of entries) {
+    const keyVar = apiKeyEnvVar(entry);
+    const key = process.env[keyVar];
+    const evidenceDate = entry.evidence.rosterVerified.date;
+    const ageDays = daysSince(evidenceDate);
+    const base: ProviderReport = {
+      provider: entry.id,
+      evidenceDate,
+      evidenceAgeDays: ageDays,
+      stale: ageDays !== undefined && ageDays > STALE_AFTER_DAYS,
+    };
+
+    const baseURL = resolveBaseURL(entry);
+    if (!key || !baseURL) {
+      reports.push({
+        ...base,
+        skipped: !key ? `no ${keyVar}` : `cannot resolve base URL`,
+      });
+      continue;
+    }
+
+    const { verdict, error } = await probeModel(
+      baseURL,
+      key,
+      entry.models.default,
+    );
+    const roster = await fetchRoster(baseURL, key);
+    // Retired ids are kept in the catalog on purpose (the frozen
+    // public-surface snapshot pins their enum members), so they are absent
+    // from the vendor roster BY DESIGN. Reporting them would mean every run
+    // re-lists dozens of already-known-dead models — and a gate that cries
+    // wolf gets muted, which is how this rot survived the first time.
+    const missing = roster.ids
+      ? Object.entries(entry.models.catalog)
+          .filter(([, spec]) => spec.status !== "retired")
+          .map(([model]) => model)
+          .filter((model) => !roster.ids?.has(model))
+      : undefined;
+
+    reports.push({
+      ...base,
+      defaultModel: entry.models.default,
+      defaultVerdict: verdict,
+      defaultError: error,
+      missingFromRoster: missing,
+      rosterError: roster.error,
+    });
+  }
+
+  const deadDefaults = reports.filter((r) => r.defaultVerdict === "dead");
+  const staleEvidence = reports.filter((r) => r.stale);
+  const skipped = reports.filter((r) => r.skipped);
+  const rosterGaps = reports.filter(
+    (r) => (r.missingFromRoster?.length ?? 0) > 0,
+  );
+
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        { reports, deadDefaults: deadDefaults.map((r) => r.provider) },
+        null,
+        2,
+      ),
+    );
+  } else {
+    for (const r of reports) {
+      if (r.skipped) {
+        console.log(`⊘ ${r.provider.padEnd(12)} SKIPPED — ${r.skipped}`);
+        continue;
+      }
+      const mark =
+        r.defaultVerdict === "alive"
+          ? "✓"
+          : r.defaultVerdict === "dead"
+            ? "✗"
+            : "?";
+      console.log(
+        `${mark} ${r.provider.padEnd(12)} default=${r.defaultModel} (${r.defaultVerdict}${r.defaultError ? `: ${r.defaultError.slice(0, 60)}` : ""})`,
+      );
+      if (r.missingFromRoster?.length) {
+        console.log(
+          `    ⚠ ${r.missingFromRoster.length} catalog model(s) absent from the vendor roster: ${r.missingFromRoster.slice(0, 4).join(", ")}${r.missingFromRoster.length > 4 ? " …" : ""}`,
+        );
+      }
+      if (r.stale) {
+        console.log(
+          `    ⚠ evidence.rosterVerified is ${r.evidenceAgeDays} days old (limit ${STALE_AFTER_DAYS})`,
+        );
+      }
+    }
+    console.log(
+      `\n${reports.length - skipped.length} checked, ${skipped.length} skipped, ${deadDefaults.length} dead default(s), ${rosterGaps.length} with roster gaps, ${staleEvidence.length} with stale evidence`,
+    );
+    if (skipped.length > 0) {
+      console.log(
+        `NOTE: skipped providers are unverified, not healthy — add their keys to see them.`,
+      );
+    }
+  }
+
+  // A run that verified nothing is not a green run: every provider skipped
+  // means no key reached the job at all (misnamed secrets, wrong env block),
+  // and that must read as failure, not health.
+  if (reports.length > 0 && skipped.length === reports.length) {
+    console.error(
+      `\n✗ nothing was verified: all ${reports.length} providers were skipped — check that the API-key secrets reach this job`,
+    );
+    process.exit(1);
+  }
+
+  // Otherwise only a vendor-confirmed dead default fails the gate. Roster gaps
+  // and stale evidence are warnings: neither proves a broken provider, and a
+  // gate that cries wolf gets muted, which is how this rot survived at first.
+  if (deadDefaults.length > 0) {
+    console.error(
+      `\n✗ ${deadDefaults.length} provider(s) have a retired default model: ${deadDefaults.map((r) => r.provider).join(", ")}`,
+    );
+    process.exit(1);
+  }
+}
+
+await main();

--- a/tsconfig.ci-scripts.json
+++ b/tsconfig.ci-scripts.json
@@ -32,6 +32,7 @@
     "scripts/env-validation.ts",
     "scripts/security-check.ts",
     "tools/verify-provider-onboarding.ts",
+    "tools/check-model-liveness.ts",
     "tools/testing/proxyLifecycleBenchmark.ts",
     "tools/testing/proxyRollingHandoffBenchmark.ts",
     "tools/testing/proxyTransportBenchmark.ts",


### PR DESCRIPTION
## What

Closes the last open item of the provider redesign: the catalog now survives what vendors do to it. Three failures, all of which presented as "the provider is broken" and none of which had a signal pointing at the cause.

Closes #1598.

## 1. Cloudflare tool calling — root-caused and fixed as catalog data

Cloudflare's OpenAI-compatible endpoint accepts `messages[].content` only as a plain string. It rejects both the content-parts array and the `null` OpenAI puts on an assistant message carrying `tool_calls`, with HTTP 400 `Type mismatch of '/messages/N/content'`. The first turn already has string content, so plain chat looked healthy while every tool round-trip failed on the follow-up turn — which is why the catalog previously declared tools unsupported.

A wire-level bisect against the live endpoint (each candidate request field probed one at a time — `tool_choice`, `response_format`, `max_tokens`, `parallel_tool_calls`, …) returned 200 for all of them, ruling out the tool schema and pinning the fault to content encoding.

The fix is one catalog quirk, `quirks.messageContentFormat: "string"`, honoured by `ConfiguredOpenAICompatProvider.adjustRequestBody`, so it covers streaming and non-streaming alike. Verified live both ways; `capabilities.tools` and `toolsWithStreaming` are now true for real.

## 2. Model data refresh — every default confirmed by a real call

Groq and Fireworks were both shipping a dead default (Groq retired all seven ids in its entry; Fireworks' `deepseek-v4-pro` accepts the connection and never answers). All nine catalog providers are refreshed from vendor evidence. Retired ids are marked `status: "retired"`, never deleted — the frozen public-surface snapshot pins their enum members.

Two classes of false verdict were found and avoided:

- **A dead-looking response is usually not a dead model.** Mistral answers every non-chat model with the same generic "Invalid model" (embed / ocr / voxtral are alive; the roster keeps them). `mistral-large-*` is a 403 plan limit, Cloudflare's `llama-3.2-11b-vision-instruct` is a 403 pending a one-time licence acceptance, SambaNova's `MiniMax-M3` is a 429. None is a retirement. Conversely, a roster listing is not proof of life (Fireworks lists two models it will not serve) and absence is not proof of death (xAI omits `grok-3` but serves it). An id is retired only when both signals agree.
- **An invalid test image masquerades as "no vision".** The earlier sweep used an 8×8 PNG vendors reject as malformed. Re-run with a valid 64×64 PNG, vision is alive and previously undeclared on Groq, Fireworks, Cerebras and SambaNova. Every vision flag here is backed by a model actually describing the image; `visionModel` is pinned away from ids that are plan-gated or slower than the client timeout.

## 3. Surviving a retired model at runtime

`InvalidModelError` is non-retryable — correctly, since switching provider cannot fix a bad model id — so the chain stopped dead even though the same provider was still serving other models named in the catalog's own `fallbacks`. Both `generate()` and `stream()` now walk them, logging a WARN naming both models (the caller asked for one and is getting another, so it must be visible). If every fallback is also rejected, the ORIGINAL error is rethrown.

Three things had to be right, and each failed silently first:

- `instanceof InvalidModelError` does not hold across the bundle/source module graphs → matched on constructor name, as the OTel error mapping in the same file already does.
- `resolvedModel` memoised the first id, so every retry re-sent the retired id → `refreshHandlersForModel` now moves the memo.
- Streaming is lazy, so the failure lands inside iteration → the retry sits below the lifecycle wrapper, only while no real content has been emitted; contentless `{noOutput: true}` sentinel chunks are held back rather than counted as output.

## 4. Anti-rot, so the next retirement is caught before a user hits it

- `tools/check-model-liveness.ts` (`pnpm run check:models`) fails only on a vendor-confirmed dead default; roster gaps and evidence older than 90 days warn. Providers without keys are reported as SKIPPED and counted, never omitted. 30 s probe deadline so one hanging vendor cannot stall the run.
- `.github/workflows/model-liveness.yml` runs it nightly and files, or comments on, a single rolling `model-rot` issue.
- `live-matrix.yml` passed `CLOUDFLARE_API_TOKEN`, which nothing reads (the catalog derives `<ID>_API_KEY`), so Cloudflare was silently skipped every night. Corrected; absent Cerebras and SambaNova keys added.

## Pre-PR adversarial review

Before opening this, the diff went through a four-lens review (fallback correctness, catalog data/compat, CI workflow, test honesty) with every finding attacked by two independent refuters. Five findings survived and are fixed in this commit:

- The stream wrapper withheld every chunk without `content`, which would have delayed reasoning and tool-call deltas until the first text token. Only the no-output sentinel and a bare empty text chunk are withheld now.
- Withheld chunks were dropped on the error exits; they are now released before any error that is not retried.
- `disableInternalFallback` (the Claude proxy sets it) was not honoured by the model-level fallback. Both paths now leave the invalid-model error alone when it is set — pinned by a new mocked test.
- `check:models` decided "dead" from body wording before looking at the status; 401/403/429/5xx are now inconclusive first.
- A run in which every provider was skipped exited 0. It now fails.

Two findings were refuted with evidence (a coverage-gap claim built on a wrong premise about the mock's stream shape, and a state-restore claim inconsistent with the success path) and were not acted on.

## Regression caught by CI and fixed

The first CI lap failed `test:tts:unit` ("consumer early-break stops queued TTS ingestion after one dispatched segment") — non-blocking shard, but real and deterministic (A/B against release's `baseProvider.ts`: 75/75 there, 74/1 here). Cause: the stream wrapper was a plain async generator, and a generator's `return()` is queued behind a pending `next()`, so a consumer break never reached a source waiting on a slow vendor. The wrapper now iterates through explicit iterators and registers the same `attachStreamCancel` hook `wrapStreamWithLifecycleCallbacks` uses, closing whichever upstream iterator is live (the source, or the fallback stream once it takes over). The suite is green again on this head.

## Verification on this head

- `pnpm run check`, `pnpm run lint`, `pnpm run codegen:catalog -- --check`, `pnpm run build` — clean.
- `providers-mocked` 77/77, `provider-structure` 3/3, `verify:provider-onboarding` green, `check:ci-scripts` and `check:tools-tests` clean.
- `check:models`: 0 dead defaults across all seven keyed providers (Perplexity and Together AI skipped — no keys).
- Each new test was confirmed to FAIL (✗, exit 1 — not ⊘ skip) with its fix removed.
- Live: Cloudflare tool round-trip completes in both modes; Groq `llama-3.3-70b-versatile` → survives via fallback in generate, stream+tools and stream-only.

## Not in this PR (needs an account action, not code)

- Cloudflare `llama-3.2-11b-vision-instruct` stays `vision: false` until the Meta Community Licence is accepted once on the account.
- Together AI and Perplexity have no keys in CI; they show as SKIPPED in `check:models` until secrets exist.
