### PR TITLE
test(localUsage): keep the overflow-boundary scans inside the fixture home

### DIFF
--- a/test/continuous-test-suite-local-usage.ts
+++ b/test/continuous-test-suite-local-usage.ts
@@ -1289,6 +1289,8 @@ async function runAllTests(): Promise<void> {
         overflowMax,
         overflowHuge,
         infinite,
+        belowCliff,
+        aboveCliff,
       ] = await withHome(home, async () => [
         await readAllLocalUsage({ sinceDays: 0 }),
         await readAllLocalUsage({ sinceDays: -5 }),
@@ -1309,6 +1311,20 @@ async function runAllTests(): Promise<void> {
         await readAllLocalUsage({ sinceDays: Number.MAX_VALUE }),
         await readAllLocalUsage({ sinceDays: 1e308 }),
         await readAllLocalUsage({ sinceDays: Infinity }),
+        // The two sides of the overflow boundary (~2.08e300 = Number.MAX_VALUE
+        // / 86_400_000), read INSIDE the fixture home. They used to sit after
+        // this block returned — after HOME was restored to the real one — so
+        // a case named "an empty window" ended by sweeping every transcript
+        // on the machine twice, concurrently, with an unbounded window.
+        // Measured: 650,530 turns in 211 s for one reader alone, against
+        // 12 ms in here. Under load that passed the suite's 240 s bound and
+        // reported as a hang in the code under test; three earlier runs had
+        // stalled at exactly this case before a watchdog caught the process
+        // reading other projects' subagent transcripts.
+        ...(await Promise.all([
+          readAllLocalUsage({ sinceDays: 2.07e300 }),
+          readAllLocalUsage({ sinceDays: 2.09e300 }),
+        ])),
       ]);
 
       assert(
@@ -1335,18 +1351,15 @@ async function runAllTests(): Promise<void> {
         (overflowHuge.totals["claude-code"]?.requests ?? 0) === 1,
         `a 1e308 sinceDays must read everything, like Infinity — expected 1 turn, got ${overflowHuge.totals["claude-code"]?.requests}`,
       );
-      // Monotonicity across the overflow boundary (~2.08e300 =
-      // Number.MAX_VALUE / 86_400_000). The two values straddle the point
-      // where the multiply stops being finite; a caller cannot see that
-      // boundary, so the answer must not change across it.
-      const [belowCliff, aboveCliff] = await Promise.all([
-        readAllLocalUsage({ sinceDays: 2.07e300 }),
-        readAllLocalUsage({ sinceDays: 2.09e300 }),
-      ]);
+      // Monotonicity across the overflow boundary: a caller cannot see where
+      // the multiply stops being finite, so the answer must not change across
+      // it. Asserted against the fixture's one turn rather than as bare
+      // equality: two full sweeps of a real machine also agree with each
+      // other, and that is precisely the case this must not pass on.
       assert(
-        (belowCliff.totals["claude-code"]?.requests ?? 0) ===
-          (aboveCliff.totals["claude-code"]?.requests ?? 0),
-        `the overflow boundary changed the answer — below and above must agree`,
+        (belowCliff.totals["claude-code"]?.requests ?? 0) === 1 &&
+          (aboveCliff.totals["claude-code"]?.requests ?? 0) === 1,
+        `the overflow boundary changed the answer, or the scan left the fixture home`,
       );
       // The control: without this, a reader that simply returned nothing for
       // every window would pass every assertion above.


### PR DESCRIPTION
## What

A test-only fix for the intermittent "hang" in `test/continuous-test-suite-local-usage.ts`.

## Root cause, measured

The case `a non-positive sinceDays is an empty window` awaited its overflow-boundary pair (`sinceDays: 2.07e300` and `2.09e300`) **after** the `withHome` block had returned, so `HOME` was the real home again. The case therefore swept every transcript on the machine twice, concurrently, with an unbounded window.

| Where the pair ran | Result on this machine |
| --- | --- |
| After `withHome` (as shipped) | 650,530 turns, 211 s, `claude-code` reader alone |
| Inside `withHome` (this PR) | 1 turn, 12 ms |

A watchdog that dumped the process when output went quiet showed the tsx process busy with no child, holding read handles on other projects' subagent transcripts under `~/.claude/projects`. Under load that crossed the harness's 240 s bound, which labels it a hang in the code under test.

## Fix

Move the pair inside the fixture-home block and assert the fixture's one turn on both sides. Bare equality could not have caught the escape, since two sweeps of the same machine agree with each other; counting against the fixture fails if a scan ever leaves it again.

## Verification

Four consecutive watchdog runs of the full suite: 50/50 passed each, no stall, 65–80 s per run. The last clean run before this change took 215 s; the stalled ones exceeded 400 s.
