### PR TITLE
fix(core): restore three native-loop recoveries the SDK removal dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,6 +1089,7 @@ jobs:
           SUITES="
             test:tts:unit@140
             test:agent-delegation@78
+            test:error-classification-e2e@71
             test:background-commands@23
             test:agent-tasks@13
             test:artifact-banking@13

--- a/src/lib/core/nativeGenerateLoop.ts
+++ b/src/lib/core/nativeGenerateLoop.ts
@@ -14,6 +14,7 @@
  * the same across Anthropic, the OpenAI-compatible family and SageMaker.
  */
 
+import { logger } from "../utils/logger.js";
 import type {
   NativeGenerateLoopArgs,
   NativeGenerateLoopResult,
@@ -144,37 +145,79 @@ export async function runNativeGenerateLoop(
   let steps = 0;
   // One bounded recovery re-ask per turn; see the empty-tool-calls branch.
   let reasked = false;
+  // True only while the NEXT step is the recovery re-ask. `reasked` stays set
+  // for the rest of the turn, so it cannot distinguish "this step is the
+  // re-ask" from "the re-ask already happened" — and degrading a later,
+  // unrelated failure would swallow a real error.
+  let reaskPending = false;
+  // The turn as it stood before the re-ask. The re-ask is a bonus request on
+  // top of a call that already produced a result, so if it fails the honest
+  // answer is that result — not a thrown turn.
+  let preReask:
+    | { text: string; finishReason: string; rawFinishReason?: string }
+    | undefined;
   const hasTools = Boolean(args.tools && args.tools.length > 0);
 
   for (let step = 0; step < args.maxSteps; step++) {
     steps = step + 1;
-    const res = await args.runStep(() =>
-      args.doGenerate({
-        prompt: args.conversation,
-        ...(args.tools && args.tools.length > 0 ? { tools: args.tools } : {}),
-        // The v3 call option is an OBJECT — `{ type: "none" }`. Passing the
-        // bare string "none" type-checks against `unknown` and is then
-        // dropped by every converter that switches on `choice.type`, so the
-        // re-ask silently went out unchanged. Caught by the stand-in asserting
-        // the wire body, not by any live provider.
-        ...(reasked
-          ? { toolChoice: { type: "none" } }
-          : args.toolChoice !== undefined
-            ? { toolChoice: args.toolChoice }
+    const runThisStep = () =>
+      args.runStep(() =>
+        args.doGenerate({
+          prompt: args.conversation,
+          ...(args.tools && args.tools.length > 0 ? { tools: args.tools } : {}),
+          // The v3 call option is an OBJECT — `{ type: "none" }`. Passing the
+          // bare string "none" type-checks against `unknown` and is then
+          // dropped by every converter that switches on `choice.type`, so the
+          // re-ask silently went out unchanged. Caught by the stand-in asserting
+          // the wire body, not by any live provider.
+          ...(reasked
+            ? { toolChoice: { type: "none" } }
+            : args.toolChoice !== undefined
+              ? { toolChoice: args.toolChoice }
+              : {}),
+          ...(args.responseFormat
+            ? { responseFormat: args.responseFormat }
             : {}),
-        ...(args.responseFormat ? { responseFormat: args.responseFormat } : {}),
-        ...(args.providerOptions
-          ? { providerOptions: args.providerOptions }
-          : {}),
-        ...(args.maxOutputTokens
-          ? { maxOutputTokens: args.maxOutputTokens }
-          : {}),
-        ...(args.temperature !== undefined
-          ? { temperature: args.temperature }
-          : {}),
-        ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
-      }),
-    );
+          ...(args.providerOptions
+            ? { providerOptions: args.providerOptions }
+            : {}),
+          ...(args.maxOutputTokens
+            ? { maxOutputTokens: args.maxOutputTokens }
+            : {}),
+          ...(args.temperature !== undefined
+            ? { temperature: args.temperature }
+            : {}),
+          ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+        }),
+      );
+
+    let res: Awaited<ReturnType<typeof args.doGenerate>>;
+    try {
+      res = await runThisStep();
+    } catch (stepError) {
+      // Ported from GenerationHandler.recoverEmptyToolCallsFinish's catch: a
+      // failed re-ask hands back the turn that already succeeded rather than
+      // turning a degraded turn into a thrown one. The native port made the
+      // re-ask a `continue`, so the failure surfaced from the NEXT step's
+      // doGenerate and propagated instead.
+      if (reaskPending && preReask) {
+        logger.warn(
+          "toolChoice: none re-ask failed; returning the original result",
+          {
+            error:
+              stepError instanceof Error
+                ? stepError.message
+                : String(stepError),
+          },
+        );
+        text = preReask.text;
+        finishReason = preReask.finishReason;
+        rawFinishReason = preReask.rawFinishReason;
+        break;
+      }
+      throw stepError;
+    }
+    reaskPending = false;
 
     const parts = asParts(res.content);
     // Each step REPLACES the text rather than appending: the final step's
@@ -228,6 +271,8 @@ export async function runNativeGenerateLoop(
         step + 1 < args.maxSteps;
       if (emptyToolCallsFinish) {
         reasked = true;
+        reaskPending = true;
+        preReask = { text, finishReason, rawFinishReason };
         args.conversation.push({ role: "assistant", content: parts });
         continue;
       }

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -59,6 +59,7 @@ import type {
   Schema,
   StreamLoopArgs,
   EnhancedGenerateResult,
+  GenerateStopReason,
   TextGenerationOptions,
   ValidationSchema,
   StreamOptions,
@@ -88,6 +89,7 @@ import {
 } from "../core/nativeGenerateLoop.js";
 import { resolveToolExecutionRecords } from "../core/toolExecutionRecorder.js";
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
+import { coerceJsonToSchema, schemaAccepts } from "../utils/json/coerce.js";
 import { resolveToolChoice } from "../utils/toolChoice.js";
 import { transformToolExecutions } from "../utils/transformationUtils.js";
 import { withProviderRetry } from "../utils/providerRetry.js";
@@ -126,6 +128,23 @@ const WINDOW_FIT_MARGIN_TOKENS = 512;
 /**
  * Abstract HTTP+SSE provider for OpenAI chat-completions-shaped endpoints.
  */
+
+/**
+ * Did the model's text yield an object the caller's schema accepts?
+ *
+ * This is the trigger for the prompt-side structured-output fallback. It asks
+ * the question the ai-package's structured-output parser used to ask by
+ * throwing: did the native `response_format` attempt actually produce the
+ * object. A schema we cannot validate with accepts everything, so an unknown
+ * schema never forces a pointless second request.
+ */
+const yieldsSchemaValidObject = (
+  text: string,
+  schema: ValidationSchema,
+): boolean => {
+  const coerced = coerceJsonToSchema(text, schema);
+  return coerced !== null && schemaAccepts(schema, coerced.structuredData);
+};
 
 export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   protected config: { baseURL: string; apiKey: string };
@@ -1165,15 +1184,54 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         undefined,
       );
     }
+
+    // The vendor can also IGNORE `response_format` and answer in prose without
+    // erroring at all — GMI Cloud's MiniMax endpoint does exactly that, and it
+    // is the case the fallback was written for. On the ai-package path the
+    // structured-output parser threw on the unparseable answer, so the catch
+    // above was reached; the native loop has no such parser, so the silent
+    // case sailed through and handed the caller prose. Same recovery, keyed on
+    // the result rather than on an exception.
+    if (
+      responseFormat !== undefined &&
+      options.schema !== undefined &&
+      !yieldsSchemaValidObject(loop.text, options.schema as ValidationSchema)
+    ) {
+      logger.warn(
+        `[${this.providerName}] response_format did not yield a schema-valid object — retrying with the schema in the system prompt`,
+        { provider: this.providerName, model: modelId },
+      );
+      loop = await runLoop(
+        appendJsonSchemaInstruction(conversation, responseFormat.schema),
+        undefined,
+      );
+    }
     const { text, finishReason, toolsUsed } = loop;
     const inputTokens = loop.inputTokens;
     const outputTokens = loop.outputTokens;
+
+    // stopReason / stepsUsed parity with the other native loops (Vertex
+    // Gemini / Claude / Bedrock) and with the ai-package path this replaced.
+    // Without them a consumer cannot tell a completed turn from one the step
+    // cap truncated: the turn that ends on a `tool-calls` finish with the
+    // budget spent is exactly the case the caller configured `maxSteps` to
+    // bound, and reporting it as a plain completion hides that.
+    const stepsUsed = loop.steps;
+    const stopReason: GenerateStopReason =
+      stepsUsed >= (options.maxSteps || DEFAULT_MAX_STEPS) &&
+      finishReason === "tool-calls"
+        ? "step-cap"
+        : finishReason === "error"
+          ? "provider-error"
+          : "completed";
 
     const enhanced: EnhancedGenerateResult = {
       content: text,
       provider: this.providerName,
       model: modelId,
       finishReason,
+      stopReason,
+      stepsUsed,
       usage: {
         input: inputTokens,
         output: outputTokens,

--- a/test/continuous-test-suite-error-classification-e2e.ts
+++ b/test/continuous-test-suite-error-classification-e2e.ts
@@ -1170,6 +1170,28 @@ async function main(): Promise<void> {
     // providers-mocked.ts already uses for this exact reason).
     // =========================================================================
     {
+      // Constructing the provider validates that SOME credential is present.
+      // Without these the constructor throws where none exists, aborting the
+      // whole suite before a single case runs — which is what happened the
+      // first time this suite was wired into CI.
+      //
+      // It is invisible locally, and NOT for the reason it first appears.
+      // `src/lib/neurolink.ts` calls `dotenvConfig({ quiet: true })` with no
+      // path, so importing the SDK loads `./.env` from the working directory
+      // — and a developer's .env has GOOGLE_APPLICATION_CREDENTIALS in it.
+      // `DOTENV_CONFIG_PATH=/dev/null` does not prevent this: that variable
+      // is read by `dotenv/config`, not by a direct `config()` call. So the
+      // "run it with the environment stripped" check documented on the
+      // extended-suites job does not actually isolate a suite that
+      // constructs a provider; only running from a directory with no .env
+      // does. Verified both ways: passes in-repo with the environment
+      // stripped, reproduces the CI abort from a cwd without .env.
+      //
+      // These cases only call formatProviderError(), which performs no
+      // network I/O, so placeholders are enough.
+      setEnv("GOOGLE_SERVICE_ACCOUNT_KEY", "e2e-placeholder-not-a-real-key");
+      setEnv("GOOGLE_VERTEX_PROJECT", "e2e-placeholder-project");
+      setEnv("GOOGLE_VERTEX_LOCATION", "us-central1");
       const vertex = new GoogleVertexProvider() as unknown as {
         formatProviderError(error: unknown): Error;
       };

--- a/test/continuous-test-suite-native-vendor-recovery.ts
+++ b/test/continuous-test-suite-native-vendor-recovery.ts
@@ -12,9 +12,16 @@ import "dotenv/config";
  *      carrying `content: null` and no `tool_calls` array. There is nothing to
  *      execute, so the loop stops and the caller gets an empty turn even though
  *      the tool ran. The recovery re-asks once with `tool_choice: "none"`.
- *   2. GMI Cloud's MiniMax endpoint ignores a strict `json_schema` request and
- *      answers in prose. The recovery drops `response_format` and spells the
- *      schema into the system prompt.
+ *   2. GMI Cloud's MiniMax endpoint does not honour a strict `json_schema`
+ *      request. The recovery drops `response_format` and spells the schema
+ *      into the system prompt. It has TWO triggers, and they are separate
+ *      cases below because conflating them is exactly how this went wrong:
+ *      the vendor can REJECT the request outright (a 400 the loop catches),
+ *      or accept it and silently answer in prose (nothing throws at all).
+ *      The original port handled only the first. This header used to describe
+ *      the second while the suite exercised the first, so a green run
+ *      certified a recovery that did not exist — three cases in
+ *      `test:error-classification-e2e` failed on release for that reason.
  *
  * Both recoveries used to live in `GenerationHandler`, on the ai-package path.
  * Every provider they were written for is a Tier-2 catalog provider on the
@@ -133,6 +140,67 @@ await test("a rejected response_format falls back to the schema in the system pr
     if (requests < 2) {
       throw new Error(
         `precondition failed: fallback never issued, saw ${requests} requests`,
+      );
+    }
+
+    const bodies = server.getAllRequestBodies();
+    const first = JSON.parse(bodies[0]) as { response_format?: unknown };
+    const second = JSON.parse(bodies[1]) as {
+      response_format?: unknown;
+      messages?: Array<{ role: string; content?: unknown }>;
+    };
+    if (first.response_format === undefined) {
+      throw new Error("first attempt did not request constrained decoding");
+    }
+    if (second.response_format !== undefined) {
+      throw new Error("fallback still sent response_format");
+    }
+    const systemText = (second.messages ?? [])
+      .filter((m) => m.role === "system")
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    if (!systemText.includes("JSON Schema")) {
+      throw new Error("fallback did not spell the schema into the prompt");
+    }
+    const data = result.structuredData as { city?: string } | undefined;
+    if (data?.city !== "Tokyo") {
+      throw new Error("recovered object did not reach the caller");
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+await test("a silently ignored response_format falls back to the schema in the system prompt", async () => {
+  // The other half of recovery 2, and the one the original port missed. The
+  // vendor accepts `response_format` with a 200 and answers in prose anyway,
+  // so nothing throws and the error-triggered fallback never fires. Reply 2
+  // answers the re-ask.
+  const server = await startScriptedChatServer([
+    chatCompletion({
+      content: "Sure! Tokyo is currently about 22 degrees.",
+      finishReason: "stop",
+    }),
+    chatCompletion({
+      content: '{"city":"Tokyo","temp":22}',
+      finishReason: "stop",
+    }),
+  ]);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "weather in Tokyo" },
+      provider: "openai",
+      model: "scripted-model",
+      credentials: credentialsFor(server.baseURL),
+      maxTokens: 64,
+      schema: z.object({ city: z.string(), temp: z.number() }),
+    });
+
+    const requests = server.requestCount();
+    if (requests < 2) {
+      throw new Error(
+        `precondition failed: no fallback for the silent case, saw ${requests} requests`,
       );
     }
 


### PR DESCRIPTION
## What broke

#1628 ported two `GenerationHandler` recoveries into the native generate loop. The port was incomplete in three ways. `test:error-classification-e2e` goes **140/140 at `1375cbfcb` → 138/141 at `c328f4d0a`**.

That was measured, not inferred: the suite was built and run at both commits. The pre-refactor run needed its own `pnpm install --frozen-lockfile`, because `node_modules` now matches the post-removal lockfile while the old tree still imports `ai`.

Reported by a parallel session working in the same repo; the attribution to #1628 is mine.

## The three defects

1. **The structured-output fallback fired only when the provider threw.** It was gated on `isToolsSchemaConflictError || isSchemaComplexityError`. The case it was written for is a vendor that *accepts* `response_format` and answers in prose anyway (GMI Cloud's MiniMax). On the ai-package path the structured-output parser threw on the unparseable answer, which is what reached the catch — the native loop has no such parser, so the silent case sailed through and handed the caller prose. It now also triggers on the result: if `response_format` was sent and the text yields no schema-accepted object, re-ask once with the schema in the system prompt.

2. **A failing `toolChoice: none` re-ask threw instead of degrading.** The native port made the re-ask a `continue`, so its failure surfaced from the *next* step's `doGenerate` and propagated. The loop now snapshots the turn before re-asking and restores it if the re-ask fails — matching `recoverEmptyToolCallsFinish`'s catch, where the re-ask is a bonus request on top of a call that already succeeded. The flag is deliberately separate from `reasked`, which stays set for the rest of the turn and would otherwise swallow a later unrelated failure.

3. **`stopReason` / `stepsUsed` were never surfaced.** The loop already returned `steps`; the OpenAI-compatible result dropped them, so a turn ended by the step cap was indistinguishable from a completed one.

## Why it merged green

**The suite runs in no CI job at all.** `ci.yml` references only `test:error-classifier-contract` — a different suite. `grep -rn error-classification .github/` returns nothing. The extended shards were green on both commits because they never executed it.

It is now wired into the extended shards, qualified under that job's own stated rule: **141/141 with the environment fully stripped** (`env -i`, `DOTENV_CONFIG_PATH=/dev/null`), 71s, entering at that weight.

## The test that gave false confidence

`continuous-test-suite-native-vendor-recovery.ts` is the suite that certified the original port. Its header described the *silent* case while the test exercised the *rejected* one — so a green run proved a recovery that did not exist. Both triggers are now separate cases; header corrected to say exactly that.

## Verification

| gate | result |
| --- | --- |
| `test:error-classification-e2e` | **141/141** (was 138/141) |
| `test:error-classification-e2e`, env stripped | 141/141, 71s |
| vendor-recovery | 3/3 (was 2/2) |
| `test:providers-mocked` | 95/95 |
| lint / typecheck / build | 0 errors / clean / clean |

Note `12.12.0` is published with these three defects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output handling when a provider returns prose despite accepting a schema request.
  * Added an automatic retry that reinforces the requested schema and preserves the last successful result if recovery fails.
  * Generation results now include more complete completion details, including stop reason and steps used.

* **Tests**
  * Added coverage for vendor responses that silently ignore structured-output requests.
  * Included the error-classification end-to-end suite in extended test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->