### PR TITLE
fix(core): honor disableInternalFallback on generate() and assert matrix structured output

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6501](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6501)
+Defined in: [neurolink.ts:6506](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6506)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8980](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8980)
+Defined in: [neurolink.ts:8998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8998)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:9063](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9063)
+Defined in: [neurolink.ts:9081](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9081)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9955](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9955)
+Defined in: [neurolink.ts:9973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9973)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9973)
+Defined in: [neurolink.ts:9991](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9991)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12388](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12388)
+Defined in: [neurolink.ts:12406](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12406)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **hasPendingHITLConfirmation**(`confirmationId`): `boolean`
 
-Defined in: [neurolink.ts:12428](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12428)
+Defined in: [neurolink.ts:12446](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12446)
 
 Whether a HITL confirmation is still awaiting a response on THIS instance.
 
@@ -888,7 +888,7 @@ neurolink.getEventEmitter().emit("hitl:confirmation-response", { ... });
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12444](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12444)
+Defined in: [neurolink.ts:12462](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12462)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -911,7 +911,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12455](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12455)
+Defined in: [neurolink.ts:12473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12473)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -929,7 +929,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12466](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12466)
+Defined in: [neurolink.ts:12484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12484)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -953,7 +953,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12483](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12483)
+Defined in: [neurolink.ts:12501](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12501)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -979,7 +979,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12528](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12528)
+Defined in: [neurolink.ts:12546](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12546)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -1031,7 +1031,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12607](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12607)
+Defined in: [neurolink.ts:12625](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12625)
 
 Emit tool start event with execution tracking
 
@@ -1067,7 +1067,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12658](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12658)
+Defined in: [neurolink.ts:12676](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12676)
 
 Emit tool end event with execution summary
 
@@ -1119,7 +1119,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12739](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12739)
+Defined in: [neurolink.ts:12757](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12757)
 
 Get current tool execution contexts for stream metadata
 
@@ -1133,7 +1133,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12746](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12746)
+Defined in: [neurolink.ts:12764](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12764)
 
 Get tool execution history
 
@@ -1147,7 +1147,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12753](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12753)
+Defined in: [neurolink.ts:12771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12771)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1161,7 +1161,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12769](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12769)
+Defined in: [neurolink.ts:12787](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12787)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1207,7 +1207,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12920](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12920)
+Defined in: [neurolink.ts:12938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12938)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1230,7 +1230,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12935](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12935)
+Defined in: [neurolink.ts:12953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12953)
 
 Get the current tool execution context
 
@@ -1246,7 +1246,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12944)
+Defined in: [neurolink.ts:12962](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12962)
 
 Clear the tool execution context
 
@@ -1260,7 +1260,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12956](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12956)
+Defined in: [neurolink.ts:12974](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12974)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1285,7 +1285,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12979](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12979)
+Defined in: [neurolink.ts:12997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12997)
 
 Unregister a custom tool
 
@@ -1309,7 +1309,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:12998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12998)
+Defined in: [neurolink.ts:13016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13016)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1334,7 +1334,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:13011](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13011)
+Defined in: [neurolink.ts:13029](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13029)
 
 Get all registered tool middlewares
 
@@ -1348,7 +1348,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13018](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13018)
+Defined in: [neurolink.ts:13036](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13036)
 
 Flush any pending batched tool calls immediately
 
@@ -1362,7 +1362,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:13027](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13027)
+Defined in: [neurolink.ts:13045](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13045)
 
 Get the current MCP enhancements configuration
 
@@ -1376,7 +1376,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13050](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13050)
+Defined in: [neurolink.ts:13068](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13068)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1426,7 +1426,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:13086](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13086)
+Defined in: [neurolink.ts:13104](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13104)
 
 Get all registered custom tools
 
@@ -1442,7 +1442,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13224](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13224)
+Defined in: [neurolink.ts:13242](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13242)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1471,7 +1471,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:13268](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13268)
+Defined in: [neurolink.ts:13286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13286)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1494,7 +1494,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13295](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13295)
+Defined in: [neurolink.ts:13313](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13313)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1524,7 +1524,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13311](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13311)
+Defined in: [neurolink.ts:13329](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13329)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1540,7 +1540,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13323](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13323)
+Defined in: [neurolink.ts:13341](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13341)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1631,7 +1631,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14423)
+Defined in: [neurolink.ts:14441](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14441)
 
 ##### Returns
 
@@ -1643,7 +1643,7 @@ Defined in: [neurolink.ts:14423](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14605](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14605)
+Defined in: [neurolink.ts:14623](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14623)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1666,7 +1666,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14786)
+Defined in: [neurolink.ts:14804](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14804)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1690,7 +1690,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14818](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14818)
+Defined in: [neurolink.ts:14836](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14836)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1714,7 +1714,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14827](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14827)
+Defined in: [neurolink.ts:14845](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14845)
 
 Get list of all available AI provider names
 
@@ -1730,7 +1730,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14837](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14837)
+Defined in: [neurolink.ts:14855](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14855)
 
 Validate if a provider name is supported
 
@@ -1754,7 +1754,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14850](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14850)
+Defined in: [neurolink.ts:14868](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14868)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1770,7 +1770,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14920](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14920)
+Defined in: [neurolink.ts:14938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14938)
 
 List all configured MCP servers with their status
 
@@ -1786,7 +1786,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14935](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14935)
+Defined in: [neurolink.ts:14953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14953)
 
 Test connectivity to a specific MCP server
 
@@ -1810,7 +1810,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14976](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14976)
+Defined in: [neurolink.ts:14994](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14994)
 
 Check if a provider has the required environment variables configured
 
@@ -1834,7 +1834,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15002](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15002)
+Defined in: [neurolink.ts:15020](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15020)
 
 Perform comprehensive health check on a specific provider
 
@@ -1878,7 +1878,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:15048](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15048)
+Defined in: [neurolink.ts:15066](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15066)
 
 Check health of all supported providers
 
@@ -1916,7 +1916,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15092](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15092)
+Defined in: [neurolink.ts:15110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15110)
 
 Get a summary of provider health across all supported providers
 
@@ -1932,7 +1932,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15139](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15139)
+Defined in: [neurolink.ts:15157](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15157)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1954,7 +1954,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:15150](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15150)
+Defined in: [neurolink.ts:15168](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15168)
 
 Get execution metrics for all tools
 
@@ -1970,7 +1970,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:15194](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15194)
+Defined in: [neurolink.ts:15212](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15212)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1993,7 +1993,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:15207](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15207)
+Defined in: [neurolink.ts:15225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15225)
 
 Get circuit breaker status for all tools
 
@@ -2009,7 +2009,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:15242](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15242)
+Defined in: [neurolink.ts:15260](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15260)
 
 Reset circuit breaker for a specific tool
 
@@ -2031,7 +2031,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:15259](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15259)
+Defined in: [neurolink.ts:15277](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15277)
 
 Clear all tool execution metrics
 
@@ -2045,7 +2045,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:15268](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15268)
+Defined in: [neurolink.ts:15286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15286)
 
 Get comprehensive tool health report
 
@@ -2061,7 +2061,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15423)
+Defined in: [neurolink.ts:15441](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15441)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2078,7 +2078,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15443](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15443)
+Defined in: [neurolink.ts:15461](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15461)
 
 Get conversation memory statistics (public API)
 
@@ -2092,7 +2092,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15470)
+Defined in: [neurolink.ts:15488](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15488)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2116,7 +2116,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15526](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15526)
+Defined in: [neurolink.ts:15544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15544)
 
 Clear conversation history for a specific session (public API)
 
@@ -2136,7 +2136,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15552)
+Defined in: [neurolink.ts:15570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15570)
 
 Clear all conversation history (public API)
 
@@ -2150,7 +2150,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15580](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15580)
+Defined in: [neurolink.ts:15598](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15598)
 
 List all conversation sessions with metadata (public API)
 
@@ -2174,7 +2174,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15629](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15629)
+Defined in: [neurolink.ts:15647](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15647)
 
 Export a single session with full history and metadata (public API)
 
@@ -2210,7 +2210,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15714](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15714)
+Defined in: [neurolink.ts:15732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15732)
 
 Export all sessions for a user (public API)
 
@@ -2246,7 +2246,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15778)
+Defined in: [neurolink.ts:15796](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15796)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2294,7 +2294,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15848](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15848)
+Defined in: [neurolink.ts:15866](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15866)
 
 Check if tool execution storage is available.
 
@@ -2315,7 +2315,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15858](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15858)
+Defined in: [neurolink.ts:15876](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15876)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2344,7 +2344,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15899](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15899)
+Defined in: [neurolink.ts:15917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15917)
 
 Replace the entire messages array for a session.
 
@@ -2378,7 +2378,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15947](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15947)
+Defined in: [neurolink.ts:15965](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15965)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2415,7 +2415,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15978](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15978)
+Defined in: [neurolink.ts:15996](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15996)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2446,7 +2446,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:16065](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16065)
+Defined in: [neurolink.ts:16083](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16083)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2471,7 +2471,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:16117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16117)
+Defined in: [neurolink.ts:16135](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16135)
 
 List all external MCP servers
 
@@ -2487,7 +2487,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:16146](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16146)
+Defined in: [neurolink.ts:16164](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16164)
 
 Get external MCP server status
 
@@ -2511,7 +2511,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `requestedToolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:16160](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16160)
+Defined in: [neurolink.ts:16178](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16178)
 
 Execute a tool from an external MCP server
 
@@ -2553,7 +2553,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16359](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16359)
+Defined in: [neurolink.ts:16377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16377)
 
 Get all tools from external MCP servers
 
@@ -2569,7 +2569,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16368](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16368)
+Defined in: [neurolink.ts:16386](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16386)
 
 Get tools from a specific external MCP server
 
@@ -2593,7 +2593,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:16377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16377)
+Defined in: [neurolink.ts:16395](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16395)
 
 Test connection to an external MCP server
 
@@ -2617,7 +2617,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:16405](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16405)
+Defined in: [neurolink.ts:16423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16423)
 
 Get external MCP server manager statistics
 
@@ -2657,7 +2657,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16420](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16420)
+Defined in: [neurolink.ts:16438](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16438)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2672,7 +2672,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16458](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16458)
+Defined in: [neurolink.ts:16476](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16476)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2703,7 +2703,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16486](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16486)
+Defined in: [neurolink.ts:16504](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16504)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2741,7 +2741,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16509)
+Defined in: [neurolink.ts:16527](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16527)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2770,7 +2770,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16534](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16534)
+Defined in: [neurolink.ts:16552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16552)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2800,7 +2800,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16561](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16561)
+Defined in: [neurolink.ts:16579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16579)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2832,7 +2832,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16589](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16589)
+Defined in: [neurolink.ts:16607](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16607)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2909,7 +2909,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16630)
+Defined in: [neurolink.ts:16648](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16648)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2990,7 +2990,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16669](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16669)
+Defined in: [neurolink.ts:16687](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16687)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -3020,7 +3020,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16691)
+Defined in: [neurolink.ts:16709](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16709)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -3061,7 +3061,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16730)
+Defined in: [neurolink.ts:16748](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16748)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3102,7 +3102,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16753](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16753)
+Defined in: [neurolink.ts:16771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16771)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3134,7 +3134,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:16992](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16992)
+Defined in: [neurolink.ts:17010](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17010)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3185,7 +3185,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:17084](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17084)
+Defined in: [neurolink.ts:17102](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17102)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3287,7 +3287,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:17222](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17222)
+Defined in: [neurolink.ts:17240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17240)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3356,7 +3356,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:17308](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17308)
+Defined in: [neurolink.ts:17326](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17326)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3417,7 +3417,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:17354](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17354)
+Defined in: [neurolink.ts:17372](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17372)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3443,7 +3443,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:17377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17377)
+Defined in: [neurolink.ts:17395](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17395)
 
 Get details of a specific evaluation preset.
 
@@ -3479,7 +3479,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:17427](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17427)
+Defined in: [neurolink.ts:17445](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17445)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3531,7 +3531,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17489](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17489)
+Defined in: [neurolink.ts:17507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17507)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3605,7 +3605,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17521](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17521)
+Defined in: [neurolink.ts:17539](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17539)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3645,7 +3645,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17620](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17620)
+Defined in: [neurolink.ts:17638](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17638)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3695,7 +3695,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17639](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17639)
+Defined in: [neurolink.ts:17657](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17657)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3728,7 +3728,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17655](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17655)
+Defined in: [neurolink.ts:17673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17673)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3753,7 +3753,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17673)
+Defined in: [neurolink.ts:17691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17691)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3791,7 +3791,7 @@ The registered tool name
 
 > **registerTaskTools**(): `void`
 
-Defined in: [neurolink.ts:17706](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17706)
+Defined in: [neurolink.ts:17724](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17724)
 
 Register the task CHECKLIST toolset — `tasks_create`, `tasks_update`,
 `tasks_list` — on this instance (TodoWrite-style planning for a
@@ -3827,7 +3827,7 @@ id for that one call.
 
 > **getTaskState**(`sessionId?`): [`ChecklistState`](../type-aliases/ChecklistState.md)
 
-Defined in: [neurolink.ts:17732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17732)
+Defined in: [neurolink.ts:17750](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17750)
 
 Read a session's task checklist — synchronous, so a completeness gate is
 one line of host code:
@@ -3853,7 +3853,7 @@ instance's tool-context session, or its default checklist).
 
 > **clearTaskState**(`sessionId?`): `boolean`
 
-Defined in: [neurolink.ts:17740](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17740)
+Defined in: [neurolink.ts:17758](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17758)
 
 Drop a session's checklist. Returns whether there was one to drop.
 Omit `sessionId` to clear the session the tools currently write to.
@@ -3874,7 +3874,7 @@ Omit `sessionId` to clear the session the tools currently write to.
 
 > **registerDelegationTools**(`options?`): `void`
 
-Defined in: [neurolink.ts:17767](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17767)
+Defined in: [neurolink.ts:17785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17785)
 
 Register the background-delegation toolset — `delegate_task` and
 `collect_results` — on this instance. Opt-in and idempotent: existing
@@ -3913,7 +3913,7 @@ Depth ceiling, pool raise, and queue wait
 
 > **spawnDelegate**(`options`): `Promise`\<[`DelegateHandle`](../type-aliases/DelegateHandle.md)\>
 
-Defined in: [neurolink.ts:17807](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17807)
+Defined in: [neurolink.ts:17825](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17825)
 
 Start a background worker and get its handle immediately — before it has
 run anything, and long before it finishes.
@@ -3957,7 +3957,7 @@ when the task is empty or the caller is at the depth ceiling
 
 > **collectDelegates**(`request`): `Promise`\<[`DelegateCollectResult`](../type-aliases/DelegateCollectResult.md)\>
 
-Defined in: [neurolink.ts:17818](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17818)
+Defined in: [neurolink.ts:17836](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17836)
 
 Claim finished background workers — in COMPLETION order, which has nothing
 to do with spawn order. Each outcome is handed out exactly once.
@@ -3982,7 +3982,7 @@ Claimed outcomes plus what is still pending/ready
 
 > **cancelDelegates**(`workerId?`): `Promise`\<`number`\>
 
-Defined in: [neurolink.ts:17832](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17832)
+Defined in: [neurolink.ts:17850](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17850)
 
 Cancel background workers: one by id, or every outstanding worker this
 instance spawned. Cancelled workers still settle into a claimable outcome
@@ -4008,7 +4008,7 @@ How many workers were cancelled
 
 > **getArtifactStore**(): [`ArtifactStore`](../type-aliases/ArtifactStore.md)
 
-Defined in: [neurolink.ts:17855](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17855)
+Defined in: [neurolink.ts:17873](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17873)
 
 This instance's artifact store, created on first use.
 
@@ -4034,7 +4034,7 @@ The artifact store backing [bankArtifact](#bankartifact) / [readArtifact](#reada
 
 > **setArtifactStore**(`store`): `void`
 
-Defined in: [neurolink.ts:17885](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17885)
+Defined in: [neurolink.ts:17903](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17903)
 
 Replace this instance's artifact store.
 
@@ -4072,7 +4072,7 @@ Any [ArtifactStore](../type-aliases/ArtifactStore.md)
 
 > **bankArtifact**(`payload`, `options`): `Promise`\<[`BankedArtifactRef`](../type-aliases/BankedArtifactRef.md)\>
 
-Defined in: [neurolink.ts:17973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17973)
+Defined in: [neurolink.ts:17991](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17991)
 
 Bank a payload to a file and get back a pointer to it.
 
@@ -4119,7 +4119,7 @@ const ref = await neurolink.bankArtifact(fullReport, {
 
 > **readArtifact**(`id`, `page?`): `Promise`\<`string` \| `null`\>
 
-Defined in: [neurolink.ts:17990](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17990)
+Defined in: [neurolink.ts:18008](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18008)
 
 Read a banked payload back from host code — the programmatic twin of the
 model's `retrieve_context({ artifactId })` call.
@@ -4151,7 +4151,7 @@ Optional character window
 
 > **registerBackgroundCommandTools**(`policy`): `void`
 
-Defined in: [neurolink.ts:18022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18022)
+Defined in: [neurolink.ts:18040](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18040)
 
 Register the background-command toolset — `run_command_bg`,
 `command_status`, `command_output`, `command_kill` — on this instance, and
@@ -4192,7 +4192,7 @@ What may run, where, for how long, and how loudly
 
 > **setBackgroundCommandPolicy**(`policy`): `void`
 
-Defined in: [neurolink.ts:18047](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18047)
+Defined in: [neurolink.ts:18065](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18065)
 
 Declare (or replace) what this instance may execute, without registering
 the model-facing tools. Host code that only drives
@@ -4216,7 +4216,7 @@ What may run, where, for how long, and how loudly
 
 > **startBackgroundCommand**(`argv`, `options`): `Promise`\<[`BackgroundCommandHandle`](../type-aliases/BackgroundCommandHandle.md)\>
 
-Defined in: [neurolink.ts:18071](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18071)
+Defined in: [neurolink.ts:18089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18089)
 
 Start a command in the background and get its task id immediately.
 
@@ -4263,7 +4263,7 @@ allowlisted, the policy vetoes it, or the cwd escapes the sandbox
 
 > **getBackgroundCommandStatus**(`taskId`): [`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)
 
-Defined in: [neurolink.ts:18085](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18085)
+Defined in: [neurolink.ts:18103](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18103)
 
 Everything known about one command right now — synchronous, so a
 mid-loop monitor costs nothing.
@@ -4290,7 +4290,7 @@ when the task id is unknown to this instance
 
 > **awaitBackgroundCommand**(`taskId`, `opts?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18097](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18097)
+Defined in: [neurolink.ts:18115](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18115)
 
 Wait for a command to settle. `timeoutMs` bounds the WAIT, not the
 command: when it elapses the current status is returned rather than
@@ -4322,7 +4322,7 @@ Task id from [startBackgroundCommand](#startbackgroundcommand)
 
 > **killBackgroundCommand**(`taskId`, `signal?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18112](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18112)
+Defined in: [neurolink.ts:18130](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18130)
 
 Kill a running command — SIGTERM, then SIGKILL five seconds later — and
 resolve with its settled status. Whatever it printed first is still
@@ -4352,7 +4352,7 @@ Signal to send first. Default SIGTERM
 
 > **readBackgroundCommandOutput**(`taskId`, `page`): `Promise`\<[`BackgroundCommandOutputPage`](../type-aliases/BackgroundCommandOutputPage.md)\>
 
-Defined in: [neurolink.ts:18127](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18127)
+Defined in: [neurolink.ts:18145](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18145)
 
 Read one character window of a command's output straight from its log
 file — while it is still running, or long after it finished. Offsets,
@@ -4382,7 +4382,7 @@ Which stream, and which window of it
 
 > **registerGitTools**(`options`): `void`
 
-Defined in: [neurolink.ts:18154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18154)
+Defined in: [neurolink.ts:18172](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18172)
 
 Register the read-only git toolset — `git_log`, `git_show`, `git_diff`,
 `git_blame`, `git_merge_base`, `git_ls_files` — on this instance. Opt-in
@@ -4415,7 +4415,7 @@ Repository root, plus timeout / byte-cap / preview bounds
 
 > **runGitCommand**(`args`, `sessionId?`): `Promise`\<[`GitToolResult`](../type-aliases/GitToolResult.md)\>
 
-Defined in: [neurolink.ts:18180](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18180)
+Defined in: [neurolink.ts:18198](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18198)
 
 Run one read-only git command from host code, with the same bounding the
 tools get: the complete stdout is banked, the result carries a preview and
@@ -4450,7 +4450,7 @@ when [registerGitTools](#registergittools) has not been called
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:18199](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18199)
+Defined in: [neurolink.ts:18217](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18217)
 
 Execute an agent network with the given input.
 
@@ -4495,7 +4495,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:18223](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18223)
+Defined in: [neurolink.ts:18241](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18241)
 
 Stream agent network execution with real-time events.
 
@@ -4539,7 +4539,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:18247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18247)
+Defined in: [neurolink.ts:18265](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18265)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -4567,7 +4567,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:18266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18266)
+Defined in: [neurolink.ts:18284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18284)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -4595,7 +4595,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:18284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18284)
+Defined in: [neurolink.ts:18302](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18302)
 
 Create a MessageBus for inter-agent communication.
 
@@ -4623,7 +4623,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18299](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18299)
+Defined in: [neurolink.ts:18317](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18317)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -4639,7 +4639,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:18518](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18518)
+Defined in: [neurolink.ts:18536](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18536)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -4656,7 +4656,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:18526](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18526)
+Defined in: [neurolink.ts:18544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18544)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -4681,7 +4681,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:18577](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18577)
+Defined in: [neurolink.ts:18595](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18595)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -4710,7 +4710,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:18619](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18619)
+Defined in: [neurolink.ts:18637](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18637)
 
 Check if a session needs compaction.
 
@@ -4738,7 +4738,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18656](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18656)
+Defined in: [neurolink.ts:18674](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18674)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4760,7 +4760,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:18704](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18704)
+Defined in: [neurolink.ts:18722](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18722)
 
 Get the currently configured authentication provider
 
@@ -4774,7 +4774,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18745](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18745)
+Defined in: [neurolink.ts:18763](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18763)
 
 Set the current authentication context for request handling.
 
@@ -4801,7 +4801,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:18760](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18760)
+Defined in: [neurolink.ts:18778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18778)
 
 Get the current authentication context.
 
@@ -4817,7 +4817,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18768](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18768)
+Defined in: [neurolink.ts:18786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18786)
 
 Clear the current authentication context
 
@@ -4831,7 +4831,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:18782](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18782)
+Defined in: [neurolink.ts:18800](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18800)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/type-aliases/AdditionalMemoryUser.md
+++ b/docs/api/type-aliases/AdditionalMemoryUser.md
@@ -8,7 +8,7 @@
 
 > **AdditionalMemoryUser** = `object`
 
-Defined in: [types/generate.ts:823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L823)
+Defined in: [types/generate.ts:837](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L837)
 
 Represents an additional user whose memory should be included in a generate/stream call.
 Allows per-user prompt overrides for different memory condensation strategies
@@ -20,7 +20,7 @@ Allows per-user prompt overrides for different memory condensation strategies
 
 > **userId**: `string`
 
-Defined in: [types/generate.ts:825](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L825)
+Defined in: [types/generate.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L839)
 
 The user/owner ID to retrieve or store memory for.
 
@@ -30,7 +30,7 @@ The user/owner ID to retrieve or store memory for.
 
 > `optional` **label?**: `string`
 
-Defined in: [types/generate.ts:831](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L831)
+Defined in: [types/generate.ts:845](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L845)
 
 Human-readable label used in the formatted memory context.
 E.g. "Organization Policy", "Team Context", "User Preferences".
@@ -42,7 +42,7 @@ If not provided, defaults to userId.
 
 > `optional` **read?**: `boolean`
 
-Defined in: [types/generate.ts:833](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L833)
+Defined in: [types/generate.ts:847](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L847)
 
 Whether to read this user's memory and include in context. Defaults to true.
 
@@ -52,7 +52,7 @@ Whether to read this user's memory and include in context. Defaults to true.
 
 > `optional` **write?**: `boolean`
 
-Defined in: [types/generate.ts:835](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L835)
+Defined in: [types/generate.ts:849](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L849)
 
 Whether to write conversation into this user's memory. Defaults to true.
 
@@ -62,7 +62,7 @@ Whether to write conversation into this user's memory. Defaults to true.
 
 > `optional` **prompt?**: `string`
 
-Defined in: [types/generate.ts:837](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L837)
+Defined in: [types/generate.ts:851](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L851)
 
 Custom condensation prompt for this user. Overrides the default Hippocampus prompt.
 
@@ -72,6 +72,6 @@ Custom condensation prompt for this user. Overrides the default Hippocampus prom
 
 > `optional` **maxWords?**: `number`
 
-Defined in: [types/generate.ts:839](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L839)
+Defined in: [types/generate.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L853)
 
 Max words for this user's condensed memory. Overrides the default maxWords.

--- a/docs/api/type-aliases/EnhancedGenerateResult.md
+++ b/docs/api/type-aliases/EnhancedGenerateResult.md
@@ -8,7 +8,7 @@
 
 > **EnhancedGenerateResult** = [`GenerateResult`](GenerateResult.md) & `object`
 
-Defined in: [types/generate.ts:1705](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1705)
+Defined in: [types/generate.ts:1728](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1728)
 
 ## Type Declaration
 

--- a/docs/api/type-aliases/EnhancedProvider.md
+++ b/docs/api/type-aliases/EnhancedProvider.md
@@ -8,7 +8,7 @@
 
 > **EnhancedProvider** = `object`
 
-Defined in: [types/generate.ts:1190](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1190)
+Defined in: [types/generate.ts:1204](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1204)
 
 Enhanced provider type with generate method
 
@@ -18,7 +18,7 @@ Enhanced provider type with generate method
 
 > **generate**(`options`): `Promise`\<[`GenerateResult`](GenerateResult.md)\>
 
-Defined in: [types/generate.ts:1191](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1191)
+Defined in: [types/generate.ts:1205](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1205)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/generate.ts:1191](https://github.com/juspay/neurolink/blob/re
 
 > **getName**(): `string`
 
-Defined in: [types/generate.ts:1192](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1192)
+Defined in: [types/generate.ts:1206](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1206)
 
 #### Returns
 
@@ -48,7 +48,7 @@ Defined in: [types/generate.ts:1192](https://github.com/juspay/neurolink/blob/re
 
 > **isAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [types/generate.ts:1193](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1193)
+Defined in: [types/generate.ts:1207](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1207)
 
 #### Returns
 

--- a/docs/api/type-aliases/FactoryEnhancedProvider.md
+++ b/docs/api/type-aliases/FactoryEnhancedProvider.md
@@ -8,7 +8,7 @@
 
 > **FactoryEnhancedProvider** = [`EnhancedProvider`](EnhancedProvider.md) & `object`
 
-Defined in: [types/generate.ts:1200](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1200)
+Defined in: [types/generate.ts:1214](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1214)
 
 Factory-enhanced provider type
 Supports domain configuration and streaming optimizations

--- a/docs/api/type-aliases/GenerateOptions.md
+++ b/docs/api/type-aliases/GenerateOptions.md
@@ -777,11 +777,30 @@ Disable tool result caching for this request (overrides global mcp.cache.enabled
 
 ---
 
+### disableInternalFallback?
+
+> `optional` **disableInternalFallback?**: `boolean`
+
+Defined in: [types/generate.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L509)
+
+Disable NeuroLink's internal fallback for this request: the static
+provider-priority walk that runs when no provider was requested, and the
+catalog model-fallback walk a provider performs when its model is
+rejected as invalid. Callers that own fallback order (a caller-supplied
+`providerFallback` / `modelChain`, or a router that retries on its own,
+as the Claude proxy does for its streams) set this so an invalid model
+or an unavailable provider surfaces as exactly that.
+A configured `ModelPool`, `providerFallback` and `modelChain` are the
+caller's own fallback and are unaffected. Mirrors the same flag on
+`StreamOptions`.
+
+---
+
 ### maxSteps?
 
 > `optional` **maxSteps?**: `number`
 
-Defined in: [types/generate.ts:498](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L498)
+Defined in: [types/generate.ts:512](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L512)
 
 Maximum number of tool execution steps (default: 200)
 
@@ -791,7 +810,7 @@ Maximum number of tool execution steps (default: 200)
 
 > `optional` **toolChoice?**: [`ToolChoice`](ToolChoice.md)\<`Record`\<`string`, [`Tool`](Tool.md)\>\>
 
-Defined in: [types/generate.ts:513](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L513)
+Defined in: [types/generate.ts:527](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L527)
 
 Tool choice configuration for the generation.
 Controls whether and which tools the model must call.
@@ -811,7 +830,7 @@ will cause infinite tool calls until `maxSteps` is exhausted.
 
 > `optional` **prepareStep?**: (`options`) => `PromiseLike`\<\{ `model?`: [`LanguageModel`](LanguageModel.md); `toolChoice?`: [`ToolChoice`](ToolChoice.md)\<`Record`\<`string`, [`Tool`](Tool.md)\>\>; `experimental_activeTools?`: `string`[]; \} \| `undefined`\>
 
-Defined in: [types/generate.ts:538](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L538)
+Defined in: [types/generate.ts:552](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L552)
 
 Optional callback that runs before each step in a multi-step generation.
 Allows dynamically changing `toolChoice` and available tools per step.
@@ -868,7 +887,7 @@ https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#parameters
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/generate.ts:553](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L553)
+Defined in: [types/generate.ts:567](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L567)
 
 ---
 
@@ -876,7 +895,7 @@ Defined in: [types/generate.ts:553](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/generate.ts:554](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L554)
+Defined in: [types/generate.ts:568](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L568)
 
 ---
 
@@ -884,7 +903,7 @@ Defined in: [types/generate.ts:554](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **context?**: [`StandardRecord`](StandardRecord.md)
 
-Defined in: [types/generate.ts:555](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L555)
+Defined in: [types/generate.ts:569](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L569)
 
 ---
 
@@ -892,7 +911,7 @@ Defined in: [types/generate.ts:555](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/generate.ts:558](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L558)
+Defined in: [types/generate.ts:572](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L572)
 
 ---
 
@@ -900,7 +919,7 @@ Defined in: [types/generate.ts:558](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/generate.ts:559](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L559)
+Defined in: [types/generate.ts:573](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L573)
 
 ---
 
@@ -908,7 +927,7 @@ Defined in: [types/generate.ts:559](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/generate.ts:566](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L566)
+Defined in: [types/generate.ts:580](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L580)
 
 #### ~~role~~
 
@@ -931,7 +950,7 @@ correctly wired through the entire generate pipeline.
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/generate.ts:574](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L574)
+Defined in: [types/generate.ts:588](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L588)
 
 Previous conversation as a ChatMessage array.
 Messages are injected as proper multi-turn conversation history before the current prompt,
@@ -944,7 +963,7 @@ Used by task continuation mode and available to external callers.
 
 > `optional` **factoryConfig?**: `object`
 
-Defined in: [types/generate.ts:577](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L577)
+Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L591)
 
 #### domainType?
 
@@ -972,7 +991,7 @@ Defined in: [types/generate.ts:577](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **streaming?**: `object`
 
-Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L591)
+Defined in: [types/generate.ts:605](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L605)
 
 #### enabled?
 
@@ -1000,7 +1019,7 @@ Defined in: [types/generate.ts:591](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **workflow?**: `string`
 
-Defined in: [types/generate.ts:600](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L600)
+Defined in: [types/generate.ts:614](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L614)
 
 ---
 
@@ -1008,7 +1027,7 @@ Defined in: [types/generate.ts:600](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **workflowConfig?**: [`WorkflowConfig`](WorkflowConfig.md)
 
-Defined in: [types/generate.ts:601](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L601)
+Defined in: [types/generate.ts:615](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L615)
 
 ---
 
@@ -1016,7 +1035,7 @@ Defined in: [types/generate.ts:601](https://github.com/juspay/neurolink/blob/rel
 
 > `optional` **rag?**: [`RAGConfig`](RAGConfig.md)
 
-Defined in: [types/generate.ts:635](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L635)
+Defined in: [types/generate.ts:649](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L649)
 
 RAG (Retrieval-Augmented Generation) configuration.
 
@@ -1055,7 +1074,7 @@ const result = await neurolink.generate({
 
 > `optional` **maxBudgetUsd?**: `number`
 
-Defined in: [types/generate.ts:650](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L650)
+Defined in: [types/generate.ts:664](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L664)
 
 Maximum budget in USD for this session. When the accumulated cost of all
 generate() calls on this NeuroLink instance exceeds this value, subsequent
@@ -1076,7 +1095,7 @@ const result = await neurolink.generate({
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/generate.ts:657](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L657)
+Defined in: [types/generate.ts:671](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L671)
 
 Optional request identifier for observability and log correlation.
 When provided, this ID is forwarded to spans, logs, and telemetry so
@@ -1088,7 +1107,7 @@ callers can correlate generation traces back to their own request lifecycle.
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/generate.ts:672](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L672)
+Defined in: [types/generate.ts:686](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L686)
 
 Per-call middleware configuration.
 
@@ -1098,7 +1117,7 @@ Per-call middleware configuration.
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/generate.ts:675](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L675)
+Defined in: [types/generate.ts:689](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L689)
 
 Callback invoked when generation completes successfully.
 
@@ -1108,7 +1127,7 @@ Callback invoked when generation completes successfully.
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/generate.ts:678](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L678)
+Defined in: [types/generate.ts:692](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L692)
 
 Callback invoked when generation encounters an error.
 
@@ -1118,7 +1137,7 @@ Callback invoked when generation encounters an error.
 
 > `optional` **requestContext?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:681](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L681)
+Defined in: [types/generate.ts:695](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L695)
 
 Pre-validated user context for the request
 
@@ -1128,7 +1147,7 @@ Pre-validated user context for the request
 
 > `optional` **useKnowledgeGrounding?**: `boolean`
 
-Defined in: [types/generate.ts:687](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L687)
+Defined in: [types/generate.ts:701](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L701)
 
 Opt this generation call into the knowledge grounding configured on the
 NeuroLink instance. Defaults to `false` when omitted.
@@ -1139,7 +1158,7 @@ NeuroLink instance. Defaults to `false` when omitted.
 
 > `optional` **knowledgeContext?**: [`KnowledgeRequestScope`](KnowledgeRequestScope.md)
 
-Defined in: [types/generate.ts:694](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L694)
+Defined in: [types/generate.ts:708](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L708)
 
 Enabled integrations used to scope knowledge retrieval for this turn.
 Used only when `useKnowledgeGrounding` is true and knowledge grounding is
@@ -1151,7 +1170,7 @@ enabled on the NeuroLink instance.
 
 > `optional` **auth?**: `object`
 
-Defined in: [types/generate.ts:697](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L697)
+Defined in: [types/generate.ts:711](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L711)
 
 Raw auth token — validated by configured auth provider
 
@@ -1165,7 +1184,7 @@ Raw auth token — validated by configured auth provider
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/generate.ts:704](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L704)
+Defined in: [types/generate.ts:718](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L718)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -1177,7 +1196,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **providerFallback?**: (`error`) => `Promise`\<\{ `provider?`: `string`; `model?`: `string`; \} \| `null`\>
 
-Defined in: [types/generate.ts:715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L715)
+Defined in: [types/generate.ts:729](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L729)
 
 Curator P2-3: per-call fallback callback. Overrides any
 instance-level `providerFallback` set on `new NeuroLink({...})`.
@@ -1203,7 +1222,7 @@ retry, `null` to bubble.
 
 > `optional` **modelChain?**: `string`[]
 
-Defined in: [types/generate.ts:725](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L725)
+Defined in: [types/generate.ts:739](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L739)
 
 Curator P2-3: per-call ordered model chain. Overrides any
 instance-level `modelChain`. Without an explicit `providerFallback`
@@ -1216,7 +1235,7 @@ other failures (network, 5xx, timeouts) bubble immediately.
 
 > `optional` **memory?**: `object`
 
-Defined in: [types/generate.ts:735](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L735)
+Defined in: [types/generate.ts:749](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L749)
 
 Per-call memory control.
 
@@ -1256,7 +1275,7 @@ Primary user is still determined by context.userId.
 
 > `optional` **piiDetection?**: `object`
 
-Defined in: [types/generate.ts:754](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L754)
+Defined in: [types/generate.ts:768](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L768)
 
 PII detection — scans and optionally redacts PII from input before the LLM call.
 
@@ -1296,7 +1315,7 @@ PII detection — scans and optionally redacts PII from input before the LLM cal
 
 > `optional` **responseValidation?**: `object`
 
-Defined in: [types/generate.ts:779](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L779)
+Defined in: [types/generate.ts:793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L793)
 
 Response validation — validates and optionally transforms the LLM response.
 Supports retry-with-feedback when `retryOnFailure: true`.
@@ -1363,7 +1382,7 @@ Supports retry-with-feedback when `retryOnFailure: true`.
 
 > `optional` **inputValidation?**: `object`
 
-Defined in: [types/generate.ts:797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L797)
+Defined in: [types/generate.ts:811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L811)
 
 Input validation — validates input text before any processing.
 
@@ -1389,7 +1408,7 @@ Input validation — validates input text before any processing.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/generate.ts:807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L807)
+Defined in: [types/generate.ts:821](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L821)
 
 #### Deprecated
 
@@ -1401,7 +1420,7 @@ Use `piiDetection`, `responseValidation`, and `inputValidation` instead.
 
 > `optional` **skills?**: [`SkillsCallOptions`](SkillsCallOptions.md)
 
-Defined in: [types/generate.ts:815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L815)
+Defined in: [types/generate.ts:829](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L829)
 
 Per-call skills control. Only effective when the instance was
 constructed with `skills.enabled: true`. Lets a call disable the

--- a/docs/api/type-aliases/GenerateOptionsNormalized.md
+++ b/docs/api/type-aliases/GenerateOptionsNormalized.md
@@ -8,7 +8,7 @@
 
 > **GenerateOptionsNormalized** = [`GenerateOptions`](GenerateOptions.md) & `object`
 
-Defined in: [types/generate.ts:1732](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1732)
+Defined in: [types/generate.ts:1755](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1755)
 
 Internal alias used by messageBuilder helpers after the entry-point
 (`buildMultimodalMessagesArray`) has guaranteed that `input` is non-null.

--- a/docs/api/type-aliases/GenerateResult.md
+++ b/docs/api/type-aliases/GenerateResult.md
@@ -8,7 +8,7 @@
 
 > **GenerateResult** = `object` & [`MediaGenerationOutputs`](MediaGenerationOutputs.md)
 
-Defined in: [types/generate.ts:1027](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1027)
+Defined in: [types/generate.ts:1041](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1041)
 
 Generate function result type - Primary output format
 Future-ready for multi-modal outputs while maintaining text focus

--- a/docs/api/type-aliases/GenerateStopReason.md
+++ b/docs/api/type-aliases/GenerateStopReason.md
@@ -8,7 +8,7 @@
 
 > **GenerateStopReason** = `"completed"` \| `"step-cap"` \| `"context-cap"` \| `"time-limit"` \| `"stalled"` \| `"aborted"` \| `"provider-error"`
 
-Defined in: [types/generate.ts:908](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L908)
+Defined in: [types/generate.ts:922](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L922)
 
 Why an agentic turn ended — the discriminator consumers should branch on
 instead of sniffing the provider-shaped `finishReason` (whose values are

--- a/docs/api/type-aliases/GenerationCallConfig.md
+++ b/docs/api/type-aliases/GenerationCallConfig.md
@@ -8,7 +8,7 @@
 
 > **GenerationCallConfig** = `object`
 
-Defined in: [types/generate.ts:1740](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1740)
+Defined in: [types/generate.ts:1763](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1763)
 
 Per-call configuration for GenerationHandler's AI-SDK loop invocation,
 shared by the initial call and every fallback retry so they cannot drift.
@@ -19,7 +19,7 @@ shared by the initial call and every fallback retry so they cannot drift.
 
 > **shouldUseTools**: `boolean`
 
-Defined in: [types/generate.ts:1741](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1741)
+Defined in: [types/generate.ts:1764](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1764)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/generate.ts:1741](https://github.com/juspay/neurolink/blob/re
 
 > **includeStructuredOutput**: `boolean`
 
-Defined in: [types/generate.ts:1742](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1742)
+Defined in: [types/generate.ts:1765](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1765)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/generate.ts:1742](https://github.com/juspay/neurolink/blob/re
 
 > **turnStartMs**: `number`
 
-Defined in: [types/generate.ts:1746](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1746)
+Defined in: [types/generate.ts:1769](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1769)
 
 Anchor for the turn deadline — the ORIGINAL executeGeneration start,
 shared across fallback/provider retries so they can't refresh the
@@ -47,7 +47,7 @@ wall-clock budget.
 
 > `optional` **promptJsonInstruction?**: `boolean`
 
-Defined in: [types/generate.ts:1749](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1749)
+Defined in: [types/generate.ts:1772](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1772)
 
 Structured-output fallback retry: also spell the JSON Schema out in the
 system prompt, for vendors that ignore `response_format`.
@@ -58,6 +58,6 @@ system prompt, for vendors that ignore `response_format`.
 
 > `optional` **isToolReask?**: `boolean`
 
-Defined in: [types/generate.ts:1751](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1751)
+Defined in: [types/generate.ts:1774](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1774)
 
 Set on the single toolChoice:"none" re-ask so it can never recurse.

--- a/docs/api/type-aliases/MediaGenerationOutputs.md
+++ b/docs/api/type-aliases/MediaGenerationOutputs.md
@@ -8,7 +8,7 @@
 
 > **MediaGenerationOutputs** = `object`
 
-Defined in: [types/generate.ts:923](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L923)
+Defined in: [types/generate.ts:937](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L937)
 
 Media generation/processing outputs shared by GenerateResult and
 TextGenerationResult. Extracted so both result types intersect (&) this
@@ -21,7 +21,7 @@ same audio/video/avatar/music/ppt/image/transcription fields.
 
 > `optional` **audio?**: [`TTSResult`](TTSResult.md)
 
-Defined in: [types/generate.ts:952](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L952)
+Defined in: [types/generate.ts:966](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L966)
 
 Text-to-Speech audio result
 
@@ -57,7 +57,7 @@ if (result.audio) {
 
 > `optional` **ttsMetadata?**: [`TTSMetadata`](TTSMetadata.md)
 
-Defined in: [types/generate.ts:966](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L966)
+Defined in: [types/generate.ts:980](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L980)
 
 What happened during TTS synthesis, including why it failed.
 
@@ -77,7 +77,7 @@ neurolink.ts describes, on a different field.
 
 > `optional` **video?**: [`VideoGenerationResult`](VideoGenerationResult.md)
 
-Defined in: [types/generate.ts:990](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L990)
+Defined in: [types/generate.ts:1004](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1004)
 
 Video generation result
 
@@ -109,7 +109,7 @@ if (result.video) {
 
 > `optional` **avatar?**: [`AvatarResult`](AvatarResult.md)
 
-Defined in: [types/generate.ts:994](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L994)
+Defined in: [types/generate.ts:1008](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1008)
 
 Avatar (talking-head) generation result (present when output.mode is "avatar")
 
@@ -119,7 +119,7 @@ Avatar (talking-head) generation result (present when output.mode is "avatar")
 
 > `optional` **music?**: [`MusicResult`](MusicResult.md)
 
-Defined in: [types/generate.ts:998](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L998)
+Defined in: [types/generate.ts:1012](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1012)
 
 Music generation result (present when output.mode is "music")
 
@@ -129,7 +129,7 @@ Music generation result (present when output.mode is "music")
 
 > `optional` **ppt?**: [`PPTGenerationResult`](PPTGenerationResult.md)
 
-Defined in: [types/generate.ts:1016](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1016)
+Defined in: [types/generate.ts:1030](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1030)
 
 PowerPoint generation result (present when output.mode is "ppt")
 
@@ -154,7 +154,7 @@ if (result.ppt) {
 
 > `optional` **imageOutput?**: \{ `base64`: `string`; \} \| `null`
 
-Defined in: [types/generate.ts:1018](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1018)
+Defined in: [types/generate.ts:1032](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1032)
 
 Standard format for image generation
 
@@ -164,6 +164,6 @@ Standard format for image generation
 
 > `optional` **transcription?**: [`STTResult`](STTResult.md)
 
-Defined in: [types/generate.ts:1020](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1020)
+Defined in: [types/generate.ts:1034](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1034)
 
 STT transcription result (present when stt.enabled is true and audio input was provided)

--- a/docs/api/type-aliases/ModelAliasConfig.md
+++ b/docs/api/type-aliases/ModelAliasConfig.md
@@ -8,7 +8,7 @@
 
 > **ModelAliasConfig** = `object`
 
-Defined in: [types/generate.ts:1715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1715)
+Defined in: [types/generate.ts:1738](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1738)
 
 NL-004: Model alias/deprecation configuration.
 Allows mapping deprecated model names to their replacements.
@@ -19,4 +19,4 @@ Allows mapping deprecated model names to their replacements.
 
 > **aliases**: `Record`\<`string`, \{ `target`: `string`; `action`: `"warn"` \| `"redirect"` \| `"block"`; `reason?`: `string`; \}\>
 
-Defined in: [types/generate.ts:1716](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1716)
+Defined in: [types/generate.ts:1739](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1739)

--- a/docs/api/type-aliases/NativeGenerateLoopArgs.md
+++ b/docs/api/type-aliases/NativeGenerateLoopArgs.md
@@ -8,7 +8,7 @@
 
 > **NativeGenerateLoopArgs** = `object`
 
-Defined in: [types/generate.ts:1759](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1759)
+Defined in: [types/generate.ts:1782](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1782)
 
 Inputs to the shared native generate loop (`core/nativeGenerateLoop.ts`).
 One loop serves every provider whose delegating model exposes a v3-shaped
@@ -20,7 +20,7 @@ One loop serves every provider whose delegating model exposes a v3-shaped
 
 > **doGenerate**: (`options`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1760](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1760)
+Defined in: [types/generate.ts:1783](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1783)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [types/generate.ts:1760](https://github.com/juspay/neurolink/blob/re
 
 > **conversation**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1764](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1764)
+Defined in: [types/generate.ts:1787](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1787)
 
 Conversation in the message-builder shape each doGenerate converts itself.
 
@@ -48,7 +48,7 @@ Conversation in the message-builder shape each doGenerate converts itself.
 
 > `optional` **tools?**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1766](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1766)
+Defined in: [types/generate.ts:1789](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1789)
 
 Tool declarations in the v3 shape doGenerate already knows how to convert.
 
@@ -58,7 +58,7 @@ Tool declarations in the v3 shape doGenerate already knows how to convert.
 
 > **toolsRecord**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1768](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1768)
+Defined in: [types/generate.ts:1791](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1791)
 
 Registered tools, used to execute a call the model asks for.
 
@@ -68,7 +68,7 @@ Registered tools, used to execute a call the model asks for.
 
 > `optional` **toolChoice?**: `unknown`
 
-Defined in: [types/generate.ts:1769](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1769)
+Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1792)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [types/generate.ts:1769](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **responseFormat?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1770](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1770)
+Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1793)
 
 ---
 
@@ -84,7 +84,7 @@ Defined in: [types/generate.ts:1770](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **providerOptions?**: `Record`\<`string`, `Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1771](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1771)
+Defined in: [types/generate.ts:1794](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1794)
 
 ---
 
@@ -92,7 +92,7 @@ Defined in: [types/generate.ts:1771](https://github.com/juspay/neurolink/blob/re
 
 > **maxSteps**: `number`
 
-Defined in: [types/generate.ts:1772](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1772)
+Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1795)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [types/generate.ts:1772](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1773](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1773)
+Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1796)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [types/generate.ts:1773](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1774](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1774)
+Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [types/generate.ts:1774](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1775](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1775)
+Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
 
 ---
 
@@ -124,7 +124,7 @@ Defined in: [types/generate.ts:1775](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1777](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1777)
+Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
 
 Per-tool-execution cap, forwarded into `guardToolExecutor`.
 
@@ -134,7 +134,7 @@ Per-tool-execution cap, forwarded into `guardToolExecutor`.
 
 > **runStep**: (`call`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1779](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1779)
+Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1802)
 
 Wraps one step: retry ladder plus provider error classification.
 

--- a/docs/api/type-aliases/NativeGenerateLoopResult.md
+++ b/docs/api/type-aliases/NativeGenerateLoopResult.md
@@ -8,7 +8,7 @@
 
 > **NativeGenerateLoopResult** = `object`
 
-Defined in: [types/generate.ts:1784](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1784)
+Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1807)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1784](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1785](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1785)
+Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1785](https://github.com/juspay/neurolink/blob/re
 
 > **finishReason**: `string`
 
-Defined in: [types/generate.ts:1786](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1786)
+Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1786](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/generate.ts:1787](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1787)
+Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1810)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1787](https://github.com/juspay/neurolink/blob/re
 
 > **inputTokens**: `number`
 
-Defined in: [types/generate.ts:1788](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1788)
+Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1811)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/generate.ts:1788](https://github.com/juspay/neurolink/blob/re
 
 > **outputTokens**: `number`
 
-Defined in: [types/generate.ts:1789](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1789)
+Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/generate.ts:1789](https://github.com/juspay/neurolink/blob/re
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/generate.ts:1790](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1790)
+Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1813)
 
 ---
 
@@ -64,7 +64,7 @@ Defined in: [types/generate.ts:1790](https://github.com/juspay/neurolink/blob/re
 
 > **cacheWriteTokens**: `number`
 
-Defined in: [types/generate.ts:1791](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1791)
+Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [types/generate.ts:1791](https://github.com/juspay/neurolink/blob/re
 
 > **toolsUsed**: `string`[]
 
-Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1792)
+Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1815)
 
 ---
 
@@ -80,4 +80,4 @@ Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/re
 
 > **steps**: `number`
 
-Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1793)
+Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1816)

--- a/docs/api/type-aliases/SingleShotRequest.md
+++ b/docs/api/type-aliases/SingleShotRequest.md
@@ -8,7 +8,7 @@
 
 > **SingleShotRequest** = `object`
 
-Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1796)
+Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **system?**: `string`
 
-Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
+Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1820)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/re
 
 > **prompt**: `string`
 
-Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
+Defined in: [types/generate.ts:1821](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1821)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
+Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1822)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
+Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1823)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
+Defined in: [types/generate.ts:1824](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1824)

--- a/docs/api/type-aliases/SingleShotResult.md
+++ b/docs/api/type-aliases/SingleShotResult.md
@@ -8,7 +8,7 @@
 
 > **SingleShotResult** = `object`
 
-Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1804)
+Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1827)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1805](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1805)
+Defined in: [types/generate.ts:1828](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1828)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1805](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **usage?**: `object`
 
-Defined in: [types/generate.ts:1806](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1806)
+Defined in: [types/generate.ts:1829](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1829)
 
 #### inputTokens?
 
@@ -44,4 +44,4 @@ Defined in: [types/generate.ts:1806](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1807)
+Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1830)

--- a/docs/api/type-aliases/TTSMetadata.md
+++ b/docs/api/type-aliases/TTSMetadata.md
@@ -8,7 +8,7 @@
 
 > **TTSMetadata** = `object`
 
-Defined in: [types/generate.ts:1690](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1690)
+Defined in: [types/generate.ts:1713](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1713)
 
 Enhanced result type with optional analytics/evaluation
 
@@ -18,7 +18,7 @@ Enhanced result type with optional analytics/evaluation
 
 > **attempted**: `boolean`
 
-Defined in: [types/generate.ts:1692](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1692)
+Defined in: [types/generate.ts:1715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1715)
 
 Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
@@ -28,7 +28,7 @@ Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
 > **success**: `boolean`
 
-Defined in: [types/generate.ts:1694](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1694)
+Defined in: [types/generate.ts:1717](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1717)
 
 Whether TTS synthesis completed successfully.
 
@@ -38,7 +38,7 @@ Whether TTS synthesis completed successfully.
 
 > `optional` **error?**: `object`
 
-Defined in: [types/generate.ts:1696](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1696)
+Defined in: [types/generate.ts:1719](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1719)
 
 Structured synthesis error details, present only when synthesis failed.
 
@@ -60,6 +60,6 @@ Structured synthesis error details, present only when synthesis failed.
 
 > `optional` **latency?**: `number`
 
-Defined in: [types/generate.ts:1702](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1702)
+Defined in: [types/generate.ts:1725](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1725)
 
 TTS synthesis time in milliseconds.

--- a/docs/api/type-aliases/TextGenerationOptions.md
+++ b/docs/api/type-aliases/TextGenerationOptions.md
@@ -8,7 +8,7 @@
 
 > **TextGenerationOptions** = `object`
 
-Defined in: [types/generate.ts:1216](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1216)
+Defined in: [types/generate.ts:1230](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1230)
 
 Text generation options type (consolidated from core types)
 Extended to support video generation mode
@@ -19,7 +19,7 @@ Extended to support video generation mode
 
 > `optional` **prompt?**: `string`
 
-Defined in: [types/generate.ts:1217](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1217)
+Defined in: [types/generate.ts:1231](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1231)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/generate.ts:1217](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **input?**: `object`
 
-Defined in: [types/generate.ts:1227](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1227)
+Defined in: [types/generate.ts:1241](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1241)
 
 Alternative input format for multimodal SDK operations.
 
@@ -70,7 +70,7 @@ Director Mode segments (2-10). When provided, Director Mode is activated.
 
 > `optional` **provider?**: [`AIProviderName`](../enumerations/AIProviderName.md)
 
-Defined in: [types/generate.ts:1240](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1240)
+Defined in: [types/generate.ts:1254](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1254)
 
 ---
 
@@ -78,7 +78,7 @@ Defined in: [types/generate.ts:1240](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **model?**: `string`
 
-Defined in: [types/generate.ts:1241](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1241)
+Defined in: [types/generate.ts:1255](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1255)
 
 ---
 
@@ -86,7 +86,7 @@ Defined in: [types/generate.ts:1241](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **region?**: `string`
 
-Defined in: [types/generate.ts:1242](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1242)
+Defined in: [types/generate.ts:1256](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1256)
 
 ---
 
@@ -94,7 +94,7 @@ Defined in: [types/generate.ts:1242](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1243](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1243)
+Defined in: [types/generate.ts:1257](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1257)
 
 ---
 
@@ -102,7 +102,7 @@ Defined in: [types/generate.ts:1243](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxTokens?**: `number`
 
-Defined in: [types/generate.ts:1244](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1244)
+Defined in: [types/generate.ts:1258](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1258)
 
 ---
 
@@ -110,7 +110,7 @@ Defined in: [types/generate.ts:1244](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **topP?**: `number`
 
-Defined in: [types/generate.ts:1246](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1246)
+Defined in: [types/generate.ts:1260](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1260)
 
 Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
@@ -120,7 +120,7 @@ Top-p (nucleus) sampling parameter. Controls diversity of generated tokens.
 
 > `optional` **topK?**: `number`
 
-Defined in: [types/generate.ts:1248](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1248)
+Defined in: [types/generate.ts:1262](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1262)
 
 Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini models only)
 
@@ -130,7 +130,7 @@ Top-k sampling parameter. Limits the number of tokens considered. (Google/Gemini
 
 > `optional` **stopSequences?**: `string`[]
 
-Defined in: [types/generate.ts:1250](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1250)
+Defined in: [types/generate.ts:1264](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1264)
 
 Stop sequences that will halt generation when encountered.
 
@@ -140,7 +140,7 @@ Stop sequences that will halt generation when encountered.
 
 > `optional` **systemPrompt?**: `string`
 
-Defined in: [types/generate.ts:1251](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1251)
+Defined in: [types/generate.ts:1265](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1265)
 
 ---
 
@@ -148,7 +148,7 @@ Defined in: [types/generate.ts:1251](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **schema?**: [`ZodUnknownSchema`](ZodUnknownSchema.md) \| [`Schema`](Schema.md)\<`unknown`\>
 
-Defined in: [types/generate.ts:1252](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1252)
+Defined in: [types/generate.ts:1266](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1266)
 
 ---
 
@@ -156,7 +156,7 @@ Defined in: [types/generate.ts:1252](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **output?**: `object`
 
-Defined in: [types/generate.ts:1264](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1264)
+Defined in: [types/generate.ts:1278](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1278)
 
 Output configuration options
 
@@ -221,7 +221,7 @@ output: {
 
 > `optional` **tools?**: `Record`\<`string`, [`Tool`](Tool.md)\>
 
-Defined in: [types/generate.ts:1296](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1296)
+Defined in: [types/generate.ts:1310](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1310)
 
 ---
 
@@ -229,7 +229,7 @@ Defined in: [types/generate.ts:1296](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **enabledToolNames?**: `string`[]
 
-Defined in: [types/generate.ts:1311](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1311)
+Defined in: [types/generate.ts:1325](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1325)
 
 Filter available tools by name.
 Only tools with names in this array will be made available.
@@ -251,7 +251,7 @@ await neurolink.generate({
 
 > `optional` **timeout?**: `number` \| `string`
 
-Defined in: [types/generate.ts:1312](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1312)
+Defined in: [types/generate.ts:1326](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1326)
 
 ---
 
@@ -259,7 +259,7 @@ Defined in: [types/generate.ts:1312](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **turnTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1314](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1314)
+Defined in: [types/generate.ts:1328](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1328)
 
 Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutMs.
 
@@ -269,7 +269,7 @@ Wall-clock cap for the whole agentic turn (ms). See GenerateOptions.turnTimeoutM
 
 > `optional` **stallTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1316](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1316)
+Defined in: [types/generate.ts:1330](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1330)
 
 Max time with no progress before the turn ends as "stalled" (ms). See GenerateOptions.stallTimeoutMs.
 
@@ -279,7 +279,7 @@ Max time with no progress before the turn ends as "stalled" (ms). See GenerateOp
 
 > `optional` **wrapupTimeLeadMs?**: `number`
 
-Defined in: [types/generate.ts:1318](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1318)
+Defined in: [types/generate.ts:1332](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1332)
 
 Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptions.wrapupTimeLeadMs.
 
@@ -289,7 +289,7 @@ Remaining-time threshold that triggers the wrap-up nudge (ms). See GenerateOptio
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1320](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1320)
+Defined in: [types/generate.ts:1334](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1334)
 
 Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeoutMs.
 
@@ -299,7 +299,7 @@ Per-tool-execution timeout (ms, default 300_000). See GenerateOptions.toolTimeou
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1322](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1322)
+Defined in: [types/generate.ts:1336](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1336)
 
 AbortSignal for external cancellation of the AI call
 
@@ -309,7 +309,7 @@ AbortSignal for external cancellation of the AI call
 
 > `optional` **toolExecutionCapture?**: [`ToolExecutionCaptureOptions`](ToolExecutionCaptureOptions.md)
 
-Defined in: [types/generate.ts:1324](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1324)
+Defined in: [types/generate.ts:1338](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1338)
 
 Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
@@ -319,7 +319,7 @@ Bounds for tool execution capture. See GenerateOptions.toolExecutionCapture.
 
 > `optional` **disableTools?**: `boolean`
 
-Defined in: [types/generate.ts:1332](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1332)
+Defined in: [types/generate.ts:1346](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1346)
 
 ---
 
@@ -327,7 +327,7 @@ Defined in: [types/generate.ts:1332](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **disableToolCallRepair?**: `boolean`
 
-Defined in: [types/generate.ts:1334](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1334)
+Defined in: [types/generate.ts:1348](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1348)
 
 Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (repair enabled).
 
@@ -337,7 +337,7 @@ Disable the schema-driven tool call repair mechanism (BZ-665). Default: false (r
 
 > `optional` **maxSteps?**: `number`
 
-Defined in: [types/generate.ts:1335](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1335)
+Defined in: [types/generate.ts:1349](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1349)
 
 ---
 
@@ -345,7 +345,7 @@ Defined in: [types/generate.ts:1335](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolFilter?**: `string`[]
 
-Defined in: [types/generate.ts:1338](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1338)
+Defined in: [types/generate.ts:1352](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1352)
 
 Include only these tools by name (whitelist). If set, only matching tools are available.
 
@@ -355,7 +355,7 @@ Include only these tools by name (whitelist). If set, only matching tools are av
 
 > `optional` **excludeTools?**: `string`[]
 
-Defined in: [types/generate.ts:1341](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1341)
+Defined in: [types/generate.ts:1355](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1355)
 
 Exclude these tools by name (blacklist). Applied after toolFilter.
 
@@ -365,9 +365,23 @@ Exclude these tools by name (blacklist). Applied after toolFilter.
 
 > `optional` **disableToolCache?**: `boolean`
 
-Defined in: [types/generate.ts:1344](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1344)
+Defined in: [types/generate.ts:1358](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1358)
 
 Disable tool result caching for this request (overrides global mcp.cache.enabled)
+
+---
+
+### disableInternalFallback?
+
+> `optional` **disableInternalFallback?**: `boolean`
+
+Defined in: [types/generate.ts:1367](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1367)
+
+Caller owns fallback order. Read in two places: `directProviderGeneration`
+bounds its static provider-priority walk to one candidate, and
+`BaseProvider.generate()` skips the catalog model-fallback walk so an
+invalid-model error surfaces as itself. Mapped from
+`GenerateOptions.disableInternalFallback`.
 
 ---
 
@@ -375,7 +389,7 @@ Disable tool result caching for this request (overrides global mcp.cache.enabled
 
 > `optional` **toolChoice?**: [`ToolChoice`](ToolChoice.md)\<`Record`\<`string`, [`Tool`](Tool.md)\>\>
 
-Defined in: [types/generate.ts:1359](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1359)
+Defined in: [types/generate.ts:1382](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1382)
 
 Tool choice configuration for the generation.
 Controls whether and which tools the model must call.
@@ -395,7 +409,7 @@ will cause infinite tool calls until `maxSteps` is exhausted.
 
 > `optional` **prepareStep?**: (`options`) => `PromiseLike`\<\{ `model?`: [`LanguageModel`](LanguageModel.md); `toolChoice?`: [`ToolChoice`](ToolChoice.md)\<`Record`\<`string`, [`Tool`](Tool.md)\>\>; `experimental_activeTools?`: `string`[]; \} \| `undefined`\>
 
-Defined in: [types/generate.ts:1384](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1384)
+Defined in: [types/generate.ts:1407](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1407)
 
 Optional callback that runs before each step in a multi-step generation.
 Allows dynamically changing `toolChoice` and available tools per step.
@@ -452,7 +466,7 @@ https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#parameters
 
 > `optional` **tts?**: [`TTSOptions`](TTSOptions.md)
 
-Defined in: [types/generate.ts:1427](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1427)
+Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1450)
 
 Text-to-Speech (TTS) configuration
 
@@ -489,7 +503,7 @@ const result = await neurolink.generate({
 
 > `optional` **stt?**: [`STTOptions`](STTOptions.md) & `object`
 
-Defined in: [types/generate.ts:1446](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1446)
+Defined in: [types/generate.ts:1469](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1469)
 
 Speech-to-Text (STT) configuration
 
@@ -529,7 +543,7 @@ const result = await neurolink.generate({
 
 > `optional` **enableEvaluation?**: `boolean`
 
-Defined in: [types/generate.ts:1449](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1449)
+Defined in: [types/generate.ts:1472](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1472)
 
 ---
 
@@ -537,7 +551,7 @@ Defined in: [types/generate.ts:1449](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **enableAnalytics?**: `boolean`
 
-Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1450)
+Defined in: [types/generate.ts:1473](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1473)
 
 ---
 
@@ -545,7 +559,7 @@ Defined in: [types/generate.ts:1450](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **context?**: `Record`\<`string`, [`JsonValue`](JsonValue.md)\>
 
-Defined in: [types/generate.ts:1451](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1451)
+Defined in: [types/generate.ts:1474](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1474)
 
 ---
 
@@ -553,7 +567,7 @@ Defined in: [types/generate.ts:1451](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **evaluationDomain?**: `string`
 
-Defined in: [types/generate.ts:1454](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1454)
+Defined in: [types/generate.ts:1477](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1477)
 
 ---
 
@@ -561,7 +575,7 @@ Defined in: [types/generate.ts:1454](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolUsageContext?**: `string`
 
-Defined in: [types/generate.ts:1455](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1455)
+Defined in: [types/generate.ts:1478](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1478)
 
 ---
 
@@ -569,7 +583,7 @@ Defined in: [types/generate.ts:1455](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationHistory?**: `object`[]
 
-Defined in: [types/generate.ts:1456](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1456)
+Defined in: [types/generate.ts:1479](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1479)
 
 #### role
 
@@ -585,7 +599,7 @@ Defined in: [types/generate.ts:1456](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationMessages?**: [`ChatMessage`](ChatMessage.md)[]
 
-Defined in: [types/generate.ts:1459](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1459)
+Defined in: [types/generate.ts:1482](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1482)
 
 ---
 
@@ -593,7 +607,7 @@ Defined in: [types/generate.ts:1459](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **conversationMemoryConfig?**: `Partial`\<[`ConversationMemoryConfig`](ConversationMemoryConfig.md)\>
 
-Defined in: [types/generate.ts:1462](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1462)
+Defined in: [types/generate.ts:1485](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1485)
 
 ---
 
@@ -601,7 +615,7 @@ Defined in: [types/generate.ts:1462](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **originalPrompt?**: `string`
 
-Defined in: [types/generate.ts:1463](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1463)
+Defined in: [types/generate.ts:1486](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1486)
 
 ---
 
@@ -609,7 +623,7 @@ Defined in: [types/generate.ts:1463](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **middleware?**: [`MiddlewareFactoryOptions`](MiddlewareFactoryOptions.md)
 
-Defined in: [types/generate.ts:1466](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1466)
+Defined in: [types/generate.ts:1489](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1489)
 
 ---
 
@@ -617,7 +631,7 @@ Defined in: [types/generate.ts:1466](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/generate.ts:1474](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1474)
+Defined in: [types/generate.ts:1497](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1497)
 
 ---
 
@@ -625,7 +639,7 @@ Defined in: [types/generate.ts:1474](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/generate.ts:1475](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1475)
+Defined in: [types/generate.ts:1498](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1498)
 
 ---
 
@@ -633,7 +647,7 @@ Defined in: [types/generate.ts:1475](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **expectedOutcome?**: `string`
 
-Defined in: [types/generate.ts:1478](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1478)
+Defined in: [types/generate.ts:1501](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1501)
 
 ---
 
@@ -641,7 +655,7 @@ Defined in: [types/generate.ts:1478](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **evaluationCriteria?**: `string`[]
 
-Defined in: [types/generate.ts:1479](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1479)
+Defined in: [types/generate.ts:1502](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1502)
 
 ---
 
@@ -649,7 +663,7 @@ Defined in: [types/generate.ts:1479](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **csvOptions?**: [`CSVProcessorOptions`](CSVProcessorOptions.md)
 
-Defined in: [types/generate.ts:1482](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1482)
+Defined in: [types/generate.ts:1505](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1505)
 
 ---
 
@@ -657,7 +671,7 @@ Defined in: [types/generate.ts:1482](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **pdfOptions?**: `object`
 
-Defined in: [types/generate.ts:1485](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1485)
+Defined in: [types/generate.ts:1508](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1508)
 
 PDF processing options (#258).
 
@@ -691,7 +705,7 @@ Max pages converted by the image fallback (#297); defaults to PDF_LIMITS.DEFAULT
 
 > `optional` **enableSummarization?**: `boolean`
 
-Defined in: [types/generate.ts:1496](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1496)
+Defined in: [types/generate.ts:1519](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1519)
 
 ---
 
@@ -699,7 +713,7 @@ Defined in: [types/generate.ts:1496](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **skipToolPromptInjection?**: `boolean`
 
-Defined in: [types/generate.ts:1514](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1514)
+Defined in: [types/generate.ts:1537](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1537)
 
 Skip injecting tool schemas into the system prompt.
 When true, tools are ONLY passed natively via the provider's `tools` parameter,
@@ -712,7 +726,7 @@ Default: false (backward compatible — tool schemas are injected into system pr
 
 > `optional` **thinking?**: `boolean`
 
-Defined in: [types/generate.ts:1571](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1571)
+Defined in: [types/generate.ts:1594](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1594)
 
 Enable extended thinking capability (simplified option).
 Equivalent to `thinkingConfig.enabled = true`.
@@ -724,7 +738,7 @@ Works with both Anthropic and Gemini 3 models.
 
 > `optional` **thinkingBudget?**: `number`
 
-Defined in: [types/generate.ts:1578](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1578)
+Defined in: [types/generate.ts:1601](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1601)
 
 Token budget for thinking (Anthropic models only).
 Equivalent to `thinkingConfig.budgetTokens`.
@@ -736,7 +750,7 @@ Range: 5000-100000 tokens. Ignored for Gemini models.
 
 > `optional` **thinkingLevel?**: `"minimal"` \| `"low"` \| `"medium"` \| `"high"`
 
-Defined in: [types/generate.ts:1589](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1589)
+Defined in: [types/generate.ts:1612](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1612)
 
 Thinking level for Gemini 3 models only.
 Equivalent to `thinkingConfig.thinkingLevel`.
@@ -753,7 +767,7 @@ Equivalent to `thinkingConfig.thinkingLevel`.
 
 > `optional` **thinkingConfig?**: `object`
 
-Defined in: [types/generate.ts:1597](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1597)
+Defined in: [types/generate.ts:1620](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1620)
 
 Full thinking/reasoning configuration (recommended for SDK usage).
 Takes precedence over simplified options (thinking, thinkingBudget, thinkingLevel).
@@ -792,7 +806,7 @@ Above documentation for provider-specific behavior and option compatibility.
 
 > `optional` **credentials?**: [`NeurolinkCredentials`](NeurolinkCredentials.md)
 
-Defined in: [types/generate.ts:1613](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1613)
+Defined in: [types/generate.ts:1636](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1636)
 
 Per-provider credential overrides for this request.
 Overrides instance-level credentials set in `new NeuroLink({ credentials })`.
@@ -804,7 +818,7 @@ Unset providers fall through to instance credentials, then environment variables
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/generate.ts:1620](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1620)
+Defined in: [types/generate.ts:1643](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1643)
 
 Optional request identifier for observability and log correlation.
 When provided, this ID is forwarded to spans, logs, and telemetry so
@@ -816,7 +830,7 @@ callers can correlate generation traces back to their own request lifecycle.
 
 > `optional` **piiDetection?**: [`GenerateOptions`](GenerateOptions.md)\[`"piiDetection"`\]
 
-Defined in: [types/generate.ts:1623](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1623)
+Defined in: [types/generate.ts:1646](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1646)
 
 PII detection config — forwarded from GenerateOptions/StreamOptions.
 
@@ -826,7 +840,7 @@ PII detection config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **responseValidation?**: [`GenerateOptions`](GenerateOptions.md)\[`"responseValidation"`\]
 
-Defined in: [types/generate.ts:1626](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1626)
+Defined in: [types/generate.ts:1649](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1649)
 
 Response validation config — forwarded from GenerateOptions/StreamOptions.
 
@@ -836,7 +850,7 @@ Response validation config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **inputValidation?**: [`GenerateOptions`](GenerateOptions.md)\[`"inputValidation"`\]
 
-Defined in: [types/generate.ts:1629](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1629)
+Defined in: [types/generate.ts:1652](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1652)
 
 Input validation config — forwarded from GenerateOptions/StreamOptions.
 
@@ -846,7 +860,7 @@ Input validation config — forwarded from GenerateOptions/StreamOptions.
 
 > `optional` **processors?**: [`ProcessorPipelineConfig`](ProcessorPipelineConfig.md)
 
-Defined in: [types/generate.ts:1632](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1632)
+Defined in: [types/generate.ts:1655](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1655)
 
 #### Deprecated
 

--- a/docs/api/type-aliases/TextGenerationResult.md
+++ b/docs/api/type-aliases/TextGenerationResult.md
@@ -8,7 +8,7 @@
 
 > **TextGenerationResult** = `object` & [`MediaGenerationOutputs`](MediaGenerationOutputs.md)
 
-Defined in: [types/generate.ts:1638](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1638)
+Defined in: [types/generate.ts:1661](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1661)
 
 Text generation result (consolidated from core types)
 

--- a/docs/api/type-aliases/ToolExecutionCaptureOptions.md
+++ b/docs/api/type-aliases/ToolExecutionCaptureOptions.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionCaptureOptions** = `object`
 
-Defined in: [types/generate.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L875)
+Defined in: [types/generate.ts:889](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L889)
 
 Bounds for per-call tool execution capture (see `ToolExecutionRecord`).
 Capture is ON by default with these caps; raise them when a caller needs
@@ -20,7 +20,7 @@ full result texts (e.g. caller-side evidence verification).
 
 > `optional` **maxResultChars?**: `number`
 
-Defined in: [types/generate.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L877)
+Defined in: [types/generate.ts:891](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L891)
 
 Max serialized result characters kept per record (default 8192).
 
@@ -30,7 +30,7 @@ Max serialized result characters kept per record (default 8192).
 
 > `optional` **maxRecords?**: `number`
 
-Defined in: [types/generate.ts:879](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L879)
+Defined in: [types/generate.ts:893](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L893)
 
 Max records kept per turn; oldest are dropped first (default 500).
 
@@ -40,7 +40,7 @@ Max records kept per turn; oldest are dropped first (default 500).
 
 > `optional` **onRecord?**: (`record`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/generate.ts:887](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L887)
+Defined in: [types/generate.ts:901](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L901)
 
 Fire-and-forget per-record callback, invoked as each tool execution
 completes. Listener errors — synchronous throws AND async rejections —

--- a/docs/api/type-aliases/ToolExecutionRecord.md
+++ b/docs/api/type-aliases/ToolExecutionRecord.md
@@ -8,7 +8,7 @@
 
 > **ToolExecutionRecord** = `object`
 
-Defined in: [types/generate.ts:851](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L851)
+Defined in: [types/generate.ts:865](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L865)
 
 One real tool invocation captured during an agentic turn.
 
@@ -24,7 +24,7 @@ to observe their own tool traffic.
 
 > **toolName**: `string`
 
-Defined in: [types/generate.ts:853](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L853)
+Defined in: [types/generate.ts:867](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L867)
 
 Tool name as the model called it.
 
@@ -34,7 +34,7 @@ Tool name as the model called it.
 
 > **params**: `unknown`
 
-Defined in: [types/generate.ts:855](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L855)
+Defined in: [types/generate.ts:869](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L869)
 
 Parameters the tool was invoked with, as parsed by the loop.
 
@@ -44,7 +44,7 @@ Parameters the tool was invoked with, as parsed by the loop.
 
 > **resultText**: `string`
 
-Defined in: [types/generate.ts:861](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L861)
+Defined in: [types/generate.ts:875](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L875)
 
 Serialized tool result (JSON when serializable, else String()), bounded
 by `toolExecutionCapture.maxResultChars` (default ~8KB). Truncated text
@@ -56,7 +56,7 @@ ends with a `…[truncated N chars]` marker.
 
 > **isError**: `boolean`
 
-Defined in: [types/generate.ts:863](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L863)
+Defined in: [types/generate.ts:877](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L877)
 
 True when the execution threw or returned an error-shaped result.
 
@@ -66,7 +66,7 @@ True when the execution threw or returned an error-shaped result.
 
 > **startedAt**: `number`
 
-Defined in: [types/generate.ts:865](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L865)
+Defined in: [types/generate.ts:879](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L879)
 
 Epoch milliseconds when the execution started.
 
@@ -76,6 +76,6 @@ Epoch milliseconds when the execution started.
 
 > **durationMs**: `number`
 
-Defined in: [types/generate.ts:867](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L867)
+Defined in: [types/generate.ts:881](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L881)
 
 Wall-clock duration of the execution in milliseconds.

--- a/docs/api/type-aliases/UnifiedGenerationOptions.md
+++ b/docs/api/type-aliases/UnifiedGenerationOptions.md
@@ -8,7 +8,7 @@
 
 > **UnifiedGenerationOptions** = [`GenerateOptions`](GenerateOptions.md) & `object`
 
-Defined in: [types/generate.ts:1181](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1181)
+Defined in: [types/generate.ts:1195](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1195)
 
 Unified options for both generation and streaming
 Supports factory patterns and domain configuration

--- a/docs/features/provider-fallback.md
+++ b/docs/features/provider-fallback.md
@@ -135,6 +135,16 @@ model-router value. Two per-call knobs control the retry:
   `metadata.stopReason === "step-cap"` after the stream is drained. Default
   (unset) preserves the retry.
 
+`generate()` has no no-output retry, but the same flag governs its two
+internal fallbacks: the static provider-priority walk that runs when no
+provider was requested, and the catalog model-fallback walk a provider performs
+when the vendor rejects its model as invalid. With
+`disableInternalFallback: true`, `generate()` tries exactly one provider from
+that static list and surfaces an invalid model as the classified
+`InvalidModelError` after a single request. A configured `ModelPool`,
+`providerFallback` and `modelChain` are your own fallback and are unaffected on
+either path: a pool still walks its own candidates.
+
 ---
 
 ## Observability

--- a/src/cli/loop/optionsSchema.ts
+++ b/src/cli/loop/optionsSchema.ts
@@ -176,6 +176,11 @@ export const textGenerationOptionsSchema: Record<
     description:
       "Disable tool result caching for this request (overrides global mcp.cache.enabled).",
   },
+  disableInternalFallback: {
+    type: "boolean",
+    description:
+      "Own fallback order yourself: skip NeuroLink's provider-priority walk and the catalog model fallback, so an invalid model or unavailable provider surfaces as its own error.",
+  },
   disableToolCallRepair: {
     type: "boolean",
     description:

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -1758,12 +1758,10 @@ export abstract class BaseProvider implements AIProvider {
       );
     };
 
-    // TextGenerationOptions does not declare the flag (it lives on
-    // StreamOptions), but callers that own fallback order pass it on both
-    // paths, so honour it here as well.
-    const callerOwnsFallback =
-      "disableInternalFallback" in options &&
-      options.disableInternalFallback === true;
+    // Callers that own fallback order (providerFallback / modelChain callers,
+    // or a router that retries on its own) pass the flag on both paths;
+    // TextGenerationOptions declares it, so a plain read is enough here.
+    const callerOwnsFallback = options.disableInternalFallback === true;
     return await this.runGenerateWithModelFallback(attempt, callerOwnsFallback);
   }
 

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5577,6 +5577,11 @@ Current user's request: ${currentInput}`;
       disableTools: options.disableTools,
       toolFilter: options.toolFilter,
       excludeTools: options.excludeTools,
+      // This explicit field list is the only road into the provider, so a
+      // flag left out here never reaches BaseProvider — which is exactly how
+      // disableInternalFallback was dropped on generate() while stream()
+      // (which spreads its options) honoured it.
+      disableInternalFallback: options.disableInternalFallback,
       maxSteps: options.maxSteps,
       toolChoice: options.toolChoice,
       prepareStep: options.prepareStep,
@@ -8149,12 +8154,25 @@ Current user's request: ${currentInput}`;
       : requestedProvider
         ? [requestedProvider]
         : providerPriority;
+    // The caller owns fallback order (a providerFallback / modelChain caller,
+    // or a router that retries on its own): bound the walk to its first
+    // candidate so an unavailable provider surfaces as its own error instead
+    // of a silent switch. An explicit provider is already a one-element
+    // list; this only changes the "auto" and orchestrated-preference walks.
+    const providersToTry =
+      options.disableInternalFallback === true
+        ? tryProviders.slice(0, 1)
+        : tryProviders;
+    // Caller-owned fallback never enters tryProviders: providerFallback and
+    // modelChain are walked by runWithFallbackOrchestration around the public
+    // generate() call, and a configured ModelPool is consumed by the block
+    // above. Slicing here therefore never clips a caller's own list.
 
     logger.debug(`[${functionTag}] Starting direct generation`, {
       requestedProvider: requestedProvider || "auto",
       preferredOrchestrated: preferredOrchestrated || "none",
-      tryProviders,
-      allowFallback: !requestedProvider || !!preferredOrchestrated,
+      tryProviders: providersToTry,
+      allowFallback: providersToTry.length > 1,
     });
 
     // ─── ModelPool path ──────────────────────────────────────────────────────
@@ -8343,7 +8361,7 @@ Current user's request: ${currentInput}`;
     let lastError: Error | null = null;
 
     // Try each provider in order
-    for (const providerName of tryProviders) {
+    for (const providerName of providersToTry) {
       if (options.abortSignal?.aborted) {
         throw new DOMException("The operation was aborted", "AbortError");
       }
@@ -8795,7 +8813,7 @@ Current user's request: ${currentInput}`;
     // All providers failed
     const responseTime = Date.now() - startTime;
     logger.error(`[${functionTag}] All providers failed`, {
-      triedProviders: tryProviders,
+      triedProviders: providersToTry,
       lastError: lastError?.message,
       responseTime,
     });

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -494,6 +494,20 @@ export type GenerateOptions = {
   /** Disable tool result caching for this request (overrides global mcp.cache.enabled) */
   disableToolCache?: boolean;
 
+  /**
+   * Disable NeuroLink's internal fallback for this request: the static
+   * provider-priority walk that runs when no provider was requested, and the
+   * catalog model-fallback walk a provider performs when its model is
+   * rejected as invalid. Callers that own fallback order (a caller-supplied
+   * `providerFallback` / `modelChain`, or a router that retries on its own,
+   * as the Claude proxy does for its streams) set this so an invalid model
+   * or an unavailable provider surfaces as exactly that.
+   * A configured `ModelPool`, `providerFallback` and `modelChain` are the
+   * caller's own fallback and are unaffected. Mirrors the same flag on
+   * `StreamOptions`.
+   */
+  disableInternalFallback?: boolean;
+
   /** Maximum number of tool execution steps (default: 200) */
   maxSteps?: number;
 
@@ -1342,6 +1356,15 @@ export type TextGenerationOptions = {
 
   /** Disable tool result caching for this request (overrides global mcp.cache.enabled) */
   disableToolCache?: boolean;
+
+  /**
+   * Caller owns fallback order. Read in two places: `directProviderGeneration`
+   * bounds its static provider-priority walk to one candidate, and
+   * `BaseProvider.generate()` skips the catalog model-fallback walk so an
+   * invalid-model error surfaces as itself. Mapped from
+   * `GenerateOptions.disableInternalFallback`.
+   */
+  disableInternalFallback?: boolean;
 
   /**
    * Tool choice configuration for the generation.

--- a/test/continuous-test-suite-error-classification-e2e.ts
+++ b/test/continuous-test-suite-error-classification-e2e.ts
@@ -2022,6 +2022,100 @@ async function main(): Promise<void> {
           );
         }
       }
+
+      // --- 6. catalog model fallback is generate()'s default --------------
+      // A model the vendor rejects as invalid is retried on the catalog's
+      // fallback list (BaseProvider.runGenerateWithModelFallback). Case 7
+      // turns that off, so the default is pinned first: the retry carries
+      // the catalog's first fallback id and the call resolves.
+      {
+        type ModelBody = ChatRequestBody & { model?: string };
+        const bodies: ModelBody[] = [];
+        setHandler(() => {
+          const body = parseBody(lastRequestBody) as ModelBody;
+          bodies.push(body);
+          if (body.model === "mancer-ghost") {
+            return {
+              status: 400,
+              body: JSON.stringify({ error: { message: "Unknown Model" } }),
+            };
+          }
+          return completion({ role: "assistant", content: "ready" }, "stop");
+        });
+        const name =
+          "mancer: an invalid model is retried on the catalog fallback by default";
+        try {
+          const r = (await nl().generate({
+            provider: "mancer",
+            model: "mancer-ghost",
+            input: { text: "Say ready." },
+            disableTools: true,
+          } as Parameters<InstanceType<typeof NeuroLink>["generate"]>[0])) as {
+            content?: string;
+          };
+          const problems: string[] = [];
+          if (bodies.length < 2) {
+            problems.push(
+              `expected a fallback request, saw ${bodies.length} request(s)`,
+            );
+          }
+          if (bodies[0]?.model !== "mancer-ghost") {
+            problems.push("first request did not carry the requested model");
+          }
+          if (bodies.length >= 2 && bodies[1]?.model !== "deepseek-v4-flash") {
+            problems.push(
+              "fallback request did not carry the catalog's first fallback model",
+            );
+          }
+          if (!/ready/i.test(r.content ?? "")) {
+            problems.push("answer did not come back");
+          }
+          record(name, problems.length === 0, problems.join("; ") || undefined);
+        } catch (err) {
+          record(
+            name,
+            false,
+            `generate() threw: ${err instanceof Error ? err.constructor.name : "non-Error"}`,
+          );
+        }
+      }
+
+      // --- 7. disableInternalFallback reaches the provider on generate() --
+      // GenerateOptions declares the flag and buildGenerateTextOptions maps
+      // it through. Before that, the explicit field list dropped it and
+      // generate() fell back regardless of what the caller asked (stream()
+      // spreads its options, so it always honoured the flag). With the flag
+      // the vendor's rejection surfaces as the classified InvalidModelError
+      // after exactly one request.
+      {
+        type ModelBody = ChatRequestBody & { model?: string };
+        const bodies: ModelBody[] = [];
+        setHandler(() => {
+          bodies.push(parseBody(lastRequestBody) as ModelBody);
+          return {
+            status: 400,
+            body: JSON.stringify({ error: { message: "Unknown Model" } }),
+          };
+        });
+        await expectGenerateError({
+          name: "mancer: disableInternalFallback on generate() surfaces the invalid model instead of falling back",
+          run: () =>
+            nl().generate({
+              provider: "mancer",
+              model: "mancer-ghost",
+              input: { text: "Say ready." },
+              disableTools: true,
+              disableInternalFallback: true,
+            } as Parameters<InstanceType<typeof NeuroLink>["generate"]>[0]),
+          expectClass: InvalidModelError,
+          messageIncludes: ["mancer-ghost"],
+        });
+        record(
+          "mancer: disableInternalFallback on generate() sends exactly one request",
+          bodies.length === 1,
+          bodies.length === 1 ? undefined : `saw ${bodies.length} request(s)`,
+        );
+      }
     }
   } finally {
     restoreEnv();

--- a/test/continuous-test-suite-provider-matrix.ts
+++ b/test/continuous-test-suite-provider-matrix.ts
@@ -219,22 +219,59 @@ async function runMatrix(): Promise<void> {
             greeting: zod.z.string(),
             count: zod.z.number(),
           });
-          let lastContent: string | undefined;
+          let last:
+            | {
+                content?: string;
+                structuredData?: unknown;
+                jsonTruncated?: boolean;
+              }
+            | undefined;
           for (let attempt = 1; attempt <= 2; attempt++) {
             const r = await sdk.generate({
               ...baseOpts,
               input: { text: 'Reply with greeting="hi" and count=42 in JSON.' },
               maxTokens: 200,
               disableTools: true,
-              structuredOutput: { schema },
-            } as never);
-            lastContent = r.content;
-            if (lastContent && lastContent.length > 0) {
+              // `schema` is the option generate() honours. The previous
+              // `structuredOutput: { schema }` was never a GenerateOptions
+              // field (the `as never` cast hid that) and was silently
+              // ignored, so this cell passed on plain text. The real
+              // parameter type replaces the `as never` cast here so a
+              // wrong option name is a compile error, not a silent no-op.
+              schema,
+            } as Parameters<NeuroLink["generate"]>[0]);
+            last = r;
+            if (
+              r.content &&
+              r.content.length > 0 &&
+              r.structuredData !== undefined
+            ) {
               break;
             }
           }
-          if (!lastContent || lastContent.length === 0) {
+          if (!last?.content || last.content.length === 0) {
             throw new Error("empty response");
+          }
+          // generate({ schema }) yields a parsed `structuredData` whenever the
+          // model produced anything JSON-shaped; a response cut off at the
+          // token cap yields a partial object and sets `jsonTruncated`, so
+          // only an untruncated result is held to the schema. Pure prose
+          // with no JSON at all leaves `structuredData` undefined (the SDK
+          // logs a WARN and returns the raw text). After two attempts that is
+          // the row's `structuredOutput: true` claim being false for this
+          // model, which must stay visible rather than downgrade to a skip.
+          if (last.structuredData === undefined) {
+            throw new Error(
+              "no JSON was recoverable from a schema request after two attempts",
+            );
+          }
+          if (
+            !last.jsonTruncated &&
+            !schema.safeParse(last.structuredData).success
+          ) {
+            throw new Error(
+              "structuredData did not satisfy the request schema",
+            );
           }
         } catch (err) {
           skipIfProviderError(err);

--- a/test/continuous-test-suite-vertex-loop-characterization.ts
+++ b/test/continuous-test-suite-vertex-loop-characterization.ts
@@ -956,9 +956,9 @@ await test("the generate path declares and executes a caller's tools", async () 
       maxTokens: 32,
       maxSteps: 3,
       disableTools: false,
-      // disableInternalFallback is a StreamOptions-only field (src/lib/types/stream.ts);
-      // GenerateOptions never reads it (grep confirms neurolink.ts uses it only
-      // inside stream()), so it was a no-op copied from the streaming cases below.
+      // GenerateOptions declares disableInternalFallback and generate() maps it
+      // through to the provider, so it is as load-bearing here as on the
+      // streaming cases below: no cross-provider or catalog-model retry.
       tools: customTool(counter),
       credentials: credentialsFor(server.port),
     });


### PR DESCRIPTION
## Summary

Two follow-ups recorded during the provider campaign (#1625, #1631), both about `generate()` options that looked honoured but were not.

### 1. `disableInternalFallback` never reached the provider on `generate()`

`StreamOptions` declared the flag and `stream()` honoured it (BaseProvider's `withStreamModelFallback` / `retryStreamWithFallbackModel`, the no-output retry in `neurolink.ts`). `GenerateOptions` did not declare it, and `buildGenerateTextOptions` rebuilds the provider options from an explicit field list, so the flag was dropped before `BaseProvider.generate()` could read it. A caller that owns fallback order could turn the catalog model fallback off for streams but not for one-shot calls.

- `GenerateOptions.disableInternalFallback` and `TextGenerationOptions.disableInternalFallback` are declared (docs mirror the stream flag; the REPL options schema gets the matching entry, which the `Record<keyof TextGenerationOptions, …>` type requires).
- `buildGenerateTextOptions` maps it through.
- `directProviderGeneration` bounds its static provider-priority walk to the first candidate when the flag is set. An explicit `provider` was already a one-element list; this only changes the `"auto"` and orchestrated-preference walks. A configured `ModelPool`, `providerFallback` and `modelChain` are the caller's own fallback and are untouched, on both paths.
- `BaseProvider.generate()` drops the `"disableInternalFallback" in options` workaround now that the field is typed. The three provider-level reads (openai-compat base, Anthropic, SageMaker) are left as they are; another session owns the openai-compat stream path.
- `docs/features/provider-fallback.md` documents the generate-side behaviour.

### 2. The provider matrix's structured-output cell was testing nothing

`test/continuous-test-suite-provider-matrix.ts` passed `structuredOutput: { schema }`, which has never been a `GenerateOptions` field; the `as never` cast hid it and `generate()` ignored it, so the cell only checked for non-empty text. It now passes the honoured top-level `schema` and asserts that `structuredData` is present and satisfies the schema, with the documented `jsonTruncated` exemption.

## Proof

Mock-server e2e (`test/continuous-test-suite-error-classification-e2e.ts`, Mancer block, cases 6 and 7):

- default: a model the vendor rejects with `Unknown Model` is retried on the catalog's first fallback (`deepseek-v4-flash`) and the call resolves;
- `disableInternalFallback: true`: the classified `InvalidModelError` naming the requested model surfaces after **exactly one** request.

On the pre-change build the request-count assertion fails with three requests (ghost model, then both catalog fallbacks), so the test is a real regression guard. Break-one ritual: with the count deliberately changed, the case reports `✗` and the suite exits non-zero.

Credential-free proof, rebased onto 69c749b94 (which wires this suite into CI and adds the Vertex placeholders): run from an empty directory with no `.env`, an empty `HOME` and a node-only `PATH`, the suite is **144/144** with all four Mancer cases passing. A run that keeps `HOME` or the repo cwd is not credential-free, because the SDK loads the working directory's `.env` itself.

Live: the rewritten matrix cell against Google AI (`gemini-2.5-flash`): `✓ [google-ai] structured output`, 7/7 cells passed (run twice: before and after the review fixes). With the schema assertion deliberately inverted the cell reports `✗`, not `⊘`: `✗ [google-ai] structured output`, Failed: 1, exit code 1.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm run check` | 0 errors (svelte-check + tsc --strict) |
| `pnpm run lint` | 0 errors; the 58 warnings are the pre-existing method-length warnings |
| `pnpm run build` | green (SDK + CLI + pack) |
| `test:error-classification-e2e` | 144/144 after the rebase onto 69c749b94 (141/144 before it: the 3 failures were the release regressions #1635 fixed) |
| `test:providers-mocked` | 95/95 |
| `test:provider-structure` | 3/3 |
| docs:api regenerated | yes, 22 generated pages refreshed; `disableInternalFallback` appears on `GenerateOptions` and `TextGenerationOptions` |
| adversarial review (4 lenses, 2 skeptics per finding) | 6 findings, all addressed (below) |

Review findings and what changed:

- **Matrix cell hard-failed on the SDK's documented pure-prose outcome** (confirmed). `generate({ schema })` leaves `structuredData` undefined when the model returns no JSON at all, distinct from truncation. The cell now retries once more when that happens and then fails with a precise message. It deliberately stays a failure rather than a skip: the row's `structuredOutput: true` is the claim under test, and prose after two attempts means the claim is false for that model. The message was checked against the harness's expected-provider-error patterns and is not downgraded.
- **`TextGenerationOptions` JSDoc named only one of the two walks the flag bounds** (confirmed). Reworded to name both.
- **`docs/api` not regenerated** (confirmed). Regenerated as the last step before the commit.
- **Code comments cited the Claude proxy as a `generate()` caller** (confirmed). The proxy only calls `stream()`; the comments and the type doc now say "a router that retries on its own" and mention the proxy only for streams.
- **Stale comment in `continuous-test-suite-vertex-loop-characterization.ts`** said `GenerateOptions` never reads the flag (confirmed). Corrected; that suite's `generate()` case now genuinely relies on it.
- **Docs paragraph said `generate()` "tries exactly one provider" even with a `ModelPool`** (contested, one skeptic refuted). Made precise anyway: one provider from the static list; a pool still walks its own candidates.

## Not in this PR

Three structured-output recovery cases in the e2e suite (`vendor ignores response_format -> fallback re-asks…`, `failing tool_choice:none re-ask degrades…`, `empty tool_calls finish on the last budgeted step…`) fail identically on a clean `release` checkout at c328f4d0a (138/141 there, 140/140 at 1375cbfcb, the commit before 653d1ff69). They are an incomplete port in the Vercel AI SDK removal; the session that owns that change has reproduced them and is fixing them, and this PR neither touches nor fixes them.

`test:error-classification-e2e` is wired into no CI job (ci.yml references only `test:error-classifier-contract`), which is why CI stayed green through the regression. Wiring it in belongs with that fix, not here; until then the two new cases in this PR run only where someone runs the suite.

## Overlap check

Both live neurolink sessions on this machine were asked before work started and answered NOT MINE on all three items. The openai-compat stream path and `src/lib/middleware` were left untouched by agreement with the session working there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to disable automatic provider and model fallback for text generation.
  - Added CLI support for configuring this option.
  - When enabled, invalid model or unavailable provider errors are surfaced directly, while caller-managed fallback settings remain unaffected.

- **Documentation**
  - Clarified fallback behavior and refreshed API reference links.

- **Tests**
  - Added coverage for fallback and no-fallback behavior.
  - Improved structured-output validation and provider test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->