### PR TITLE
fix(tools): bound the whole tool execution, not just each attempt

### DIFF
--- a/docs/api/classes/MCPToolRegistry.md
+++ b/docs/api/classes/MCPToolRegistry.md
@@ -405,7 +405,7 @@ Register a server with its tools - ONLY accepts MCPServerInfo (zero conversions)
 
 > **executeTool**\<`T`\>(`toolName`, `args?`, `context?`): `Promise`\<`T`\>
 
-Defined in: [mcp/toolRegistry.ts:318](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L318)
+Defined in: [mcp/toolRegistry.ts:327](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L327)
 
 Execute a tool with enhanced context and automatic result wrapping
 
@@ -479,7 +479,7 @@ const result = await toolRegistry.executeTool("complexTool", { input: "test" });
 
 > **listTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [mcp/toolRegistry.ts:608](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L608)
+Defined in: [mcp/toolRegistry.ts:617](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L617)
 
 List all available tools (updated signature with filtering)
 
@@ -495,7 +495,7 @@ List all available tools (updated signature with filtering)
 
 > **listTools**(`context`): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [mcp/toolRegistry.ts:609](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L609)
+Defined in: [mcp/toolRegistry.ts:618](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L618)
 
 List all available tools (updated signature with filtering)
 
@@ -517,7 +517,7 @@ List all available tools (updated signature with filtering)
 
 > **listTools**(`filter`): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [mcp/toolRegistry.ts:610](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L610)
+Defined in: [mcp/toolRegistry.ts:619](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L619)
 
 List all available tools (updated signature with filtering)
 
@@ -559,7 +559,7 @@ List all available tools (updated signature with filtering)
 
 > **getToolInfo**(`toolName`): \{ `tool`: [`ToolInfo`](../type-aliases/ToolInfo.md); `server`: \{ `id`: `string`; \}; \} \| `undefined`
 
-Defined in: [mcp/toolRegistry.ts:747](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L747)
+Defined in: [mcp/toolRegistry.ts:756](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L756)
 
 Get tool information with server details
 
@@ -579,7 +579,7 @@ Get tool information with server details
 
 > **getExecutionStats**(): `Record`\<`string`, \{ `count`: `number`; `averageTime`: `number`; `totalTime`: `number`; \}\>
 
-Defined in: [mcp/toolRegistry.ts:792](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L792)
+Defined in: [mcp/toolRegistry.ts:801](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L801)
 
 Get execution statistics
 
@@ -593,7 +593,7 @@ Get execution statistics
 
 > **clearStats**(): `void`
 
-Defined in: [mcp/toolRegistry.ts:815](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L815)
+Defined in: [mcp/toolRegistry.ts:824](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L824)
 
 Clear execution statistics
 
@@ -607,7 +607,7 @@ Clear execution statistics
 
 > **getBuiltInServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [mcp/toolRegistry.ts:823](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L823)
+Defined in: [mcp/toolRegistry.ts:832](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L832)
 
 Get built-in servers
 
@@ -623,7 +623,7 @@ Array of MCPServerInfo for built-in tools
 
 > **getToolsByCategory**(`category`): [`ToolInfo`](../type-aliases/ToolInfo.md)[]
 
-Defined in: [mcp/toolRegistry.ts:830](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L830)
+Defined in: [mcp/toolRegistry.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L839)
 
 Get tools by category
 
@@ -643,7 +643,7 @@ Get tools by category
 
 > **getAvailableTools**(`circuitBreakers`): `object`
 
-Defined in: [mcp/toolRegistry.ts:845](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L845)
+Defined in: [mcp/toolRegistry.ts:854](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L854)
 
 NL-001: Get available tools, filtering out those with OPEN circuit breakers.
 Returns both the filtered tools and the list of unavailable tool names.
@@ -672,7 +672,7 @@ Returns both the filtered tools and the list of unavailable tool names.
 
 > **hasTool**(`toolName`): `boolean`
 
-Defined in: [mcp/toolRegistry.ts:871](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L871)
+Defined in: [mcp/toolRegistry.ts:880](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L880)
 
 Check if tool exists
 
@@ -692,7 +692,7 @@ Check if tool exists
 
 > **registerTool**(`toolId`, `toolInfo`, `toolImpl`): `Promise`\<`void`\>
 
-Defined in: [mcp/toolRegistry.ts:888](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L888)
+Defined in: [mcp/toolRegistry.ts:897](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L897)
 
 Register a tool with implementation directly
 This is used for external MCP server tools
@@ -721,7 +721,7 @@ This is used for external MCP server tools
 
 > **removeTool**(`toolName`): `boolean`
 
-Defined in: [mcp/toolRegistry.ts:930](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L930)
+Defined in: [mcp/toolRegistry.ts:939](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L939)
 
 Remove a tool
 
@@ -741,7 +741,7 @@ Remove a tool
 
 > **getToolCount**(): `number`
 
-Defined in: [mcp/toolRegistry.ts:957](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L957)
+Defined in: [mcp/toolRegistry.ts:966](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L966)
 
 Get tool count
 
@@ -755,7 +755,7 @@ Get tool count
 
 > **getStats**(): `object`
 
-Defined in: [mcp/toolRegistry.ts:964](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L964)
+Defined in: [mcp/toolRegistry.ts:973](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L973)
 
 Get comprehensive statistics
 
@@ -789,7 +789,7 @@ Get comprehensive statistics
 
 > **unregisterServer**(`serverId`): `boolean`
 
-Defined in: [mcp/toolRegistry.ts:1004](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L1004)
+Defined in: [mcp/toolRegistry.ts:1013](https://github.com/juspay/neurolink/blob/release/src/lib/mcp/toolRegistry.ts#L1013)
 
 Unregister a server
 

--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -1207,7 +1207,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12919](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12919)
+Defined in: [neurolink.ts:12920](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12920)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1230,7 +1230,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12934](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12934)
+Defined in: [neurolink.ts:12935](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12935)
 
 Get the current tool execution context
 
@@ -1246,7 +1246,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12943](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12943)
+Defined in: [neurolink.ts:12944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12944)
 
 Clear the tool execution context
 
@@ -1260,7 +1260,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12955](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12955)
+Defined in: [neurolink.ts:12956](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12956)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1285,7 +1285,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12978](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12978)
+Defined in: [neurolink.ts:12979](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12979)
 
 Unregister a custom tool
 
@@ -1309,7 +1309,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12997)
+Defined in: [neurolink.ts:12998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12998)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1334,7 +1334,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:13010](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13010)
+Defined in: [neurolink.ts:13011](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13011)
 
 Get all registered tool middlewares
 
@@ -1348,7 +1348,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13017](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13017)
+Defined in: [neurolink.ts:13018](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13018)
 
 Flush any pending batched tool calls immediately
 
@@ -1362,7 +1362,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:13026](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13026)
+Defined in: [neurolink.ts:13027](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13027)
 
 Get the current MCP enhancements configuration
 
@@ -1376,7 +1376,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13049](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13049)
+Defined in: [neurolink.ts:13050](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13050)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1426,7 +1426,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:13085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13085)
+Defined in: [neurolink.ts:13086](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13086)
 
 Get all registered custom tools
 
@@ -1442,7 +1442,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13223](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13223)
+Defined in: [neurolink.ts:13224](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13224)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1471,7 +1471,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:13267](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13267)
+Defined in: [neurolink.ts:13268](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13268)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1494,7 +1494,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13294](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13294)
+Defined in: [neurolink.ts:13295](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13295)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1524,7 +1524,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13310](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13310)
+Defined in: [neurolink.ts:13311](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13311)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1540,7 +1540,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13322](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13322)
+Defined in: [neurolink.ts:13323](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13323)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1573,9 +1573,19 @@ Execution options including optional authentication context
 
 `number`
 
+Bound on ONE attempt.
+
 ###### maxRetries?
 
 `number`
+
+###### totalTimeoutMs?
+
+`number`
+
+Bound on the WHOLE execution — every attempt plus the delays between
+them. Defaults to `timeout * (maxRetries + 1)`, which is what the
+retry loop already spent, so omitting it changes nothing.
 
 ###### retryDelayMs?
 
@@ -1621,7 +1631,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14353](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14353)
+Defined in: [neurolink.ts:14423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14423)
 
 ##### Returns
 
@@ -1633,7 +1643,7 @@ Defined in: [neurolink.ts:14353](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14535](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14535)
+Defined in: [neurolink.ts:14605](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14605)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1656,7 +1666,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14716](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14716)
+Defined in: [neurolink.ts:14786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14786)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1680,7 +1690,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14748](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14748)
+Defined in: [neurolink.ts:14818](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14818)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1704,7 +1714,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14757](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14757)
+Defined in: [neurolink.ts:14827](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14827)
 
 Get list of all available AI provider names
 
@@ -1720,7 +1730,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14767](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14767)
+Defined in: [neurolink.ts:14837](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14837)
 
 Validate if a provider name is supported
 
@@ -1744,7 +1754,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14780](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14780)
+Defined in: [neurolink.ts:14850](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14850)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1760,7 +1770,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14850](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14850)
+Defined in: [neurolink.ts:14920](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14920)
 
 List all configured MCP servers with their status
 
@@ -1776,7 +1786,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14865](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14865)
+Defined in: [neurolink.ts:14935](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14935)
 
 Test connectivity to a specific MCP server
 
@@ -1800,7 +1810,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14906](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14906)
+Defined in: [neurolink.ts:14976](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14976)
 
 Check if a provider has the required environment variables configured
 
@@ -1824,7 +1834,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:14932](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14932)
+Defined in: [neurolink.ts:15002](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15002)
 
 Perform comprehensive health check on a specific provider
 
@@ -1868,7 +1878,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:14978](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14978)
+Defined in: [neurolink.ts:15048](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15048)
 
 Check health of all supported providers
 
@@ -1906,7 +1916,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15022)
+Defined in: [neurolink.ts:15092](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15092)
 
 Get a summary of provider health across all supported providers
 
@@ -1922,7 +1932,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15069)
+Defined in: [neurolink.ts:15139](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15139)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1944,7 +1954,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:15080](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15080)
+Defined in: [neurolink.ts:15150](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15150)
 
 Get execution metrics for all tools
 
@@ -1960,7 +1970,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:15124](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15124)
+Defined in: [neurolink.ts:15194](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15194)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1983,7 +1993,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:15137](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15137)
+Defined in: [neurolink.ts:15207](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15207)
 
 Get circuit breaker status for all tools
 
@@ -1999,7 +2009,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:15172](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15172)
+Defined in: [neurolink.ts:15242](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15242)
 
 Reset circuit breaker for a specific tool
 
@@ -2021,7 +2031,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:15189](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15189)
+Defined in: [neurolink.ts:15259](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15259)
 
 Clear all tool execution metrics
 
@@ -2035,7 +2045,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:15198](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15198)
+Defined in: [neurolink.ts:15268](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15268)
 
 Get comprehensive tool health report
 
@@ -2051,7 +2061,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15353](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15353)
+Defined in: [neurolink.ts:15423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15423)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2068,7 +2078,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15373](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15373)
+Defined in: [neurolink.ts:15443](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15443)
 
 Get conversation memory statistics (public API)
 
@@ -2082,7 +2092,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15400](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15400)
+Defined in: [neurolink.ts:15470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15470)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2106,7 +2116,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15456](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15456)
+Defined in: [neurolink.ts:15526](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15526)
 
 Clear conversation history for a specific session (public API)
 
@@ -2126,7 +2136,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15482](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15482)
+Defined in: [neurolink.ts:15552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15552)
 
 Clear all conversation history (public API)
 
@@ -2140,7 +2150,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15510)
+Defined in: [neurolink.ts:15580](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15580)
 
 List all conversation sessions with metadata (public API)
 
@@ -2164,7 +2174,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15559](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15559)
+Defined in: [neurolink.ts:15629](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15629)
 
 Export a single session with full history and metadata (public API)
 
@@ -2200,7 +2210,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15644](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15644)
+Defined in: [neurolink.ts:15714](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15714)
 
 Export all sessions for a user (public API)
 
@@ -2236,7 +2246,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15708](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15708)
+Defined in: [neurolink.ts:15778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15778)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2284,7 +2294,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15778)
+Defined in: [neurolink.ts:15848](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15848)
 
 Check if tool execution storage is available.
 
@@ -2305,7 +2315,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15788](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15788)
+Defined in: [neurolink.ts:15858](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15858)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2334,7 +2344,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15829](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15829)
+Defined in: [neurolink.ts:15899](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15899)
 
 Replace the entire messages array for a session.
 
@@ -2368,7 +2378,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15877](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15877)
+Defined in: [neurolink.ts:15947](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15947)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2405,7 +2415,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15908](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15908)
+Defined in: [neurolink.ts:15978](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15978)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2436,7 +2446,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:15995](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15995)
+Defined in: [neurolink.ts:16065](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16065)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2461,7 +2471,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:16047](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16047)
+Defined in: [neurolink.ts:16117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16117)
 
 List all external MCP servers
 
@@ -2477,7 +2487,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:16076](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16076)
+Defined in: [neurolink.ts:16146](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16146)
 
 Get external MCP server status
 
@@ -2501,7 +2511,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `requestedToolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:16090](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16090)
+Defined in: [neurolink.ts:16160](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16160)
 
 Execute a tool from an external MCP server
 
@@ -2543,7 +2553,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16289](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16289)
+Defined in: [neurolink.ts:16359](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16359)
 
 Get all tools from external MCP servers
 
@@ -2559,7 +2569,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16298](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16298)
+Defined in: [neurolink.ts:16368](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16368)
 
 Get tools from a specific external MCP server
 
@@ -2583,7 +2593,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:16307](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16307)
+Defined in: [neurolink.ts:16377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16377)
 
 Test connection to an external MCP server
 
@@ -2607,7 +2617,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:16335](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16335)
+Defined in: [neurolink.ts:16405](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16405)
 
 Get external MCP server manager statistics
 
@@ -2647,7 +2657,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16350](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16350)
+Defined in: [neurolink.ts:16420](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16420)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2662,7 +2672,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16388](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16388)
+Defined in: [neurolink.ts:16458](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16458)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2693,7 +2703,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16416](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16416)
+Defined in: [neurolink.ts:16486](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16486)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2731,7 +2741,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16439](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16439)
+Defined in: [neurolink.ts:16509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16509)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2760,7 +2770,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16464](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16464)
+Defined in: [neurolink.ts:16534](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16534)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2790,7 +2800,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16491](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16491)
+Defined in: [neurolink.ts:16561](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16561)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2822,7 +2832,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16519](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16519)
+Defined in: [neurolink.ts:16589](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16589)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2899,7 +2909,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16560](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16560)
+Defined in: [neurolink.ts:16630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16630)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2980,7 +2990,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16599](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16599)
+Defined in: [neurolink.ts:16669](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16669)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -3010,7 +3020,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16621](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16621)
+Defined in: [neurolink.ts:16691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16691)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -3051,7 +3061,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16660](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16660)
+Defined in: [neurolink.ts:16730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16730)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3092,7 +3102,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16683](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16683)
+Defined in: [neurolink.ts:16753](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16753)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3124,7 +3134,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16922](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16922)
+Defined in: [neurolink.ts:16992](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16992)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3175,7 +3185,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:17014](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17014)
+Defined in: [neurolink.ts:17084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17084)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3277,7 +3287,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:17152](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17152)
+Defined in: [neurolink.ts:17222](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17222)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3346,7 +3356,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:17238](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17238)
+Defined in: [neurolink.ts:17308](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17308)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3407,7 +3417,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:17284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17284)
+Defined in: [neurolink.ts:17354](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17354)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3433,7 +3443,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:17307](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17307)
+Defined in: [neurolink.ts:17377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17377)
 
 Get details of a specific evaluation preset.
 
@@ -3469,7 +3479,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:17357](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17357)
+Defined in: [neurolink.ts:17427](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17427)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3521,7 +3531,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17419](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17419)
+Defined in: [neurolink.ts:17489](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17489)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3595,7 +3605,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17451](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17451)
+Defined in: [neurolink.ts:17521](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17521)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3635,7 +3645,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17550)
+Defined in: [neurolink.ts:17620](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17620)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3685,7 +3695,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17569](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17569)
+Defined in: [neurolink.ts:17639](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17639)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3718,7 +3728,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17585)
+Defined in: [neurolink.ts:17655](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17655)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3743,7 +3753,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17603](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17603)
+Defined in: [neurolink.ts:17673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17673)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3781,7 +3791,7 @@ The registered tool name
 
 > **registerTaskTools**(): `void`
 
-Defined in: [neurolink.ts:17636](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17636)
+Defined in: [neurolink.ts:17706](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17706)
 
 Register the task CHECKLIST toolset — `tasks_create`, `tasks_update`,
 `tasks_list` — on this instance (TodoWrite-style planning for a
@@ -3817,7 +3827,7 @@ id for that one call.
 
 > **getTaskState**(`sessionId?`): [`ChecklistState`](../type-aliases/ChecklistState.md)
 
-Defined in: [neurolink.ts:17662](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17662)
+Defined in: [neurolink.ts:17732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17732)
 
 Read a session's task checklist — synchronous, so a completeness gate is
 one line of host code:
@@ -3843,7 +3853,7 @@ instance's tool-context session, or its default checklist).
 
 > **clearTaskState**(`sessionId?`): `boolean`
 
-Defined in: [neurolink.ts:17670](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17670)
+Defined in: [neurolink.ts:17740](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17740)
 
 Drop a session's checklist. Returns whether there was one to drop.
 Omit `sessionId` to clear the session the tools currently write to.
@@ -3864,7 +3874,7 @@ Omit `sessionId` to clear the session the tools currently write to.
 
 > **registerDelegationTools**(`options?`): `void`
 
-Defined in: [neurolink.ts:17697](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17697)
+Defined in: [neurolink.ts:17767](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17767)
 
 Register the background-delegation toolset — `delegate_task` and
 `collect_results` — on this instance. Opt-in and idempotent: existing
@@ -3903,7 +3913,7 @@ Depth ceiling, pool raise, and queue wait
 
 > **spawnDelegate**(`options`): `Promise`\<[`DelegateHandle`](../type-aliases/DelegateHandle.md)\>
 
-Defined in: [neurolink.ts:17737](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17737)
+Defined in: [neurolink.ts:17807](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17807)
 
 Start a background worker and get its handle immediately — before it has
 run anything, and long before it finishes.
@@ -3947,7 +3957,7 @@ when the task is empty or the caller is at the depth ceiling
 
 > **collectDelegates**(`request`): `Promise`\<[`DelegateCollectResult`](../type-aliases/DelegateCollectResult.md)\>
 
-Defined in: [neurolink.ts:17748](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17748)
+Defined in: [neurolink.ts:17818](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17818)
 
 Claim finished background workers — in COMPLETION order, which has nothing
 to do with spawn order. Each outcome is handed out exactly once.
@@ -3972,7 +3982,7 @@ Claimed outcomes plus what is still pending/ready
 
 > **cancelDelegates**(`workerId?`): `Promise`\<`number`\>
 
-Defined in: [neurolink.ts:17762](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17762)
+Defined in: [neurolink.ts:17832](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17832)
 
 Cancel background workers: one by id, or every outstanding worker this
 instance spawned. Cancelled workers still settle into a claimable outcome
@@ -3998,7 +4008,7 @@ How many workers were cancelled
 
 > **getArtifactStore**(): [`ArtifactStore`](../type-aliases/ArtifactStore.md)
 
-Defined in: [neurolink.ts:17785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17785)
+Defined in: [neurolink.ts:17855](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17855)
 
 This instance's artifact store, created on first use.
 
@@ -4024,7 +4034,7 @@ The artifact store backing [bankArtifact](#bankartifact) / [readArtifact](#reada
 
 > **setArtifactStore**(`store`): `void`
 
-Defined in: [neurolink.ts:17815](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17815)
+Defined in: [neurolink.ts:17885](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17885)
 
 Replace this instance's artifact store.
 
@@ -4062,7 +4072,7 @@ Any [ArtifactStore](../type-aliases/ArtifactStore.md)
 
 > **bankArtifact**(`payload`, `options`): `Promise`\<[`BankedArtifactRef`](../type-aliases/BankedArtifactRef.md)\>
 
-Defined in: [neurolink.ts:17903](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17903)
+Defined in: [neurolink.ts:17973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17973)
 
 Bank a payload to a file and get back a pointer to it.
 
@@ -4109,7 +4119,7 @@ const ref = await neurolink.bankArtifact(fullReport, {
 
 > **readArtifact**(`id`, `page?`): `Promise`\<`string` \| `null`\>
 
-Defined in: [neurolink.ts:17920](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17920)
+Defined in: [neurolink.ts:17990](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17990)
 
 Read a banked payload back from host code — the programmatic twin of the
 model's `retrieve_context({ artifactId })` call.
@@ -4141,7 +4151,7 @@ Optional character window
 
 > **registerBackgroundCommandTools**(`policy`): `void`
 
-Defined in: [neurolink.ts:17952](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17952)
+Defined in: [neurolink.ts:18022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18022)
 
 Register the background-command toolset — `run_command_bg`,
 `command_status`, `command_output`, `command_kill` — on this instance, and
@@ -4182,7 +4192,7 @@ What may run, where, for how long, and how loudly
 
 > **setBackgroundCommandPolicy**(`policy`): `void`
 
-Defined in: [neurolink.ts:17977](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17977)
+Defined in: [neurolink.ts:18047](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18047)
 
 Declare (or replace) what this instance may execute, without registering
 the model-facing tools. Host code that only drives
@@ -4206,7 +4216,7 @@ What may run, where, for how long, and how loudly
 
 > **startBackgroundCommand**(`argv`, `options`): `Promise`\<[`BackgroundCommandHandle`](../type-aliases/BackgroundCommandHandle.md)\>
 
-Defined in: [neurolink.ts:18001](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18001)
+Defined in: [neurolink.ts:18071](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18071)
 
 Start a command in the background and get its task id immediately.
 
@@ -4253,7 +4263,7 @@ allowlisted, the policy vetoes it, or the cwd escapes the sandbox
 
 > **getBackgroundCommandStatus**(`taskId`): [`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)
 
-Defined in: [neurolink.ts:18015](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18015)
+Defined in: [neurolink.ts:18085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18085)
 
 Everything known about one command right now — synchronous, so a
 mid-loop monitor costs nothing.
@@ -4280,7 +4290,7 @@ when the task id is unknown to this instance
 
 > **awaitBackgroundCommand**(`taskId`, `opts?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18027](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18027)
+Defined in: [neurolink.ts:18097](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18097)
 
 Wait for a command to settle. `timeoutMs` bounds the WAIT, not the
 command: when it elapses the current status is returned rather than
@@ -4312,7 +4322,7 @@ Task id from [startBackgroundCommand](#startbackgroundcommand)
 
 > **killBackgroundCommand**(`taskId`, `signal?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18042](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18042)
+Defined in: [neurolink.ts:18112](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18112)
 
 Kill a running command — SIGTERM, then SIGKILL five seconds later — and
 resolve with its settled status. Whatever it printed first is still
@@ -4342,7 +4352,7 @@ Signal to send first. Default SIGTERM
 
 > **readBackgroundCommandOutput**(`taskId`, `page`): `Promise`\<[`BackgroundCommandOutputPage`](../type-aliases/BackgroundCommandOutputPage.md)\>
 
-Defined in: [neurolink.ts:18057](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18057)
+Defined in: [neurolink.ts:18127](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18127)
 
 Read one character window of a command's output straight from its log
 file — while it is still running, or long after it finished. Offsets,
@@ -4372,7 +4382,7 @@ Which stream, and which window of it
 
 > **registerGitTools**(`options`): `void`
 
-Defined in: [neurolink.ts:18084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18084)
+Defined in: [neurolink.ts:18154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18154)
 
 Register the read-only git toolset — `git_log`, `git_show`, `git_diff`,
 `git_blame`, `git_merge_base`, `git_ls_files` — on this instance. Opt-in
@@ -4405,7 +4415,7 @@ Repository root, plus timeout / byte-cap / preview bounds
 
 > **runGitCommand**(`args`, `sessionId?`): `Promise`\<[`GitToolResult`](../type-aliases/GitToolResult.md)\>
 
-Defined in: [neurolink.ts:18110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18110)
+Defined in: [neurolink.ts:18180](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18180)
 
 Run one read-only git command from host code, with the same bounding the
 tools get: the complete stdout is banked, the result carries a preview and
@@ -4440,7 +4450,7 @@ when [registerGitTools](#registergittools) has not been called
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:18129](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18129)
+Defined in: [neurolink.ts:18199](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18199)
 
 Execute an agent network with the given input.
 
@@ -4485,7 +4495,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:18153](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18153)
+Defined in: [neurolink.ts:18223](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18223)
 
 Stream agent network execution with real-time events.
 
@@ -4529,7 +4539,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:18177](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18177)
+Defined in: [neurolink.ts:18247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18247)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -4557,7 +4567,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:18196](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18196)
+Defined in: [neurolink.ts:18266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18266)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -4585,7 +4595,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:18214](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18214)
+Defined in: [neurolink.ts:18284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18284)
 
 Create a MessageBus for inter-agent communication.
 
@@ -4613,7 +4623,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18229](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18229)
+Defined in: [neurolink.ts:18299](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18299)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -4629,7 +4639,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:18448](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18448)
+Defined in: [neurolink.ts:18518](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18518)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -4646,7 +4656,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:18456](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18456)
+Defined in: [neurolink.ts:18526](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18526)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -4671,7 +4681,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:18507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18507)
+Defined in: [neurolink.ts:18577](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18577)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -4700,7 +4710,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:18549](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18549)
+Defined in: [neurolink.ts:18619](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18619)
 
 Check if a session needs compaction.
 
@@ -4728,7 +4738,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18586](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18586)
+Defined in: [neurolink.ts:18656](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18656)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4750,7 +4760,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:18634](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18634)
+Defined in: [neurolink.ts:18704](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18704)
 
 Get the currently configured authentication provider
 
@@ -4764,7 +4774,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18675](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18675)
+Defined in: [neurolink.ts:18745](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18745)
 
 Set the current authentication context for request handling.
 
@@ -4791,7 +4801,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:18690](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18690)
+Defined in: [neurolink.ts:18760](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18760)
 
 Get the current authentication context.
 
@@ -4807,7 +4817,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18698)
+Defined in: [neurolink.ts:18768](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18768)
 
 Clear the current authentication context
 
@@ -4821,7 +4831,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:18712](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18712)
+Defined in: [neurolink.ts:18782](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18782)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/functions/isAbortError.md
+++ b/docs/api/functions/isAbortError.md
@@ -8,7 +8,7 @@
 
 > **isAbortError**(`error`): `boolean`
 
-Defined in: [utils/errorHandling.ts:1392](https://github.com/juspay/neurolink/blob/release/src/lib/utils/errorHandling.ts#L1392)
+Defined in: [utils/errorHandling.ts:1417](https://github.com/juspay/neurolink/blob/release/src/lib/utils/errorHandling.ts#L1417)
 
 Detect AbortError from any source (DOMException, plain Error, or message-based).
 Used to short-circuit retry/fallback loops when an abort signal fires.

--- a/docs/api/functions/isToolDefinition.md
+++ b/docs/api/functions/isToolDefinition.md
@@ -8,7 +8,7 @@
 
 > **isToolDefinition**(`value`): `value is ToolDefinition<ToolArgs, JsonValue>`
 
-Defined in: [types/tools.ts:636](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L636)
+Defined in: [types/tools.ts:659](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L659)
 
 Type guard for tool definition
 

--- a/docs/api/functions/isToolResult.md
+++ b/docs/api/functions/isToolResult.md
@@ -8,7 +8,7 @@
 
 > **isToolResult**(`value`): `value is ToolResult<unknown>`
 
-Defined in: [types/tools.ts:624](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L624)
+Defined in: [types/tools.ts:647](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L647)
 
 Type guard for tool result
 

--- a/docs/api/type-aliases/AiSdkToolCall.md
+++ b/docs/api/type-aliases/AiSdkToolCall.md
@@ -8,7 +8,7 @@
 
 > **AiSdkToolCall** = `object`
 
-Defined in: [types/tools.ts:590](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L590)
+Defined in: [types/tools.ts:613](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L613)
 
 AI SDK Tool Call format (from Vercel AI SDK)
 
@@ -18,7 +18,7 @@ AI SDK Tool Call format (from Vercel AI SDK)
 
 > **type**: `"tool-call"`
 
-Defined in: [types/tools.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L591)
+Defined in: [types/tools.ts:614](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L614)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:591](https://github.com/juspay/neurolink/blob/releas
 
 > **toolCallId**: `string`
 
-Defined in: [types/tools.ts:592](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L592)
+Defined in: [types/tools.ts:615](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L615)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:592](https://github.com/juspay/neurolink/blob/releas
 
 > **toolName**: `string`
 
-Defined in: [types/tools.ts:593](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L593)
+Defined in: [types/tools.ts:616](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L616)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/tools.ts:593](https://github.com/juspay/neurolink/blob/releas
 
 > **params**: [`ToolArgs`](ToolArgs.md)
 
-Defined in: [types/tools.ts:594](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L594)
+Defined in: [types/tools.ts:617](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L617)

--- a/docs/api/type-aliases/AllToolsMap.md
+++ b/docs/api/type-aliases/AllToolsMap.md
@@ -8,7 +8,7 @@
 
 > **AllToolsMap** = `object`
 
-Defined in: [types/tools.ts:496](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L496)
+Defined in: [types/tools.ts:519](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L519)
 
 Full directAgentTools map, with the opt-in bashTool appended.
 
@@ -18,7 +18,7 @@ Full directAgentTools map, with the opt-in bashTool appended.
 
 > **getCurrentTime**: `Tool`
 
-Defined in: [types/tools.ts:497](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L497)
+Defined in: [types/tools.ts:520](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L520)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:497](https://github.com/juspay/neurolink/blob/releas
 
 > **calculateMath**: `Tool`
 
-Defined in: [types/tools.ts:498](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L498)
+Defined in: [types/tools.ts:521](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L521)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:498](https://github.com/juspay/neurolink/blob/releas
 
 > **readFile**: `Tool`
 
-Defined in: [types/tools.ts:499](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L499)
+Defined in: [types/tools.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L522)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:499](https://github.com/juspay/neurolink/blob/releas
 
 > **listDirectory**: `Tool`
 
-Defined in: [types/tools.ts:500](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L500)
+Defined in: [types/tools.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L523)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/tools.ts:500](https://github.com/juspay/neurolink/blob/releas
 
 > **writeFile**: `Tool`
 
-Defined in: [types/tools.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L501)
+Defined in: [types/tools.ts:524](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L524)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/tools.ts:501](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **executeBashCommand?**: `Tool`
 
-Defined in: [types/tools.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L502)
+Defined in: [types/tools.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L525)

--- a/docs/api/type-aliases/AvailableTool.md
+++ b/docs/api/type-aliases/AvailableTool.md
@@ -8,7 +8,7 @@
 
 > **AvailableTool** = `object`
 
-Defined in: [types/tools.ts:558](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L558)
+Defined in: [types/tools.ts:581](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L581)
 
 Available tool information
 
@@ -18,7 +18,7 @@ Available tool information
 
 > **name**: `string`
 
-Defined in: [types/tools.ts:559](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L559)
+Defined in: [types/tools.ts:582](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L582)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:559](https://github.com/juspay/neurolink/blob/releas
 
 > **description**: `string`
 
-Defined in: [types/tools.ts:560](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L560)
+Defined in: [types/tools.ts:583](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L583)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:560](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **serverId?**: `string`
 
-Defined in: [types/tools.ts:561](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L561)
+Defined in: [types/tools.ts:584](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L584)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:561](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **toolName?**: `string`
 
-Defined in: [types/tools.ts:562](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L562)
+Defined in: [types/tools.ts:585](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L585)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/tools.ts:562](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **parameters?**: [`ToolParameterSchema`](ToolParameterSchema.md)
 
-Defined in: [types/tools.ts:563](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L563)
+Defined in: [types/tools.ts:586](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L586)

--- a/docs/api/type-aliases/BashToolResult.md
+++ b/docs/api/type-aliases/BashToolResult.md
@@ -8,7 +8,7 @@
 
 > **BashToolResult** = `object`
 
-Defined in: [types/tools.ts:653](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L653)
+Defined in: [types/tools.ts:676](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L676)
 
 Result shape returned by the built-in `bashTool` execute function in
 `src/lib/agent/directTools.ts`. Centralised here per CLAUDE.md rule 2
@@ -21,7 +21,7 @@ local re-shaping of the runtime contract.
 
 > **success**: `boolean`
 
-Defined in: [types/tools.ts:654](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L654)
+Defined in: [types/tools.ts:677](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L677)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [types/tools.ts:654](https://github.com/juspay/neurolink/blob/releas
 
 > **code**: `number`
 
-Defined in: [types/tools.ts:655](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L655)
+Defined in: [types/tools.ts:678](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L678)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [types/tools.ts:655](https://github.com/juspay/neurolink/blob/releas
 
 > **stdout**: `string`
 
-Defined in: [types/tools.ts:656](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L656)
+Defined in: [types/tools.ts:679](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L679)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [types/tools.ts:656](https://github.com/juspay/neurolink/blob/releas
 
 > **stderr**: `string`
 
-Defined in: [types/tools.ts:657](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L657)
+Defined in: [types/tools.ts:680](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L680)
 
 ---
 
@@ -53,4 +53,4 @@ Defined in: [types/tools.ts:657](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tools.ts:658](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L658)
+Defined in: [types/tools.ts:681](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L681)

--- a/docs/api/type-aliases/BasicToolsMap.md
+++ b/docs/api/type-aliases/BasicToolsMap.md
@@ -8,7 +8,7 @@
 
 > **BasicToolsMap** = `object`
 
-Defined in: [types/tools.ts:476](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L476)
+Defined in: [types/tools.ts:499](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L499)
 
 Subset of directAgentTools exposing only the "basic" category.
 
@@ -18,7 +18,7 @@ Subset of directAgentTools exposing only the "basic" category.
 
 > **getCurrentTime**: `Tool`
 
-Defined in: [types/tools.ts:477](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L477)
+Defined in: [types/tools.ts:500](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L500)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/tools.ts:477](https://github.com/juspay/neurolink/blob/releas
 
 > **calculateMath**: `Tool`
 
-Defined in: [types/tools.ts:478](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L478)
+Defined in: [types/tools.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L501)

--- a/docs/api/type-aliases/EnhancedValidationResult.md
+++ b/docs/api/type-aliases/EnhancedValidationResult.md
@@ -8,7 +8,7 @@
 
 > **EnhancedValidationResult** = `object`
 
-Defined in: [types/tools.ts:610](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L610)
+Defined in: [types/tools.ts:633](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L633)
 
 Result of a validation operation
 Contains validation status, errors, warnings, and suggestions for improvement
@@ -19,7 +19,7 @@ Contains validation status, errors, warnings, and suggestions for improvement
 
 > **isValid**: `boolean`
 
-Defined in: [types/tools.ts:612](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L612)
+Defined in: [types/tools.ts:635](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L635)
 
 Whether the validation passed without errors
 
@@ -29,7 +29,7 @@ Whether the validation passed without errors
 
 > **errors**: `ValidationError`[]
 
-Defined in: [types/tools.ts:614](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L614)
+Defined in: [types/tools.ts:637](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L637)
 
 Array of validation errors that must be fixed
 
@@ -39,7 +39,7 @@ Array of validation errors that must be fixed
 
 > **warnings**: `string`[]
 
-Defined in: [types/tools.ts:616](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L616)
+Defined in: [types/tools.ts:639](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L639)
 
 Array of warning messages that should be addressed
 
@@ -49,6 +49,6 @@ Array of warning messages that should be addressed
 
 > **suggestions**: [`StringArray`](StringArray.md)
 
-Defined in: [types/tools.ts:618](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L618)
+Defined in: [types/tools.ts:641](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L641)
 
 Array of suggestions to improve the validated object

--- a/docs/api/type-aliases/FilesystemToolsMap.md
+++ b/docs/api/type-aliases/FilesystemToolsMap.md
@@ -8,7 +8,7 @@
 
 > **FilesystemToolsMap** = `object`
 
-Defined in: [types/tools.ts:482](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L482)
+Defined in: [types/tools.ts:505](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L505)
 
 Subset of directAgentTools exposing only the "filesystem" category.
 
@@ -18,7 +18,7 @@ Subset of directAgentTools exposing only the "filesystem" category.
 
 > **readFile**: `Tool`
 
-Defined in: [types/tools.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L483)
+Defined in: [types/tools.ts:506](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L506)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:483](https://github.com/juspay/neurolink/blob/releas
 
 > **listDirectory**: `Tool`
 
-Defined in: [types/tools.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L484)
+Defined in: [types/tools.ts:507](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L507)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/tools.ts:484](https://github.com/juspay/neurolink/blob/releas
 
 > **writeFile**: `Tool`
 
-Defined in: [types/tools.ts:485](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L485)
+Defined in: [types/tools.ts:508](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L508)

--- a/docs/api/type-aliases/PendingToolExecution.md
+++ b/docs/api/type-aliases/PendingToolExecution.md
@@ -8,7 +8,7 @@
 
 > **PendingToolExecution** = `object`
 
-Defined in: [types/tools.ts:532](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L532)
+Defined in: [types/tools.ts:555](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L555)
 
 Pending tool execution type for Redis memory manager
 Temporary storage for tool execution data to avoid race conditions
@@ -19,7 +19,7 @@ Temporary storage for tool execution data to avoid race conditions
 
 > **toolCalls**: `object`[]
 
-Defined in: [types/tools.ts:533](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L533)
+Defined in: [types/tools.ts:556](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L556)
 
 #### Index Signature
 
@@ -55,7 +55,7 @@ Defined in: [types/tools.ts:533](https://github.com/juspay/neurolink/blob/releas
 
 > **toolResults**: `object`[]
 
-Defined in: [types/tools.ts:542](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L542)
+Defined in: [types/tools.ts:565](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L565)
 
 #### Index Signature
 
@@ -95,4 +95,4 @@ Defined in: [types/tools.ts:542](https://github.com/juspay/neurolink/blob/releas
 
 > **timestamp**: `number`
 
-Defined in: [types/tools.ts:552](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L552)
+Defined in: [types/tools.ts:575](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L575)

--- a/docs/api/type-aliases/SDKToolContext.md
+++ b/docs/api/type-aliases/SDKToolContext.md
@@ -8,7 +8,7 @@
 
 > **SDKToolContext** = [`ToolContext`](ToolContext.md) & `object`
 
-Defined in: [types/tools.ts:268](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L268)
+Defined in: [types/tools.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L291)
 
 SDK-specific tool context with additional fields for SDK usage
 Extends the base ToolContext with session management, provider info, and logging

--- a/docs/api/type-aliases/SdkSimpleTool.md
+++ b/docs/api/type-aliases/SdkSimpleTool.md
@@ -8,7 +8,7 @@
 
 > **SdkSimpleTool**\<`TArgs`, `TResult`\> = `Omit`\<[`SimpleTool`](SimpleTool.md)\<`TArgs`, `TResult`\>, `"execute"`\> & `object`
 
-Defined in: [types/tools.ts:454](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L454)
+Defined in: [types/tools.ts:477](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L477)
 
 Simple tool type accepted by the SDK registerTool() helper. Uses
 SDKToolContext (richer tool context with request metadata).

--- a/docs/api/type-aliases/SimpleTool.md
+++ b/docs/api/type-aliases/SimpleTool.md
@@ -8,7 +8,7 @@
 
 > **SimpleTool**\<`TArgs`, `TResult`\> = `object`
 
-Defined in: [types/tools.ts:443](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L443)
+Defined in: [types/tools.ts:466](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L466)
 
 Simple tool type (for SDK)
 
@@ -28,7 +28,7 @@ Simple tool type (for SDK)
 
 > **description**: `string`
 
-Defined in: [types/tools.ts:444](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L444)
+Defined in: [types/tools.ts:467](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L467)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [types/tools.ts:444](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **parameters?**: [`ZodUnknownSchema`](ZodUnknownSchema.md)
 
-Defined in: [types/tools.ts:445](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L445)
+Defined in: [types/tools.ts:468](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L468)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [types/tools.ts:445](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **metadata?**: [`ToolMetadata`](ToolMetadata.md)
 
-Defined in: [types/tools.ts:446](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L446)
+Defined in: [types/tools.ts:469](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L469)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [types/tools.ts:446](https://github.com/juspay/neurolink/blob/releas
 
 > **execute**: (`params`, `context?`) => `Promise`\<`TResult`\>
 
-Defined in: [types/tools.ts:447](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L447)
+Defined in: [types/tools.ts:470](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L470)
 
 #### Parameters
 

--- a/docs/api/type-aliases/ToolCall.md
+++ b/docs/api/type-aliases/ToolCall.md
@@ -8,7 +8,7 @@
 
 > **ToolCall** = `object`
 
-Defined in: [types/tools.ts:581](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L581)
+Defined in: [types/tools.ts:604](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L604)
 
 Tool call information (for AI SDK integration)
 
@@ -18,7 +18,7 @@ Tool call information (for AI SDK integration)
 
 > **toolName**: `string`
 
-Defined in: [types/tools.ts:582](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L582)
+Defined in: [types/tools.ts:605](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L605)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:582](https://github.com/juspay/neurolink/blob/releas
 
 > **parameters**: [`ToolArgs`](ToolArgs.md)
 
-Defined in: [types/tools.ts:583](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L583)
+Defined in: [types/tools.ts:606](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L606)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/tools.ts:583](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **id?**: `string`
 
-Defined in: [types/tools.ts:584](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L584)
+Defined in: [types/tools.ts:607](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L607)

--- a/docs/api/type-aliases/ToolCallObject.md
+++ b/docs/api/type-aliases/ToolCallObject.md
@@ -8,7 +8,7 @@
 
 > **ToolCallObject** = [`UnknownRecord`](UnknownRecord.md) & `object`
 
-Defined in: [types/tools.ts:349](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L349)
+Defined in: [types/tools.ts:372](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L372)
 
 Tool call object type for type-safe access to tool call properties
 

--- a/docs/api/type-aliases/ToolCallResult.md
+++ b/docs/api/type-aliases/ToolCallResult.md
@@ -8,7 +8,7 @@
 
 > **ToolCallResult** = `object`
 
-Defined in: [types/tools.ts:600](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L600)
+Defined in: [types/tools.ts:623](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L623)
 
 Tool call result (for AI SDK integration)
 
@@ -18,7 +18,7 @@ Tool call result (for AI SDK integration)
 
 > `optional` **id?**: `string`
 
-Defined in: [types/tools.ts:601](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L601)
+Defined in: [types/tools.ts:624](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L624)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:601](https://github.com/juspay/neurolink/blob/releas
 
 > **result**: [`ToolResult`](ToolResult.md)
 
-Defined in: [types/tools.ts:602](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L602)
+Defined in: [types/tools.ts:625](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L625)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/tools.ts:602](https://github.com/juspay/neurolink/blob/releas
 
 > **formattedForAI**: `string`
 
-Defined in: [types/tools.ts:603](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L603)
+Defined in: [types/tools.ts:626](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L626)

--- a/docs/api/type-aliases/ToolContext.md
+++ b/docs/api/type-aliases/ToolContext.md
@@ -8,7 +8,7 @@
 
 > **ToolContext** = `object`
 
-Defined in: [types/tools.ts:257](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L257)
+Defined in: [types/tools.ts:280](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L280)
 
 Tool execution context
 
@@ -18,7 +18,7 @@ Tool execution context
 
 > `optional` **sessionId?**: `string`
 
-Defined in: [types/tools.ts:258](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L258)
+Defined in: [types/tools.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L281)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:258](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/tools.ts:259](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L259)
+Defined in: [types/tools.ts:282](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L282)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:259](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **aiProvider?**: `string`
 
-Defined in: [types/tools.ts:260](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L260)
+Defined in: [types/tools.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L283)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/tools.ts:260](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **metadata?**: [`ToolExecutionMetadata`](ToolExecutionMetadata.md)
 
-Defined in: [types/tools.ts:261](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L261)
+Defined in: [types/tools.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L284)

--- a/docs/api/type-aliases/ToolDefinition.md
+++ b/docs/api/type-aliases/ToolDefinition.md
@@ -8,7 +8,7 @@
 
 > **ToolDefinition**\<`TArgs`, `TResult`\> = `object`
 
-Defined in: [types/tools.ts:430](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L430)
+Defined in: [types/tools.ts:453](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L453)
 
 Tool definition type
 
@@ -28,7 +28,7 @@ Tool definition type
 
 > **description**: `string`
 
-Defined in: [types/tools.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L431)
+Defined in: [types/tools.ts:454](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L454)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [types/tools.ts:431](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **parameters?**: [`ToolParameterSchema`](ToolParameterSchema.md)
 
-Defined in: [types/tools.ts:432](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L432)
+Defined in: [types/tools.ts:455](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L455)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [types/tools.ts:432](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **metadata?**: [`ToolMetadata`](ToolMetadata.md)
 
-Defined in: [types/tools.ts:433](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L433)
+Defined in: [types/tools.ts:456](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L456)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [types/tools.ts:433](https://github.com/juspay/neurolink/blob/releas
 
 > **execute**: (`params`, `context?`) => `Promise`\<[`ToolResult`](ToolResult.md)\<`TResult`\>\> \| [`ToolResult`](ToolResult.md)\<`TResult`\>
 
-Defined in: [types/tools.ts:434](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L434)
+Defined in: [types/tools.ts:457](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L457)
 
 #### Parameters
 

--- a/docs/api/type-aliases/ToolEventPayload.md
+++ b/docs/api/type-aliases/ToolEventPayload.md
@@ -8,7 +8,7 @@
 
 > **ToolEventPayload** = `object`
 
-Defined in: [types/tools.ts:395](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L395)
+Defined in: [types/tools.ts:418](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L418)
 
 Payload emitted for tool:start and tool:end events.
 Always includes both `tool` and `toolName` for backward compatibility.
@@ -19,7 +19,7 @@ Always includes both `tool` and `toolName` for backward compatibility.
 
 > **tool**: `string`
 
-Defined in: [types/tools.ts:396](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L396)
+Defined in: [types/tools.ts:419](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L419)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/tools.ts:396](https://github.com/juspay/neurolink/blob/releas
 
 > **toolName**: `string`
 
-Defined in: [types/tools.ts:397](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L397)
+Defined in: [types/tools.ts:420](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L420)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/tools.ts:397](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **input?**: `unknown`
 
-Defined in: [types/tools.ts:398](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L398)
+Defined in: [types/tools.ts:421](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L421)
 
 ---
 
@@ -43,7 +43,7 @@ Defined in: [types/tools.ts:398](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/tools.ts:399](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L399)
+Defined in: [types/tools.ts:422](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L422)
 
 ---
 
@@ -51,7 +51,7 @@ Defined in: [types/tools.ts:399](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tools.ts:400](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L400)
+Defined in: [types/tools.ts:423](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L423)
 
 ---
 
@@ -59,7 +59,7 @@ Defined in: [types/tools.ts:400](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **success?**: `boolean`
 
-Defined in: [types/tools.ts:401](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L401)
+Defined in: [types/tools.ts:424](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L424)
 
 ---
 
@@ -67,7 +67,7 @@ Defined in: [types/tools.ts:401](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **responseTime?**: `number`
 
-Defined in: [types/tools.ts:402](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L402)
+Defined in: [types/tools.ts:425](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L425)
 
 ---
 
@@ -75,7 +75,7 @@ Defined in: [types/tools.ts:402](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **timestamp?**: `number`
 
-Defined in: [types/tools.ts:403](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L403)
+Defined in: [types/tools.ts:426](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L426)
 
 ---
 
@@ -83,7 +83,7 @@ Defined in: [types/tools.ts:403](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **duration?**: `number`
 
-Defined in: [types/tools.ts:404](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L404)
+Defined in: [types/tools.ts:427](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L427)
 
 ---
 
@@ -91,4 +91,4 @@ Defined in: [types/tools.ts:404](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **executionId?**: `string`
 
-Defined in: [types/tools.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L405)
+Defined in: [types/tools.ts:428](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L428)

--- a/docs/api/type-aliases/ToolExecution.md
+++ b/docs/api/type-aliases/ToolExecution.md
@@ -8,7 +8,7 @@
 
 > **ToolExecution** = `object`
 
-Defined in: [types/tools.ts:520](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L520)
+Defined in: [types/tools.ts:543](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L543)
 
 Tool execution information
 
@@ -18,7 +18,7 @@ Tool execution information
 
 > **toolName**: `string`
 
-Defined in: [types/tools.ts:521](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L521)
+Defined in: [types/tools.ts:544](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L544)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:521](https://github.com/juspay/neurolink/blob/releas
 
 > **params**: [`ToolArgs`](ToolArgs.md)
 
-Defined in: [types/tools.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L522)
+Defined in: [types/tools.ts:545](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L545)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:522](https://github.com/juspay/neurolink/blob/releas
 
 > **result**: [`ToolResult`](ToolResult.md)
 
-Defined in: [types/tools.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L523)
+Defined in: [types/tools.ts:546](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L546)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:523](https://github.com/juspay/neurolink/blob/releas
 
 > **executionTime**: `number`
 
-Defined in: [types/tools.ts:524](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L524)
+Defined in: [types/tools.ts:547](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L547)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/tools.ts:524](https://github.com/juspay/neurolink/blob/releas
 
 > **timestamp**: `number`
 
-Defined in: [types/tools.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L525)
+Defined in: [types/tools.ts:548](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L548)

--- a/docs/api/type-aliases/ToolExecutionContext.md
+++ b/docs/api/type-aliases/ToolExecutionContext.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionContext** = `object`
 
-Defined in: [types/tools.ts:361](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L361)
+Defined in: [types/tools.ts:384](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L384)
 
 Tool execution context for tracking
 
@@ -18,7 +18,7 @@ Tool execution context for tracking
 
 > **executionId**: `string`
 
-Defined in: [types/tools.ts:362](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L362)
+Defined in: [types/tools.ts:385](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L385)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:362](https://github.com/juspay/neurolink/blob/releas
 
 > **tool**: `string`
 
-Defined in: [types/tools.ts:363](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L363)
+Defined in: [types/tools.ts:386](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L386)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:363](https://github.com/juspay/neurolink/blob/releas
 
 > **startTime**: `number`
 
-Defined in: [types/tools.ts:364](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L364)
+Defined in: [types/tools.ts:387](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L387)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:364](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **endTime?**: `number`
 
-Defined in: [types/tools.ts:365](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L365)
+Defined in: [types/tools.ts:388](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L388)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/tools.ts:365](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/tools.ts:366](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L366)
+Defined in: [types/tools.ts:389](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L389)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/tools.ts:366](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tools.ts:367](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L367)
+Defined in: [types/tools.ts:390](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L390)
 
 ---
 
@@ -66,4 +66,4 @@ Defined in: [types/tools.ts:367](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **metadata?**: [`JsonObject`](JsonObject.md)
 
-Defined in: [types/tools.ts:368](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L368)
+Defined in: [types/tools.ts:391](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L391)

--- a/docs/api/type-aliases/ToolExecutionEvent.md
+++ b/docs/api/type-aliases/ToolExecutionEvent.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionEvent** = `object`
 
-Defined in: [types/tools.ts:378](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L378)
+Defined in: [types/tools.ts:401](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L401)
 
 Tool execution event for real-time streaming
 
@@ -18,7 +18,7 @@ Tool execution event for real-time streaming
 
 > **type**: `"tool:start"` \| `"tool:end"`
 
-Defined in: [types/tools.ts:379](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L379)
+Defined in: [types/tools.ts:402](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L402)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:379](https://github.com/juspay/neurolink/blob/releas
 
 > **tool**: `string`
 
-Defined in: [types/tools.ts:380](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L380)
+Defined in: [types/tools.ts:403](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L403)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:380](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **toolName?**: `string`
 
-Defined in: [types/tools.ts:382](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L382)
+Defined in: [types/tools.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L405)
 
 Compatibility alias for older consumers that expect `toolName`.
 
@@ -44,7 +44,7 @@ Compatibility alias for older consumers that expect `toolName`.
 
 > `optional` **input?**: `unknown`
 
-Defined in: [types/tools.ts:383](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L383)
+Defined in: [types/tools.ts:406](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L406)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [types/tools.ts:383](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/tools.ts:384](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L384)
+Defined in: [types/tools.ts:407](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L407)
 
 ---
 
@@ -60,7 +60,7 @@ Defined in: [types/tools.ts:384](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tools.ts:385](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L385)
+Defined in: [types/tools.ts:408](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L408)
 
 ---
 
@@ -68,7 +68,7 @@ Defined in: [types/tools.ts:385](https://github.com/juspay/neurolink/blob/releas
 
 > **timestamp**: `number`
 
-Defined in: [types/tools.ts:386](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L386)
+Defined in: [types/tools.ts:409](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L409)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [types/tools.ts:386](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **duration?**: `number`
 
-Defined in: [types/tools.ts:387](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L387)
+Defined in: [types/tools.ts:410](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L410)
 
 ---
 
@@ -84,4 +84,4 @@ Defined in: [types/tools.ts:387](https://github.com/juspay/neurolink/blob/releas
 
 > **executionId**: `string`
 
-Defined in: [types/tools.ts:388](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L388)
+Defined in: [types/tools.ts:411](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L411)

--- a/docs/api/type-aliases/ToolExecutionMetadata.md
+++ b/docs/api/type-aliases/ToolExecutionMetadata.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionMetadata** = `object`
 
-Defined in: [types/tools.ts:247](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L247)
+Defined in: [types/tools.ts:270](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L270)
 
 Tool execution metadata
 
@@ -22,7 +22,7 @@ Tool execution metadata
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/tools.ts:248](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L248)
+Defined in: [types/tools.ts:271](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L271)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/tools.ts:248](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **startTime?**: `number`
 
-Defined in: [types/tools.ts:249](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L249)
+Defined in: [types/tools.ts:272](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L272)
 
 ---
 
@@ -38,4 +38,4 @@ Defined in: [types/tools.ts:249](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **version?**: `string`
 
-Defined in: [types/tools.ts:250](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L250)
+Defined in: [types/tools.ts:273](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L273)

--- a/docs/api/type-aliases/ToolExecutionOptions.md
+++ b/docs/api/type-aliases/ToolExecutionOptions.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionOptions** = `object`
 
-Defined in: [types/tools.ts:157](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L157)
+Defined in: [types/tools.ts:170](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L170)
 
 Tool execution options for enhanced control
 Extracted from toolRegistry.ts for centralized type management
@@ -19,7 +19,7 @@ Extracted from toolRegistry.ts for centralized type management
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/tools.ts:163](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L163)
+Defined in: [types/tools.ts:176](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L176)
 
 Caller-specified execution timeout in milliseconds.
 Used by executeTool() callers to override the default timeout for a
@@ -31,7 +31,7 @@ single invocation. Takes precedence over `timeoutMs` when both are set.
 
 > `optional` **retries?**: `number`
 
-Defined in: [types/tools.ts:164](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L164)
+Defined in: [types/tools.ts:177](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L177)
 
 ---
 
@@ -39,7 +39,7 @@ Defined in: [types/tools.ts:164](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **context?**: `unknown`
 
-Defined in: [types/tools.ts:165](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L165)
+Defined in: [types/tools.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L178)
 
 ---
 
@@ -47,7 +47,7 @@ Defined in: [types/tools.ts:165](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **preferredSource?**: `string`
 
-Defined in: [types/tools.ts:166](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L166)
+Defined in: [types/tools.ts:179](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L179)
 
 ---
 
@@ -55,7 +55,7 @@ Defined in: [types/tools.ts:166](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **fallbackEnabled?**: `boolean`
 
-Defined in: [types/tools.ts:167](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L167)
+Defined in: [types/tools.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L180)
 
 ---
 
@@ -63,7 +63,7 @@ Defined in: [types/tools.ts:167](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **validateBeforeExecution?**: `boolean`
 
-Defined in: [types/tools.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L168)
+Defined in: [types/tools.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L181)
 
 ---
 
@@ -71,7 +71,7 @@ Defined in: [types/tools.ts:168](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [types/tools.ts:177](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L177)
+Defined in: [types/tools.ts:190](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L190)
 
 Per-tool timeout in milliseconds, copied from ToolInfo at registration
 time. Acts as the tool-level default; overridden by `timeout` when the
@@ -89,4 +89,17 @@ may be consolidated in a future release.
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/tools.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L178)
+Defined in: [types/tools.ts:191](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L191)
+
+---
+
+### totalTimeoutMs?
+
+> `optional` **totalTimeoutMs?**: `number`
+
+Defined in: [types/tools.ts:198](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L198)
+
+Ceiling on the WHOLE execution — every attempt plus the delays between
+them. `timeout` bounds one attempt. Defaults to
+`timeout * (maxRetries + 1)`, which is what the retry loop already spent,
+so supplying nothing changes nothing.

--- a/docs/api/type-aliases/ToolExecutionResult.md
+++ b/docs/api/type-aliases/ToolExecutionResult.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionResult**\<`T`\> = `object`
 
-Defined in: [types/tools.ts:220](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L220)
+Defined in: [types/tools.ts:243](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L243)
 
 Tool execution result
 Moved from src/lib/mcp/contracts/mcpContract.ts
@@ -25,7 +25,7 @@ Moved from src/lib/mcp/contracts/mcpContract.ts
 
 > **result**: `T`
 
-Defined in: [types/tools.ts:221](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L221)
+Defined in: [types/tools.ts:244](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L244)
 
 ---
 
@@ -33,7 +33,7 @@ Defined in: [types/tools.ts:221](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **context?**: [`ExecutionContext`](ExecutionContext.md)
 
-Defined in: [types/tools.ts:222](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L222)
+Defined in: [types/tools.ts:245](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L245)
 
 ---
 
@@ -41,7 +41,7 @@ Defined in: [types/tools.ts:222](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **performance?**: `object`
 
-Defined in: [types/tools.ts:223](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L223)
+Defined in: [types/tools.ts:246](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L246)
 
 #### duration
 
@@ -61,7 +61,7 @@ Defined in: [types/tools.ts:223](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **validation?**: [`ValidationResult`](ValidationResult.md)
 
-Defined in: [types/tools.ts:228](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L228)
+Defined in: [types/tools.ts:251](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L251)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [types/tools.ts:228](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **cached?**: `boolean`
 
-Defined in: [types/tools.ts:229](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L229)
+Defined in: [types/tools.ts:252](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L252)
 
 ---
 
@@ -77,4 +77,4 @@ Defined in: [types/tools.ts:229](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **fallback?**: `boolean`
 
-Defined in: [types/tools.ts:230](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L230)
+Defined in: [types/tools.ts:253](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L253)

--- a/docs/api/type-aliases/ToolExecutionSummary.md
+++ b/docs/api/type-aliases/ToolExecutionSummary.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionSummary** = `object`
 
-Defined in: [types/tools.ts:411](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L411)
+Defined in: [types/tools.ts:434](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L434)
 
 Tool execution summary for completed executions
 
@@ -18,7 +18,7 @@ Tool execution summary for completed executions
 
 > **tool**: `string`
 
-Defined in: [types/tools.ts:412](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L412)
+Defined in: [types/tools.ts:435](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L435)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:412](https://github.com/juspay/neurolink/blob/releas
 
 > **startTime**: `number`
 
-Defined in: [types/tools.ts:413](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L413)
+Defined in: [types/tools.ts:436](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L436)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:413](https://github.com/juspay/neurolink/blob/releas
 
 > **endTime**: `number`
 
-Defined in: [types/tools.ts:414](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L414)
+Defined in: [types/tools.ts:437](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L437)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:414](https://github.com/juspay/neurolink/blob/releas
 
 > **duration**: `number`
 
-Defined in: [types/tools.ts:415](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L415)
+Defined in: [types/tools.ts:438](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L438)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/tools.ts:415](https://github.com/juspay/neurolink/blob/releas
 
 > **success**: `boolean`
 
-Defined in: [types/tools.ts:416](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L416)
+Defined in: [types/tools.ts:439](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L439)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/tools.ts:416](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **result?**: `unknown`
 
-Defined in: [types/tools.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L417)
+Defined in: [types/tools.ts:440](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L440)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/tools.ts:417](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **error?**: `string`
 
-Defined in: [types/tools.ts:418](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L418)
+Defined in: [types/tools.ts:441](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L441)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/tools.ts:418](https://github.com/juspay/neurolink/blob/releas
 
 > **executionId**: `string`
 
-Defined in: [types/tools.ts:419](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L419)
+Defined in: [types/tools.ts:442](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L442)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/tools.ts:419](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **metadata?**: `object`
 
-Defined in: [types/tools.ts:420](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L420)
+Defined in: [types/tools.ts:443](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L443)
 
 #### serverId?
 

--- a/docs/api/type-aliases/ToolImplementation.md
+++ b/docs/api/type-aliases/ToolImplementation.md
@@ -8,7 +8,7 @@
 
 > **ToolImplementation** = `object`
 
-Defined in: [types/tools.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L138)
+Defined in: [types/tools.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L144)
 
 Tool Implementation type for MCP tool registry
 Extracted from toolRegistry.ts for centralized type management
@@ -19,7 +19,7 @@ Extracted from toolRegistry.ts for centralized type management
 
 > **execute**: (`params`, `context?`) => `Promise`\<`unknown`\> \| `unknown`
 
-Defined in: [types/tools.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L139)
+Defined in: [types/tools.ts:145](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L145)
 
 #### Parameters
 
@@ -41,7 +41,7 @@ Defined in: [types/tools.ts:139](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **description?**: `string`
 
-Defined in: [types/tools.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L143)
+Defined in: [types/tools.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L149)
 
 ---
 
@@ -49,7 +49,7 @@ Defined in: [types/tools.ts:143](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **inputSchema?**: `unknown`
 
-Defined in: [types/tools.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L144)
+Defined in: [types/tools.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L150)
 
 ---
 
@@ -57,7 +57,7 @@ Defined in: [types/tools.ts:144](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **outputSchema?**: `unknown`
 
-Defined in: [types/tools.ts:145](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L145)
+Defined in: [types/tools.ts:151](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L151)
 
 ---
 
@@ -65,7 +65,7 @@ Defined in: [types/tools.ts:145](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **category?**: `string`
 
-Defined in: [types/tools.ts:146](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L146)
+Defined in: [types/tools.ts:152](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L152)
 
 ---
 
@@ -73,7 +73,7 @@ Defined in: [types/tools.ts:146](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **permissions?**: `string`[]
 
-Defined in: [types/tools.ts:147](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L147)
+Defined in: [types/tools.ts:153](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L153)
 
 ---
 
@@ -81,7 +81,7 @@ Defined in: [types/tools.ts:147](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [types/tools.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L149)
+Defined in: [types/tools.ts:155](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L155)
 
 Per-tool timeout in milliseconds, set at registration time
 
@@ -91,4 +91,17 @@ Per-tool timeout in milliseconds, set at registration time
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/tools.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L150)
+Defined in: [types/tools.ts:156](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L156)
+
+---
+
+### totalTimeoutMs?
+
+> `optional` **totalTimeoutMs?**: `number`
+
+Defined in: [types/tools.ts:163](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L163)
+
+Ceiling on the WHOLE execution — every attempt plus the delays between
+them — in milliseconds. `timeoutMs` bounds one attempt; without this, a
+tool that reliably hangs burns `timeoutMs * (maxRetries + 1)`.
+Defaults to exactly that product, so behaviour is unchanged unless set.

--- a/docs/api/type-aliases/ToolInfo.md
+++ b/docs/api/type-aliases/ToolInfo.md
@@ -92,3 +92,15 @@ Per-tool timeout in milliseconds, set at registration time
 > `optional` **maxRetries?**: `number`
 
 Defined in: [types/tools.ts:130](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L130)
+
+---
+
+### totalTimeoutMs?
+
+> `optional` **totalTimeoutMs?**: `number`
+
+Defined in: [types/tools.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L136)
+
+Ceiling on the WHOLE execution — every attempt plus the delays between
+them. Declared explicitly rather than left to the index signature below,
+which would type it `unknown` and silently defeat the default.

--- a/docs/api/type-aliases/ToolMetadata.md
+++ b/docs/api/type-aliases/ToolMetadata.md
@@ -8,7 +8,7 @@
 
 > **ToolMetadata** = `object`
 
-Defined in: [types/tools.ts:337](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L337)
+Defined in: [types/tools.ts:360](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L360)
 
 Tool metadata for registration
 
@@ -22,7 +22,7 @@ Tool metadata for registration
 
 > `optional` **category?**: `string`
 
-Defined in: [types/tools.ts:338](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L338)
+Defined in: [types/tools.ts:361](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L361)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/tools.ts:338](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **version?**: `string`
 
-Defined in: [types/tools.ts:339](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L339)
+Defined in: [types/tools.ts:362](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L362)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/tools.ts:339](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **author?**: `string`
 
-Defined in: [types/tools.ts:340](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L340)
+Defined in: [types/tools.ts:363](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L363)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/tools.ts:340](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **tags?**: `string`[]
 
-Defined in: [types/tools.ts:341](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L341)
+Defined in: [types/tools.ts:364](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L364)
 
 ---
 
@@ -54,4 +54,4 @@ Defined in: [types/tools.ts:341](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **documentation?**: `string`
 
-Defined in: [types/tools.ts:342](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L342)
+Defined in: [types/tools.ts:365](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L365)

--- a/docs/api/type-aliases/ToolRegistrationOptions.md
+++ b/docs/api/type-aliases/ToolRegistrationOptions.md
@@ -8,7 +8,7 @@
 
 > **ToolRegistrationOptions** = `object`
 
-Defined in: [types/tools.ts:195](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L195)
+Defined in: [types/tools.ts:215](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L215)
 
 Options for tool registration via registerTool()
 
@@ -32,7 +32,7 @@ sdk.registerTool("myTool", tool);
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/tools.ts:198](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L198)
+Defined in: [types/tools.ts:218](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L218)
 
 Per-tool execution timeout in milliseconds. Only applied when explicitly set.
 When omitted, the SDK's global default (30s) is used.
@@ -43,7 +43,7 @@ When omitted, the SDK's global default (30s) is used.
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/tools.ts:202](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L202)
+Defined in: [types/tools.ts:222](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L222)
 
 Maximum retry attempts on failure. Only applied when explicitly set.
 When omitted, the SDK's global default (2 retries) is used.
@@ -51,11 +51,22 @@ Set to 0 to disable retries for this tool.
 
 ---
 
+### totalTimeoutMs?
+
+> `optional` **totalTimeoutMs?**: `number`
+
+Defined in: [types/tools.ts:225](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L225)
+
+Ceiling on the whole execution across every attempt and the delays
+between them. When omitted, `timeout * (maxRetries + 1)` is used.
+
+---
+
 ### cacheable?
 
 > `optional` **cacheable?**: `boolean`
 
-Defined in: [types/tools.ts:213](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L213)
+Defined in: [types/tools.ts:236](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L236)
 
 Whether this tool's result may be served from the tool-result cache
 (default true).

--- a/docs/api/type-aliases/ToolRegistryEntry.md
+++ b/docs/api/type-aliases/ToolRegistryEntry.md
@@ -8,7 +8,7 @@
 
 > **ToolRegistryEntry** = `object`
 
-Defined in: [types/tools.ts:508](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L508)
+Defined in: [types/tools.ts:531](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L531)
 
 Tool registry entry
 
@@ -18,7 +18,7 @@ Tool registry entry
 
 > **name**: `string`
 
-Defined in: [types/tools.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L509)
+Defined in: [types/tools.ts:532](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L532)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:509](https://github.com/juspay/neurolink/blob/releas
 
 > **description**: `string`
 
-Defined in: [types/tools.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L510)
+Defined in: [types/tools.ts:533](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L533)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/tools.ts:510](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **serverId?**: `string`
 
-Defined in: [types/tools.ts:511](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L511)
+Defined in: [types/tools.ts:534](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L534)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/tools.ts:511](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **isImplemented?**: `boolean`
 
-Defined in: [types/tools.ts:512](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L512)
+Defined in: [types/tools.ts:535](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L535)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/tools.ts:512](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **parameters?**: [`ToolParameterSchema`](ToolParameterSchema.md)
 
-Defined in: [types/tools.ts:513](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L513)
+Defined in: [types/tools.ts:536](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L536)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/tools.ts:513](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **execute?**: [`ToolDefinition`](ToolDefinition.md)\[`"execute"`\]
 
-Defined in: [types/tools.ts:514](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L514)
+Defined in: [types/tools.ts:537](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L537)

--- a/docs/api/type-aliases/ToolResult.md
+++ b/docs/api/type-aliases/ToolResult.md
@@ -8,7 +8,7 @@
 
 > **ToolResult**\<`T`\> = [`Result`](Result.md)\<`T`, [`ErrorInfo`](ErrorInfo.md) \| `string`\> & `object`
 
-Defined in: [types/tools.ts:323](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L323)
+Defined in: [types/tools.ts:346](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L346)
 
 Tool execution result
 

--- a/docs/api/type-aliases/ToolResultMetadata.md
+++ b/docs/api/type-aliases/ToolResultMetadata.md
@@ -8,7 +8,7 @@
 
 > **ToolResultMetadata** = `object`
 
-Defined in: [types/tools.ts:298](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L298)
+Defined in: [types/tools.ts:321](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L321)
 
 Tool execution result metadata
 
@@ -22,7 +22,7 @@ Tool execution result metadata
 
 > `optional` **toolName?**: `string`
 
-Defined in: [types/tools.ts:299](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L299)
+Defined in: [types/tools.ts:322](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L322)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/tools.ts:299](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **executionTime?**: `number`
 
-Defined in: [types/tools.ts:300](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L300)
+Defined in: [types/tools.ts:323](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L323)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [types/tools.ts:300](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **timestamp?**: `number`
 
-Defined in: [types/tools.ts:301](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L301)
+Defined in: [types/tools.ts:324](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L324)
 
 ---
 
@@ -46,7 +46,7 @@ Defined in: [types/tools.ts:301](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **source?**: `string`
 
-Defined in: [types/tools.ts:302](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L302)
+Defined in: [types/tools.ts:325](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L325)
 
 ---
 
@@ -54,7 +54,7 @@ Defined in: [types/tools.ts:302](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **version?**: `string`
 
-Defined in: [types/tools.ts:303](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L303)
+Defined in: [types/tools.ts:326](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L326)
 
 ---
 
@@ -62,7 +62,7 @@ Defined in: [types/tools.ts:303](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **serverId?**: `string`
 
-Defined in: [types/tools.ts:304](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L304)
+Defined in: [types/tools.ts:327](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L327)
 
 ---
 
@@ -70,7 +70,7 @@ Defined in: [types/tools.ts:304](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **sessionId?**: `string`
 
-Defined in: [types/tools.ts:305](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L305)
+Defined in: [types/tools.ts:328](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L328)
 
 ---
 
@@ -78,4 +78,4 @@ Defined in: [types/tools.ts:305](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **blocked?**: `boolean`
 
-Defined in: [types/tools.ts:306](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L306)
+Defined in: [types/tools.ts:329](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L329)

--- a/docs/api/type-aliases/ToolResultUsage.md
+++ b/docs/api/type-aliases/ToolResultUsage.md
@@ -8,7 +8,7 @@
 
 > **ToolResultUsage** = `object`
 
-Defined in: [types/tools.ts:313](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L313)
+Defined in: [types/tools.ts:336](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L336)
 
 Tool result usage information
 
@@ -22,7 +22,7 @@ Tool result usage information
 
 > `optional` **executionTime?**: `number`
 
-Defined in: [types/tools.ts:314](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L314)
+Defined in: [types/tools.ts:337](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L337)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [types/tools.ts:314](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **tokensUsed?**: `number`
 
-Defined in: [types/tools.ts:315](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L315)
+Defined in: [types/tools.ts:338](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L338)
 
 ---
 
@@ -38,4 +38,4 @@ Defined in: [types/tools.ts:315](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **cost?**: `number`
 
-Defined in: [types/tools.ts:316](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L316)
+Defined in: [types/tools.ts:339](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L339)

--- a/docs/api/type-aliases/ToolValidationOptions.md
+++ b/docs/api/type-aliases/ToolValidationOptions.md
@@ -8,7 +8,7 @@
 
 > **ToolValidationOptions** = `object`
 
-Defined in: [types/tools.ts:569](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L569)
+Defined in: [types/tools.ts:592](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L592)
 
 Tool validation options
 
@@ -18,7 +18,7 @@ Tool validation options
 
 > `optional` **customValidator?**: (`toolName`, `params`) => `boolean` \| `Promise`\<`boolean`\>
 
-Defined in: [types/tools.ts:570](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L570)
+Defined in: [types/tools.ts:593](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L593)
 
 #### Parameters
 
@@ -40,7 +40,7 @@ Defined in: [types/tools.ts:570](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **validateSchema?**: `boolean`
 
-Defined in: [types/tools.ts:574](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L574)
+Defined in: [types/tools.ts:597](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L597)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/tools.ts:574](https://github.com/juspay/neurolink/blob/releas
 
 > `optional` **allowUnknownProperties?**: `boolean`
 
-Defined in: [types/tools.ts:575](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L575)
+Defined in: [types/tools.ts:598](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L598)

--- a/docs/api/type-aliases/UtilityToolsMap.md
+++ b/docs/api/type-aliases/UtilityToolsMap.md
@@ -8,7 +8,7 @@
 
 > **UtilityToolsMap** = `object`
 
-Defined in: [types/tools.ts:489](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L489)
+Defined in: [types/tools.ts:512](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L512)
 
 Subset of directAgentTools exposing the "utility" category.
 
@@ -18,7 +18,7 @@ Subset of directAgentTools exposing the "utility" category.
 
 > **getCurrentTime**: `Tool`
 
-Defined in: [types/tools.ts:490](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L490)
+Defined in: [types/tools.ts:513](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L513)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/tools.ts:490](https://github.com/juspay/neurolink/blob/releas
 
 > **calculateMath**: `Tool`
 
-Defined in: [types/tools.ts:491](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L491)
+Defined in: [types/tools.ts:514](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L514)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/tools.ts:491](https://github.com/juspay/neurolink/blob/releas
 
 > **listDirectory**: `Tool`
 
-Defined in: [types/tools.ts:492](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L492)
+Defined in: [types/tools.ts:515](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L515)

--- a/docs/api/type-aliases/ValidationResult.md
+++ b/docs/api/type-aliases/ValidationResult.md
@@ -8,7 +8,7 @@
 
 > **ValidationResult** = `object`
 
-Defined in: [types/tools.ts:237](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L237)
+Defined in: [types/tools.ts:260](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L260)
 
 Validation result for runtime checks
 Moved from src/lib/mcp/contracts/mcpContract.ts
@@ -19,7 +19,7 @@ Moved from src/lib/mcp/contracts/mcpContract.ts
 
 > **valid**: `boolean`
 
-Defined in: [types/tools.ts:238](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L238)
+Defined in: [types/tools.ts:261](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L261)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/tools.ts:238](https://github.com/juspay/neurolink/blob/releas
 
 > **missing**: `string`[]
 
-Defined in: [types/tools.ts:239](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L239)
+Defined in: [types/tools.ts:262](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L262)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/tools.ts:239](https://github.com/juspay/neurolink/blob/releas
 
 > **warnings**: `string`[]
 
-Defined in: [types/tools.ts:240](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L240)
+Defined in: [types/tools.ts:263](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L263)
 
 ---
 
@@ -43,4 +43,4 @@ Defined in: [types/tools.ts:240](https://github.com/juspay/neurolink/blob/releas
 
 > **recommendations**: `string`[]
 
-Defined in: [types/tools.ts:241](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L241)
+Defined in: [types/tools.ts:264](https://github.com/juspay/neurolink/blob/release/src/lib/types/tools.ts#L264)

--- a/src/lib/mcp/toolRegistry.ts
+++ b/src/lib/mcp/toolRegistry.ts
@@ -232,6 +232,9 @@ export class MCPToolRegistry extends MCPRegistry {
       const toolMaxRetries = serverInfo.metadata?.toolMaxRetries as
         | number
         | undefined;
+      const toolTotalTimeoutMs = serverInfo.metadata?.toolTotalTimeoutMs as
+        | number
+        | undefined;
       const toolInfo = {
         name: tool.name,
         description: tool.description,
@@ -245,6 +248,9 @@ export class MCPToolRegistry extends MCPRegistry {
         permissions: [], // MCPServerInfo.tools doesn't have permissions
         ...(toolTimeoutMs !== undefined && { timeoutMs: toolTimeoutMs }),
         ...(toolMaxRetries !== undefined && { maxRetries: toolMaxRetries }),
+        ...(toolTotalTimeoutMs !== undefined && {
+          totalTimeoutMs: toolTotalTimeoutMs,
+        }),
       };
 
       // Register only with fully-qualified toolId to avoid collisions
@@ -265,6 +271,9 @@ export class MCPToolRegistry extends MCPRegistry {
         }),
         ...(toolTimeoutMs !== undefined && { timeoutMs: toolTimeoutMs }),
         ...(toolMaxRetries !== undefined && { maxRetries: toolMaxRetries }),
+        ...(toolTotalTimeoutMs !== undefined && {
+          totalTimeoutMs: toolTotalTimeoutMs,
+        }),
       });
 
       // Tool registered successfully

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -12884,6 +12884,7 @@ Current user's request: ${currentInput}`;
         convertedTool,
         options?.timeout,
         options?.maxRetries,
+        options?.totalTimeoutMs,
       );
 
       // Register with toolRegistry using MCPServerInfo directly
@@ -13323,8 +13324,15 @@ Current user's request: ${currentInput}`;
     toolName: string,
     params: unknown = {},
     options?: {
+      /** Bound on ONE attempt. */
       timeout?: number;
       maxRetries?: number;
+      /**
+       * Bound on the WHOLE execution — every attempt plus the delays between
+       * them. Defaults to `timeout * (maxRetries + 1)`, which is what the
+       * retry loop already spent, so omitting it changes nothing.
+       */
+      totalTimeoutMs?: number;
       retryDelayMs?: number;
       /** Disable tool result caching for this call */
       disableToolCache?: boolean;
@@ -13494,6 +13502,8 @@ Current user's request: ${currentInput}`;
       | {
           timeout?: number;
           maxRetries?: number;
+          /** Ceiling on the whole execution across every attempt. */
+          totalTimeoutMs?: number;
           retryDelayMs?: number;
           disableToolCache?: boolean;
           bypassBatcher?: boolean;
@@ -13510,6 +13520,7 @@ Current user's request: ${currentInput}`;
     finalOptions: {
       timeout: number;
       maxRetries: number;
+      totalTimeout: number;
       retryDelayMs: number;
       authContext:
         | {
@@ -13582,16 +13593,35 @@ Current user's request: ${currentInput}`;
     );
 
     const toolInfo = this.toolRegistry.getToolInfo(toolName);
+    const attemptTimeout =
+      options?.timeout ??
+      toolInfo?.tool?.timeoutMs ??
+      TOOL_TIMEOUTS.EXECUTION_BATCH_MS;
+    const maxRetries =
+      options?.maxRetries ??
+      toolInfo?.tool?.maxRetries ??
+      RETRY_ATTEMPTS.DEFAULT;
+    const retryDelayMs = options?.retryDelayMs || RETRY_DELAYS.BASE_MS;
     const finalOptions = {
-      timeout:
-        options?.timeout ??
-        toolInfo?.tool?.timeoutMs ??
-        TOOL_TIMEOUTS.EXECUTION_BATCH_MS,
-      maxRetries:
-        options?.maxRetries ??
-        toolInfo?.tool?.maxRetries ??
-        RETRY_ATTEMPTS.DEFAULT,
-      retryDelayMs: options?.retryDelayMs || RETRY_DELAYS.BASE_MS,
+      timeout: attemptTimeout,
+      maxRetries,
+      // Ceiling on the whole execution, not one attempt. The default is what
+      // the retry loop already spent, and that is BOTH terms: every attempt at
+      // full length PLUS the fixed wait between them. Omitting the delays
+      // makes the default ceiling shorter than the envelope it is meant to
+      // reproduce, so `attemptTimeout = min(timeout, remaining)` clamps a
+      // later attempt below its configured timeout — the opposite of the
+      // "unchanged unless you ask for less" contract this default exists to
+      // keep. Before any of this the total was unbounded and merely implied:
+      // a tool that reliably hung burned every attempt at full length, and
+      // the surfaced error reported the per-attempt bound beside the
+      // whole-execution elapsed time, which reads as a timeout that was never
+      // enforced.
+      totalTimeout:
+        options?.totalTimeoutMs ??
+        toolInfo?.tool?.totalTimeoutMs ??
+        attemptTimeout * (maxRetries + 1) + retryDelayMs * maxRetries,
+      retryDelayMs,
       authContext: options?.authContext,
       disableToolCache: options?.disableToolCache,
     };
@@ -13654,23 +13684,63 @@ Current user's request: ${currentInput}`;
           circuitBreakerState: prepared.circuitBreaker.getState(),
         },
       );
+      const maxAttempts = prepared.finalOptions.maxRetries + 1;
+      const totalTimeout = prepared.finalOptions.totalTimeout;
+      const budgetStart = Date.now();
+      const deadline = budgetStart + totalTimeout;
+      let attemptNumber = 0;
       const result: T = await prepared.circuitBreaker.execute(async () => {
         return withRetry(
-          async () =>
-            withTimeout(
+          async () => {
+            attemptNumber++;
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+              throw ErrorFactory.toolTimeout(
+                toolName,
+                totalTimeout,
+                undefined,
+                {
+                  attempt: attemptNumber,
+                  maxAttempts,
+                  attemptTimeoutMs: prepared.finalOptions.timeout,
+                  totalTimeoutMs: totalTimeout,
+                  elapsedMs: Date.now() - budgetStart,
+                  exhausted: true,
+                },
+              );
+            }
+            // Clamping to what is left is what makes the ceiling hard. Gating
+            // retries alone would not: the last attempt could start just under
+            // the deadline and still run a full attempt timeout past it.
+            const attemptTimeout = Math.min(
+              prepared.finalOptions.timeout,
+              remaining,
+            );
+            return withTimeout(
               this.executeToolInternal<T>(
                 toolName,
                 params,
                 prepared.finalOptions,
                 executionContext.hitlState,
               ),
-              prepared.finalOptions.timeout,
-              ErrorFactory.toolTimeout(toolName, prepared.finalOptions.timeout),
-            ),
+              attemptTimeout,
+              ErrorFactory.toolTimeout(toolName, attemptTimeout, undefined, {
+                attempt: attemptNumber,
+                maxAttempts,
+                attemptTimeoutMs: prepared.finalOptions.timeout,
+                totalTimeoutMs: totalTimeout,
+                elapsedMs: Date.now() - budgetStart,
+              }),
+            );
+          },
           {
-            maxAttempts: prepared.finalOptions.maxRetries + 1,
+            maxAttempts,
             delayMs: prepared.finalOptions.retryDelayMs,
-            isRetriable: isRetriableError,
+            // Stop when there is not enough budget left for the retry delay
+            // plus any real work after it.
+            isRetriable: (error: Error) =>
+              Date.now() + prepared.finalOptions.retryDelayMs < deadline &&
+              isRetriableError(error),
             onRetry: (attempt, error) => {
               toolRetryCount = attempt;
               mcpLogger.warn(

--- a/src/lib/types/tools.ts
+++ b/src/lib/types/tools.ts
@@ -128,6 +128,12 @@ export type ToolInfo = {
   /** Per-tool timeout in milliseconds, set at registration time */
   timeoutMs?: number;
   maxRetries?: number;
+  /**
+   * Ceiling on the WHOLE execution — every attempt plus the delays between
+   * them. Declared explicitly rather than left to the index signature below,
+   * which would type it `unknown` and silently defeat the default.
+   */
+  totalTimeoutMs?: number;
   [key: string]: unknown; // Generic extensibility
 };
 
@@ -148,6 +154,13 @@ export type ToolImplementation = {
   /** Per-tool timeout in milliseconds, set at registration time */
   timeoutMs?: number;
   maxRetries?: number;
+  /**
+   * Ceiling on the WHOLE execution — every attempt plus the delays between
+   * them — in milliseconds. `timeoutMs` bounds one attempt; without this, a
+   * tool that reliably hangs burns `timeoutMs * (maxRetries + 1)`.
+   * Defaults to exactly that product, so behaviour is unchanged unless set.
+   */
+  totalTimeoutMs?: number;
 };
 
 /**
@@ -176,6 +189,13 @@ export type ToolExecutionOptions = {
    */
   timeoutMs?: number;
   maxRetries?: number;
+  /**
+   * Ceiling on the WHOLE execution — every attempt plus the delays between
+   * them. `timeout` bounds one attempt. Defaults to
+   * `timeout * (maxRetries + 1)`, which is what the retry loop already spent,
+   * so supplying nothing changes nothing.
+   */
+  totalTimeoutMs?: number;
 };
 
 /**
@@ -200,6 +220,9 @@ export type ToolRegistrationOptions = {
    *  When omitted, the SDK's global default (2 retries) is used.
    *  Set to 0 to disable retries for this tool. */
   maxRetries?: number;
+  /** Ceiling on the whole execution across every attempt and the delays
+   *  between them. When omitted, `timeout * (maxRetries + 1)` is used. */
+  totalTimeoutMs?: number;
   /**
    * Whether this tool's result may be served from the tool-result cache
    * (default true).

--- a/src/lib/utils/errorHandling.ts
+++ b/src/lib/utils/errorHandling.ts
@@ -204,20 +204,45 @@ export class ErrorFactory {
   }
 
   /**
-   * Create a tool timeout error
+   * Create a tool timeout error.
+   *
+   * `timeoutMs` is the bound that was actually exceeded. Pass `budget` when
+   * the timeout happened inside a retry loop, so the error can say which
+   * number it is reporting: a reader who sees `timeoutMs: 120000` next to an
+   * `executionTime` of 483005 will otherwise conclude the timeout was never
+   * enforced, when in fact four attempts of 120s each were.
+   *
+   * `budget.exhausted` marks the case where the whole-execution ceiling ran
+   * out rather than a single attempt overrunning; that error is NOT retriable,
+   * because there is no budget left to retry into.
    */
   static toolTimeout(
     toolName: string,
     timeoutMs: number,
     serverId?: string,
+    budget?: {
+      attempt?: number;
+      maxAttempts?: number;
+      attemptTimeoutMs?: number;
+      totalTimeoutMs?: number;
+      elapsedMs?: number;
+      exhausted?: boolean;
+    },
   ): NeuroLinkError {
+    const scope = budget?.exhausted
+      ? `exhausted its ${budget.totalTimeoutMs}ms total budget`
+      : budget?.maxAttempts && budget.maxAttempts > 1
+        ? `timed out after ${timeoutMs}ms on attempt ${budget.attempt ?? 1} of ${budget.maxAttempts}`
+        : `timed out after ${timeoutMs}ms`;
     return new NeuroLinkError({
       code: ERROR_CODES.TOOL_TIMEOUT,
-      message: `Tool '${toolName}' timed out after ${timeoutMs}ms`,
+      message: `Tool '${toolName}' ${scope}`,
       category: ErrorCategory.TIMEOUT,
       severity: ErrorSeverity.HIGH,
-      retriable: true,
-      context: { timeoutMs },
+      // A single attempt timing out is worth another try; an exhausted total
+      // budget is not — retrying it can only overshoot the caller's ceiling.
+      retriable: budget?.exhausted !== true,
+      context: { timeoutMs, ...(budget ?? {}) },
       toolName,
       serverId,
     });

--- a/src/lib/utils/mcpDefaults.ts
+++ b/src/lib/utils/mcpDefaults.ts
@@ -138,6 +138,7 @@ export function createCustomToolServerInfo(
   tool: MCPExecutableTool,
   timeoutMs?: number,
   maxRetries?: number,
+  totalTimeoutMs?: number,
 ): MCPServerInfo {
   const serverInfo = createMCPServerInfo({
     id: `custom-tool-${toolName}`,
@@ -157,6 +158,9 @@ export function createCustomToolServerInfo(
     }
     if (maxRetries !== undefined) {
       serverInfo.metadata.toolMaxRetries = maxRetries;
+    }
+    if (totalTimeoutMs !== undefined) {
+      serverInfo.metadata.toolTotalTimeoutMs = totalTimeoutMs;
     }
   }
 

--- a/test/continuous-test-suite-mcp-infra.ts
+++ b/test/continuous-test-suite-mcp-infra.ts
@@ -96,6 +96,123 @@ async function disposeQuietly(
   }
 }
 
+/**
+ * The retry loop must not be able to overshoot the caller's ceiling.
+ *
+ * `timeout` bounds ONE attempt; the loop then runs `maxRetries + 1` of them,
+ * so a tool that reliably hangs used to burn the product with nothing
+ * bounding the total. The surfaced error reported the per-attempt bound
+ * beside the whole-execution elapsed time, which reads as a timeout that was
+ * never enforced. Both halves are asserted here: the ceiling holds, and the
+ * error says which bound it is talking about.
+ */
+async function testToolTotalTimeoutBudget(): Promise<void> {
+  logSection("Tool total-timeout budget");
+  let sdk: InstanceType<typeof NeuroLink> | null = null;
+  try {
+    sdk = new NeuroLink();
+    sdk.registerTool("hangs_forever", {
+      name: "hangs_forever",
+      description: "Never settles, so every attempt hits its timeout",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => new Promise(() => {}),
+    });
+
+    // 4 attempts x 200ms would be 800ms; the budget says stop at 450ms.
+    const start = Date.now();
+    let thrown: unknown;
+    try {
+      await sdk.executeTool(
+        "hangs_forever",
+        {},
+        {
+          timeout: 200,
+          maxRetries: 3,
+          retryDelayMs: 10,
+          totalTimeoutMs: 450,
+          bypassBatcher: true,
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    const elapsed = Date.now() - start;
+
+    recordTest("total budget rejects the call", thrown !== undefined);
+    // Generous upper bound: the point is that it is nowhere near the 800ms
+    // the unbounded loop would have spent, not that the timer is precise.
+    recordTest(
+      "total budget caps elapsed time below the attempt product",
+      elapsed < 700,
+    );
+
+    const context = (
+      thrown as { context?: Record<string, unknown> } | undefined
+    )?.context;
+    recordTest(
+      "timeout error reports the attempt bound",
+      context?.attemptTimeoutMs === 200,
+    );
+    recordTest(
+      "timeout error reports the total bound",
+      context?.totalTimeoutMs === 450,
+    );
+    recordTest(
+      "timeout error reports which attempt it was",
+      typeof context?.attempt === "number" &&
+        typeof context?.maxAttempts === "number",
+    );
+    // maxRetries: 3 means four attempts. Assert the reported metadata rather
+    // than inferring the retry count from the clock, which cannot distinguish
+    // "stopped at the ceiling" from "failed early for another reason".
+    recordTest(
+      "reported attempt count matches the configured retry budget",
+      context?.maxAttempts === 4 &&
+        typeof context?.attempt === "number" &&
+        context.attempt >= 1 &&
+        context.attempt <= 4,
+    );
+
+    // Default path: omitting totalTimeoutMs must not change anything, so the
+    // ceiling falls back to timeout x attempts and all three attempts run.
+    const defaultStart = Date.now();
+    let defaultThrown: unknown;
+    try {
+      await sdk.executeTool(
+        "hangs_forever",
+        {},
+        { timeout: 100, maxRetries: 2, retryDelayMs: 10, bypassBatcher: true },
+      );
+    } catch (error) {
+      defaultThrown = error;
+    }
+    const defaultElapsed = Date.now() - defaultStart;
+    recordTest(
+      "default budget still rejects the call",
+      defaultThrown !== undefined,
+    );
+    // timeout 100 x 3 attempts + retryDelayMs 10 x 2 waits = 320ms. The
+    // default ceiling must reproduce BOTH terms. Computing it as
+    // timeout x attempts alone lands at 300 and clamps the third attempt
+    // below its configured 100ms — the defect this asserts against.
+    recordTest(
+      "default budget reproduces the full envelope including retry delays",
+      defaultElapsed >= 300,
+    );
+    const defaultContext = (
+      defaultThrown as { context?: Record<string, unknown> } | undefined
+    )?.context;
+    recordTest(
+      "default ceiling is derived from attempts AND delays",
+      defaultContext?.totalTimeoutMs === 320,
+    );
+  } catch (error) {
+    recordTest("Tool total-timeout budget", false);
+  } finally {
+    await disposeQuietly(sdk);
+  }
+}
+
 // ============================================================
 // Part 1 — Core MCP infrastructure
 // ============================================================
@@ -1361,4 +1478,7 @@ await runSuite(async () => {
   await testWiredMiddleware();
   await testWiredPublicAPIs();
   await testWiredDispose();
+
+  // Tool execution budget
+  await testToolTotalTimeoutBudget();
 });


### PR DESCRIPTION
## The bug

`executeTool` wraps each attempt in `withTimeout(..., finalOptions.timeout)` and hands that to `withRetry` with `maxAttempts = maxRetries + 1`. **Nothing bounded the sum.**

With the defaults — `TOOL_TIMEOUTS.EXECUTION_BATCH_MS` = 120000 and `RETRY_ATTEMPTS.DEFAULT` = 3 — a tool that reliably hangs burns:

```
4 attempts × 120000ms  +  3 delays × 1000ms  =  483000ms
```

`ErrorFactory.toolTimeout` sets `retriable: true`, so every attempt is used. This is not hypothetical: Yama reported ~8 minutes per `explore_context` call on juspay/svelte-ui-components#506, with `totalExecutions: 6, successfulExecutions: 1`.

## Why it looked like a propagation bug

The surfaced error carried both numbers in the same context object:

```json
{ "code": "TOOL_TIMEOUT", "timeoutMs": 120000, "executionTime": 483005 }
```

`timeoutMs` is **one attempt**. `executionTime` is the **whole envelope**. Side by side they read as a timeout that was never enforced — it was enforced, four times. That framing is what sent the reporter looking for a missing timeout rather than a missing ceiling.

## The fix

**`totalTimeoutMs`** bounds the execution. Settable per call on `executeTool`, per tool on `registerTool`, carried through server metadata onto `ToolInfo`.

It defaults to `timeout * (maxRetries + 1)` — exactly what the loop already spent — so **nothing changes for callers who do not set it**.

Enforcement clamps each attempt to the remaining budget rather than only gating retries. Gating alone would not hold the ceiling: the last attempt could start just under the deadline and still run a full attempt timeout past it. Exhausting the total produces a **non-retriable** error, since there is no budget left to retry into.

`ErrorFactory.toolTimeout` now takes an optional budget context and names which bound it is reporting — `attemptTimeoutMs`, `totalTimeoutMs`, `attempt`, `maxAttempts`, `elapsedMs` — and its message distinguishes `timed out after 200ms on attempt 2 of 4` from `exhausted its 450ms total budget`.

One subtlety worth flagging: `totalTimeoutMs` is declared explicitly on `ToolInfo` rather than left to its `[key: string]: unknown` index signature, which would type it `unknown` and silently defeat the default.

## Tests

Seven assertions in the no-API MCP infrastructure suite cover both halves — the ceiling holds below the attempt product, the error names its bounds, and omitting the option preserves the full retry envelope.

Three were initially **inert**. `recordTest(name, passed, skipped?, error?)` takes a boolean third argument, so the diagnostic strings I passed marked them *skipped* rather than failed — the same class of hazard `CLAUDE.md` documents for assertion messages. Removed, then verified by breaking an assertion on purpose: it reports `✗` with exit 1, not `⊘`.

## Verification

| check | result |
| --- | --- |
| `test:mcp` (mcp-infra) | 95/95 |
| provider contract gate | pass |
| `validate:all`, lint | 0 errors |
| typecheck | clean |
| provider-structure, error-classifier, model-manifests, provider-onboarding, `check:deps` | pass |
| `docs/api` | regenerated |

Pre-commit hook ran and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional total execution timeout for tools, covering all retry attempts and delays.
  - Tool registration now supports configuring the overall execution time limit.
  - Existing behavior remains unchanged when no total timeout is specified.

- **Bug Fixes**
  - Retry processing stops when the total timeout budget is exhausted.
  - Timeout errors now include clearer budget, attempt, and elapsed-time details.

- **Documentation**
  - Updated API references with timeout options and refreshed source links.

- **Tests**
  - Added coverage for timeout enforcement and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->