### PR TITLE
fix(middleware): apply model middleware on the OpenAI-compatible streaming path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,6 +1125,7 @@ jobs:
             test:tool-resolution@3
             test:autoresearch@2
             test:loop-engine@2
+            test:stream-middleware@5
             test:handler-registry@1
           "
           # Normalise every entry to name@weight (missing or non-numeric

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "test:bedrock-inference-profile": "pnpm exec tsx test/continuous-test-suite-bedrock-inference-profile.ts",
     "test:loop-engine": "pnpm exec tsx test/continuous-test-suite-loop-engine.ts",
     "test:middleware": "pnpm exec tsx test/continuous-test-suite-middleware.ts",
+    "test:stream-middleware": "pnpm exec tsx test/continuous-test-suite-stream-middleware.ts",
     "test:observability": "pnpm exec tsx test/continuous-test-suite-observability.ts",
     "test:ppt": "pnpm exec tsx test/continuous-test-suite-ppt.ts",
     "test:vertex-loop-characterization": "tsx test/continuous-test-suite-vertex-loop-characterization.ts",

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -2723,9 +2723,22 @@ export abstract class BaseProvider implements AIProvider {
   protected async getAISDKModelWithMiddleware(
     options: TextGenerationOptions | StreamOptions = {},
   ): Promise<LanguageModel> {
-    // Get the base model
-    const baseModel = await this.getAISDKModel();
+    return this.applyMiddlewareToModel(await this.getAISDKModel(), options);
+  }
 
+  /**
+   * Apply the configured middleware chain to a caller-supplied base model.
+   *
+   * `getAISDKModelWithMiddleware()` always wraps `getAISDKModel()`, which is
+   * the model the non-streaming path drives. Streaming paths build a
+   * different base — one whose `doStream` starts the provider's own stream
+   * loop — and need the same chain applied to it, so the wrapping is split
+   * out here rather than duplicated per provider.
+   */
+  protected async applyMiddlewareToModel(
+    baseModel: LanguageModel,
+    options: TextGenerationOptions | StreamOptions = {},
+  ): Promise<LanguageModel> {
     logger.debug(`Retrieved base model for ${this.providerName}`, {
       provider: this.providerName,
       model: this.modelName,

--- a/src/lib/middleware/builtin/guardrails.ts
+++ b/src/lib/middleware/builtin/guardrails.ts
@@ -2,6 +2,7 @@ import type {
   NeuroLinkMiddleware,
   NeuroLinkMiddlewareMetadata,
   GuardrailsMiddlewareConfig,
+  LanguageModelV3StreamPart,
 } from "../../types/index.js";
 import {
   createBlockedResponse,
@@ -67,8 +68,7 @@ export function createGuardrailsMiddleware(
 
   const middleware: LanguageModelMiddleware = {
     specificationVersion: "v3" as const,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    transformParams: async ({ params }: any) => {
+    transformParams: async ({ params }) => {
       if (config.precallEvaluation?.enabled) {
         const { shouldBlock, transformedParams } =
           await handlePrecallGuardrails(params, config.precallEvaluation);
@@ -79,8 +79,7 @@ export function createGuardrailsMiddleware(
       return params;
     },
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    wrapGenerate: async ({ doGenerate, params }: any) => {
+    wrapGenerate: async ({ doGenerate, params }) => {
       logger.debug(`[GuardrailsMiddleware] Applying to generate call.`);
       // Check if this request should be blocked (set by transformParams)
       if (config.precallEvaluation?.enabled && blockingState.get(params)) {
@@ -89,19 +88,30 @@ export function createGuardrailsMiddleware(
 
       let result = await doGenerate();
 
-      const filterResult = applyContentFiltering(
-        result.text || "",
-        config.badWords,
-        "generate",
-      );
-      if (filterResult.hasChanges) {
-        result = { ...result, text: filterResult.filteredText };
-      }
+      result = {
+        ...result,
+        content: result.content.map((part) =>
+          part.type === "text"
+            ? {
+                ...part,
+                text: applyContentFiltering(
+                  part.text,
+                  config.badWords,
+                  "generate",
+                ).filteredText,
+              }
+            : part,
+        ),
+      };
 
       if (config.modelFilter?.enabled && config.modelFilter.filterModel) {
         logger.debug(`[GuardrailsMiddleware] Invoking model-based filter.`);
         try {
-          const filterPrompt = `Is the following text safe? Respond with only "safe" or "unsafe".\n\nText: "${result.text}"`;
+          const text = result.content
+            .filter((part) => part.type === "text")
+            .map((part) => part.text)
+            .join("");
+          const filterPrompt = `Is the following text safe? Respond with only "safe" or "unsafe".\n\nText: "${text}"`;
           // `ModelFilterConfig.filterModel` is typed `LanguageModel`, which
           // admits a bare model id, and the documented examples used one.
           // `generateOnceNative` needs a handle exposing doGenerate, so a
@@ -119,7 +129,14 @@ export function createGuardrailsMiddleware(
             logger.warn(
               `[GuardrailsMiddleware] Model-based filter flagged content as unsafe.`,
             );
-            result = { ...result, text: "<REDACTED BY AI GUARDRAIL>" };
+            result = {
+              ...result,
+              content: result.content.map((part) =>
+                part.type === "text"
+                  ? { ...part, text: "<REDACTED BY AI GUARDRAIL>" }
+                  : part,
+              ),
+            };
           }
         } catch (error) {
           logger.error(`[GuardrailsMiddleware] Model-based filter failed.`, {
@@ -131,8 +148,7 @@ export function createGuardrailsMiddleware(
       return result;
     },
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    wrapStream: async ({ doStream, params }: any) => {
+    wrapStream: async ({ doStream, params }) => {
       logger.debug(`[GuardrailsMiddleware] Applying to stream call.`);
 
       // Check if this request should be blocked (set by transformParams)
@@ -147,23 +163,23 @@ export function createGuardrailsMiddleware(
       const { stream, ...rest } = await doStream();
       let hasYieldedChunks = false;
 
-      const transformStream = new TransformStream({
+      const transformStream = new TransformStream<
+        LanguageModelV3StreamPart,
+        LanguageModelV3StreamPart
+      >({
         transform(chunk, controller) {
           hasYieldedChunks = true;
           let filteredChunk = chunk;
-          if (
-            typeof filteredChunk === "object" &&
-            "textDelta" in filteredChunk
-          ) {
+          if (filteredChunk.type === "text-delta") {
             const filterResult = applyContentFiltering(
-              filteredChunk.textDelta,
+              filteredChunk.delta,
               config.badWords,
               "stream",
             );
             if (filterResult.hasChanges) {
               filteredChunk = {
                 ...filteredChunk,
-                textDelta: filterResult.filteredText,
+                delta: filterResult.filteredText,
               };
             }
           }

--- a/src/lib/middleware/utils/guardrailsUtils.ts
+++ b/src/lib/middleware/utils/guardrailsUtils.ts
@@ -2,6 +2,8 @@ import { AIProviderFactory } from "../../core/factory.js";
 import { logger } from "../../utils/logger.js";
 import type {
   BadWordsConfig,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
   ContentFilteringResult,
   EvaluationActionResult,
   PrecallEvaluationConfig,
@@ -338,28 +340,34 @@ export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function createBlockedResponse() {
+export function createBlockedResponse(): LanguageModelV3GenerateResult {
   return {
-    text: "Request contains inappropriate content and has been blocked.",
-    usage: { promptTokens: 0, completionTokens: 0 },
-    finishReason: "stop" as const,
+    content: [
+      {
+        type: "text",
+        text: "Request contains inappropriate content and has been blocked.",
+      },
+    ],
+    usage: { inputTokens: { total: 0 }, outputTokens: { total: 0 } },
+    finishReason: { unified: "stop" },
     warnings: [],
-    rawCall: { rawPrompt: null, rawSettings: {} },
   };
 }
 
-export function createBlockedStream() {
-  return new ReadableStream({
+export function createBlockedStream(): ReadableStream<LanguageModelV3StreamPart> {
+  return new ReadableStream<LanguageModelV3StreamPart>({
     start(controller) {
+      controller.enqueue({ type: "text-start", id: "blocked" });
       controller.enqueue({
         type: "text-delta",
-        textDelta:
-          "Request contains inappropriate content and has been blocked.",
+        id: "blocked",
+        delta: "Request contains inappropriate content and has been blocked.",
       });
+      controller.enqueue({ type: "text-end", id: "blocked" });
       controller.enqueue({
         type: "finish",
-        finishReason: "stop",
-        usage: { promptTokens: 0, completionTokens: 0 },
+        finishReason: { unified: "stop" },
+        usage: { inputTokens: { total: 0 }, outputTokens: { total: 0 } },
       });
       controller.close();
     },

--- a/src/lib/middleware/wrapLanguageModel.ts
+++ b/src/lib/middleware/wrapLanguageModel.ts
@@ -6,10 +6,9 @@
  * `wrapGenerate` / `wrapStream` hooks. Reproduced here so the middleware
  * factory no longer needs the ai package.
  *
- * Worth recording: `wrapStream` does not currently run in this codebase. Every
- * streaming path is native and bypasses the wrapped model entirely, so only
- * `wrapGenerate` is reachable. That is a pre-existing gap, not one this
- * introduced.
+ * The OpenAI-compatible streaming path also uses this wrapper. Other native
+ * streaming implementations must opt in explicitly; exposing a middleware
+ * option or a model-shaped handle alone does not apply the chain.
  */
 
 import type {

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -40,6 +40,9 @@ import { createProxyFetch } from "../proxy/proxyFetch.js";
 import type {
   DeferredUsage,
   LanguageModel,
+  LanguageModelV3StreamPart,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
   ModelsResponse,
   OpenAICompatBuildBodyArgs,
   OpenAICompatChatChoice,
@@ -145,6 +148,76 @@ const yieldsSchemaValidObject = (
   const coerced = coerceJsonToSchema(text, schema);
   return coerced !== null && schemaAccepts(schema, coerced.structuredData);
 };
+
+// Pull one native chunk at a time and forward cancellation to its iterator.
+const chunksToV3Stream = (
+  source: AsyncIterable<OpenAICompatStreamChunk>,
+  completion: Promise<LanguageModelV3StreamPart>,
+  cancel: () => void,
+): ReadableStream<LanguageModelV3StreamPart> => {
+  const iterator = source[Symbol.asyncIterator]();
+  return new ReadableStream<LanguageModelV3StreamPart>({
+    async pull(controller) {
+      try {
+        const next = await iterator.next();
+        if (next.done) {
+          controller.enqueue(await completion);
+          controller.close();
+        } else if (next.value.reasoning) {
+          controller.enqueue({
+            type: "reasoning-delta",
+            delta: next.value.reasoning,
+          });
+        } else {
+          controller.enqueue({ type: "text-delta", delta: next.value.content });
+        }
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      cancel();
+      await iterator.return?.();
+    },
+  });
+};
+
+async function* v3StreamToChunks(
+  stream: ReadableStream<LanguageModelV3StreamPart>,
+  onFinish: (
+    part: Extract<LanguageModelV3StreamPart, { type: "finish" }>,
+  ) => void,
+): AsyncIterable<OpenAICompatStreamChunk> {
+  const reader = stream.getReader();
+  let done = false;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) {
+        done = true;
+        return;
+      }
+      const part = next.value;
+      if (part.type === "text-delta") {
+        yield { content: part.delta };
+      } else if (part.type === "reasoning-delta") {
+        yield { content: "", reasoning: part.delta };
+      } else if (part.type === "finish") {
+        onFinish(part);
+      } else if (part.type === "error") {
+        throw part.error;
+      }
+    }
+  } finally {
+    try {
+      if (!done) {
+        await reader.cancel();
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}
 
 export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
   protected config: { baseURL: string; apiKey: string };
@@ -1287,7 +1360,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     let wireNameMaps: ReturnType<typeof buildWireToolNameMaps>;
     let openAITools: OpenAICompatChatTool[] | undefined;
     let openAIToolChoice: OpenAICompatToolChoiceWire | undefined;
-    let conversation: OpenAICompatChatMessage[];
+    // The prompt is kept in its pre-wire shape. Model middleware transforms
+    // `params.prompt`, and the conversion to the chat-completions wire format
+    // has to happen AFTER that or the transform would be discarded.
+    let promptMessages: OpenAICompatMessage[];
     try {
       modelId = await this.resolveModelName();
       const shouldUseTools = !options.disableTools && this.supportsTools();
@@ -1307,11 +1383,9 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         wireNameMaps?.toWire,
       );
 
-      const initialMessages = await this.buildMessagesForStream(options);
-      conversation = messageBuilderToOpenAI(
-        initialMessages as OpenAICompatMessage[],
-        wireNameMaps?.toWire,
-      );
+      promptMessages = (await this.buildMessagesForStream(
+        options,
+      )) as OpenAICompatMessage[];
     } catch (setupErr) {
       timeoutController?.cleanup();
       throw setupErr;
@@ -1333,26 +1407,152 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     // Per-provider lifecycle hook (e.g. OTel span wrap for LiteLLM).
     const lifecycle = this.onStreamStart(modelId);
 
-    const loopPromise = this.runStreamLoop({
-      maxSteps,
+    // Model middleware on the streaming path.
+    //
+    // The base model below is not `buildDelegatingModel()`'s — that one's
+    // `doGenerate` is a single wire call and its `doStream` is a stub. This
+    // one's `doStream` starts the real multi-step stream loop, which is what
+    // "produce the stream for this request" means here. Wrapping it gives the
+    // streaming path the contract the generate path has always had:
+    // `transformParams` can rewrite the prompt before a byte is sent, and
+    // `wrapStream` can observe, filter, or replace the stream outright.
+    //
+    // Honoured on the way back in: `prompt`, `maxOutputTokens`, `temperature`
+    // and `topP`. `tools` is offered read-only — a middleware that rewrites it
+    // gets a WARN rather than a silent drop, because re-deriving the wire tool
+    // list here would diverge from `buildToolsForOpenAI`.
+    const v3Tools = openAITools?.map((t) => ({
+      type: "function" as const,
+      name: t.function.name,
+      description: t.function.description,
+      inputSchema: t.function.parameters,
+    }));
+    const v3Params: LanguageModelV3CallOptions = {
+      prompt: promptMessages as LanguageModelV3CallOptions["prompt"],
+      ...(v3Tools ? { tools: v3Tools } : {}),
+      ...(options.maxTokens !== undefined
+        ? { maxOutputTokens: options.maxTokens }
+        : {}),
+      ...(options.temperature !== undefined
+        ? { temperature: options.temperature }
+        : {}),
+      ...(options.topP !== undefined ? { topP: options.topP } : {}),
+    };
+
+    let loopPromise: Promise<unknown> | undefined;
+    const providerNameForLoop = this.providerName;
+    const streamBaseModel: LanguageModelV3 = {
+      specificationVersion: "v3" as const,
+      provider: providerNameForLoop,
       modelId,
-      url,
-      fetchImpl,
-      abortSignal,
-      options,
-      conversation,
-      openAITools,
-      openAIToolChoice,
-      toolsRecord,
-      toolNameFromWire: wireNameMaps?.fromWire,
-      emitter,
-      toolsUsed,
-      toolExecutionSummaries,
-      pushChunk: channel.push,
-      closeChannel: channel.close,
-      resolveUsage,
-      resolveFinish,
-    });
+      supportedUrls: {},
+      doGenerate: async (params) => {
+        const model = await this.getAISDKModel();
+        if (typeof model === "string") {
+          throw new Error("Native model handle required");
+        }
+        return model.doGenerate(params);
+      },
+      doStream: async (params) => {
+        if (params?.tools !== undefined && params.tools !== v3Tools) {
+          logger.warn(
+            `${providerNameForLoop}: middleware rewrote 'tools' on the streaming path; tool rewrites are not applied to the wire request yet — the original tool list was sent.`,
+          );
+        }
+        const transformedPrompt = Array.isArray(params?.prompt)
+          ? (params.prompt as OpenAICompatMessage[])
+          : promptMessages;
+        const conversation = messageBuilderToOpenAI(
+          transformedPrompt,
+          wireNameMaps?.toWire,
+        );
+        const sampled: StreamOptions = {
+          ...options,
+          ...(typeof params?.maxOutputTokens === "number"
+            ? { maxTokens: params.maxOutputTokens }
+            : {}),
+          ...(typeof params?.temperature === "number"
+            ? { temperature: params.temperature }
+            : {}),
+          ...(typeof params?.topP === "number" ? { topP: params.topP } : {}),
+        };
+        loopPromise = this.runStreamLoop({
+          maxSteps,
+          modelId,
+          url,
+          fetchImpl,
+          abortSignal,
+          options: sampled,
+          conversation,
+          openAITools,
+          openAIToolChoice,
+          toolsRecord,
+          toolNameFromWire: wireNameMaps?.fromWire,
+          emitter,
+          toolsUsed,
+          toolExecutionSummaries,
+          pushChunk: channel.push,
+          closeChannel: channel.close,
+          resolveUsage,
+          resolveFinish,
+        });
+        const completion: Promise<LanguageModelV3StreamPart> = loopPromise.then(
+          () =>
+            Promise.all([usagePromise, finishPromise]).then(
+              ([usage, reason]) => ({
+                type: "finish" as const,
+                finishReason: { unified: reason },
+                usage: {
+                  inputTokens: {
+                    total: usage.promptTokens,
+                    cacheRead: usage.cacheReadTokens,
+                  },
+                  outputTokens: { total: usage.completionTokens },
+                },
+              }),
+            ),
+        );
+        // The producer can reject before the consumer pulls its terminal event.
+        void completion.catch(() => undefined);
+        return {
+          stream: chunksToV3Stream(channel.iterable, completion, () =>
+            consumerAbortController.abort(),
+          ),
+        };
+      },
+    };
+
+    // A middleware chain that blocks (guardrails' precall path) returns its own
+    // stream without calling `doStream`, so the loop may never start. Every
+    // later reader of `loopPromise` has to tolerate that.
+    let chunkSource: AsyncIterable<OpenAICompatStreamChunk>;
+    try {
+      const wrappedStreamModel = await this.applyMiddlewareToModel(
+        streamBaseModel,
+        options,
+      );
+      if (typeof wrappedStreamModel === "string") {
+        throw new Error("Native stream model handle required");
+      }
+      const { stream } = await wrappedStreamModel.doStream(v3Params);
+      chunkSource = v3StreamToChunks(stream, (part) => {
+        if (!loopPromise) {
+          const input = part.usage.inputTokens.total ?? 0;
+          const output = part.usage.outputTokens.total ?? 0;
+          resolveUsage({
+            promptTokens: input,
+            completionTokens: output,
+            totalTokens: input + output,
+          });
+          resolveFinish(part.finishReason.unified);
+        }
+      });
+    } catch (error) {
+      consumerAbortController.abort();
+      channel.close();
+      timeoutController?.cleanup();
+      throw error;
+    }
 
     // Closure-scoped capture: the runStreamLoop's catch block stashes the
     // underlying provider error here so we can pass it through to
@@ -1382,7 +1582,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     const transformedStream = async function* () {
       let contentYielded = 0;
       try {
-        for await (const chunk of channel.iterable) {
+        for await (const chunk of chunkSource) {
           if (
             "content" in chunk &&
             typeof chunk.content === "string" &&
@@ -1393,6 +1593,8 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
           yield chunk;
         }
         // Surface any error that the loop threw after we drained the channel.
+        // `loopPromise` is undefined when a middleware blocked the request
+        // before `doStream` ran, in which case there is no loop to surface.
         await loopPromise;
         // No-output path: stream completed normally but yielded zero text.
         // Build an enriched sentinel + stamp the active OTel span so
@@ -1433,6 +1635,15 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
         yield sentinel as { content: string };
         throw streamError;
       } finally {
+        if (!loopPromise) {
+          resolveUsage({
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+          });
+          resolveFinish("stop");
+        }
+        timeoutController?.cleanup();
         if (!consumerAbortController.signal.aborted) {
           consumerAbortController.abort();
         }
@@ -1484,7 +1695,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
     });
 
     loopPromise
-      .finally(() => timeoutController?.cleanup())
+      ?.finally(() => timeoutController?.cleanup())
       .catch((error) => {
         captureProviderError(error);
       });

--- a/test/continuous-test-suite-stream-middleware.ts
+++ b/test/continuous-test-suite-stream-middleware.ts
@@ -1,0 +1,842 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Public generate()/stream() middleware contracts for the OpenAI-compatible
+ * family. Local HTTP fixtures prove prompt rewrites, real tool execution,
+ * guardrail blocking/filtering, error propagation, completion and cancellation.
+ * Runtime imports use only the built entry; type-only imports are erased.
+ *
+ * Run: pnpm run build && pnpm run test:stream-middleware
+ */
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { z } from "zod";
+import type {
+  NeuroLinkMiddleware,
+  LanguageModelV3StreamPart,
+  StreamResult,
+} from "../src/lib/types/index.js";
+import { defineSuite } from "./helpers/harness.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+import {
+  mockOpenAICredentials,
+  startMockChatServer,
+  startScriptedChatServer,
+  chatCompletion,
+} from "./helpers/mockChatServer.js";
+import { NeuroLink, tool } from "../dist/index.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("Stream middleware", {
+  offline: true,
+});
+
+const MARKER = "MIDDLEWARE_TOUCHED_THE_PROMPT";
+
+type ProbeRecord = {
+  transformParamsCalls: Array<"generate" | "stream">;
+  wrapGenerateCalls: number;
+  wrapStreamCalls: number;
+};
+
+/**
+ * A middleware that records which hooks fired and rewrites the outgoing
+ * prompt. The rewrite is what separates "the hook ran" from "the hook
+ * affected the request" — the stand-in captures the wire body, so the
+ * marker either reached the provider or it did not.
+ *
+ * `metadata` is mandatory. A probe without it registers under an `undefined`
+ * id and silently never runs, which measures the probe rather than the code.
+ */
+const createProbe = (record: ProbeRecord): NeuroLinkMiddleware => ({
+  specificationVersion: "v3",
+  metadata: { id: "stream-probe", name: "Stream probe" },
+  transformParams: async ({ type, params }) => {
+    record.transformParamsCalls.push(type);
+    return {
+      ...params,
+      prompt: [
+        ...params.prompt,
+        { role: "user", content: [{ type: "text", text: MARKER }] },
+      ],
+    };
+  },
+  wrapGenerate: async ({ doGenerate }) => {
+    record.wrapGenerateCalls += 1;
+    return doGenerate();
+  },
+  wrapStream: async ({ doStream }) => {
+    record.wrapStreamCalls += 1;
+    return doStream();
+  },
+});
+
+const emptyRecord = (): ProbeRecord => ({
+  transformParamsCalls: [],
+  wrapGenerateCalls: 0,
+  wrapStreamCalls: 0,
+});
+
+const middlewareOptions = (record: ProbeRecord) => ({
+  middleware: [createProbe(record)],
+  enabledMiddleware: ["stream-probe"],
+});
+
+// ---------------------------------------------------------------------------
+// PRECONDITION — the probe is correctly registered and does run on generate.
+// ---------------------------------------------------------------------------
+
+await test("generate applies model middleware (precondition)", async () => {
+  const server = await startMockChatServer();
+  const record = emptyRecord();
+  try {
+    const nl = new NeuroLink();
+    await nl.generate({
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: middlewareOptions(record),
+    });
+
+    if (record.transformParamsCalls.length === 0) {
+      throw new Error(
+        "probe never ran on generate — the probe is mis-registered, so the " +
+          "stream assertions below would be meaningless",
+      );
+    }
+    if (record.wrapGenerateCalls === 0) {
+      throw new Error("wrapGenerate never fired on the generate path");
+    }
+    const body = server.getLastRequestBody();
+    if (!body || !body.includes(MARKER)) {
+      throw new Error(
+        "the transformParams rewrite did not reach the wire on generate",
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// THE GAP — the same middleware, the same provider, the streaming path.
+// ---------------------------------------------------------------------------
+
+await test("stream applies model middleware", async () => {
+  const server = await startMockChatServer();
+  const record = emptyRecord();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: middlewareOptions(record),
+    });
+
+    for await (const _chunk of result.stream) {
+      // Drain. The assertions are about what was sent, not what came back.
+    }
+
+    if (!server.wasCalled()) {
+      throw new Error(
+        "the stand-in was never called — the stream never left the machine, " +
+          "so nothing below can be concluded about middleware",
+      );
+    }
+    if (record.transformParamsCalls.length === 0) {
+      throw new Error("transformParams never fired on the streaming path");
+    }
+    if (!record.transformParamsCalls.includes("stream")) {
+      throw new Error(
+        'transformParams fired but never with type "stream" on stream()',
+      );
+    }
+    if (record.wrapStreamCalls === 0) {
+      throw new Error("wrapStream never fired on the streaming path");
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+await test("a stream transformParams rewrite reaches the wire", async () => {
+  const server = await startMockChatServer();
+  const record = emptyRecord();
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.stream({
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: middlewareOptions(record),
+    });
+
+    for await (const _chunk of result.stream) {
+      // Drain.
+    }
+
+    const body = server.getLastRequestBody();
+    if (!body) {
+      throw new Error("the stand-in captured no request body for the stream");
+    }
+    if (!body.includes(MARKER)) {
+      throw new Error(
+        "the transformParams rewrite did not reach the wire on stream",
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+const readText = async (result: StreamResult): Promise<string> => {
+  let text = "";
+  for await (const chunk of result.stream) {
+    if ("content" in chunk && typeof chunk.content === "string") {
+      text += chunk.content;
+    }
+  }
+  return text;
+};
+
+// The deadline is generous on purpose. The two cancellation cases below
+// failed once with "request never reached the fixture" while a 53-suite sweep
+// saturated the CPU in parallel — stream setup alone exceeded a 3s bound before
+// the HTTP request went out — and passed 20/20 in isolation. A bound exists to
+// catch a hang, not to race the scheduler.
+const bounded = async <T>(
+  promise: PromiseLike<T>,
+  deadlineMs = 30_000,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(promise),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("middleware completion did not settle")),
+          deadlineMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+await test("wrapStream filters text and observes the V3 terminal event", async () => {
+  const server = await startMockChatServer();
+  const sdk = new NeuroLink();
+  const seen: LanguageModelV3StreamPart[] = [];
+  const middleware: NeuroLinkMiddleware = {
+    specificationVersion: "v3",
+    metadata: { id: "wire-filter", name: "Wire filter" },
+    wrapStream: async ({ doStream }) => {
+      const result = await doStream();
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(
+          new TransformStream({
+            transform(part: LanguageModelV3StreamPart, controller) {
+              seen.push(part);
+              controller.enqueue(
+                part.type === "text-delta"
+                  ? { ...part, delta: part.delta.toUpperCase() }
+                  : part,
+              );
+            },
+          }),
+        ),
+      };
+    },
+  };
+  try {
+    const result = await sdk.stream({
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: {
+        middleware: [middleware],
+        enabledMiddleware: ["wire-filter"],
+      },
+    });
+    assert.equal(
+      await bounded(readText(result)),
+      "MOCK REPLY",
+      "filtered text lost",
+    );
+    assert.ok(server.wasCalled(), "wire request did not run");
+    assert.equal(
+      seen.filter((part) => part.type === "finish").length,
+      1,
+      "terminal event not forwarded",
+    );
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+await test("a synthetic blocking stream delivers text and settles analytics without HTTP", async () => {
+  const server = await startMockChatServer();
+  const sdk = new NeuroLink();
+  let invoked = false;
+  const middleware: NeuroLinkMiddleware = {
+    specificationVersion: "v3",
+    metadata: { id: "block-stream", name: "Block stream" },
+    wrapStream: async () => {
+      invoked = true;
+      return {
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            controller.enqueue({ type: "text-start", id: "blocked" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "blocked",
+              delta: "BLOCKED",
+            });
+            controller.enqueue({ type: "text-end", id: "blocked" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: { unified: "stop" },
+              usage: { inputTokens: { total: 0 }, outputTokens: { total: 0 } },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+  try {
+    const result = await sdk.stream({
+      input: { text: "block this" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      disableInternalFallback: true,
+      enableAnalytics: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: {
+        middleware: [middleware],
+        enabledMiddleware: ["block-stream"],
+      },
+    });
+    assert.equal(
+      await bounded(readText(result)),
+      "BLOCKED",
+      "blocked content lost",
+    );
+    assert.ok(invoked, "blocking middleware did not run");
+    assert.equal(
+      server.getAllRequestBodies().length,
+      0,
+      "blocked request reached HTTP",
+    );
+    assert.ok(result.analytics, "analytics were not exposed");
+    await bounded(Promise.resolve(result.analytics));
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+for (const mode of ["generate", "stream"] as const) {
+  await test(`guardrail bad-word filtering changes ${mode} content`, async () => {
+    const server = await startMockChatServer();
+    const sdk = new NeuroLink();
+    try {
+      const options = {
+        input: { text: "hello" },
+        provider: "openai",
+        model: "gpt-4o-mini",
+        disableTools: true,
+        disableInternalFallback: true,
+        credentials: mockOpenAICredentials(server),
+        middleware: {
+          middlewareConfig: {
+            guardrails: {
+              enabled: true,
+              config: {
+                badWords: {
+                  enabled: true,
+                  list: ["mock"],
+                  replacementText: "CLEAN",
+                },
+              },
+            },
+          },
+        },
+      };
+      const content =
+        mode === "generate"
+          ? (await sdk.generate(options)).content
+          : await bounded(readText(await sdk.stream(options)));
+      assert.ok(server.wasCalled(), "provider was not exercised");
+      assert.equal(
+        content,
+        "CLEAN reply",
+        "guardrail filtering did not reach consumer",
+      );
+    } finally {
+      await sdk.shutdown();
+      await server.close();
+    }
+  });
+
+  await test(`precall guardrail blocks ${mode} after evaluator returns unsafe`, async () => {
+    const evaluator = await startScriptedChatServer([
+      chatCompletion({
+        content: JSON.stringify({
+          overall: "unsafe",
+          safetyScore: 1,
+          appropriatenessScore: 1,
+          confidenceLevel: 10,
+          suggestedAction: "block",
+          reasoning: "Deterministic blocking fixture",
+        }),
+      }),
+    ]);
+    const target = await startMockChatServer();
+    const saved = {
+      key: process.env.OPENAI_COMPATIBLE_API_KEY,
+      url: process.env.OPENAI_COMPATIBLE_BASE_URL,
+    };
+    process.env.OPENAI_COMPATIBLE_API_KEY = "test-evaluator-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = evaluator.baseURL;
+    const sdk = new NeuroLink();
+    try {
+      const options = {
+        input: { text: "block this request" },
+        provider: "openai",
+        model: "gpt-4o-mini",
+        disableTools: true,
+        disableInternalFallback: true,
+        enableAnalytics: true,
+        credentials: mockOpenAICredentials(target),
+        middleware: {
+          middlewareConfig: {
+            guardrails: {
+              enabled: true,
+              config: {
+                precallEvaluation: {
+                  enabled: true,
+                  provider: "openai-compatible",
+                  evaluationModel: "fixture-evaluator",
+                },
+              },
+            },
+          },
+        },
+      };
+      const result =
+        mode === "generate"
+          ? await sdk.generate(options)
+          : await sdk.stream(options);
+      const content =
+        "stream" in result ? await bounded(readText(result)) : result.content;
+      assert.ok(evaluator.wasCalled(), "guardrail evaluator was not exercised");
+      assert.equal(
+        target.getAllRequestBodies().length,
+        0,
+        "blocked input reached target provider",
+      );
+      assert.equal(
+        content,
+        "Request contains inappropriate content and has been blocked.",
+        "guardrail refusal was lost",
+      );
+      if (result.analytics) {
+        await bounded(Promise.resolve(result.analytics));
+      }
+    } finally {
+      if (saved.key === undefined) {
+        delete process.env.OPENAI_COMPATIBLE_API_KEY;
+      } else {
+        process.env.OPENAI_COMPATIBLE_API_KEY = saved.key;
+      }
+      if (saved.url === undefined) {
+        delete process.env.OPENAI_COMPATIBLE_BASE_URL;
+      } else {
+        process.env.OPENAI_COMPATIBLE_BASE_URL = saved.url;
+      }
+      await sdk.shutdown();
+      await target.close();
+      await evaluator.close();
+    }
+  });
+
+  await test(`${mode} executes a real tool round trip with middleware enabled`, async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const body: Record<string, unknown> = JSON.parse(
+        Buffer.concat(chunks).toString(),
+      );
+      bodies.push(body);
+      const first = bodies.length === 1;
+      const call = {
+        id: "call_fixture",
+        type: "function",
+        function: { name: "lookup", arguments: '{"value":7}' },
+      };
+      if (body.stream === true) {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        const delta = first
+          ? { tool_calls: [{ index: 0, ...call }] }
+          : { content: "answer 42" };
+        for (const data of [
+          { choices: [{ index: 0, delta, finish_reason: null }] },
+          {
+            choices: [
+              {
+                index: 0,
+                delta: {},
+                finish_reason: first ? "tool_calls" : "stop",
+              },
+            ],
+            usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+          },
+        ]) {
+          res.write(`data: ${JSON.stringify(data)}\n\n`);
+        }
+        res.end("data: [DONE]\n\n");
+      } else {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify(
+            chatCompletion(
+              first
+                ? { finishReason: "tool_calls", toolCalls: [call] }
+                : { content: "answer 42" },
+            ),
+          ),
+        );
+      }
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const sdk = new NeuroLink();
+    let calls = 0;
+    try {
+      const options = {
+        input: { text: "call lookup" },
+        provider: "openai",
+        model: "gpt-4o-mini",
+        maxSteps: 3,
+        disableInternalFallback: true,
+        enabledToolNames: ["lookup"],
+        credentials: {
+          openai: {
+            apiKey: "test-key",
+            baseURL: `http://127.0.0.1:${address.port}/v1`,
+          },
+        },
+        tools: {
+          lookup: tool({
+            inputSchema: z.object({ value: z.number() }),
+            execute: async ({ value }) => {
+              calls++;
+              assert.equal(value, 7, "tool arguments changed");
+              return { answer: 42 };
+            },
+          }),
+        },
+        middleware: middlewareOptions(emptyRecord()),
+      };
+      const result =
+        mode === "generate"
+          ? await sdk.generate(options)
+          : await sdk.stream(options);
+      const content =
+        "stream" in result ? await bounded(readText(result)) : result.content;
+      assert.equal(calls, 1, "tool was not invoked once");
+      assert.equal(
+        bodies.length,
+        2,
+        "tool round trip did not send two requests",
+      );
+      assert.ok(
+        JSON.stringify(bodies[1].messages).includes("42"),
+        "tool result not sent back",
+      );
+      assert.equal(content, "answer 42", "final tool answer lost");
+    } finally {
+      await sdk.shutdown();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+}
+
+await test("breaking out of a wrapped stream cancels the upstream socket", async () => {
+  let closed = false;
+  let received = false;
+  const server = createServer(async (req, res) => {
+    for await (const _chunk of req) {
+      /* Read the request before streaming. */
+    }
+    received = true;
+    res.on("close", () => {
+      closed = true;
+    });
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.write(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "first" }, finish_reason: null }] })}\n\n`,
+    );
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.stream({
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: {
+        openai: {
+          apiKey: "test-key",
+          baseURL: `http://127.0.0.1:${address.port}/v1`,
+        },
+      },
+      middleware: middlewareOptions(emptyRecord()),
+    });
+    await bounded(
+      (async () => {
+        for await (const chunk of result.stream) {
+          if ("content" in chunk && chunk.content) {
+            break;
+          }
+        }
+      })(),
+    );
+    assert.ok(received, "server was never reached");
+    await bounded(
+      (async () => {
+        while (!closed) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      })(),
+    );
+    assert.ok(closed, "upstream socket not closed");
+  } finally {
+    await sdk.shutdown();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+for (const mode of ["generate", "stream"] as const) {
+  await test(`${mode} propagates provider failure with middleware enabled`, async () => {
+    const server = await startScriptedChatServer([
+      { status: 400, body: { error: { message: "fixture rejected" } } },
+    ]);
+    const sdk = new NeuroLink();
+    let caught: unknown;
+    try {
+      const options = {
+        input: { text: "hello" },
+        provider: "openai",
+        model: "gpt-4o-mini",
+        disableTools: true,
+        disableInternalFallback: true,
+        credentials: mockOpenAICredentials(server),
+        middleware: middlewareOptions(emptyRecord()),
+      };
+      try {
+        if (mode === "generate") {
+          await sdk.generate(options);
+        } else {
+          await readText(await sdk.stream(options));
+        }
+      } catch (error) {
+        caught = error;
+      }
+      assert.ok(server.wasCalled(), "failure fixture was not reached");
+      assert.ok(caught, "provider failure was swallowed");
+    } finally {
+      await sdk.shutdown();
+      await server.close();
+    }
+  });
+
+  for (const end of ["abort", "timeout"] as const) {
+    await test(`${mode} ${end} closes an in-flight HTTP request`, async () => {
+      const controller = new AbortController();
+      let received = false;
+      let closed = false;
+      const server = createServer(async (req, res) => {
+        for await (const _part of req) {
+          /* Ensure the model request arrived. */
+        }
+        received = true;
+        res.on("close", () => {
+          closed = true;
+        });
+        if (end === "abort") {
+          controller.abort(new Error("fixture abort"));
+        }
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      assert.ok(address && typeof address === "object");
+      const sdk = new NeuroLink();
+      let caught: unknown;
+      try {
+        const options = {
+          input: { text: "hello" },
+          provider: "openai",
+          model: "gpt-4o-mini",
+          disableTools: true,
+          disableInternalFallback: true,
+          abortSignal: controller.signal,
+          timeout: 1000,
+          turnTimeoutMs: 1500,
+          credentials: {
+            openai: {
+              apiKey: "test-key",
+              baseURL: `http://127.0.0.1:${address.port}/v1`,
+            },
+          },
+          middleware: middlewareOptions(emptyRecord()),
+        };
+        try {
+          await bounded(
+            (async () => {
+              if (mode === "generate") {
+                await sdk.generate(options);
+              } else {
+                await readText(await sdk.stream(options));
+              }
+            })(),
+          );
+        } catch (error) {
+          caught = error;
+        }
+        assert.ok(received, "request never reached the fixture");
+        assert.ok(caught, "cancellation did not terminate the call");
+        assert.notEqual(
+          caught instanceof Error ? caught.message : "",
+          "middleware completion did not settle",
+          "only the test deadline ended the call",
+        );
+        await bounded(
+          (async () => {
+            while (!closed) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+          })(),
+        );
+        assert.ok(closed, "upstream request stayed open");
+      } finally {
+        controller.abort();
+        await sdk.shutdown();
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+  }
+}
+
+await test("stream middleware sampling edits reach the wire and preserve native fields", async () => {
+  const server = await startMockChatServer();
+  const sdk = new NeuroLink();
+  const middleware: NeuroLinkMiddleware = {
+    specificationVersion: "v3",
+    metadata: { id: "sampling", name: "Sampling" },
+    transformParams: async ({ params }) => ({
+      ...params,
+      maxOutputTokens: 77,
+      temperature: 0.25,
+      topP: 0.9,
+    }),
+  };
+  try {
+    await readText(
+      await sdk.stream({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        input: { text: "hello" },
+        disableTools: true,
+        disableInternalFallback: true,
+        maxTokens: 128,
+        temperature: 0.7,
+        credentials: mockOpenAICredentials(server),
+        middleware: {
+          middleware: [middleware],
+          enabledMiddleware: ["sampling"],
+        },
+      }),
+    );
+    assert.ok(server.wasCalled(), "sampling fixture not reached");
+    const body: Record<string, unknown> = JSON.parse(
+      server.getLastRequestBody() ?? "{}",
+    );
+    assert.equal(body.max_tokens, 77, "token override lost");
+    assert.equal(body.temperature, 0.25, "temperature override lost");
+    assert.equal(body.top_p, 0.9, "top-p override lost");
+    assert.equal(body.stream, true, "stream mode changed");
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+await test("generate schema recovery still works with middleware enabled", async () => {
+  const server = await startScriptedChatServer([
+    chatCompletion({ content: '{"answer":42}' }),
+  ]);
+  const sdk = new NeuroLink();
+  const schema = z.object({ answer: z.number() });
+  try {
+    const result = await sdk.generate({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      input: { text: "answer" },
+      schema,
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: mockOpenAICredentials(server),
+      middleware: middlewareOptions(emptyRecord()),
+    });
+    assert.ok(server.wasCalled(), "schema fixture not reached");
+    assert.equal(
+      schema.parse(result.structuredData).answer,
+      42,
+      "structured data changed",
+    );
+    assert.deepEqual(
+      JSON.parse(result.content),
+      result.structuredData,
+      "JSON text disagrees with object",
+    );
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+await runSuite();


### PR DESCRIPTION
## What

`middleware` is a public option on both `generate()` and `stream()`, but every site that applied it was a generate path. `wrapStream` was dead code repo-wide, `transformParams({ type: "stream" })` never fired, and a guardrail that blocks a prompt under `generate()` was bypassed entirely by `stream()`.

This closes that gap for the **OpenAI-compatible family only** — every provider on `OpenAIChatCompletionsProvider` (the catalog providers, DeepSeek, Cohere, Azure OpenAI, LM Studio, llama.cpp, LiteLLM). Anthropic, Vertex, AI Studio and Bedrock each have their own `executeStream` and still bypass middleware on stream; that is tracked separately and is not claimed here. An earlier version of this PR described itself as "the streaming path" — that overstated it, and the title, commit and this body are the correction.

## How

- `BaseProvider.applyMiddlewareToModel` splits chain-application out of `getAISDKModelWithMiddleware`, which always wrapped the non-streaming model.
- `executeStream` builds a V3 base model whose `doStream` starts the real multi-step stream loop, wraps it with the middleware chain, and drives the wrapped model. The prompt is converted to the wire format only **after** `transformParams`, which is what makes a rewrite actually reach the wire.
- Honoured on the way back in: `prompt`, `maxOutputTokens`, `temperature`, `topP`. `tools` is read-only — a rewrite gets a WARN rather than a silent drop.

## Defects found in review and fixed at the root

Review (Yama) flagged that the reader keyed on `textDelta`. That was a symptom of a wider problem — the bridge was not a faithful V3 stream — and stronger tests then found four defects. All are fixed here:

1. **No terminal `finish` part.** A middleware observing the stream could not see usage or the finish reason. The bridge now emits `finish` from the loop's deferred usage/finish promises; a synthetic stream from a blocking middleware settles analytics too.
2. **Blocking middleware hung analytics.** Guardrails' precall path returns its own stream without calling `doStream`, so `loopPromise` never existed and the turn's usage/finish never resolved. Every reader now tolerates its absence.
3. **Cancellation never reached upstream.** Breaking out of a wrapped stream left the HTTP request open. `chunksToV3Stream` pulls one chunk at a time and forwards `cancel()` to the consumer abort controller and the iterator.
4. **Guardrails emitted v1/v2 parts** (`textDelta`, `promptTokens`) and filtered on `"textDelta" in chunk`, so its blocked stream surfaced as the "Stream produced no output" sentinel and its bad-word filter never matched a V3 delta. `createBlockedResponse` / `createBlockedStream` now emit V3 parts and the filter reads `delta`. This is the root fix for the review finding, not a fallback in the reader.

## Proof

`test/continuous-test-suite-stream-middleware.ts` — 20 cases driving the shipped `dist` against local HTTP stand-ins, on both `generate()` and `stream()`:

- prompt rewrite reaches the wire; V3 `finish` observed with usage
- blocking stream delivers text and settles analytics with **zero** HTTP requests
- guardrail bad-word filtering and precall blocking on both modes, with the evaluator itself a scripted stand-in
- a real tool round trip with middleware enabled, both modes
- provider failure propagates; abort and timeout close the in-flight request on both modes
- middleware sampling edits reach the wire; schema recovery still works

Also run with an empty `HOME` and cwd (no `.env`) so no ambient credential can satisfy anything. The suite is wired into the extended CI shards (`test:stream-middleware@5`).

Full gate on the final code (all against the rebuilt `dist`):

| gate | result |
| --- | --- |
| `check:dts` | every shipped declaration resolves |
| `test:stream-middleware` | 20/20 |
| `test:providers-mocked` | 95/95 |
| `test:vendor-recovery` | 3/3 |
| `test:openai-compat-streaming-retry` | 2/2 |
| `test:adjust-body-after-400` | 2/2 |
| `test:error-classification-e2e` | 144/144 |
| `test:anthropic-loop-characterization` | 10/10 |
| `test:middleware` (live, Vertex) | 6/7 — see below |

The one miss in the chain was `generate() onFinish`: Vertex (`gemini-2.5-flash`, a thinking model) returned empty content at the suite's `maxTokens: 50`. Re-run alone on the same build: **7/7**. A probe with the case's own prompt at 50 tokens shows 28 of 29 output tokens spent on reasoning, so an empty reply there is the budget, not the middleware — this PR does not touch Vertex's generate path. The budget is fixed in a separate test-harness PR.

## Not in this PR

- Middleware on the native stream paths of Anthropic, Vertex, AI Studio and Bedrock.
- A mutable `tools` in `transformParams` for streams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model middleware now applies consistently to streaming responses, including prompt transformations, guardrails, tool interactions, and sampling overrides.
  - OpenAI-compatible streaming supports middleware-driven response filtering and request blocking.

- **Bug Fixes**
  - Guardrails now correctly filter unsafe content across generated text and streamed output.
  - Improved handling of blocked requests, provider errors, aborted requests, timeouts, and interrupted streams.
  - Streaming usage and completion status are reported correctly when middleware intervenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->