### PR TITLE
ci(security): widen the scanner bound so a slow registry is not a failed scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,24 @@ jobs:
 
       - name: 🔒 Security & Environment Validation
         if: matrix.group == 'validate'
+        env:
+          # `pnpm audit` posts the whole dependency tree to npm's audit API and
+          # waits on it. security-check.ts kills any scanner at 120s and treats
+          # the kill as a failed scan — correct, because a scan that did not
+          # finish cannot be trusted. But the bound was measured against a
+          # ~1.4s local run, and when that endpoint degrades the real audit
+          # takes longer than the bound: on 2026-09-04 it ran 129s locally and
+          # every branch in the repo went red on this step, `release` included.
+          #
+          # 300s is still a bound, so the hang this exists to prevent is still
+          # prevented; it is just wide enough that a slow-but-working registry
+          # produces a verdict instead of a kill. Set here rather than in the
+          # script so local runs keep the tighter default, where a developer is
+          # present to notice a stall.
+          NEUROLINK_SCANNER_TIMEOUT_MS: "300000"
+        # A slow scanner must not hold a runner indefinitely even with the
+        # wider bound.
+        timeout-minutes: 12
         run: |
           echo "🔍 Running build rule enforcement validations..."
           pnpm run validate:all


### PR DESCRIPTION
## What broke

`security-check.ts` kills any scanner at 120s and treats the kill as a failed scan. That default is right — a scan that didn't finish can't be trusted, and the bound exists to stop a wedged scanner hanging the job.

The bound was measured against a ~1.4s local run, roughly 85x headroom for everything the script does. **`pnpm audit` is the exception**: it posts the whole dependency tree to npm's audit API and waits, so its runtime is a property of *that endpoint*, not of this repository.

On 2026-09-04 the endpoint degraded. A full audit took **129s locally**, past the bound. Every branch went red on this single step:

| branch | validate shard |
| --- | --- |
| `release` | ❌ |
| `feat/provider-wave2` | ❌ |
| `refactor/remove-ai-sdk-stage1-browser` | ❌ |
| `fix/tool-execution-timeout-budget` | ❌, and ❌ again on re-run |

The re-run failed identically — its security step ran **125s**, the cap plus overhead.

## The change

Raised to 300s **for the CI validate shard only**, via the override `security-check.ts` already exposes.

Three things this deliberately does **not** do:

- **It does not remove the bound.** A hung scanner still dies, and the step now also carries `timeout-minutes: 12` so a slow scan can't hold a runner indefinitely at the wider cap.
- **It does not change the local default.** A developer running this has a terminal in front of them and should still see a stall at 120s. CI doesn't.
- **It does not make a timed-out scan pass.** Fail-closed behaviour is untouched. The only change is how long "not finished yet" may take before it becomes "did not finish".

## Verification

The override is proven wired end to end rather than assumed — with `NEUROLINK_SCANNER_TIMEOUT_MS=1`, every scanner is killed and reported as an incomplete scan, and the script's own default is still `120_000`.

**On the evidence, honestly:** by the time this was written the registry had recovered and a full audit completed in 5s. So a green run on this PR does *not* demonstrate the fix works. The justification is the recorded incident above — the 129s local audit, the 125s CI step, and four branches red on the same step — not a reproduction that no longer reproduces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the time allowed for Security & Environment Validation checks.
  * Added an explicit 12-minute limit to prevent validation steps from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->