### PR TITLE
ci(guards): wire the vendor-recovery and browser-bundle suites and the dts guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,13 @@ jobs:
         if: matrix.group == 'types'
         run: pnpm run check:tools-tests
 
+      # The shipped-declaration guard reads dist/*.d.ts, so it belongs in the
+      # one shard that builds. It was added in #1627 and hardened in #1632 and
+      # until now ran only when someone ran it by hand.
+      - name: 🔎 Check shipped declarations resolve
+        if: matrix.group == 'types'
+        run: pnpm run check:dts
+
       - name: Test CLI build
         if: matrix.group == 'types'
         run: |
@@ -1126,6 +1133,8 @@ jobs:
             test:autoresearch@2
             test:loop-engine@2
             test:handler-registry@1
+            test:vendor-recovery@5
+            test:browser-bundle@5
           "
           # Normalise every entry to name@weight (missing or non-numeric
           # weights become 30), then sort by weight descending. Greedy

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "test:mcp:spans": "pnpm exec tsx test/continuous-test-suite-mcp-spans.ts",
     "test:mcp:infra": "pnpm exec tsx test/continuous-test-suite-mcp-infra.ts",
     "test:vendor-recovery": "pnpm exec tsx test/continuous-test-suite-native-vendor-recovery.ts",
+    "test:browser-bundle": "pnpm exec tsx test/continuous-test-suite-browser-bundle.ts",
     "test:providers-mocked": "pnpm exec tsx test/continuous-test-suite-providers-mocked.ts",
     "scaffold:provider": "pnpm exec tsx tools/scaffold-provider.ts",
     "verify:provider-onboarding": "pnpm exec tsx tools/verify-provider-onboarding.ts",

--- a/test/continuous-test-suite-browser-bundle.ts
+++ b/test/continuous-test-suite-browser-bundle.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — browser bundle
+ *
+ * `dist/browser/neurolink.min.js` (the `@juspay/neurolink/browser` subpath)
+ * had no test at all until the Vercel AI SDK removal replaced its provider
+ * factories with native ones. The smoke written then lived in a scratch
+ * directory and was never committed, so the bundle was back to zero coverage
+ * the moment that session ended. This is that smoke, committed and wired in.
+ *
+ * It proves the bundle loads in Node, that the six factory exports the SDK
+ * used to supply are still present and callable, that each factory hands back
+ * a V3-shaped model handle synchronously, and that NeuroLink itself is still
+ * exported. It also drives generate() and stream() through that bundled
+ * NeuroLink constructor against a loopback HTTP server. No live credentials.
+ * This is a Node smoke of the browser artifact, not a browser-engine test.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-browser-bundle.ts
+ */
+
+import assert from "node:assert/strict";
+import type { NeuroLink } from "../dist/index.js";
+import { defineSuite } from "./helpers/harness.js";
+import {
+  startMockChatServer,
+  mockOpenAICredentials,
+} from "./helpers/mockChatServer.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("Browser bundle", { offline: true });
+
+// Resolve at runtime: TypeScript must check the test, not re-check generated
+// minified JavaScript as source through allowJs/checkJs.
+const bundleURL = new URL("../dist/browser/neurolink.min.js", import.meta.url);
+const bundle: Record<string, unknown> = await import(bundleURL.href);
+
+const FACTORY_EXPORTS = [
+  "createAnthropic",
+  "anthropic",
+  "createOpenAI",
+  "openai",
+  "createMistral",
+  "mistral",
+];
+
+type Factory = (
+  options: Record<string, unknown>,
+) => (modelId: string) => Record<string, unknown>;
+
+await test("every provider factory is exported and callable", async () => {
+  const missing = FACTORY_EXPORTS.filter(
+    (name) => typeof bundle[name] !== "function",
+  );
+  if (missing.length > 0) {
+    throw new Error(`not exported as a function: ${missing.join(", ")}`);
+  }
+});
+
+await test("each factory returns a V3-shaped model handle synchronously", async () => {
+  const cases: Array<[string, string]> = [
+    ["createAnthropic", "claude-sonnet-4-5"],
+    ["createOpenAI", "gpt-4o-mini"],
+    ["createMistral", "mistral-small-latest"],
+  ];
+  const problems: string[] = [];
+  for (const [factory, modelId] of cases) {
+    const make = bundle[factory] as Factory;
+    const alias = factory.slice("create".length).toLowerCase();
+    const direct = bundle[alias] as (id: string) => Record<string, unknown>;
+    const handle = direct(modelId);
+    assert.equal(handle.modelId, modelId, "direct export model ID mismatch");
+    assert.equal(
+      handle.specificationVersion,
+      "v3",
+      "direct export version mismatch",
+    );
+    assert.equal(
+      typeof handle.doGenerate,
+      "function",
+      "direct export generation missing",
+    );
+    assert.equal(
+      typeof handle.doStream,
+      "function",
+      "direct export streaming missing",
+    );
+    const model = make({})(modelId);
+    if (model.specificationVersion !== "v3") {
+      problems.push(`${factory}: specificationVersion`);
+    }
+    if (typeof model.doGenerate !== "function") {
+      problems.push(`${factory}: doGenerate`);
+    }
+    if (typeof model.doStream !== "function") {
+      problems.push(`${factory}: doStream`);
+    }
+    if (model.modelId !== modelId) {
+      problems.push(`${factory}: modelId`);
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(`model handle shape mismatch — ${problems.join("; ")}`);
+  }
+});
+
+await test("NeuroLink is exported from the bundle", async () => {
+  if (typeof bundle.NeuroLink !== "function") {
+    throw new Error("NeuroLink is not exported as a constructor");
+  }
+});
+
+for (const mode of ["generate", "stream"] as const) {
+  await test(`bundled NeuroLink ${mode} reaches the wire and returns content`, async () => {
+    assert.equal(
+      typeof bundle.NeuroLink,
+      "function",
+      "bundle constructor missing",
+    );
+    const BundledNeuroLink = bundle.NeuroLink as typeof NeuroLink;
+    const server = await startMockChatServer();
+    const sdk = new BundledNeuroLink();
+    try {
+      const options = {
+        input: { text: "BROWSER_WIRE_MARKER" },
+        provider: "openai" as const,
+        model: "gpt-4o-mini",
+        disableTools: true,
+        disableInternalFallback: true,
+        credentials: mockOpenAICredentials(server),
+        timeout: 10000,
+      };
+      let content = "";
+      if (mode === "generate") {
+        content = (await sdk.generate(options)).content;
+      } else {
+        const result = await sdk.stream(options);
+        for await (const chunk of result.stream) {
+          if ("content" in chunk && typeof chunk.content === "string") {
+            content += chunk.content;
+          }
+        }
+      }
+      assert.equal(
+        server.getAllRequestBodies().length,
+        1,
+        "unexpected request count",
+      );
+      const body: Record<string, unknown> = JSON.parse(
+        server.getLastRequestBody() ?? "{}",
+      );
+      assert.equal(
+        body.stream === true,
+        mode === "stream",
+        "wrong wire streaming mode",
+      );
+      assert.equal(body.model, "gpt-4o-mini", "wrong wire model");
+      assert.ok(
+        JSON.stringify(body.messages).includes("BROWSER_WIRE_MARKER"),
+        "wire prompt missing",
+      );
+      assert.equal(content, "mock reply", "bundled response not delivered");
+    } finally {
+      await sdk.shutdown();
+      await server.close();
+    }
+  });
+}
+
+await runSuite();


### PR DESCRIPTION
Three things this repo added recently ran only when someone ran them by hand:

- `test:vendor-recovery`, the offline suite that proves the two vendor
  recoveries ported into the native generate loop in 653d1ff69. It was the
  evidence that PR cited and it was in no CI job.
- `check:dts`, the shipped-declaration guard from #1627 (hardened in #1632).
  It reads `dist/*.d.ts`, so it now runs in the `types` shard, the one shard
  that builds.
- The browser bundle, which had no committed test at all. The smoke written
  during the SDK removal lived in a scratch directory and was never committed,
  so `dist/browser/neurolink.min.js` was back to zero coverage the moment that
  session ended. `test:browser-bundle` is that smoke, committed: the bundle
  loads in Node, the six factory exports are present and callable, each hands
  back a V3-shaped model handle synchronously, and NeuroLink is exported.

This is the same failure the extended-suites job documents — "a suite wired
into nothing is documentation, not a test" — and it is the one this repo hit
twice in the last two days, once with the error-classification suite and once
with a guard I wrote and never gated. Both new suites are offline and pass
with no credentials; they enter the extended shards at weight 5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added offline smoke-test coverage for the browser bundle.
  * Verified provider factory exports and model handles are available and callable.
  * Confirmed the main NeuroLink export remains constructible.
  * Validated generation and streaming requests through the bundled browser entry point.
  * Added declaration validation to the test workflow.
* **Chores**
  * Integrated browser-bundle and vendor-recovery suites into shard balancing.
  * Added the browser-bundle test to the available test commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->