### PR TITLE
chore(catalog): record why Cloudflare's vision model stays vision:false after licence acceptance

### DIFF
--- a/src/lib/providers/catalog/cloudflare.json
+++ b/src/lib/providers/catalog/cloudflare.json
@@ -47,7 +47,7 @@
         "contextWindow": 24000,
         "vision": false,
         "status": "production",
-        "description": "Llama 3.2 11B Vision Instruct — gated: Cloudflare returns 403 until the model's Community License is accepted once on the account, so it is unusable here and its vision flag is false despite being a vision model"
+        "description": "Llama 3.2 11B Vision Instruct — Meta Community License accepted on the account 2026-09-02, but Cloudflare's OpenAI-compatible endpoint accepts no image input for it: an image content part is rejected (400) and a top-level image is ignored ('There is no image'). The model reads images only through the native /ai/run prompt+image shape, which this OpenAI-compatible provider does not speak, so vision stays false here"
       },
       "@cf/mistral/mistral-7b-instruct-v0.2": {
         "enumMember": "MISTRAL_7B_INSTRUCT_V0_2",
@@ -114,8 +114,8 @@
       "method": "real chat call per id against the live account"
     },
     "liveMatrix": {
-      "date": "2026-08-30",
-      "result": "Live tool round-trip verified on @cf/meta/llama-3.1-8b-instruct-fast, both non-streaming and streaming, once messageContentFormat normalization was applied; before it the follow-up turn was rejected with HTTP 400 (content sent as array/null). Of the three ids that failed, only two are actually gone: mistral-7b-instruct-v0.2 ('No such model') and qwen1.5-14b-chat-awq ('deprecated on 2025-10-01'). llama-3.2-11b-vision-instruct is alive but gated behind a one-time Community License acceptance on the account, so it answers 403 and is left production with vision false rather than retired."
+      "date": "2026-09-02",
+      "result": "Live tool round-trip verified on @cf/meta/llama-3.1-8b-instruct-fast, both non-streaming and streaming, once messageContentFormat normalization was applied; before it the follow-up turn was rejected with HTTP 400 (content sent as array/null). Of the three ids that failed, only two are actually gone: mistral-7b-instruct-v0.2 ('No such model') and qwen1.5-14b-chat-awq ('deprecated on 2025-10-01'). llama-3.2-11b-vision-instruct is alive but gated behind a one-time Community License acceptance on the account, so it answers 403 and is left production with vision false rather than retired. Update 2026-09-02: the Community License was accepted on the account; plain chat on llama-3.2-11b-vision-instruct now returns 200 on both endpoints, and the native /ai/run prompt+image call describes a 64x64 test image correctly. The OpenAI-compatible endpoint still cannot carry an image (content-part array → 400, top-level image ignored), so the vision flag remains false for this provider."
     },
     "addedInPR": "https://github.com/juspay/neurolink/pull/1587"
   },


### PR DESCRIPTION
## What

Catalog-only change for `@cf/meta/llama-3.2-11b-vision-instruct`: the entry's description and the provider's `evidence.liveMatrix` now state the model's real limitation instead of the licence gate that no longer applies. No code, no flag change.

## Why the flag stays `vision: false`

- The Meta Community License was accepted on the account on 2026-09-02 (Cloudflare: "Thank you for agreeing to this model's terms. You may now use the model."). Plain chat on the model returns 200 on both the native `/ai/run` endpoint and the OpenAI-compatible endpoint.
- The model does read images, but only through the native `/ai/run` call with the legacy `prompt` + `image` (bytes) shape: a 64×64 blue test image is described as "Blue.".
- Cloudflare's OpenAI-compatible endpoint, which is the route `ConfiguredOpenAICompatProvider` drives, carries no image for this model: an OpenAI image content part is rejected with 400 ("Unable to add image when there are no user-supplied nor system-supplied messages" / "Internal Server Error"), and a top-level `image` field is ignored ("There is no image").

Flipping the flag would promise something the framework cannot deliver on this route, so the catalog states the fact and the evidence block records the probes.

## Verification

- `pnpm run codegen:catalog -- --check` — clean (no enum change).
- `pnpm run verify:provider-onboarding` — 2/2.
- Pre-push hook: build + `providers-mocked` + `provider-structure`.

## Follow-up (not in this PR)

A Cloudflare-specific image path (native `/ai/run` `prompt`+`image` for single-turn, tool-less vision requests) could be expressed as a catalog quirk if single-turn image description on Cloudflare is worth having; it would not cover conversations or tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Cloudflare model catalog information to reflect the latest license acceptance verification.
  - Confirmed that standard chat requests are successful for the model.
  - Clarified that image input remains unsupported through the OpenAI-compatible endpoint.
  - Refreshed the verification date and supporting live-matrix details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->